### PR TITLE
try to fix non-repudiation pushing

### DIFF
--- a/ci/publish-artifactory.sh
+++ b/ci/publish-artifactory.sh
@@ -37,38 +37,13 @@ push daml-script-runner $SCRIPT_RUNNER.asc
 push non-repudiation $NON_REPUDIATION
 push non-repudiation $NON_REPUDIATION.asc
 
-# FIXME
-# Uncomment the following lines to attempt to publish these libraries.
-# The previous attempts failed with a 409 Conflict error code when
-# uploading the libraries POM.
-
-#NON_REPUDIATION_CORE_JAR=non-repudiation-core-$RELEASE_TAG.jar
-#NON_REPUDIATION_CORE_POM=non-repudiation-core-$RELEASE_TAG.pom
-#NON_REPUDIATION_CORE_SRC=non-repudiation-core-$RELEASE_TAG-sources.jar
-#NON_REPUDIATION_CORE_DOC=non-repudiation-core-$RELEASE_TAG-javadoc.jar
-
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CORE_JAR
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CORE_JAR.asc
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CORE_POM
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CORE_POM.asc
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CORE_SRC
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CORE_SRC.asc
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CORE_DOC
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CORE_DOC.asc
-
-#NON_REPUDIATION_CLIENT_JAR=non-repudiation-client-$RELEASE_TAG.jar
-#NON_REPUDIATION_CLIENT_POM=non-repudiation-client-$RELEASE_TAG.pom
-#NON_REPUDIATION_CLIENT_SRC=non-repudiation-client-$RELEASE_TAG-sources.jar
-#NON_REPUDIATION_CLIENT_DOC=non-repudiation-client-$RELEASE_TAG-javadoc.jar
-
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CLIENT_JAR
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CLIENT_JAR.asc
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CLIENT_POM
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CLIENT_POM.asc
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CLIENT_SRC
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CLIENT_SRC.asc
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CLIENT_DOC
-#push connect-ee-mvn/com/daml $NON_REPUDIATION_CLIENT_DOC.asc
+for base in non-repudiation-core non-repudiation-client; do
+    for end in .jar .pom -sources.jar -javadoc.jar; do
+        for sign in "" .asc; do
+            push connect-ee-mvn/com/daml/$base $base-${RELEASE_TAG}${end}${sign}
+        done
+    done
+done
 
 for platform in linux macos windows; do
     EE_TARBALL=daml-sdk-$RELEASE_TAG-$platform-ee.tar.gz


### PR DESCRIPTION
I've seen reports of Artifactory returning 409 when it detects an invalid POM file, which would map cleanly to our observed behaviour (as other files do seem to upload fine). I'm not a POM expert so not entirely sure how to check the actual files, but I do see one error in the existing, commented code: the path is not a valid Maven repository path. It should be `groupid/artifactid/version`, i.e. it is currently missing the `artifactid` bit. So I'd like to try adding that.

I don't know how to test this without making a release, so my plan is to make a release once this is merged. Open to suggestion on faster ways to test this.

CHANGELOG_BEGIN
CHANGELOG_END