### PR TITLE
DPP-316: Enable the use of the append only index database

### DIFF
--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
@@ -10,7 +10,11 @@ import com.daml.bazeltools.BazelRunfiles._
 import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, OwnedResource, SuiteResource}
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.on.memory.Owner
-import com.daml.ledger.participant.state.kvutils.app.{ParticipantConfig, ParticipantRunMode}
+import com.daml.ledger.participant.state.kvutils.app.{
+  ParticipantConfig,
+  ParticipantIndexerConfig,
+  ParticipantRunMode,
+}
 import com.daml.ledger.participant.state.kvutils.{app => kvutils}
 import com.daml.ledger.participant.state.v1
 import com.daml.ledger.resources.ResourceContext
@@ -51,7 +55,9 @@ trait MultiParticipantFixture
     port = Port.Dynamic,
     portFile = Some(participant1Portfile),
     serverJdbcUrl = ParticipantConfig.defaultIndexJdbcUrl(participantId1),
-    allowExistingSchemaForIndex = false,
+    indexerConfig = ParticipantIndexerConfig(
+      allowExistingSchema = false
+    ),
     maxCommandsInFlight = None,
   )
   private val participantId2 = v1.ParticipantId.assertFromString("participant2")
@@ -63,7 +69,9 @@ trait MultiParticipantFixture
     port = Port.Dynamic,
     portFile = Some(participant2Portfile),
     serverJdbcUrl = ParticipantConfig.defaultIndexJdbcUrl(participantId2),
-    allowExistingSchemaForIndex = false,
+    indexerConfig = ParticipantIndexerConfig(
+      allowExistingSchema = false
+    ),
     maxCommandsInFlight = None,
   )
   override protected lazy val suiteResource = {

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -40,7 +40,13 @@ object SqlLedgerFactory extends LedgerFactory[ReadWriteService, ExtraConfig] {
   }
 
   override def manipulateConfig(config: Config[ExtraConfig]): Config[ExtraConfig] =
-    config.copy(participants = config.participants.map(_.copy(allowExistingSchemaForIndex = true)))
+    config.copy(participants =
+      config.participants.map(participantConfig =>
+        participantConfig.copy(indexerConfig =
+          participantConfig.indexerConfig.copy(allowExistingSchema = true)
+        )
+      )
+    )
 
   override def readWriteServiceOwner(
       config: Config[ExtraConfig],

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
@@ -26,4 +26,6 @@ case class ApiServerConfig(
     portFile: Option[Path],
     seeding: Seeding,
     managementServiceTimeout: Duration,
+    // TODO append-only: remove after removing support for the current (mutating) schema
+    enableAppendOnlySchema: Boolean,
 )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -80,6 +80,7 @@ final class StandaloneApiServer(
           metrics = metrics,
           lfValueTranslationCache = lfValueTranslationCache,
           enricher = valueEnricher,
+          enableAppendOnlySchema = config.enableAppendOnlySchema
         )
         .map(index => new SpannedIndexService(new TimedIndexService(index, metrics)))
       authorizer = new Authorizer(Clock.systemUTC.instant _, ledgerId, participantId)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -80,7 +80,7 @@ final class StandaloneApiServer(
           metrics = metrics,
           lfValueTranslationCache = lfValueTranslationCache,
           enricher = valueEnricher,
-          enableAppendOnlySchema = config.enableAppendOnlySchema
+          enableAppendOnlySchema = config.enableAppendOnlySchema,
         )
         .map(index => new SpannedIndexService(new TimedIndexService(index, metrics)))
       authorizer = new Authorizer(Clock.systemUTC.instant _, ledgerId, participantId)

--- a/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
@@ -28,6 +28,7 @@ private[platform] object JdbcIndex {
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslationCache.Cache,
       enricher: ValueEnricher,
+      enableAppendOnlySchema: Boolean,
   )(implicit mat: Materializer, loggingContext: LoggingContext): ResourceOwner[IndexService] =
     new ReadOnlySqlLedger.Owner(
       serverRole = serverRole,
@@ -39,6 +40,7 @@ private[platform] object JdbcIndex {
       metrics = metrics,
       lfValueTranslationCache = lfValueTranslationCache,
       enricher = enricher,
+      enableAppendOnlySchema = enableAppendOnlySchema,
     ).map { ledger =>
       new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId)
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -43,6 +43,8 @@ private[platform] object ReadOnlySqlLedger {
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslationCache.Cache,
       enricher: ValueEnricher,
+      // TODO append-only: remove after removing support for the current (mutating) schema
+      enableAppendOnlySchema: Boolean,
   )(implicit mat: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[ReadOnlyLedger] {
     override def acquire()(implicit context: ResourceContext): Resource[ReadOnlyLedger] =
@@ -100,16 +102,29 @@ private[platform] object ReadOnlySqlLedger {
     private def ledgerDaoOwner(
         servicesExecutionContext: ExecutionContext
     ): ResourceOwner[LedgerReadDao] =
-      JdbcLedgerDao.readOwner(
-        serverRole,
-        jdbcUrl,
-        databaseConnectionPoolSize,
-        eventsPageSize,
-        servicesExecutionContext,
-        metrics,
-        lfValueTranslationCache,
-        Some(enricher),
-      )
+      if (enableAppendOnlySchema) {
+        com.daml.platform.store.appendonlydao.JdbcLedgerDao.readOwner(
+          serverRole,
+          jdbcUrl,
+          databaseConnectionPoolSize,
+          eventsPageSize,
+          servicesExecutionContext,
+          metrics,
+          lfValueTranslationCache,
+          Some(enricher),
+        )
+      } else {
+        JdbcLedgerDao.readOwner(
+          serverRole,
+          jdbcUrl,
+          databaseConnectionPoolSize,
+          eventsPageSize,
+          servicesExecutionContext,
+          metrics,
+          lfValueTranslationCache,
+          Some(enricher),
+        )
+      }
 
     private def dispatcherOwner(ledgerEnd: Offset): ResourceOwner[Dispatcher[Offset]] =
       Dispatcher.owner(

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -22,6 +22,13 @@ case class IndexerConfig(
     // TODO append-only: remove after removing support for the current (mutating) schema
     enableAppendOnlySchema: Boolean = false,
     asyncCommitMode: DbType.AsyncCommitMode = DefaultAsyncCommitMode,
+    inputMappingParallelism: Int = 3,
+    ingestionParallelism: Int = 4,
+    submissionBatchSize: Long = 1L,
+    tailingRateLimitPerSecond: Int = 100,
+    batchWithinMillis: Long = 10,
+    runStageUntil: Int = 6,
+    enableCompression: Boolean = true,
 )
 
 object IndexerConfig {

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -22,13 +22,12 @@ case class IndexerConfig(
     // TODO append-only: remove after removing support for the current (mutating) schema
     enableAppendOnlySchema: Boolean = false,
     asyncCommitMode: DbType.AsyncCommitMode = DefaultAsyncCommitMode,
-    // TODO append-only: review these defaults, the differ from com.daml.ledger.participant.state.kvutils.app.Config
-    inputMappingParallelism: Int = 3,
-    ingestionParallelism: Int = 4,
-    submissionBatchSize: Long = 1L,
-    tailingRateLimitPerSecond: Int = 100,
-    batchWithinMillis: Long = 10,
-    enableCompression: Boolean = true,
+    inputMappingParallelism: Int = DefaultInputMappingParallelism,
+    ingestionParallelism: Int = DefaultIngestionParallelism,
+    submissionBatchSize: Long = DefaultSubmissionBatchSize,
+    tailingRateLimitPerSecond: Int = DefaultTailingRateLimitPerSecond,
+    batchWithinMillis: Long = DefaultBatchWithinMillis,
+    enableCompression: Boolean = DefaultEnableCompression,
 )
 
 object IndexerConfig {
@@ -39,4 +38,10 @@ object IndexerConfig {
   val DefaultDatabaseConnectionPoolSize: Int = 3
   val DefaultAsyncCommitMode: DbType.AsyncCommitMode = DbType.AsynchronousCommit
 
+  val DefaultInputMappingParallelism: Int = 16
+  val DefaultIngestionParallelism: Int = 16
+  val DefaultSubmissionBatchSize: Long = 50L
+  val DefaultTailingRateLimitPerSecond: Int = 20
+  val DefaultBatchWithinMillis: Long = 50L
+  val DefaultEnableCompression: Boolean = false
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -22,12 +22,12 @@ case class IndexerConfig(
     // TODO append-only: remove after removing support for the current (mutating) schema
     enableAppendOnlySchema: Boolean = false,
     asyncCommitMode: DbType.AsyncCommitMode = DefaultAsyncCommitMode,
+    // TODO append-only: review these defaults, the differ from com.daml.ledger.participant.state.kvutils.app.Config
     inputMappingParallelism: Int = 3,
     ingestionParallelism: Int = 4,
     submissionBatchSize: Long = 1L,
     tailingRateLimitPerSecond: Int = 100,
     batchWithinMillis: Long = 10,
-    runStageUntil: Int = 6,
     enableCompression: Boolean = true,
 )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -45,7 +45,7 @@ final class StandaloneIndexerServer(
         Resource
           .fromFuture(
             indexerFactory
-              .migrateSchema(config.allowExistingSchema, config.enableAppendOnlySchema)
+              .migrateSchema(config.allowExistingSchema)
           )
           .flatMap(startIndexer(indexer, _))
           .map { _ =>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
@@ -177,7 +177,7 @@ final class JdbcIndexerSpec
       participantId: String,
       mockFlow: Flow[OffsetUpdate, Unit, NotUsed] = noOpFlow,
       jdbcAsyncCommitMode: DbType.AsyncCommitMode = DbType.AsynchronousCommit,
-  ): Future[ResourceOwner[JdbcIndexer]] = {
+  ): Future[ResourceOwner[Indexer]] = {
     val config = IndexerConfig(
       participantId = v1.ParticipantId.assertFromString(participantId),
       jdbcUrl = postgresDatabase.url,
@@ -204,7 +204,8 @@ final class JdbcIndexerSpec
         mockedUpdateFlowOwnerBuilder(metrics, config.participantId, mockFlow),
       ledgerDaoOwner = ledgerDaoOwner,
       flywayMigrations = new FlywayMigrations(config.jdbcUrl),
-    ).migrateSchema(allowExistingSchema = true, enableAppendOnlySchema = false)
+      LfValueTranslationCache.Cache.none,
+    ).migrateSchema(allowExistingSchema = true)
   }
 
   private def mockedUpdateFlowOwnerBuilder(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -392,7 +392,7 @@ object Config {
           )
           .action((_, config) => config.copy(enableAppendOnlySchema = true))
 
-        opt[Int]("index-input-mapping-parallelism")
+        opt[Int]("indexer-input-mapping-parallelism")
           .optional()
           .hidden()
           .action((p, c) => c.copy(indexerInputMappingParallelism = p))

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -405,7 +405,7 @@ object Config {
           .hidden()
           .action((p, c) => c.copy(indexerIngestionParallelism = p))
           .text(
-            s"Level of parallelism of the database ingestion. Sets parallelism for postgreSQL inserts. Default: ${Config.DefaultIndexerIngestionParallelism}."
+            s"Level of parallelism of the database ingestion. Default: ${Config.DefaultIndexerIngestionParallelism}."
           )
 
         opt[Long]("indexer-submission-batch-size")

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -160,42 +160,42 @@ object Config {
             val apiServerConnectionPoolSize = kv
               .get("api-server-connection-pool-size")
               .map(_.toInt)
-              .getOrElse(ParticipantConfig.defaultApiServerDatabaseConnectionPoolSize)
+              .getOrElse(ParticipantConfig.DefaultApiServerDatabaseConnectionPoolSize)
             val indexerConnectionPoolSize = kv
               .get("indexer-connection-pool-size")
               .map(_.toInt)
-              .getOrElse(ParticipantIndexerConfig.defaultDatabaseConnectionPoolSize)
+              .getOrElse(ParticipantIndexerConfig.DefaultDatabaseConnectionPoolSize)
             val indexerInputMappingParallelism = kv
               .get("indexer-input-mapping-parallelism")
               .map(_.toInt)
-              .getOrElse(ParticipantIndexerConfig.defaultInputMappingParallelism)
+              .getOrElse(ParticipantIndexerConfig.DefaultInputMappingParallelism)
             val indexerIngestionParallelism = kv
               .get("indexer-ingestion-parallelism")
               .map(_.toInt)
-              .getOrElse(ParticipantIndexerConfig.defaultIngestionParallelism)
+              .getOrElse(ParticipantIndexerConfig.DefaultIngestionParallelism)
             val indexerSubmissionBatchSize = kv
               .get("indexer-submission-batch-size")
               .map(_.toLong)
-              .getOrElse(ParticipantIndexerConfig.defaultSubmissionBatchSize)
+              .getOrElse(ParticipantIndexerConfig.DefaultSubmissionBatchSize)
             val indexerTailingRateLimitPerSecond = kv
               .get("indexer-tailing-rate-limit-per-second")
               .map(_.toInt)
-              .getOrElse(ParticipantIndexerConfig.defaultTailingRateLimitPerSecond)
+              .getOrElse(ParticipantIndexerConfig.DefaultTailingRateLimitPerSecond)
             val indexerBatchWithinMillis = kv
               .get("indexer-batch-within-millis")
               .map(_.toLong)
-              .getOrElse(ParticipantIndexerConfig.defaultBatchWithinMillis)
+              .getOrElse(ParticipantIndexerConfig.DefaultBatchWithinMillis)
             val indexerEnableCompression = kv
               .get("indexer-enable-compression")
               .map(_.toBoolean)
-              .getOrElse(ParticipantIndexerConfig.defaultEnableCompression)
+              .getOrElse(ParticipantIndexerConfig.DefaultEnableCompression)
 
             val maxCommandsInFlight =
               kv.get("max-commands-in-flight").map(_.toInt)
             val managementServiceTimeout = kv
               .get("management-service-timeout")
               .map(Duration.parse)
-              .getOrElse(ParticipantConfig.defaultManagementServiceTimeout)
+              .getOrElse(ParticipantConfig.DefaultManagementServiceTimeout)
             val shardName = kv.get("shard-name")
             val partConfig = ParticipantConfig(
               runMode,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -43,6 +43,11 @@ trait ConfigProvider[ExtraConfig] {
       eventsPageSize = config.eventsPageSize,
       allowExistingSchema = participantConfig.allowExistingSchemaForIndex,
       enableAppendOnlySchema = config.enableAppendOnlySchema,
+      inputMappingParallelism = config.indexerIngestionParallelism,
+      submissionBatchSize = config.indexerSubmissionBatchSize,
+      tailingRateLimitPerSecond = config.indexerTailingRateLimitPerSecond,
+      batchWithinMillis = config.indexerBatchWithinMillis,
+      enableCompression = config.indexerEnableCompression,
     )
 
   def apiServerConfig(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -62,6 +62,7 @@ trait ConfigProvider[ExtraConfig] {
       portFile = participantConfig.portFile,
       seeding = config.seeding,
       managementServiceTimeout = participantConfig.managementServiceTimeout,
+      enableAppendOnlySchema = config.enableAppendOnlySchema,
     )
 
   def commandConfig(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -38,16 +38,16 @@ trait ConfigProvider[ExtraConfig] {
     IndexerConfig(
       participantConfig.participantId,
       jdbcUrl = participantConfig.serverJdbcUrl,
-      databaseConnectionPoolSize = participantConfig.indexerDatabaseConnectionPoolSize,
+      databaseConnectionPoolSize = participantConfig.indexerConfig.databaseConnectionPoolSize,
       startupMode = IndexerStartupMode.MigrateAndStart,
       eventsPageSize = config.eventsPageSize,
-      allowExistingSchema = participantConfig.allowExistingSchemaForIndex,
+      allowExistingSchema = participantConfig.indexerConfig.allowExistingSchema,
       enableAppendOnlySchema = config.enableAppendOnlySchema,
-      inputMappingParallelism = config.indexerIngestionParallelism,
-      submissionBatchSize = config.indexerSubmissionBatchSize,
-      tailingRateLimitPerSecond = config.indexerTailingRateLimitPerSecond,
-      batchWithinMillis = config.indexerBatchWithinMillis,
-      enableCompression = config.indexerEnableCompression,
+      inputMappingParallelism = participantConfig.indexerConfig.ingestionParallelism,
+      submissionBatchSize = participantConfig.indexerConfig.submissionBatchSize,
+      tailingRateLimitPerSecond = participantConfig.indexerConfig.tailingRateLimitPerSecond,
+      batchWithinMillis = participantConfig.indexerConfig.batchWithinMillis,
+      enableCompression = participantConfig.indexerConfig.enableCompression,
     )
 
   def apiServerConfig(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
@@ -19,18 +19,18 @@ final case class ParticipantConfig(
     portFile: Option[Path],
     serverJdbcUrl: String,
     maxCommandsInFlight: Option[Int],
-    managementServiceTimeout: Duration = ParticipantConfig.defaultManagementServiceTimeout,
+    managementServiceTimeout: Duration = ParticipantConfig.DefaultManagementServiceTimeout,
     indexerConfig: ParticipantIndexerConfig,
     apiServerDatabaseConnectionPoolSize: Int =
-      ParticipantConfig.defaultApiServerDatabaseConnectionPoolSize,
+      ParticipantConfig.DefaultApiServerDatabaseConnectionPoolSize,
 )
 
 object ParticipantConfig {
   def defaultIndexJdbcUrl(participantId: ParticipantId): String =
     s"jdbc:h2:mem:$participantId;db_close_delay=-1;db_close_on_exit=false"
 
-  val defaultManagementServiceTimeout: Duration = Duration.ofMinutes(2)
+  val DefaultManagementServiceTimeout: Duration = Duration.ofMinutes(2)
 
   // this pool is used for all data access for the ledger api (command submission, transaction service, ...)
-  val defaultApiServerDatabaseConnectionPoolSize = 16
+  val DefaultApiServerDatabaseConnectionPoolSize = 16
 }

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
@@ -9,8 +9,6 @@ import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ports.Port
 import java.time.Duration
 
-import com.daml.platform.indexer.IndexerConfig
-
 final case class ParticipantConfig(
     mode: ParticipantRunMode,
     participantId: ParticipantId,
@@ -20,11 +18,9 @@ final case class ParticipantConfig(
     port: Port,
     portFile: Option[Path],
     serverJdbcUrl: String,
-    allowExistingSchemaForIndex: Boolean,
     maxCommandsInFlight: Option[Int],
     managementServiceTimeout: Duration = ParticipantConfig.defaultManagementServiceTimeout,
-    indexerDatabaseConnectionPoolSize: Int =
-      ParticipantConfig.defaultIndexerDatabaseConnectionPoolSize,
+    indexerConfig: ParticipantIndexerConfig,
     apiServerDatabaseConnectionPoolSize: Int =
       ParticipantConfig.defaultApiServerDatabaseConnectionPoolSize,
 )
@@ -34,8 +30,6 @@ object ParticipantConfig {
     s"jdbc:h2:mem:$participantId;db_close_delay=-1;db_close_on_exit=false"
 
   val defaultManagementServiceTimeout: Duration = Duration.ofMinutes(2)
-
-  val defaultIndexerDatabaseConnectionPoolSize = IndexerConfig.DefaultDatabaseConnectionPoolSize
 
   // this pool is used for all data access for the ledger api (command submission, transaction service, ...)
   val defaultApiServerDatabaseConnectionPoolSize = 16

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantIndexerConfig.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantIndexerConfig.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.app
+
+import com.daml.platform.indexer.IndexerConfig
+
+/** Indexer-specific configuration of a participant.
+  *
+  * Parameters that are shared between the indexer and the ledger API server are stored in the parent [[ParticipantConfig]].
+  * Parameters that are shared between all ledger participants are stored in the parent [[Config]]
+  */
+final case class ParticipantIndexerConfig(
+    allowExistingSchema: Boolean,
+    databaseConnectionPoolSize: Int = ParticipantIndexerConfig.defaultDatabaseConnectionPoolSize,
+    inputMappingParallelism: Int = ParticipantIndexerConfig.defaultInputMappingParallelism,
+    ingestionParallelism: Int = ParticipantIndexerConfig.defaultIngestionParallelism,
+    submissionBatchSize: Long = ParticipantIndexerConfig.defaultSubmissionBatchSize,
+    tailingRateLimitPerSecond: Int = ParticipantIndexerConfig.defaultTailingRateLimitPerSecond,
+    batchWithinMillis: Long = ParticipantIndexerConfig.defaultBatchWithinMillis,
+    enableCompression: Boolean = ParticipantIndexerConfig.defaultEnableCompression,
+)
+
+object ParticipantIndexerConfig {
+  val defaultDatabaseConnectionPoolSize: Int = IndexerConfig.DefaultDatabaseConnectionPoolSize
+  val defaultInputMappingParallelism: Int = IndexerConfig.DefaultInputMappingParallelism
+  val defaultIngestionParallelism: Int = IndexerConfig.DefaultIngestionParallelism
+  val defaultSubmissionBatchSize: Long = IndexerConfig.DefaultSubmissionBatchSize
+  val defaultTailingRateLimitPerSecond: Int = IndexerConfig.DefaultTailingRateLimitPerSecond
+  val defaultBatchWithinMillis: Long = IndexerConfig.DefaultBatchWithinMillis
+  val defaultEnableCompression: Boolean = IndexerConfig.DefaultEnableCompression
+}

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantIndexerConfig.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantIndexerConfig.scala
@@ -12,21 +12,21 @@ import com.daml.platform.indexer.IndexerConfig
   */
 final case class ParticipantIndexerConfig(
     allowExistingSchema: Boolean,
-    databaseConnectionPoolSize: Int = ParticipantIndexerConfig.defaultDatabaseConnectionPoolSize,
-    inputMappingParallelism: Int = ParticipantIndexerConfig.defaultInputMappingParallelism,
-    ingestionParallelism: Int = ParticipantIndexerConfig.defaultIngestionParallelism,
-    submissionBatchSize: Long = ParticipantIndexerConfig.defaultSubmissionBatchSize,
-    tailingRateLimitPerSecond: Int = ParticipantIndexerConfig.defaultTailingRateLimitPerSecond,
-    batchWithinMillis: Long = ParticipantIndexerConfig.defaultBatchWithinMillis,
-    enableCompression: Boolean = ParticipantIndexerConfig.defaultEnableCompression,
+    databaseConnectionPoolSize: Int = ParticipantIndexerConfig.DefaultDatabaseConnectionPoolSize,
+    inputMappingParallelism: Int = ParticipantIndexerConfig.DefaultInputMappingParallelism,
+    ingestionParallelism: Int = ParticipantIndexerConfig.DefaultIngestionParallelism,
+    submissionBatchSize: Long = ParticipantIndexerConfig.DefaultSubmissionBatchSize,
+    tailingRateLimitPerSecond: Int = ParticipantIndexerConfig.DefaultTailingRateLimitPerSecond,
+    batchWithinMillis: Long = ParticipantIndexerConfig.DefaultBatchWithinMillis,
+    enableCompression: Boolean = ParticipantIndexerConfig.DefaultEnableCompression,
 )
 
 object ParticipantIndexerConfig {
-  val defaultDatabaseConnectionPoolSize: Int = IndexerConfig.DefaultDatabaseConnectionPoolSize
-  val defaultInputMappingParallelism: Int = IndexerConfig.DefaultInputMappingParallelism
-  val defaultIngestionParallelism: Int = IndexerConfig.DefaultIngestionParallelism
-  val defaultSubmissionBatchSize: Long = IndexerConfig.DefaultSubmissionBatchSize
-  val defaultTailingRateLimitPerSecond: Int = IndexerConfig.DefaultTailingRateLimitPerSecond
-  val defaultBatchWithinMillis: Long = IndexerConfig.DefaultBatchWithinMillis
-  val defaultEnableCompression: Boolean = IndexerConfig.DefaultEnableCompression
+  val DefaultDatabaseConnectionPoolSize: Int = IndexerConfig.DefaultDatabaseConnectionPoolSize
+  val DefaultInputMappingParallelism: Int = IndexerConfig.DefaultInputMappingParallelism
+  val DefaultIngestionParallelism: Int = IndexerConfig.DefaultIngestionParallelism
+  val DefaultSubmissionBatchSize: Long = IndexerConfig.DefaultSubmissionBatchSize
+  val DefaultTailingRateLimitPerSecond: Int = IndexerConfig.DefaultTailingRateLimitPerSecond
+  val DefaultBatchWithinMillis: Long = IndexerConfig.DefaultBatchWithinMillis
+  val DefaultEnableCompression: Boolean = IndexerConfig.DefaultEnableCompression
 }

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -20,7 +20,7 @@ import com.daml.logging.LoggingContext
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode, JdbcIndexer}
+import com.daml.platform.indexer.{Indexer, IndexerConfig, IndexerStartupMode, JdbcIndexer}
 import com.daml.platform.store.LfValueTranslationCache
 
 import scala.concurrent.duration.Duration
@@ -233,7 +233,7 @@ class IntegrityChecker[LogResult](
       resourceContext: ResourceContext,
       materializer: Materializer,
       loggingContext: LoggingContext,
-  ): ResourceOwner[JdbcIndexer] =
+  ): ResourceOwner[Indexer] =
     for {
       servicesExecutionContext <- ResourceOwner
         .forExecutorService(() => Executors.newWorkStealingPool())
@@ -247,7 +247,7 @@ class IntegrityChecker[LogResult](
         lfValueTranslationCache,
       )
       migrating <- ResourceOwner.forFuture(() =>
-        indexerFactory.migrateSchema(allowExistingSchema = false, enableAppendOnlySchema = false)
+        indexerFactory.migrateSchema(allowExistingSchema = false)
       )
       migrated <- migrating
     } yield migrated

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -235,6 +235,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   portFile = config.portFile,
                   seeding = config.seeding.get,
                   managementServiceTimeout = config.managementServiceTimeout,
+                  enableAppendOnlySchema = false,
                 ),
                 engine = engine,
                 commandConfig = config.commandConfig,


### PR DESCRIPTION
This PR enables the use of the new append-only index database and parallel ingestion indexer in ledgers based on `com.daml.ledger.participant.state.kvutils.app`.

*Reminder: The new indexer is PoC quality and behind feature flags. All corresponding CLI flags are hidden, and the main CLI flag is marked as unsafe.*