### PR TITLE
Expose Oracle support in the EE trigger service

### DIFF
--- a/daml-assistant/daml-sdk/validate.sh
+++ b/daml-assistant/daml-sdk/validate.sh
@@ -32,7 +32,9 @@ for cmd in sandbox sandbox-classic; do
     $JAVA -jar $SDK_EE $cmd --help | grep -q profile-dir
 done
 
-$JAVA -jar $SDK_EE trigger-service --help | grep -q oracle
+if ! ($JAVA -jar $SDK_EE trigger-service --help | grep -q oracle); then
+  exit 1
+fi
 if $JAVA -jar $SDK_CE trigger-service --help | grep -q oracle; then
     exit 1
 fi

--- a/daml-assistant/daml-sdk/validate.sh
+++ b/daml-assistant/daml-sdk/validate.sh
@@ -31,3 +31,8 @@ done
 for cmd in sandbox sandbox-classic; do
     $JAVA -jar $SDK_EE $cmd --help | grep -q profile-dir
 done
+
+$JAVA -jar $SDK_EE trigger-service --help | grep -q oracle
+if $JAVA -jar $SDK_CE trigger-service --help | grep -q oracle; then
+    exit 1
+fi

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -11,9 +11,12 @@ load(
 load("@build_environment//:configuration.bzl", "sdk_version")
 load("@os_info//:os_info.bzl", "is_windows")
 
-tsvc_main_scalacopts = ["-P:wartremover:traverser:org.wartremover.warts.%s" % wart for wart in [
-    "NonUnitStatements",
-]]
+tsvc_main_scalacopts = [
+    "-P:wartremover:traverser:org.wartremover.warts.%s" % wart
+    for wart in [
+        "NonUnitStatements",
+    ]
+]
 
 da_scala_library(
     name = "trigger-service",
@@ -83,9 +86,21 @@ da_scala_library(
 )
 
 da_scala_binary(
-    name = "trigger-service-binary",
+    name = "trigger-service-binary-ce",
     main_class = "com.daml.lf.engine.trigger.ServiceMain",
     visibility = ["//visibility:public"],
+    deps = [
+        ":trigger-service",
+    ],
+)
+
+da_scala_binary(
+    name = "trigger-service-binary-ee",
+    main_class = "com.daml.lf.engine.trigger.ServiceMain",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@maven//:com_oracle_database_jdbc_ojdbc8",
+    ],
     deps = [
         ":trigger-service",
     ],
@@ -180,6 +195,7 @@ scala_test_deps = [
     "@maven//:io_spray_spray_json",
     "@maven//:org_scalatest_scalatest",
     "@maven//:org_scalaz_scalaz_core",
+    "@maven//:com_github_scopt_scopt",
 ]
 
 da_scala_test_suite(

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -81,7 +81,7 @@ object ServiceMain {
   }
 
   def main(args: Array[String]): Unit = {
-    ServiceConfig.parse(args) match {
+    ServiceConfig.parse(args, DbTriggerDao.supportedJdbcDriverNames) match {
       case None => sys.exit(1)
       case Some(config) =>
         val logger = ContextualizedLogger.get(this.getClass)

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
@@ -332,6 +332,10 @@ object DbTriggerDao {
     "oracle.jdbc.OracleDriver" -> ((d, xa) => new DbTriggerDaoOracle(d, xa)),
   )
 
+  lazy val supportedJdbcDriverNames = supportedJdbcDrivers.keySet filter { d =>
+    scala.util.Try(Class forName d).isSuccess
+  }
+
   def apply(c: JdbcConfig, poolSize: PoolSize = Production)(implicit
       ec: ExecutionContext
   ): DbTriggerDao = {

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/ServiceConfigTest.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/ServiceConfigTest.scala
@@ -14,8 +14,26 @@ class ServiceConfigTest extends AnyWordSpec with Matchers with OptionValues {
     val baseOpts = Array("--ledger-host", "localhost", "--ledger-port", "9999")
 
     "read address" in {
-      parse(baseOpts).value.address should ===(defaultAddress)
-      parse(baseOpts ++ Seq("--address", "0.0.0.0")).value.address should ===("0.0.0.0")
+      parse(baseOpts, Set()).value.address should ===(defaultAddress)
+      parse(baseOpts ++ Seq("--address", "0.0.0.0"), Set()).value.address should ===("0.0.0.0")
+    }
+    "default to postgresql jdbc driver" in {
+      parse(
+        baseOpts ++ Seq("--jdbc", "url=url,user=user,password=password"),
+        Set("org.postgresql.Driver"),
+      ).value.jdbcConfig.value.driver should ===("org.postgresql.Driver")
+    }
+    "support a custom jdbc driver" in {
+      parse(
+        baseOpts ++ Seq("--jdbc", "driver=custom,url=url,user=user,password=password"),
+        Set("custom"),
+      ).value.jdbcConfig.value.driver should ===("custom")
+    }
+    "fails for unsupported jdbc driver" in {
+      parse(
+        baseOpts ++ Seq("--jdbc", "driver=custom,url=url,user=user,password=password"),
+        Set("notcustom"),
+      ) should ===(None)
     }
   }
 }


### PR DESCRIPTION
This PR builds on the previous PR that did all the actual work on
Oracle support and exposes it in the enterprise edition. This PR only
releases the enterprise edition via the SDK tarball. I’ll add
artifactory publishing separately.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
