### PR TITLE
Fork com.daml.platform.store.dao

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/CommandCompletionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/CommandCompletionsReader.scala
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.lf.data.Ref
+import com.daml.ledger.ApplicationId
+import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.ApiOffset
+import com.daml.platform.store.DbType
+import com.daml.platform.store.appendonlydao.events.{QueryNonPruned, SqlFunctions}
+import com.daml.platform.store.dao.LedgerDaoCommandCompletionsReader
+
+import scala.concurrent.{ExecutionContext, Future}
+
+private[appendonlydao] final class CommandCompletionsReader(
+    dispatcher: DbDispatcher,
+    dbType: DbType,
+    metrics: Metrics,
+    executionContext: ExecutionContext,
+) extends LedgerDaoCommandCompletionsReader {
+
+  private val sqlFunctions = SqlFunctions(dbType)
+
+  private def offsetFor(response: CompletionStreamResponse): Offset =
+    ApiOffset.assertFromString(response.checkpoint.get.offset.get.getAbsolute)
+
+  override def getCommandCompletions(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      applicationId: ApplicationId,
+      parties: Set[Ref.Party],
+  )(implicit
+      loggingContext: LoggingContext
+  ): Source[(Offset, CompletionStreamResponse), NotUsed] = {
+    val query = CommandCompletionsTable.prepareGet(
+      startExclusive = startExclusive,
+      endInclusive = endInclusive,
+      applicationId = applicationId,
+      parties = parties,
+      sqlFunctions = sqlFunctions,
+    )
+    Source
+      .future(
+        dispatcher
+          .executeSql(metrics.daml.index.db.getCompletions) { implicit connection =>
+            QueryNonPruned.executeSql[List[CompletionStreamResponse]](
+              query.as(CommandCompletionsTable.parser.*),
+              startExclusive,
+              pruned =>
+                s"Command completions request from ${startExclusive.toHexString} to ${endInclusive.toHexString} overlaps with pruned offset ${pruned.toHexString}",
+            )
+          }
+          .flatMap(_.fold(Future.failed, Future.successful))(executionContext)
+      )
+      .mapConcat(_.map(response => offsetFor(response) -> response))
+  }
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/CommandCompletionsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/CommandCompletionsTable.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.time.Instant
+
+import anorm.{Row, RowParser, SimpleSql, SqlParser, SqlStringInterpolation, ~}
+import com.daml.ledger.ApplicationId
+import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
+import com.daml.ledger.api.v1.completion.Completion
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.lf.data.Ref
+import com.daml.platform.store.CompletionFromTransaction.toApiCheckpoint
+import com.daml.platform.store.Conversions._
+import com.daml.platform.store.appendonlydao.events.SqlFunctions
+import com.google.rpc.status.Status
+
+private[platform] object CommandCompletionsTable {
+
+  import SqlParser.{int, str}
+
+  private val sharedColumns: RowParser[Offset ~ Instant ~ String] =
+    offset("completion_offset") ~ instant("record_time") ~ str("command_id")
+
+  private val acceptedCommandParser: RowParser[CompletionStreamResponse] =
+    sharedColumns ~ str("transaction_id") map {
+      case offset ~ recordTime ~ commandId ~ transactionId =>
+        CompletionStreamResponse(
+          checkpoint = toApiCheckpoint(recordTime, offset),
+          completions = Seq(Completion(commandId, Some(Status()), transactionId)),
+        )
+    }
+
+  private val rejectedCommandParser: RowParser[CompletionStreamResponse] =
+    sharedColumns ~ int("status_code") ~ str("status_message") map {
+      case offset ~ recordTime ~ commandId ~ statusCode ~ statusMessage =>
+        CompletionStreamResponse(
+          checkpoint = toApiCheckpoint(recordTime, offset),
+          completions = Seq(Completion(commandId, Some(Status(statusCode, statusMessage)))),
+        )
+    }
+
+  val parser: RowParser[CompletionStreamResponse] = acceptedCommandParser | rejectedCommandParser
+
+  def prepareGet(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      applicationId: ApplicationId,
+      parties: Set[Ref.Party],
+      sqlFunctions: SqlFunctions,
+  ): SimpleSql[Row] = {
+    val submittersInPartiesClause =
+      sqlFunctions.arrayIntersectionWhereClause("submitters", parties)
+    SQL"select completion_offset, record_time, command_id, transaction_id, status_code, status_message from participant_command_completions where completion_offset > $startExclusive and completion_offset <= $endInclusive and application_id = $applicationId and #$submittersInPartiesClause order by completion_offset asc"
+  }
+
+  def prepareCompletionsDelete(endInclusive: Offset): SimpleSql[Row] =
+    SQL"delete from participant_command_completions where completion_offset <= $endInclusive"
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/DbDispatcher.scala
@@ -1,0 +1,125 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.sql.Connection
+import java.util.concurrent.{Executor, Executors, TimeUnit}
+
+import com.codahale.metrics.{InstrumentedExecutorService, Timer}
+import com.daml.ledger.api.health.{HealthStatus, ReportsHealth}
+import com.daml.ledger.resources.ResourceOwner
+import com.daml.logging.LoggingContext.withEnrichedLoggingContext
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.metrics.{DatabaseMetrics, Metrics}
+import com.daml.platform.configuration.ServerRole
+import com.daml.platform.store.DbType
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NonFatal
+
+private[platform] final class DbDispatcher private (
+    val maxConnections: Int,
+    connectionProvider: HikariJdbcConnectionProvider,
+    executor: Executor,
+    overallWaitTimer: Timer,
+    overallExecutionTimer: Timer,
+) extends ReportsHealth {
+
+  private val logger = ContextualizedLogger.get(this.getClass)
+
+  private val executionContext = ExecutionContext.fromExecutor(executor)
+
+  override def currentHealth(): HealthStatus =
+    connectionProvider.currentHealth()
+
+  /** Runs an SQL statement in a dedicated Executor. The whole block will be run in a single database transaction.
+    *
+    * The isolation level by default is the one defined in the JDBC driver, it can be however overridden per query on
+    * the Connection. See further details at: https://docs.oracle.com/cd/E19830-01/819-4721/beamv/index.html
+    */
+  def executeSql[T](databaseMetrics: DatabaseMetrics)(
+      sql: Connection => T
+  )(implicit loggingContext: LoggingContext): Future[T] =
+    withEnrichedLoggingContext("metric" -> databaseMetrics.name) { implicit loggingContext =>
+      val startWait = System.nanoTime()
+      Future {
+        val waitNanos = System.nanoTime() - startWait
+        logger.trace(s"Waited ${(waitNanos / 1e6).toLong} ms to acquire connection")
+        databaseMetrics.waitTimer.update(waitNanos, TimeUnit.NANOSECONDS)
+        overallWaitTimer.update(waitNanos, TimeUnit.NANOSECONDS)
+        val startExec = System.nanoTime()
+        try {
+          // Actual execution
+          val result = connectionProvider.runSQL(databaseMetrics)(sql)
+          result
+        } catch {
+          case NonFatal(e) =>
+            logger.error("Exception while executing SQL query. Rolled back.", e)
+            throw e
+          // fatal errors don't make it for some reason to the setUncaughtExceptionHandler
+          case t: Throwable =>
+            logger.error("Fatal error!", t)
+            throw t
+        } finally {
+          // decouple metrics updating from sql execution above
+          try {
+            val execNanos = System.nanoTime() - startExec
+            logger.trace(s"Executed query in ${(execNanos / 1e6).toLong} ms")
+            databaseMetrics.executionTimer.update(execNanos, TimeUnit.NANOSECONDS)
+            overallExecutionTimer.update(execNanos, TimeUnit.NANOSECONDS)
+          } catch {
+            case NonFatal(e) =>
+              logger.error("Got an exception while updating timer metrics. Ignoring.", e)
+          }
+        }
+      }(executionContext)
+    }
+}
+
+private[platform] object DbDispatcher {
+  private val logger = ContextualizedLogger.get(this.getClass)
+
+  def owner(
+      serverRole: ServerRole,
+      jdbcUrl: String,
+      connectionPoolSize: Int,
+      connectionTimeout: FiniteDuration,
+      metrics: Metrics,
+      connectionAsyncCommitMode: DbType.AsyncCommitMode,
+  )(implicit loggingContext: LoggingContext): ResourceOwner[DbDispatcher] =
+    for {
+      connectionProvider <- HikariJdbcConnectionProvider.owner(
+        serverRole,
+        jdbcUrl,
+        connectionPoolSize,
+        connectionTimeout,
+        metrics.registry,
+        connectionAsyncCommitMode,
+      )
+      threadPoolName = s"daml.index.db.threadpool.connection.${serverRole.threadPoolSuffix}"
+      executor <- ResourceOwner.forExecutorService(() =>
+        new InstrumentedExecutorService(
+          Executors.newFixedThreadPool(
+            connectionPoolSize,
+            new ThreadFactoryBuilder()
+              .setNameFormat(s"$threadPoolName-%d")
+              .setUncaughtExceptionHandler((_, e) =>
+                logger.error("Uncaught exception in the SQL executor.", e)
+              )
+              .build(),
+          ),
+          metrics.registry,
+          threadPoolName,
+        )
+      )
+    } yield new DbDispatcher(
+      maxConnections = connectionPoolSize,
+      connectionProvider = connectionProvider,
+      executor = executor,
+      overallWaitTimer = metrics.daml.index.db.waitAll,
+      overallExecutionTimer = metrics.daml.index.db.execAll,
+    )
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/HikariJdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/HikariJdbcConnectionProvider.scala
@@ -1,0 +1,195 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.sql.{Connection, SQLTransientConnectionException}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.{Timer, TimerTask}
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.api.health.{HealthStatus, Healthy, Unhealthy}
+import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.metrics.{DatabaseMetrics, Timed}
+import com.daml.platform.configuration.ServerRole
+import com.daml.platform.store.DbType
+import com.daml.platform.store.appendonlydao.HikariJdbcConnectionProvider._
+import com.daml.timer.RetryStrategy
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.util.control.NonFatal
+
+private[platform] final class HikariConnection(
+    serverRole: ServerRole,
+    jdbcUrl: String,
+    minimumIdle: Int,
+    maxPoolSize: Int,
+    connectionTimeout: FiniteDuration,
+    metrics: Option[MetricRegistry],
+    connectionPoolPrefix: String,
+    maxInitialConnectRetryAttempts: Int,
+    connectionAsyncCommitMode: DbType.AsyncCommitMode,
+)(implicit loggingContext: LoggingContext)
+    extends ResourceOwner[HikariDataSource] {
+
+  private val logger = ContextualizedLogger.get(this.getClass)
+
+  override def acquire()(implicit context: ResourceContext): Resource[HikariDataSource] = {
+    val config = new HikariConfig
+    val dbType = DbType.jdbcType(jdbcUrl)
+
+    config.setJdbcUrl(jdbcUrl)
+    config.setDriverClassName(dbType.driver)
+    config.addDataSourceProperty("cachePrepStmts", "true")
+    config.addDataSourceProperty("prepStmtCacheSize", "128")
+    config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048")
+    config.setAutoCommit(false)
+    config.setMaximumPoolSize(maxPoolSize)
+    config.setMinimumIdle(minimumIdle)
+    config.setConnectionTimeout(connectionTimeout.toMillis)
+    config.setPoolName(s"$connectionPoolPrefix.${serverRole.threadPoolSuffix}")
+    metrics.foreach(config.setMetricRegistry)
+
+    configureAsyncCommit(config, dbType)
+
+    // Hikari dies if a database connection could not be opened almost immediately
+    // regardless of any connection timeout settings. We retry connections so that
+    // Postgres and Sandbox can be started in any order.
+    Resource(
+      RetryStrategy.constant(
+        attempts = maxInitialConnectRetryAttempts,
+        waitTime = 1.second,
+      ) { (i, _) =>
+        Future {
+          logger.info(
+            s"Attempting to connect to the database (attempt $i/$maxInitialConnectRetryAttempts)"
+          )
+          new HikariDataSource(config)
+        }
+      }
+    )(conn => Future { conn.close() })
+  }
+
+  private def configureAsyncCommit(config: HikariConfig, dbType: DbType): Unit =
+    if (dbType.supportsAsynchronousCommits) {
+      logger.info(
+        s"Creating Hikari connections with synchronous commit ${connectionAsyncCommitMode.setting}"
+      )
+      config.setConnectionInitSql(s"SET synchronous_commit=${connectionAsyncCommitMode.setting}")
+    } else if (connectionAsyncCommitMode != DbType.SynchronousCommit) {
+      logger.warn(
+        s"Asynchronous commit setting ${connectionAsyncCommitMode.setting} is not compatible with ${dbType.name} database backend"
+      )
+    }
+}
+
+private[platform] object HikariConnection {
+  private val MaxInitialConnectRetryAttempts = 600
+  private val ConnectionPoolPrefix: String = "daml.index.db.connection"
+
+  def owner(
+      serverRole: ServerRole,
+      jdbcUrl: String,
+      minimumIdle: Int,
+      maxPoolSize: Int,
+      connectionTimeout: FiniteDuration,
+      metrics: Option[MetricRegistry],
+      connectionAsyncCommitMode: DbType.AsyncCommitMode,
+  )(implicit loggingContext: LoggingContext): HikariConnection =
+    new HikariConnection(
+      serverRole,
+      jdbcUrl,
+      minimumIdle,
+      maxPoolSize,
+      connectionTimeout,
+      metrics,
+      ConnectionPoolPrefix,
+      MaxInitialConnectRetryAttempts,
+      connectionAsyncCommitMode,
+    )
+}
+
+private[platform] class HikariJdbcConnectionProvider(
+    dataSource: HikariDataSource,
+    healthPoller: Timer,
+) extends JdbcConnectionProvider {
+  private val transientFailureCount = new AtomicInteger(0)
+
+  private val checkHealth = new TimerTask {
+    override def run(): Unit = {
+      try {
+        dataSource.getConnection().close()
+        transientFailureCount.set(0)
+      } catch {
+        case _: SQLTransientConnectionException =>
+          val _ = transientFailureCount.incrementAndGet()
+      }
+    }
+  }
+
+  healthPoller.schedule(checkHealth, 0, HealthPollingSchedule.toMillis)
+
+  override def currentHealth(): HealthStatus =
+    if (transientFailureCount.get() < MaxTransientFailureCount)
+      Healthy
+    else
+      Unhealthy
+
+  override def runSQL[T](databaseMetrics: DatabaseMetrics)(block: Connection => T): T = {
+    val conn = dataSource.getConnection()
+    conn.setAutoCommit(false)
+    try {
+      val res = Timed.value(
+        databaseMetrics.queryTimer,
+        block(conn),
+      )
+      Timed.value(
+        databaseMetrics.commitTimer,
+        conn.commit(),
+      )
+      res
+    } catch {
+      case e: SQLTransientConnectionException =>
+        transientFailureCount.incrementAndGet()
+        throw e
+      case NonFatal(t) =>
+        // Log the error in the caller with access to more logging context (such as the sql statement description)
+        conn.rollback()
+        throw t
+    } finally {
+      conn.close()
+    }
+  }
+}
+
+private[platform] object HikariJdbcConnectionProvider {
+  private val MaxTransientFailureCount: Int = 5
+  private val HealthPollingSchedule: FiniteDuration = 1.second
+
+  def owner(
+      serverRole: ServerRole,
+      jdbcUrl: String,
+      maxConnections: Int,
+      connectionTimeout: FiniteDuration,
+      metrics: MetricRegistry,
+      connectionAsyncCommitMode: DbType.AsyncCommitMode = DbType.SynchronousCommit,
+  )(implicit loggingContext: LoggingContext): ResourceOwner[HikariJdbcConnectionProvider] =
+    for {
+      // these connections should never time out as we have the same number of threads as connections
+      dataSource <- HikariConnection.owner(
+        serverRole,
+        jdbcUrl,
+        maxConnections,
+        maxConnections,
+        connectionTimeout,
+        Some(metrics),
+        connectionAsyncCommitMode,
+      )
+      healthPoller <- ResourceOwner.forTimer(() =>
+        new Timer(s"${classOf[HikariJdbcConnectionProvider].getName}#healthPoller")
+      )
+    } yield new HikariJdbcConnectionProvider(dataSource, healthPoller)
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcConnectionProvider.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.sql.Connection
+
+import com.daml.ledger.api.health.ReportsHealth
+import com.daml.metrics.DatabaseMetrics
+
+/** A helper to run JDBC queries using a pool of managed connections */
+private[platform] trait JdbcConnectionProvider extends ReportsHealth {
+
+  /** Blocks are running in a single transaction as the commit happens when the connection
+    * is returned to the pool.
+    * The block must not recursively call [[runSQL]], as this could result in a deadlock
+    * waiting for a free connection from the same pool.
+    */
+  def runSQL[T](databaseMetrics: DatabaseMetrics)(block: Connection => T): T
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -1,0 +1,903 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.daml.platform.store.appendonlydao
+
+import java.sql.Connection
+import java.time.Instant
+import java.util.Date
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import anorm.SqlParser._
+import anorm.{Macro, RowParser, SQL, SqlParser}
+import com.daml.daml_lf_dev.DamlLf.Archive
+import com.daml.ledger.api.domain
+import com.daml.ledger.api.domain.{LedgerId, ParticipantId, PartyDetails}
+import com.daml.ledger.api.health.HealthStatus
+import com.daml.ledger.participant.state.index.v2.{
+  CommandDeduplicationDuplicate,
+  CommandDeduplicationNew,
+  CommandDeduplicationResult,
+  PackageDetails,
+}
+import com.daml.ledger.participant.state.v1._
+import com.daml.ledger.resources.ResourceOwner
+import com.daml.ledger.{TransactionId, WorkflowId}
+import com.daml.lf.archive.Decode
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.{PackageId, Party}
+import com.daml.lf.engine.ValueEnricher
+import com.daml.lf.transaction.{BlindingInfo, GlobalKey}
+import com.daml.lf.value.Value.ContractId
+import com.daml.logging.LoggingContext.withEnrichedLoggingContext
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.metrics.{Metrics, Timed}
+import com.daml.platform.configuration.ServerRole
+import com.daml.platform.indexer.OffsetStep
+import com.daml.platform.store.Conversions._
+import com.daml.platform.store.SimpleSqlAsVectorOf.SimpleSqlAsVectorOf
+import com.daml.platform.store._
+import com.daml.platform.store.appendonlydao.CommandCompletionsTable.prepareCompletionsDelete
+import com.daml.platform.store.appendonlydao.events._
+import com.daml.platform.store.appendonlydao.events.EventsTableDelete
+import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
+import com.daml.platform.store.dao.{
+  LedgerDao,
+  LedgerReadDao,
+  MeteredLedgerDao,
+  MeteredLedgerReadDao,
+  PersistenceResponse,
+}
+import com.daml.platform.store.entries.{
+  ConfigurationEntry,
+  LedgerEntry,
+  PackageLedgerEntry,
+  PartyLedgerEntry,
+}
+import scalaz.syntax.tag._
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+private final case class ParsedPartyData(
+    party: String,
+    displayName: Option[String],
+    ledgerOffset: Offset,
+    explicit: Boolean,
+    isLocal: Boolean,
+)
+
+private final case class ParsedPackageData(
+    packageId: String,
+    sourceDescription: Option[String],
+    size: Long,
+    knownSince: Date,
+)
+
+private final case class ParsedCommandData(deduplicateUntil: Instant)
+
+private class JdbcLedgerDao(
+    dbDispatcher: DbDispatcher,
+    dbType: DbType,
+    servicesExecutionContext: ExecutionContext,
+    eventsPageSize: Int,
+    performPostCommitValidation: Boolean,
+    metrics: Metrics,
+    lfValueTranslationCache: LfValueTranslation.Cache,
+    validatePartyAllocation: Boolean,
+    enricher: Option[ValueEnricher],
+) extends LedgerDao {
+
+  import JdbcLedgerDao._
+
+  private val queries = dbType match {
+    case DbType.Postgres => PostgresQueries
+    case DbType.H2Database => H2DatabaseQueries
+  }
+
+  private val logger = ContextualizedLogger.get(this.getClass)
+
+  override def currentHealth(): HealthStatus = dbDispatcher.currentHealth()
+
+  override def lookupLedgerId()(implicit loggingContext: LoggingContext): Future[Option[LedgerId]] =
+    dbDispatcher.executeSql(metrics.daml.index.db.getLedgerId)(ParametersTable.getLedgerId)
+
+  override def lookupParticipantId()(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[ParticipantId]] =
+    dbDispatcher.executeSql(metrics.daml.index.db.getParticipantId)(
+      ParametersTable.getParticipantId
+    )
+
+  /** Defaults to Offset.begin if ledger_end is unset
+    */
+  override def lookupLedgerEnd()(implicit loggingContext: LoggingContext): Future[Offset] =
+    dbDispatcher.executeSql(metrics.daml.index.db.getLedgerEnd)(ParametersTable.getLedgerEnd)
+
+  override def lookupInitialLedgerEnd()(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Offset]] =
+    dbDispatcher.executeSql(metrics.daml.index.db.getInitialLedgerEnd)(
+      ParametersTable.getInitialLedgerEnd
+    )
+
+  override def initializeLedger(
+      ledgerId: LedgerId
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
+    dbDispatcher.executeSql(metrics.daml.index.db.initializeLedgerParameters) {
+      implicit connection =>
+        queries.enforceSynchronousCommit
+        ParametersTable.setLedgerId(ledgerId.unwrap)(connection)
+    }
+
+  override def initializeParticipantId(
+      participantId: ParticipantId
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
+    dbDispatcher.executeSql(metrics.daml.index.db.initializeParticipantId) { implicit connection =>
+      queries.enforceSynchronousCommit
+      ParametersTable.setParticipantId(participantId.unwrap)(connection)
+    }
+
+  private val SQL_GET_CONFIGURATION_ENTRIES = SQL(
+    "select * from configuration_entries where ledger_offset > {startExclusive} and ledger_offset <= {endInclusive} order by ledger_offset asc limit {pageSize} offset {queryOffset}"
+  )
+
+  override def lookupLedgerConfiguration()(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[(Offset, Configuration)]] =
+    dbDispatcher.executeSql(metrics.daml.index.db.lookupConfiguration)(
+      ParametersTable.getLedgerEndAndConfiguration
+    )
+
+  private val configurationEntryParser: RowParser[(Offset, ConfigurationEntry)] =
+    (offset("ledger_offset") ~
+      str("typ") ~
+      str("submission_id") ~
+      str("rejection_reason").map(s => if (s.isEmpty) null else s).? ~
+      byteArray("configuration"))
+      .map(flatten)
+      .map { case (offset, typ, submissionId, rejectionReason, configBytes) =>
+        val config = Configuration
+          .decode(configBytes)
+          .fold(err => sys.error(s"Failed to decode configuration: $err"), identity)
+        offset ->
+          (typ match {
+            case `acceptType` =>
+              ConfigurationEntry.Accepted(
+                submissionId = submissionId,
+                configuration = config,
+              )
+            case `rejectType` =>
+              ConfigurationEntry.Rejected(
+                submissionId = submissionId,
+                rejectionReason = rejectionReason.getOrElse("<missing reason>"),
+                proposedConfiguration = config,
+              )
+
+            case _ =>
+              sys.error(s"getConfigurationEntries: Unknown configuration entry type: $typ")
+          })
+      }
+
+  override def getConfigurationEntries(
+      startExclusive: Offset,
+      endInclusive: Offset,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed] =
+    PaginatingAsyncStream(PageSize) { queryOffset =>
+      withEnrichedLoggingContext("queryOffset" -> queryOffset.toString) { implicit loggingContext =>
+        dbDispatcher.executeSql(metrics.daml.index.db.loadConfigurationEntries) {
+          implicit connection =>
+            SQL_GET_CONFIGURATION_ENTRIES
+              .on(
+                "startExclusive" -> startExclusive,
+                "endInclusive" -> endInclusive,
+                "pageSize" -> PageSize,
+                "queryOffset" -> queryOffset,
+              )
+              .asVectorOf(configurationEntryParser)
+        }
+      }
+    }
+
+  override def storeConfigurationEntry(
+      offsetStep: OffsetStep,
+      recordedAt: Instant,
+      submissionId: String,
+      configuration: Configuration,
+      rejectionReason: Option[String],
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
+    throw new UnsupportedOperationException("not supported") // TODO add support
+
+  override def storePartyEntry(
+      offsetStep: OffsetStep,
+      partyEntry: PartyLedgerEntry,
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
+    throw new UnsupportedOperationException("not supported") // TODO add support
+
+  private val SQL_GET_PARTY_ENTRIES = SQL(
+    "select * from party_entries where ledger_offset>{startExclusive} and ledger_offset<={endInclusive} order by ledger_offset asc limit {pageSize} offset {queryOffset}"
+  )
+
+  private val partyEntryParser: RowParser[(Offset, PartyLedgerEntry)] =
+    (offset("ledger_offset") ~
+      date("recorded_at") ~
+      ledgerString("submission_id").? ~
+      party("party").? ~
+      str("display_name").? ~
+      str("typ") ~
+      str("rejection_reason").? ~
+      bool("is_local").?)
+      .map(flatten)
+      .map {
+        case (
+              offset,
+              recordTime,
+              submissionIdOpt,
+              Some(party),
+              displayNameOpt,
+              `acceptType`,
+              None,
+              Some(isLocal),
+            ) =>
+          offset ->
+            PartyLedgerEntry.AllocationAccepted(
+              submissionIdOpt,
+              recordTime.toInstant,
+              PartyDetails(party, displayNameOpt, isLocal),
+            )
+        case (
+              offset,
+              recordTime,
+              Some(submissionId),
+              None,
+              None,
+              `rejectType`,
+              Some(reason),
+              None,
+            ) =>
+          offset -> PartyLedgerEntry.AllocationRejected(
+            submissionId,
+            recordTime.toInstant,
+            reason,
+          )
+        case invalidRow =>
+          sys.error(s"getPartyEntries: invalid party entry row: $invalidRow")
+      }
+
+  override def getPartyEntries(
+      startExclusive: Offset,
+      endInclusive: Offset,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, PartyLedgerEntry), NotUsed] = {
+    PaginatingAsyncStream(PageSize) { queryOffset =>
+      withEnrichedLoggingContext("queryOffset" -> queryOffset.toString) { implicit loggingContext =>
+        dbDispatcher.executeSql(metrics.daml.index.db.loadPartyEntries) { implicit connection =>
+          SQL_GET_PARTY_ENTRIES
+            .on(
+              "startExclusive" -> startExclusive,
+              "endInclusive" -> endInclusive,
+              "pageSize" -> PageSize,
+              "queryOffset" -> queryOffset,
+            )
+            .asVectorOf(partyEntryParser)
+        }
+      }
+    }
+  }
+
+  override def lookupKey(key: GlobalKey, forParties: Set[Party])(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[ContractId]] =
+    contractsReader.lookupContractKey(forParties, key)
+
+  override def prepareTransactionInsert(
+      submitterInfo: Option[SubmitterInfo],
+      workflowId: Option[WorkflowId],
+      transactionId: TransactionId,
+      ledgerEffectiveTime: Instant,
+      offset: Offset,
+      transaction: CommittedTransaction,
+      divulgedContracts: Iterable[DivulgedContract],
+      blindingInfo: Option[BlindingInfo],
+  ): PreparedInsert =
+    throw new UnsupportedOperationException(
+      "not supported by append-only code"
+    ) // TODO append-only: cleanup
+
+  // TODO append-only: cleanup
+  override def storeTransactionState(
+      preparedInsert: PreparedInsert
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
+    throw new UnsupportedOperationException(
+      "not supported by append-only code"
+    ) // TODO append-only: cleanup
+
+  override def storeTransactionEvents(
+      preparedInsert: PreparedInsert
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
+    throw new UnsupportedOperationException(
+      "not supported by append-only code"
+    ) // TODO append-only: cleanup
+
+  override def completeTransaction(
+      submitterInfo: Option[SubmitterInfo],
+      transactionId: TransactionId,
+      recordTime: Instant,
+      offsetStep: OffsetStep,
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
+    throw new UnsupportedOperationException(
+      "not supported by append-only code"
+    ) // TODO append-only: cleanup
+
+  override def storeTransaction(
+      preparedInsert: PreparedInsert,
+      submitterInfo: Option[SubmitterInfo],
+      transactionId: TransactionId,
+      recordTime: Instant,
+      ledgerEffectiveTime: Instant,
+      offsetStep: OffsetStep,
+      transaction: CommittedTransaction,
+      divulged: Iterable[DivulgedContract],
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
+    throw new UnsupportedOperationException(
+      "not supported by append-only code"
+    ) // TODO append-only: cleanup
+
+  // TODO this private method is needed for wiring post-commit-validation for sandbox-classic integration later.
+  //  Until then it is a protected field, to pass the build. TODO switch back to private.
+  protected def validate(
+      ledgerEffectiveTime: Instant,
+      transaction: CommittedTransaction,
+      divulged: Iterable[DivulgedContract],
+  )(implicit connection: Connection): Option[RejectionReason] =
+    Timed.value(
+      metrics.daml.index.db.storeTransactionDbMetrics.commitValidation,
+      postCommitValidation.validate(
+        transaction = transaction,
+        transactionLedgerEffectiveTime = ledgerEffectiveTime,
+        divulged = divulged.iterator.map(_.contractId).toSet,
+      ),
+    )
+
+  override def storeRejection(
+      submitterInfo: Option[SubmitterInfo],
+      recordTime: Instant,
+      offsetStep: OffsetStep,
+      reason: RejectionReason,
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
+    throw new UnsupportedOperationException("not supported") // TODO add support
+
+  override def storeInitialState(
+      ledgerEntries: Vector[(Offset, LedgerEntry)],
+      newLedgerEnd: Offset,
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
+    throw new UnsupportedOperationException(
+      "not supported by append-only code"
+    ) // TODO append-only: cleanup
+
+  private val PageSize = 100
+
+  override def lookupMaximumLedgerTime(
+      contractIds: Set[ContractId]
+  )(implicit loggingContext: LoggingContext): Future[Option[Instant]] =
+    contractsReader.lookupMaximumLedgerTime(contractIds)
+
+  override def lookupActiveOrDivulgedContract(
+      contractId: ContractId,
+      forParties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[ContractInst]] =
+    contractsReader.lookupActiveContract(forParties, contractId)
+
+  private val SQL_SELECT_ALL_PARTIES =
+    SQL(
+      "select parties.party, parties.display_name, parties.ledger_offset, parties.explicit, parties.is_local from parties, parameters where parameters.ledger_end >= parties.ledger_offset"
+    )
+
+  override def getParties(
+      parties: Seq[Party]
+  )(implicit loggingContext: LoggingContext): Future[List[PartyDetails]] =
+    if (parties.isEmpty)
+      Future.successful(List.empty)
+    else
+      dbDispatcher
+        .executeSql(metrics.daml.index.db.loadParties) { implicit conn =>
+          selectParties(parties)
+        }
+        .map(_.map(constructPartyDetails))(servicesExecutionContext)
+
+  override def listKnownParties()(implicit
+      loggingContext: LoggingContext
+  ): Future[List[PartyDetails]] =
+    dbDispatcher
+      .executeSql(metrics.daml.index.db.loadAllParties) { implicit conn =>
+        SQL_SELECT_ALL_PARTIES
+          .as(PartyDataParser.*)
+      }
+      .map(_.map(constructPartyDetails))(servicesExecutionContext)
+
+  private val SQL_SELECT_PACKAGES =
+    SQL(
+      """select packages.package_id, packages.source_description, packages.known_since, packages.size
+        |from packages, parameters
+        |where packages.ledger_offset <= parameters.ledger_end
+        |""".stripMargin
+    )
+
+  private val SQL_SELECT_PACKAGE =
+    SQL("""select packages.package
+        |from packages, parameters
+        |where package_id = {package_id}
+        |and packages.ledger_offset <= parameters.ledger_end
+        |""".stripMargin)
+
+  private val PackageDataParser: RowParser[ParsedPackageData] =
+    Macro.parser[ParsedPackageData](
+      "package_id",
+      "source_description",
+      "size",
+      "known_since",
+    )
+
+  override def listLfPackages()(implicit
+      loggingContext: LoggingContext
+  ): Future[Map[PackageId, PackageDetails]] =
+    dbDispatcher
+      .executeSql(metrics.daml.index.db.loadPackages) { implicit conn =>
+        SQL_SELECT_PACKAGES
+          .as(PackageDataParser.*)
+      }
+      .map(
+        _.map(d =>
+          PackageId.assertFromString(d.packageId) -> PackageDetails(
+            d.size,
+            d.knownSince.toInstant,
+            d.sourceDescription,
+          )
+        ).toMap
+      )(servicesExecutionContext)
+
+  override def getLfArchive(
+      packageId: PackageId
+  )(implicit loggingContext: LoggingContext): Future[Option[Archive]] =
+    dbDispatcher
+      .executeSql(metrics.daml.index.db.loadArchive) { implicit conn =>
+        SQL_SELECT_PACKAGE
+          .on(
+            "package_id" -> packageId
+          )
+          .as[Option[Array[Byte]]](SqlParser.byteArray("package").singleOpt)
+      }
+      .map(_.map(data => Archive.parseFrom(Decode.damlLfCodedInputStreamFromBytes(data))))(
+        servicesExecutionContext
+      )
+
+  override def storePackageEntry(
+      offsetStep: OffsetStep,
+      packages: List[(Archive, PackageDetails)],
+      optEntry: Option[PackageLedgerEntry],
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
+    throw new UnsupportedOperationException("not supported") // TODO add support
+
+  private val SQL_GET_PACKAGE_ENTRIES = SQL(
+    "select * from package_entries where ledger_offset>{startExclusive} and ledger_offset<={endInclusive} order by ledger_offset asc limit {pageSize} offset {queryOffset}"
+  )
+
+  private val packageEntryParser: RowParser[(Offset, PackageLedgerEntry)] =
+    (offset("ledger_offset") ~
+      date("recorded_at") ~
+      ledgerString("submission_id").? ~
+      str("typ") ~
+      str("rejection_reason").?)
+      .map(flatten)
+      .map {
+        case (offset, recordTime, Some(submissionId), `acceptType`, None) =>
+          offset ->
+            PackageLedgerEntry.PackageUploadAccepted(submissionId, recordTime.toInstant)
+        case (offset, recordTime, Some(submissionId), `rejectType`, Some(reason)) =>
+          offset ->
+            PackageLedgerEntry.PackageUploadRejected(submissionId, recordTime.toInstant, reason)
+        case invalidRow =>
+          sys.error(s"packageEntryParser: invalid party entry row: $invalidRow")
+      }
+
+  override def getPackageEntries(
+      startExclusive: Offset,
+      endInclusive: Offset,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, PackageLedgerEntry), NotUsed] =
+    PaginatingAsyncStream(PageSize) { queryOffset =>
+      withEnrichedLoggingContext("queryOffset" -> queryOffset.toString) { implicit loggingContext =>
+        dbDispatcher.executeSql(metrics.daml.index.db.loadPackageEntries) { implicit connection =>
+          SQL_GET_PACKAGE_ENTRIES
+            .on(
+              "startExclusive" -> startExclusive,
+              "endInclusive" -> endInclusive,
+              "pageSize" -> PageSize,
+              "queryOffset" -> queryOffset,
+            )
+            .asVectorOf(packageEntryParser)
+        }
+      }
+    }
+
+  private val SQL_SELECT_COMMAND = SQL("""
+      |select deduplicate_until
+      |from participant_command_submissions
+      |where deduplication_key = {deduplicationKey}
+    """.stripMargin)
+
+  private val CommandDataParser: RowParser[ParsedCommandData] =
+    Macro.parser[ParsedCommandData](
+      "deduplicate_until"
+    )
+
+  override def deduplicateCommand(
+      commandId: domain.CommandId,
+      submitters: List[Ref.Party],
+      submittedAt: Instant,
+      deduplicateUntil: Instant,
+  )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult] =
+    dbDispatcher.executeSql(metrics.daml.index.db.deduplicateCommandDbMetrics) { implicit conn =>
+      val key = deduplicationKey(commandId, submitters)
+      // Insert a new deduplication entry, or update an expired entry
+      val updated = SQL(queries.SQL_INSERT_COMMAND)
+        .on(
+          "deduplicationKey" -> key,
+          "submittedAt" -> submittedAt,
+          "deduplicateUntil" -> deduplicateUntil,
+        )
+        .executeUpdate()
+
+      if (updated == 1) {
+        // New row inserted, this is the first time the command is submitted
+        CommandDeduplicationNew
+      } else {
+        // Deduplication row already exists
+        val result = SQL_SELECT_COMMAND
+          .on("deduplicationKey" -> key)
+          .as(CommandDataParser.single)
+
+        CommandDeduplicationDuplicate(result.deduplicateUntil)
+      }
+    }
+
+  private val SQL_DELETE_EXPIRED_COMMANDS = SQL("""
+      |delete from participant_command_submissions
+      |where deduplicate_until < {currentTime}
+    """.stripMargin)
+
+  override def removeExpiredDeduplicationData(
+      currentTime: Instant
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
+    dbDispatcher.executeSql(metrics.daml.index.db.removeExpiredDeduplicationDataDbMetrics) {
+      implicit conn =>
+        SQL_DELETE_EXPIRED_COMMANDS
+          .on("currentTime" -> currentTime)
+          .execute()
+        ()
+    }
+
+  private val SQL_DELETE_COMMAND = SQL("""
+      |delete from participant_command_submissions
+      |where deduplication_key = {deduplicationKey}
+    """.stripMargin)
+
+  private[this] def stopDeduplicatingCommandSync(
+      commandId: domain.CommandId,
+      submitters: List[Party],
+  )(implicit conn: Connection): Unit = {
+    val key = deduplicationKey(commandId, submitters)
+    SQL_DELETE_COMMAND
+      .on("deduplicationKey" -> key)
+      .execute()
+    ()
+  }
+
+  override def stopDeduplicatingCommand(
+      commandId: domain.CommandId,
+      submitters: List[Party],
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
+    dbDispatcher.executeSql(metrics.daml.index.db.stopDeduplicatingCommandDbMetrics) {
+      implicit conn =>
+        stopDeduplicatingCommandSync(commandId, submitters)
+    }
+
+  private val SQL_UPDATE_MOST_RECENT_PRUNING = SQL("""
+      |update parameters set participant_pruned_up_to_inclusive={pruned_up_to_inclusive}
+      |where participant_pruned_up_to_inclusive < {pruned_up_to_inclusive} or participant_pruned_up_to_inclusive is null
+      |""".stripMargin)
+
+  private def updateMostRecentPruning(
+      prunedUpToInclusive: Offset
+  )(implicit conn: Connection): Unit = {
+    SQL_UPDATE_MOST_RECENT_PRUNING
+      .on("pruned_up_to_inclusive" -> prunedUpToInclusive)
+      .execute()
+    ()
+  }
+
+  override def prune(
+      pruneUpToInclusive: Offset
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
+    dbDispatcher.executeSql(metrics.daml.index.db.pruneDbMetrics) { implicit conn =>
+      EventsTableDelete.prepareEventsDelete(pruneUpToInclusive).execute()
+      prepareCompletionsDelete(pruneUpToInclusive).execute()
+      updateMostRecentPruning(pruneUpToInclusive)
+      logger.info(s"Pruned ledger api server index db up to ${pruneUpToInclusive.toHexString}")
+    }
+
+  override def reset()(implicit loggingContext: LoggingContext): Future[Unit] =
+    dbDispatcher.executeSql(metrics.daml.index.db.truncateAllTables) { implicit conn =>
+      val _ = SQL(queries.SQL_TRUNCATE_TABLES).execute()
+    }
+
+  private val translation: LfValueTranslation =
+    new LfValueTranslation(
+      cache = lfValueTranslationCache,
+      metrics = metrics,
+      enricherO = enricher,
+      loadPackage = (packageId, loggingContext) => this.getLfArchive(packageId)(loggingContext),
+    )
+
+  override val transactionsReader: TransactionsReader =
+    new TransactionsReader(dbDispatcher, dbType, eventsPageSize, metrics, translation)(
+      servicesExecutionContext
+    )
+
+  private val contractsReader: ContractsReader =
+    ContractsReader(dbDispatcher, dbType, metrics, lfValueTranslationCache)(
+      servicesExecutionContext
+    )
+
+  override val completions: CommandCompletionsReader =
+    new CommandCompletionsReader(dbDispatcher, dbType, metrics, servicesExecutionContext)
+
+  private val postCommitValidation =
+    if (performPostCommitValidation)
+      new PostCommitValidation.BackedBy(contractsReader.committedContracts, validatePartyAllocation)
+    else
+      PostCommitValidation.Skip
+}
+
+private[platform] object JdbcLedgerDao {
+
+  object Logging {
+
+    def submissionId(id: String): (String, String) = "submissionId" -> id
+
+    def transactionId(id: TransactionId): (String, String) =
+      "transactionId" -> id
+
+  }
+
+  def readOwner(
+      serverRole: ServerRole,
+      jdbcUrl: String,
+      connectionPoolSize: Int,
+      eventsPageSize: Int,
+      servicesExecutionContext: ExecutionContext,
+      metrics: Metrics,
+      lfValueTranslationCache: LfValueTranslation.Cache,
+      enricher: Option[ValueEnricher],
+  )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerReadDao] = {
+    owner(
+      serverRole,
+      jdbcUrl,
+      connectionPoolSize,
+      eventsPageSize,
+      validate = false,
+      servicesExecutionContext,
+      metrics,
+      lfValueTranslationCache,
+      enricher = enricher,
+    ).map(new MeteredLedgerReadDao(_, metrics))
+  }
+
+  def writeOwner(
+      serverRole: ServerRole,
+      jdbcUrl: String,
+      connectionPoolSize: Int,
+      eventsPageSize: Int,
+      servicesExecutionContext: ExecutionContext,
+      metrics: Metrics,
+      lfValueTranslationCache: LfValueTranslation.Cache,
+      jdbcAsyncCommitMode: DbType.AsyncCommitMode,
+      enricher: Option[ValueEnricher],
+  )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerDao] = {
+    val dbType = DbType.jdbcType(jdbcUrl)
+    owner(
+      serverRole,
+      jdbcUrl,
+      dbType.maxSupportedWriteConnections(connectionPoolSize),
+      eventsPageSize,
+      validate = false,
+      servicesExecutionContext,
+      metrics,
+      lfValueTranslationCache,
+      jdbcAsyncCommitMode =
+        if (dbType.supportsAsynchronousCommits) jdbcAsyncCommitMode else DbType.SynchronousCommit,
+      enricher = enricher,
+    ).map(new MeteredLedgerDao(_, metrics))
+  }
+
+  def validatingWriteOwner(
+      serverRole: ServerRole,
+      jdbcUrl: String,
+      connectionPoolSize: Int,
+      eventsPageSize: Int,
+      servicesExecutionContext: ExecutionContext,
+      metrics: Metrics,
+      lfValueTranslationCache: LfValueTranslation.Cache,
+      validatePartyAllocation: Boolean = false,
+      enricher: Option[ValueEnricher],
+  )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerDao] = {
+    val dbType = DbType.jdbcType(jdbcUrl)
+    owner(
+      serverRole,
+      jdbcUrl,
+      dbType.maxSupportedWriteConnections(connectionPoolSize),
+      eventsPageSize,
+      validate = true,
+      servicesExecutionContext,
+      metrics,
+      lfValueTranslationCache,
+      validatePartyAllocation,
+      enricher = enricher,
+    ).map(new MeteredLedgerDao(_, metrics))
+  }
+
+  private[appendonlydao] def selectParties(
+      parties: Seq[Party]
+  )(implicit connection: Connection): List[ParsedPartyData] =
+    SQL_SELECT_MULTIPLE_PARTIES
+      .on("parties" -> parties)
+      .as(PartyDataParser.*)
+
+  private[appendonlydao] def constructPartyDetails(data: ParsedPartyData): PartyDetails =
+    PartyDetails(Party.assertFromString(data.party), data.displayName, data.isLocal)
+
+  private val SQL_SELECT_MULTIPLE_PARTIES =
+    SQL(
+      "select parties.party, parties.display_name, parties.ledger_offset, parties.explicit, parties.is_local from parties, parameters where party in ({parties}) and parties.ledger_offset <= parameters.ledger_end"
+    )
+
+  private val PartyDataParser: RowParser[ParsedPartyData] =
+    Macro.parser[ParsedPartyData](
+      "party",
+      "display_name",
+      "ledger_offset",
+      "explicit",
+      "is_local",
+    )
+
+  private def owner(
+      serverRole: ServerRole,
+      jdbcUrl: String,
+      connectionPoolSize: Int,
+      eventsPageSize: Int,
+      validate: Boolean,
+      servicesExecutionContext: ExecutionContext,
+      metrics: Metrics,
+      lfValueTranslationCache: LfValueTranslation.Cache,
+      validatePartyAllocation: Boolean = false,
+      jdbcAsyncCommitMode: DbType.AsyncCommitMode = DbType.SynchronousCommit,
+      enricher: Option[ValueEnricher],
+  )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerDao] =
+    for {
+      dbDispatcher <- DbDispatcher.owner(
+        serverRole,
+        jdbcUrl,
+        connectionPoolSize,
+        250.millis,
+        metrics,
+        jdbcAsyncCommitMode,
+      )
+    } yield new JdbcLedgerDao(
+      dbDispatcher,
+      DbType.jdbcType(jdbcUrl),
+      servicesExecutionContext,
+      eventsPageSize,
+      validate,
+      metrics,
+      lfValueTranslationCache,
+      validatePartyAllocation,
+      enricher,
+    )
+
+  sealed trait Queries {
+
+    protected[JdbcLedgerDao] def enforceSynchronousCommit(implicit conn: Connection): Unit
+
+    protected[JdbcLedgerDao] def SQL_INSERT_COMMAND: String
+
+    protected[JdbcLedgerDao] def SQL_TRUNCATE_TABLES: String
+
+    // TODO: Avoid brittleness of error message checks
+    protected[JdbcLedgerDao] def DUPLICATE_KEY_ERROR: String
+  }
+
+  object PostgresQueries extends Queries {
+    override protected[JdbcLedgerDao] val SQL_INSERT_COMMAND: String =
+      """insert into participant_command_submissions as pcs (deduplication_key, deduplicate_until)
+        |values ({deduplicationKey}, {deduplicateUntil})
+        |on conflict (deduplication_key)
+        |  do update
+        |  set deduplicate_until={deduplicateUntil}
+        |  where pcs.deduplicate_until < {submittedAt}""".stripMargin
+
+    override protected[JdbcLedgerDao] val DUPLICATE_KEY_ERROR: String =
+      "duplicate key"
+
+    override protected[JdbcLedgerDao] val SQL_TRUNCATE_TABLES: String =
+      """truncate table configuration_entries cascade;
+        |truncate table package_entries cascade;
+        |truncate table parameters cascade;
+        |truncate table participant_command_completions cascade;
+        |truncate table participant_command_submissions cascade;
+        |truncate table participant_events cascade;
+        |truncate table parties cascade;
+        |truncate table party_entries cascade;
+      """.stripMargin
+
+    override protected[JdbcLedgerDao] def enforceSynchronousCommit(implicit
+        conn: Connection
+    ): Unit = {
+      val statement =
+        conn.prepareStatement("SET LOCAL synchronous_commit = 'on'")
+      try {
+        statement.execute()
+        ()
+      } finally {
+        statement.close()
+      }
+    }
+  }
+
+  // TODO H2 support
+  object H2DatabaseQueries extends Queries {
+    override protected[JdbcLedgerDao] val SQL_INSERT_COMMAND: String =
+      """merge into participant_command_submissions pcs
+        |using dual on deduplication_key = {deduplicationKey}
+        |when not matched then
+        |  insert (deduplication_key, deduplicate_until)
+        |  values ({deduplicationKey}, {deduplicateUntil})
+        |when matched and pcs.deduplicate_until < {submittedAt} then
+        |  update set deduplicate_until={deduplicateUntil}""".stripMargin
+
+    override protected[JdbcLedgerDao] val DUPLICATE_KEY_ERROR: String =
+      "Unique index or primary key violation"
+
+    override protected[JdbcLedgerDao] val SQL_TRUNCATE_TABLES: String =
+      """set referential_integrity false;
+        |truncate table configuration_entries;
+        |truncate table package_entries;
+        |truncate table parameters;
+        |truncate table participant_command_completions;
+        |truncate table participant_command_submissions;
+        |truncate table participant_events;
+        |truncate table participant_contracts;
+        |truncate table participant_contract_witnesses;
+        |truncate table parties;
+        |truncate table party_entries;
+        |set referential_integrity true;
+      """.stripMargin
+
+    /** H2 does not support asynchronous commits */
+    override protected[JdbcLedgerDao] def enforceSynchronousCommit(implicit
+        conn: Connection
+    ): Unit = ()
+  }
+
+  def deduplicationKey(
+      commandId: domain.CommandId,
+      submitters: List[Ref.Party],
+  ): String = {
+    val submitterPart =
+      if (submitters.length == 1)
+        submitters.head
+      else
+        submitters.sorted(Ordering.String).distinct.mkString("%")
+    commandId.unwrap + "%" + submitterPart
+  }
+
+  val acceptType = "accept"
+  val rejectType = "reject"
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/PaginatingAsyncStream.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/PaginatingAsyncStream.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import com.daml.dec.DirectExecutionContext
+
+import scala.concurrent.Future
+
+private[platform] object PaginatingAsyncStream {
+
+  /** Concatenates the results of multiple asynchronous calls into
+    * a single [[Source]], injecting the offset of the next page to
+    * retrieve for every call.
+    *
+    * This is designed to work with database limit/offset pagination and
+    * in particular to break down large queries intended to serve streams
+    * into smaller ones. The reason for this is that we are currently using
+    * simple blocking JDBC APIs and a long-running stream would end up
+    * occupying a thread in the DB pool, severely limiting the ability
+    * of keeping multiple, concurrent, long-running streams while serving
+    * lookup calls.
+    *
+    * This is not designed to page through results using the "seek method":
+    * https://use-the-index-luke.com/sql/partial-results/fetch-next-page
+    *
+    * @param pageSize number of items to retrieve per call
+    * @param queryPage takes the offset from which to start the next page and returns that page
+    * @tparam T the type of the items returned in each call
+    */
+  def apply[T](pageSize: Int)(queryPage: Long => Future[Vector[T]]): Source[T, NotUsed] = {
+    Source
+      .unfoldAsync(Option(0L)) {
+        case None => Future.successful(None)
+        case Some(queryOffset) =>
+          queryPage(queryOffset).map { result =>
+            val resultSize = result.size.toLong
+            val newQueryOffset = if (resultSize < pageSize) None else Some(queryOffset + pageSize)
+            Some(newQueryOffset -> result)
+          }(DirectExecutionContext)
+      }
+      .flatMapConcat(Source(_))
+  }
+
+  /** Concatenates the results of multiple asynchronous calls into
+    * a single [[Source]], passing the last seen event's offset to the
+    * next iteration query, so it can continue reading events from this point.
+    *
+    * This is to implement pagination based on generic offset.
+    * The main purpose of the pagination is to break down large queries
+    * into smaller batches. The reason for this is that we are currently using
+    * simple blocking JDBC APIs and a long-running stream would end up
+    * occupying a thread in the DB pool, severely limiting the ability
+    * of keeping multiple, concurrent, long-running streams while serving
+    * lookup calls.
+    *
+    * @param startFromOffset initial offset
+    * @param getOffset function that returns a position/offset from the element of type [[T]]
+    * @param query a function that fetches results starting from provided offset
+    * @tparam Off the type of the offset
+    * @tparam T the type of the items returned in each call
+    */
+  def streamFrom[Off, T](startFromOffset: Off, getOffset: T => Off)(
+      query: Off => Future[Vector[T]]
+  ): Source[T, NotUsed] = {
+    Source
+      .unfoldAsync(Option(startFromOffset)) {
+        case None =>
+          Future.successful(None) // finished reading the whole thing
+        case Some(offset) =>
+          query(offset).map { result =>
+            val nextPageOffset: Option[Off] = result.lastOption.map(getOffset)
+            Some((nextPageOffset, result))
+          }(
+            DirectExecutionContext
+          ) // run in the same thread as the query, avoid context switch for a cheap operation
+      }
+      .flatMapConcat(Source(_))
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/ParametersTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/ParametersTable.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.sql.Connection
+
+import anorm.SqlParser.byteArray
+import anorm.{Row, RowParser, SimpleSql, SqlStringInterpolation, ~}
+import com.daml.ledger.api.domain.{LedgerId, ParticipantId}
+import com.daml.ledger.participant.state.v1.{Configuration, Offset}
+import com.daml.platform.store.Conversions.{ledgerString, offset, participantId}
+import com.daml.scalautil.Statement.discard
+
+private[appendonlydao] object ParametersTable {
+
+  private val TableName: String = "parameters"
+  private val LedgerIdColumnName: String = "ledger_id"
+  private val ParticipantIdColumnName: String = "participant_id"
+  private val LedgerEndColumnName: String = "ledger_end"
+  private val ConfigurationColumnName: String = "configuration"
+
+  private val LedgerIdParser: RowParser[LedgerId] =
+    ledgerString(LedgerIdColumnName).map(LedgerId(_))
+
+  private val ParticipantIdParser: RowParser[Option[ParticipantId]] =
+    participantId(ParticipantIdColumnName).map(ParticipantId(_)).?
+
+  private val LedgerEndParser: RowParser[Option[Offset]] =
+    offset(LedgerEndColumnName).?
+
+  private val LedgerEndOrBeforeBeginParser: RowParser[Offset] =
+    LedgerEndParser.map(_.getOrElse(Offset.beforeBegin))
+
+  private val ConfigurationParser: RowParser[Option[Configuration]] =
+    byteArray(ConfigurationColumnName).? map (_.flatMap(Configuration.decode(_).toOption))
+
+  private val LedgerEndAndConfigurationParser: RowParser[Option[(Offset, Configuration)]] =
+    LedgerEndParser ~ ConfigurationParser map { case ledgerEnd ~ configuration =>
+      for {
+        e <- ledgerEnd
+        c <- configuration
+      } yield (e, c)
+    }
+
+  private val SelectLedgerEnd: SimpleSql[Row] = SQL"select #$LedgerEndColumnName from #$TableName"
+
+  def getLedgerId(connection: Connection): Option[LedgerId] =
+    SQL"select #$LedgerIdColumnName from #$TableName".as(LedgerIdParser.singleOpt)(connection)
+
+  def setLedgerId(ledgerId: String)(connection: Connection): Unit =
+    discard(
+      SQL"insert into #$TableName(#$LedgerIdColumnName) values($ledgerId)".execute()(connection)
+    )
+
+  def getParticipantId(connection: Connection): Option[ParticipantId] =
+    SQL"select #$ParticipantIdColumnName from #$TableName".as(ParticipantIdParser.single)(
+      connection
+    )
+
+  def setParticipantId(participantId: String)(connection: Connection): Unit =
+    discard(
+      SQL"update #$TableName set #$ParticipantIdColumnName = $participantId".execute()(
+        connection
+      )
+    )
+
+  def getLedgerEnd(connection: Connection): Offset =
+    SelectLedgerEnd.as(LedgerEndOrBeforeBeginParser.single)(connection)
+
+  def getInitialLedgerEnd(connection: Connection): Option[Offset] =
+    SelectLedgerEnd.as(LedgerEndParser.single)(connection)
+
+  def getLedgerEndAndConfiguration(connection: Connection): Option[(Offset, Configuration)] =
+    SQL"select #$LedgerEndColumnName, #$ConfigurationColumnName from #$TableName".as(
+      LedgerEndAndConfigurationParser.single
+    )(connection)
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/CompressionMetrics.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/CompressionMetrics.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import com.codahale.metrics.Histogram
+import com.daml.metrics.Metrics
+
+object CompressionMetrics {
+
+  final class Field(val compressed: Histogram, val uncompressed: Histogram)
+
+  def createArgument(metrics: Metrics): CompressionMetrics.Field =
+    new Field(
+      compressed = metrics.daml.index.db.compression.createArgumentCompressed,
+      uncompressed = metrics.daml.index.db.compression.createArgumentUncompressed,
+    )
+
+  def createKeyValue(metrics: Metrics) =
+    new Field(
+      compressed = metrics.daml.index.db.compression.createKeyValueCompressed,
+      uncompressed = metrics.daml.index.db.compression.createKeyValueUncompressed,
+    )
+
+  def exerciseArgument(metrics: Metrics) =
+    new Field(
+      compressed = metrics.daml.index.db.compression.exerciseArgumentCompressed,
+      uncompressed = metrics.daml.index.db.compression.exerciseArgumentUncompressed,
+    )
+
+  def exerciseResult(metrics: Metrics) =
+    new Field(
+      compressed = metrics.daml.index.db.compression.exerciseResultCompressed,
+      uncompressed = metrics.daml.index.db.compression.exerciseResultUncompressed,
+    )
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/CompressionStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/CompressionStrategy.scala
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.io.ByteArrayOutputStream
+
+import com.daml.metrics.Metrics
+import com.daml.platform.store.serialization.Compression
+
+final case class CompressionStrategy(
+    createArgumentCompression: FieldCompressionStrategy,
+    createKeyValueCompression: FieldCompressionStrategy,
+    exerciseArgumentCompression: FieldCompressionStrategy,
+    exerciseResultCompression: FieldCompressionStrategy,
+)
+
+object CompressionStrategy {
+
+  def none(metrics: Metrics): CompressionStrategy =
+    buildUniform(Compression.Algorithm.None, metrics)
+
+  def allGZIP(metrics: Metrics): CompressionStrategy =
+    buildUniform(Compression.Algorithm.GZIP, metrics)
+
+  def buildUniform(algorithm: Compression.Algorithm, metrics: Metrics): CompressionStrategy =
+    build(algorithm, algorithm, algorithm, algorithm, metrics)
+
+  def build(
+      createArgumentAlgorithm: Compression.Algorithm,
+      createKeyValueAlgorithm: Compression.Algorithm,
+      exerciseArgumentAlgorithm: Compression.Algorithm,
+      exerciseResultAlgorithm: Compression.Algorithm,
+      metrics: Metrics,
+  ): CompressionStrategy = CompressionStrategy(
+    createArgumentCompression =
+      FieldCompressionStrategy(createArgumentAlgorithm, CompressionMetrics.createArgument(metrics)),
+    createKeyValueCompression =
+      FieldCompressionStrategy(createKeyValueAlgorithm, CompressionMetrics.createKeyValue(metrics)),
+    exerciseArgumentCompression = FieldCompressionStrategy(
+      exerciseArgumentAlgorithm,
+      CompressionMetrics.exerciseArgument(metrics),
+    ),
+    exerciseResultCompression =
+      FieldCompressionStrategy(exerciseResultAlgorithm, CompressionMetrics.exerciseResult(metrics)),
+  )
+}
+
+case class FieldCompressionStrategy(id: Option[Int], compress: Array[Byte] => Array[Byte])
+
+object FieldCompressionStrategy {
+  def apply(a: Compression.Algorithm, metric: CompressionMetrics.Field): FieldCompressionStrategy =
+    FieldCompressionStrategy(
+      a.id,
+      uncompressed => {
+        val output = new ByteArrayOutputStream(uncompressed.length)
+        val gzip = a.compress(output)
+        try {
+          gzip.write(uncompressed)
+        } finally {
+          gzip.close()
+        }
+        val compressed = output.toByteArray
+        output.close()
+        metric.compressed.update(compressed.length)
+        metric.uncompressed.update(uncompressed.length)
+        compressed
+      },
+    )
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
@@ -1,0 +1,321 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.io.InputStream
+import java.time.Instant
+
+import anorm.SqlParser.{binaryStream, int, str}
+import anorm.{Row, RowParser, SimpleSql, SqlParser, SqlStringInterpolation}
+import com.codahale.metrics.Timer
+import com.daml.ledger.participant.state.index.v2.ContractStore
+import com.daml.logging.LoggingContext
+import com.daml.metrics.{Metrics, Timed}
+import com.daml.platform.store.Conversions._
+import com.daml.platform.store.DbType
+import com.daml.platform.store.appendonlydao.DbDispatcher
+import com.daml.platform.store.appendonlydao.events.SqlFunctions.{
+  H2SqlFunctions,
+  PostgresSqlFunctions,
+}
+import com.daml.platform.store.serialization.{Compression, ValueSerializer}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** @see [[ContractsTable]]
+  */
+private[appendonlydao] sealed class ContractsReader(
+    dispatcher: DbDispatcher,
+    metrics: Metrics,
+    lfValueTranslationCache: LfValueTranslation.Cache,
+    sqlFunctions: SqlFunctions,
+)(implicit ec: ExecutionContext)
+    extends ContractStore {
+
+  val committedContracts: PostCommitValidationData = ContractsTable
+
+  import ContractsReader._
+
+  private val contractRowParser: RowParser[(String, InputStream, Option[Int])] =
+    str("template_id") ~ binaryStream("create_argument") ~ int(
+      "create_argument_compression"
+    ).? map SqlParser.flatten
+
+  private val contractWithoutValueRowParser: RowParser[String] =
+    str("template_id")
+
+  /** Lookup of a contract in the case the contract value is not already known */
+  private def lookupActiveContractAndLoadArgument(
+      readers: Set[Party],
+      contractId: ContractId,
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] = {
+    val tree_event_witnessesWhere =
+      sqlFunctions.arrayIntersectionWhereClause("tree_event_witnesses", readers)
+    dispatcher
+      .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
+        SQL"""
+  WITH archival_event AS (
+         SELECT participant_events.*
+           FROM participant_events, parameters
+          WHERE contract_id = $contractId
+            AND event_kind = 20  -- consuming exercise
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+            AND #$tree_event_witnessesWhere  -- only use visible archivals
+          LIMIT 1
+       ),
+       create_event AS (
+         SELECT contract_id, template_id, create_argument, create_argument_compression
+           FROM participant_events, parameters
+          WHERE contract_id = $contractId
+            AND event_kind = 10  -- create
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+            AND #$tree_event_witnessesWhere
+          LIMIT 1 -- limit here to guide planner wrt expected number of results
+       ),
+       -- no visibility check, as it is used to backfill missing template_id and create_arguments for divulged contracts
+       create_event_unrestricted AS (
+         SELECT contract_id, template_id, create_argument, create_argument_compression
+           FROM participant_events, parameters
+          WHERE contract_id = $contractId
+            AND event_kind = 10  -- create
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+          LIMIT 1 -- limit here to guide planner wrt expected number of results
+       ),
+       divulged_contract AS (
+         SELECT divulgence_events.contract_id,
+                -- Note: the divulgance_event.template_id and .create_argument can be NULL
+                -- for certain integrations. For example, the KV integration exploits that
+                -- every participant node knows about all create events. The integration
+                -- therefore only communicates the change in visibility to the IndexDB, but
+                -- does not include a full divulgence event.
+                COALESCE(divulgence_events.template_id, create_event_unrestricted.template_id),
+                COALESCE(divulgence_events.create_argument, create_event_unrestricted.create_argument),
+                COALESCE(divulgence_events.create_argument_compression, create_event_unrestricted.create_argument_compression)
+           FROM participant_events AS divulgence_events LEFT OUTER JOIN create_event_unrestricted USING (contract_id),
+                parameters
+          WHERE divulgence_events.contract_id = $contractId -- restrict to aid query planner
+            AND divulgence_events.event_kind = 0 -- divulgence
+            AND divulgence_events.event_sequential_id <= parameters.ledger_end_sequential_id
+            AND #$tree_event_witnessesWhere
+          ORDER BY divulgence_events.event_sequential_id
+            -- prudent engineering: make results more stable by preferring earlier divulgence events
+            -- Results might still change due to pruning.
+          LIMIT 1
+       ),
+       create_and_divulged_contracts AS (
+         (SELECT * FROM create_event)   -- prefer create over divulgance events
+         UNION ALL
+         (SELECT * FROM divulged_contract)
+       )
+  SELECT contract_id, template_id, create_argument, create_argument_compression
+    FROM create_and_divulged_contracts
+   WHERE NOT EXISTS (SELECT 1 FROM archival_event)
+   LIMIT 1;""".as(contractRowParser.singleOpt)
+      }
+      .map(_.map { case (templateId, createArgument, createArgumentCompression) =>
+        toContract(
+          contractId = contractId,
+          templateId = templateId,
+          createArgument = createArgument,
+          createArgumentCompression = Compression.Algorithm.assertLookup(createArgumentCompression),
+          decompressionTimer = metrics.daml.index.db.lookupActiveContractDbMetrics.compressionTimer,
+          deserializationTimer =
+            metrics.daml.index.db.lookupActiveContractDbMetrics.translationTimer,
+        )
+      })
+  }
+
+  /** Lookup of a contract in the case the contract value is already known (loaded from a cache) */
+  private def lookupActiveContractWithCachedArgument(
+      readers: Set[Party],
+      contractId: ContractId,
+      createArgument: Value,
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] = {
+    val tree_event_witnessesWhere =
+      sqlFunctions.arrayIntersectionWhereClause("tree_event_witnesses", readers)
+    dispatcher
+      .executeSql(metrics.daml.index.db.lookupActiveContractWithCachedArgumentDbMetrics) {
+        implicit connection =>
+          SQL"""
+  WITH archival_event AS (
+         SELECT participant_events.*
+           FROM participant_events, parameters
+          WHERE contract_id = $contractId
+            AND event_kind = 20  -- consuming exercise
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+            AND #$tree_event_witnessesWhere  -- only use visible archivals
+          LIMIT 1
+       ),
+       create_event AS (
+         SELECT contract_id, template_id
+           FROM participant_events, parameters
+          WHERE contract_id = $contractId
+            AND event_kind = 10  -- create
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+            AND #$tree_event_witnessesWhere
+          LIMIT 1 -- limit here to guide planner wrt expected number of results
+       ),
+       divulged_contract AS (
+         SELECT divulgence_events.contract_id,
+                -- Note: the divulgance_event.template_id can be NULL
+                -- for certain integrations. For example, the KV integration exploits that
+                -- every participant node knows about all create events. The integration
+                -- therefore only communicates the change in visibility to the IndexDB, but
+                -- does not include a full divulgence event.
+                COALESCE(divulgence_events.template_id, create_event_unrestricted.template_id)
+           FROM participant_events AS divulgence_events LEFT OUTER JOIN create_event_unrestricted USING (contract_id),
+                parameters
+          WHERE divulgence_events.contract_id = $contractId -- restrict to aid query planner
+            AND divulgence_events.event_kind = 0 -- divulgence
+            AND divulgence_events.event_sequential_id <= parameters.ledger_end_sequential_id
+            AND #$tree_event_witnessesWhere
+          ORDER BY divulgence_events.event_sequential_id
+            -- prudent engineering: make results more stable by preferring earlier divulgence events
+            -- Results might still change due to pruning.
+          LIMIT 1
+       ),
+       create_and_divulged_contracts AS (
+         (SELECT * FROM create_event)   -- prefer create over divulgence events
+         UNION ALL
+         (SELECT * FROM divulged_contract)
+       )
+  SELECT contract_id, template_id
+    FROM create_and_divulged_contracts
+   WHERE NOT EXISTS (SELECT 1 FROM archival_event)
+   LIMIT 1;
+           """
+            .as(contractWithoutValueRowParser.singleOpt)
+      }
+      .map(
+        _.map(templateId =>
+          toContract(
+            templateId = templateId,
+            createArgument = createArgument,
+          )
+        )
+      )
+  }
+
+  override def lookupActiveContract(
+      readers: Set[Party],
+      contractId: ContractId,
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
+    // Depending on whether the contract argument is cached or not, submit a different query to the database
+    lfValueTranslationCache.contracts
+      .getIfPresent(LfValueTranslation.ContractCache.Key(contractId)) match {
+      case Some(createArgument) =>
+        lookupActiveContractWithCachedArgument(readers, contractId, createArgument.argument)
+      case None =>
+        lookupActiveContractAndLoadArgument(readers, contractId)
+
+    }
+
+  override def lookupContractKey(
+      readers: Set[Party],
+      key: Key,
+  )(implicit loggingContext: LoggingContext): Future[Option[ContractId]] =
+    dispatcher.executeSql(metrics.daml.index.db.lookupContractByKey) { implicit connection =>
+      lookupContractKeyQuery(readers, key).as(contractId("contract_id").singleOpt)
+    }
+
+  private def lookupContractKeyQuery(readers: Set[Party], key: Key): SimpleSql[Row] = {
+    def flat_event_witnessesWhere(columnPrefix: String) =
+      sqlFunctions.arrayIntersectionWhereClause(s"$columnPrefix.flat_event_witnesses", readers)
+    SQL"""
+  WITH last_contract_key_create AS (
+         SELECT participant_events.*
+           FROM participant_events, parameters
+          WHERE event_kind = 10 -- create
+            AND create_key_hash = ${key.hash}
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+                -- do NOT check visibility here, as otherwise we do not abort the scan early
+          ORDER BY event_sequential_id DESC
+          LIMIT 1
+       )
+  SELECT contract_id
+    FROM last_contract_key_create -- creation only, as divulged contracts cannot be fetched by key
+  WHERE #${flat_event_witnessesWhere("last_contract_key_create")} -- check visibility only here
+    AND NOT EXISTS       -- check no archival visible
+         (SELECT 1
+            FROM participant_events, parameters
+           WHERE event_kind = 20 -- consuming exercise
+             AND event_sequential_id <= parameters.ledger_end_sequential_id
+             AND #${flat_event_witnessesWhere("participant_events")}
+             AND contract_id = last_contract_key_create.contract_id
+         );
+       """
+  }
+
+  override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Instant]] =
+    dispatcher
+      .executeSql(metrics.daml.index.db.lookupMaximumLedgerTimeDbMetrics) { implicit connection =>
+        committedContracts.lookupMaximumLedgerTime(ids)
+      }
+      .map(_.get)
+
+}
+
+private[appendonlydao] object ContractsReader {
+
+  private[appendonlydao] def apply(
+      dispatcher: DbDispatcher,
+      dbType: DbType,
+      metrics: Metrics,
+      lfValueTranslationCache: LfValueTranslation.Cache,
+  )(implicit ec: ExecutionContext): ContractsReader = {
+    def sqlFunctions = dbType match {
+      case DbType.Postgres => PostgresSqlFunctions
+      case DbType.H2Database => H2SqlFunctions
+    }
+    new ContractsReader(
+      dispatcher = dispatcher,
+      metrics = metrics,
+      lfValueTranslationCache = lfValueTranslationCache,
+      sqlFunctions = sqlFunctions,
+    )
+  }
+
+  // The contracts table _does not_ store agreement texts as they are
+  // unnecessary for interpretation and validation. The contracts returned
+  // from this table will _always_ have an empty agreement text.
+  private def toContract(
+      contractId: ContractId,
+      templateId: String,
+      createArgument: InputStream,
+      createArgumentCompression: Compression.Algorithm,
+      decompressionTimer: Timer,
+      deserializationTimer: Timer,
+  ): Contract = {
+    val decompressed =
+      Timed.value(
+        timer = decompressionTimer,
+        value = createArgumentCompression.decompress(createArgument),
+      )
+    val deserialized =
+      Timed.value(
+        timer = deserializationTimer,
+        value = ValueSerializer.deserializeValue(
+          stream = decompressed,
+          errorContext = s"Failed to deserialize create argument for contract ${contractId.coid}",
+        ),
+      )
+    Contract(
+      template = Identifier.assertFromString(templateId),
+      arg = deserialized,
+      agreementText = "",
+    )
+  }
+
+  private def toContract(
+      templateId: String,
+      createArgument: Value,
+  ): Contract =
+    Contract(
+      template = Identifier.assertFromString(templateId),
+      arg = createArgument,
+      agreementText = "",
+    )
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsTable.scala
@@ -1,0 +1,119 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.sql.Connection
+import java.time.Instant
+
+import anorm.SqlStringInterpolation
+import com.daml.ledger.api.domain.PartyDetails
+import com.daml.platform.store.Conversions._
+import com.daml.platform.store.appendonlydao.JdbcLedgerDao
+
+import scala.util.{Failure, Success, Try}
+
+private[events] object ContractsTable extends PostCommitValidationData {
+
+  override final def lookupContractKeyGlobally(
+      key: Key
+  )(implicit connection: Connection): Option[ContractId] =
+    SQL"""
+  WITH last_contract_key_create AS (
+         SELECT participant_events.*
+           FROM participant_events, parameters
+          WHERE event_kind = 10 -- create
+            AND create_key_hash = ${key.hash}
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+          ORDER BY event_sequential_id DESC
+          LIMIT 1
+       )
+  SELECT contract_id
+    FROM last_contract_key_create -- creation only, as divulged contracts cannot be fetched by key
+   WHERE NOT EXISTS
+         (SELECT 1
+            FROM participant_events, parameters
+           WHERE event_kind = 20 -- consuming exercise
+             AND event_sequential_id <= parameters.ledger_end_sequential_id
+             AND contract_id = last_contract_key_create.contract_id
+         );
+       """
+      .as(contractId("contract_id").singleOpt)
+
+  // TODO append-only: revisit this approach when doing cleanup, so we can decide if it is enough or not.
+  override final def lookupMaximumLedgerTime(
+      ids: Set[ContractId]
+  )(implicit connection: Connection): Try[Option[Instant]] = {
+    if (ids.isEmpty) {
+      Failure(ContractsTable.emptyContractIds)
+    } else {
+      def lookup(id: ContractId): Option[Option[Instant]] =
+        SQL"""
+  WITH archival_event AS (
+         SELECT participant_events.*
+           FROM participant_events, parameters
+          WHERE contract_id = $id
+            AND event_kind = 20  -- consuming exercise
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+          LIMIT 1
+       ),
+       create_event AS (
+         SELECT ledger_effective_time
+           FROM participant_events, parameters
+          WHERE contract_id = $id
+            AND event_kind = 10  -- create
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+          LIMIT 1 -- limit here to guide planner wrt expected number of results
+       ),
+       divulged_contract AS (
+         SELECT ledger_effective_time
+           FROM participant_events, parameters
+          WHERE contract_id = $id
+            AND event_kind = 0 -- divulgence
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+          ORDER BY event_sequential_id
+            -- prudent engineering: make results more stable by preferring earlier divulgence events
+            -- Results might still change due to pruning.
+          LIMIT 1
+       ),
+       create_and_divulged_contracts AS (
+         (SELECT * FROM create_event)   -- prefer create over divulgance events
+         UNION ALL
+         (SELECT * FROM divulged_contract)
+       )
+  SELECT ledger_effective_time
+    FROM create_and_divulged_contracts
+   WHERE NOT EXISTS (SELECT 1 FROM archival_event)
+   LIMIT 1;
+               """.as(instant("ledger_effective_time").?.singleOpt)
+
+      val queriedIds: List[(ContractId, Option[Option[Instant]])] = ids.toList
+        .map(id => id -> lookup(id))
+      val foundLedgerEffectiveTimes: List[Option[Instant]] = queriedIds
+        .collect { case (_, Some(found)) =>
+          found
+        }
+      if (foundLedgerEffectiveTimes.size != ids.size) {
+        val missingIds = queriedIds.collect { case (missingId, None) =>
+          missingId
+        }
+        Failure(ContractsTable.notFound(missingIds.toSet))
+      } else Success(foundLedgerEffectiveTimes.max)
+    }
+  }
+
+  override final def lookupParties(parties: Seq[Party])(implicit
+      connection: Connection
+  ): List[PartyDetails] =
+    JdbcLedgerDao.selectParties(parties).map(JdbcLedgerDao.constructPartyDetails)
+
+  private def emptyContractIds: Throwable =
+    new IllegalArgumentException(
+      "Cannot lookup the maximum ledger time for an empty set of contract identifiers"
+    )
+
+  private def notFound(missingContractIds: Set[ContractId]): Throwable =
+    new IllegalArgumentException(
+      s"The following contracts have not been found: ${missingContractIds.map(_.coid).mkString(", ")}"
+    )
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsRange.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsRange.scala
@@ -1,0 +1,95 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.daml.platform.store.appendonlydao.events
+
+import anorm.SqlParser.get
+import anorm.{Row, RowParser, SimpleSql, SqlStringInterpolation}
+import com.daml.ledger.participant.state.v1.Offset
+
+// (startExclusive, endInclusive]
+private[events] final case class EventsRange[A](startExclusive: A, endInclusive: A) {
+  def map[B](f: A => B): EventsRange[B] =
+    copy(startExclusive = f(startExclusive), endInclusive = f(endInclusive))
+}
+
+private[events] object EventsRange {
+  private val EmptyLedgerEventSeqId = 0L
+
+  // (0, 0] -- non-existent range
+  private val EmptyEventSeqIdRange = EventsRange(EmptyLedgerEventSeqId, EmptyLedgerEventSeqId)
+
+  def isEmpty[A: Ordering](range: EventsRange[A]): Boolean = {
+    val A = implicitly[Ordering[A]]
+    A.gteq(range.startExclusive, range.endInclusive)
+  }
+
+  /** Converts Offset range to Event Sequential ID range.
+    *
+    * @param range offset range
+    * @param connection SQL connection
+    * @return Event Sequential ID range
+    */
+  def readEventSeqIdRange(range: EventsRange[Offset])(
+      connection: java.sql.Connection
+  ): EventsRange[Long] =
+    if (isEmpty(range))
+      EmptyEventSeqIdRange
+    else
+      EventsRange(
+        startExclusive = readEventSeqId(range.startExclusive)(connection),
+        endInclusive = readEventSeqId(range.endInclusive)(connection),
+      )
+
+  /** Converts ledger end offset to Event Sequential ID.
+    *
+    * @param endInclusive ledger end offset
+    * @param connection SQL connection
+    * @return Event Sequential ID range.
+    */
+  def readEventSeqIdRange(endInclusive: Offset)(
+      connection: java.sql.Connection
+  ): EventsRange[Long] = {
+    if (endInclusive == Offset.beforeBegin) EmptyEventSeqIdRange
+    else EmptyEventSeqIdRange.copy(endInclusive = readEventSeqId(endInclusive)(connection))
+  }
+
+  private def readEventSeqId(offset: Offset)(connection: java.sql.Connection): Long = {
+    import com.daml.platform.store.Conversions.OffsetToStatement
+    // This query could be: "select max(event_sequential_id) from participant_events where event_offset <= ${range.endInclusive}"
+    // however tests using PostgreSQL 12 with tens of millions of events have shown that the index
+    // on `event_offset` is not used unless we _hint_ at it by specifying `order by event_offset`
+    SQL"select max(event_sequential_id) from participant_events where event_offset <= ${offset} group by event_offset order by event_offset desc limit 1"
+      .as(get[Long](1).singleOpt)(connection)
+      .getOrElse(EmptyLedgerEventSeqId)
+  }
+
+  private[events] def readPage[A](
+      read: (EventsRange[Long], String) => SimpleSql[Row], // takes range and limit sub-expression
+      row: RowParser[A],
+      range: EventsRange[Long],
+      pageSize: Int,
+  ): SqlSequence[Vector[A]] = {
+    val minPageSize = 10 min pageSize max (pageSize / 10)
+    val guessedPageEnd = range.endInclusive min (range.startExclusive + pageSize)
+    SqlSequence
+      .vector(
+        read(range copy (endInclusive = guessedPageEnd), "") withFetchSize Some(pageSize),
+        row,
+      )
+      .flatMap { arithPage =>
+        val found = arithPage.size
+        if (guessedPageEnd == range.endInclusive || found >= minPageSize)
+          SqlSequence point arithPage
+        else
+          SqlSequence
+            .vector(
+              read(
+                range copy (startExclusive = guessedPageEnd),
+                s"limit ${minPageSize - found: Int}",
+              ) withFetchSize Some(minPageSize - found),
+              row,
+            )
+            .map(arithPage ++ _)
+      }
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTable.scala
@@ -1,0 +1,207 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.io.InputStream
+import java.sql.Connection
+import java.time.Instant
+
+import anorm.SqlParser.{array, binaryStream, bool, int, long, str}
+import anorm.{RowParser, ~}
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
+import com.daml.ledger.api.v1.event.Event
+import com.daml.ledger.api.v1.transaction.{
+  TreeEvent,
+  Transaction => ApiTransaction,
+  TransactionTree => ApiTransactionTree,
+}
+import com.daml.ledger.api.v1.transaction_service.{
+  GetFlatTransactionResponse,
+  GetTransactionResponse,
+  GetTransactionTreesResponse,
+  GetTransactionsResponse,
+}
+import com.daml.platform.ApiOffset
+import com.daml.platform.api.v1.event.EventOps.{EventOps, TreeEventOps}
+import com.daml.platform.index.TransactionConversion
+import com.daml.platform.store.Conversions.{identifier, instant, offset}
+import com.google.protobuf.timestamp.Timestamp
+
+private[events] object EventsTable {
+
+  private type SharedRow =
+    Offset ~ String ~ Int ~ Long ~ String ~ String ~ Instant ~ Identifier ~ Option[String] ~
+      Option[String] ~ Array[String]
+
+  private val sharedRow: RowParser[SharedRow] =
+    offset("event_offset") ~
+      str("transaction_id") ~
+      int("node_index") ~
+      long("event_sequential_id") ~
+      str("event_id") ~
+      str("contract_id") ~
+      instant("ledger_effective_time") ~
+      identifier("template_id") ~
+      str("command_id").? ~
+      str("workflow_id").? ~
+      array[String]("event_witnesses")
+
+  type CreatedEventRow =
+    SharedRow ~ InputStream ~ Option[Int] ~ Array[String] ~ Array[String] ~ Option[String] ~
+      Option[InputStream] ~ Option[Int]
+
+  val createdEventRow: RowParser[CreatedEventRow] =
+    sharedRow ~
+      binaryStream("create_argument") ~
+      int("create_argument_compression").? ~
+      array[String]("create_signatories") ~
+      array[String]("create_observers") ~
+      str("create_agreement_text").? ~
+      binaryStream("create_key_value").? ~
+      int("create_key_value_compression").?
+
+  type ExercisedEventRow =
+    SharedRow ~ Boolean ~ String ~ InputStream ~ Option[Int] ~ Option[InputStream] ~ Option[Int] ~
+      Array[String] ~ Array[String]
+
+  val exercisedEventRow: RowParser[ExercisedEventRow] =
+    sharedRow ~
+      bool("exercise_consuming") ~
+      str("exercise_choice") ~
+      binaryStream("exercise_argument") ~
+      int("exercise_argument_compression").? ~
+      binaryStream("exercise_result").? ~
+      int("exercise_result_compression").? ~
+      array[String]("exercise_actors") ~
+      array[String]("exercise_child_event_ids")
+
+  type ArchiveEventRow = SharedRow
+
+  val archivedEventRow: RowParser[ArchiveEventRow] = sharedRow
+
+  trait Batches {
+    def execute()(implicit connection: Connection): Unit
+  }
+
+  final case class Entry[+E](
+      eventOffset: Offset,
+      transactionId: String,
+      nodeIndex: Int,
+      eventSequentialId: Long,
+      ledgerEffectiveTime: Instant,
+      commandId: String,
+      workflowId: String,
+      event: E,
+  )
+
+  object Entry {
+
+    private def instantToTimestamp(t: Instant): Timestamp =
+      Timestamp(seconds = t.getEpochSecond, nanos = t.getNano)
+
+    private def flatTransaction(events: Vector[Entry[Event]]): Option[ApiTransaction] =
+      events.headOption.flatMap { first =>
+        val flatEvents =
+          TransactionConversion.removeTransient(events.iterator.map(_.event).toVector)
+        if (flatEvents.nonEmpty || first.commandId.nonEmpty)
+          Some(
+            ApiTransaction(
+              transactionId = first.transactionId,
+              commandId = first.commandId,
+              effectiveAt = Some(instantToTimestamp(first.ledgerEffectiveTime)),
+              workflowId = first.workflowId,
+              offset = ApiOffset.toApiString(first.eventOffset),
+              events = flatEvents,
+            )
+          )
+        else None
+      }
+
+    def toGetTransactionsResponse(
+        events: Vector[Entry[Event]]
+    ): List[GetTransactionsResponse] =
+      flatTransaction(events).toList.map(tx => GetTransactionsResponse(Seq(tx)))
+
+    def toGetFlatTransactionResponse(
+        events: Vector[Entry[Event]]
+    ): Option[GetFlatTransactionResponse] =
+      flatTransaction(events).map(tx => GetFlatTransactionResponse(Some(tx)))
+
+    def toGetActiveContractsResponse(
+        events: Vector[Entry[Event]]
+    ): Vector[GetActiveContractsResponse] = {
+      events.map {
+        case entry if entry.event.isCreated =>
+          GetActiveContractsResponse(
+            offset = "", // only the last response will have an offset.
+            workflowId = entry.workflowId,
+            activeContracts = Seq(entry.event.getCreated),
+            traceContext = None,
+          )
+        case entry =>
+          throw new IllegalStateException(
+            s"Non-create event ${entry.event.eventId} fetched as part of the active contracts"
+          )
+      }
+    }
+
+    private def treeOf(
+        events: Vector[Entry[TreeEvent]]
+    ): (Map[String, TreeEvent], Vector[String]) = {
+
+      // The identifiers of all visible events in this transactions, preserving
+      // the order in which they are retrieved from the index
+      val visible = events.map(_.event.eventId)
+      val visibleSet = visible.toSet
+
+      // All events in this transaction by their identifier, with their children
+      // filtered according to those visible for this request
+      val eventsById =
+        events.iterator
+          .map(_.event)
+          .map(e => e.eventId -> e.filterChildEventIds(visibleSet))
+          .toMap
+
+      // All event identifiers that appear as a child of another item in this response
+      val children = eventsById.valuesIterator.flatMap(_.childEventIds).toSet
+
+      // The roots for this request are all visible items
+      // that are not a child of some other visible item
+      val rootEventIds = visible.filterNot(children)
+
+      (eventsById, rootEventIds)
+
+    }
+
+    private def transactionTree(
+        events: Vector[Entry[TreeEvent]]
+    ): Option[ApiTransactionTree] =
+      events.headOption.map { first =>
+        val (eventsById, rootEventIds) = treeOf(events)
+        ApiTransactionTree(
+          transactionId = first.transactionId,
+          commandId = first.commandId,
+          workflowId = first.workflowId,
+          effectiveAt = Some(instantToTimestamp(first.ledgerEffectiveTime)),
+          offset = ApiOffset.toApiString(first.eventOffset),
+          eventsById = eventsById,
+          rootEventIds = rootEventIds,
+          traceContext = None,
+        )
+      }
+
+    def toGetTransactionTreesResponse(
+        events: Vector[Entry[TreeEvent]]
+    ): List[GetTransactionTreesResponse] =
+      transactionTree(events).toList.map(tx => GetTransactionTreesResponse(Seq(tx)))
+
+    def toGetTransactionResponse(
+        events: Vector[Entry[TreeEvent]]
+    ): Option[GetTransactionResponse] =
+      transactionTree(events).map(tx => GetTransactionResponse(Some(tx)))
+
+  }
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableDelete.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableDelete.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import anorm.{Row, SimpleSql, SqlStringInterpolation}
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.platform.store.Conversions.OffsetToStatement
+
+object EventsTableDelete {
+
+  /** Delete
+    * - archive events before or at specified offset and
+    * - create events that have been archived before or at the specific offset.
+    */
+  def prepareEventsDelete(endInclusive: Offset): SimpleSql[Row] =
+    SQL"""
+          delete from participant_events as delete_events
+          where
+            delete_events.event_offset <= $endInclusive and
+            delete_events.event_kind in (10, 0) and   -- create and divulgence events
+            exists (
+              SELECT 1 FROM participant_events as archive_events
+              WHERE
+                archive_events.event_offset <= $endInclusive AND
+                archive_events.event_kind = 20 AND -- consuming
+                archive_events.contract_id = delete_events.contract_id
+            );
+          delete from participant_events as delete_events
+          where
+            delete_events.event_offset <= $endInclusive and
+            delete_events.event_kind in (20, 25);  -- consuming and non-consuming exercise events
+       """
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableFlatEvents.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableFlatEvents.scala
@@ -1,0 +1,189 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import anorm.{Row, RowParser, SimpleSql, SqlStringInterpolation, ~}
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger.TransactionId
+import com.daml.platform.store.Conversions._
+
+import scala.collection.compat.immutable.ArraySeq
+
+private[events] object EventsTableFlatEvents {
+
+  private val createdFlatEventParser: RowParser[EventsTable.Entry[Raw.FlatEvent.Created]] =
+    EventsTable.createdEventRow map {
+      case eventOffset ~ transactionId ~ nodeIndex ~ eventSequentialId ~ eventId ~ contractId ~ ledgerEffectiveTime ~
+          templateId ~ commandId ~ workflowId ~ eventWitnesses ~ createArgument ~ createArgumentCompression ~
+          createSignatories ~ createObservers ~ createAgreementText ~ createKeyValue ~ createKeyValueCompression =>
+        // ArraySeq.unsafeWrapArray is safe here
+        // since we get the Array from parsing and don't let it escape anywhere.
+        EventsTable.Entry(
+          eventOffset = eventOffset,
+          transactionId = transactionId,
+          nodeIndex = nodeIndex,
+          eventSequentialId = eventSequentialId,
+          ledgerEffectiveTime = ledgerEffectiveTime,
+          commandId = commandId.getOrElse(""),
+          workflowId = workflowId.getOrElse(""),
+          event = Raw.FlatEvent.Created(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = templateId,
+            createArgument = createArgument,
+            createArgumentCompression = createArgumentCompression,
+            createSignatories = ArraySeq.unsafeWrapArray(createSignatories),
+            createObservers = ArraySeq.unsafeWrapArray(createObservers),
+            createAgreementText = createAgreementText,
+            createKeyValue = createKeyValue,
+            createKeyValueCompression = createKeyValueCompression,
+            eventWitnesses = ArraySeq.unsafeWrapArray(eventWitnesses),
+          ),
+        )
+    }
+
+  private val archivedFlatEventParser: RowParser[EventsTable.Entry[Raw.FlatEvent.Archived]] =
+    EventsTable.archivedEventRow map {
+      case eventOffset ~ transactionId ~ nodeIndex ~ eventSequentialId ~ eventId ~ contractId ~ ledgerEffectiveTime ~ templateId ~ commandId ~ workflowId ~ eventWitnesses =>
+        // ArraySeq.unsafeWrapArray is safe here
+        // since we get the Array from parsing and don't let it escape anywhere.
+        EventsTable.Entry(
+          eventOffset = eventOffset,
+          transactionId = transactionId,
+          nodeIndex = nodeIndex,
+          eventSequentialId = eventSequentialId,
+          ledgerEffectiveTime = ledgerEffectiveTime,
+          commandId = commandId.getOrElse(""),
+          workflowId = workflowId.getOrElse(""),
+          event = Raw.FlatEvent.Archived(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = templateId,
+            eventWitnesses = ArraySeq.unsafeWrapArray(eventWitnesses),
+          ),
+        )
+    }
+
+  val rawFlatEventParser: RowParser[EventsTable.Entry[Raw.FlatEvent]] =
+    createdFlatEventParser | archivedFlatEventParser
+
+  private val selectColumns =
+    Seq(
+      "event_offset",
+      "transaction_id",
+      "node_index",
+      "event_sequential_id",
+      "ledger_effective_time",
+      "workflow_id",
+      "participant_events.event_id",
+      "contract_id",
+      "template_id",
+      "create_argument",
+      "create_argument_compression",
+      "create_signatories",
+      "create_observers",
+      "create_agreement_text",
+      "create_key_value",
+      "create_key_value_compression",
+    ).mkString(", ")
+
+  private val selectColumnsForACS =
+    Seq(
+      "active_cs.event_offset",
+      "active_cs.transaction_id",
+      "active_cs.node_index",
+      "active_cs.event_sequential_id",
+      "active_cs.ledger_effective_time",
+      "active_cs.workflow_id",
+      "active_cs.event_id",
+      "active_cs.contract_id",
+      "active_cs.template_id",
+      "active_cs.create_argument",
+      "active_cs.create_argument_compression",
+      "active_cs.create_signatories",
+      "active_cs.create_observers",
+      "active_cs.create_agreement_text",
+      "active_cs.create_key_value",
+      "active_cs.create_key_value_compression",
+    ).mkString(", ")
+
+  def prepareLookupFlatTransactionById(sqlFunctions: SqlFunctions)(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  ): SimpleSql[Row] =
+    route(requestingParties)(
+      single = singlePartyLookup(sqlFunctions)(transactionId, _),
+      multi = multiPartyLookup(sqlFunctions)(transactionId, _),
+    )
+
+  private def singlePartyLookup(sqlFunctions: SqlFunctions)(
+      transactionId: TransactionId,
+      requestingParty: Party,
+  ): SimpleSql[Row] = {
+    val witnessesWhereClause =
+      // TODO varchars are not texts according to postgreSQL - we need to do lot of casting. since these are primarlily the same I suggest for the final approach to pick either and align
+      sqlFunctions.arrayIntersectionWhereClause("flat_event_witnesses", requestingParty)
+    SQL"""select #$selectColumns, array[$requestingParty] as event_witnesses,
+                 case when submitters = array[$requestingParty]::text[] then command_id else '' end as command_id
+          from participant_events
+          join parameters on
+              (participant_pruned_up_to_inclusive is null or event_offset > participant_pruned_up_to_inclusive)
+              and event_offset <= ledger_end
+          where transaction_id = $transactionId and #$witnessesWhereClause and event_kind != 0 -- we do not want to fetch divulgence events
+          order by event_sequential_id"""
+  }
+
+  private def multiPartyLookup(sqlFunctions: SqlFunctions)(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  ): SimpleSql[Row] = {
+    val witnessesWhereClause =
+      sqlFunctions.arrayIntersectionWhereClause("flat_event_witnesses", requestingParties)
+    val submittersInPartiesClause =
+      sqlFunctions.arrayIntersectionWhereClause("submitters", requestingParties)
+    // TODO check existence of a test which fails when the transaction_id and flat_event_witnesses restriction wouldn't be there, if not add test.
+    SQL"""select #$selectColumns, flat_event_witnesses as event_witnesses,
+                 case when #$submittersInPartiesClause then command_id else '' end as command_id
+          from participant_events
+          join parameters on
+              (participant_pruned_up_to_inclusive is null or event_offset > participant_pruned_up_to_inclusive)
+              and event_offset <= ledger_end
+          where transaction_id = $transactionId and #$witnessesWhereClause and event_kind != 0 -- we do not want to fetch divulgence events
+          order by event_sequential_id"""
+  }
+
+  private def getFlatTransactionsQueries(sqlFunctions: SqlFunctions) =
+    new EventsTableFlatEventsRangeQueries.GetTransactions(
+      selectColumns = selectColumns,
+      sqlFunctions = sqlFunctions,
+    )
+
+  def preparePagedGetFlatTransactions(sqlFunctions: SqlFunctions)(
+      range: EventsRange[Long],
+      filter: FilterRelation,
+      pageSize: Int,
+  ): SqlSequence[Vector[EventsTable.Entry[Raw.FlatEvent]]] =
+    getFlatTransactionsQueries(sqlFunctions)(
+      range,
+      filter,
+      pageSize,
+    )
+
+  private def getActiveContractsQueries(sqlFunctions: SqlFunctions) =
+    new EventsTableFlatEventsRangeQueries.GetActiveContracts(
+      selectColumns = selectColumnsForACS,
+      sqlFunctions = sqlFunctions,
+    )
+
+  def preparePagedGetActiveContracts(sqlFunctions: SqlFunctions)(
+      range: EventsRange[(Offset, Long)],
+      filter: FilterRelation,
+      pageSize: Int,
+  ): SqlSequence[Vector[EventsTable.Entry[Raw.FlatEvent]]] =
+    getActiveContractsQueries(sqlFunctions)(
+      range,
+      filter,
+      pageSize,
+    )
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableFlatEventsRangeQueries.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableFlatEventsRangeQueries.scala
@@ -1,0 +1,504 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import anorm.{Row, SimpleSql, SqlStringInterpolation}
+import com.daml.lf.data.Ref.{Identifier => ApiIdentifier}
+import com.daml.platform.store.Conversions._
+
+private[events] sealed abstract class EventsTableFlatEventsRangeQueries[Offset] {
+
+  import EventsTableFlatEventsRangeQueries.QueryParts
+
+  protected def singleWildcardParty(
+      offset: Offset,
+      party: Party,
+      pageSize: Int,
+  ): QueryParts
+
+  protected def singlePartyWithTemplates(
+      offset: Offset,
+      party: Party,
+      templateIds: Set[ApiIdentifier],
+      pageSize: Int,
+  ): QueryParts
+
+  protected def onlyWildcardParties(
+      offset: Offset,
+      parties: Set[Party],
+      pageSize: Int,
+  ): QueryParts
+
+  protected def sameTemplates(
+      offset: Offset,
+      parties: Set[Party],
+      templateIds: Set[ApiIdentifier],
+      pageSize: Int,
+  ): QueryParts
+
+  protected def mixedTemplates(
+      offset: Offset,
+      partiesAndTemplateIds: Set[(Party, ApiIdentifier)],
+      pageSize: Int,
+  ): QueryParts
+
+  protected def mixedTemplatesWithWildcardParties(
+      offset: Offset,
+      wildcardParties: Set[Party],
+      partiesAndTemplateIds: Set[(Party, ApiIdentifier)],
+      pageSize: Int,
+  ): QueryParts
+
+  protected def offsetRange(offset: Offset): EventsRange[Long]
+
+  final def apply(
+      offset: Offset,
+      filter: FilterRelation,
+      pageSize: Int,
+  ): SqlSequence[Vector[EventsTable.Entry[Raw.FlatEvent]]] = {
+    require(filter.nonEmpty, "The request must be issued by at least one party")
+
+    // Route the request to the correct underlying query
+    val frqK = if (filter.size == 1) {
+      val (party, templateIds) = filter.iterator.next()
+      if (templateIds.isEmpty) {
+        // Single-party request, no specific template identifier
+        singleWildcardParty(offset, party, pageSize)
+      } else {
+        // Single-party request, restricted to a set of template identifiers
+        singlePartyWithTemplates(offset, party, templateIds, pageSize)
+      }
+    } else {
+      // Multi-party requests
+      // If no party requests specific template identifiers
+      val parties = filter.keySet
+      if (filter.forall(_._2.isEmpty))
+        onlyWildcardParties(
+          offset = offset,
+          parties = parties,
+          pageSize = pageSize,
+        )
+      else {
+        // If all parties request the same template identifier
+        val templateIds = filter.valuesIterator.flatten.toSet
+        if (filter.valuesIterator.forall(_ == templateIds)) {
+          sameTemplates(
+            offset,
+            parties = parties,
+            templateIds = templateIds,
+            pageSize = pageSize,
+          )
+        } else {
+          // If there are different template identifier but there are no wildcard parties
+          val partiesAndTemplateIds = Relation.flatten(filter).toSet
+          val wildcardParties = filter.filter(_._2.isEmpty).keySet
+          if (wildcardParties.isEmpty) {
+            mixedTemplates(
+              offset,
+              partiesAndTemplateIds = partiesAndTemplateIds,
+              pageSize = pageSize,
+            )
+          } else {
+            // If there are wildcard parties and different template identifiers
+            mixedTemplatesWithWildcardParties(
+              offset,
+              wildcardParties,
+              partiesAndTemplateIds,
+              pageSize,
+            )
+          }
+        }
+      }
+    }
+
+    frqK match {
+      case QueryParts.ByArith(read) =>
+        EventsRange.readPage(
+          read,
+          EventsTableFlatEvents.rawFlatEventParser,
+          offsetRange(offset),
+          pageSize,
+        )
+      case QueryParts.ByLimit(sql) =>
+        SqlSequence.vector(
+          sql withFetchSize Some(pageSize),
+          EventsTableFlatEvents.rawFlatEventParser,
+        )
+    }
+  }
+}
+
+private[events] object EventsTableFlatEventsRangeQueries {
+
+  import com.daml.ledger.participant.state.v1.Offset
+
+  private[EventsTableFlatEventsRangeQueries] sealed abstract class QueryParts
+      extends Product
+      with Serializable
+  private[EventsTableFlatEventsRangeQueries] object QueryParts {
+    final case class ByArith(read: (EventsRange[Long], String) => SimpleSql[Row]) extends QueryParts
+    final case class ByLimit(saferRead: SimpleSql[Row]) extends QueryParts
+    import language.implicitConversions
+    implicit def `go by limit`(saferRead: SimpleSql[Row]): ByLimit = ByLimit(saferRead)
+  }
+
+  final class GetTransactions(
+      selectColumns: String,
+      sqlFunctions: SqlFunctions,
+  ) extends EventsTableFlatEventsRangeQueries[EventsRange[Long]] {
+
+    override protected def singleWildcardParty(
+        range: EventsRange[Long],
+        party: Party,
+        pageSize: Int,
+    ): QueryParts = {
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause("flat_event_witnesses", party)
+      QueryParts.ByArith(
+        read = (range, limitExpr) => SQL"""
+            select #$selectColumns, array[$party] as event_witnesses,
+                   case when submitters = array[$party]::text[] then command_id else '' end as command_id
+            from participant_events
+            where event_sequential_id > ${range.startExclusive}
+                  and event_sequential_id <= ${range.endInclusive}
+                  and #$witnessesWhereClause
+            order by event_sequential_id #$limitExpr"""
+      )
+    }
+
+    override protected def singlePartyWithTemplates(
+        range: EventsRange[Long],
+        party: Party,
+        templateIds: Set[ApiIdentifier],
+        pageSize: Int,
+    ): QueryParts = {
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause("flat_event_witnesses", party)
+      QueryParts.ByArith(
+        read = (range, limitExpr) => SQL"""
+            select #$selectColumns, array[$party] as event_witnesses,
+                   case when submitters = array[$party]::text[] then command_id else '' end as command_id
+            from participant_events
+            where event_sequential_id > ${range.startExclusive}
+                  and event_sequential_id <= ${range.endInclusive}
+                  and #$witnessesWhereClause
+                  and template_id in ($templateIds)
+            order by event_sequential_id #$limitExpr"""
+      )
+    }
+
+    override protected def onlyWildcardParties(
+        range: EventsRange[Long],
+        parties: Set[Party],
+        pageSize: Int,
+    ): QueryParts = {
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause("flat_event_witnesses", parties)
+      val filteredWitnesses =
+        sqlFunctions.arrayIntersectionValues("flat_event_witnesses", parties)
+      val submittersInPartiesClause =
+        sqlFunctions.arrayIntersectionWhereClause("submitters", parties)
+      QueryParts.ByArith(
+        read = (range, limitExpr) => SQL"""
+            select #$selectColumns, #$filteredWitnesses as event_witnesses,
+                   case when #$submittersInPartiesClause then command_id else '' end as command_id
+            from participant_events
+            where event_sequential_id > ${range.startExclusive}
+                  and event_sequential_id <= ${range.endInclusive}
+                  and #$witnessesWhereClause
+            order by event_sequential_id #$limitExpr"""
+      )
+    }
+
+    override protected def sameTemplates(
+        range: EventsRange[Long],
+        parties: Set[Party],
+        templateIds: Set[ApiIdentifier],
+        pageSize: Int,
+    ): QueryParts = {
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause("flat_event_witnesses", parties)
+      val filteredWitnesses =
+        sqlFunctions.arrayIntersectionValues("flat_event_witnesses", parties)
+      val submittersInPartiesClause =
+        sqlFunctions.arrayIntersectionWhereClause("submitters", parties)
+      QueryParts.ByArith(
+        read = (range, limitExpr) => SQL"""
+            select #$selectColumns, #$filteredWitnesses as event_witnesses,
+                   case when #$submittersInPartiesClause then command_id else '' end as command_id
+            from participant_events
+            where event_sequential_id > ${range.startExclusive}
+                  and event_sequential_id <= ${range.endInclusive}
+                  and #$witnessesWhereClause
+                  and template_id in ($templateIds)
+            order by event_sequential_id #$limitExpr"""
+      )
+    }
+
+    override protected def mixedTemplates(
+        range: EventsRange[Long],
+        partiesAndTemplateIds: Set[(Party, ApiIdentifier)],
+        pageSize: Int,
+    ): QueryParts = {
+      val parties = partiesAndTemplateIds.map(_._1)
+      val partiesAndTemplatesCondition =
+        formatPartiesAndTemplatesWhereClause(
+          sqlFunctions,
+          "flat_event_witnesses",
+          partiesAndTemplateIds,
+        )
+      val filteredWitnesses =
+        sqlFunctions.arrayIntersectionValues("flat_event_witnesses", parties)
+      val submittersInPartiesClause =
+        sqlFunctions.arrayIntersectionWhereClause("submitters", parties)
+      QueryParts.ByArith(
+        read = (range, limitExpr) => SQL"""
+            select #$selectColumns, #$filteredWitnesses as event_witnesses,
+                   case when #$submittersInPartiesClause then command_id else '' end as command_id
+            from participant_events
+            where event_sequential_id > ${range.startExclusive}
+                  and event_sequential_id <= ${range.endInclusive}
+                  and #$partiesAndTemplatesCondition
+            order by event_sequential_id #$limitExpr"""
+      )
+    }
+
+    override protected def mixedTemplatesWithWildcardParties(
+        range: EventsRange[Long],
+        wildcardParties: Set[Party],
+        partiesAndTemplateIds: Set[(Party, ApiIdentifier)],
+        pageSize: Int,
+    ): QueryParts = {
+      val parties = wildcardParties ++ partiesAndTemplateIds.map(_._1)
+      val partiesAndTemplatesCondition =
+        formatPartiesAndTemplatesWhereClause(
+          sqlFunctions,
+          "flat_event_witnesses",
+          partiesAndTemplateIds,
+        )
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause("flat_event_witnesses", wildcardParties)
+      val filteredWitnesses =
+        sqlFunctions.arrayIntersectionValues("flat_event_witnesses", parties)
+      val submittersInPartiesClause =
+        sqlFunctions.arrayIntersectionWhereClause("submitters", parties)
+      QueryParts.ByArith(
+        read = (range, limitExpr) => SQL"""
+            select #$selectColumns, #$filteredWitnesses as event_witnesses,
+                   case when #$submittersInPartiesClause then command_id else '' end as command_id
+            from participant_events
+            where event_sequential_id > ${range.startExclusive}
+                  and event_sequential_id <= ${range.endInclusive}
+                  and (#$witnessesWhereClause or #$partiesAndTemplatesCondition)
+            order by event_sequential_id #$limitExpr"""
+      )
+    }
+
+    override protected def offsetRange(offset: EventsRange[Long]) = offset
+  }
+
+  final class GetActiveContracts(
+      selectColumns: String,
+      sqlFunctions: SqlFunctions,
+  ) extends EventsTableFlatEventsRangeQueries[EventsRange[(Offset, Long)]] {
+
+    override protected def singleWildcardParty(
+        range: EventsRange[(Offset, Long)],
+        party: Party,
+        pageSize: Int,
+    ): QueryParts = {
+      // TODO inline the def, only used once
+      def witnessesWhereClause(prefix: String) =
+        sqlFunctions.arrayIntersectionWhereClause(s"$prefix.flat_event_witnesses", party)
+      SQL"""select #$selectColumns, array[$party] as event_witnesses,
+                   case when active_cs.submitters = array[$party]::text[] then active_cs.command_id else '' end as command_id
+            from participant_events as active_cs
+            where active_cs.event_kind = 10 -- create
+                  and active_cs.event_sequential_id > ${range.startExclusive._2: Long}
+                  and active_cs.event_sequential_id <= ${range.endInclusive._2: Long}
+                  and not exists (
+                    select 1
+                    from participant_events as archived_cs
+                    where
+                      archived_cs.contract_id = active_cs.contract_id and
+                      archived_cs.event_kind = 20 and -- consuming
+                      archived_cs.event_offset <= ${range.endInclusive._1: Offset}
+                  )
+                  and #${witnessesWhereClause("active_cs")}
+            order by active_cs.event_sequential_id limit $pageSize"""
+    }
+
+    override protected def singlePartyWithTemplates(
+        range: EventsRange[(Offset, Long)],
+        party: Party,
+        templateIds: Set[ApiIdentifier],
+        pageSize: Int,
+    ): QueryParts = {
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause("active_cs.flat_event_witnesses", party)
+      SQL"""select #$selectColumns, array[$party] as event_witnesses,
+                   case when active_cs.submitters = array[$party]::text[] then active_cs.command_id else '' end as command_id
+            from participant_events as active_cs
+            where active_cs.event_kind = 10 -- create
+                  and active_cs.event_sequential_id > ${range.startExclusive._2: Long}
+                  and active_cs.event_sequential_id <= ${range.endInclusive._2: Long}
+                  and not exists (
+                    select 1
+                    from participant_events as archived_cs
+                    where
+                      archived_cs.contract_id = active_cs.contract_id and
+                      archived_cs.event_kind = 20 and -- consuming
+                      archived_cs.event_offset <= ${range.endInclusive._1: Offset}
+                  )
+                  and #$witnessesWhereClause
+                  and active_cs.template_id in ($templateIds)
+            order by active_cs.event_sequential_id limit $pageSize"""
+    }
+
+    override def onlyWildcardParties(
+        range: EventsRange[(Offset, Long)],
+        parties: Set[Party],
+        pageSize: Int,
+    ): QueryParts = {
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause("active_cs.flat_event_witnesses", parties)
+      val filteredWitnesses =
+        sqlFunctions.arrayIntersectionValues("active_cs.flat_event_witnesses", parties)
+      val submittersInPartiesClause =
+        sqlFunctions.arrayIntersectionWhereClause("active_cs.submitters", parties)
+      SQL"""select #$selectColumns, #$filteredWitnesses as event_witnesses,
+                   case when #$submittersInPartiesClause then active_cs.command_id else '' end as command_id
+            from participant_events as active_cs
+            where active_cs.event_kind = 10 -- create
+                  and active_cs.event_sequential_id > ${range.startExclusive._2: Long}
+                  and active_cs.event_sequential_id <= ${range.endInclusive._2: Long}
+                  and not exists (
+                    select 1
+                    from participant_events as archived_cs
+                    where
+                      archived_cs.contract_id = active_cs.contract_id and
+                      archived_cs.event_kind = 20 and -- consuming
+                      archived_cs.event_offset <= ${range.endInclusive._1: Offset}
+                  )
+                  and #$witnessesWhereClause
+            order by active_cs.event_sequential_id limit $pageSize"""
+    }
+
+    override def sameTemplates(
+        range: EventsRange[(Offset, Long)],
+        parties: Set[Party],
+        templateIds: Set[ApiIdentifier],
+        pageSize: Int,
+    ): QueryParts = {
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause("active_cs.flat_event_witnesses", parties)
+      val filteredWitnesses =
+        sqlFunctions.arrayIntersectionValues("active_cs.flat_event_witnesses", parties)
+      val submittersInPartiesClause =
+        sqlFunctions.arrayIntersectionWhereClause("active_cs.submitters", parties)
+      SQL"""select #$selectColumns, #$filteredWitnesses as event_witnesses,
+                   case when #$submittersInPartiesClause then active_cs.command_id else '' end as command_id
+            from participant_events as active_cs
+            where active_cs.event_kind = 10 -- create
+                  and active_cs.event_sequential_id > ${range.startExclusive._2: Long}
+                  and active_cs.event_sequential_id <= ${range.endInclusive._2: Long}
+                  and not exists (
+                    select 1
+                    from participant_events as archived_cs
+                    where
+                      archived_cs.contract_id = active_cs.contract_id and
+                      archived_cs.event_kind = 20 and -- consuming
+                      archived_cs.event_offset <= ${range.endInclusive._1: Offset}
+                  )
+                  and #$witnessesWhereClause
+                  and active_cs.template_id in ($templateIds)
+            order by active_cs.event_sequential_id limit $pageSize"""
+    }
+
+    override def mixedTemplates(
+        range: EventsRange[(Offset, Long)],
+        partiesAndTemplateIds: Set[(Party, ApiIdentifier)],
+        pageSize: Int,
+    ): QueryParts = {
+      val parties = partiesAndTemplateIds.map(_._1)
+      val partiesAndTemplatesCondition =
+        formatPartiesAndTemplatesWhereClause(
+          sqlFunctions,
+          "active_cs.flat_event_witnesses",
+          partiesAndTemplateIds,
+        )
+      val filteredWitnesses =
+        sqlFunctions.arrayIntersectionValues("active_cs.flat_event_witnesses", parties)
+      val submittersInPartiesClause =
+        sqlFunctions.arrayIntersectionWhereClause("active_cs.submitters", parties)
+      // TODO these repetitions are painful to maintain. Ideas: Adding SQL views (do reuse in SQL schema), pursue anorm to enable reuse, using something else then anorm here.
+      SQL"""select #$selectColumns, #$filteredWitnesses as event_witnesses,
+                   case when #$submittersInPartiesClause then active_cs.command_id else '' end as command_id
+            from participant_events as active_cs
+            where active_cs.event_kind = 10 -- create
+                  and active_cs.event_sequential_id > ${range.startExclusive._2: Long}
+                  and active_cs.event_sequential_id <= ${range.endInclusive._2: Long}
+                  and not exists (
+                    select 1
+                    from participant_events as archived_cs
+                    where
+                      archived_cs.contract_id = active_cs.contract_id and
+                      archived_cs.event_kind = 20 and -- consuming
+                      archived_cs.event_offset <= ${range.endInclusive._1: Offset}
+                  )
+                  and #$partiesAndTemplatesCondition
+            order by active_cs.event_sequential_id limit $pageSize"""
+    }
+
+    override def mixedTemplatesWithWildcardParties(
+        range: EventsRange[(Offset, Long)],
+        wildcardParties: Set[Party],
+        partiesAndTemplateIds: Set[(Party, ApiIdentifier)],
+        pageSize: Int,
+    ): QueryParts = {
+      val parties = wildcardParties ++ partiesAndTemplateIds.map(_._1)
+      val partiesAndTemplatesCondition =
+        formatPartiesAndTemplatesWhereClause(
+          sqlFunctions,
+          "flat_event_witnesses",
+          partiesAndTemplateIds,
+        )
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause("active_cs.flat_event_witnesses", wildcardParties)
+      val filteredWitnesses =
+        sqlFunctions.arrayIntersectionValues("active_cs.flat_event_witnesses", parties)
+      val submittersInPartiesClause =
+        sqlFunctions.arrayIntersectionWhereClause("active_cs.submitters", parties)
+      SQL"""select #$selectColumns, #$filteredWitnesses as event_witnesses,
+                   case when #$submittersInPartiesClause then active_cs.command_id else '' end as command_id
+            from participant_events as active_cs
+            where active_cs.event_kind = 10 -- create
+                  and active_cs.event_sequential_id > ${range.startExclusive._2: Long}
+                  and active_cs.event_sequential_id <= ${range.endInclusive._2: Long}
+                  and not exists (
+                    select 1
+                    from participant_events as archived_cs
+                    where
+                      archived_cs.contract_id = active_cs.contract_id and
+                      archived_cs.event_kind = 20 and -- consuming
+                      archived_cs.event_offset <= ${range.endInclusive._1: Offset}
+                  )
+                  and (#$witnessesWhereClause or #$partiesAndTemplatesCondition)
+            order by active_cs.event_sequential_id limit $pageSize"""
+    }
+
+    override protected def offsetRange(offset: EventsRange[(Offset, Long)]) = offset map (_._2)
+  }
+
+  private def formatPartiesAndTemplatesWhereClause(
+      sqlFunctions: SqlFunctions,
+      witnessesAggregationColumn: String,
+      partiesAndTemplateIds: Set[(Party, Identifier)],
+  ): String =
+    partiesAndTemplateIds.view
+      .map { case (p, i) =>
+        s"(${sqlFunctions.arrayIntersectionWhereClause(witnessesAggregationColumn, p)} and template_id = '$i')"
+      }
+      .mkString("(", " or ", ")")
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableQueries.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableQueries.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+private[events] object EventsTableQueries {
+  def format(ps: Set[Party]): String =
+    ps.view.map(p => s"'$p'").mkString(",")
+  def format(ps: List[Party]): String =
+    ps.map(p => s"'$p'").mkString(",")
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableTreeEvents.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableTreeEvents.scala
@@ -1,0 +1,211 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import anorm.{Row, RowParser, SimpleSql, SqlStringInterpolation, ~}
+import com.daml.ledger.TransactionId
+import com.daml.platform.store.Conversions._
+
+import scala.collection.compat.immutable.ArraySeq
+
+private[events] object EventsTableTreeEvents {
+
+  private val createdTreeEventParser: RowParser[EventsTable.Entry[Raw.TreeEvent.Created]] =
+    EventsTable.createdEventRow map {
+      case eventOffset ~ transactionId ~ nodeIndex ~ eventSequentialId ~ eventId ~ contractId ~ ledgerEffectiveTime ~ templateId ~ commandId ~ workflowId ~ eventWitnesses ~ createArgument ~ createArgumentCompression ~ createSignatories ~ createObservers ~ createAgreementText ~ createKeyValue ~ createKeyValueCompression =>
+        // ArraySeq.unsafeWrapArray is safe here
+        // since we get the Array from parsing and don't let it escape anywhere.
+        EventsTable.Entry(
+          eventOffset = eventOffset,
+          transactionId = transactionId,
+          nodeIndex = nodeIndex,
+          eventSequentialId = eventSequentialId,
+          ledgerEffectiveTime = ledgerEffectiveTime,
+          commandId = commandId.getOrElse(""),
+          workflowId = workflowId.getOrElse(""),
+          event = Raw.TreeEvent.Created(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = templateId,
+            createArgument = createArgument,
+            createArgumentCompression = createArgumentCompression,
+            createSignatories = ArraySeq.unsafeWrapArray(createSignatories),
+            createObservers = ArraySeq.unsafeWrapArray(createObservers),
+            createAgreementText = createAgreementText,
+            createKeyValue = createKeyValue,
+            createKeyValueCompression = createKeyValueCompression,
+            eventWitnesses = ArraySeq.unsafeWrapArray(eventWitnesses),
+          ),
+        )
+    }
+
+  private val exercisedTreeEventParser: RowParser[EventsTable.Entry[Raw.TreeEvent.Exercised]] =
+    EventsTable.exercisedEventRow map {
+      case eventOffset ~ transactionId ~ nodeIndex ~ eventSequentialId ~ eventId ~ contractId ~ ledgerEffectiveTime ~ templateId ~ commandId ~ workflowId ~ eventWitnesses ~ exerciseConsuming ~ exerciseChoice ~ exerciseArgument ~ exerciseArgumentCompression ~ exerciseResult ~ exerciseResultCompression ~ exerciseActors ~ exerciseChildEventIds =>
+        // ArraySeq.unsafeWrapArray is safe here
+        // since we get the Array from parsing and don't let it escape anywhere.
+        EventsTable.Entry(
+          eventOffset = eventOffset,
+          transactionId = transactionId,
+          nodeIndex = nodeIndex,
+          eventSequentialId = eventSequentialId,
+          ledgerEffectiveTime = ledgerEffectiveTime,
+          commandId = commandId.getOrElse(""),
+          workflowId = workflowId.getOrElse(""),
+          event = Raw.TreeEvent.Exercised(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = templateId,
+            exerciseConsuming = exerciseConsuming,
+            exerciseChoice = exerciseChoice,
+            exerciseArgument = exerciseArgument,
+            exerciseArgumentCompression = exerciseArgumentCompression,
+            exerciseResult = exerciseResult,
+            exerciseResultCompression = exerciseResultCompression,
+            exerciseActors = ArraySeq.unsafeWrapArray(exerciseActors),
+            exerciseChildEventIds = ArraySeq.unsafeWrapArray(exerciseChildEventIds),
+            eventWitnesses = ArraySeq.unsafeWrapArray(eventWitnesses),
+          ),
+        )
+    }
+
+  val rawTreeEventParser: RowParser[EventsTable.Entry[Raw.TreeEvent]] =
+    createdTreeEventParser | exercisedTreeEventParser
+
+  private val selectColumns = Seq(
+    "event_offset",
+    "transaction_id",
+    "node_index",
+    "event_sequential_id",
+    "participant_events.event_id",
+    "contract_id",
+    "ledger_effective_time",
+    "template_id",
+    "workflow_id",
+    "create_argument",
+    "create_argument_compression",
+    "create_signatories",
+    "create_observers",
+    "create_agreement_text",
+    "create_key_value",
+    "create_key_value_compression",
+    "exercise_choice",
+    "exercise_argument",
+    "exercise_argument_compression",
+    "exercise_result",
+    "exercise_result_compression",
+    "exercise_actors",
+    "exercise_child_event_ids",
+  ).mkString(", ")
+
+  def prepareLookupTransactionTreeById(sqlFunctions: SqlFunctions)(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  ): SimpleSql[Row] =
+    route(requestingParties)(
+      single = singlePartyLookup(sqlFunctions)(transactionId, _),
+      multi = multiPartyLookup(sqlFunctions)(transactionId, _),
+    )
+
+  private def singlePartyLookup(sqlFunctions: SqlFunctions)(
+      transactionId: TransactionId,
+      requestingParty: Party,
+  ): SimpleSql[Row] = {
+    val witnessesWhereClause =
+      sqlFunctions.arrayIntersectionWhereClause("tree_event_witnesses", requestingParty)
+    SQL"""select #$selectColumns, array[$requestingParty] as event_witnesses,
+                 event_kind = 20 as exercise_consuming,
+                 case when submitters = array[$requestingParty]::text[] then command_id else '' end as command_id
+          from participant_events
+          join parameters on
+              (participant_pruned_up_to_inclusive is null or event_offset > participant_pruned_up_to_inclusive)
+              and event_offset <= ledger_end
+          where transaction_id = $transactionId and #$witnessesWhereClause and event_kind != 0 -- we do not want to fetch divulgence events
+          order by node_index asc"""
+  }
+
+  private def multiPartyLookup(sqlFunctions: SqlFunctions)(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  ): SimpleSql[Row] = {
+    val witnessesWhereClause =
+      sqlFunctions.arrayIntersectionWhereClause("tree_event_witnesses", requestingParties)
+    val filteredWitnesses =
+      sqlFunctions.arrayIntersectionValues("tree_event_witnesses", requestingParties)
+    val submittersInPartiesClause =
+      sqlFunctions.arrayIntersectionWhereClause("submitters", requestingParties)
+    SQL"""select #$selectColumns, #$filteredWitnesses as event_witnesses,
+                 event_kind = 20 as exercise_consuming,
+                 case when #$submittersInPartiesClause then command_id else '' end as command_id
+          from participant_events
+          join parameters on
+              (participant_pruned_up_to_inclusive is null or event_offset > participant_pruned_up_to_inclusive)
+              and event_offset <= ledger_end
+          where transaction_id = $transactionId and #$witnessesWhereClause and event_kind != 0 -- we do not want to fetch divulgence events
+          order by node_index asc"""
+  }
+
+  def preparePagedGetTransactionTrees(sqlFunctions: SqlFunctions)(
+      eventsRange: EventsRange[Long],
+      requestingParties: Set[Party],
+      pageSize: Int,
+  ): SqlSequence[Vector[EventsTable.Entry[Raw.TreeEvent]]] =
+    route(requestingParties)(
+      single = singlePartyTrees(sqlFunctions)(eventsRange, _, pageSize),
+      multi = multiPartyTrees(sqlFunctions)(eventsRange, _, pageSize),
+    )
+
+  private def singlePartyTrees(sqlFunctions: SqlFunctions)(
+      range: EventsRange[Long],
+      requestingParty: Party,
+      pageSize: Int,
+  ): SqlSequence[Vector[EventsTable.Entry[Raw.TreeEvent]]] = {
+    val witnessesWhereClause =
+      sqlFunctions.arrayIntersectionWhereClause("tree_event_witnesses", requestingParty)
+    EventsRange.readPage(
+      read = (range, limitExpr) => SQL"""
+        select #$selectColumns, array[$requestingParty] as event_witnesses,
+               event_kind = 20 as exercise_consuming,
+               case when submitters = array[$requestingParty]::text[] then command_id else '' end as command_id
+        from participant_events
+        where event_sequential_id > ${range.startExclusive}
+              and event_sequential_id <= ${range.endInclusive}
+              and #$witnessesWhereClause
+              and event_kind != 0 -- we do not want to fetch divulgence events
+        order by event_sequential_id #$limitExpr""",
+      rawTreeEventParser,
+      range,
+      pageSize,
+    )
+  }
+
+  private def multiPartyTrees(sqlFunctions: SqlFunctions)(
+      range: EventsRange[Long],
+      requestingParties: Set[Party],
+      pageSize: Int,
+  ): SqlSequence[Vector[EventsTable.Entry[Raw.TreeEvent]]] = {
+    val witnessesWhereClause =
+      sqlFunctions.arrayIntersectionWhereClause("tree_event_witnesses", requestingParties)
+    val filteredWitnesses =
+      sqlFunctions.arrayIntersectionValues("tree_event_witnesses", requestingParties)
+    val submittersInPartiesClause =
+      sqlFunctions.arrayIntersectionWhereClause("submitters", requestingParties)
+    EventsRange.readPage(
+      read = (range, limitExpr) => SQL"""
+        select #$selectColumns, #$filteredWitnesses as event_witnesses,
+               event_kind = 20 as exercise_consuming,
+               case when #$submittersInPartiesClause then command_id else '' end as command_id
+        from participant_events
+        where event_sequential_id > ${range.startExclusive}
+              and event_sequential_id <= ${range.endInclusive}
+              and #$witnessesWhereClause
+              and event_kind != 0 -- we do not want to fetch divulgence events
+        order by event_sequential_id #$limitExpr""",
+      rawTreeEventParser,
+      range,
+      pageSize,
+    )
+  }
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
@@ -1,0 +1,402 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.io.InputStream
+
+import com.daml.caching
+import com.daml.ledger.EventId
+import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
+import com.daml.ledger.api.v1.value.{
+  Record => ApiRecord,
+  Value => ApiValue,
+  Identifier => ApiIdentifier,
+}
+import com.daml.lf.engine.ValueEnricher
+import com.daml.lf.{engine => LfEngine}
+import com.daml.lf.value.Value.VersionedValue
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.packages.DeduplicatingPackageLoader
+import com.daml.platform.participant.util.LfEngineToApi
+import com.daml.platform.store.appendonlydao.events.{
+  ChoiceName => LfChoiceName,
+  PackageId => LfPackageId,
+  Identifier => LfIdentifier,
+  QualifiedName => LfQualifiedName,
+  DottedName => LfDottedName,
+  ModuleName => LfModuleName,
+  Value => LfValue,
+}
+import com.daml.platform.store.serialization.{Compression, ValueSerializer}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+final class LfValueTranslation(
+    val cache: LfValueTranslation.Cache,
+    metrics: Metrics,
+    enricherO: Option[LfEngine.ValueEnricher],
+    loadPackage: (
+        LfPackageId,
+        LoggingContext,
+    ) => Future[Option[com.daml.daml_lf_dev.DamlLf.Archive]],
+) {
+
+  private[this] val packageLoader = new DeduplicatingPackageLoader()
+
+  private def cantSerialize(attribute: String, forContract: ContractId): String =
+    s"Cannot serialize $attribute for ${forContract.coid}"
+
+  private def serializeCreateArgOrThrow(
+      contractId: ContractId,
+      arg: VersionedValue[ContractId],
+  ): Array[Byte] =
+    ValueSerializer.serializeValue(
+      value = arg,
+      errorContext = cantSerialize(attribute = "create argument", forContract = contractId),
+    )
+
+  private def serializeCreateArgOrThrow(c: Create): Array[Byte] =
+    serializeCreateArgOrThrow(c.coid, c.versionedCoinst.arg)
+
+  private def serializeNullableKeyOrThrow(c: Create): Option[Array[Byte]] =
+    c.versionedKey.map(k =>
+      ValueSerializer.serializeValue(
+        value = k.key,
+        errorContext = cantSerialize(attribute = "key", forContract = c.coid),
+      )
+    )
+
+  private def serializeExerciseArgOrThrow(e: Exercise): Array[Byte] =
+    ValueSerializer.serializeValue(
+      value = e.versionedChosenValue,
+      errorContext = cantSerialize(attribute = "exercise argument", forContract = e.targetCoid),
+    )
+
+  private def serializeNullableExerciseResultOrThrow(e: Exercise): Option[Array[Byte]] =
+    e.versionedExerciseResult.map(exerciseResult =>
+      ValueSerializer.serializeValue(
+        value = exerciseResult,
+        errorContext = cantSerialize(attribute = "exercise result", forContract = e.targetCoid),
+      )
+    )
+
+  def serialize(
+      contractId: ContractId,
+      contractArgument: VersionedValue[ContractId],
+  ): Array[Byte] = {
+    cache.contracts.put(
+      key = LfValueTranslation.ContractCache.Key(contractId),
+      value = LfValueTranslation.ContractCache.Value(contractArgument),
+    )
+    serializeCreateArgOrThrow(contractId, contractArgument)
+  }
+
+  def serialize(eventId: EventId, create: Create): (Array[Byte], Option[Array[Byte]]) = {
+    cache.events.put(
+      key = LfValueTranslation.EventCache.Key(eventId),
+      value = LfValueTranslation.EventCache.Value
+        .Create(create.versionedCoinst.arg, create.versionedKey.map(_.key)),
+    )
+    cache.contracts.put(
+      key = LfValueTranslation.ContractCache.Key(create.coid),
+      value = LfValueTranslation.ContractCache.Value(create.versionedCoinst.arg),
+    )
+    (serializeCreateArgOrThrow(create), serializeNullableKeyOrThrow(create))
+  }
+
+  def serialize(eventId: EventId, exercise: Exercise): (Array[Byte], Option[Array[Byte]]) = {
+    cache.events.put(
+      key = LfValueTranslation.EventCache.Key(eventId),
+      value = LfValueTranslation.EventCache.Value
+        .Exercise(exercise.versionedChosenValue, exercise.versionedExerciseResult),
+    )
+    (serializeExerciseArgOrThrow(exercise), serializeNullableExerciseResultOrThrow(exercise))
+  }
+
+  private[this] def consumeEnricherResult[V](
+      result: LfEngine.Result[V]
+  )(implicit
+      ec: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[V] = {
+    result match {
+      case LfEngine.ResultDone(r) => Future.successful(r)
+      case LfEngine.ResultError(e) => Future.failed(new RuntimeException(e.msg))
+      case LfEngine.ResultNeedPackage(packageId, resume) =>
+        packageLoader
+          .loadPackage(
+            packageId = packageId,
+            delegate = packageId => loadPackage(packageId, loggingContext),
+            metric = metrics.daml.index.db.translation.getLfPackage,
+          )
+          .flatMap(pkgO => consumeEnricherResult(resume(pkgO)))
+      case result =>
+        Future.failed(new RuntimeException(s"Unexpected ValueEnricher result: $result"))
+    }
+  }
+
+  private[this] def toApiValue(
+      value: LfValue,
+      verbose: Boolean,
+      attribute: => String,
+      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value[ContractId]],
+  )(implicit
+      ec: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[ApiValue] = for {
+    enrichedValue <-
+      if (verbose)
+        consumeEnricherResult(enrich(value))
+      else
+        Future.successful(value.value)
+  } yield {
+    LfEngineToApi.assertOrRuntimeEx(
+      failureContext = s"attempting to deserialize persisted $attribute to value",
+      LfEngineToApi
+        .lfValueToApiValue(
+          verbose = verbose,
+          value0 = enrichedValue,
+        ),
+    )
+  }
+
+  private[this] def toApiRecord(
+      value: LfValue,
+      verbose: Boolean,
+      attribute: => String,
+      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value[ContractId]],
+  )(implicit
+      ec: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[ApiRecord] = for {
+    enrichedValue <-
+      if (verbose)
+        consumeEnricherResult(enrich(value))
+      else
+        Future.successful(value.value)
+  } yield {
+    LfEngineToApi.assertOrRuntimeEx(
+      failureContext = s"attempting to deserialize persisted $attribute to record",
+      LfEngineToApi
+        .lfValueToApiRecord(
+          verbose = verbose,
+          recordValue = enrichedValue,
+        ),
+    )
+  }
+
+  private[this] def apiIdentifierToDamlLfIdentifier(id: ApiIdentifier): LfIdentifier =
+    LfIdentifier(
+      LfPackageId.assertFromString(id.packageId),
+      LfQualifiedName(
+        LfModuleName.assertFromString(id.moduleName),
+        LfDottedName.assertFromString(id.entityName),
+      ),
+    )
+
+  private def eventKey(s: String) = LfValueTranslation.EventCache.Key(EventId.assertFromString(s))
+
+  private def decompressAndDeserialize(algorithm: Compression.Algorithm, value: InputStream) =
+    ValueSerializer.deserializeValue(algorithm.decompress(value))
+
+  private[this] def enricher: ValueEnricher = {
+    // Note: LfValueTranslation is used by JdbcLedgerDao for both serialization and deserialization.
+    // Sometimes the JdbcLedgerDao is used in a way that it never needs to deserialize data in verbose mode
+    // (e.g., the indexer, or some tests). In this case, the enricher is not required.
+    enricherO.getOrElse(
+      sys.error(
+        "LfValueTranslation used to deserialize values in verbose mode without a ValueEnricher"
+      )
+    )
+  }
+
+  def deserialize[E](
+      raw: Raw.Created[E],
+      verbose: Boolean,
+  )(implicit
+      ec: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[CreatedEvent] = {
+    // Load the deserialized contract argument and contract key from the cache
+    // This returns the values in DAML-LF format.
+    val create =
+      cache.events
+        .getIfPresent(eventKey(raw.partial.eventId))
+        .getOrElse(
+          LfValueTranslation.EventCache.Value.Create(
+            argument = decompressAndDeserialize(raw.createArgumentCompression, raw.createArgument),
+            key = raw.createKeyValue.map(decompressAndDeserialize(raw.createKeyValueCompression, _)),
+          )
+        )
+        .assertCreate()
+
+    lazy val templateId: LfIdentifier = apiIdentifierToDamlLfIdentifier(raw.partial.templateId.get)
+
+    // Convert DAML-LF values to ledger API values.
+    // In verbose mode, this involves loading DAML-LF packages and filling in missing type information.
+    for {
+      createArguments <- toApiRecord(
+        value = create.argument,
+        verbose = verbose,
+        attribute = "create argument",
+        enrich = value => enricher.enrichContract(templateId, value.value),
+      )
+      contractKey <- create.key match {
+        case Some(key) =>
+          toApiValue(
+            value = key,
+            verbose = verbose,
+            attribute = "create key",
+            enrich = value => enricher.enrichContractKey(templateId, value.value),
+          ).map(Some(_))
+        case None => Future.successful(None)
+      }
+    } yield {
+      raw.partial.copy(
+        createArguments = Some(createArguments),
+        contractKey = contractKey,
+      )
+    }
+  }
+
+  def deserialize(
+      raw: Raw.TreeEvent.Exercised,
+      verbose: Boolean,
+  )(implicit
+      ec: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[ExercisedEvent] = {
+    // Load the deserialized choice argument and choice result from the cache
+    // This returns the values in DAML-LF format.
+    val exercise =
+      cache.events
+        .getIfPresent(eventKey(raw.partial.eventId))
+        .getOrElse(
+          LfValueTranslation.EventCache.Value.Exercise(
+            argument =
+              decompressAndDeserialize(raw.exerciseArgumentCompression, raw.exerciseArgument),
+            result =
+              raw.exerciseResult.map(decompressAndDeserialize(raw.exerciseResultCompression, _)),
+          )
+        )
+        .assertExercise()
+
+    lazy val templateId: LfIdentifier = apiIdentifierToDamlLfIdentifier(raw.partial.templateId.get)
+    lazy val choiceName: LfChoiceName = LfChoiceName.assertFromString(raw.partial.choice)
+
+    // Convert DAML-LF values to ledger API values.
+    // In verbose mode, this involves loading DAML-LF packages and filling in missing type information.
+    for {
+      choiceArgument <- toApiValue(
+        value = exercise.argument,
+        verbose = verbose,
+        attribute = "exercise argument",
+        enrich = value => enricher.enrichChoiceArgument(templateId, choiceName, value.value),
+      )
+      exerciseResult <- exercise.result match {
+        case Some(result) =>
+          toApiValue(
+            value = result,
+            verbose = verbose,
+            attribute = "exercise result",
+            enrich = value => enricher.enrichChoiceResult(templateId, choiceName, value.value),
+          ).map(Some(_))
+        case None => Future.successful(None)
+      }
+    } yield {
+      raw.partial.copy(
+        choiceArgument = Some(choiceArgument),
+        exerciseResult = exerciseResult,
+      )
+    }
+  }
+}
+
+object LfValueTranslation {
+
+  final case class Cache(events: EventCache, contracts: ContractCache)
+  type EventCache = caching.Cache[EventCache.Key, EventCache.Value]
+  type ContractCache = caching.Cache[ContractCache.Key, ContractCache.Value]
+
+  object Cache {
+
+    def none: Cache = Cache(caching.Cache.none, caching.Cache.none)
+
+    def newInstance(
+        eventConfiguration: caching.SizedCache.Configuration,
+        contractConfiguration: caching.SizedCache.Configuration,
+    ): Cache =
+      Cache(
+        events = EventCache.newInstance(eventConfiguration),
+        contracts = ContractCache.newInstance(contractConfiguration),
+      )
+
+    def newInstrumentedInstance(
+        eventConfiguration: caching.SizedCache.Configuration,
+        contractConfiguration: caching.SizedCache.Configuration,
+        metrics: Metrics,
+    ): Cache =
+      Cache(
+        events = EventCache.newInstrumentedInstance(eventConfiguration, metrics),
+        contracts = ContractCache.newInstrumentedInstance(contractConfiguration, metrics),
+      )
+  }
+
+  object EventCache {
+
+    def newInstance(configuration: caching.SizedCache.Configuration): EventCache =
+      caching.SizedCache.from(configuration)
+
+    def newInstrumentedInstance(
+        configuration: caching.SizedCache.Configuration,
+        metrics: Metrics,
+    ): EventCache =
+      caching.SizedCache.from(
+        configuration = configuration,
+        metrics = metrics.daml.index.db.translation.cache,
+      )
+
+    final class UnexpectedTypeException(value: Value)
+        extends RuntimeException(s"Unexpected value $value")
+
+    final case class Key(eventId: EventId)
+
+    sealed abstract class Value {
+      def assertCreate(): Value.Create
+      def assertExercise(): Value.Exercise
+    }
+
+    object Value {
+      final case class Create(argument: LfValue, key: Option[LfValue]) extends Value {
+        override def assertCreate(): Create = this
+        override def assertExercise(): Exercise = throw new UnexpectedTypeException(this)
+      }
+      final case class Exercise(argument: LfValue, result: Option[LfValue]) extends Value {
+        override def assertCreate(): Create = throw new UnexpectedTypeException(this)
+        override def assertExercise(): Exercise = this
+      }
+    }
+
+  }
+
+  object ContractCache {
+
+    def newInstance(configuration: caching.SizedCache.Configuration): ContractCache =
+      caching.SizedCache.from(configuration)
+
+    def newInstrumentedInstance(
+        configuration: caching.SizedCache.Configuration,
+        metrics: Metrics,
+    ): ContractCache =
+      caching.SizedCache.from(
+        configuration = configuration,
+        metrics = metrics.daml.index.db.translation.cache,
+      )
+
+    final case class Key(contractId: ContractId)
+
+    final case class Value(argument: LfValue)
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/PostCommitValidation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/PostCommitValidation.scala
@@ -1,0 +1,262 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.sql.Connection
+import java.time.Instant
+
+import com.daml.ledger.participant.state.v1.{CommittedTransaction, RejectionReason}
+
+/** Performs post-commit validation on transactions for Sandbox Classic.
+  * This is intended exclusively as a temporary replacement for
+  * [[com.daml.platform.store.ActiveLedgerState]] and [[com.daml.platform.store.ActiveLedgerStateManager]]
+  * so that the old post-commit validation backed by the old participant schema can be
+  * dropped and the DAML-on-X-backed implementation of the Sandbox can skip it entirely.
+  *
+  * Post-commit validation is relevant for three reasons:
+  * - keys can be referenced by two concurrent interpretations, potentially leading to
+  *   either create nodes with duplicate active keys or lookup-by-key nodes referring to
+  *   inactive keys
+  * - contracts may have been consumed by a concurrent interpretation, potentially leading
+  *   to double spends
+  * - the transaction's ledger effective time is determined after interpretation,
+  *   meaning that causal monotonicity cannot be verified while interpreting a command
+  */
+private[appendonlydao] sealed trait PostCommitValidation {
+
+  def validate(
+      transaction: CommittedTransaction,
+      transactionLedgerEffectiveTime: Instant,
+      divulged: Set[ContractId],
+  )(implicit connection: Connection): Option[RejectionReason]
+
+}
+
+private[appendonlydao] object PostCommitValidation {
+
+  /** Accept unconditionally a transaction.
+    *
+    * Designed to be used by a ledger integration that
+    * already performs post-commit validation.
+    */
+  object Skip extends PostCommitValidation {
+    @inline override def validate(
+        committedTransaction: CommittedTransaction,
+        transactionLedgerEffectiveTime: Instant,
+        divulged: Set[ContractId],
+    )(implicit connection: Connection): Option[RejectionReason] =
+      None
+  }
+
+  final class BackedBy(data: PostCommitValidationData, validatePartyAllocation: Boolean)
+      extends PostCommitValidation {
+
+    def validate(
+        transaction: CommittedTransaction,
+        transactionLedgerEffectiveTime: Instant,
+        divulged: Set[ContractId],
+    )(implicit connection: Connection): Option[RejectionReason] = {
+
+      val causalMonotonicityViolation =
+        validateCausalMonotonicity(transaction, transactionLedgerEffectiveTime, divulged)
+
+      val invalidKeyUsage = validateKeyUsages(transaction)
+
+      val unallocatedParties =
+        if (validatePartyAllocation)
+          validateParties(transaction)
+        else
+          None
+
+      unallocatedParties.orElse(invalidKeyUsage.orElse(causalMonotonicityViolation))
+    }
+
+    /** Do all exercise, fetch and lookup-by-key nodes
+      * 1. exist, and
+      * 2. refer exclusively to contracts with a ledger effective time smaller than or equal to the transaction's?
+      */
+    private def validateCausalMonotonicity(
+        transaction: CommittedTransaction,
+        transactionLedgerEffectiveTime: Instant,
+        divulged: Set[ContractId],
+    )(implicit connection: Connection): Option[RejectionReason] = {
+      val referredContracts = collectReferredContracts(transaction, divulged)
+      if (referredContracts.isEmpty) {
+        None
+      } else {
+        data
+          .lookupMaximumLedgerTime(referredContracts)
+          .map(validateCausalMonotonicity(_, transactionLedgerEffectiveTime))
+          .getOrElse(Some(UnknownContract))
+      }
+    }
+
+    private def validateCausalMonotonicity(
+        maximumLedgerEffectiveTime: Option[Instant],
+        transactionLedgerEffectiveTime: Instant,
+    ): Option[RejectionReason] =
+      maximumLedgerEffectiveTime
+        .filter(_.isAfter(transactionLedgerEffectiveTime))
+        .fold(Option.empty[RejectionReason])(contractLedgerEffectiveTime => {
+          Some(
+            CausalMonotonicityViolation(
+              contractLedgerEffectiveTime = contractLedgerEffectiveTime,
+              transactionLedgerEffectiveTime = transactionLedgerEffectiveTime,
+            )
+          )
+        })
+
+    private def validateParties(
+        transaction: CommittedTransaction
+    )(implicit connection: Connection): Option[RejectionReason] = {
+      def foldInformees[T](tx: CommittedTransaction, init: T)(
+          f: (T, String) => T
+      ): T =
+        tx.fold(init) { case (accum, (_, node)) =>
+          node.informeesOfNode.foldLeft(accum)(f)
+        }
+
+      val informees = foldInformees(transaction, Seq.empty[Party]) { (informeesSoFar, partyId) =>
+        Party.assertFromString(partyId) +: informeesSoFar
+      }
+      val allocatedInformees = data.lookupParties(informees).map(_.party)
+      if (allocatedInformees.toSet == informees.toSet)
+        None
+      else
+        Some(RejectionReason.PartyNotKnownOnLedger("Some parties are unallocated"))
+    }
+
+    private def collectReferredContracts(
+        transaction: CommittedTransaction,
+        divulged: Set[ContractId],
+    ): Set[ContractId] = {
+      val (createdInTransaction, referred) =
+        transaction.fold((Set.empty[ContractId], Set.empty[ContractId])) {
+          case ((created, ids), (_, c: Create)) =>
+            (created + c.coid, ids)
+          case ((created, ids), (_, e: Exercise)) if !divulged(e.targetCoid) =>
+            (created, ids + e.targetCoid)
+          case ((created, ids), (_, f: Fetch)) if !divulged(f.coid) =>
+            (created, ids + f.coid)
+          case ((created, ids), (_, l: LookupByKey)) =>
+            (created, l.result.filterNot(divulged).fold(ids)(ids + _))
+          case ((created, ids), _) => (created, ids)
+        }
+      referred.diff(createdInTransaction)
+    }
+
+    private def validateKeyUsages(
+        transaction: CommittedTransaction
+    )(implicit connection: Connection): Option[RejectionReason] =
+      transaction
+        .fold[Result](Right(State.empty(data))) {
+          case (Right(state), (_, node)) => validateKeyUsages(node, state)
+          case (rejection, _) => rejection
+        }
+        .fold(Some(_), _ => None)
+
+    private def validateKeyUsages(
+        node: Node,
+        state: State,
+    )(implicit connection: Connection): Either[RejectionReason, State] =
+      node match {
+        case c: Create =>
+          state.validateCreate(c.versionedKey.map(convert(c.versionedCoinst.template, _)), c.coid)
+        case l: LookupByKey =>
+          state.validateLookupByKey(convert(l.templateId, l.versionedKey), l.result)
+        case e: Exercise if e.consuming =>
+          state.removeKeyIfDefined(e.versionedKey.map(convert(e.templateId, _)))
+        case _ =>
+          // fetch and non-consuming exercise nodes don't need to validate
+          // anything with regards to contract keys and do not alter the
+          // state in a way which is relevant for the validation of
+          // subsequent nodes
+          Right(state)
+      }
+
+  }
+
+  private type Result = Either[RejectionReason, State]
+
+  /** Represents the state of an ongoing validation.
+    * It must be carried over as the transaction is
+    * validated one node at a time in pre-order
+    * traversal for this to make sense.
+    *
+    * @param contracts All contracts created as part of the current transaction
+    * @param removed Ensures indexed contracts are not referred to by key if they are removed in the current transaction
+    * @param data Data about committed contracts for post-commit validation purposes
+    */
+  private final case class State(
+      private val contracts: Map[Hash, ContractId],
+      private val removed: Set[Hash],
+      private val data: PostCommitValidationData,
+  ) {
+
+    def validateCreate(maybeKey: Option[Key], id: ContractId)(implicit
+        connection: Connection
+    ): Either[RejectionReason, State] =
+      maybeKey.fold[Result](Right(this)) { key =>
+        lookup(key).fold[Result](Right(add(key, id)))(_ => Left(DuplicateKey))
+      }
+
+    // `causalMonotonicity` already reports unknown contracts, no need to check it here
+    def removeKeyIfDefined(maybeKey: Option[Key]): Right[RejectionReason, State] =
+      Right(maybeKey.fold(this)(remove))
+
+    def validateLookupByKey(key: Key, expectation: Option[ContractId])(implicit
+        connection: Connection
+    ): Either[RejectionReason, State] = {
+      val result = lookup(key)
+      if (result == expectation) Right(this)
+      else Left(MismatchingLookup(expectation, result))
+    }
+
+    private def add(key: Key, id: ContractId): State =
+      copy(
+        contracts = contracts.updated(key.hash, id),
+        removed = removed - key.hash,
+      )
+
+    private def remove(key: Key): State =
+      copy(
+        contracts = contracts - key.hash,
+        removed = removed + key.hash,
+      )
+
+    private def lookup(key: Key)(implicit connection: Connection): Option[ContractId] =
+      contracts.get(key.hash).orElse {
+        if (removed(key.hash)) None
+        else data.lookupContractKeyGlobally(key)
+      }
+
+  }
+
+  private object State {
+    def empty(data: PostCommitValidationData): State =
+      State(Map.empty, Set.empty, data)
+  }
+
+  private[events] val DuplicateKey: RejectionReason =
+    RejectionReason.Inconsistent("DuplicateKey: contract key is not unique")
+
+  private[events] def MismatchingLookup(
+      expectation: Option[ContractId],
+      result: Option[ContractId],
+  ): RejectionReason =
+    RejectionReason.Inconsistent(
+      s"Contract key lookup with different results: expected [$expectation], actual [$result]"
+    )
+
+  private[events] val UnknownContract: RejectionReason =
+    RejectionReason.Inconsistent("Unknown contract")
+
+  private[events] def CausalMonotonicityViolation(
+      contractLedgerEffectiveTime: Instant,
+      transactionLedgerEffectiveTime: Instant,
+  ): RejectionReason =
+    RejectionReason.InvalidLedgerTime(
+      s"Encountered contract with LET [$contractLedgerEffectiveTime] greater than the LET of the transaction [$transactionLedgerEffectiveTime]"
+    )
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/PostCommitValidationData.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/PostCommitValidationData.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.sql.Connection
+import java.time.Instant
+
+import com.daml.ledger.api.domain.PartyDetails
+
+import scala.util.Try
+
+private[events] trait PostCommitValidationData {
+
+  def lookupContractKeyGlobally(key: Key)(implicit connection: Connection): Option[ContractId]
+
+  def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
+      connection: Connection
+  ): Try[Option[Instant]]
+
+  def lookupParties(parties: Seq[Party])(implicit connection: Connection): List[PartyDetails]
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/QueryNonPruned.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/QueryNonPruned.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.sql.Connection
+
+import anorm.SQL
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.platform.server.api.validation.ErrorFactories
+import com.daml.platform.store.Conversions.offset
+
+object QueryNonPruned {
+
+  /** Runs a query and throws an error if the query accesses pruned offsets.
+    *
+    * @param query              query to execute
+    * @param minOffsetExclusive minimum, exclusive offset used by the query (i.e. all fetched offsets are larger)
+    * @param error              function that generates a context-specific error parameterized by participant pruning offset
+    * @tparam T type of result passed through
+    * @return either a PrunedLedgerOffsetNoLongerAvailable if pruned offset access attempt has occurred or query result
+    *
+    * Note in order to prevent race condition on connections at READ_COMMITTED isolation levels
+    * (in fact any level below SNAPSHOT isolation level), this check must be performed after
+    * fetching the corresponding range of data. This way we avoid a race between pruning and
+    * the query reading the offsets in which offsets are "silently skipped". First fetching
+    * the objects and only afterwards checking that no pruning operation has interfered, avoids
+    * such a race condition.
+    */
+  def executeSql[T](query: => T, minOffsetExclusive: Offset, error: Offset => String)(implicit
+      conn: Connection
+  ): Either[Throwable, T] = {
+    val result = query
+
+    SQL_SELECT_MOST_RECENT_PRUNING
+      .as(offset("participant_pruned_up_to_inclusive").?.single)
+      .fold(Right(result): Either[Throwable, T])(pruningOffsetUpToInclusive =>
+        Either.cond(
+          minOffsetExclusive >= pruningOffsetUpToInclusive,
+          result,
+          ErrorFactories.participantPrunedDataAccessed(error(pruningOffsetUpToInclusive)),
+        )
+      )
+  }
+
+  def executeSqlOrThrow[T](query: => T, minOffsetExclusive: Offset, error: Offset => String)(
+      implicit conn: Connection
+  ): T =
+    executeSql(query, minOffsetExclusive, error).fold(throw _, identity)
+
+  private val SQL_SELECT_MOST_RECENT_PRUNING = SQL(
+    "select participant_pruned_up_to_inclusive from parameters"
+  )
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/Raw.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/Raw.scala
@@ -1,0 +1,291 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.io.InputStream
+
+import com.daml.ledger.api.v1.event.{
+  ArchivedEvent => PbArchivedEvent,
+  CreatedEvent => PbCreatedEvent,
+  Event => PbFlatEvent,
+  ExercisedEvent => PbExercisedEvent,
+}
+import com.daml.ledger.api.v1.transaction.{TreeEvent => PbTreeEvent}
+import com.daml.logging.LoggingContext
+import com.daml.platform.participant.util.LfEngineToApi
+import com.daml.platform.store.serialization.Compression
+
+import scala.collection.compat.immutable.ArraySeq
+import scala.concurrent.{ExecutionContext, Future}
+
+/** An event as it's fetched from the participant index, before
+  * the deserialization the values contained therein. Allows to
+  * wrap events from the database while delaying deserialization
+  * so that it doesn't happen on the database thread pool.
+  */
+private[events] sealed trait Raw[+E] {
+
+  /** Fill the blanks left in the raw event by running
+    * the deserialization on contained values.
+    *
+    * @param lfValueTranslation The delegate in charge of applying deserialization
+    * @param verbose If true, field names of records will be included
+    */
+  def applyDeserialization(
+      lfValueTranslation: LfValueTranslation,
+      verbose: Boolean,
+  )(implicit
+      ec: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[E]
+
+}
+
+private[events] object Raw {
+
+  /** Since created events can be both a flat event or a tree event
+    * we share common code between the two variants here. What's left
+    * out is wrapping the result in the proper envelope.
+    */
+  private[events] sealed abstract class Created[E](
+      val partial: PbCreatedEvent,
+      val createArgument: InputStream,
+      val createArgumentCompression: Compression.Algorithm,
+      val createKeyValue: Option[InputStream],
+      val createKeyValueCompression: Compression.Algorithm,
+  ) extends Raw[E] {
+    protected def wrapInEvent(event: PbCreatedEvent): E
+
+    final override def applyDeserialization(
+        lfValueTranslation: LfValueTranslation,
+        verbose: Boolean,
+    )(implicit
+        ec: ExecutionContext,
+        loggingContext: LoggingContext,
+    ): Future[E] =
+      lfValueTranslation.deserialize(this, verbose).map(wrapInEvent)
+  }
+
+  private object Created {
+    def apply(
+        eventId: String,
+        contractId: String,
+        templateId: Identifier,
+        createSignatories: ArraySeq[String],
+        createObservers: ArraySeq[String],
+        createAgreementText: Option[String],
+        eventWitnesses: ArraySeq[String],
+    ): PbCreatedEvent =
+      PbCreatedEvent(
+        eventId = eventId,
+        contractId = contractId,
+        templateId = Some(LfEngineToApi.toApiIdentifier(templateId)),
+        contractKey = null,
+        createArguments = null,
+        witnessParties = eventWitnesses,
+        signatories = createSignatories,
+        observers = createObservers,
+        agreementText = createAgreementText.orElse(Some("")),
+      )
+  }
+
+  sealed trait FlatEvent extends Raw[PbFlatEvent]
+
+  object FlatEvent {
+
+    final class Created private[Raw] (
+        raw: PbCreatedEvent,
+        createArgument: InputStream,
+        createArgumentCompression: Compression.Algorithm,
+        createKeyValue: Option[InputStream],
+        createKeyValueCompression: Compression.Algorithm,
+    ) extends Raw.Created[PbFlatEvent](
+          raw,
+          createArgument,
+          createArgumentCompression,
+          createKeyValue,
+          createKeyValueCompression,
+        )
+        with FlatEvent {
+      override protected def wrapInEvent(event: PbCreatedEvent): PbFlatEvent =
+        PbFlatEvent(PbFlatEvent.Event.Created(event))
+    }
+
+    object Created {
+      def apply(
+          eventId: String,
+          contractId: String,
+          templateId: Identifier,
+          createArgument: InputStream,
+          createArgumentCompression: Option[Int],
+          createSignatories: ArraySeq[String],
+          createObservers: ArraySeq[String],
+          createAgreementText: Option[String],
+          createKeyValue: Option[InputStream],
+          createKeyValueCompression: Option[Int],
+          eventWitnesses: ArraySeq[String],
+      ): Raw.FlatEvent.Created =
+        new Raw.FlatEvent.Created(
+          raw = Raw.Created(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = templateId,
+            createSignatories = createSignatories,
+            createObservers = createObservers,
+            createAgreementText = createAgreementText,
+            eventWitnesses = eventWitnesses,
+          ),
+          createArgument = createArgument,
+          createArgumentCompression = Compression.Algorithm.assertLookup(createArgumentCompression),
+          createKeyValue = createKeyValue,
+          createKeyValueCompression = Compression.Algorithm.assertLookup(createKeyValueCompression),
+        )
+    }
+
+    /** Archived events don't actually have anything to deserialize
+      */
+    final class Archived private[Raw] (
+        raw: PbArchivedEvent
+    ) extends FlatEvent {
+      override def applyDeserialization(
+          lfValueTranslation: LfValueTranslation,
+          verbose: Boolean,
+      )(implicit
+          ec: ExecutionContext,
+          loggingContext: LoggingContext,
+      ): Future[PbFlatEvent] =
+        Future.successful(PbFlatEvent(PbFlatEvent.Event.Archived(raw)))
+    }
+
+    object Archived {
+      def apply(
+          eventId: String,
+          contractId: String,
+          templateId: Identifier,
+          eventWitnesses: ArraySeq[String],
+      ): Raw.FlatEvent.Archived =
+        new Raw.FlatEvent.Archived(
+          raw = PbArchivedEvent(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = Some(LfEngineToApi.toApiIdentifier(templateId)),
+            witnessParties = eventWitnesses,
+          )
+        )
+
+    }
+
+  }
+
+  sealed trait TreeEvent extends Raw[PbTreeEvent]
+
+  object TreeEvent {
+
+    final class Created(
+        raw: PbCreatedEvent,
+        createArgument: InputStream,
+        createArgumentCompression: Compression.Algorithm,
+        createKeyValue: Option[InputStream],
+        createKeyValueCompression: Compression.Algorithm,
+    ) extends Raw.Created[PbTreeEvent](
+          raw,
+          createArgument,
+          createArgumentCompression,
+          createKeyValue,
+          createKeyValueCompression,
+        )
+        with TreeEvent {
+      override protected def wrapInEvent(event: PbCreatedEvent): PbTreeEvent =
+        PbTreeEvent(PbTreeEvent.Kind.Created(event))
+    }
+
+    object Created {
+      def apply(
+          eventId: String,
+          contractId: String,
+          templateId: Identifier,
+          createArgument: InputStream,
+          createArgumentCompression: Option[Int],
+          createSignatories: ArraySeq[String],
+          createObservers: ArraySeq[String],
+          createAgreementText: Option[String],
+          createKeyValue: Option[InputStream],
+          createKeyValueCompression: Option[Int],
+          eventWitnesses: ArraySeq[String],
+      ): Raw.TreeEvent.Created =
+        new Raw.TreeEvent.Created(
+          raw = Raw.Created(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = templateId,
+            createSignatories = createSignatories,
+            createObservers = createObservers,
+            createAgreementText = createAgreementText,
+            eventWitnesses = eventWitnesses,
+          ),
+          createArgument = createArgument,
+          createArgumentCompression = Compression.Algorithm.assertLookup(createArgumentCompression),
+          createKeyValue = createKeyValue,
+          createKeyValueCompression = Compression.Algorithm.assertLookup(createKeyValueCompression),
+        )
+    }
+
+    final class Exercised(
+        val partial: PbExercisedEvent,
+        val exerciseArgument: InputStream,
+        val exerciseArgumentCompression: Compression.Algorithm,
+        val exerciseResult: Option[InputStream],
+        val exerciseResultCompression: Compression.Algorithm,
+    ) extends TreeEvent {
+      override def applyDeserialization(
+          lfValueTranslation: LfValueTranslation,
+          verbose: Boolean,
+      )(implicit
+          ec: ExecutionContext,
+          loggingContext: LoggingContext,
+      ): Future[PbTreeEvent] =
+        lfValueTranslation
+          .deserialize(this, verbose)
+          .map(event => PbTreeEvent(PbTreeEvent.Kind.Exercised(event)))
+
+    }
+
+    object Exercised {
+      def apply(
+          eventId: String,
+          contractId: String,
+          templateId: Identifier,
+          exerciseConsuming: Boolean,
+          exerciseChoice: String,
+          exerciseArgument: InputStream,
+          exerciseArgumentCompression: Option[Int],
+          exerciseResult: Option[InputStream],
+          exerciseResultCompression: Option[Int],
+          exerciseActors: ArraySeq[String],
+          exerciseChildEventIds: ArraySeq[String],
+          eventWitnesses: ArraySeq[String],
+      ): Raw.TreeEvent.Exercised =
+        new Raw.TreeEvent.Exercised(
+          partial = PbExercisedEvent(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = Some(LfEngineToApi.toApiIdentifier(templateId)),
+            choice = exerciseChoice,
+            choiceArgument = null,
+            actingParties = exerciseActors,
+            consuming = exerciseConsuming,
+            witnessParties = eventWitnesses,
+            childEventIds = exerciseChildEventIds,
+            exerciseResult = null,
+          ),
+          exerciseArgument = exerciseArgument,
+          exerciseArgumentCompression =
+            Compression.Algorithm.assertLookup(exerciseArgumentCompression),
+          exerciseResult = exerciseResult,
+          exerciseResultCompression = Compression.Algorithm.assertLookup(exerciseResultCompression),
+        )
+    }
+  }
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/SqlFunctions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/SqlFunctions.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import com.daml.platform.store.DbType
+import com.daml.platform.store.appendonlydao.events.EventsTableQueries.format
+
+private[appendonlydao] trait SqlFunctions {
+  def arrayIntersectionWhereClause(arrayColumn: String, party: Party): String =
+    arrayIntersectionWhereClause(arrayColumn: String, Set(party))
+
+  def arrayIntersectionWhereClause(arrayColumn: String, parties: Set[Party]): String
+
+  def arrayIntersectionValues(arrayColumn: String, parties: Set[Party]): String
+}
+
+private[appendonlydao] object SqlFunctions {
+  def arrayIntersection(a: Array[String], b: Array[String]): Array[String] =
+    a.toSet.intersect(b.toSet).toArray
+
+  def apply(dbType: DbType): SqlFunctions = dbType match {
+    case DbType.Postgres => PostgresSqlFunctions
+    case DbType.H2Database => H2SqlFunctions
+  }
+
+  object PostgresSqlFunctions extends SqlFunctions {
+    override def arrayIntersectionWhereClause(arrayColumn: String, parties: Set[Party]): String =
+      s"$arrayColumn::text[] && array[${format(parties)}]::text[]"
+
+    def arrayIntersectionValues(arrayColumn: String, parties: Set[Party]): String =
+      s"array(select unnest($arrayColumn) intersect select unnest(array[${format(parties)}]))"
+  }
+
+  object H2SqlFunctions extends SqlFunctions {
+    override def arrayIntersectionWhereClause(arrayColumn: String, parties: Set[Party]): String =
+      if (parties.isEmpty)
+        "false"
+      else
+        parties.view.map(p => s"array_contains($arrayColumn, '$p')").mkString("(", " or ", ")")
+
+    def arrayIntersectionValues(arrayColumn: String, parties: Set[Party]): String =
+      s"array_intersection($arrayColumn, array[${format(parties)}])"
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/SqlSequence.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/SqlSequence.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import com.daml.platform.store.SimpleSqlAsVectorOf._
+import anorm.{ResultSetParser, Row, RowParser, SimpleSql}
+import scalaz.{-\/, Free, Functor, \/-}
+
+import java.sql.Connection
+
+object SqlSequence {
+
+  /** A sequence of `SimpleSql`s, terminating in A. */
+  type T[A] = Free[Element, A]
+
+  // this representation is just trampolined Reader, but exposing that
+  // would be unsound because it is _not_ distributive, and anyway
+  // we may want to make the representation more explicit for more complex
+  // analysis (e.g. applying polymorphic transforms to all contained SimpleSqls...)
+  final class Element[+A] private[SqlSequence] (private[SqlSequence] val run: Connection => A)
+
+  object Element {
+    implicit final class syntax[A](private val self: T[A]) extends AnyVal {
+      def executeSql(implicit conn: Connection): A = {
+        @annotation.tailrec
+        def go(self: T[A]): A =
+          self.resume match {
+            case -\/(elt) => go(elt.run(conn))
+            case \/-(a) => a
+          }
+        go(self)
+      }
+    }
+
+    implicit val covariant: Functor[Element] = new Functor[Element] {
+      override def map[A, B](fa: Element[A])(f: A => B) = new Element(run = fa.run andThen f)
+    }
+  }
+
+  def apply[A](s: SimpleSql[_], p: ResultSetParser[A]): T[A] =
+    Free liftF new Element(implicit conn => s as p)
+
+  def vector[A](s: SimpleSql[Row], p: RowParser[A]): T[Vector[A]] =
+    Free liftF new Element(implicit conn => s asVectorOf p)
+
+  def point[A](a: A): T[A] = Free point a
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionsReader.scala
@@ -1,0 +1,398 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.sql.Connection
+
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.Source
+import akka.{Done, NotUsed}
+import com.daml
+import com.daml.ledger.api.TraceIdentifiers
+import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
+import com.daml.ledger.api.v1.event.Event
+import com.daml.ledger.api.v1.transaction.TreeEvent
+import com.daml.ledger.api.v1.transaction_service.{
+  GetFlatTransactionResponse,
+  GetTransactionResponse,
+  GetTransactionTreesResponse,
+  GetTransactionsResponse,
+}
+import com.daml.ledger.participant.state.v1.{Offset, TransactionId}
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.metrics._
+import com.daml.platform.ApiOffset
+import com.daml.platform.store.DbType
+import com.daml.platform.store.SimpleSqlAsVectorOf.SimpleSqlAsVectorOf
+import com.daml.platform.store.appendonlydao.{DbDispatcher, PaginatingAsyncStream}
+import com.daml.platform.store.dao.LedgerDaoTransactionsReader
+import io.opentelemetry.api.trace.Span
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/** @param dispatcher Executes the queries prepared by this object
+  * @param executionContext Runs transformations on data fetched from the database, including DAML-LF value deserialization
+  * @param pageSize The number of events to fetch at a time the database when serving streaming calls
+  * @param lfValueTranslation The delegate in charge of translating serialized DAML-LF values
+  * @see [[PaginatingAsyncStream]]
+  */
+private[appendonlydao] final class TransactionsReader(
+    dispatcher: DbDispatcher,
+    dbType: DbType,
+    pageSize: Int,
+    metrics: Metrics,
+    lfValueTranslation: LfValueTranslation,
+)(implicit executionContext: ExecutionContext)
+    extends LedgerDaoTransactionsReader {
+
+  private val dbMetrics = metrics.daml.index.db
+
+  private val sqlFunctions = SqlFunctions(dbType)
+
+  private val logger = ContextualizedLogger.get(this.getClass)
+
+  // TransactionReader adds an Akka stream buffer at the end of all streaming queries.
+  // This significantly improves the performance of the transaction service.
+  private val outputStreamBufferSize = 128
+
+  private def offsetFor(response: GetTransactionsResponse): Offset =
+    ApiOffset.assertFromString(response.transactions.head.offset)
+
+  private def offsetFor(response: GetTransactionTreesResponse): Offset =
+    ApiOffset.assertFromString(response.transactions.head.offset)
+
+  private def deserializeEvent[E](verbose: Boolean)(entry: EventsTable.Entry[Raw[E]])(implicit
+      loggingContext: LoggingContext
+  ): Future[E] =
+    entry.event.applyDeserialization(lfValueTranslation, verbose)
+
+  private def deserializeEntry[E](verbose: Boolean)(
+      entry: EventsTable.Entry[Raw[E]]
+  )(implicit loggingContext: LoggingContext): Future[EventsTable.Entry[E]] =
+    deserializeEvent(verbose)(entry).map(event => entry.copy(event = event))
+
+  override def getFlatTransactions(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      filter: FilterRelation,
+      verbose: Boolean,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] = {
+    val span =
+      ParticipantTracer
+        .spanBuilder(
+          "com.daml.platform.store.appendonlydao.events.TransactionsReader.getFlatTransactions"
+        )
+        .setNoParent()
+        .setAttribute(SpanAttribute.OffsetFrom.key, startExclusive.toHexString)
+        .setAttribute(SpanAttribute.OffsetTo.key, endInclusive.toHexString)
+        .startSpan()
+    logger.debug(s"getFlatTransactions($startExclusive, $endInclusive, $filter, $verbose)")
+
+    val requestedRangeF = getEventSeqIdRange(startExclusive, endInclusive)
+
+    val query = (range: EventsRange[(Offset, Long)]) => {
+      implicit connection: Connection =>
+        logger.debug(s"getFlatTransactions query($range)")
+        QueryNonPruned.executeSqlOrThrow(
+          EventsTableFlatEvents
+            .preparePagedGetFlatTransactions(sqlFunctions)(
+              range = EventsRange(range.startExclusive._2, range.endInclusive._2),
+              filter = filter,
+              pageSize = pageSize,
+            )
+            .executeSql,
+          range.startExclusive._1,
+          pruned =>
+            s"Transactions request from ${range.startExclusive._1.toHexString} to ${range.endInclusive._1.toHexString} precedes pruned offset ${pruned.toHexString}",
+        )
+    }
+
+    val events: Source[EventsTable.Entry[Event], NotUsed] =
+      Source
+        .futureSource(requestedRangeF.map { requestedRange =>
+          streamEvents(
+            verbose,
+            dbMetrics.getFlatTransactions,
+            query,
+            nextPageRange[Event](requestedRange.endInclusive),
+          )(requestedRange)
+        })
+        .mapMaterializedValue(_ => NotUsed)
+
+    groupContiguous(events)(by = _.transactionId)
+      .mapConcat { events =>
+        val response = EventsTable.Entry.toGetTransactionsResponse(events)
+        response.map(r => offsetFor(r) -> r)
+      }
+      .buffer(outputStreamBufferSize, OverflowStrategy.backpressure)
+      .wireTap(_ match {
+        case (_, response) =>
+          response.transactions.foreach(txn =>
+            Spans.addEventToSpan(
+              daml.metrics.Event("transaction", TraceIdentifiers.fromTransaction(txn)),
+              span,
+            )
+          )
+      })
+      .watchTermination()(endSpanOnTermination(span))
+  }
+
+  override def lookupFlatTransactionById(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]] = {
+    val query =
+      EventsTableFlatEvents.prepareLookupFlatTransactionById(sqlFunctions)(
+        transactionId,
+        requestingParties,
+      )
+    dispatcher
+      .executeSql(dbMetrics.lookupFlatTransactionById) { implicit connection =>
+        query.asVectorOf(EventsTableFlatEvents.rawFlatEventParser)
+      }
+      .flatMap(rawEvents =>
+        Timed.value(
+          timer = dbMetrics.lookupFlatTransactionById.translationTimer,
+          value = Future.traverse(rawEvents)(deserializeEntry(verbose = true)),
+        )
+      )
+      .map(EventsTable.Entry.toGetFlatTransactionResponse)
+  }
+
+  override def getTransactionTrees(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      requestingParties: Set[Party],
+      verbose: Boolean,
+  )(implicit
+      loggingContext: LoggingContext
+  ): Source[(Offset, GetTransactionTreesResponse), NotUsed] = {
+    val span =
+      ParticipantTracer
+        .spanBuilder(
+          "com.daml.platform.store.appendonlydao.events.TransactionsReader.getTransactionTrees"
+        )
+        .setNoParent()
+        .setAttribute(SpanAttribute.OffsetFrom.key, startExclusive.toHexString)
+        .setAttribute(SpanAttribute.OffsetTo.key, endInclusive.toHexString)
+        .startSpan()
+    logger.debug(
+      s"getTransactionTrees($startExclusive, $endInclusive, $requestingParties, $verbose)"
+    )
+
+    val requestedRangeF = getEventSeqIdRange(startExclusive, endInclusive)
+
+    val query = (range: EventsRange[(Offset, Long)]) => {
+      implicit connection: Connection =>
+        logger.debug(s"getTransactionTrees query($range)")
+        QueryNonPruned.executeSqlOrThrow(
+          EventsTableTreeEvents
+            .preparePagedGetTransactionTrees(sqlFunctions)(
+              eventsRange = EventsRange(range.startExclusive._2, range.endInclusive._2),
+              requestingParties = requestingParties,
+              pageSize = pageSize,
+            )
+            .executeSql,
+          range.startExclusive._1,
+          pruned =>
+            s"Transactions request from ${range.startExclusive._1.toHexString} to ${range.endInclusive._1.toHexString} precedes pruned offset ${pruned.toHexString}",
+        )
+    }
+
+    val events: Source[EventsTable.Entry[TreeEvent], NotUsed] =
+      Source
+        .futureSource(requestedRangeF.map { requestedRange =>
+          streamEvents(
+            verbose,
+            dbMetrics.getTransactionTrees,
+            query,
+            nextPageRange[TreeEvent](requestedRange.endInclusive),
+          )(requestedRange)
+        })
+        .mapMaterializedValue(_ => NotUsed)
+
+    groupContiguous(events)(by = _.transactionId)
+      .mapConcat { events =>
+        val response = EventsTable.Entry.toGetTransactionTreesResponse(events)
+        response.map(r => offsetFor(r) -> r)
+      }
+      .buffer(outputStreamBufferSize, OverflowStrategy.backpressure)
+      .wireTap(_ match {
+        case (_, response) =>
+          response.transactions.foreach(txn =>
+            Spans.addEventToSpan(
+              daml.metrics.Event("transaction", TraceIdentifiers.fromTransactionTree(txn)),
+              span,
+            )
+          )
+      })
+      .watchTermination()(endSpanOnTermination(span))
+  }
+
+  override def lookupTransactionTreeById(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]] = {
+    val query =
+      EventsTableTreeEvents.prepareLookupTransactionTreeById(sqlFunctions)(
+        transactionId,
+        requestingParties,
+      )
+    dispatcher
+      .executeSql(dbMetrics.lookupTransactionTreeById) { implicit connection =>
+        query.asVectorOf(EventsTableTreeEvents.rawTreeEventParser)
+      }
+      .flatMap(rawEvents =>
+        Timed.value(
+          timer = dbMetrics.lookupTransactionTreeById.translationTimer,
+          value = Future.traverse(rawEvents)(deserializeEntry(verbose = true)),
+        )
+      )
+      .map(EventsTable.Entry.toGetTransactionResponse)
+  }
+
+  override def getActiveContracts(
+      activeAt: Offset,
+      filter: FilterRelation,
+      verbose: Boolean,
+  )(implicit loggingContext: LoggingContext): Source[GetActiveContractsResponse, NotUsed] = {
+    val span =
+      ParticipantTracer
+        .spanBuilder(
+          "com.daml.platform.store.appendonlydao.events.TransactionsReader.getActiveContracts"
+        )
+        .setNoParent()
+        .setAttribute(SpanAttribute.Offset.key, activeAt.toHexString)
+        .startSpan()
+    logger.debug(s"getActiveContracts($activeAt, $filter, $verbose)")
+
+    val requestedRangeF: Future[EventsRange[(Offset, Long)]] = getAcsEventSeqIdRange(activeAt)
+
+    val query = (range: EventsRange[(Offset, Long)]) => {
+      implicit connection: Connection =>
+        logger.debug(s"getActiveContracts query($range)")
+        QueryNonPruned.executeSqlOrThrow(
+          EventsTableFlatEvents
+            .preparePagedGetActiveContracts(sqlFunctions)(
+              range = range,
+              filter = filter,
+              pageSize = pageSize,
+            )
+            .executeSql,
+          activeAt,
+          pruned =>
+            s"Active contracts request after ${activeAt.toHexString} precedes pruned offset ${pruned.toHexString}",
+        )
+    }
+
+    val events: Source[EventsTable.Entry[Event], NotUsed] =
+      Source
+        .futureSource(requestedRangeF.map { requestedRange =>
+          streamEvents(
+            verbose,
+            dbMetrics.getActiveContracts,
+            query,
+            nextPageRange[Event](requestedRange.endInclusive),
+          )(requestedRange)
+        })
+        .mapMaterializedValue(_ => NotUsed)
+
+    groupContiguous(events)(by = _.transactionId)
+      .mapConcat(EventsTable.Entry.toGetActiveContractsResponse)
+      .buffer(outputStreamBufferSize, OverflowStrategy.backpressure)
+      .wireTap(response => {
+        Spans.addEventToSpan(
+          com.daml.metrics.Event("contract", Map((SpanAttribute.Offset, response.offset))),
+          span,
+        )
+      })
+      .watchTermination()(endSpanOnTermination(span))
+  }
+
+  private def nextPageRange[E](endEventSeqId: (Offset, Long))(
+      a: EventsTable.Entry[E]
+  ): EventsRange[(Offset, Long)] =
+    EventsRange(startExclusive = (a.eventOffset, a.eventSequentialId), endInclusive = endEventSeqId)
+
+  private def getAcsEventSeqIdRange(activeAt: Offset)(implicit
+      loggingContext: LoggingContext
+  ): Future[EventsRange[(Offset, Long)]] =
+    dispatcher
+      .executeSql(dbMetrics.getAcsEventSeqIdRange)(implicit connection =>
+        QueryNonPruned.executeSql(
+          EventsRange.readEventSeqIdRange(activeAt)(connection),
+          activeAt,
+          pruned =>
+            s"Active contracts request after ${activeAt.toHexString} precedes pruned offset ${pruned.toHexString}",
+        )
+      )
+      .flatMap(_.fold(Future.failed, Future.successful))
+      .map { x =>
+        EventsRange(
+          startExclusive = (Offset.beforeBegin, 0),
+          endInclusive = (activeAt, x.endInclusive),
+        )
+      }
+
+  private def getEventSeqIdRange(
+      startExclusive: Offset,
+      endInclusive: Offset,
+  )(implicit loggingContext: LoggingContext): Future[EventsRange[(Offset, Long)]] =
+    dispatcher
+      .executeSql(dbMetrics.getEventSeqIdRange)(implicit connection =>
+        QueryNonPruned.executeSql(
+          EventsRange.readEventSeqIdRange(EventsRange(startExclusive, endInclusive))(connection),
+          startExclusive,
+          pruned =>
+            s"Transactions request from ${startExclusive.toHexString} to ${endInclusive.toHexString} precedes pruned offset ${pruned.toHexString}",
+        )
+      )
+      .flatMap(
+        _.fold(
+          Future.failed,
+          x =>
+            Future.successful(
+              EventsRange(
+                startExclusive = (startExclusive, x.startExclusive),
+                endInclusive = (endInclusive, x.endInclusive),
+              )
+            ),
+        )
+      )
+
+  private def streamEvents[A: Ordering, E](
+      verbose: Boolean,
+      queryMetric: DatabaseMetrics,
+      query: EventsRange[A] => Connection => Vector[EventsTable.Entry[Raw[E]]],
+      getNextPageRange: EventsTable.Entry[E] => EventsRange[A],
+  )(range: EventsRange[A])(implicit
+      loggingContext: LoggingContext
+  ): Source[EventsTable.Entry[E], NotUsed] =
+    PaginatingAsyncStream.streamFrom(range, getNextPageRange) { range1 =>
+      if (EventsRange.isEmpty(range1))
+        Future.successful(Vector.empty)
+      else {
+        val rawEvents: Future[Vector[EventsTable.Entry[Raw[E]]]] =
+          dispatcher.executeSql(queryMetric)(query(range1))
+        rawEvents.flatMap(es =>
+          Timed.future(
+            future = Future.traverse(es)(deserializeEntry(verbose)),
+            timer = queryMetric.translationTimer,
+          )
+        )
+      }
+    }
+
+  private def endSpanOnTermination[Mat, Out](span: Span)(mat: Mat, done: Future[Done]): Mat = {
+    done.onComplete {
+      case Failure(exception) =>
+        span.recordException(exception)
+        span.end()
+      case Success(_) =>
+        span.end()
+    }
+    mat
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/package.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import akka.stream.scaladsl.Source
+import anorm.{BatchSql, NamedParameter}
+import com.daml.lf.transaction.Node.KeyWithMaintainers
+
+// TODO append-only: revisit visibility, and necessity during cleanup
+/** Type aliases used throughout the package
+  */
+package object events {
+
+  type SqlSequence[A] = SqlSequence.T[A]
+
+  import com.daml.lf.value.{Value => lfval}
+  type ContractId = lfval.ContractId
+  val ContractId = com.daml.lf.value.Value.ContractId
+  type Value = lfval.VersionedValue[ContractId]
+  type Contract = lfval.ContractInst[Value]
+  val Contract = lfval.ContractInst
+
+  import com.daml.lf.{transaction => lftx}
+  type NodeId = lftx.NodeId
+  type Node = lftx.Node.GenNode[NodeId, ContractId]
+  type Create = lftx.Node.NodeCreate[ContractId]
+  type Exercise = lftx.Node.NodeExercises[NodeId, ContractId]
+  type Fetch = lftx.Node.NodeFetch[ContractId]
+  type LookupByKey = lftx.Node.NodeLookupByKey[ContractId]
+  type Key = lftx.GlobalKey
+  val Key = lftx.GlobalKey
+
+  import com.daml.lf.{data => lfdata}
+  type Party = lfdata.Ref.Party
+  val Party = lfdata.Ref.Party
+  type Identifier = lfdata.Ref.Identifier
+  val Identifier = lfdata.Ref.Identifier
+  type QualifiedName = lfdata.Ref.QualifiedName
+  val QualifiedName = lfdata.Ref.QualifiedName
+  type DottedName = lfdata.Ref.DottedName
+  val DottedName = lfdata.Ref.DottedName
+  type ModuleName = lfdata.Ref.ModuleName
+  val ModuleName = lfdata.Ref.ModuleName
+  type LedgerString = lfdata.Ref.LedgerString
+  val LedgerString = lfdata.Ref.LedgerString
+  type ChoiceName = lfdata.Ref.ChoiceName
+  val ChoiceName = lfdata.Ref.ChoiceName
+  type PackageId = lfdata.Ref.PackageId
+  val PackageId = lfdata.Ref.PackageId
+  type WitnessRelation[A] = lfdata.Relation.Relation[A, Party]
+  type DisclosureRelation = WitnessRelation[NodeId]
+  type DivulgenceRelation = WitnessRelation[ContractId]
+  private[appendonlydao] type FilterRelation =
+    lfdata.Relation.Relation[Party, lfdata.Ref.Identifier]
+  val Relation = lfdata.Relation.Relation
+
+  import com.daml.lf.crypto
+  type Hash = crypto.Hash
+
+  /** Groups together items of type [[A]] that share an attribute [[K]] over a
+    * contiguous stretch of the input [[Source]]. Well suited to perform group-by
+    * operations of streams where [[K]] attributes are either sorted or at least
+    * show up in blocks.
+    *
+    * Implementation detail: this method _must_ use concatSubstreams instead of
+    * mergeSubstreams to prevent the substreams to be processed in parallel,
+    * potentially causing the outputs to be delivered in a different order.
+    *
+    * Docs: https://doc.akka.io/docs/akka/2.6.10/stream/stream-substream.html#groupby
+    */
+  def groupContiguous[A, K, Mat](
+      source: Source[A, Mat]
+  )(by: A => K): Source[Vector[A], Mat] =
+    source
+      .statefulMapConcat(() => {
+        var previousSegmentKey: K = null.asInstanceOf[K]
+        entry => {
+          val keyForEntry = by(entry)
+          val entryWithSplit = entry -> (keyForEntry != previousSegmentKey)
+          previousSegmentKey = keyForEntry
+          List(entryWithSplit)
+        }
+      })
+      .splitWhen(_._2)
+      .map(_._1)
+      .fold(Vector.empty[A])(_ :+ _)
+      .concatSubstreams
+
+  // Dispatches the call to either function based on the cardinality of the input
+  // This is mostly designed to route requests to queries specialized for single/multi-party subs
+  // Callers should ensure that the set is not empty, which in the usage this
+  // is designed for should be provided by the Ledger API validation layer
+  def route[A, B](
+      set: Set[A]
+  )(single: A => B, multi: Set[A] => B): B = {
+    assume(set.nonEmpty, "Empty set, unable to dispatch to single/multi implementation")
+    set.size match {
+      case 1 => single(set.iterator.next())
+      case n if n > 1 => multi(set)
+    }
+  }
+
+  def convert(template: Identifier, key: lftx.Node.KeyWithMaintainers[Value]): Key =
+    Key.assertBuild(template, key.key.value)
+
+  def convertLfValueKey(
+      template: Identifier,
+      key: KeyWithMaintainers[lfval[ContractId]],
+  ) =
+    Key.assertBuild(template, key.key)
+
+  def batch(query: String, parameters: Seq[Seq[NamedParameter]]): Option[BatchSql] =
+    if (parameters.isEmpty) None else Some(BatchSql(query, parameters.head, parameters.tail: _*))
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -236,6 +236,7 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
       loggingContext: LoggingContext
   ): Future[Unit]
 
+  // TODO append-only: cleanup
   def prepareTransactionInsert(
       submitterInfo: Option[SubmitterInfo],
       workflowId: Option[WorkflowId],
@@ -247,6 +248,7 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
       blindingInfo: Option[BlindingInfo],
   ): TransactionsWriter.PreparedInsert
 
+  // TODO append-only: cleanup
   def storeTransaction(
       preparedInsert: PreparedInsert,
       submitterInfo: Option[SubmitterInfo],
@@ -258,14 +260,17 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
       divulged: Iterable[DivulgedContract],
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
+  // TODO append-only: cleanup
   def storeTransactionState(preparedInsert: PreparedInsert)(implicit
       loggingContext: LoggingContext
   ): Future[PersistenceResponse]
 
+  // TODO append-only: cleanup
   def storeTransactionEvents(preparedInsert: PreparedInsert)(implicit
       loggingContext: LoggingContext
   ): Future[PersistenceResponse]
 
+  // TODO append-only: cleanup
   def completeTransaction(
       submitterInfo: Option[SubmitterInfo],
       transactionId: TransactionId,
@@ -280,7 +285,9 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
       reason: RejectionReason,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
-  /** Stores the initial ledger state, e.g., computed by the scenario loader.
+  /** !!! Please kindly not use this.
+    * !!! This method is solely for supporting sandbox-classic. Targeted for removal as soon sandbox classic is removed.
+    * Stores the initial ledger state, e.g., computed by the scenario loader.
     * Must be called at most once, before any call to storeLedgerEntry.
     *
     * @param ledgerEntries the list of LedgerEntries to save

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTable.scala
@@ -83,7 +83,7 @@ private[events] object ContractsTable {
 
   private def notFound(contractIds: Set[ContractId]): Throwable =
     new IllegalArgumentException(
-      s"One or more of the following contract identifiers has been found: ${contractIds.map(_.coid).mkString(", ")}"
+      s"One or more of the following contract identifiers has not been found: ${contractIds.map(_.coid).mkString(", ")}"
     )
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/serialization/Compression.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/serialization/Compression.scala
@@ -11,6 +11,7 @@ import com.daml.platform.store.dao.events.CompressionMetrics
 private[platform] object Compression {
 
   sealed abstract class Algorithm(val id: Option[Int]) {
+    // TODO append-only: cleanup. This is not used by new Compression related mechanics in append-only implementation
     final def compress(
         uncompressed: Array[Byte],
         metrics: CompressionMetrics.Field,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
@@ -161,7 +161,7 @@ private[dao] trait JdbcLedgerDaoContractsSpec extends LoneElement with Inside wi
     } yield {
       failure shouldBe an[IllegalArgumentException]
       failure.getMessage should startWith(
-        "One or more of the following contract identifiers has been found"
+        "One or more of the following contract identifiers has not been found"
       )
     }
   }
@@ -228,7 +228,7 @@ private[dao] trait JdbcLedgerDaoContractsSpec extends LoneElement with Inside wi
     } yield {
       failure shouldBe an[IllegalArgumentException]
       failure.getMessage should startWith(
-        "One or more of the following contract identifiers has been found"
+        "One or more of the following contract identifiers has not been found"
       )
     }
   }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
@@ -467,7 +467,7 @@ object PostCommitValidationSpec {
 
   private def notFound(contractIds: Set[ContractId]): Throwable =
     new IllegalArgumentException(
-      s"One or more of the following contract identifiers has been found: ${contractIds.map(_.coid).mkString(", ")}"
+      s"One or more of the following contract identifiers has not been found: ${contractIds.map(_.coid).mkString(", ")}"
     )
 
   private def noCommittedContract(parties: List[PartyDetails]): ContractStoreFixture =


### PR DESCRIPTION
Forking
- below LedgerDao interface
- into com.daml.platform.store.appendonlydao
- based on PoC code
This commit duplicates JdbcLedgerDao and dependencies as part of
the parallel ingestion rollout work. The fork will be removed as
the complete rollout is finished.

- adds appendonlydao package
- adapts LedgerDao: marks LedgerWriteDao methods for cleanup
- deprecates LedgerWriteDao/storeInitialState

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
