### PR TITLE
infra/hoogle: use nix

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -26,6 +26,9 @@ Changing the template of an instance manager tends to kill all the machines in
 the current group. Therefore, we're experimenting with keeping two groups per
 logical group. (This is currently done only for the Hoogle servers.)
 
+> You can follow along with an example of such a deployment in the
+> commit-by-commit view of [#9362](https://github.com/digital-asset/daml/pull/9362/commits).
+
 The default state should be to split machines between the two groups evenly,
 and have the exact same configuration in each group. When a change needs to be
 made, one can set the size of one of the groups to 0, make the appropriate

--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -41,7 +41,7 @@ locals {
     {
       suffix         = "-blue",
       ubuntu_version = "2004",
-      size           = 1,
+      size           = 3,
       install        = <<EOF
 mkdir /nix
 chown hoogle:hoogle /nix
@@ -59,7 +59,7 @@ EOF
     {
       suffix         = "-green",
       ubuntu_version = "2004",
-      size           = 2,
+      size           = 0,
       install        = <<EOF
 curl -sSL https://get.haskellstack.org/ | sh
 runuser -u hoogle bash <<HOOGLE_SETUP

--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -42,34 +42,11 @@ locals {
       suffix         = "-blue",
       ubuntu_version = "2004",
       size           = 3,
-      install        = <<EOF
-mkdir /nix
-chown hoogle:hoogle /nix
-runuser -l hoogle <<'HOOGLE_SETUP'
-curl -sSfL https://nixos.org/nix/install | sh
-. /home/hoogle/.nix-profile/etc/profile.d/nix.sh
-# Feel free to bump the commit, this was the latest
-# # at the time of creation.
-NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/c50e680b03adecae01fdd1ea4e44c82e641de0cf.tar.gz
-HOOGLE_PATH=$(nix-build --no-out-link -E '(import <nixpkgs> {}).haskellPackages.hoogle')
-mkdir -p /home/hoogle/.local/bin
-ln -s $HOOGLE_PATH/bin/hoogle /home/hoogle/.local/bin/hoogle
-EOF
     },
     {
       suffix         = "-green",
       ubuntu_version = "2004",
       size           = 0,
-      install        = <<EOF
-curl -sSL https://get.haskellstack.org/ | sh
-runuser -u hoogle bash <<HOOGLE_SETUP
-git clone https://github.com/ndmitchell/hoogle.git
-cd hoogle
-git checkout 73fa6b5c156e0015e135a564e2821719611abe03
-stack init --resolver=lts-14.7
-stack build
-stack install
-EOF
     }
   ]
 }
@@ -127,7 +104,17 @@ useradd hoogle
 mkdir /home/hoogle
 chown hoogle:hoogle /home/hoogle
 cd /home/hoogle
-${trimspace(local.h_clusters[count.index].install)}
+mkdir /nix
+chown hoogle:hoogle /nix
+runuser -l hoogle <<'HOOGLE_SETUP'
+curl -sSfL https://nixos.org/nix/install | sh
+. /home/hoogle/.nix-profile/etc/profile.d/nix.sh
+# Feel free to bump the commit, this was the latest
+# # at the time of creation.
+NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/c50e680b03adecae01fdd1ea4e44c82e641de0cf.tar.gz
+HOOGLE_PATH=$(nix-build --no-out-link -E '(import <nixpkgs> {}).haskellPackages.hoogle')
+mkdir -p /home/hoogle/.local/bin
+ln -s $HOOGLE_PATH/bin/hoogle /home/hoogle/.local/bin/hoogle
 export PATH=/home/hoogle/.local/bin:$PATH
 mkdir daml
 curl https://docs.daml.com/hoogle_db/base.txt --output daml/base.txt

--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -24,11 +24,31 @@ locals {
       suffix         = "-blue",
       ubuntu_version = "2004",
       size           = 1,
+      install        = <<EOF
+curl -sSL https://get.haskellstack.org/ | sh
+runuser -u hoogle bash <<HOOGLE_SETUP
+git clone https://github.com/ndmitchell/hoogle.git
+cd hoogle
+git checkout 73fa6b5c156e0015e135a564e2821719611abe03
+stack init --resolver=lts-14.7
+stack build
+stack install
+EOF
     },
     {
       suffix         = "-green",
       ubuntu_version = "2004",
       size           = 2,
+      install        = <<EOF
+curl -sSL https://get.haskellstack.org/ | sh
+runuser -u hoogle bash <<HOOGLE_SETUP
+git clone https://github.com/ndmitchell/hoogle.git
+cd hoogle
+git checkout 73fa6b5c156e0015e135a564e2821719611abe03
+stack init --resolver=lts-14.7
+stack build
+stack install
+EOF
     }
   ]
 }
@@ -86,14 +106,7 @@ useradd hoogle
 mkdir /home/hoogle
 chown hoogle:hoogle /home/hoogle
 cd /home/hoogle
-curl -sSL https://get.haskellstack.org/ | sh
-runuser -u hoogle bash <<HOOGLE_SETUP
-git clone https://github.com/ndmitchell/hoogle.git
-cd hoogle
-git checkout 73fa6b5c156e0015e135a564e2821719611abe03
-stack init --resolver=lts-14.7
-stack build
-stack install
+${trimspace(local.h_clusters[count.index].install)}
 export PATH=/home/hoogle/.local/bin:$PATH
 mkdir daml
 curl https://docs.daml.com/hoogle_db/base.txt --output daml/base.txt

--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -25,14 +25,17 @@ locals {
       ubuntu_version = "2004",
       size           = 1,
       install        = <<EOF
-curl -sSL https://get.haskellstack.org/ | sh
-runuser -u hoogle bash <<HOOGLE_SETUP
-git clone https://github.com/ndmitchell/hoogle.git
-cd hoogle
-git checkout 73fa6b5c156e0015e135a564e2821719611abe03
-stack init --resolver=lts-14.7
-stack build
-stack install
+mkdir /nix
+chown hoogle:hoogle /nix
+runuser -l hoogle <<'HOOGLE_SETUP'
+curl -sSfL https://nixos.org/nix/install | sh
+. /home/hoogle/.nix-profile/etc/profile.d/nix.sh
+# Feel free to bump the commit, this was the latest
+# # at the time of creation.
+NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/c50e680b03adecae01fdd1ea4e44c82e641de0cf.tar.gz
+HOOGLE_PATH=$(nix-build --no-out-link -E '(import <nixpkgs> {}).haskellPackages.hoogle')
+mkdir -p /home/hoogle/.local/bin
+ln -s $HOOGLE_PATH/bin/hoogle /home/hoogle/.local/bin/hoogle
 EOF
     },
     {

--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -18,6 +18,24 @@ resource "google_compute_firewall" "hoogle" {
   }
 }
 
+resource "google_compute_firewall" "hoogle-ssh" {
+  count   = 0
+  name    = "hoogle-ssh"
+  network = google_compute_network.hoogle.name
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  source_ranges = [
+    "35.194.81.56/32",  # North Virginia
+    "35.189.40.124/32", # Sydney
+    "35.198.147.95/32", # Frankfurt
+  ]
+}
+
 locals {
   h_clusters = [
     {


### PR DESCRIPTION
This is a demonstration, commit-by-commit, of how to use the blue/green deployment for Hoogle servers.

The actual change (using nix) is stolen from #9352.

CHANGELOG_BEGIN
CHANGELOG_END