### PR TITLE
use {tag, value} format for SQLizing advanced JSON queries

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
@@ -128,12 +128,13 @@ sealed abstract class ValuePredicate extends Product with Serializable {
 
         case VariantMatch((dc, q)) =>
           val Rec(vraw, v_==, v_@>) = go(path objectAt JsonVariant.valueKey, q)
-          // @> is safe because in a variant-typed context, all JsObjects
-          // have exactly two keys
+          // @> induction is safe because in a variant-typed context, all JsObjects
+          // have exactly two keys. @> is conjoined with raw so we use it to add
+          // the tag check
           Rec(
             vraw,
-            v_== map (jv => JsonVariant(dc, jv)),
-            v_@> map (jv => JsonVariant(dc, jv)),
+            v_== map (JsonVariant(dc, _)),
+            v_@> map (JsonVariant(dc, _)) orElse Some(JsonVariant withoutValue dc),
           )
 
         case OptionalMatch(None) =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
@@ -127,7 +127,7 @@ sealed abstract class ValuePredicate extends Product with Serializable {
           goObject(path, cqs, qs.length)
 
         case VariantMatch((dc, q)) =>
-          val Rec(vraw, v_==, v_@>) = go(path objectAt dc, q) // TODO SC exercise this path
+          val Rec(vraw, v_==, v_@>) = go(path objectAt JsonVariant.valueKey, q)
           // @> is safe because in a variant-typed context, all JsObjects
           // have exactly two keys
           Rec(

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -246,7 +246,7 @@ class ValuePredicateTest
           sql"payload->${"foo": String} <= ${JsNumber(42): JsValue}::jsonb AND payload @> ${JsObject(): JsValue}::jsonb",
         ),
         (
-          """{"tag": "Left", "value": 42}""",
+          """{"tag": "Left", "value": "42"}""",
           eitherVA,
           sql"payload = ${"""{"foo": {"tag": "Left", "value": 42}}""".parseJson}::jsonb",
         ),

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -250,6 +250,11 @@ class ValuePredicateTest
           eitherVA,
           sql"payload = ${"""{"foo": {"tag": "Left", "value": 42}}""".parseJson}::jsonb",
         ),
+        (
+          """{"tag": "Left", "value": {"%lte": 42}}""",
+          eitherVA,
+          sql"payload->${"foo"}->${"value"} <= ${"42".parseJson}::jsonb AND payload @> ${"""{"foo": {"tag": "Left"}}""".parseJson}::jsonb",
+        ),
       )
     }
 

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/JsonVariant.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/JsonVariant.scala
@@ -3,11 +3,14 @@
 
 package com.daml.lf.value.json
 
+import com.daml.lf.data.Ref
 import spray.json.{JsObject, JsString, JsValue}
 
 object JsonVariant {
   def apply(tag: String, body: JsValue): JsObject =
-    JsObject("tag" -> JsString(tag), "value" -> body)
+    JsObject("tag" -> JsString(tag), valueKey -> body)
+
+  val valueKey: Ref.Name = Ref.Name assertFromString "value"
 
   def unapply(o: JsObject): Option[(String, JsValue)] =
     (o.fields.size, o.fields.get("tag"), o.fields.get("value")) match {

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/JsonVariant.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/JsonVariant.scala
@@ -8,12 +8,16 @@ import spray.json.{JsObject, JsString, JsValue}
 
 object JsonVariant {
   def apply(tag: String, body: JsValue): JsObject =
-    JsObject("tag" -> JsString(tag), valueKey -> body)
+    JsObject(tagKey -> JsString(tag), valueKey -> body)
 
+  def withoutValue(tag: String): JsObject =
+    JsObject(tagKey -> JsString(tag))
+
+  val tagKey = "tag"
   val valueKey: Ref.Name = Ref.Name assertFromString "value"
 
   def unapply(o: JsObject): Option[(String, JsValue)] =
-    (o.fields.size, o.fields.get("tag"), o.fields.get("value")) match {
+    (o.fields.size, o.fields.get(tagKey), o.fields.get(valueKey)) match {
       case (2, Some(JsString(tag)), Some(nv)) => Some((tag, nv))
       case _ => None
     }


### PR DESCRIPTION
#3882 changed the JSON format of variants, but the code that produces SQL predicates from the query language wasn't updated in one respect: for advanced queries within the variant data. The easiest example is a range query, included as a test case here. (We also test simpler queries of variants, which did not have this problem.)

Prerequisite to #9278.

```rst
CHANGELOG_BEGIN
- [HTTP JSON API] Range queries within variant data would not return matching
  data when using the PostgreSQL backend with JSON API; this is fixed.
  See `issue #9321 <https://github.com/digital-asset/daml/pull/9321>`__.
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
