### PR TITLE
Add BigNumeric literals in Daml.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -969,7 +969,7 @@ convertExpr env0 e = do
         = fmap (, args) $ convertRationalDecimal env top bot
     go env (VarIn GHC_Real "fromRational") (LType (isNumLitTy -> Just n) : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = fmap (, args) $ convertRationalNumericMono env n top bot
-    go env (VarIn GHC_Real "fromRational") (LType (TypeCon (NameIn GHC_Types "Numeric") [(isNumLitTy -> Just n)]) : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
+    go env (VarIn GHC_Real "fromRational") (LType (TypeCon (NameIn GHC_Types "Numeric") [isNumLitTy -> Just n]) : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = fmap (, args) $ convertRationalNumericMono env n top bot
     go env (VarIn GHC_Real "fromRational") (LType (TypeCon (NameIn GHC_Types "BigNumeric") []) : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = fmap (, args) $ convertRationalBigNumeric env top bot

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -332,9 +332,15 @@ convertRationalNumericMono env scale num denom
 -- values that will fit in a Numeric.
 convertRationalBigNumeric :: Env -> Integer -> Integer -> ConvertM LF.Expr
 convertRationalBigNumeric env num denom =
-    if (scale > fromIntegral numericMaxScale)
+    if (denom <= 0)
+        || (scale > fromIntegral numericMaxScale)
         || (abs (rational * 10 ^ scale) >= 10 ^ numericMaxPrecision)
         || ((num * 10^scale) `mod` denom /= 0)
+            -- This includes checks against using this function incorrectly
+            -- that should never come up in practice, like
+            --      (denom <= 0)
+            -- and
+            --      ((num * 10^scale) `mod` denom /= 0)))
       then
         unsupported "Large BigNumeric literals are not currently supported. Please construct the number from smaller literals." ()
       else

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -328,6 +328,28 @@ convertRationalNumericMono env scale num denom
         double = (fromInteger num / fromInteger denom) :: Double
         maxPower = fromIntegral numericMaxPrecision - scale
 
+-- | Convert a rational into a BigNumeric expression. Currently only supports
+-- values that will fit in a Numeric.
+convertRationalBigNumeric :: Env -> Integer -> Integer -> ConvertM LF.Expr
+convertRationalBigNumeric env num denom =
+    if (scale > fromIntegral numericMaxScale)
+        || (abs (rational * 10 ^ scale) >= 10 ^ numericMaxPrecision)
+        || ((num * 10^scale) `mod` denom /= 0)
+      then
+        unsupported "Large BigNumeric literals are not currently supported. Please construct the number from smaller literals." ()
+      else
+        pure (EBuiltin BEFromNumericBigNumeric
+            `ETyApp` TNat (typeLevelNat scale)
+            `ETmApp` EBuiltin (BENumeric $ numeric
+                (fromIntegral scale)
+                ((num * 10^scale) `div` denom)))
+
+    where
+        rational = num % denom
+
+        scale :: Integer
+        scale = ceiling (log @Double (fromInteger denom) / log 10.0)
+
 data TemplateBinds = TemplateBinds
     { tbTyCon :: Maybe GHC.TyCon
     , tbSignatory :: Maybe (GHC.Expr Var)
@@ -947,6 +969,10 @@ convertExpr env0 e = do
         = fmap (, args) $ convertRationalDecimal env top bot
     go env (VarIn GHC_Real "fromRational") (LType (isNumLitTy -> Just n) : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = fmap (, args) $ convertRationalNumericMono env n top bot
+    go env (VarIn GHC_Real "fromRational") (LType (TypeCon (NameIn GHC_Types "Numeric") [(isNumLitTy -> Just n)]) : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
+        = fmap (, args) $ convertRationalNumericMono env n top bot
+    go env (VarIn GHC_Real "fromRational") (LType (TypeCon (NameIn GHC_Types "BigNumeric") []) : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
+        = fmap (, args) $ convertRationalBigNumeric env top bot
     go env (VarIn GHC_Real "fromRational") (LType scaleTyCoRep : _ : LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = unsupported ("Polymorphic numeric literal. Specify a fixed scale by giving the type, e.g. (" ++ show (fromRational (top % bot) :: Decimal.Decimal) ++ " : Numeric 10)") ()
     go env (VarIn GHC_Num "negate") (tyInt : LExpr (VarIs "$fAdditiveInt") : LExpr (untick -> VarIs "fromInteger" `App` Lit (LitNumber _ x _)) : args)

--- a/compiler/damlc/daml-prim-src/GHC/Classes.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Classes.daml
@@ -54,6 +54,9 @@ module GHC.Classes(
     #ifdef DAML_NUMERIC
     NumericScale (numericScale),
     #endif
+    #ifdef DAML_BIGNUMERIC
+    IsNumeric (..),
+    #endif
  ) where
 
 import GHC.Base
@@ -460,6 +463,27 @@ instance NumericScale 36 where numericScale _ = 36; numericScalePrivate _ = ()
 instance NumericScale 37 where numericScale _ = 37; numericScalePrivate _ = ()
 #endif
 
+#ifdef DAML_BIGNUMERIC
+
+-- | Types that can be represented by decimal literals in Daml.
+class IsNumeric t where
+    -- | Convert from `Numeric`. Raises an error if the number can't be
+    -- represented exactly in the target type.
+    fromNumeric : NumericScale m => Numeric m -> t
+
+    -- | Convert from `BigNumeric`. Raises an error if the number can't be
+    -- represented exactly in the target type.
+    fromBigNumeric : BigNumeric -> t
+
+instance NumericScale n => IsNumeric (Numeric n) where
+    fromNumeric = primitive @"BECastNumeric"
+    fromBigNumeric = primitive @"BEToNumericBigNumeric"
+
+instance IsNumeric BigNumeric where
+    fromNumeric = primitive @"BEFromNumericBigNumeric"
+    fromBigNumeric x = x
+
+#endif
 
 -- Constraint tuples
 

--- a/compiler/damlc/daml-prim-src/GHC/Num.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Num.daml
@@ -156,11 +156,11 @@ instance Additive BigNumeric where
     (+) = primitive @"BEAddBigNumeric"
     (-) = primitive @"BESubBigNumeric"
     negate x = aunit - x
-    aunit = (primitive @"BEFromNumericBigNumeric" : Numeric 0 -> BigNumeric) (0.0 : Numeric 0)
+    aunit = 0.0
 
 instance Multiplicative BigNumeric where
     (*) = primitive @"BEMulBigNumeric"
-    munit = (primitive @"BEFromNumericBigNumeric" : Numeric 0 -> BigNumeric) (1.0 : Numeric 0)
+    munit = 1.0
     x ^ n
         | n == 0 = munit
         | n == 2 = x * x

--- a/compiler/damlc/daml-prim-src/GHC/Real.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Real.daml
@@ -18,11 +18,14 @@ data Ratio a = !a :% !a
 
 type Rational = Ratio Integer
 
+#ifdef DAML_BIGNUMERIC
+fromRational : IsNumeric t => Rational -> t
+#else
 #ifdef DAML_NUMERIC
 fromRational : NumericScale n => Rational -> Numeric n
 #else
 fromRational : Rational -> Decimal
 #endif
+#endif
 fromRational = magic @"fromRational"
-
 {-# NOINLINE fromRational #-}

--- a/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
@@ -18,7 +18,6 @@ module DA.BigNumeric where
 
 import GHC.Types (primitive)
 
-
 -- TODO https://github.com/digital-asset/daml/issues/8719
 --  Expose these as constructors.
 roundingUp, roundingDown, roundingCeiling, roundingFloor, roundingHalfUp, roundingHalfDown, roundingHalfEven, roundingUnnecessary : RoundingMode
@@ -31,14 +30,6 @@ roundingHalfDown = primitive @"BERoundingHalfDown"
 roundingHalfEven = primitive @"BERoundingHalfEven"
 roundingUnnecessary = primitive @"BERoundingUnnecessary"
 
-
--- TODO https://github.com/digital-asset/daml/issues/8719
---  Remove once we have literals.
-zero, one, ten: BigNumeric
-zero = fromNumeric (0.0: Numeric 0)
-one = fromNumeric (1.0: Numeric 0)
-ten = fromNumeric (10.0: Numeric 0)
-
 scale, precision: BigNumeric -> Int
 scale = primitive @"BEScaleBigNumeric"
 precision = primitive @"BEPrecisionBigNumeric"
@@ -47,15 +38,9 @@ div : Int -> RoundingMode -> BigNumeric -> BigNumeric -> BigNumeric
 div = primitive @"BEDivBigNumeric"
 
 round: Int -> RoundingMode -> BigNumeric -> BigNumeric
-round scale rounding x = div scale rounding x one
+round scale rounding x = div scale rounding x 1.0
 
 shift: Int -> BigNumeric -> BigNumeric
 shift = primitive @"BEShiftBigNumeric"
-
-fromNumeric:  forall n. NumericScale n => Numeric n -> BigNumeric
-fromNumeric = primitive @"BEFromNumericBigNumeric"
-
-toNumeric: forall n. NumericScale n => BigNumeric -> Numeric n
-toNumeric = primitive @"BEToNumericBigNumeric"
 
 #endif

--- a/compiler/damlc/tests/daml-test-files/BigNumericTooBig.daml
+++ b/compiler/damlc/tests/daml-test-files/BigNumericTooBig.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @SINCE-LF 1.dev
+-- @ERROR Large BigNumeric literals are not currently supported.
+
+module BigNumericTooBig where
+
+tooBig : BigNumeric
+tooBig = 123456789012345678901233456789012345678.0

--- a/daml-lf/tests/scenario/dev/big-numeric/Test.daml
+++ b/daml-lf/tests/scenario/dev/big-numeric/Test.daml
@@ -14,14 +14,14 @@ template BigNumericResults
     signatory party
 
 x : BigNumeric
-x = BigNumeric.fromNumeric (0.5: Numeric 10)
+x = 0.5
 
 run = scenario do
   alice <- getParty "Alice"
   submit alice do
      create BigNumericResults with
         party = alice
-        values = map BigNumeric.toNumeric [
+        values = map fromBigNumeric [
               x + x
             , negate x
             , x * x


### PR DESCRIPTION
Adds support for BigNumeric literals (when available). Only literals that will fit in a single Numeric are supported for now.

I introduced the `IsNumeric t` typeclass because this is an easy way to restrict `fromRational` without moving it into its own typeclass. (Moving it into a typeclass causes some gnarly problems with the specializer -- it starts creating references to GHC.Real in an attempt to optimize the invocation, and that's a problem because  GHC.Real doesn't exist in LF.)

I then added the "fromNumeric" and "fromBigNumeric" conversion functions in that class, since they seem really convenient, and it also means we could in the future make it so that any type that implements `IsNumeric` gains literals (via Numeric or BigNumeric literals). This would improve a lot of Numeric code, since it eliminates the need to annotate types so often! But for now only Numeric and BigNumeric literals are supported.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
