### PR TITLE
Fix typo in profiler docs, file name starts with profile (not profiler)

### DIFF
--- a/docs/source/tools/profiler.rst
+++ b/docs/source/tools/profiler.rst
@@ -37,7 +37,7 @@ included in the skeleton project does the job admirably:
 
 .. code-block:: sh
 
-   daml script --dar .daml/dist/profiler-tutorial-0.0.1.dar --ledger-host localhost --ledger-port 6865 --script-name Main:setup
+   daml script --dar .daml/dist/profile-tutorial-0.0.1.dar --ledger-host localhost --ledger-port 6865 --script-name Main:setup
 
 If we now look at the contents of the ``profile-results`` directory,
 we can see one JSON file per transaction produced by the script. Each


### PR DESCRIPTION
### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

Fixes this:

```
anthonylusardizdhtdg:profile-tutorial anthonylusardi$ daml script --dar .daml/dist/profiler-tutorial-0.0.1.dar --ledger-host localhost --ledger-port 6865 --script-name Main:setup
Exception in thread "main" java.io.FileNotFoundException: .daml/dist/profiler-tutorial-0.0.1.dar (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:213)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:155)
	at com.daml.lf.archive.DarReader.readArchiveFromFile(DarReader.scala:30)
	at com.daml.lf.engine.script.RunnerMain$.main(RunnerMain.scala:37)
	at com.daml.sdk.SdkMain$.main(SdkMain.scala:23)
	at com.daml.sdk.SdkMain.main(SdkMain.scala)
daml-helper: Received ExitFailure 1 when running
Raw command: java -Dlogback.configurationFile=/Users/anthonylusardi/.daml/sdk/1.11.1/daml-sdk/script-logback.xml -jar /Users/anthonylusardi/.daml/sdk/1.11.1/daml-sdk/daml-sdk.jar script --dar .daml/dist/profiler-tutorial-0.0.1.dar --ledger-host localhost --ledger-port 6865 --script-name Main:setup
```