### PR TITLE
Expose rounding modes as constructors + add BigNumeric docs.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1487,6 +1487,9 @@ convertAlt env (TConApp tcon targs) alt@(DataAlt con, vs, x) = do
                     projBinds <- mkProjBindings env (EVar vArg) (TypeConApp (synthesizeVariantRecord patVariant <$> tcon) targs) vsFlds x'
                     pure $ CaseAlternative CPVariant{..} projBinds
 
+convertAlt _ TRoundingMode alt@(DataAlt con, _, _) = do
+    unsupported "Pattern matching on RoundingMode is not currently supported. Please use (==) instead" con
+
 convertAlt _ _ x = unsupported "Case alternative of this form" x
 
 mkProjBindings :: Env -> LF.Expr -> TypeConApp -> [(Var, FieldName)] -> LF.Expr -> ConvertM LF.Expr

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1143,6 +1143,16 @@ convertExpr env0 e = do
             pure (ESome t x, args)
 
     go env (VarIn GHC_Tuple "()") args = pure (EUnit, args)
+
+    go env (VarIn GHC_Types "RoundingCeiling"    ) args = pure (EBuiltin BERoundingCeiling, args)
+    go env (VarIn GHC_Types "RoundingFloor"      ) args = pure (EBuiltin BERoundingFloor, args)
+    go env (VarIn GHC_Types "RoundingDown"       ) args = pure (EBuiltin BERoundingDown, args)
+    go env (VarIn GHC_Types "RoundingUp"         ) args = pure (EBuiltin BERoundingUp, args)
+    go env (VarIn GHC_Types "RoundingHalfDown"   ) args = pure (EBuiltin BERoundingHalfDown, args)
+    go env (VarIn GHC_Types "RoundingHalfEven"   ) args = pure (EBuiltin BERoundingHalfEven, args)
+    go env (VarIn GHC_Types "RoundingHalfUp"     ) args = pure (EBuiltin BERoundingHalfUp, args)
+    go env (VarIn GHC_Types "RoundingUnnecessary") args = pure (EBuiltin BERoundingUnnecessary, args)
+
     go env (VarIn GHC_Types "True") args = pure (mkBool True, args)
     go env (VarIn GHC_Types "False") args = pure (mkBool False, args)
     go env (VarIn GHC_Types "I#") args = pure (mkIdentity TInt64, args)

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1144,14 +1144,14 @@ convertExpr env0 e = do
 
     go env (VarIn GHC_Tuple "()") args = pure (EUnit, args)
 
-    go env (VarIn GHC_Types "RoundingCeiling"    ) args = pure (EBuiltin BERoundingCeiling, args)
-    go env (VarIn GHC_Types "RoundingFloor"      ) args = pure (EBuiltin BERoundingFloor, args)
-    go env (VarIn GHC_Types "RoundingDown"       ) args = pure (EBuiltin BERoundingDown, args)
-    go env (VarIn GHC_Types "RoundingUp"         ) args = pure (EBuiltin BERoundingUp, args)
-    go env (VarIn GHC_Types "RoundingHalfDown"   ) args = pure (EBuiltin BERoundingHalfDown, args)
-    go env (VarIn GHC_Types "RoundingHalfEven"   ) args = pure (EBuiltin BERoundingHalfEven, args)
-    go env (VarIn GHC_Types "RoundingHalfUp"     ) args = pure (EBuiltin BERoundingHalfUp, args)
-    go env (VarIn GHC_Types "RoundingUnnecessary") args = pure (EBuiltin BERoundingUnnecessary, args)
+    go env (VarIn GHC_Types "RoundingCeiling"    ) args = pure (EBuiltin (BERoundingMode LitRoundingCeiling    ), args)
+    go env (VarIn GHC_Types "RoundingFloor"      ) args = pure (EBuiltin (BERoundingMode LitRoundingFloor      ), args)
+    go env (VarIn GHC_Types "RoundingDown"       ) args = pure (EBuiltin (BERoundingMode LitRoundingDown       ), args)
+    go env (VarIn GHC_Types "RoundingUp"         ) args = pure (EBuiltin (BERoundingMode LitRoundingUp         ), args)
+    go env (VarIn GHC_Types "RoundingHalfDown"   ) args = pure (EBuiltin (BERoundingMode LitRoundingHalfDown   ), args)
+    go env (VarIn GHC_Types "RoundingHalfEven"   ) args = pure (EBuiltin (BERoundingMode LitRoundingHalfEven   ), args)
+    go env (VarIn GHC_Types "RoundingHalfUp"     ) args = pure (EBuiltin (BERoundingMode LitRoundingHalfUp     ), args)
+    go env (VarIn GHC_Types "RoundingUnnecessary") args = pure (EBuiltin (BERoundingMode LitRoundingUnnecessary), args)
 
     go env (VarIn GHC_Types "True") args = pure (mkBool True, args)
     go env (VarIn GHC_Types "False") args = pure (mkBool False, args)

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -239,6 +239,6 @@ data RoundingMode
       -- are equidistant, in which case round away from zero.
   | RoundingUnnecessary
       -- ^ Do not round. Raises an error if the result cannot
-      -- be represented without rounding.
+      -- be represented without rounding at the targeted scale.
 
 #endif

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -29,7 +29,7 @@ module GHC.Types (
 #endif
 #ifdef DAML_BIGNUMERIC
         BigNumeric,
-        RoundingMode,
+        RoundingMode(..),
 #endif
     ) where
 

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -208,13 +208,37 @@ data Decimal =
 --  Better documentation for BigNumeric and RoundingMode.
 
 -- | A big numeric type, capable of holding large decimal values with many digits.
+--
+-- `BigNumeric` represents any positive or negative decimal number with up to
+-- 2^15 digits before the decimal point, and up to 2^15 digits after the decimal
+-- point.
+--
+-- `BigNumeric` is not serializable, it is only intended for intermediate computation.
+-- You must round and convert `BigNumeric` to a fixed-width numeric (`Numeric n`)
+-- in order to store it in a template. The rounding operations are `round` and
+-- `div` from the `DA.BigNumeric` module. The casting operations are `fromNumeric`
+-- and `fromBigNumeric` from the `IsNumeric` typeclass.
 data BigNumeric =
   -- | HIDE
   BigNumeric Opaque
 
--- | Represents a rounding mode for `BigNumeric` operations. See `DA.BigNumeric`.
-data RoundingMode =
-  -- | HIDE
-  RoundingMode Opaque
+-- | Rounding modes for `BigNumeric` operations like `div` and `round` from `DA.BigNumeric`.
+data RoundingMode
+  = RoundingCeiling -- ^ Round towards positive infinity.
+  | RoundingFloor -- ^ Round towards negative infinity.
+  | RoundingDown -- ^ Round towards zero.
+  | RoundingUp -- ^ Round away from zero.
+  | RoundingHalfDown
+      -- ^ Round towards the nearest neighbor unless both neighbors
+      -- are equidistant, in which case round towards zero.
+  | RoundingHalfEven
+      -- ^ Round towards the nearest neighbor unless both neighbors
+      -- are equidistant, in which case round towards the even neighbor.
+  | RoundingHalfUp
+      -- ^ Round towards the nearest neighbor unless both neighbors
+      -- are equidistant, in which case round away from zero.
+  | RoundingUnnecessary
+      -- ^ Do not round. Raises an error if the result cannot
+      -- be represented without rounding.
 
 #endif

--- a/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
@@ -10,37 +10,59 @@ module DA.BigNumeric where
 
 #else
 
--- TODO https://github.com/digital-asset/daml/issues/8719
---  Better documentation for BigNumeric module.
-
--- | Big Numeric type
+-- | This module exposes operations for working with the `BigNumeric` type.
 module DA.BigNumeric where
 
 import GHC.Types (primitive)
 
--- TODO https://github.com/digital-asset/daml/issues/8719
---  Expose these as constructors.
-roundingUp, roundingDown, roundingCeiling, roundingFloor, roundingHalfUp, roundingHalfDown, roundingHalfEven, roundingUnnecessary : RoundingMode
-roundingUp = primitive @"BERoundingUp"
-roundingDown = primitive @"BERoundingDown"
-roundingCeiling = primitive @"BERoundingCeiling"
-roundingFloor = primitive @"BERoundingFloor"
-roundingHalfUp = primitive @"BERoundingHalfUp"
-roundingHalfDown = primitive @"BERoundingHalfDown"
-roundingHalfEven = primitive @"BERoundingHalfEven"
-roundingUnnecessary = primitive @"BERoundingUnnecessary"
-
-scale, precision: BigNumeric -> Int
+-- | Calculate the scale of a `BigNumeric` number. The `BigNumeric` number is
+-- represented as `n * 10^-s` where `n` is an integer with no trailing zeros,
+-- and `s` is the scale.
+--
+-- Thus, the scale represents the number of nonzero digits after the decimal point.
+-- Note that the scale can be negative if the `BigNumeric` represents an integer
+-- with trailing zeros. In that case, it represents the number of trailing zeros
+-- (negated).
+--
+-- The scale ranges between 2^15 and -2^15 + 1.
+-- The scale of `0` is `0` by convention.
+scale : BigNumeric -> Int
 scale = primitive @"BEScaleBigNumeric"
+
+-- | Calculate the precision of a `BigNumeric` number. The `BigNumeric` number is
+-- represented as `n * 10^-s` where `n` is an integer with no trailing zeros,
+-- and `s` is the scale. The precision is the number of digits in `n`.
+--
+-- Thus, the precision represents the number of significant digits in the `BigNumeric`.
+--
+-- The precision ranges between 0 and 2^16 - 1.
+precision : BigNumeric -> Int
 precision = primitive @"BEPrecisionBigNumeric"
 
+-- | Calculate a division of `BigNumeric` numbers. The value of `div n r a b`
+-- is the division of `a` by `b`, rounded to `n` decimal places (i.e. scale),
+-- according to the rounding mode `r`.
+--
+-- This will fail when dividing by `0`, and when using the `RoundingUnnecessary`
+-- mode for a number that cannot be represented exactly with at most `n` decimal
+-- places.
 div : Int -> RoundingMode -> BigNumeric -> BigNumeric -> BigNumeric
 div = primitive @"BEDivBigNumeric"
 
-round: Int -> RoundingMode -> BigNumeric -> BigNumeric
+-- | Round a `BigNumeric` number. The value of `round n r a` is the value
+-- of `a` rounded to `n` decimal places (i.e. scale), according to the rounding
+-- mode `r`.
+--
+-- This will fail when using the `RoundingUnnecessary` mode for a number that cannot
+-- be represented exactly with at most `n` decimal places.
+round : Int -> RoundingMode -> BigNumeric -> BigNumeric
 round scale rounding x = div scale rounding x 1.0
 
-shift: Int -> BigNumeric -> BigNumeric
+-- | Shift a `BigNumeric` number up or down by a power of 10. The value
+-- `shift n a` is the value of `a` times `10^n`.
+--
+-- This will fail if the resulting `BigNumeric` is out of bounds.
+shift : Int -> BigNumeric -> BigNumeric
 shift = primitive @"BEShiftBigNumeric"
 
 #endif

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -30,7 +30,7 @@ import GHC.Types as GHC (Bool (..), Int, Ordering (..), Text, Decimal, DamlEnum,
 #endif
 #ifdef DAML_BIGNUMERIC
   , BigNumeric
-  , RoundingMode
+  , RoundingMode (..)
 #endif
   )
 -- Not reexported

--- a/compiler/damlc/tests/daml-test-files/BigNumericTooBig.daml
+++ b/compiler/damlc/tests/daml-test-files/BigNumericTooBig.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @SINCE-LF 1.dev
+-- @SINCE-LF 1.13
 -- @ERROR Large BigNumeric literals are not currently supported.
 
 module BigNumericTooBig where

--- a/compiler/damlc/tests/daml-test-files/RoundingModeMatch.daml
+++ b/compiler/damlc/tests/daml-test-files/RoundingModeMatch.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- | Test that you get errors when trying to pattern match on rounding mode.
+module RoundingModeMatch where
+
+-- @ERROR Pattern matching on RoundingMode is not currently supported
+foo : RoundingMode -> Int
+foo RoundingCeiling = 10
+foo _ = 20

--- a/compiler/damlc/tests/daml-test-files/RoundingModeMatch.daml
+++ b/compiler/damlc/tests/daml-test-files/RoundingModeMatch.daml
@@ -1,6 +1,8 @@
 -- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
+-- @SINCE-LF 1.dev
+
 -- | Test that you get errors when trying to pattern match on rounding mode.
 module RoundingModeMatch where
 

--- a/compiler/damlc/tests/daml-test-files/RoundingModeMatch.daml
+++ b/compiler/damlc/tests/daml-test-files/RoundingModeMatch.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @SINCE-LF 1.dev
+-- @SINCE-LF 1.13
 
 -- | Test that you get errors when trying to pattern match on rounding mode.
 module RoundingModeMatch where

--- a/daml-lf/tests/scenario/dev/big-numeric/Test.daml
+++ b/daml-lf/tests/scenario/dev/big-numeric/Test.daml
@@ -25,8 +25,8 @@ run = scenario do
               x + x
             , negate x
             , x * x
-            , BigNumeric.round 0 BigNumeric.roundingUp x
-            , BigNumeric.round 0 BigNumeric.roundingDown x
-            , BigNumeric.round 0 BigNumeric.roundingHalfUp x
-            , BigNumeric.round 0 BigNumeric.roundingCeiling (negate x)
+            , BigNumeric.round 0 RoundingUp x
+            , BigNumeric.round 0 RoundingDown x
+            , BigNumeric.round 0 RoundingHalfUp x
+            , BigNumeric.round 0 RoundingCeiling (negate x)
           ]

--- a/docs/source/daml/reference/data-types.rst
+++ b/docs/source/daml/reference/data-types.rst
@@ -33,7 +33,7 @@ Table of built-in primitive types
    * - ``Numeric n``
      - fixed point decimal numbers
      - ``1.0``
-     - ``Numeric n`` values are rational numbers with up to ``38`` decimal digits. The scale parameter ``n`` controls the number of digits after the decimal point, so for example, ``Numeric 10`` values have 10 decimal places, and ``Numeric 20`` values have 20 decimal places. The value of ``n`` must be between ``0`` and ``37`` inclusive.
+     - ``Numeric n`` values are rational numbers with ``38`` decimal digits. The scale parameter ``n`` controls the number of digits after the decimal point, so for example, ``Numeric 10`` values have 10 digits after the decimal point, and ``Numeric 20`` values have 20 digits after the decimal point. The value of ``n`` must be between ``0`` and ``37`` inclusive.
    * - ``BigNumeric``
      - large fixed point decimal numbers
      - ``1.0``

--- a/docs/source/daml/reference/data-types.rst
+++ b/docs/source/daml/reference/data-types.rst
@@ -33,7 +33,11 @@ Table of built-in primitive types
    * - ``Numeric n``
      - fixed point decimal numbers
      - ``1.0``
-     - `Numeric n` values are rational numbers with up to ``38`` digits. The scale parameter ``n`` controls the number of digits after the decimal point, so for example, ``Numeric 10`` values have 10 decimal places, and ``Numeric 20`` values have 20 decimal places. The value of ``n`` must be between ``0`` and ``37`` inclusive.
+     - ``Numeric n`` values are rational numbers with up to ``38`` decimal digits. The scale parameter ``n`` controls the number of digits after the decimal point, so for example, ``Numeric 10`` values have 10 decimal places, and ``Numeric 20`` values have 20 decimal places. The value of ``n`` must be between ``0`` and ``37`` inclusive.
+   * - ``BigNumeric``
+     - large fixed point decimal numbers
+     - ``1.0``
+     - ``BigNumeric`` values are rational numbers with up to ``2^16`` decimal digits. They can have up to ``2^15`` digits before the decimal point, and up to ``2^15`` digits after the decimal point.
    * - ``Text``
      - strings
      - ``"hello"``


### PR DESCRIPTION
This PR exposes the rounding modes as constructors for RoundingMode. Pattern matching for RoundingMode is not implemented and not critical (will open a separate issue).

This PR also adds documentation for BigNumeric.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
