### PR TITLE
Improve TX normalization.

### DIFF
--- a/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/NormalizerSpec.scala
+++ b/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/NormalizerSpec.scala
@@ -4,10 +4,12 @@
 package com.daml.lf.kv
 
 import com.daml.lf.transaction._
+import com.daml.lf.transaction.Node._
 import org.scalatest.wordspec.AnyWordSpec
 import com.daml.lf.value.test.ValueGenerators._
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import com.daml.lf.data.ImmArray
 
 class NormalizerSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
@@ -15,30 +17,87 @@ class NormalizerSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProp
 
     "only keeps Create and Exercise nodes" in {
       forAll(noDanglingRefGenVersionedTransaction(allowRollback = true)) { tx =>
-        val createIds = tx.nodes.collect { case (nid, _: Node.NodeCreate[_]) => nid }.toSet
-        val exeIds = tx.nodes.collect { case (nid, _: Node.NodeExercises[_, _]) => nid }.toSet
-        val preservedIds = createIds union exeIds
-
         val normalized = Normalizer.normalizeTransaction(CommittedTransaction(tx))
 
-        // version is not modified
-        //  normalized.version shouldBe tx.version
-        // Fetch and Lookup are filtered out from roots
-        normalized.roots shouldBe tx.roots.filter(preservedIds)
+        val nidsBefore: Set[NodeId] = tx.nodes.keySet
+        val nidsAfter: Set[NodeId] = normalized.nodes.keySet
 
-        // Fetch and Lookup are filtered out from nodes
-        normalized.nodes.keySet shouldBe preservedIds
+        // Every kept nid existed before
+        assert(nidsAfter.forall(nid => nidsBefore.contains(nid)))
 
-        // Create nodes are preserved.
-        normalized.nodes.filter { case (id, _) => createIds(id) } shouldBe
-          tx.nodes.filter { case (id, _) => createIds(id) }
+        // The normalized nodes mapping does not contain anything unreachanble
+        nidsAfter shouldBe normalized.reachableNodeIds
 
-        // Exercises are preserved but Fetch and Lookup nodes are filtered out from their children.
-        normalized.nodes.filter { case (id, _) => exeIds(id) } shouldBe
-          tx.nodes.collect { case (nid, exe: Node.NodeExercises[_, _]) =>
-            nid -> exe.copy(children = exe.children.filter(preservedIds))
-          }
+        // Only create/exercise nodes are kept
+        assert(
+          nidsAfter
+            .map(normalized.nodes(_))
+            .forall(isCreateOrExercise)
+        )
+
+        // Everything kept is unchanged (except children may be dropped)
+        def unchangedByNormalization(nid: NodeId): Boolean = {
+          val before = tx.nodes(nid)
+          val after = normalized.nodes(nid)
+          // the node is unchanged when disregarding the children
+          nodeSansChildren(after) == nodeSansChildren(before)
+          // children can be lost, but nothing else
+          val beforeChildren = nodeChildren(before)
+          val afterChildren = nodeChildren(after)
+          afterChildren.forall(beforeChildren.contains(_))
+        }
+        assert(
+          nidsAfter.forall(unchangedByNormalization)
+        )
+
+        // Does a Nid reference a create/exercise node (in the before tx) ?
+        def isNidCE(nid: NodeId): Boolean = {
+          isCreateOrExercise(tx.nodes(nid))
+        }
+
+        // Is a Nid kept in the after transaction ?
+        def isKept(nid: NodeId): Boolean = {
+          nidsAfter.contains(nid)
+        }
+
+        // Create/exercise root nodes are kept
+        assert(
+          tx.roots.toList
+            .filter(isNidCE)
+            .forall(isKept)
+        )
+
+        // Create/exercise children of kept nodes should also be kept
+        assert(
+          nidsAfter
+            .flatMap(nid => nodeChildren(tx.nodes(nid)))
+            .filter(isNidCE)
+            .forall(isKept)
+        )
+
       }
+    }
+  }
+
+  def isCreateOrExercise[N, C](node: GenNode[N, C]): Boolean = {
+    node match {
+      case _: NodeExercises[_, _] => true
+      case _: NodeCreate[_] => true
+      case _ => false
+    }
+  }
+
+  def nodeSansChildren[N, C](node: GenNode[N, C]): GenNode[N, C] = {
+    node match {
+      case exe: NodeExercises[_, _] => exe.copy(children = ImmArray.empty)
+      case _ => node
+    }
+  }
+
+  def nodeChildren[N, C](node: GenNode[N, C]): List[N] = {
+    node match {
+      case exe: NodeExercises[_, _] => exe.children.toList
+      case _ => List()
     }
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/ContractKeysValidation.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/ContractKeysValidation.scala
@@ -72,13 +72,20 @@ private[transaction] object ContractKeysValidation {
         )
       )(
         (keyValidationStatus, _, exerciseBeginNode) =>
-          checkNodeContractKey(
-            exerciseBeginNode,
-            contractKeysToContractIds,
-            keyValidationStatus,
+          (
+            checkNodeContractKey(
+              exerciseBeginNode,
+              contractKeysToContractIds,
+              keyValidationStatus,
+            ),
+            true,
           ),
+        (_, _, _) =>
+          // TODO https://github.com/digital-asset/daml/issues/8020
+          sys.error("rollback nodes are not supported"),
         (keyValidationStatus, _, leafNode) =>
           checkNodeContractKey(leafNode, contractKeysToContractIds, keyValidationStatus),
+        (accum, _, _) => accum,
         (accum, _, _) => accum,
       )
 


### PR DESCRIPTION
Improve TX normalization.

- Extend `foreachInExecutionOrder` / `foldInExecutionOrder` to handle rollback nodes. Two new args control behaviour when entering/leaving rollback nodes. Caller can control (with a bool) if the traversal continues under exercise/rollback nodes. Update existing callers.

- Use `foldInExecutionOrder` to define `reachableNodeIds`. And test.

- Use `foldInExecutionOrder` to improve the behaviour of `NormalizeTransaction` so that all nodes within a rollback node are dropped. Also completely reworking the spec/test for the new behaviour.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
