### PR TITLE
Fix build command for non-repudiation-client

### DIFF
--- a/ci/copy-unix-release-artifacts.sh
+++ b/ci/copy-unix-release-artifacts.sh
@@ -54,8 +54,10 @@ if [[ "$NAME" == "linux" ]]; then
     NON_REPUDIATION_CLIENT_POM=non-repudiation-client-$RELEASE_TAG.pom
     NON_REPUDIATION_CLIENT_SRC=non-repudiation-client-$RELEASE_TAG-sources.jar
     NON_REPUDIATION_CLIENT_DOC=non-repudiation-cleint-$RELEASE_TAG-javadoc.jar
-    bazel build //runtime-components/non-repudiation-client
-    bazel build //runtime-components/non-repudiation-client:non-repudiation-client_javadoc
+    bazel build \
+          //runtime-components/non-repudiation-client \
+          //runtime-components/non-repudiation-client:non-repudiation-client_javadoc \
+          //runtime-components/non-repudiation-client:libnon-repudiation-client-src.jar
     cp bazel-bin/runtime-components/non-repudiation-client/libnon-repudiation-client.jar $OUTPUT_DIR/artifactory/$NON_REPUDIATION_CLIENT_JAR
     cp bazel-bin/runtime-components/non-repudiation-client/non-repudiation-client_pom.xml $OUTPUT_DIR/artifactory/$NON_REPUDIATION_CLIENT_POM
     cp bazel-bin/runtime-components/non-repudiation-client/libnon-repudiation-client-src.jar $OUTPUT_DIR/artifactory/$NON_REPUDIATION_CLIENT_SRC


### PR DESCRIPTION
The first attempt failed because the src jar wasn’t there. Afaict, the
path is fine but we didn’t build it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
