### PR TITLE
Optimize race condition integration tests [DPP-330]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/RaceConditionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/RaceConditionIT.scala
@@ -27,6 +27,7 @@ final class RaceConditionIT extends LedgerTestSuite {
   raceConditionTest(
     "WWDoubleNonTransientCreate",
     "Cannot concurrently create multiple non-transient contracts with the same key",
+    runConcurrently = true,
   ) { implicit ec => ledger => alice =>
     val Attempts = 5
     Future
@@ -45,6 +46,7 @@ final class RaceConditionIT extends LedgerTestSuite {
   raceConditionTest(
     "WWDoubleArchive",
     "Cannot archive the same contract multiple times",
+    runConcurrently = true,
   ) { implicit ec => ledger => alice =>
     val Attempts = 5
     for {
@@ -66,6 +68,7 @@ final class RaceConditionIT extends LedgerTestSuite {
   raceConditionTest(
     "WWArchiveVsNonTransientCreate",
     "Cannot create a contract with a key if that key is still used by another contract",
+    runConcurrently = true,
   ) { implicit ec => ledger => alice =>
     /*
     This test case is intended to catch a race condition ending up in two consecutive successful contract

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/RaceConditionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/RaceConditionIT.scala
@@ -128,13 +128,15 @@ final class RaceConditionIT extends LedgerTestSuite {
     for {
       wrapper <- ledger.create(alice, CreateWrapper(alice))
       _ <- Future.traverse(1 to Attempts) { attempt =>
-        if (attempt == Attempts) {
-          ledger.create(alice, ContractWithKey(alice)).map(_ => ()).transform(Success(_))
-        } else {
-          ledger
-            .exercise(alice, wrapper.exerciseCreateWrapper_CreateTransient)
-            .map(_ => ())
-            .transform(Success(_))
+        scheduleWithRandomDelay(20.millis) { _ =>
+          if (attempt == Attempts) {
+            ledger.create(alice, ContractWithKey(alice)).map(_ => ()).transform(Success(_))
+          } else {
+            ledger
+              .exercise(alice, wrapper.exerciseCreateWrapper_CreateTransient)
+              .map(_ => ())
+              .transform(Success(_))
+          }
         }
       }
       transactions <- transactions(ledger, alice)
@@ -163,15 +165,16 @@ final class RaceConditionIT extends LedgerTestSuite {
     "RWArchiveVsNonConsumingChoice",
     "Cannot exercise a choice after a contract archival",
   ) { implicit ec => ledger => alice =>
-    val ArchiveAt = 5
     val Attempts = 10
     for {
       contract <- ledger.create(alice, ContractWithKey(alice))
       _ <- Future.traverse(1 to Attempts) { attempt =>
-        if (attempt == ArchiveAt) {
-          ledger.exercise(alice, contract.exerciseContractWithKey_Archive).transform(Success(_))
-        } else {
-          ledger.exercise(alice, contract.exerciseContractWithKey_Exercise).transform(Success(_))
+        scheduleWithRandomDelay(20.millis) { _ =>
+          if (attempt == Attempts) {
+            ledger.exercise(alice, contract.exerciseContractWithKey_Archive).transform(Success(_))
+          } else {
+            ledger.exercise(alice, contract.exerciseContractWithKey_Exercise).transform(Success(_))
+          }
         }
       }
       transactions <- transactions(ledger, alice)
@@ -198,10 +201,12 @@ final class RaceConditionIT extends LedgerTestSuite {
       contract <- ledger.create(alice, ContractWithKey(alice))
       fetchConract <- ledger.create(alice, FetchWrapper(alice, contract))
       _ <- Future.traverse(1 to Attempts) { attempt =>
-        if (attempt == Attempts) {
-          ledger.exercise(alice, contract.exerciseContractWithKey_Archive).transform(Success(_))
-        } else {
-          ledger.exercise(alice, fetchConract.exerciseFetchWrapper_Fetch).transform(Success(_))
+        scheduleWithRandomDelay(20.millis) { _ =>
+          if (attempt == Attempts) {
+            ledger.exercise(alice, contract.exerciseContractWithKey_Archive).transform(Success(_))
+          } else {
+            ledger.exercise(alice, fetchConract.exerciseFetchWrapper_Fetch).transform(Success(_))
+          }
         }
       }
       transactions <- transactions(ledger, alice)
@@ -223,16 +228,17 @@ final class RaceConditionIT extends LedgerTestSuite {
     "RWArchiveVsLookupByKey",
     "Cannot successfully lookup by key an archived contract",
   ) { implicit ec => ledger => alice =>
-    val ArchiveAt = 20
     val Attempts = 20
     for {
       contract <- ledger.create(alice, ContractWithKey(alice))
       looker <- ledger.create(alice, LookupWrapper(alice))
       _ <- Future.traverse(1 to Attempts) { attempt =>
-        if (attempt == ArchiveAt) {
-          ledger.exercise(alice, contract.exerciseContractWithKey_Archive).transform(Success(_))
-        } else {
-          ledger.exercise(alice, looker.exerciseLookupWrapper_Lookup).transform(Success(_))
+        scheduleWithRandomDelay(20.millis) { _ =>
+          if (attempt == Attempts) {
+            ledger.exercise(alice, contract.exerciseContractWithKey_Archive).transform(Success(_))
+          } else {
+            ledger.exercise(alice, looker.exerciseLookupWrapper_Lookup).transform(Success(_))
+          }
         }
       }
       transactions <- transactions(ledger, alice)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/RaceConditionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/RaceConditionIT.scala
@@ -20,8 +20,7 @@ import scala.util.Success
 
 final class RaceConditionIT extends LedgerTestSuite {
 
-  // TODO: reduce the repetition parameter
-  private val DefaultRepetitionsNumber: Int = 5
+  private val DefaultRepetitionsNumber: Int = 3
   private val WaitBeforeGettingTransactions: FiniteDuration = 500.millis
 
   raceConditionTest(


### PR DESCRIPTION
### Motivation
Race condition integration tests in the `ledger-api-test-tool` take ~90 seconds to complete. We would like to reduce this duration as much as possible not to make compatibility tests slow in the future (when multiple `ledger-api-test-tool` releases containing race condition tests are available).

### Main changes
- Reduced the number of test case repetitions from 5 to 3
- Enabled concurrent runs for several test cases
- Reduced number of executed commands for several test cases
- Reduced processing delays (before proceeding to the next stage of a test)

As a result the total duration of race condition tests drops from ~90 seconds to ~20 seconds.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
