### PR TITLE
fix macOS cache cleaning

### DIFF
--- a/infra/macos/3-running-box/init.sh
+++ b/infra/macos/3-running-box/init.sh
@@ -108,6 +108,9 @@ RESET_CACHES
 chown vsts:staff $CACHE_SCRIPT
 chmod +x $CACHE_SCRIPT
 
+su -l vsts <<END
+/Users/vsts/reset_caches.sh
+END
 
 ## Hardening
 chown -R root:wheel /Users/vsts/agent/{*.sh,bin,externals}


### PR DESCRIPTION
The script needs to run once before the first build, otherwise the cache
folders get created on the main partition.

CHANGELOG_BEGIN
CHANGELOG_END