### PR TITLE
Deduplicate LfValueTranslation cache

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -28,7 +28,7 @@ import com.daml.platform.configuration.{
 import com.daml.platform.index.JdbcIndex
 import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.services.time.TimeProviderType
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.LfValueTranslationCache
 import com.daml.ports.{Port, PortFiles}
 import io.grpc.{BindableService, ServerInterceptor}
 
@@ -52,7 +52,7 @@ final class StandaloneApiServer(
     otherInterceptors: List[ServerInterceptor] = List.empty,
     engine: Engine,
     servicesExecutionContext: ExecutionContextExecutor,
-    lfValueTranslationCache: LfValueTranslation.Cache,
+    lfValueTranslationCache: LfValueTranslationCache.Cache,
 )(implicit actorSystem: ActorSystem, materializer: Materializer, loggingContext: LoggingContext)
     extends ResourceOwner[ApiServer] {
 

--- a/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
@@ -12,7 +12,7 @@ import com.daml.lf.engine.ValueEnricher
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.LfValueTranslationCache
 
 import scala.concurrent.ExecutionContext
 
@@ -26,7 +26,7 @@ private[platform] object JdbcIndex {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       enricher: ValueEnricher,
   )(implicit mat: Materializer, loggingContext: LoggingContext): ResourceOwner[IndexService] =
     new ReadOnlySqlLedger.Owner(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -20,9 +20,8 @@ import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.common.{LedgerIdNotFoundException, MismatchException}
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerReadDao}
-import com.daml.platform.store.{BaseLedger, ReadOnlyLedger}
+import com.daml.platform.store.{BaseLedger, LfValueTranslationCache, ReadOnlyLedger}
 import com.daml.resources.ProgramResource.StartupException
 import com.daml.timer.RetryStrategy
 
@@ -42,7 +41,7 @@ private[platform] object ReadOnlySqlLedger {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       enricher: ValueEnricher,
   )(implicit mat: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[ReadOnlyLedger] {

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -19,9 +19,8 @@ import com.daml.platform.ApiOffset.ApiOffsetConverter
 import com.daml.platform.common
 import com.daml.platform.common.MismatchException
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao}
-import com.daml.platform.store.{DbType, FlywayMigrations}
+import com.daml.platform.store.{DbType, FlywayMigrations, LfValueTranslationCache}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -43,7 +42,7 @@ object JdbcIndexer {
         readService: ReadService,
         servicesExecutionContext: ExecutionContext,
         metrics: Metrics,
-        lfValueTranslationCache: LfValueTranslation.Cache,
+        lfValueTranslationCache: LfValueTranslationCache.Cache,
     )(implicit materializer: Materializer, loggingContext: LoggingContext) =
       this(
         config,

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.LfValueTranslationCache
 
 import scala.concurrent.ExecutionContext
 
@@ -18,7 +18,7 @@ final class StandaloneIndexerServer(
     config: IndexerConfig,
     servicesExecutionContext: ExecutionContext,
     metrics: Metrics,
-    lfValueTranslationCache: LfValueTranslation.Cache,
+    lfValueTranslationCache: LfValueTranslationCache.Cache,
 )(implicit materializer: Materializer, loggingContext: LoggingContext)
     extends ResourceOwner[Unit] {
 
@@ -70,7 +70,7 @@ final class StandaloneIndexerServer(
 
   private def startIndexer(
       indexer: RecoveringIndexer,
-      initializedIndexerFactory: ResourceOwner[JdbcIndexer],
+      initializedIndexerFactory: ResourceOwner[Indexer],
   )(implicit context: ResourceContext): Resource[Unit] =
     indexer
       .start(() => initializedIndexerFactory.flatMap(_.subscription(readService)).acquire())

--- a/ledger/participant-integration-api/src/main/scala/platform/store/IndexMetadata.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/IndexMetadata.scala
@@ -13,7 +13,6 @@ import com.daml.metrics.Metrics
 import com.daml.platform.ApiOffset
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.store.dao.JdbcLedgerDao
-import com.daml.platform.store.dao.events.LfValueTranslation
 import scalaz.Tag
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -44,7 +43,7 @@ object IndexMetadata {
       eventsPageSize = 1000,
       servicesExecutionContext = executionContext,
       metrics = new Metrics(new MetricRegistry),
-      lfValueTranslationCache = LfValueTranslation.Cache.none,
+      lfValueTranslationCache = LfValueTranslationCache.Cache.none,
       enricher = None,
     )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/LfValueTranslationCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/LfValueTranslationCache.scala
@@ -1,0 +1,106 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store
+
+import com.daml.caching
+import com.daml.ledger.EventId
+import com.daml.lf.value.Value.{ContractId, VersionedValue}
+import com.daml.metrics.Metrics
+
+/** Definitions of caches used for serializing and deserializing Daml-LF values.
+  * The cache is shared between the read and write path:
+  * The indexer writes values into the cache, the ledger API server looks up values.
+  */
+object LfValueTranslationCache {
+
+  final case class Cache(events: EventCache, contracts: ContractCache)
+  type EventCache = caching.Cache[EventCache.Key, EventCache.Value]
+  type ContractCache = caching.Cache[ContractCache.Key, ContractCache.Value]
+
+  object Cache {
+
+    def none: Cache = Cache(caching.Cache.none, caching.Cache.none)
+
+    def newInstance(
+        eventConfiguration: caching.SizedCache.Configuration,
+        contractConfiguration: caching.SizedCache.Configuration,
+    ): Cache =
+      Cache(
+        events = EventCache.newInstance(eventConfiguration),
+        contracts = ContractCache.newInstance(contractConfiguration),
+      )
+
+    def newInstrumentedInstance(
+        eventConfiguration: caching.SizedCache.Configuration,
+        contractConfiguration: caching.SizedCache.Configuration,
+        metrics: Metrics,
+    ): Cache =
+      Cache(
+        events = EventCache.newInstrumentedInstance(eventConfiguration, metrics),
+        contracts = ContractCache.newInstrumentedInstance(contractConfiguration, metrics),
+      )
+  }
+
+  object EventCache {
+
+    def newInstance(configuration: caching.SizedCache.Configuration): EventCache =
+      caching.SizedCache.from(configuration)
+
+    def newInstrumentedInstance(
+        configuration: caching.SizedCache.Configuration,
+        metrics: Metrics,
+    ): EventCache =
+      caching.SizedCache.from(
+        configuration = configuration,
+        metrics = metrics.daml.index.db.translation.cache,
+      )
+
+    final class UnexpectedTypeException(value: Value)
+        extends RuntimeException(s"Unexpected value $value")
+
+    final case class Key(eventId: EventId)
+
+    sealed abstract class Value {
+      def assertCreate(): Value.Create
+      def assertExercise(): Value.Exercise
+    }
+
+    object Value {
+      final case class Create(
+          argument: VersionedValue[ContractId],
+          key: Option[VersionedValue[ContractId]],
+      ) extends Value {
+        override def assertCreate(): Create = this
+        override def assertExercise(): Exercise = throw new UnexpectedTypeException(this)
+      }
+      final case class Exercise(
+          argument: VersionedValue[ContractId],
+          result: Option[VersionedValue[ContractId]],
+      ) extends Value {
+        override def assertCreate(): Create = throw new UnexpectedTypeException(this)
+        override def assertExercise(): Exercise = this
+      }
+    }
+
+  }
+
+  object ContractCache {
+
+    def newInstance(configuration: caching.SizedCache.Configuration): ContractCache =
+      caching.SizedCache.from(configuration)
+
+    def newInstrumentedInstance(
+        configuration: caching.SizedCache.Configuration,
+        metrics: Metrics,
+    ): ContractCache =
+      caching.SizedCache.from(
+        configuration = configuration,
+        metrics = metrics.daml.index.db.translation.cache,
+      )
+
+    final case class Key(contractId: ContractId)
+
+    final case class Value(argument: VersionedValue[ContractId])
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -83,7 +83,7 @@ private class JdbcLedgerDao(
     eventsPageSize: Int,
     performPostCommitValidation: Boolean,
     metrics: Metrics,
-    lfValueTranslationCache: LfValueTranslation.Cache,
+    lfValueTranslationCache: LfValueTranslationCache.Cache,
     validatePartyAllocation: Boolean,
     enricher: Option[ValueEnricher],
 ) extends LedgerDao {
@@ -675,7 +675,7 @@ private[platform] object JdbcLedgerDao {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       enricher: Option[ValueEnricher],
   )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerReadDao] = {
     owner(
@@ -698,7 +698,7 @@ private[platform] object JdbcLedgerDao {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       jdbcAsyncCommitMode: DbType.AsyncCommitMode,
       enricher: Option[ValueEnricher],
   )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerDao] = {
@@ -725,7 +725,7 @@ private[platform] object JdbcLedgerDao {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       validatePartyAllocation: Boolean = false,
       enricher: Option[ValueEnricher],
   )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerDao] = {
@@ -776,7 +776,7 @@ private[platform] object JdbcLedgerDao {
       validate: Boolean,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       validatePartyAllocation: Boolean = false,
       jdbcAsyncCommitMode: DbType.AsyncCommitMode = DbType.SynchronousCommit,
       enricher: Option[ValueEnricher],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.participant.state.index.v2.ContractStore
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.Conversions._
-import com.daml.platform.store.DbType
+import com.daml.platform.store.{DbType, LfValueTranslationCache}
 import com.daml.platform.store.appendonlydao.DbDispatcher
 import com.daml.platform.store.appendonlydao.events.SqlFunctions.{
   H2SqlFunctions,
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 private[appendonlydao] sealed class ContractsReader(
     dispatcher: DbDispatcher,
     metrics: Metrics,
-    lfValueTranslationCache: LfValueTranslation.Cache,
+    lfValueTranslationCache: LfValueTranslationCache.Cache,
     sqlFunctions: SqlFunctions,
 )(implicit ec: ExecutionContext)
     extends ContractStore {
@@ -203,7 +203,7 @@ private[appendonlydao] sealed class ContractsReader(
   )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
     // Depending on whether the contract argument is cached or not, submit a different query to the database
     lfValueTranslationCache.contracts
-      .getIfPresent(LfValueTranslation.ContractCache.Key(contractId)) match {
+      .getIfPresent(LfValueTranslationCache.ContractCache.Key(contractId)) match {
       case Some(createArgument) =>
         lookupActiveContractWithCachedArgument(readers, contractId, createArgument.argument)
       case None =>
@@ -264,7 +264,7 @@ private[appendonlydao] object ContractsReader {
       dispatcher: DbDispatcher,
       dbType: DbType,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
   )(implicit ec: ExecutionContext): ContractsReader = {
     def sqlFunctions = dbType match {
       case DbType.Postgres => PostgresSqlFunctions

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
@@ -5,13 +5,12 @@ package com.daml.platform.store.appendonlydao.events
 
 import java.io.InputStream
 
-import com.daml.caching
 import com.daml.ledger.EventId
 import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
 import com.daml.ledger.api.v1.value.{
+  Identifier => ApiIdentifier,
   Record => ApiRecord,
   Value => ApiValue,
-  Identifier => ApiIdentifier,
 }
 import com.daml.lf.engine.ValueEnricher
 import com.daml.lf.{engine => LfEngine}
@@ -20,13 +19,14 @@ import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.packages.DeduplicatingPackageLoader
 import com.daml.platform.participant.util.LfEngineToApi
+import com.daml.platform.store.LfValueTranslationCache
 import com.daml.platform.store.appendonlydao.events.{
   ChoiceName => LfChoiceName,
-  PackageId => LfPackageId,
-  Identifier => LfIdentifier,
-  QualifiedName => LfQualifiedName,
   DottedName => LfDottedName,
+  Identifier => LfIdentifier,
   ModuleName => LfModuleName,
+  PackageId => LfPackageId,
+  QualifiedName => LfQualifiedName,
   Value => LfValue,
 }
 import com.daml.platform.store.serialization.{Compression, ValueSerializer}
@@ -34,7 +34,7 @@ import com.daml.platform.store.serialization.{Compression, ValueSerializer}
 import scala.concurrent.{ExecutionContext, Future}
 
 final class LfValueTranslation(
-    val cache: LfValueTranslation.Cache,
+    val cache: LfValueTranslationCache.Cache,
     metrics: Metrics,
     enricherO: Option[LfEngine.ValueEnricher],
     loadPackage: (
@@ -87,29 +87,29 @@ final class LfValueTranslation(
       contractArgument: VersionedValue[ContractId],
   ): Array[Byte] = {
     cache.contracts.put(
-      key = LfValueTranslation.ContractCache.Key(contractId),
-      value = LfValueTranslation.ContractCache.Value(contractArgument),
+      key = LfValueTranslationCache.ContractCache.Key(contractId),
+      value = LfValueTranslationCache.ContractCache.Value(contractArgument),
     )
     serializeCreateArgOrThrow(contractId, contractArgument)
   }
 
   def serialize(eventId: EventId, create: Create): (Array[Byte], Option[Array[Byte]]) = {
     cache.events.put(
-      key = LfValueTranslation.EventCache.Key(eventId),
-      value = LfValueTranslation.EventCache.Value
+      key = LfValueTranslationCache.EventCache.Key(eventId),
+      value = LfValueTranslationCache.EventCache.Value
         .Create(create.versionedCoinst.arg, create.versionedKey.map(_.key)),
     )
     cache.contracts.put(
-      key = LfValueTranslation.ContractCache.Key(create.coid),
-      value = LfValueTranslation.ContractCache.Value(create.versionedCoinst.arg),
+      key = LfValueTranslationCache.ContractCache.Key(create.coid),
+      value = LfValueTranslationCache.ContractCache.Value(create.versionedCoinst.arg),
     )
     (serializeCreateArgOrThrow(create), serializeNullableKeyOrThrow(create))
   }
 
   def serialize(eventId: EventId, exercise: Exercise): (Array[Byte], Option[Array[Byte]]) = {
     cache.events.put(
-      key = LfValueTranslation.EventCache.Key(eventId),
-      value = LfValueTranslation.EventCache.Value
+      key = LfValueTranslationCache.EventCache.Key(eventId),
+      value = LfValueTranslationCache.EventCache.Value
         .Exercise(exercise.versionedChosenValue, exercise.versionedExerciseResult),
     )
     (serializeExerciseArgOrThrow(exercise), serializeNullableExerciseResultOrThrow(exercise))
@@ -196,7 +196,8 @@ final class LfValueTranslation(
       ),
     )
 
-  private def eventKey(s: String) = LfValueTranslation.EventCache.Key(EventId.assertFromString(s))
+  private def eventKey(s: String) =
+    LfValueTranslationCache.EventCache.Key(EventId.assertFromString(s))
 
   private def decompressAndDeserialize(algorithm: Compression.Algorithm, value: InputStream) =
     ValueSerializer.deserializeValue(algorithm.decompress(value))
@@ -225,7 +226,7 @@ final class LfValueTranslation(
       cache.events
         .getIfPresent(eventKey(raw.partial.eventId))
         .getOrElse(
-          LfValueTranslation.EventCache.Value.Create(
+          LfValueTranslationCache.EventCache.Value.Create(
             argument = decompressAndDeserialize(raw.createArgumentCompression, raw.createArgument),
             key = raw.createKeyValue.map(decompressAndDeserialize(raw.createKeyValueCompression, _)),
           )
@@ -274,7 +275,7 @@ final class LfValueTranslation(
       cache.events
         .getIfPresent(eventKey(raw.partial.eventId))
         .getOrElse(
-          LfValueTranslation.EventCache.Value.Exercise(
+          LfValueTranslationCache.EventCache.Value.Exercise(
             argument =
               decompressAndDeserialize(raw.exerciseArgumentCompression, raw.exerciseArgument),
             result =
@@ -311,92 +312,5 @@ final class LfValueTranslation(
         exerciseResult = exerciseResult,
       )
     }
-  }
-}
-
-object LfValueTranslation {
-
-  final case class Cache(events: EventCache, contracts: ContractCache)
-  type EventCache = caching.Cache[EventCache.Key, EventCache.Value]
-  type ContractCache = caching.Cache[ContractCache.Key, ContractCache.Value]
-
-  object Cache {
-
-    def none: Cache = Cache(caching.Cache.none, caching.Cache.none)
-
-    def newInstance(
-        eventConfiguration: caching.SizedCache.Configuration,
-        contractConfiguration: caching.SizedCache.Configuration,
-    ): Cache =
-      Cache(
-        events = EventCache.newInstance(eventConfiguration),
-        contracts = ContractCache.newInstance(contractConfiguration),
-      )
-
-    def newInstrumentedInstance(
-        eventConfiguration: caching.SizedCache.Configuration,
-        contractConfiguration: caching.SizedCache.Configuration,
-        metrics: Metrics,
-    ): Cache =
-      Cache(
-        events = EventCache.newInstrumentedInstance(eventConfiguration, metrics),
-        contracts = ContractCache.newInstrumentedInstance(contractConfiguration, metrics),
-      )
-  }
-
-  object EventCache {
-
-    def newInstance(configuration: caching.SizedCache.Configuration): EventCache =
-      caching.SizedCache.from(configuration)
-
-    def newInstrumentedInstance(
-        configuration: caching.SizedCache.Configuration,
-        metrics: Metrics,
-    ): EventCache =
-      caching.SizedCache.from(
-        configuration = configuration,
-        metrics = metrics.daml.index.db.translation.cache,
-      )
-
-    final class UnexpectedTypeException(value: Value)
-        extends RuntimeException(s"Unexpected value $value")
-
-    final case class Key(eventId: EventId)
-
-    sealed abstract class Value {
-      def assertCreate(): Value.Create
-      def assertExercise(): Value.Exercise
-    }
-
-    object Value {
-      final case class Create(argument: LfValue, key: Option[LfValue]) extends Value {
-        override def assertCreate(): Create = this
-        override def assertExercise(): Exercise = throw new UnexpectedTypeException(this)
-      }
-      final case class Exercise(argument: LfValue, result: Option[LfValue]) extends Value {
-        override def assertCreate(): Create = throw new UnexpectedTypeException(this)
-        override def assertExercise(): Exercise = this
-      }
-    }
-
-  }
-
-  object ContractCache {
-
-    def newInstance(configuration: caching.SizedCache.Configuration): ContractCache =
-      caching.SizedCache.from(configuration)
-
-    def newInstrumentedInstance(
-        configuration: caching.SizedCache.Configuration,
-        metrics: Metrics,
-    ): ContractCache =
-      caching.SizedCache.from(
-        configuration = configuration,
-        metrics = metrics.daml.index.db.translation.cache,
-      )
-
-    final case class Key(contractId: ContractId)
-
-    final case class Value(argument: LfValue)
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -83,7 +83,7 @@ private class JdbcLedgerDao(
     eventsPageSize: Int,
     performPostCommitValidation: Boolean,
     metrics: Metrics,
-    lfValueTranslationCache: LfValueTranslation.Cache,
+    lfValueTranslationCache: LfValueTranslationCache.Cache,
     validatePartyAllocation: Boolean,
     idempotentEntryInserts: Boolean,
     enricher: Option[ValueEnricher],
@@ -998,7 +998,7 @@ private[platform] object JdbcLedgerDao {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       enricher: Option[ValueEnricher],
   )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerReadDao] = {
     owner(
@@ -1022,7 +1022,7 @@ private[platform] object JdbcLedgerDao {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       jdbcAsyncCommitMode: DbType.AsyncCommitMode,
       enricher: Option[ValueEnricher],
   )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerDao] = {
@@ -1050,7 +1050,7 @@ private[platform] object JdbcLedgerDao {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       validatePartyAllocation: Boolean = false,
       enricher: Option[ValueEnricher],
   )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerDao] = {
@@ -1102,7 +1102,7 @@ private[platform] object JdbcLedgerDao {
       validate: Boolean,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       validatePartyAllocation: Boolean = false,
       jdbcAsyncCommitMode: DbType.AsyncCommitMode = DbType.SynchronousCommit,
       idempotentEventInserts: Boolean,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.participant.state.index.v2.ContractStore
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.Conversions._
-import com.daml.platform.store.DbType
+import com.daml.platform.store.{DbType, LfValueTranslationCache}
 import com.daml.platform.store.dao.DbDispatcher
 import com.daml.platform.store.dao.events.SqlFunctions.{H2SqlFunctions, PostgresSqlFunctions}
 import com.daml.platform.store.serialization.{Compression, ValueSerializer}
@@ -26,7 +26,7 @@ private[dao] sealed class ContractsReader(
     val committedContracts: PostCommitValidationData,
     dispatcher: DbDispatcher,
     metrics: Metrics,
-    lfValueTranslationCache: LfValueTranslation.Cache,
+    lfValueTranslationCache: LfValueTranslationCache.Cache,
     sqlFunctions: SqlFunctions,
 )(implicit ec: ExecutionContext)
     extends ContractStore {
@@ -90,7 +90,7 @@ private[dao] sealed class ContractsReader(
   )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
     // Depending on whether the contract argument is cached or not, submit a different query to the database
     lfValueTranslationCache.contracts
-      .getIfPresent(LfValueTranslation.ContractCache.Key(contractId)) match {
+      .getIfPresent(LfValueTranslationCache.ContractCache.Key(contractId)) match {
       case Some(createArgument) =>
         lookupActiveContractWithCachedArgument(readers, contractId, createArgument.argument)
       case None =>
@@ -129,7 +129,7 @@ private[dao] object ContractsReader {
       dispatcher: DbDispatcher,
       dbType: DbType,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
   )(implicit ec: ExecutionContext): ContractsReader = {
     def sqlFunctions = dbType match {
       case DbType.Postgres => PostgresSqlFunctions

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -14,8 +14,7 @@ import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.store.dao.JdbcLedgerDaoBackend.{TestLedgerId, TestParticipantId}
-import com.daml.platform.store.dao.events.LfValueTranslation
-import com.daml.platform.store.{DbType, FlywayMigrations}
+import com.daml.platform.store.{DbType, FlywayMigrations, LfValueTranslationCache}
 import org.scalatest.AsyncTestSuite
 
 import scala.concurrent.Await
@@ -50,7 +49,7 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll {
       eventsPageSize = eventsPageSize,
       servicesExecutionContext = executionContext,
       metrics = new Metrics(new MetricRegistry),
-      lfValueTranslationCache = LfValueTranslation.Cache.none,
+      lfValueTranslationCache = LfValueTranslationCache.Cache.none,
       jdbcAsyncCommitMode = DbType.AsynchronousCommit,
       enricher = Some(new ValueEnricher(new Engine())),
     )

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPostCommitValidationSpec.scala
@@ -11,7 +11,7 @@ import com.daml.lf.value.Value.ContractId
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.LfValueTranslationCache
 import org.scalatest.LoneElement
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -30,7 +30,7 @@ private[dao] trait JdbcLedgerDaoPostCommitValidationSpec extends LoneElement {
         eventsPageSize = eventsPageSize,
         servicesExecutionContext = executionContext,
         metrics = new Metrics(new MetricRegistry),
-        lfValueTranslationCache = LfValueTranslation.Cache.none,
+        lfValueTranslationCache = LfValueTranslationCache.Cache.none,
         enricher = None,
       )
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
@@ -27,9 +27,8 @@ import com.daml.metrics.Metrics
 import com.daml.platform.common.MismatchException
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.indexer
-import com.daml.platform.store.{DbType, FlywayMigrations, IndexMetadata}
+import com.daml.platform.store.{DbType, FlywayMigrations, IndexMetadata, LfValueTranslationCache}
 import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao}
-import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.platform.testing.LogCollector
 import com.daml.testing.postgresql.PostgresAroundEach
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
@@ -192,7 +191,7 @@ final class JdbcIndexerSpec
       config.eventsPageSize,
       materializer.executionContext,
       metrics,
-      LfValueTranslation.Cache.none,
+      LfValueTranslationCache.Cache.none,
       jdbcAsyncCommitMode = jdbcAsyncCommitMode,
       enricher = None,
     )

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/AppendOnlySchemaMigrationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/AppendOnlySchemaMigrationSpec.scala
@@ -13,8 +13,7 @@ import com.daml.logging.LoggingContext
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.store.dao.events.LfValueTranslation
-import com.daml.platform.store.{DbType, FlywayMigrations}
+import com.daml.platform.store.{DbType, FlywayMigrations, LfValueTranslationCache}
 import com.daml.testing.postgresql.PostgresResource
 import org.scalatest.wordspec.AsyncWordSpec
 
@@ -77,7 +76,7 @@ class AppendOnlySchemaMigrationSpec extends AsyncWordSpec with AkkaBeforeAndAfte
       eventsPageSize = eventsPageSize,
       servicesExecutionContext = executionContext,
       metrics = new Metrics(new MetricRegistry),
-      lfValueTranslationCache = LfValueTranslation.Cache.none,
+      lfValueTranslationCache = LfValueTranslationCache.Cache.none,
       jdbcAsyncCommitMode = DbType.AsynchronousCommit,
       enricher = Some(new ValueEnricher(new Engine())),
     )

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -24,8 +24,7 @@ import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.JvmMetricSet
 import com.daml.platform.apiserver.StandaloneApiServer
 import com.daml.platform.indexer.StandaloneIndexerServer
-import com.daml.platform.store.IndexMetadata
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.{IndexMetadata, LfValueTranslationCache}
 
 import scala.compat.java8.FutureConverters.CompletionStageOps
 import scala.concurrent.{ExecutionContext, Future}
@@ -102,7 +101,7 @@ final class Runner[T <: ReadWriteService, Extra](
           val metrics = factory.createMetrics(participantConfig, config)
           metrics.registry.registerAll(new JvmMetricSet)
           val lfValueTranslationCache =
-            LfValueTranslation.Cache.newInstrumentedInstance(
+            LfValueTranslationCache.Cache.newInstrumentedInstance(
               eventConfiguration = config.lfValueTranslationEventCache,
               contractConfiguration = config.lfValueTranslationContractCache,
               metrics = metrics,

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -21,7 +21,7 @@ import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode, JdbcIndexer}
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.LfValueTranslationCache
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
@@ -126,7 +126,7 @@ class IntegrityChecker[LogResult](
           createIndexerConfig(config),
           readService,
           metrics,
-          LfValueTranslation.Cache.none,
+          LfValueTranslationCache.Cache.none,
         )
         feedHandle <- indexer.subscription(readService)
       } yield (feedHandle, System.nanoTime())
@@ -228,7 +228,7 @@ class IntegrityChecker[LogResult](
       config: IndexerConfig,
       readService: ReadService,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
   )(implicit
       resourceContext: ResourceContext,
       materializer: Materializer,

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -26,8 +26,7 @@ import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.indexer.RecoveringIndexerIntegrationSpec._
-import com.daml.platform.store.DbType
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.{DbType, LfValueTranslationCache}
 import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao}
 import com.daml.platform.testing.LogCollector
 import com.daml.timer.RetryStrategy
@@ -212,7 +211,7 @@ class RecoveringIndexerIntegrationSpec
         ),
         servicesExecutionContext = servicesExecutionContext,
         metrics = new Metrics(new MetricRegistry),
-        lfValueTranslationCache = LfValueTranslation.Cache.none,
+        lfValueTranslationCache = LfValueTranslationCache.Cache.none,
       )(materializer, loggingContext)
     } yield participantState
   }
@@ -227,7 +226,7 @@ class RecoveringIndexerIntegrationSpec
       eventsPageSize = 100,
       servicesExecutionContext = executionContext,
       metrics = new Metrics(new MetricRegistry),
-      lfValueTranslationCache = LfValueTranslation.Cache.none,
+      lfValueTranslationCache = LfValueTranslationCache.Cache.none,
       jdbcAsyncCommitMode = DbType.AsynchronousCommit,
       enricher = None,
     )

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -47,8 +47,7 @@ import com.daml.platform.sandbox.stores.ledger._
 import com.daml.platform.sandbox.stores.ledger.sql.SqlStartMode
 import com.daml.platform.sandbox.stores.{InMemoryActiveLedgerState, SandboxIndexAndWriteService}
 import com.daml.platform.services.time.TimeProviderType
-import com.daml.platform.store.FlywayMigrations
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.{FlywayMigrations, LfValueTranslationCache}
 import com.daml.ports.Port
 import scalaz.syntax.tag._
 
@@ -294,7 +293,7 @@ final class SandboxServer(
         .fold[TransactionCommitter](LegacyTransactionCommitter)(_ => StandardTransactionCommitter)
 
     val lfValueTranslationCache =
-      LfValueTranslation.Cache.newInstrumentedInstance(
+      LfValueTranslationCache.Cache.newInstrumentedInstance(
         eventConfiguration = config.lfValueTranslationEventCacheConfiguration,
         contractConfiguration = config.lfValueTranslationContractCacheConfiguration,
         metrics = metrics,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -27,7 +27,7 @@ import com.daml.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryOrBump
 import com.daml.platform.sandbox.stores.ledger.inmemory.InMemoryLedger
 import com.daml.platform.sandbox.stores.ledger.sql.{SqlLedger, SqlStartMode}
 import com.daml.platform.sandbox.stores.ledger.{Ledger, MeteredLedger}
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.LfValueTranslationCache
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -58,7 +58,7 @@ private[sandbox] object SandboxIndexAndWriteService {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       engine: Engine,
       validatePartyAllocation: Boolean = false,
   )(implicit

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -36,10 +36,9 @@ import com.daml.platform.sandbox.config.LedgerName
 import com.daml.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryOrBump
 import com.daml.platform.sandbox.stores.ledger.sql.SqlLedger._
 import com.daml.platform.sandbox.stores.ledger.{Ledger, SandboxOffset}
-import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao, LedgerWriteDao}
 import com.daml.platform.store.entries.{LedgerEntry, PackageLedgerEntry, PartyLedgerEntry}
-import com.daml.platform.store.{BaseLedger, FlywayMigrations}
+import com.daml.platform.store.{BaseLedger, FlywayMigrations, LfValueTranslationCache}
 import com.daml.resources.ProgramResource.StartupException
 import scalaz.Tag
 
@@ -79,7 +78,7 @@ private[sandbox] object SqlLedger {
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
-      lfValueTranslationCache: LfValueTranslation.Cache,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
       engine: Engine,
       validatePartyAllocation: Boolean = false,
   )(implicit mat: Materializer, loggingContext: LoggingContext)

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
@@ -26,7 +26,7 @@ import com.daml.platform.sandbox.stores.ledger.Ledger
 import com.daml.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryOrBump
 import com.daml.platform.sandbox.stores.ledger.inmemory.InMemoryLedger
 import com.daml.platform.sandbox.stores.ledger.sql.{SqlLedger, SqlStartMode}
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.LfValueTranslationCache
 import com.daml.testing.postgresql.PostgresResource
 
 import scala.concurrent.ExecutionContext
@@ -89,7 +89,7 @@ private[sandbox] object LedgerResource {
           eventsPageSize = 100,
           servicesExecutionContext = servicesExecutionContext,
           metrics = new Metrics(metrics),
-          lfValueTranslationCache = LfValueTranslation.Cache.none,
+          lfValueTranslationCache = LfValueTranslationCache.Cache.none,
           engine = new Engine(),
         )
       } yield ledger

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -28,8 +28,7 @@ import com.daml.platform.sandbox.MetricsAround
 import com.daml.platform.sandbox.config.LedgerName
 import com.daml.platform.sandbox.stores.ledger.Ledger
 import com.daml.platform.sandbox.stores.ledger.sql.SqlLedgerSpec._
-import com.daml.platform.store.IndexMetadata
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.{IndexMetadata, LfValueTranslationCache}
 import com.daml.platform.testing.LogCollector
 import com.daml.testing.postgresql.PostgresAroundEach
 import org.scalatest.concurrent.{AsyncTimeLimitedTests, Eventually, ScaledTimeSpans}
@@ -305,7 +304,7 @@ final class SqlLedgerSpec
         eventsPageSize = 100,
         servicesExecutionContext = executionContext,
         metrics = new Metrics(metrics),
-        lfValueTranslationCache = LfValueTranslation.Cache.none,
+        lfValueTranslationCache = LfValueTranslationCache.Cache.none,
         engine = new Engine(),
         validatePartyAllocation = validatePartyAllocation,
       ).acquire()(ResourceContext(system.dispatcher))

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -43,7 +43,7 @@ import com.daml.platform.sandbox.metrics.MetricsReporting
 import com.daml.platform.sandbox.services.SandboxResetService
 import com.daml.platform.sandboxnext.Runner._
 import com.daml.platform.services.time.TimeProviderType
-import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.LfValueTranslationCache
 import com.daml.ports.Port
 import com.daml.resources.ResettableResourceOwner
 import scalaz.syntax.tag._
@@ -123,7 +123,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
           config.metricsReporter,
           config.metricsReportingInterval,
         )
-        lfValueTranslationCache = LfValueTranslation.Cache.newInstrumentedInstance(
+        lfValueTranslationCache = LfValueTranslationCache.Cache.newInstrumentedInstance(
           eventConfiguration = config.lfValueTranslationEventCacheConfiguration,
           contractConfiguration = config.lfValueTranslationContractCacheConfiguration,
           metrics = metrics,


### PR DESCRIPTION
This PR only includes refactoring.

It extracts and deduplicates the definition of `LfValueTranslation` caches. The definition was duplicated in `dao` and `appendonlydao`, and it was hard to pass around the cache for sharing between the read and write side.