### PR TITLE
DO NOT MERGE: First test for the append-only indexer schema

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -871,7 +871,7 @@ buildifier_dependencies()
 
 nixpkgs_package(
     name = "postgresql_nix",
-    attribute_path = "postgresql_9_6",
+    attribute_path = "postgresql_12",
     fail_not_supported = False,
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,

--- a/compatibility/WORKSPACE
+++ b/compatibility/WORKSPACE
@@ -157,7 +157,7 @@ dev_env_tool(
 
 nixpkgs_package(
     name = "postgresql_nix",
-    attribute_path = "postgresql_9_6",
+    attribute_path = "postgresql_12",
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
 filegroup(

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -323,3 +323,18 @@ da_scala_test_suite(
     )
     for db in supported_databases
 ]
+
+conformance_test(
+    name = "conformance-test-append-only",
+    ports = [6865],
+    server = ":conformance-test-postgresql-bin",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant participant-id=conformance-test,port=6865",
+        "--index-append-only-schema-unsafe",
+    ],
+    tags = [],
+    test_tool_args = [
+        "--verbose",
+    ],
+)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
@@ -26,4 +26,6 @@ case class ApiServerConfig(
     portFile: Option[Path],
     seeding: Seeding,
     managementServiceTimeout: Duration,
+    // TODO append-only: remove after removing support for the current (mutating) schema
+    enableAppendOnlySchema: Boolean,
 )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -80,6 +80,7 @@ final class StandaloneApiServer(
           metrics = metrics,
           lfValueTranslationCache = lfValueTranslationCache,
           enricher = valueEnricher,
+          enableAppendOnlySchema = config.enableAppendOnlySchema
         )
         .map(index => new SpannedIndexService(new TimedIndexService(index, metrics)))
       authorizer = new Authorizer(Clock.systemUTC.instant _, ledgerId, participantId)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -80,7 +80,7 @@ final class StandaloneApiServer(
           metrics = metrics,
           lfValueTranslationCache = lfValueTranslationCache,
           enricher = valueEnricher,
-          enableAppendOnlySchema = config.enableAppendOnlySchema
+          enableAppendOnlySchema = config.enableAppendOnlySchema,
         )
         .map(index => new SpannedIndexService(new TimedIndexService(index, metrics)))
       authorizer = new Authorizer(Clock.systemUTC.instant _, ledgerId, participantId)

--- a/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
@@ -28,6 +28,7 @@ private[platform] object JdbcIndex {
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslationCache.Cache,
       enricher: ValueEnricher,
+      enableAppendOnlySchema: Boolean,
   )(implicit mat: Materializer, loggingContext: LoggingContext): ResourceOwner[IndexService] =
     new ReadOnlySqlLedger.Owner(
       serverRole = serverRole,
@@ -39,6 +40,7 @@ private[platform] object JdbcIndex {
       metrics = metrics,
       lfValueTranslationCache = lfValueTranslationCache,
       enricher = enricher,
+      enableAppendOnlySchema = enableAppendOnlySchema,
     ).map { ledger =>
       new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId)
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -43,6 +43,8 @@ private[platform] object ReadOnlySqlLedger {
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslationCache.Cache,
       enricher: ValueEnricher,
+      // TODO append-only: remove after removing support for the current (mutating) schema
+      enableAppendOnlySchema: Boolean,
   )(implicit mat: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[ReadOnlyLedger] {
     override def acquire()(implicit context: ResourceContext): Resource[ReadOnlyLedger] =
@@ -100,16 +102,29 @@ private[platform] object ReadOnlySqlLedger {
     private def ledgerDaoOwner(
         servicesExecutionContext: ExecutionContext
     ): ResourceOwner[LedgerReadDao] =
-      JdbcLedgerDao.readOwner(
-        serverRole,
-        jdbcUrl,
-        databaseConnectionPoolSize,
-        eventsPageSize,
-        servicesExecutionContext,
-        metrics,
-        lfValueTranslationCache,
-        Some(enricher),
-      )
+      if (enableAppendOnlySchema) {
+        com.daml.platform.store.appendonlydao.JdbcLedgerDao.readOwner(
+          serverRole,
+          jdbcUrl,
+          databaseConnectionPoolSize,
+          eventsPageSize,
+          servicesExecutionContext,
+          metrics,
+          lfValueTranslationCache,
+          Some(enricher),
+        )
+      } else {
+        JdbcLedgerDao.readOwner(
+          serverRole,
+          jdbcUrl,
+          databaseConnectionPoolSize,
+          eventsPageSize,
+          servicesExecutionContext,
+          metrics,
+          lfValueTranslationCache,
+          Some(enricher),
+        )
+      }
 
     private def dispatcherOwner(ledgerEnd: Offset): ResourceOwner[Dispatcher[Offset]] =
       Dispatcher.owner(

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -22,6 +22,13 @@ case class IndexerConfig(
     // TODO append-only: remove after removing support for the current (mutating) schema
     enableAppendOnlySchema: Boolean = false,
     asyncCommitMode: DbType.AsyncCommitMode = DefaultAsyncCommitMode,
+    inputMappingParallelism: Int = 3,
+    ingestionParallelism: Int = 4,
+    submissionBatchSize: Long = 1L,
+    tailingRateLimitPerSecond: Int = 100,
+    batchWithinMillis: Long = 10,
+    runStageUntil: Int = 6,
+    enableCompression: Boolean = true,
 )
 
 object IndexerConfig {

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -45,7 +45,7 @@ final class StandaloneIndexerServer(
         Resource
           .fromFuture(
             indexerFactory
-              .migrateSchema(config.allowExistingSchema, config.enableAppendOnlySchema)
+              .migrateSchema(config.allowExistingSchema)
           )
           .flatMap(startIndexer(indexer, _))
           .map { _ =>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
@@ -177,7 +177,7 @@ final class JdbcIndexerSpec
       participantId: String,
       mockFlow: Flow[OffsetUpdate, Unit, NotUsed] = noOpFlow,
       jdbcAsyncCommitMode: DbType.AsyncCommitMode = DbType.AsynchronousCommit,
-  ): Future[ResourceOwner[JdbcIndexer]] = {
+  ): Future[ResourceOwner[Indexer]] = {
     val config = IndexerConfig(
       participantId = v1.ParticipantId.assertFromString(participantId),
       jdbcUrl = postgresDatabase.url,
@@ -204,7 +204,8 @@ final class JdbcIndexerSpec
         mockedUpdateFlowOwnerBuilder(metrics, config.participantId, mockFlow),
       ledgerDaoOwner = ledgerDaoOwner,
       flywayMigrations = new FlywayMigrations(config.jdbcUrl),
-    ).migrateSchema(allowExistingSchema = true, enableAppendOnlySchema = false)
+      LfValueTranslationCache.Cache.none,
+    ).migrateSchema(allowExistingSchema = true)
   }
 
   private def mockedUpdateFlowOwnerBuilder(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -43,6 +43,11 @@ trait ConfigProvider[ExtraConfig] {
       eventsPageSize = config.eventsPageSize,
       allowExistingSchema = participantConfig.allowExistingSchemaForIndex,
       enableAppendOnlySchema = config.enableAppendOnlySchema,
+      inputMappingParallelism = config.indexerIngestionParallelism,
+      submissionBatchSize = config.indexerSubmissionBatchSize,
+      tailingRateLimitPerSecond = config.indexerTailingRateLimitPerSecond,
+      batchWithinMillis = config.indexerBatchWithinMillis,
+      enableCompression = config.indexerEnableCompression,
     )
 
   def apiServerConfig(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -62,6 +62,7 @@ trait ConfigProvider[ExtraConfig] {
       portFile = participantConfig.portFile,
       seeding = config.seeding,
       managementServiceTimeout = participantConfig.managementServiceTimeout,
+      enableAppendOnlySchema = config.enableAppendOnlySchema,
     )
 
   def commandConfig(

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -20,7 +20,7 @@ import com.daml.logging.LoggingContext
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode, JdbcIndexer}
+import com.daml.platform.indexer.{Indexer, IndexerConfig, IndexerStartupMode, JdbcIndexer}
 import com.daml.platform.store.LfValueTranslationCache
 
 import scala.concurrent.duration.Duration
@@ -233,7 +233,7 @@ class IntegrityChecker[LogResult](
       resourceContext: ResourceContext,
       materializer: Materializer,
       loggingContext: LoggingContext,
-  ): ResourceOwner[JdbcIndexer] =
+  ): ResourceOwner[Indexer] =
     for {
       servicesExecutionContext <- ResourceOwner
         .forExecutorService(() => Executors.newWorkStealingPool())
@@ -247,7 +247,7 @@ class IntegrityChecker[LogResult](
         lfValueTranslationCache,
       )
       migrating <- ResourceOwner.forFuture(() =>
-        indexerFactory.migrateSchema(allowExistingSchema = false, enableAppendOnlySchema = false)
+        indexerFactory.migrateSchema(allowExistingSchema = false)
       )
       migrated <- migrating
     } yield migrated

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -235,6 +235,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   portFile = config.portFile,
                   seeding = config.seeding.get,
                   managementServiceTimeout = config.managementServiceTimeout,
+                  enableAppendOnlySchema = false,
                 ),
                 engine = engine,
                 commandConfig = config.commandConfig,

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -23,7 +23,7 @@ let shared = rec {
     openssl
     gnupatch
     patchelf
-    postgresql_9_6
+    postgresql_12
     protobuf3_8
     python3
     toxiproxy

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -27,7 +27,7 @@ let
       installPhase = ''
         mkdir -p $out
         PREFIX=$out make install
-        wrapProgram $out/bin/pg_tmp --prefix PATH : ${pkgs.postgresql_9_6}/bin:$out/bin
+        wrapProgram $out/bin/pg_tmp --prefix PATH : ${pkgs.postgresql_12}/bin:$out/bin
       '';
     });
     scala_2_12 = pkgs.scala_2_12;


### PR DESCRIPTION
This PR adds a test for #9368.

It must not be merged because it contains a bump of the Postgres version. It serves as a one-time verification of the append-only indexer.

Once we improve the append-only schema to run with the current Postgres version, we can merge a change that adds a conformance test that uses the append-only schema.