### PR TITLE
LF: fix preprocessing of exercise

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -72,13 +72,17 @@ private[preprocessing] final class TransactionPreprocessor(
             choiceObservers @ _,
             children @ _,
             exerciseResult @ _,
-            key @ _,
+            key,
             byKey @ _,
             version @ _,
           ) =>
         val templateId = template
-        val (cmd, newCids) =
-          commandPreprocessor.unsafePreprocessExercise(templateId, coid, choice, chosenVal)
+        val (cmd, newCids) = key match {
+          case Some(Node.KeyWithMaintainers(key, _)) =>
+            commandPreprocessor.unsafePreprocessExerciseByKey(templateId, key, choice, chosenVal)
+          case None =>
+            commandPreprocessor.unsafePreprocessExercise(templateId, coid, choice, chosenVal)
+        }
         (cmd, (localCids | newCids.filterNot(globalCids), globalCids))
       case Node.NodeFetch(coid, templateId, _, _, _, _, _, _, _) =>
         val cmd = commandPreprocessor.unsafePreprocessFetch(templateId, coid)


### PR DESCRIPTION
All exercise nodes with key are replay as ExerciseByKey.

CHANGELOG_BEGIN
 - [Engine] fix cid freshness check

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
