### PR TITLE
LedgerDao and ContractsReader interface updates

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -361,10 +361,6 @@ final class Metrics(val registry: MetricRegistry) {
           registry.timer(Prefix :+ "lookup_ledger_configuration")
         val lookupKey: Timer = registry.timer(Prefix :+ "lookup_key")
         val lookupActiveContract: Timer = registry.timer(Prefix :+ "lookup_active_contract")
-        val lookupActiveContractWithCachedArgument: Timer =
-          registry.timer(Prefix :+ "lookup_active_contract_with_provided_argument")
-        val lookupContractState: Timer = registry.timer(Prefix :+ "lookup_contract_state")
-        val lookupKeyState: Timer = registry.timer(Prefix :+ "lookup_key_state")
         val lookupMaximumLedgerTime: Timer = registry.timer(Prefix :+ "lookup_maximum_ledger_time")
         val getParties: Timer = registry.timer(Prefix :+ "get_parties")
         val listKnownParties: Timer = registry.timer(Prefix :+ "list_known_parties")
@@ -453,15 +449,12 @@ final class Metrics(val registry: MetricRegistry) {
           "prune"
         ) // FIXME Base name conflicts with prune
         val truncateAllTables: DatabaseMetrics = createDbMetrics("truncate_all_tables")
-        val lookupContractStateDbMetrics: DatabaseMetrics = createDbMetrics("lookup_contract_state")
-        val lookupKeyStateDbMetrics: DatabaseMetrics = createDbMetrics("lookup_key_state")
         val lookupActiveContractDbMetrics: DatabaseMetrics = createDbMetrics(
           "lookup_active_contract"
         ) // FIXME Base name conflicts with lookupActiveContract
-        val lookupActiveContractWithCachedArgumentDbMetrics: DatabaseMetrics = createDbMetrics(
-          "lookup_active_contract_with_cached_argument"
+        val lookupContractByKeyDbMetrics: DatabaseMetrics = createDbMetrics(
+          "lookup_contract_by_key"
         )
-        val lookupContractByKey: DatabaseMetrics = createDbMetrics("lookup_contract_by_key")
         val lookupMaximumLedgerTimeDbMetrics: DatabaseMetrics = createDbMetrics(
           "lookup_maximum_ledger_time"
         ) // FIXME Base name conflicts with lookupActiveContract

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -354,11 +354,17 @@ final class Metrics(val registry: MetricRegistry) {
         val lookupLedgerId: Timer = registry.timer(Prefix :+ "lookup_ledger_id")
         val lookupParticipantId: Timer = registry.timer(Prefix :+ "lookup_participant_id")
         val lookupLedgerEnd: Timer = registry.timer(Prefix :+ "lookup_ledger_end")
+        val lookupLedgerEndSequentialId: Timer =
+          registry.timer(Prefix :+ "lookup_ledger_end_sequential_id")
         val lookupTransaction: Timer = registry.timer(Prefix :+ "lookup_transaction")
         val lookupLedgerConfiguration: Timer =
           registry.timer(Prefix :+ "lookup_ledger_configuration")
         val lookupKey: Timer = registry.timer(Prefix :+ "lookup_key")
         val lookupActiveContract: Timer = registry.timer(Prefix :+ "lookup_active_contract")
+        val lookupActiveContractWithCachedArgument: Timer =
+          registry.timer(Prefix :+ "lookup_active_contract_with_provided_argument")
+        val lookupContractState: Timer = registry.timer(Prefix :+ "lookup_contract_state")
+        val lookupKeyState: Timer = registry.timer(Prefix :+ "lookup_key_state")
         val lookupMaximumLedgerTime: Timer = registry.timer(Prefix :+ "lookup_maximum_ledger_time")
         val getParties: Timer = registry.timer(Prefix :+ "get_parties")
         val listKnownParties: Timer = registry.timer(Prefix :+ "list_known_parties")
@@ -382,6 +388,9 @@ final class Metrics(val registry: MetricRegistry) {
         val getLedgerId: DatabaseMetrics = createDbMetrics("get_ledger_id")
         val getParticipantId: DatabaseMetrics = createDbMetrics("get_participant_id")
         val getLedgerEnd: DatabaseMetrics = createDbMetrics("get_ledger_end")
+        val getLedgerEndSequentialId: DatabaseMetrics = createDbMetrics(
+          "get_ledger_end_sequential_id"
+        )
         val getInitialLedgerEnd: DatabaseMetrics = createDbMetrics("get_initial_ledger_end")
         val initializeLedgerParameters: DatabaseMetrics = createDbMetrics(
           "initialize_ledger_parameters"
@@ -444,6 +453,8 @@ final class Metrics(val registry: MetricRegistry) {
           "prune"
         ) // FIXME Base name conflicts with prune
         val truncateAllTables: DatabaseMetrics = createDbMetrics("truncate_all_tables")
+        val lookupContractStateDbMetrics: DatabaseMetrics = createDbMetrics("lookup_contract_state")
+        val lookupKeyStateDbMetrics: DatabaseMetrics = createDbMetrics("lookup_key_state")
         val lookupActiveContractDbMetrics: DatabaseMetrics = createDbMetrics(
           "lookup_active_contract"
         ) // FIXME Base name conflicts with lookupActiveContract

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -21,9 +21,9 @@ import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.common.{LedgerIdNotFoundException, MismatchException}
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader
 import com.daml.platform.store.dao.events.contracts.TranslationCacheBackedContractsStore
 import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerReadDao}
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader
 import com.daml.platform.store.{BaseLedger, LfValueTranslationCache, ReadOnlyLedger}
 import com.daml.resources.ProgramResource.StartupException
 import com.daml.timer.RetryStrategy

--- a/ledger/participant-integration-api/src/main/scala/platform/store/Conversions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/Conversions.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.participant.state.v1.RejectionReason._
 import com.daml.ledger.participant.state.v1.{Offset, RejectionReason}
 import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.Party
 import com.daml.lf.value.Value
 import io.grpc.Status.Code
 
@@ -121,6 +122,11 @@ private[platform] object Conversions {
 
   def contractId(columnName: String): RowParser[Value.ContractId] =
     SqlParser.get[Value.ContractId](columnName)(columnToContractId)
+
+  def flatEventWitnessesColumn(columnName: String): RowParser[Set[Party]] =
+    SqlParser
+      .get[Array[String]](columnName)(Column.columnToArray)
+      .map(_.iterator.map(Party.assertFromString).toSet)
 
   // ContractIdString
 
@@ -231,7 +237,6 @@ private[platform] object Conversions {
       s.setArray(index, ts)
     }
   }
-
   // RejectionReason
 
   implicit def domainRejectionReasonToErrorCode(reason: domain.RejectionReason): Code =
@@ -262,5 +267,4 @@ private[platform] object Conversions {
         SubmitterCannotActViaParticipant(r.description)
       case r: domain.RejectionReason.InvalidLedgerTime => InvalidLedgerTime(r.description)
     }
-
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/LedgerDaoContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/LedgerDaoContractsReader.scala
@@ -1,0 +1,107 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.time.Instant
+
+import com.daml.lf.data.Ref.Party
+import com.daml.lf.transaction.GlobalKey
+import com.daml.logging.LoggingContext
+import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader._
+
+import scala.concurrent.Future
+
+private[platform] trait LedgerDaoContractsReader {
+
+  /** Returns the largest ledger time of any of the given contracts.
+    *
+    * @param ids the contract ids for which to resolve the maximum ledger time
+    * @return the optional [[Instant]] maximum ledger time
+    */
+  def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Instant]]
+
+  /** Looks up an active or divulged contract if it is visible for the given party.
+    *
+    * @param forParties a set of parties for one of which the contract must be visible
+    * @param contractId the contract id to query
+    * @return the optional [[Contract]] value
+    */
+  def lookupActiveContractAndLoadArgument(
+      readers: Set[Party],
+      contractId: ContractId,
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]]
+
+  /** Looks up an active or divulged contract if it is visible for the given party.
+    * This method uses the provided create argument for building the [[Contract]] value
+    * instead of decoding it again.
+    *
+    * @param forParties a set of parties for one of which the contract must be visible
+    * @param contractId the contract id to query
+    * @param createArgument the contract create argument
+    * @return the optional [[Contract]] value
+    */
+  def lookupActiveContractWithCachedArgument(
+      readers: Set[Party],
+      contractId: ContractId,
+      createArgument: Value,
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]]
+
+  /** Looks up a Contract given a contract key and a party
+    *
+    * @param key the contract key to query
+    * @param forParties a set of parties for one of which the contract must be visible
+    * @return the optional [[ContractId]]
+    */
+  def lookupContractKey(
+      key: GlobalKey,
+      forParties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[ContractId]]
+
+  /** Looks up the contract by id at a specific ledger event sequential id.
+    *
+    * @param contractId the contract id to query
+    * @param validAt the event sequential id at which to resolve the contract state
+    * @return the optional [[ContractState]]
+    */
+  def lookupContractState(contractId: ContractId, validAt: Long)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[ContractState]]
+
+  /** Looks up the state of a contract key at a specific event sequential id.
+    *
+    * @param key the contract key to query
+    * @param validAt the event sequential id at which to resolve the key state
+    * @return the [[KeyState]]
+    */
+  def lookupKeyState(key: GlobalKey, validAt: Long)(implicit
+      loggingContext: LoggingContext
+  ): Future[KeyState]
+}
+
+object LedgerDaoContractsReader {
+  import com.daml.lf.value.{Value => lfval}
+  private type ContractId = lfval.ContractId
+  private type Value = lfval.VersionedValue[ContractId]
+  private type Contract = lfval.ContractInst[Value]
+
+  sealed trait ContractState extends Product with Serializable {
+    def stakeholders: Set[Party]
+  }
+
+  final case class ActiveContract(
+      contract: Contract,
+      stakeholders: Set[Party],
+      ledgerEffectiveTime: Instant,
+  ) extends ContractState
+
+  final case class ArchivedContract(stakeholders: Set[Party]) extends ContractState
+
+  sealed trait KeyState extends Product with Serializable
+
+  final case class KeyAssigned(contractId: ContractId, stakeholders: Set[Party]) extends KeyState
+
+  final case object KeyUnassigned extends KeyState
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
@@ -9,18 +9,18 @@ import java.time.Instant
 import anorm.SqlParser._
 import anorm.{RowParser, SqlParser, SqlStringInterpolation, _}
 import com.codahale.metrics.Timer
-import com.daml.lf.transaction.GlobalKey
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.Conversions._
 import com.daml.platform.store.DbType
-import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader._
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader._
 import com.daml.platform.store.appendonlydao.events.ContractsReader._
 import com.daml.platform.store.appendonlydao.events.SqlFunctions.{
   H2SqlFunctions,
   PostgresSqlFunctions,
 }
-import com.daml.platform.store.appendonlydao.{DbDispatcher, LedgerDaoContractsReader}
+import com.daml.platform.store.appendonlydao.DbDispatcher
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader
 import com.daml.platform.store.serialization.{Compression, ValueSerializer}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -29,7 +29,7 @@ private[appendonlydao] sealed class ContractsReader(
     val committedContracts: PostCommitValidationData,
     dispatcher: DbDispatcher,
     metrics: Metrics,
-   sqlFunctions: SqlFunctions,
+    sqlFunctions: SqlFunctions,
 )(implicit ec: ExecutionContext)
     extends LedgerDaoContractsReader {
 
@@ -51,17 +51,18 @@ private[appendonlydao] sealed class ContractsReader(
     * @param validAt the event_sequential_id of the ledger at which to query for the key state
     * @return the key state.
     */
-  override def lookupKeyState(key: GlobalKey, validAt: Long)(implicit
+  override def lookupKeyState(key: Key, validAt: Long)(implicit
       loggingContext: LoggingContext
   ): Future[KeyState] =
     Timed.future(
-      metrics.daml.index.db.lookupKeyState,
-      dispatcher.executeSql(metrics.daml.index.db.lookupContractByKey) { implicit connection =>
-        SQL"""
+      metrics.daml.index.db.lookupKey,
+      dispatcher.executeSql(metrics.daml.index.db.lookupContractByKeyDbMetrics) {
+        implicit connection =>
+          SQL"""
           WITH last_contract_key_create AS (
                  SELECT contract_id, flat_event_witnesses
                    FROM participant_events
-                  WHERE event_kind = #$EventKindCreated
+                  WHERE event_kind = 10 -- create
                     AND create_key_hash = ${key.hash}
                     AND event_sequential_id <= $validAt
                   ORDER BY event_sequential_id DESC
@@ -72,17 +73,17 @@ private[appendonlydao] sealed class ContractsReader(
           WHERE NOT EXISTS       -- check no archival visible
                  (SELECT 1
                     FROM participant_events
-                   WHERE event_kind = #$EventKindArchived
+                   WHERE event_kind = 20 -- consuming exercise
                      AND event_sequential_id <= $validAt
                      AND contract_id = last_contract_key_create.contract_id
          );
          """
-          .as(
-            (contractId("contract_id") ~ flatEventWitnessesColumn("flat_event_witnesses")).map {
-              case cId ~ stakeholders => KeyAssigned(cId, stakeholders)
-            }.singleOpt
-          )
-          .getOrElse(KeyUnassigned)
+            .as(
+              (contractId("contract_id") ~ flatEventWitnessesColumn("flat_event_witnesses")).map {
+                case cId ~ stakeholders => KeyAssigned(cId, stakeholders)
+              }.singleOpt
+            )
+            .getOrElse(KeyUnassigned)
       },
     )
 
@@ -90,9 +91,9 @@ private[appendonlydao] sealed class ContractsReader(
       loggingContext: LoggingContext
   ): Future[Option[ContractState]] =
     Timed.future(
-      metrics.daml.index.db.lookupContractState,
+      metrics.daml.index.db.lookupActiveContract,
       dispatcher
-        .executeSql(metrics.daml.index.db.lookupContractStateDbMetrics) { implicit connection =>
+        .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
           SQL"""
            SELECT
              template_id,
@@ -105,7 +106,7 @@ private[appendonlydao] sealed class ContractsReader(
            WHERE
              contract_id = $contractId
              AND event_sequential_id <= $before
-             AND (event_kind = #$EventKindCreated OR event_kind = #$EventKindArchived)
+             AND (event_kind = 10 OR event_kind = 20)
            ORDER BY event_sequential_id DESC
            LIMIT 1;
            """
@@ -117,7 +118,7 @@ private[appendonlydao] sealed class ContractsReader(
                 stakeholders,
                 createArgument,
                 createArgumentCompression,
-                EventKindCreated,
+                10,
                 maybeCreateLedgerEffectiveTime,
               ) =>
             val contract = toContract(
@@ -129,9 +130,9 @@ private[appendonlydao] sealed class ContractsReader(
               createArgumentCompression =
                 Compression.Algorithm.assertLookup(createArgumentCompression),
               decompressionTimer =
-                metrics.daml.index.db.lookupContractStateDbMetrics.compressionTimer,
+                metrics.daml.index.db.lookupActiveContractDbMetrics.compressionTimer,
               deserializationTimer =
-                metrics.daml.index.db.lookupContractStateDbMetrics.translationTimer,
+                metrics.daml.index.db.lookupActiveContractDbMetrics.translationTimer,
             )
             ActiveContract(
               contract,
@@ -140,7 +141,7 @@ private[appendonlydao] sealed class ContractsReader(
                 "ledger_effective_time must be present for a create event"
               ),
             )
-          case (_, stakeholders, _, _, EventKindArchived, _) => ArchivedContract(stakeholders)
+          case (_, stakeholders, _, _, 20, _) => ArchivedContract(stakeholders)
           case (_, _, _, _, kind, _) => throw ContractsReaderError(s"Unexpected event kind $kind")
         }),
     )
@@ -150,11 +151,74 @@ private[appendonlydao] sealed class ContractsReader(
       readers: Set[Party],
       contractId: ContractId,
   )(implicit loggingContext: LoggingContext): Future[Option[Contract]] = {
+
+    Timed.future(
+      metrics.daml.index.db.lookupActiveContract,
+      dispatcher
+        .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
+          lookupActiveContractAndLoadArgumentQuery(contractId, readers)
+            .as(contractRowParser.singleOpt)
+        }
+        .map(_.map { case (templateId, createArgument, createArgumentCompression) =>
+          toContract(
+            contractId = contractId,
+            templateId = templateId,
+            createArgument = createArgument,
+            createArgumentCompression =
+              Compression.Algorithm.assertLookup(createArgumentCompression),
+            decompressionTimer =
+              metrics.daml.index.db.lookupActiveContractDbMetrics.compressionTimer,
+            deserializationTimer =
+              metrics.daml.index.db.lookupActiveContractDbMetrics.translationTimer,
+          )
+        }),
+    )
+  }
+
+  /** Lookup of a contract in the case the contract value is already known (loaded from a cache) */
+  override def lookupActiveContractWithCachedArgument(
+      readers: Set[Party],
+      contractId: ContractId,
+      createArgument: Value,
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] = {
+
+    Timed.future(
+      metrics.daml.index.db.lookupActiveContract,
+      dispatcher
+        .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
+          lookupActiveContractWithCachedArgumentQuery(contractId, readers)
+            .as(contractWithoutValueRowParser.singleOpt)
+        }
+        .map(
+          _.map(templateId =>
+            toContract(
+              templateId = templateId,
+              createArgument = createArgument,
+            )
+          )
+        ),
+    )
+  }
+
+  override def lookupContractKey(
+      key: Key,
+      readers: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[ContractId]] =
+    Timed.future(
+      metrics.daml.index.db.lookupKey,
+      dispatcher.executeSql(metrics.daml.index.db.lookupContractByKeyDbMetrics) {
+        implicit connection =>
+          lookupContractKeyQuery(readers, key).as(contractId("contract_id").singleOpt)
+      },
+    )
+
+  private def lookupActiveContractAndLoadArgumentQuery(
+      contractId: ContractId,
+      readers: Set[Party],
+  ) = {
     val tree_event_witnessesWhere =
       sqlFunctions.arrayIntersectionWhereClause("tree_event_witnesses", readers)
-    dispatcher
-      .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
-        SQL"""
+    SQL"""
   WITH archival_event AS (
          SELECT participant_events.*
            FROM participant_events, parameters
@@ -211,33 +275,17 @@ private[appendonlydao] sealed class ContractsReader(
   SELECT contract_id, template_id, create_argument, create_argument_compression
     FROM create_and_divulged_contracts
    WHERE NOT EXISTS (SELECT 1 FROM archival_event)
-   LIMIT 1;""".as(contractRowParser.singleOpt)
-      }
-      .map(_.map { case (templateId, createArgument, createArgumentCompression) =>
-        toContract(
-          contractId = contractId,
-          templateId = templateId,
-          createArgument = createArgument,
-          createArgumentCompression = Compression.Algorithm.assertLookup(createArgumentCompression),
-          decompressionTimer = metrics.daml.index.db.lookupActiveContractDbMetrics.compressionTimer,
-          deserializationTimer =
-            metrics.daml.index.db.lookupActiveContractDbMetrics.translationTimer,
-        )
-      })
+   LIMIT 1;"""
   }
 
-  /** Lookup of a contract in the case the contract value is already known (loaded from a cache) */
-  override def lookupActiveContractWithCachedArgument(
-      readers: Set[Party],
+  private def lookupActiveContractWithCachedArgumentQuery(
       contractId: ContractId,
-      createArgument: Value,
-  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] = {
+      readers: Set[Party],
+  ) = {
     val tree_event_witnessesWhere =
       sqlFunctions.arrayIntersectionWhereClause("tree_event_witnesses", readers)
-    dispatcher
-      .executeSql(metrics.daml.index.db.lookupActiveContractWithCachedArgumentDbMetrics) {
-        implicit connection =>
-          SQL"""
+
+    SQL"""
   WITH archival_event AS (
          SELECT participant_events.*
            FROM participant_events, parameters
@@ -285,28 +333,7 @@ private[appendonlydao] sealed class ContractsReader(
    WHERE NOT EXISTS (SELECT 1 FROM archival_event)
    LIMIT 1;
            """
-            .as(contractWithoutValueRowParser.singleOpt)
-      }
-      .map(
-        _.map(templateId =>
-          toContract(
-            templateId = templateId,
-            createArgument = createArgument,
-          )
-        )
-      )
   }
-
- override def lookupContractKey(
-      key: Key,
-      readers: Set[Party],
-  )(implicit loggingContext: LoggingContext): Future[Option[ContractId]] =
-    Timed.future(
-      metrics.daml.index.db.lookupKey,
-      dispatcher.executeSql(metrics.daml.index.db.lookupContractByKey) { implicit connection =>
-        lookupContractKeyQuery(readers, key).as(contractId("contract_id").singleOpt)
-      },
-    )
 
   private def lookupContractKeyQuery(readers: Set[Party], key: Key): SimpleSql[Row] = {
     def flat_event_witnessesWhere(columnPrefix: String) =
@@ -315,7 +342,7 @@ private[appendonlydao] sealed class ContractsReader(
   WITH last_contract_key_create AS (
          SELECT participant_events.*
            FROM participant_events, parameters
-          WHERE event_kind = #$EventKindCreated
+          WHERE event_kind = 10 -- create
             AND create_key_hash = ${key.hash}
             AND event_sequential_id <= parameters.ledger_end_sequential_id
                 -- do NOT check visibility here, as otherwise we do not abort the scan early
@@ -328,7 +355,7 @@ private[appendonlydao] sealed class ContractsReader(
     AND NOT EXISTS       -- check no archival visible
          (SELECT 1
             FROM participant_events, parameters
-           WHERE event_kind = #$EventKindArchived
+           WHERE event_kind = 20 -- consuming exercise
              AND event_sequential_id <= parameters.ledger_end_sequential_id
              AND #${flat_event_witnessesWhere("participant_events")}
              AND contract_id = last_contract_key_create.contract_id
@@ -338,10 +365,9 @@ private[appendonlydao] sealed class ContractsReader(
 }
 
 private[appendonlydao] object ContractsReader {
-  private val EventKindCreated = 10
-  private val EventKindArchived = 20
   private val contractWithoutValueRowParser: RowParser[String] =
     str("template_id")
+
   private val fullDetailsContractRowParser: RowParser[
     (Option[String], Set[Party], Option[InputStream], Option[Int], Int, Option[Instant])
   ] =
@@ -352,6 +378,7 @@ private[appendonlydao] object ContractsReader {
     ).? ~ int("event_kind") ~ get[Instant](
       "ledger_effective_time"
     )(anorm.Column.columnToInstant).? map SqlParser.flatten
+
   private val contractRowParser: RowParser[(String, InputStream, Option[Int])] =
     str("template_id") ~ binaryStream("create_argument") ~ int(
       "create_argument_compression"
@@ -361,7 +388,7 @@ private[appendonlydao] object ContractsReader {
       dispatcher: DbDispatcher,
       dbType: DbType,
       metrics: Metrics,
- )(implicit ec: ExecutionContext): ContractsReader = {
+  )(implicit ec: ExecutionContext): ContractsReader = {
     def sqlFunctions = dbType match {
       case DbType.Postgres => PostgresSqlFunctions
       case DbType.H2Database => H2SqlFunctions

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -26,7 +26,6 @@ import com.daml.lf.data.Ref.{PackageId, Party}
 import com.daml.lf.transaction.BlindingInfo
 import com.daml.logging.LoggingContext
 import com.daml.platform.indexer.OffsetStep
-import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader
 import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 import com.daml.platform.store.dao.events.{FilterRelation, TransactionsWriter}
 import com.daml.platform.store.entries.{
@@ -35,6 +34,7 @@ import com.daml.platform.store.entries.{
   PackageLedgerEntry,
   PartyLedgerEntry,
 }
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader
 
 import scala.concurrent.Future
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -8,19 +8,18 @@ import java.time.Instant
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.daml_lf_dev.DamlLf.Archive
-import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.ledger.api.domain.{CommandId, LedgerId, ParticipantId, PartyDetails}
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.participant.state.index.v2.{CommandDeduplicationResult, PackageDetails}
 import com.daml.ledger.participant.state.v1._
+import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{PackageId, Party}
-import com.daml.lf.transaction.{BlindingInfo, GlobalKey}
-import com.daml.lf.value.Value
-import com.daml.lf.value.Value.{ContractId, ContractInst}
+import com.daml.lf.transaction.BlindingInfo
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.indexer.OffsetStep
+import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader
 import com.daml.platform.store.dao.events.TransactionsWriter
 import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 import com.daml.platform.store.entries.{
@@ -48,36 +47,20 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
   override def lookupLedgerEnd()(implicit loggingContext: LoggingContext): Future[Offset] =
     Timed.future(metrics.daml.index.db.lookupLedgerEnd, ledgerDao.lookupLedgerEnd())
 
+  def lookupLedgerEndSequentialId()(implicit loggingContext: LoggingContext): Future[Long] =
+    Timed.future(
+      metrics.daml.index.db.lookupLedgerEndSequentialId,
+      ledgerDao.lookupLedgerEndSequentialId(),
+    )
+
   override def lookupInitialLedgerEnd()(implicit
       loggingContext: LoggingContext
   ): Future[Option[Offset]] =
     Timed.future(metrics.daml.index.db.lookupLedgerEnd, ledgerDao.lookupInitialLedgerEnd())
 
-  override def lookupActiveOrDivulgedContract(
-      contractId: Value.ContractId,
-      forParties: Set[Party],
-  )(implicit
-      loggingContext: LoggingContext
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
-    Timed.future(
-      metrics.daml.index.db.lookupActiveContract,
-      ledgerDao.lookupActiveOrDivulgedContract(contractId, forParties),
-    )
-
-  override def lookupMaximumLedgerTime(
-      contractIds: Set[ContractId]
-  )(implicit loggingContext: LoggingContext): Future[Option[Instant]] =
-    Timed.future(
-      metrics.daml.index.db.lookupMaximumLedgerTime,
-      ledgerDao.lookupMaximumLedgerTime(contractIds),
-    )
-
   override def transactionsReader: LedgerDaoTransactionsReader = ledgerDao.transactionsReader
 
-  override def lookupKey(key: GlobalKey, forParties: Set[Party])(implicit
-      loggingContext: LoggingContext
-  ): Future[Option[Value.ContractId]] =
-    Timed.future(metrics.daml.index.db.lookupKey, ledgerDao.lookupKey(key, forParties))
+  override def contractsReader: LedgerDaoContractsReader = ledgerDao.contractsReader
 
   override def getParties(parties: Seq[Party])(implicit
       loggingContext: LoggingContext

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -19,7 +19,6 @@ import com.daml.lf.transaction.BlindingInfo
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.indexer.OffsetStep
-import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader
 import com.daml.platform.store.dao.events.TransactionsWriter
 import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 import com.daml.platform.store.entries.{
@@ -28,6 +27,7 @@ import com.daml.platform.store.entries.{
   PackageLedgerEntry,
   PartyLedgerEntry,
 }
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader
 
 import scala.concurrent.Future
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -6,130 +6,137 @@ package com.daml.platform.store.dao.events
 import java.io.InputStream
 import java.time.Instant
 
-import anorm.SqlParser.{binaryStream, int, str}
-import anorm.{Row, RowParser, SimpleSql, SqlParser, SqlStringInterpolation}
+import anorm.SqlParser._
+import anorm.{RowParser, SqlParser, SqlStringInterpolation}
 import com.codahale.metrics.Timer
-import com.daml.ledger.participant.state.index.v2.ContractStore
+import com.daml.lf.transaction.GlobalKey
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.Conversions._
-import com.daml.platform.store.{DbType, LfValueTranslationCache}
+import com.daml.platform.store.DbType
+import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader
+import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader._
 import com.daml.platform.store.dao.DbDispatcher
+import com.daml.platform.store.dao.events.ContractsReader._
 import com.daml.platform.store.dao.events.SqlFunctions.{H2SqlFunctions, PostgresSqlFunctions}
 import com.daml.platform.store.serialization.{Compression, ValueSerializer}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-/** @see [[ContractsTable]]
-  */
 private[dao] sealed class ContractsReader(
     val committedContracts: PostCommitValidationData,
     dispatcher: DbDispatcher,
     metrics: Metrics,
-    lfValueTranslationCache: LfValueTranslationCache.Cache,
     sqlFunctions: SqlFunctions,
 )(implicit ec: ExecutionContext)
-    extends ContractStore {
+    extends LedgerDaoContractsReader {
 
-  import ContractsReader._
+  override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Instant]] =
+    Timed.future(
+      metrics.daml.index.db.lookupMaximumLedgerTime,
+      dispatcher
+        .executeSql(metrics.daml.index.db.lookupMaximumLedgerTimeDbMetrics) { implicit connection =>
+          committedContracts.lookupMaximumLedgerTime(ids)
+        }
+        .map(_.get),
+    )
 
+  override def lookupContractKey(
+      key: Key,
+      readers: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[ContractId]] =
+    Timed.future(
+      metrics.daml.index.db.lookupKey, {
+        val stakeholdersWhere =
+          sqlFunctions.arrayIntersectionWhereClause("create_stakeholders", readers)
+
+        dispatcher.executeSql(metrics.daml.index.db.lookupContractByKey) { implicit connection =>
+          SQL"select participant_contracts.contract_id from #$contractsTable where #$stakeholdersWhere and contract_witness in ($readers) and create_key_hash = ${key.hash} limit 1"
+            .as(contractId("contract_id").singleOpt)
+        }
+      },
+    )
+
+  override def lookupActiveContractAndLoadArgument(
+      readers: Set[Party],
+      contractId: ContractId,
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
+    Timed.future(
+      metrics.daml.index.db.lookupActiveContract,
+      dispatcher
+        .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
+          SQL"select participant_contracts.contract_id, template_id, create_argument, create_argument_compression from #$contractsTable where contract_witness in ($readers) and participant_contracts.contract_id = $contractId limit 1"
+            .as(contractRowParser.singleOpt)
+        }
+        .map(_.map { case (templateId, createArgument, createArgumentCompression) =>
+          toContract(
+            contractId = contractId,
+            templateId = templateId,
+            createArgument = createArgument,
+            createArgumentCompression =
+              Compression.Algorithm.assertLookup(createArgumentCompression),
+            decompressionTimer =
+              metrics.daml.index.db.lookupActiveContractDbMetrics.compressionTimer,
+            deserializationTimer =
+              metrics.daml.index.db.lookupActiveContractDbMetrics.translationTimer,
+          )
+        }),
+    )
+
+  override def lookupActiveContractWithCachedArgument(
+      readers: Set[Party],
+      contractId: ContractId,
+      createArgument: Value,
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
+    Timed.future(
+      metrics.daml.index.db.lookupActiveContractWithCachedArgument,
+      dispatcher
+        .executeSql(metrics.daml.index.db.lookupActiveContractWithCachedArgumentDbMetrics) {
+          implicit connection =>
+            SQL"select participant_contracts.contract_id, template_id from #$contractsTable where contract_witness in ($readers) and participant_contracts.contract_id = $contractId limit 1"
+              .as(contractWithoutValueRowParser.singleOpt)
+        }
+        .map(
+          _.map(templateId =>
+            toContract(
+              templateId = templateId,
+              createArgument = createArgument,
+            )
+          )
+        ),
+    )
+
+  override def lookupKeyState(key: GlobalKey, validAt: Long)(implicit
+      loggingContext: LoggingContext
+  ): Future[KeyState] = {
+    val _ = (key, validAt)
+    Future.failed(NotSupportedError("lookupKeyState"))
+  }
+
+  override def lookupContractState(contractId: ContractId, before: Long)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[ContractState]] = {
+    val _ = (contractId, before)
+    Future.failed(NotSupportedError("lookupContractState"))
+  }
+}
+
+private[dao] object ContractsReader {
+  private val contractsTable =
+    "participant_contracts natural join participant_contract_witnesses"
+  private val contractWithoutValueRowParser: RowParser[String] =
+    str("template_id")
   private val contractRowParser: RowParser[(String, InputStream, Option[Int])] =
     str("template_id") ~ binaryStream("create_argument") ~ int(
       "create_argument_compression"
     ).? map SqlParser.flatten
 
-  private val contractWithoutValueRowParser: RowParser[String] =
-    str("template_id")
-
-  /** Lookup of a contract in the case the contract value is not already known */
-  private def lookupActiveContractAndLoadArgument(
-      readers: Set[Party],
-      contractId: ContractId,
-  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
-    dispatcher
-      .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
-        SQL"select participant_contracts.contract_id, template_id, create_argument, create_argument_compression from #$contractsTable where contract_witness in ($readers) and participant_contracts.contract_id = $contractId limit 1"
-          .as(contractRowParser.singleOpt)
-      }
-      .map(_.map { case (templateId, createArgument, createArgumentCompression) =>
-        toContract(
-          contractId = contractId,
-          templateId = templateId,
-          createArgument = createArgument,
-          createArgumentCompression = Compression.Algorithm.assertLookup(createArgumentCompression),
-          decompressionTimer = metrics.daml.index.db.lookupActiveContractDbMetrics.compressionTimer,
-          deserializationTimer =
-            metrics.daml.index.db.lookupActiveContractDbMetrics.translationTimer,
-        )
-      })
-
-  /** Lookup of a contract in the case the contract value is already known (loaded from a cache) */
-  private def lookupActiveContractWithCachedArgument(
-      readers: Set[Party],
-      contractId: ContractId,
-      createArgument: Value,
-  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
-    dispatcher
-      .executeSql(metrics.daml.index.db.lookupActiveContractWithCachedArgumentDbMetrics) {
-        implicit connection =>
-          SQL"select participant_contracts.contract_id, template_id from #$contractsTable where contract_witness in ($readers) and participant_contracts.contract_id = $contractId limit 1"
-            .as(contractWithoutValueRowParser.singleOpt)
-      }
-      .map(
-        _.map(templateId =>
-          toContract(
-            templateId = templateId,
-            createArgument = createArgument,
-          )
-        )
-      )
-
-  override def lookupActiveContract(
-      readers: Set[Party],
-      contractId: ContractId,
-  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
-    // Depending on whether the contract argument is cached or not, submit a different query to the database
-    lfValueTranslationCache.contracts
-      .getIfPresent(LfValueTranslationCache.ContractCache.Key(contractId)) match {
-      case Some(createArgument) =>
-        lookupActiveContractWithCachedArgument(readers, contractId, createArgument.argument)
-      case None =>
-        lookupActiveContractAndLoadArgument(readers, contractId)
-
-    }
-
-  override def lookupContractKey(
-      readers: Set[Party],
-      key: Key,
-  )(implicit loggingContext: LoggingContext): Future[Option[ContractId]] =
-    dispatcher.executeSql(metrics.daml.index.db.lookupContractByKey) { implicit connection =>
-      lookupContractKeyQuery(readers, key).as(contractId("contract_id").singleOpt)
-    }
-
-  private def lookupContractKeyQuery(readers: Set[Party], key: Key): SimpleSql[Row] = {
-    val stakeholdersWhere =
-      sqlFunctions.arrayIntersectionWhereClause("create_stakeholders", readers)
-    SQL"select participant_contracts.contract_id from #$contractsTable where #$stakeholdersWhere and contract_witness in ($readers) and create_key_hash = ${key.hash} limit 1"
-  }
-
-  override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
-      loggingContext: LoggingContext
-  ): Future[Option[Instant]] =
-    dispatcher
-      .executeSql(metrics.daml.index.db.lookupMaximumLedgerTimeDbMetrics) { implicit connection =>
-        committedContracts.lookupMaximumLedgerTime(ids)
-      }
-      .map(_.get)
-
-}
-
-private[dao] object ContractsReader {
-
   private[dao] def apply(
       dispatcher: DbDispatcher,
       dbType: DbType,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslationCache.Cache,
   )(implicit ec: ExecutionContext): ContractsReader = {
     def sqlFunctions = dbType match {
       case DbType.Postgres => PostgresSqlFunctions
@@ -139,12 +146,9 @@ private[dao] object ContractsReader {
       committedContracts = ContractsTable(dbType),
       dispatcher = dispatcher,
       metrics = metrics,
-      lfValueTranslationCache = lfValueTranslationCache,
       sqlFunctions = sqlFunctions,
     )
   }
-
-  private val contractsTable = "participant_contracts natural join participant_contract_witnesses"
 
   // The contracts table _does not_ store agreement texts as they are
   // unnecessary for interpretation and validation. The contracts returned
@@ -186,4 +190,7 @@ private[dao] object ContractsReader {
       arg = createArgument,
       agreementText = "",
     )
+
+  case class NotSupportedError(methodName: String)
+      extends RuntimeException(s"Method $methodName not supported on the legacy index schema")
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/contracts/TranslationCacheBackedContractsStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/contracts/TranslationCacheBackedContractsStore.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events.contracts
+
+import java.time.Instant
+
+import com.daml.ledger.participant.state.index.v2.ContractStore
+import com.daml.ledger.resources.Resource
+import com.daml.lf.data.Ref
+import com.daml.lf.transaction.GlobalKey
+import com.daml.logging.LoggingContext
+import com.daml.platform.store.LfValueTranslationCache
+import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader
+import com.daml.platform.store.dao.events._
+
+import scala.concurrent.Future
+
+class TranslationCacheBackedContractsStore(
+    lfValueTranslationCache: LfValueTranslationCache.Cache,
+    contractsReader: LedgerDaoContractsReader,
+) extends ContractStore {
+  override def lookupActiveContract(
+      readers: Set[Party],
+      contractId: ContractId,
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
+    lfValueTranslationCache.contracts
+      .getIfPresent(LfValueTranslationCache.ContractCache.Key(contractId)) match {
+      case Some(createArgument) =>
+        contractsReader.lookupActiveContractWithCachedArgument(
+          readers,
+          contractId,
+          createArgument.argument,
+        )
+      case None =>
+        contractsReader.lookupActiveContractAndLoadArgument(readers, contractId)
+    }
+
+  override def lookupContractKey(readers: Set[Ref.Party], key: GlobalKey)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[ContractId]] =
+    contractsReader.lookupContractKey(key, readers)
+
+  /** @return The maximum ledger effective time of all contracts in ids, fails as follows:
+    *         - if ids is empty or not all the non-divulged ids can be found, a failed [[Future]]
+    *         - if all ids are found but each refer to a divulged contract, a successful [[None]]
+    */
+  override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Instant]] =
+    contractsReader.lookupMaximumLedgerTime(ids)
+}
+
+object TranslationCacheBackedContractsStore {
+  def owner(
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
+      contractsReader: LedgerDaoContractsReader,
+  ): Resource[TranslationCacheBackedContractsStore] =
+    Resource.successful(
+      new TranslationCacheBackedContractsStore(
+        lfValueTranslationCache,
+        contractsReader,
+      )
+    )
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/contracts/TranslationCacheBackedContractsStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/contracts/TranslationCacheBackedContractsStore.scala
@@ -11,8 +11,8 @@ import com.daml.lf.data.Ref
 import com.daml.lf.transaction.GlobalKey
 import com.daml.logging.LoggingContext
 import com.daml.platform.store.LfValueTranslationCache
-import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader
 import com.daml.platform.store.dao.events._
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader
 
 import scala.concurrent.Future
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
@@ -1,14 +1,14 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.platform.store.appendonlydao
+package com.daml.platform.store.interfaces
 
 import java.time.Instant
 
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.transaction.GlobalKey
 import com.daml.logging.LoggingContext
-import com.daml.platform.store.appendonlydao.LedgerDaoContractsReader._
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader._
 
 import scala.concurrent.Future
 
@@ -25,7 +25,7 @@ private[platform] trait LedgerDaoContractsReader {
 
   /** Looks up an active or divulged contract if it is visible for the given party.
     *
-    * @param forParties a set of parties for one of which the contract must be visible
+    * @param readers a set of parties for one of which the contract must be visible
     * @param contractId the contract id to query
     * @return the optional [[Contract]] value
     */
@@ -38,7 +38,7 @@ private[platform] trait LedgerDaoContractsReader {
     * This method uses the provided create argument for building the [[Contract]] value
     * instead of decoding it again.
     *
-    * @param forParties a set of parties for one of which the contract must be visible
+    * @param readers a set of parties for one of which the contract must be visible
     * @param contractId the contract id to query
     * @param createArgument the contract create argument
     * @return the optional [[Contract]] value

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsWriterSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsWriterSpec.scala
@@ -63,7 +63,10 @@ private[dao] trait JdbcLedgerDaoTransactionsWriterSpec extends LoneElement {
         blindingInfo = Some(mismatchingBlindingInfo),
         divulgedContracts = Map.empty,
       )
-      result <- ledgerDao.lookupActiveOrDivulgedContract(nonTransient(tx).loneElement, Set(alice))
+      result <- ledgerDao.contractsReader.lookupActiveContractAndLoadArgument(
+        Set(alice),
+        nonTransient(tx).loneElement,
+      )
     } yield {
       result shouldBe None
     }


### PR DESCRIPTION
This PR contains interface changes to the `LedgerDao` and `ContractsReader` as preparation for the incoming changes of the mutable contract state cache implementation:
* Expose all contracts related read queries through `ContractsReader`.
* Extract the legacy caching layer out of the `ContractsReader`.
* The legacy caching layer (based on `LfValueTranslation` cache) is extracted into `TranslationCacheBackedContractsStore`, exposed at the level of `ReadOnlySqlLedger`.
* Implement `lookupContractState` and `lookupKeyState` JDBC access methods in `ContractsReader`.

**NOTE:** Tests asserting the new methods in this PR (`ContractsReader.lookupKeyState` and `ContractsReader.lookupContractState`) are left out on purpose and extracted in a separate [branch](https://github.com/digital-asset/daml/tree/tudor/dpp-344-tests-for-mutable-contracts-store-dao). They will be merged when the DAO integration testing suite will be adapted for the append-only schema.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
