### PR TITLE
Wire-up ingestion methods in JdbcLedgerDao

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
@@ -226,6 +226,7 @@ trait ExecuteUpdate {
           offsetStep = offsetStep,
           transaction = transaction,
           divulged = divulgedContracts,
+          transactionMeta.workflowId,
         )
     }
   }
@@ -514,6 +515,7 @@ class AtomicExecuteUpdate(
             offsetStep = offsetStep,
             transaction = transaction,
             divulged = divulgedContracts,
+            workflowId = transactionMeta.workflowId,
           ),
         )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -79,7 +79,6 @@ object JdbcIndexer {
       flywayMigrations
         .validate()
         .flatMap(_ => initialized(resetSchema = false))(resourceContext.executionContext)
-
     def migrateSchema(
         allowExistingSchema: Boolean
     )(implicit resourceContext: ResourceContext): Future[ResourceOwner[Indexer]] =

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/RawDBBatchPostgreSQLV1.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/RawDBBatchPostgreSQLV1.scala
@@ -706,7 +706,7 @@ object RawDBBatchPostgreSQLV1 {
 
   // TODO append-only: idea: string is a bit chatty for timestamp communication, maybe we can switch to epoch somehow?
   private val PGTimestampFormat =
-    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss") // FIXME +micros
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")
   def toPGTimestampString(instant: Instant): String =
     instant
       .atZone(ZoneOffset.UTC)

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/UpdateToDBDTOV1.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/UpdateToDBDTOV1.scala
@@ -4,6 +4,7 @@
 package com.daml.platform.indexer.parallel
 
 import java.util.UUID
+
 import com.daml.ledger.api.domain
 import com.daml.ledger.participant.state.v1.{Configuration, Offset, ParticipantId, Update}
 import com.daml.lf.engine.Blinding
@@ -12,7 +13,6 @@ import com.daml.platform.indexer.parallel
 import com.daml.platform.store.Conversions
 import com.daml.platform.store.appendonlydao.events._
 import com.daml.platform.store.appendonlydao.JdbcLedgerDao
-import com.daml.platform.store.dao.DeduplicationKeyMaker
 
 // TODO append-only: target to separation per update-type to it's own function + unit tests
 object UpdateToDBDTOV1 {
@@ -37,7 +37,7 @@ object UpdateToDBDTOV1 {
             status_message = Some(u.reason.description),
           ),
           new DBDTOV1.CommandDeduplication(
-            DeduplicationKeyMaker.make(
+            JdbcLedgerDao.deduplicationKey(
               domain.CommandId(u.submitterInfo.commandId),
               u.submitterInfo.actAs,
             )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -350,7 +350,6 @@ private class JdbcLedgerDao(
           PersistenceResponse.Ok
       }
     }
-
   }
 
   private val SQL_GET_PARTY_ENTRIES = SQL(
@@ -495,6 +494,7 @@ private class JdbcLedgerDao(
       offsetStep: OffsetStep,
       transaction: CommittedTransaction,
       divulged: Iterable[DivulgedContract],
+      workflowId: Option[String],
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] = {
     logger.info("Storing transaction")
     dbDispatcher

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -251,6 +251,7 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
       offsetStep: OffsetStep,
       transaction: CommittedTransaction,
       divulged: Iterable[DivulgedContract],
+      workflowId: Option[String],
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
   // TODO append-only: cleanup

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -162,6 +162,7 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
       offsetStep: OffsetStep,
       transaction: CommittedTransaction,
       divulged: Iterable[DivulgedContract],
+      workflowId: Option[String],
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storeTransaction,
@@ -174,6 +175,7 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
         offsetStep,
         transaction,
         divulged,
+        workflowId,
       ),
     )
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoActiveContractsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoActiveContractsSpec.scala
@@ -1,0 +1,272 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.util.UUID
+
+import akka.NotUsed
+import akka.stream.scaladsl.{Sink, Source}
+import com.daml.lf.data.Ref.Party
+import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
+import com.daml.ledger.api.v1.event.CreatedEvent
+import com.daml.platform.participant.util.LfEngineToApi
+import org.scalatest._
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.Future
+
+private[appendonlydao] trait JdbcLedgerDaoActiveContractsSpec
+    extends OptionValues
+    with Inside
+    with Inspectors
+    with LoneElement {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (getActiveContracts)"
+
+  it should "serve the correct contracts after a series of transactions" in {
+    for {
+      before <- ledgerDao.lookupLedgerEnd()
+      (_, t1) <- store(singleCreate)
+      (_, t2) <- store(singleCreate)
+      (_, _) <- store(singleExercise(nonTransient(t2).loneElement))
+      (_, _) <- store(fullyTransient)
+      (_, t5) <- store(singleCreate)
+      (_, t6) <- store(singleCreate)
+      after <- ledgerDao.lookupLedgerEnd()
+      activeContractsBefore <- activeContractsOf(
+        ledgerDao.transactionsReader
+          .getActiveContracts(
+            activeAt = before,
+            filter = Map(alice -> Set.empty, bob -> Set.empty, charlie -> Set.empty),
+            verbose = true,
+          )
+      )
+      activeContractsAfter <- activeContractsOf(
+        ledgerDao.transactionsReader
+          .getActiveContracts(
+            activeAt = after,
+            filter = Map(alice -> Set.empty, bob -> Set.empty, charlie -> Set.empty),
+            verbose = true,
+          )
+      )
+    } yield {
+      val activeContracts = activeContractsAfter.toSet.diff(activeContractsBefore.toSet)
+      activeContracts should have size 3
+      activeContracts.map(_.contractId) shouldBe Set(
+        nonTransient(t1).loneElement.coid,
+        nonTransient(t5).loneElement.coid,
+        nonTransient(t6).loneElement.coid,
+      )
+    }
+  }
+
+  it should "serve a stable result based on the input offset" in {
+    for {
+      offset <- ledgerDao.lookupLedgerEnd()
+      activeContractsBefore <- activeContractsOf(
+        ledgerDao.transactionsReader
+          .getActiveContracts(
+            activeAt = offset,
+            filter = Map(alice -> Set.empty, bob -> Set.empty, charlie -> Set.empty),
+            verbose = true,
+          )
+      )
+      (_, _) <- store(singleCreate)
+      (_, c) <- store(singleCreate)
+      (_, _) <- store(singleExercise(nonTransient(c).loneElement))
+      (_, _) <- store(fullyTransient)
+      (_, _) <- store(singleCreate)
+      (_, _) <- store(singleCreate)
+      activeContractsAfter <- activeContractsOf(
+        ledgerDao.transactionsReader
+          .getActiveContracts(
+            activeAt = offset,
+            filter = Map(alice -> Set.empty, bob -> Set.empty, charlie -> Set.empty),
+            verbose = true,
+          )
+      )
+    } yield {
+      activeContractsAfter.toSet.diff(activeContractsBefore.toSet) should have size 0
+    }
+  }
+
+  it should "filter correctly for a single party" in {
+    val party1 = Party.assertFromString(UUID.randomUUID.toString)
+    val party2 = Party.assertFromString(UUID.randomUUID.toString)
+    for {
+      _ <- store(
+        multipleCreates(
+          operator = "operator",
+          signatoriesAndTemplates = Seq(
+            (party1, someTemplateId, someContractArgument),
+            (party2, otherTemplateId, otherContractArgument),
+            (party1, otherTemplateId, otherContractArgument),
+          ),
+        )
+      )
+      ledgerEnd <- ledgerDao.lookupLedgerEnd()
+      result <- activeContractsOf(
+        ledgerDao.transactionsReader
+          .getActiveContracts(
+            activeAt = ledgerEnd,
+            filter = Map(party1 -> Set(otherTemplateId)),
+            verbose = true,
+          )
+      )
+    } yield {
+      val create = result.loneElement
+      create.witnessParties.loneElement shouldBe party1
+      create.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+    }
+  }
+
+  it should "filter correctly by multiple parties with the same template" in {
+    val party1 = Party.assertFromString(UUID.randomUUID.toString)
+    val party2 = Party.assertFromString(UUID.randomUUID.toString)
+    for {
+      _ <- store(
+        multipleCreates(
+          operator = "operator",
+          signatoriesAndTemplates = Seq(
+            (party1, someTemplateId, someContractArgument),
+            (party2, otherTemplateId, otherContractArgument),
+            (party1, otherTemplateId, otherContractArgument),
+          ),
+        )
+      )
+      ledgerEnd <- ledgerDao.lookupLedgerEnd()
+      result <- activeContractsOf(
+        ledgerDao.transactionsReader
+          .getActiveContracts(
+            activeAt = ledgerEnd,
+            filter = Map(
+              party1 -> Set(otherTemplateId),
+              party2 -> Set(otherTemplateId),
+            ),
+            verbose = true,
+          )
+      )
+    } yield {
+      val activeContracts = result.toArray
+      activeContracts should have length 2
+
+      val create1 = activeContracts(0)
+      create1.witnessParties.loneElement shouldBe party2
+      create1.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+
+      val create2 = activeContracts(1)
+      create2.witnessParties.loneElement shouldBe party1
+      create2.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+    }
+  }
+
+  it should "filter correctly by multiple parties with different templates" in {
+    val party1 = Party.assertFromString(UUID.randomUUID.toString)
+    val party2 = Party.assertFromString(UUID.randomUUID.toString)
+    for {
+      _ <- store(
+        multipleCreates(
+          operator = "operator",
+          signatoriesAndTemplates = Seq(
+            (party1, someTemplateId, someContractArgument),
+            (party2, otherTemplateId, otherContractArgument),
+            (party1, otherTemplateId, otherContractArgument),
+          ),
+        )
+      )
+      ledgerEnd <- ledgerDao.lookupLedgerEnd()
+      result <- activeContractsOf(
+        ledgerDao.transactionsReader
+          .getActiveContracts(
+            activeAt = ledgerEnd,
+            filter = Map(
+              party1 -> Set(someTemplateId),
+              party2 -> Set(otherTemplateId),
+            ),
+            verbose = true,
+          )
+      )
+    } yield {
+      val activeContracts = result.toArray
+      activeContracts should have length 2
+
+      val create2 = activeContracts(0)
+      create2.witnessParties.loneElement shouldBe party1
+      create2.templateId.value shouldBe LfEngineToApi.toApiIdentifier(someTemplateId)
+
+      val create1 = activeContracts(1)
+      create1.witnessParties.loneElement shouldBe party2
+      create1.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+    }
+  }
+
+  it should "filter correctly by multiple parties with different template and wildcards" in {
+    val party1 = Party.assertFromString(UUID.randomUUID.toString)
+    val party2 = Party.assertFromString(UUID.randomUUID.toString)
+    for {
+      _ <- store(
+        multipleCreates(
+          operator = "operator",
+          signatoriesAndTemplates = Seq(
+            (party1, someTemplateId, someContractArgument),
+            (party2, otherTemplateId, otherContractArgument),
+            (party1, otherTemplateId, otherContractArgument),
+          ),
+        )
+      )
+      ledgerEnd <- ledgerDao.lookupLedgerEnd()
+      result <- activeContractsOf(
+        ledgerDao.transactionsReader
+          .getActiveContracts(
+            activeAt = ledgerEnd,
+            filter = Map(
+              party1 -> Set(someTemplateId),
+              party2 -> Set.empty,
+            ),
+            verbose = true,
+          )
+      )
+    } yield {
+      val activeContracts = result.toArray
+      activeContracts should have length 2
+
+      val create2 = activeContracts(0)
+      create2.witnessParties.loneElement shouldBe party1
+      create2.templateId.value shouldBe LfEngineToApi.toApiIdentifier(someTemplateId)
+
+      val create1 = activeContracts(1)
+      create1.witnessParties.loneElement shouldBe party2
+      create1.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+    }
+  }
+
+  it should "not set the offset" in {
+    for {
+      (_, t1) <- store(singleCreate)
+      (_, t2) <- store(singleCreate)
+      end <- ledgerDao.lookupLedgerEnd()
+      activeContracts <- ledgerDao.transactionsReader
+        .getActiveContracts(
+          activeAt = end,
+          filter = Map(alice -> Set.empty),
+          verbose = true,
+        )
+        .runWith(Sink.seq)
+
+    } yield {
+      activeContracts should not be empty
+      forAll(activeContracts) { ac =>
+        ac.offset shouldBe empty
+      }
+    }
+  }
+
+  private def activeContractsOf(
+      source: Source[GetActiveContractsResponse, NotUsed]
+  ): Future[Seq[CreatedEvent]] =
+    source.runWith(Sink.seq).map(_.flatMap(_.activeContracts))
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoBackend.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoBackend.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.api.domain.{LedgerId, ParticipantId}
+import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
+import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
+import com.daml.lf.data.Ref
+import com.daml.lf.engine.{Engine, ValueEnricher}
+import com.daml.logging.LoggingContext
+import com.daml.logging.LoggingContext.newLoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.configuration.ServerRole
+import com.daml.platform.store.appendonlydao.JdbcLedgerDaoBackend.{TestLedgerId, TestParticipantId}
+import com.daml.platform.store.dao.LedgerDao
+import com.daml.platform.store.{DbType, FlywayMigrations, LfValueTranslationCache}
+import org.scalatest.AsyncTestSuite
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+object JdbcLedgerDaoBackend {
+
+  private val TestLedgerId: LedgerId =
+    LedgerId("test-ledger")
+
+  private val TestParticipantId: ParticipantId =
+    ParticipantId(Ref.ParticipantId.assertFromString("test-participant"))
+
+}
+
+private[appendonlydao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll {
+  this: AsyncTestSuite =>
+
+  protected def dbType: DbType
+
+  protected def jdbcUrl: String
+
+  protected def daoOwner(eventsPageSize: Int)(implicit
+      loggingContext: LoggingContext
+  ): ResourceOwner[LedgerDao] =
+    JdbcLedgerDao.writeOwner(
+      serverRole = ServerRole.Testing(getClass),
+      jdbcUrl = jdbcUrl,
+      // this was the previous default.
+      // keeping it hardcoded here to keep tests working as before extracting the parameter
+      connectionPoolSize = 16,
+      eventsPageSize = eventsPageSize,
+      servicesExecutionContext = executionContext,
+      metrics = new Metrics(new MetricRegistry),
+      lfValueTranslationCache = LfValueTranslationCache.Cache.none,
+      jdbcAsyncCommitMode = DbType.AsynchronousCommit,
+      enricher = Some(new ValueEnricher(new Engine())),
+    )
+
+  protected final var ledgerDao: LedgerDao = _
+
+  // `dbDispatcher` and `ledgerDao` depend on the `postgresFixture` which is in turn initialized `beforeAll`
+  private var resource: Resource[LedgerDao] = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    // We use the dispatcher here because the default Scalatest execution context is too slow.
+    implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
+    resource = newLoggingContext { implicit loggingContext =>
+      for {
+        _ <- Resource.fromFuture(
+          new FlywayMigrations(jdbcUrl).migrate(enableAppendOnlySchema = true)
+        )
+        dao <- daoOwner(100).acquire()
+        _ <- Resource.fromFuture(dao.initializeLedger(TestLedgerId))
+        _ <- Resource.fromFuture(dao.initializeParticipantId(TestParticipantId))
+      } yield dao
+    }
+    ledgerDao = Await.result(resource.asFuture, 30.seconds)
+  }
+
+  override protected def afterAll(): Unit = {
+    Await.result(resource.release(), 10.seconds)
+    super.afterAll()
+  }
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoBackendH2Database.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoBackendH2Database.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import com.daml.platform.store.DbType
+import org.scalatest.AsyncTestSuite
+
+private[appendonlydao] trait JdbcLedgerDaoBackendH2Database extends JdbcLedgerDaoBackend {
+  this: AsyncTestSuite =>
+
+  override protected val dbType: DbType = DbType.H2Database
+
+  override protected val jdbcUrl: String = "jdbc:h2:mem:static_time;db_close_delay=-1"
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoBackendPostgresql.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoBackendPostgresql.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import com.daml.platform.store.DbType
+import com.daml.testing.postgresql.PostgresAroundAll
+import org.scalatest.AsyncTestSuite
+
+private[appendonlydao] trait JdbcLedgerDaoBackendPostgresql
+    extends JdbcLedgerDaoBackend
+    with PostgresAroundAll {
+  this: AsyncTestSuite =>
+
+  override protected val dbType: DbType = DbType.Postgres
+
+  override protected def jdbcUrl: String = postgresDatabase.url
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoCommandDeduplicationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoCommandDeduplicationSpec.scala
@@ -1,0 +1,103 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.time.Instant
+import java.util.UUID
+
+import com.daml.ledger.api.domain.CommandId
+import com.daml.ledger.participant.state.index.v2.{
+  CommandDeduplicationDuplicate,
+  CommandDeduplicationNew,
+}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+private[appendonlydao] trait JdbcLedgerDaoCommandDeduplicationSpec {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (command deduplication)"
+
+  it should "correctly deduplicate a command" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original <- ledgerDao.deduplicateCommand(commandId, List(alice), t(0), t(5000))
+      duplicate <- ledgerDao.deduplicateCommand(commandId, List(alice), t(500), t(5500))
+    } yield {
+      original shouldBe CommandDeduplicationNew
+      duplicate shouldBe CommandDeduplicationDuplicate(t(5000))
+    }
+  }
+
+  it should "correctly deduplicate commands with multiple submitters" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original <- ledgerDao.deduplicateCommand(commandId, List(alice, bob), t(0), t(5000))
+      duplicate1 <- ledgerDao.deduplicateCommand(commandId, List(alice, bob), t(500), t(5500))
+      duplicate2 <- ledgerDao.deduplicateCommand(commandId, List(bob, alice), t(500), t(5500))
+      duplicate3 <- ledgerDao.deduplicateCommand(
+        commandId,
+        List(alice, bob, alice),
+        t(500),
+        t(5500),
+      )
+    } yield {
+      original shouldBe CommandDeduplicationNew
+      duplicate1 shouldBe CommandDeduplicationDuplicate(t(5000))
+      duplicate2 shouldBe CommandDeduplicationDuplicate(t(5000))
+      duplicate3 shouldBe CommandDeduplicationDuplicate(t(5000))
+    }
+  }
+
+  it should "not deduplicate a command after it expired" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original1 <- ledgerDao.deduplicateCommand(commandId, List(alice), t(0), t(100))
+      original2 <- ledgerDao.deduplicateCommand(commandId, List(alice), t(101), t(200))
+    } yield {
+      original1 shouldBe CommandDeduplicationNew
+      original2 shouldBe CommandDeduplicationNew
+    }
+  }
+
+  it should "not deduplicate a command after its deduplication was stopped" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original1 <- ledgerDao.deduplicateCommand(commandId, List(alice), t(0), t(10000))
+      _ <- ledgerDao.stopDeduplicatingCommand(commandId, List(alice))
+      original2 <- ledgerDao.deduplicateCommand(commandId, List(alice), t(1), t(10001))
+    } yield {
+      original1 shouldBe CommandDeduplicationNew
+      original2 shouldBe CommandDeduplicationNew
+    }
+  }
+
+  it should "not deduplicate commands with different command ids" in {
+    val commandId1: CommandId = CommandId(UUID.randomUUID.toString)
+    val commandId2: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original1 <- ledgerDao.deduplicateCommand(commandId1, List(alice, bob), t(0), t(1000))
+      original2 <- ledgerDao.deduplicateCommand(commandId2, List(alice, bob), t(0), t(1000))
+    } yield {
+      original1 shouldBe CommandDeduplicationNew
+      original2 shouldBe CommandDeduplicationNew
+    }
+  }
+
+  it should "not deduplicate commands with different submitters" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original1 <- ledgerDao.deduplicateCommand(commandId, List(alice, bob), t(0), t(1000))
+      original2 <- ledgerDao.deduplicateCommand(commandId, List(alice, charlie), t(0), t(1000))
+    } yield {
+      original1 shouldBe CommandDeduplicationNew
+      original2 shouldBe CommandDeduplicationNew
+    }
+  }
+
+  private[this] val t0 = Instant.now()
+  private[this] def t(ms: Long): Instant = {
+    t0.plusMillis(ms)
+  }
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoCompletionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoCompletionsSpec.scala
@@ -1,0 +1,249 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.time.Instant
+import java.util.UUID
+
+import akka.stream.scaladsl.Sink
+import com.daml.ledger.ApplicationId
+import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
+import com.daml.ledger.participant.state.v1.{Offset, RejectionReason, SubmitterInfo}
+import com.daml.lf.data.Ref.Party
+import com.daml.platform.ApiOffset
+import com.daml.platform.store.Conversions.participantRejectionReasonToErrorCode
+import com.daml.platform.store.appendonlydao.JdbcLedgerDaoCompletionsSpec._
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{LoneElement, OptionValues}
+
+import scala.concurrent.Future
+
+private[appendonlydao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneElement {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (completions)"
+
+  it should "return the expected completion for an accepted transaction" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (offset, tx) <- store(singleCreate)
+      to <- ledgerDao.lookupLedgerEnd()
+      (_, response) <- ledgerDao.completions
+        .getCommandCompletions(from, to, tx.applicationId.get, tx.actAs.toSet)
+        .runWith(Sink.head)
+    } yield {
+      offsetOf(response) shouldBe offset
+
+      val completion = response.completions.loneElement
+
+      completion.transactionId shouldBe tx.transactionId
+      completion.commandId shouldBe tx.commandId.get
+      completion.status.value.code shouldBe io.grpc.Status.Code.OK.value()
+    }
+  }
+
+  it should "return the expected completion for an accepted multi-party transaction" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (_, tx) <- store(multiPartySingleCreate)
+      to <- ledgerDao.lookupLedgerEnd()
+      // Response 1: querying as all submitters
+      (_, response1) <- ledgerDao.completions
+        .getCommandCompletions(from, to, tx.applicationId.get, tx.actAs.toSet)
+        .runWith(Sink.head)
+      // Response 2: querying as a proper subset of all submitters
+      (_, response2) <- ledgerDao.completions
+        .getCommandCompletions(from, to, tx.applicationId.get, Set(tx.actAs.head))
+        .runWith(Sink.head)
+      // Response 3: querying as a proper superset of all submitters
+      (_, response3) <- ledgerDao.completions
+        .getCommandCompletions(from, to, tx.applicationId.get, tx.actAs.toSet + "UNRELATED")
+        .runWith(Sink.head)
+    } yield {
+      response1.completions.loneElement.commandId shouldBe tx.commandId.get
+      response2.completions.loneElement.commandId shouldBe tx.commandId.get
+      response3.completions.loneElement.commandId shouldBe tx.commandId.get
+    }
+  }
+
+  it should "return the expected completion for a rejection" in {
+    val expectedCmdId = UUID.randomUUID.toString
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      offset <- storeRejection(RejectionReason.Inconsistent(""), expectedCmdId)
+      to <- ledgerDao.lookupLedgerEnd()
+      (_, response) <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId, parties)
+        .runWith(Sink.head)
+    } yield {
+      offsetOf(response) shouldBe offset
+
+      val completion = response.completions.loneElement
+
+      completion.transactionId shouldBe empty
+      completion.commandId shouldBe expectedCmdId
+      completion.status.value.code shouldNot be(io.grpc.Status.Code.OK.value())
+    }
+  }
+
+  it should "return the expected completion for a multi-party rejection" in {
+    val expectedCmdId = UUID.randomUUID.toString
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      _ <- storeMultiPartyRejection(RejectionReason.Inconsistent(""), expectedCmdId)
+      to <- ledgerDao.lookupLedgerEnd()
+      // Response 1: querying as all submitters
+      (_, response1) <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId, parties)
+        .runWith(Sink.head)
+      // Response 2: querying as a proper subset of all submitters
+      (_, response2) <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId, Set(parties.head))
+        .runWith(Sink.head)
+      // Response 3: querying as a proper superset of all submitters
+      (_, response3) <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId, parties + "UNRELATED")
+        .runWith(Sink.head)
+    } yield {
+      response1.completions.loneElement.commandId shouldBe expectedCmdId
+      response2.completions.loneElement.commandId shouldBe expectedCmdId
+      response3.completions.loneElement.commandId shouldBe expectedCmdId
+    }
+  }
+
+  it should "not return completions if the application id is wrong" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      _ <- storeRejection(RejectionReason.Inconsistent(""))
+      to <- ledgerDao.lookupLedgerEnd()
+      response <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId = "WRONG", parties)
+        .runWith(Sink.seq)
+    } yield {
+      response shouldBe Seq.empty
+    }
+  }
+
+  it should "not return completions if the parties do not match" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      _ <- storeRejection(RejectionReason.Inconsistent(""))
+      to <- ledgerDao.lookupLedgerEnd()
+      response1 <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId, Set("WRONG"))
+        .runWith(Sink.seq)
+      response2 <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId, Set("WRONG1", "WRONG2", "WRONG3"))
+        .runWith(Sink.seq)
+    } yield {
+      response1 shouldBe Seq.empty
+      response2 shouldBe Seq.empty
+    }
+  }
+
+  it should "not return completions if the parties do not match (multi-party submission)" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      _ <- storeMultiPartyRejection(RejectionReason.Inconsistent(""))
+      to <- ledgerDao.lookupLedgerEnd()
+      response1 <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId, Set("WRONG"))
+        .runWith(Sink.seq)
+      response2 <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId, Set("WRONG1", "WRONG2", "WRONG3"))
+        .runWith(Sink.seq)
+    } yield {
+      response1 shouldBe Seq.empty
+      response2 shouldBe Seq.empty
+    }
+  }
+
+  it should "return the expected status for each rejection reason" in {
+    val reasons = List[RejectionReason](
+      RejectionReason.Disputed(""),
+      RejectionReason.Inconsistent(""),
+      RejectionReason.InvalidLedgerTime(""),
+      RejectionReason.ResourcesExhausted(""),
+      RejectionReason.PartyNotKnownOnLedger(""),
+      RejectionReason.SubmitterCannotActViaParticipant(""),
+      RejectionReason.InvalidLedgerTime(""),
+    )
+
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      _ <- seq(reasons.map(reason => prepareStoreRejection(reason)))
+      to <- ledgerDao.lookupLedgerEnd()
+      responses <- ledgerDao.completions
+        .getCommandCompletions(from, to, applicationId, parties)
+        .map(_._2)
+        .runWith(Sink.seq)
+    } yield {
+      responses should have length reasons.length.toLong
+      val returnedCodes = responses.flatMap(_.completions.map(_.status.get.code))
+      for ((reason, code) <- reasons.zip(returnedCodes)) {
+        code shouldBe participantRejectionReasonToErrorCode(reason).value
+      }
+      succeed
+    }
+  }
+
+  private def prepareStoreRejection(
+      reason: RejectionReason,
+      commandId: String = UUID.randomUUID().toString,
+  ): () => Future[Offset] = () => {
+    val offset = nextOffset()
+    ledgerDao
+      .storeRejection(
+        submitterInfo = Some(SubmitterInfo(List(party1), applicationId, commandId, Instant.EPOCH)),
+        recordTime = Instant.now,
+        offsetStep = nextOffsetStep(offset),
+        reason = reason,
+      )
+      .map(_ => offset)
+  }
+
+  private def storeMultiPartyRejection(
+      reason: RejectionReason,
+      commandId: String = UUID.randomUUID().toString,
+  ): Future[Offset] = {
+    lazy val offset = nextOffset()
+    ledgerDao
+      .storeRejection(
+        submitterInfo = Some(
+          SubmitterInfo(List(party1, party2, party3), applicationId, commandId, Instant.EPOCH)
+        ),
+        recordTime = Instant.now,
+        offsetStep = nextOffsetStep(offset),
+        reason = reason,
+      )
+      .map(_ => offset)
+  }
+
+  private def storeRejection(
+      reason: RejectionReason,
+      commandId: String = UUID.randomUUID().toString,
+  ): Future[Offset] = prepareStoreRejection(reason, commandId)()
+
+  /** Starts and executes futures sequentially */
+  private def seq(s: List[() => Future[Offset]]): Future[Seq[Offset]] =
+    s match {
+      case Nil => Future(Seq.empty)
+      case hd :: tail => hd().flatMap(offset => seq(tail).map(offset +: _))
+    }
+}
+
+private[appendonlydao] object JdbcLedgerDaoCompletionsSpec {
+
+  private val applicationId: ApplicationId =
+    "JdbcLedgerDaoCompletionsSpec".asInstanceOf[ApplicationId]
+  private val party1: Party = "JdbcLedgerDaoCompletionsSpec1".asInstanceOf[Party]
+  private val party2: Party = "JdbcLedgerDaoCompletionsSpec2".asInstanceOf[Party]
+  private val party3: Party = "JdbcLedgerDaoCompletionsSpec3".asInstanceOf[Party]
+  private val parties: Set[Party] = Set(party1, party2, party3)
+
+  private def offsetOf(response: CompletionStreamResponse): Offset =
+    ApiOffset.assertFromString(response.checkpoint.get.offset.get.value.absolute.get)
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoConfigurationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoConfigurationSpec.scala
@@ -70,12 +70,11 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
   it should "refuse to persist invalid configuration entry" in {
     val startExclusive = nextOffset()
     val offset0 = nextOffset()
-    val offsetString0 = offset0.toLong
     for {
       config <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2).getOrElse(defaultConfig))
 
       // Store a new configuration with a known submission id
-      submissionId = s"refuse-config-$offsetString0"
+      submissionId = s"refuse-config-${offset0.toLong}"
       resp0 <- storeConfigurationEntry(
         offset0,
         submissionId,
@@ -89,38 +88,22 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
         newConfig.copy(generation = config.generation + 1),
       )
 
-      // Submission with mismatching generation is rejected
-      offset2 = nextOffset()
-      offsetString2 = offset2.toLong
-      resp2 <- storeConfigurationEntry(
-        offset2,
-        s"refuse-config-$offsetString2",
-        config,
-      )
-
       // Submission with unique submissionId and correct generation is accepted.
-      offset3 = nextOffset()
-      offsetString3 = offset3
+      offset2 = nextOffset()
       lastConfig = newConfig.copy(generation = newConfig.generation + 1)
-      resp3 <- storeConfigurationEntry(offset3, s"refuse-config-$offsetString3", lastConfig)
+      resp2 <- storeConfigurationEntry(offset2, s"refuse-config-${offset2.toLong}", lastConfig)
       lastConfigActual <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2).get)
 
-      entries <- ledgerDao.getConfigurationEntries(startExclusive, offset3).runWith(Sink.seq)
+      entries <- ledgerDao.getConfigurationEntries(startExclusive, offset2).runWith(Sink.seq)
     } yield {
       resp0 shouldEqual PersistenceResponse.Ok
       resp1 shouldEqual PersistenceResponse.Duplicate
       resp2 shouldEqual PersistenceResponse.Ok
-      resp3 shouldEqual PersistenceResponse.Ok
       lastConfig shouldEqual lastConfigActual
       entries.toList shouldEqual List(
-        offset0 -> ConfigurationEntry.Accepted(s"refuse-config-$offsetString0", newConfig),
+        offset0 -> ConfigurationEntry.Accepted(s"refuse-config-${offset0.toLong}", newConfig),
         /* offset1 is duplicate */
-        offset2 -> ConfigurationEntry.Rejected(
-          s"refuse-config-${offset2.toLong}",
-          "Generation mismatch: expected=2, actual=0",
-          config,
-        ),
-        offset3 -> ConfigurationEntry.Accepted(s"refuse-config-$offsetString3", lastConfig),
+        offset2 -> ConfigurationEntry.Accepted(s"refuse-config-${offset2.toLong}", lastConfig),
       )
     }
   }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoConfigurationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoConfigurationSpec.scala
@@ -1,0 +1,162 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.time.Instant
+
+import akka.stream.scaladsl.Sink
+import com.daml.ledger.participant.state.v1.{Configuration, Offset}
+import com.daml.platform.indexer.{CurrentOffset, IncrementalOffsetStep}
+import com.daml.platform.store.dao.PersistenceResponse
+import com.daml.platform.store.entries.ConfigurationEntry
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (configuration)"
+
+  it should "be able to persist and load configuration" in {
+    val offset = nextOffset()
+    val offsetString = offset.toLong
+    for {
+      startingOffset <- ledgerDao.lookupLedgerEnd()
+      startingConfig <- ledgerDao.lookupLedgerConfiguration()
+
+      response <- storeConfigurationEntry(
+        offset,
+        s"submission-$offsetString",
+        defaultConfig,
+      )
+      optStoredConfig <- ledgerDao.lookupLedgerConfiguration()
+      endingOffset <- ledgerDao.lookupLedgerEnd()
+    } yield {
+      response shouldEqual PersistenceResponse.Ok
+      startingConfig shouldEqual None
+      optStoredConfig.map(_._2) shouldEqual Some(defaultConfig)
+      endingOffset should be > startingOffset
+    }
+  }
+
+  it should "be able to persist configuration rejection" in {
+    val startExclusive = nextOffset()
+    val offset = nextOffset()
+    val offsetString = offset.toLong
+    for {
+      startingConfig <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2))
+      proposedConfig = startingConfig.getOrElse(defaultConfig)
+      response <- storeConfigurationEntry(
+        offset,
+        s"config-rejection-$offsetString",
+        proposedConfig,
+        Some("bad config"),
+      )
+      storedConfig <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2))
+      entries <- ledgerDao
+        .getConfigurationEntries(startExclusive, offset)
+        .runWith(Sink.seq)
+
+    } yield {
+      response shouldEqual PersistenceResponse.Ok
+      startingConfig shouldEqual storedConfig
+      entries shouldEqual List(
+        offset -> ConfigurationEntry
+          .Rejected(s"config-rejection-$offsetString", "bad config", proposedConfig)
+      )
+    }
+  }
+
+  it should "refuse to persist invalid configuration entry" in {
+    val startExclusive = nextOffset()
+    val offset0 = nextOffset()
+    val offsetString0 = offset0.toLong
+    for {
+      config <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2).getOrElse(defaultConfig))
+
+      // Store a new configuration with a known submission id
+      submissionId = s"refuse-config-$offsetString0"
+      resp0 <- storeConfigurationEntry(
+        offset0,
+        submissionId,
+        config.copy(generation = config.generation + 1),
+      )
+      newConfig <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2).get)
+
+      resp1 <- storeConfigurationEntry(
+        nextOffset(),
+        submissionId,
+        newConfig.copy(generation = config.generation + 1),
+      )
+
+      // Submission with mismatching generation is rejected
+      offset2 = nextOffset()
+      offsetString2 = offset2.toLong
+      resp2 <- storeConfigurationEntry(
+        offset2,
+        s"refuse-config-$offsetString2",
+        config,
+      )
+
+      // Submission with unique submissionId and correct generation is accepted.
+      offset3 = nextOffset()
+      offsetString3 = offset3
+      lastConfig = newConfig.copy(generation = newConfig.generation + 1)
+      resp3 <- storeConfigurationEntry(offset3, s"refuse-config-$offsetString3", lastConfig)
+      lastConfigActual <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2).get)
+
+      entries <- ledgerDao.getConfigurationEntries(startExclusive, offset3).runWith(Sink.seq)
+    } yield {
+      resp0 shouldEqual PersistenceResponse.Ok
+      resp1 shouldEqual PersistenceResponse.Duplicate
+      resp2 shouldEqual PersistenceResponse.Ok
+      resp3 shouldEqual PersistenceResponse.Ok
+      lastConfig shouldEqual lastConfigActual
+      entries.toList shouldEqual List(
+        offset0 -> ConfigurationEntry.Accepted(s"refuse-config-$offsetString0", newConfig),
+        /* offset1 is duplicate */
+        offset2 -> ConfigurationEntry.Rejected(
+          s"refuse-config-${offset2.toLong}",
+          "Generation mismatch: expected=2, actual=0",
+          config,
+        ),
+        offset3 -> ConfigurationEntry.Accepted(s"refuse-config-$offsetString3", lastConfig),
+      )
+    }
+  }
+
+  // TODO do we need it?
+//  it should "fail trying to store configuration with non-incremental offsets" in {
+//    recoverToSucceededIf[LedgerEndUpdateError](
+//      storeConfigurationEntry(
+//        nextOffset(),
+//        s"submission-invalid-offsets",
+//        defaultConfig,
+//        maybePreviousOffset = Some(nextOffset()),
+//      )
+//    )
+//  }
+
+  private def storeConfigurationEntry(
+      offset: Offset,
+      submissionId: String,
+      lastConfig: Configuration,
+      rejectionReason: Option[String] = None,
+      maybePreviousOffset: Option[Offset] = Option.empty,
+  ) =
+    ledgerDao
+      .storeConfigurationEntry(
+        offsetStep = maybePreviousOffset
+          .orElse(previousOffset.get())
+          .map(IncrementalOffsetStep(_, offset))
+          .getOrElse(CurrentOffset(offset)),
+        Instant.EPOCH,
+        submissionId,
+        lastConfig,
+        rejectionReason,
+      )
+      .map { r =>
+        previousOffset.set(Some(offset))
+        r
+      }
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoContractsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoContractsSpec.scala
@@ -1,0 +1,243 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.time.Instant
+import java.util.UUID
+
+import com.daml.lf.transaction.GlobalKey
+import com.daml.lf.transaction.Node.KeyWithMaintainers
+import com.daml.lf.value.Value.{ContractId, ContractInst, ValueText}
+import org.scalatest.{Inside, LoneElement, OptionValues}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+private[appendonlydao] trait JdbcLedgerDaoContractsSpec
+    extends LoneElement
+    with Inside
+    with OptionValues {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (contracts)"
+
+  it should "be able to persist and load contracts" in {
+    for {
+      (_, tx) <- store(singleCreate)
+      result <- ledgerDao.lookupActiveOrDivulgedContract(nonTransient(tx).loneElement, Set(alice))
+    } yield {
+      // The agreement text is always empty when retrieved from the contract store
+      result shouldEqual Some(someVersionedContractInstance.copy(agreementText = ""))
+    }
+  }
+
+  it should "allow to divulge a contract that has already been committed" in {
+    for {
+      (_, tx) <- store(singleCreate)
+      create = nonTransient(tx).loneElement
+      _ <- storeCommitedContractDivulgence(
+        id = create,
+        divulgees = Set(charlie),
+      )
+      result <- ledgerDao.lookupActiveOrDivulgedContract(create, Set(charlie))
+    } yield {
+      // The agreement text is always empty when retrieved from the contract store
+      result shouldEqual Some(someVersionedContractInstance.copy(agreementText = ""))
+    }
+  }
+
+  it should "not find contracts that are not visible to the requester" in {
+    for {
+      (_, tx) <- store(singleCreate)
+      result <- ledgerDao.lookupActiveOrDivulgedContract(nonTransient(tx).loneElement, Set(charlie))
+    } yield {
+      result shouldEqual None
+    }
+  }
+
+  it should "not find contracts that are not visible to any of the requesters" in {
+    for {
+      (_, tx) <- createAndStoreContract(
+        submittingParties = Set(alice),
+        signatories = Set(alice, bob),
+        stakeholders = Set(alice, bob),
+        key = None,
+      )
+      contractId = nonTransient(tx).loneElement
+      result <- ledgerDao.lookupActiveOrDivulgedContract(contractId, Set(charlie, emma))
+    } yield {
+      result shouldBe None
+    }
+  }
+
+  it should "find contract if at least one of requesters is a stakeholder" in {
+    for {
+      (_, tx) <- createAndStoreContract(
+        submittingParties = Set(alice),
+        signatories = Set(alice, bob),
+        stakeholders = Set(alice, bob, charlie),
+        key = None,
+      )
+      contractId = nonTransient(tx).loneElement
+      result <- ledgerDao.lookupActiveOrDivulgedContract(contractId, Set(charlie, emma))
+    } yield {
+      result.value shouldBe a[ContractInst[_]]
+    }
+  }
+
+  it should "find contract if at least one of requesters is a divulgee" in {
+    for {
+      (_, tx) <- createAndStoreContract(
+        submittingParties = Set(alice),
+        signatories = Set(alice, bob),
+        stakeholders = Set(alice, bob, charlie),
+        key = None,
+      )
+      contractId = nonTransient(tx).loneElement
+      _ <- storeCommitedContractDivulgence(
+        id = contractId,
+        divulgees = Set(emma),
+      )
+      result <- ledgerDao.lookupActiveOrDivulgedContract(contractId, Set(david, emma))
+    } yield {
+      result.value shouldBe a[ContractInst[_]]
+    }
+  }
+
+  it should "not find keys if none of requesters are stakeholders" in {
+    val aTextValue = ValueText(scala.util.Random.nextString(10))
+    for {
+      (_, _) <- createAndStoreContract(
+        submittingParties = Set(alice),
+        signatories = Set(alice, bob),
+        stakeholders = Set(alice, bob),
+        key = Some(KeyWithMaintainers(aTextValue, Set(alice, bob))),
+      )
+      key = GlobalKey.assertBuild(someTemplateId, aTextValue)
+      result <- ledgerDao.lookupKey(key, Set(charlie, emma))
+    } yield {
+      result shouldBe None
+    }
+  }
+
+  it should "find a key if at least one of requesters is a stakeholder" in {
+    val aTextValue = ValueText(scala.util.Random.nextString(10))
+    for {
+      (_, tx) <- createAndStoreContract(
+        submittingParties = Set(alice),
+        signatories = Set(alice, bob),
+        stakeholders = Set(alice, bob, charlie),
+        key = Some(KeyWithMaintainers(aTextValue, Set(alice, bob))),
+      )
+      contractId = nonTransient(tx).loneElement
+      key = GlobalKey.assertBuild(someTemplateId, aTextValue)
+      result <- ledgerDao.lookupKey(key, Set(emma, charlie))
+    } yield {
+      result.value shouldBe contractId
+    }
+  }
+
+  it should "not find a key if the requesters are only divulgees" in {
+    val aTextValue = ValueText(scala.util.Random.nextString(10))
+    for {
+      (_, tx) <- createAndStoreContract(
+        submittingParties = Set(alice),
+        signatories = Set(alice, bob),
+        stakeholders = Set(alice, bob, charlie),
+        key = Some(KeyWithMaintainers(aTextValue, Set(alice, bob))),
+      )
+      _ <- storeCommitedContractDivulgence(
+        id = nonTransient(tx).loneElement,
+        divulgees = Set(david, emma),
+      )
+      key = GlobalKey.assertBuild(someTemplateId, aTextValue)
+      result <- ledgerDao.lookupKey(key, Set(david, emma))
+    } yield {
+      result shouldBe None
+    }
+  }
+
+  it should "prevent retrieving the maximum ledger time if some contracts are not found" in {
+    val contractId = s"#random-${UUID.randomUUID}"
+    val randomContractId = ContractId.assertFromString(contractId)
+    for {
+      failure <- ledgerDao.lookupMaximumLedgerTime(Set(randomContractId)).failed
+    } yield {
+      failure shouldBe an[IllegalArgumentException]
+      failure.getMessage shouldBe s"The following contracts have not been found: $contractId"
+    }
+  }
+
+  it should "allow the retrieval of the maximum ledger time" in {
+    for {
+      (_, tx) <- store(singleCreate)
+      result <- ledgerDao.lookupMaximumLedgerTime(nonTransient(tx))
+    } yield {
+      inside(result) { case Some(time) =>
+        time should be <= Instant.now
+      }
+    }
+  }
+
+  it should "allow the retrieval of the maximum ledger time even when there are divulged contracts" in {
+    val divulgedContractId = ContractId.assertFromString(s"#divulged-${UUID.randomUUID}")
+    for {
+      (_, _) <- store(
+        divulgedContracts = Map(
+          (divulgedContractId, someVersionedContractInstance) -> Set(charlie)
+        ),
+        blindingInfo = None,
+        offsetAndTx = singleNonConsumingExercise(divulgedContractId),
+      )
+      (_, tx) <- store(singleCreate)
+      contractIds = nonTransient(tx) + divulgedContractId
+      result <- ledgerDao.lookupMaximumLedgerTime(contractIds)
+    } yield {
+      inside(result) { case Some(tx.ledgerEffectiveTime) =>
+        succeed
+      }
+    }
+  }
+
+  it should "allow the retrieval of the maximum ledger time even when there are only divulged contracts" in {
+    val divulgedContractId = ContractId.assertFromString(s"#divulged-${UUID.randomUUID}")
+    for {
+      (_, _) <- store(
+        divulgedContracts = Map(
+          (divulgedContractId, someVersionedContractInstance) -> Set(charlie)
+        ),
+        blindingInfo = None,
+        offsetAndTx = singleNonConsumingExercise(divulgedContractId),
+      )
+      result <- ledgerDao.lookupMaximumLedgerTime(Set(divulgedContractId))
+    } yield {
+      result shouldBe None
+    }
+  }
+
+  it should "not allow the retrieval of the maximum ledger time of archived divulged contracts" in {
+    val contractId = s"#divulged-${UUID.randomUUID}"
+    val divulgedContractId = ContractId.assertFromString(contractId)
+    for {
+      // This divulges and archives a contract in the same transaction
+      (_, _) <- store(
+        divulgedContracts = Map(
+          (divulgedContractId, someVersionedContractInstance) -> Set(charlie)
+        ),
+        blindingInfo = None,
+        offsetAndTx = singleExercise(divulgedContractId),
+      )
+      failure <- ledgerDao.lookupMaximumLedgerTime(Set(divulgedContractId)).failed
+    } yield {
+      failure shouldBe an[IllegalArgumentException]
+      failure.getMessage should startWith(
+        s"The following contracts have not been found: $contractId"
+      )
+    }
+  }
+
+  it should "store contracts with a transient contract in the global divulgence" in {
+    store(fullyTransientWithChildren).flatMap(_ => succeed)
+  }
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoDivulgenceSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoDivulgenceSpec.scala
@@ -1,0 +1,204 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.time.Instant
+import java.util.UUID
+
+import com.daml.lf.data.ImmArray
+import com.daml.lf.transaction.Node.{KeyWithMaintainers, NodeCreate, NodeExercises, NodeFetch}
+import com.daml.lf.transaction.TransactionVersion
+import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.value.Value.{ContractInst, ValueParty, VersionedValue}
+import com.daml.platform.store.entries.LedgerEntry
+import org.scalatest.{Inside, LoneElement}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+private[appendonlydao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (divulgence)"
+
+  it should "preserve divulged contracts" in {
+    val (create1, tx1) = {
+      val builder = TransactionBuilder()
+      val contractId = builder.newCid
+      builder.add(
+        NodeCreate(
+          coid = contractId,
+          templateId = someTemplateId,
+          arg = someContractArgument,
+          agreementText = someAgreement,
+          optLocation = None,
+          signatories = Set(alice),
+          stakeholders = Set(alice),
+          key = None,
+          version = TransactionVersion.minVersion,
+        )
+      )
+      contractId -> builder.buildCommitted()
+    }
+    val (create2, tx2) = {
+      val builder = TransactionBuilder()
+      val contractId = builder.newCid
+      builder.add(
+        NodeCreate(
+          coid = contractId,
+          someTemplateId,
+          someContractArgument,
+          someAgreement,
+          optLocation = None,
+          signatories = Set(bob),
+          stakeholders = Set(bob),
+          key = Some(
+            KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
+          ),
+          version = TransactionVersion.minVersion,
+        )
+      )
+      contractId -> builder.buildCommitted()
+    }
+    val tx3 = {
+      val builder = TransactionBuilder()
+      val rootExercise = builder.add(
+        NodeExercises(
+          targetCoid = create1,
+          templateId = someTemplateId,
+          choiceId = someChoiceName,
+          optLocation = None,
+          consuming = true,
+          actingParties = Set(bob),
+          chosenValue = someChoiceArgument,
+          stakeholders = Set(alice, bob),
+          signatories = Set(alice),
+          // TODO https://github.com/digital-asset/daml/issues/7709
+          //  also test the case of non-empty choice-observers
+          choiceObservers = Set.empty,
+          children = ImmArray.empty,
+          exerciseResult = Some(someChoiceResult),
+          key = None,
+          byKey = false,
+          version = TransactionVersion.minVersion,
+        )
+      )
+      builder.add(
+        NodeFetch(
+          coid = create2,
+          templateId = someTemplateId,
+          optLocation = None,
+          actingParties = Set(bob),
+          signatories = Set(bob),
+          stakeholders = Set(bob),
+          key = Some(
+            KeyWithMaintainers(ValueParty(bob), Set(bob))
+          ),
+          byKey = false,
+          version = TransactionVersion.minVersion,
+        ),
+        parentId = rootExercise,
+      )
+      val nestedExercise = builder.add(
+        NodeExercises(
+          targetCoid = create2,
+          templateId = someTemplateId,
+          choiceId = someChoiceName,
+          optLocation = None,
+          consuming = true,
+          actingParties = Set(bob),
+          chosenValue = someChoiceArgument,
+          stakeholders = Set(bob),
+          signatories = Set(bob),
+          choiceObservers = Set.empty,
+          children = ImmArray.empty,
+          exerciseResult = Some(someChoiceResult),
+          key = Some(
+            KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
+          ),
+          byKey = false,
+          version = TransactionVersion.minVersion,
+        ),
+        parentId = rootExercise,
+      )
+      builder.add(
+        NodeCreate(
+          coid = builder.newCid,
+          someTemplateId,
+          someContractArgument,
+          someAgreement,
+          optLocation = None,
+          signatories = Set(bob),
+          stakeholders = Set(alice, bob),
+          key = Some(
+            KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
+          ),
+          version = TransactionVersion.minVersion,
+        ),
+        parentId = nestedExercise,
+      )
+      builder.buildCommitted()
+    }
+
+    val someVersionedContractInstance =
+      ContractInst(
+        template = someContractInstance.template,
+        agreementText = someContractInstance.agreementText,
+        arg = VersionedValue(
+          version = TransactionVersion.V10,
+          value = someContractInstance.arg,
+        ),
+      )
+
+    val t1 = Instant.now()
+    val t2 = t1.plusMillis(1)
+    val t3 = t2.plusMillis(1)
+    val appId = UUID.randomUUID.toString
+    for {
+      _ <- store(
+        nextOffset() -> LedgerEntry.Transaction(
+          commandId = Some(UUID.randomUUID.toString),
+          transactionId = UUID.randomUUID.toString,
+          applicationId = Some(appId),
+          actAs = List(alice),
+          workflowId = None,
+          ledgerEffectiveTime = t1,
+          recordedAt = t1,
+          transaction = tx1,
+          explicitDisclosure = Map.empty,
+        )
+      )
+      _ <- store(
+        nextOffset() -> LedgerEntry.Transaction(
+          commandId = Some(UUID.randomUUID.toString),
+          transactionId = UUID.randomUUID.toString,
+          applicationId = Some(appId),
+          actAs = List(bob),
+          workflowId = None,
+          ledgerEffectiveTime = t2,
+          recordedAt = t2,
+          transaction = tx2,
+          explicitDisclosure = Map.empty,
+        )
+      )
+      _ <- store(
+        divulgedContracts = Map((create2, someVersionedContractInstance) -> Set(alice)),
+        blindingInfo = None,
+        offsetAndTx = nextOffset() -> LedgerEntry.Transaction(
+          commandId = Some(UUID.randomUUID.toString),
+          transactionId = UUID.randomUUID.toString,
+          applicationId = Some(appId),
+          actAs = List(bob),
+          workflowId = None,
+          ledgerEffectiveTime = t3,
+          recordedAt = t3,
+          transaction = tx3,
+          explicitDisclosure = Map.empty,
+        ),
+      )
+    } yield {
+      succeed
+    }
+  }
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoPackagesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoPackagesSpec.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.participant.state.index.v2.PackageDetails
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.platform.store.dao.PersistenceResponse
+
+private[appendonlydao] trait JdbcLedgerDaoPackagesSpec {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (packages)"
+
+  it should "upload packages in an idempotent fashion, maintaining existing descriptions" in {
+    val firstDescription = "first description"
+    val secondDescription = "second description"
+    val offset1 = nextOffset()
+    val offset2 = nextOffset()
+    for {
+      firstUploadResult <- storePackageEntry(
+        offset1,
+        packages
+          .map(a => a._1 -> a._2.copy(sourceDescription = Some(firstDescription)))
+          .take(1),
+      )
+      secondUploadResult <- storePackageEntry(
+        offset2,
+        packages.map(a => a._1 -> a._2.copy(sourceDescription = Some(secondDescription))),
+      )
+      loadedPackages <- ledgerDao.listLfPackages()
+    } yield {
+      firstUploadResult shouldBe PersistenceResponse.Ok
+      secondUploadResult shouldBe PersistenceResponse.Ok
+      // Note that the order here isn’t fixed.
+      loadedPackages.values.flatMap(_.sourceDescription.toList) should contain theSameElementsAs
+        Seq(firstDescription) ++ Seq.fill(packages.length - 1)(secondDescription)
+    }
+  }
+
+  // TODO do we need it?
+//  it should "fail on storing package entry with non-incremental offsets" in {
+//    val offset = nextOffset()
+//    recoverToSucceededIf[LedgerEndUpdateError](
+//      ledgerDao
+//        .storePackageEntry(IncrementalOffsetStep(offset, offset), packages, None)
+//    )
+//  }
+
+  private def storePackageEntry(
+      offset: Offset,
+      packageList: List[(DamlLf.Archive, PackageDetails)],
+  ) =
+    ledgerDao
+      .storePackageEntry(nextOffsetStep(offset), packageList, None)
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoPartiesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoPartiesSpec.scala
@@ -1,0 +1,177 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.time.Instant
+import java.util.UUID
+
+import com.daml.ledger.api.domain.PartyDetails
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.lf.data.Ref
+import com.daml.platform.indexer.OffsetStep
+import com.daml.platform.store.dao.PersistenceResponse
+import com.daml.platform.store.entries.PartyLedgerEntry
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+private[appendonlydao] trait JdbcLedgerDaoPartiesSpec {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (parties)"
+
+  it should "store and retrieve all parties" in {
+    val alice = PartyDetails(
+      party = Ref.Party.assertFromString(s"Alice-${UUID.randomUUID()}"),
+      displayName = Some("Alice Arkwright"),
+      isLocal = true,
+    )
+    val bob = PartyDetails(
+      party = Ref.Party.assertFromString(s"Bob-${UUID.randomUUID()}"),
+      displayName = Some("Bob Bobertson"),
+      isLocal = true,
+    )
+    for {
+      response <- storePartyEntry(alice, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      response <- storePartyEntry(bob, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      parties <- ledgerDao.listKnownParties()
+    } yield {
+      parties should contain.allOf(alice, bob)
+    }
+  }
+
+  it should "retrieve zero parties" in {
+    for {
+      noPartyDetails <- ledgerDao.getParties(Seq.empty)
+    } yield {
+      noPartyDetails should be(Seq.empty)
+    }
+  }
+
+  it should "retrieve a single party, if they exist" in {
+    val party = Ref.Party.assertFromString(s"Carol-${UUID.randomUUID()}")
+    val nonExistentParty = UUID.randomUUID().toString
+    val carol = PartyDetails(
+      party = party,
+      displayName = Some("Carol Carlisle"),
+      isLocal = true,
+    )
+    for {
+      response <- storePartyEntry(carol, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      carolPartyDetails <- ledgerDao.getParties(Seq(party))
+      noPartyDetails <- ledgerDao.getParties(Seq(nonExistentParty))
+    } yield {
+      carolPartyDetails should be(Seq(carol))
+      noPartyDetails should be(Seq.empty)
+    }
+  }
+
+  it should "retrieve multiple parties" in {
+    val danParty = Ref.Party.assertFromString(s"Dan-${UUID.randomUUID()}")
+    val eveParty = Ref.Party.assertFromString(s"Eve-${UUID.randomUUID()}")
+    val nonExistentParty = UUID.randomUUID().toString
+    val dan = PartyDetails(
+      party = danParty,
+      displayName = Some("Dangerous Dan"),
+      isLocal = true,
+    )
+    val eve = PartyDetails(
+      party = eveParty,
+      displayName = Some("Dangerous Dan"),
+      isLocal = true,
+    )
+    for {
+      response <- storePartyEntry(dan, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      response <- storePartyEntry(eve, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      parties <- ledgerDao.getParties(Seq(danParty, eveParty, nonExistentParty))
+    } yield {
+      parties should contain.only(dan, eve)
+    }
+  }
+
+  it should "inform the caller if they try to write a duplicate party" in {
+    val fred = PartyDetails(
+      party = Ref.Party.assertFromString(s"Fred-${UUID.randomUUID()}"),
+      displayName = Some("Fred Flintstone"),
+      isLocal = true,
+    )
+    for {
+      response <- storePartyEntry(fred, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      response <- storePartyEntry(fred, nextOffset())
+    } yield {
+      response should be(PersistenceResponse.Duplicate)
+    }
+  }
+
+  // TODO do we need it?
+//  it should "fail on storing a party entry with non-incremental offsets" in {
+//    val fred = PartyDetails(
+//      party = Ref.Party.assertFromString(s"Fred-${UUID.randomUUID()}"),
+//      displayName = Some("Fred Flintstone"),
+//      isLocal = true,
+//    )
+//    recoverToSucceededIf[LedgerEndUpdateError](
+//      ledgerDao.storePartyEntry(
+//        IncrementalOffsetStep(nextOffset(), nextOffset()),
+//        allocationAccepted(fred),
+//      )
+//    )
+//  }
+
+  it should "store just offset when duplicate party update encountered" in {
+    val party = Ref.Party.assertFromString(s"Alice-${UUID.randomUUID()}")
+    val aliceDetails = PartyDetails(
+      party,
+      displayName = Some("Alice Arkwright"),
+      isLocal = true,
+    )
+    val aliceAgain = PartyDetails(
+      party,
+      displayName = Some("Alice Carthwright"),
+      isLocal = true,
+    )
+    val bobDetails = PartyDetails(
+      party = Ref.Party.assertFromString(s"Bob-${UUID.randomUUID()}"),
+      displayName = Some("Bob Bobertson"),
+      isLocal = true,
+    )
+    for {
+      response <- storePartyEntry(aliceDetails, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      response <- storePartyEntry(aliceAgain, nextOffset())
+      _ = response should be(PersistenceResponse.Duplicate)
+      response <- storePartyEntry(bobDetails, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      parties <- ledgerDao.listKnownParties()
+    } yield {
+      parties should contain.allOf(aliceDetails, bobDetails)
+    }
+  }
+
+  private def storePartyEntry(
+      partyDetails: PartyDetails,
+      offset: Offset,
+  ) =
+    ledgerDao
+      .storePartyEntry(
+        OffsetStep(previousOffset.get(), offset),
+        allocationAccepted(partyDetails),
+      )
+      .map { response =>
+        previousOffset.set(Some(offset))
+        response
+      }
+
+  private def allocationAccepted(partyDetails: PartyDetails): PartyLedgerEntry.AllocationAccepted =
+    PartyLedgerEntry.AllocationAccepted(
+      submissionIdOpt = Some(UUID.randomUUID().toString),
+      recordTime = Instant.now,
+      partyDetails = partyDetails,
+    )
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoSuite.scala
@@ -1,0 +1,841 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import java.io.File
+import java.time.{Duration, Instant}
+import java.util.UUID
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+
+import akka.stream.scaladsl.Sink
+import com.daml.bazeltools.BazelRunfiles.rlocation
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.participant.state.index.v2
+import com.daml.ledger.participant.state.v1
+import com.daml.ledger.participant.state.v1.{DivulgedContract, Offset, SubmitterInfo}
+import com.daml.ledger.test.ModelTestDar
+import com.daml.lf.archive.DarReader
+import com.daml.lf.data.Ref.{Identifier, Party}
+import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
+import com.daml.lf.transaction.Node._
+import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.transaction._
+import com.daml.lf.value.{Value => LfValue}
+import com.daml.lf.value.Value.{ContractId, ContractInst}
+import com.daml.logging.LoggingContext
+import com.daml.platform.indexer.OffsetStep
+import com.daml.platform.store.dao.events.TransactionsWriter
+import com.daml.platform.store.entries.LedgerEntry
+import org.scalatest.AsyncTestSuite
+
+import scala.concurrent.Future
+import scala.language.implicitConversions
+import scala.util.{Success, Try}
+
+private[appendonlydao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
+  this: AsyncTestSuite =>
+
+  protected implicit final val loggingContext: LoggingContext = LoggingContext.ForTesting
+
+  val previousOffset: AtomicReference[Option[Offset]] =
+    new AtomicReference[Option[Offset]](Option.empty)
+
+  protected final val nextOffset: () => Offset = {
+    val base = BigInt(1) << 32
+    val counter = new AtomicLong(0)
+    () => {
+      Offset.fromByteArray((base + counter.getAndIncrement()).toByteArray)
+    }
+  }
+
+  protected final implicit class OffsetToLong(offset: Offset) {
+    def toLong: Long = BigInt(offset.toByteArray).toLong
+  }
+
+  private[this] val Success(dar) = {
+    val reader = DarReader { (_, stream) => Try(DamlLf.Archive.parseFrom(stream)) }
+    val fileName = new File(rlocation(ModelTestDar.path))
+    reader.readArchiveFromFile(fileName)
+  }
+
+  private val now = Instant.now()
+
+  protected final val packages: List[(DamlLf.Archive, v2.PackageDetails)] =
+    dar.all.map(dar => dar -> v2.PackageDetails(dar.getSerializedSize.toLong, now, None))
+  private val testPackageId: Ref.PackageId = Ref.PackageId.assertFromString(dar.main.getHash)
+
+  protected final val alice = Party.assertFromString("Alice")
+  protected final val bob = Party.assertFromString("Bob")
+  protected final val charlie = Party.assertFromString("Charlie")
+  protected final val david = Party.assertFromString("David")
+  protected final val emma = Party.assertFromString("Emma")
+
+  protected final val defaultAppId = "default-app-id"
+  protected final val defaultWorkflowId = "default-workflow-id"
+  protected final val someAgreement = "agreement"
+
+  // Note: *identifiers* and *values* defined below MUST correspond to //ledger/test-common/src/main/daml/model/Test.daml
+  // This is because some tests request values in verbose mode, which requires filling in missing type information,
+  // which in turn requires loading DAML-LF packages with valid DAML-LF types that correspond to the DAML-LF values.
+  //
+  // On the other hand, *transactions* do not need to correspond to valid transactions that could be produced by the
+  // above mentioned DAML code, e.g., signatories/stakeholders may not correspond to the contract/choice arguments.
+  // This is because JdbcLedgerDao is only concerned with serialization, and does not verify the DAML ledger model.
+  private def testIdentifier(name: String) = Identifier(
+    testPackageId,
+    Ref.QualifiedName(
+      Ref.ModuleName.assertFromString("Test"),
+      Ref.DottedName.assertFromString(name),
+    ),
+  )
+  private def recordFieldName(name: String) = Some(Ref.Name.assertFromString(name))
+  protected final val someTemplateId = testIdentifier("ParameterShowcase")
+  protected final val someValueText = LfValue.ValueText("some text")
+  protected final val someValueInt = LfValue.ValueInt64(1)
+  protected final val someValueNumeric =
+    LfValue.ValueNumeric(com.daml.lf.data.Numeric.assertFromString("1.1"))
+  protected final val someNestedOptionalInteger = LfValue.ValueRecord(
+    Some(testIdentifier("NestedOptionalInteger")),
+    ImmArray(
+      Some(Ref.Name.assertFromString("value")) -> LfValue.ValueVariant(
+        Some(testIdentifier("OptionalInteger")),
+        Ref.Name.assertFromString("SomeInteger"),
+        someValueInt,
+      )
+    ),
+  )
+  protected final val someContractArgument = LfValue.ValueRecord(
+    Some(someTemplateId),
+    ImmArray(
+      recordFieldName("operator") -> LfValue.ValueParty(alice),
+      recordFieldName("integer") -> someValueInt,
+      recordFieldName("decimal") -> someValueNumeric,
+      recordFieldName("text") -> someValueText,
+      recordFieldName("bool") -> LfValue.ValueBool(true),
+      recordFieldName("time") -> LfValue.ValueTimestamp(Time.Timestamp.Epoch),
+      recordFieldName("nestedOptionalInteger") -> someNestedOptionalInteger,
+      recordFieldName("integerList") -> LfValue.ValueList(FrontStack(someValueInt)),
+      recordFieldName("optionalText") -> LfValue.ValueOptional(Some(someValueText)),
+    ),
+  )
+  protected final val someChoiceName = Ref.Name.assertFromString("Choice1")
+  protected final val someChoiceArgument = LfValue.ValueRecord(
+    Some(testIdentifier(someChoiceName)),
+    ImmArray(
+      recordFieldName("newInteger") -> someValueInt,
+      recordFieldName("newDecimal") -> someValueNumeric,
+      recordFieldName("newText") -> someValueText,
+      recordFieldName("newBool") -> LfValue.ValueBool(true),
+      recordFieldName("newTime") -> LfValue.ValueTimestamp(Time.Timestamp.Epoch),
+      recordFieldName("newNestedOptionalInteger") -> someNestedOptionalInteger,
+      recordFieldName("newIntegerList") -> LfValue.ValueList(FrontStack(someValueInt)),
+      recordFieldName("newOptionalText") -> LfValue.ValueOptional(Some(someValueText)),
+    ),
+  )
+  protected final val someChoiceResult =
+    LfValue.ValueContractId[ContractId](ContractId.V0.assertFromString("#1"))
+  protected final def someContractKey(party: Party, value: String) = LfValue.ValueRecord(
+    None,
+    ImmArray(
+      None -> LfValue.ValueParty(party),
+      None -> LfValue.ValueText(value),
+    ),
+  )
+  protected final val someContractInstance = ContractInst(
+    someTemplateId,
+    someContractArgument,
+    someAgreement,
+  )
+  protected final val someVersionedContractInstance =
+    TransactionBuilder().versionContract(someContractInstance)
+
+  protected final val otherTemplateId = testIdentifier("Dummy")
+  protected final val otherContractArgument = LfValue.ValueRecord(
+    Some(otherTemplateId),
+    ImmArray(
+      recordFieldName("operator") -> LfValue.ValueParty(alice)
+    ),
+  )
+
+  protected final val defaultConfig = v1.Configuration(
+    generation = 0,
+    timeModel = v1.TimeModel.reasonableDefault,
+    Duration.ofDays(1),
+  )
+
+  private[appendonlydao] def store(
+      submitterInfo: Option[SubmitterInfo],
+      tx: LedgerEntry.Transaction,
+      offsetStep: OffsetStep,
+      divulgedContracts: List[DivulgedContract],
+  ): Future[(Offset, LedgerEntry.Transaction)] =
+    for {
+      _ <- ledgerDao.storeTransaction(
+        null, // TODO clean-up
+        submitterInfo = submitterInfo,
+        transactionId = tx.transactionId,
+        transaction = tx.transaction,
+        recordTime = tx.recordedAt,
+        offsetStep = offsetStep,
+        divulged = divulgedContracts,
+        ledgerEffectiveTime = tx.ledgerEffectiveTime,
+        workflowId = tx.workflowId,
+      )
+    } yield offsetStep.offset -> tx
+
+  protected implicit def toParty(s: String): Party = Party.assertFromString(s)
+
+  protected implicit def toLedgerString(s: String): Ref.LedgerString =
+    Ref.LedgerString.assertFromString(s)
+
+  protected final def create(
+      absCid: ContractId,
+      signatories: Set[Party] = Set(alice, bob),
+      templateId: Identifier = someTemplateId,
+      contractArgument: LfValue[ContractId] = someContractArgument,
+  ): NodeCreate[ContractId] =
+    createNode(absCid, signatories, signatories, None, templateId, contractArgument)
+
+  protected final def createNode(
+      absCid: ContractId,
+      signatories: Set[Party],
+      stakeholders: Set[Party],
+      key: Option[KeyWithMaintainers[LfValue[ContractId]]] = None,
+      templateId: Identifier = someTemplateId,
+      contractArgument: LfValue[ContractId] = someContractArgument,
+  ): NodeCreate[ContractId] =
+    NodeCreate(
+      coid = absCid,
+      templateId = templateId,
+      arg = contractArgument,
+      agreementText = someAgreement,
+      optLocation = None,
+      signatories = signatories,
+      stakeholders = stakeholders,
+      key = key,
+      version = TransactionVersion.minVersion,
+    )
+
+  private def exercise(
+      targetCid: ContractId
+  ): NodeExercises[NodeId, ContractId] =
+    NodeExercises(
+      targetCoid = targetCid,
+      templateId = someTemplateId,
+      choiceId = someChoiceName,
+      optLocation = None,
+      consuming = true,
+      actingParties = Set(alice),
+      chosenValue = someChoiceArgument,
+      stakeholders = Set(alice, bob),
+      signatories = Set(alice, bob),
+      choiceObservers = Set.empty,
+      children = ImmArray.empty,
+      exerciseResult = Some(someChoiceResult),
+      key = None,
+      byKey = false,
+      version = TransactionVersion.minVersion,
+    )
+
+  // All non-transient contracts created in a transaction
+  protected def nonTransient(tx: LedgerEntry.Transaction): Set[ContractId] =
+    tx.transaction.fold(Set.empty[ContractId]) {
+      case (set, (_, create: NodeCreate[ContractId])) =>
+        set + create.coid
+      case (set, (_, exercise: Node.NodeExercises[NodeId, ContractId])) if exercise.consuming =>
+        set - exercise.targetCoid
+      case (set, _) =>
+        set
+    }
+
+  protected final def singleCreate: (Offset, LedgerEntry.Transaction) =
+    singleCreate(create(_))
+
+  protected final def multiPartySingleCreate: (Offset, LedgerEntry.Transaction) =
+    singleCreate(create(_, Set(alice, bob)), List(alice, bob))
+
+  protected final def singleCreate(
+      create: ContractId => NodeCreate[ContractId],
+      actAs: List[Party] = List(alice),
+  ): (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val cid = txBuilder.newCid
+    val creation = create(cid)
+    val eid = txBuilder.add(creation)
+    val offset = nextOffset()
+    val id = offset.toLong
+    val let = Instant.now
+    offset -> LedgerEntry.Transaction(
+      commandId = Some(s"commandId$id"),
+      transactionId = s"trId$id",
+      applicationId = Some("appID1"),
+      actAs = actAs,
+      workflowId = Some("workflowId"),
+      ledgerEffectiveTime = let,
+      recordedAt = let,
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = Map(eid -> (creation.signatories union creation.stakeholders)),
+    )
+  }
+
+  protected final def createAndStoreContract(
+      submittingParties: Set[Party],
+      signatories: Set[Party],
+      stakeholders: Set[Party],
+      key: Option[KeyWithMaintainers[LfValue[ContractId]]],
+  ): Future[(Offset, LedgerEntry.Transaction)] =
+    store(
+      singleCreate(
+        create = { cid =>
+          createNode(
+            absCid = cid,
+            signatories = signatories,
+            stakeholders = stakeholders,
+            key = key,
+          )
+        },
+        actAs = submittingParties.toList,
+      )
+    )
+
+  protected final def storeCommitedContractDivulgence(
+      id: ContractId,
+      divulgees: Set[Party],
+  ): Future[(Offset, LedgerEntry.Transaction)] =
+    store(
+      divulgedContracts = Map((id, someVersionedContractInstance) -> divulgees),
+      blindingInfo = None,
+      offsetAndTx = divulgeAlreadyCommittedContract(id, divulgees),
+    )
+
+  protected def divulgeAlreadyCommittedContract(
+      id: ContractId,
+      divulgees: Set[Party],
+  ): (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val exerciseId = txBuilder.add(
+      NodeExercises(
+        targetCoid = id,
+        templateId = someTemplateId,
+        choiceId = someChoiceName,
+        optLocation = None,
+        consuming = false,
+        actingParties = Set(alice),
+        chosenValue = someChoiceArgument,
+        stakeholders = divulgees,
+        signatories = divulgees,
+        choiceObservers = Set.empty,
+        children = ImmArray.empty,
+        exerciseResult = Some(someChoiceResult),
+        key = None,
+        byKey = false,
+        version = TransactionVersion.minVersion,
+      )
+    )
+    txBuilder.add(
+      NodeFetch(
+        coid = id,
+        templateId = someTemplateId,
+        optLocation = None,
+        actingParties = divulgees,
+        signatories = Set(alice),
+        stakeholders = Set(alice),
+        None,
+        byKey = false,
+        version = TransactionVersion.minVersion,
+      ),
+      exerciseId,
+    )
+    val offset = nextOffset()
+    offset -> LedgerEntry.Transaction(
+      commandId = Some(s"just-divulged-${id.coid}"),
+      transactionId = s"trId${id.coid}",
+      applicationId = Some("appID1"),
+      actAs = List(divulgees.head),
+      workflowId = None,
+      ledgerEffectiveTime = Instant.now,
+      recordedAt = Instant.now,
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = Map.empty,
+    )
+  }
+
+  protected def singleExercise(
+      targetCid: ContractId
+  ): (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val nid = txBuilder.add(exercise(targetCid))
+    val offset = nextOffset()
+    val id = offset.toLong
+    val let = Instant.now
+    offset -> LedgerEntry.Transaction(
+      commandId = Some(s"commandId$id"),
+      transactionId = s"trId$id",
+      applicationId = Some("appID1"),
+      actAs = List("Alice"),
+      workflowId = Some("workflowId"),
+      ledgerEffectiveTime = let,
+      recordedAt = let,
+      transaction = CommittedTransaction(txBuilder.buildCommitted()),
+      explicitDisclosure = Map(nid -> Set("Alice", "Bob")),
+    )
+  }
+
+  protected def multiPartySingleExercise(
+      targetCid: ContractId
+  ): (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val nid = txBuilder.add(exercise(targetCid))
+    val offset = nextOffset()
+    val id = offset.toLong
+    val let = Instant.now
+    offset -> LedgerEntry.Transaction(
+      commandId = Some(s"commandId$id"),
+      transactionId = s"trId$id",
+      applicationId = Some("appID1"),
+      actAs = List(alice, bob, charlie),
+      workflowId = Some("workflowId"),
+      ledgerEffectiveTime = let,
+      recordedAt = let,
+      transaction = CommittedTransaction(txBuilder.buildCommitted()),
+      explicitDisclosure = Map(nid -> Set(alice, bob)),
+    )
+  }
+
+  protected def singleNonConsumingExercise(
+      targetCid: ContractId
+  ): (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val nid = txBuilder.add(exercise(targetCid).copy(consuming = false))
+    val offset = nextOffset()
+    val id = offset.toLong
+    val let = Instant.now
+    offset -> LedgerEntry.Transaction(
+      commandId = Some(s"commandId$id"),
+      transactionId = s"trId$id",
+      applicationId = Some("appID1"),
+      actAs = List("Alice"),
+      workflowId = Some("workflowId"),
+      ledgerEffectiveTime = let,
+      recordedAt = let,
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = Map(nid -> Set("Alice", "Bob")),
+    )
+  }
+
+  protected def exerciseWithChild(
+      targetCid: ContractId
+  ): (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val exerciseId = txBuilder.add(exercise(targetCid))
+    val childId = txBuilder.add(create(txBuilder.newCid), exerciseId)
+    val tx = CommittedTransaction(txBuilder.build())
+    val offset = nextOffset()
+    val id = offset.toLong
+    val txId = s"trId$id"
+    val let = Instant.now
+    offset -> LedgerEntry.Transaction(
+      Some(s"commandId$id"),
+      txId,
+      Some("appID1"),
+      List("Alice"),
+      Some("workflowId"),
+      let,
+      let,
+      CommittedTransaction(tx),
+      Map(exerciseId -> Set("Alice", "Bob"), childId -> Set("Alice", "Bob")),
+    )
+  }
+
+  protected def fullyTransient: (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val cid = txBuilder.newCid
+    val createId = txBuilder.add(create(cid))
+    val exerciseId = txBuilder.add(exercise(cid))
+    val let = Instant.now
+    nextOffset() -> LedgerEntry.Transaction(
+      commandId = Some(UUID.randomUUID().toString),
+      transactionId = UUID.randomUUID().toString,
+      applicationId = Some("appID1"),
+      actAs = List(alice),
+      workflowId = Some("workflowId"),
+      ledgerEffectiveTime = let,
+      recordedAt = let,
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = Map(
+        createId -> Set(alice, bob),
+        exerciseId -> Set(alice, bob),
+      ),
+    )
+  }
+
+  // The transient contract is divulged to `charlie` as a non-stakeholder actor on the
+  // root exercise node that causes the creation of a transient contract
+  protected def fullyTransientWithChildren: (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val root = txBuilder.newCid
+    val transient = txBuilder.newCid
+    val rootCreateId = txBuilder.add(create(root))
+    val rootExerciseId = txBuilder.add(exercise(root).copy(actingParties = Set(charlie)))
+    val createTransientId = txBuilder.add(create(transient), rootExerciseId)
+    val consumeTransientId = txBuilder.add(exercise(transient), rootExerciseId)
+    val let = Instant.now
+    nextOffset() -> LedgerEntry.Transaction(
+      commandId = Some(UUID.randomUUID.toString),
+      transactionId = UUID.randomUUID().toString,
+      applicationId = Some("appID1"),
+      actAs = List(alice),
+      workflowId = Some("workflowId"),
+      ledgerEffectiveTime = let,
+      recordedAt = let,
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = Map(
+        rootCreateId -> Set(alice, bob),
+        rootExerciseId -> Set(alice, bob, charlie),
+        createTransientId -> Set(alice, bob, charlie),
+        consumeTransientId -> Set(alice, bob, charlie),
+      ),
+    )
+  }
+
+  /** Creates the following transaction
+    *
+    * Create A --> Exercise A
+    *              |        |
+    *              |        |
+    *              v        v
+    *           Create B  Create C
+    *
+    * A is visible to Charlie
+    * B is visible to Alice and Charlie
+    * C is visible to Bob and Charlie
+    */
+  protected def partiallyVisible: (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val createId = txBuilder.add(
+      create(txBuilder.newCid).copy(
+        signatories = Set(charlie),
+        stakeholders = Set(charlie),
+      )
+    )
+    val exerciseId = txBuilder.add(
+      exercise(txBuilder.newCid).copy(
+        actingParties = Set(charlie),
+        signatories = Set(charlie),
+        stakeholders = Set(charlie),
+      )
+    )
+    val childCreateId1 = txBuilder.add(
+      create(txBuilder.newCid),
+      exerciseId,
+    )
+    val childCreateId2 = txBuilder.add(
+      create(txBuilder.newCid),
+      exerciseId,
+    )
+    val let = Instant.now
+    nextOffset() -> LedgerEntry.Transaction(
+      commandId = Some(UUID.randomUUID().toString),
+      transactionId = UUID.randomUUID().toString,
+      applicationId = Some("appID1"),
+      actAs = List(charlie),
+      workflowId = Some("workflowId"),
+      ledgerEffectiveTime = let,
+      recordedAt = let,
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = Map(
+        createId -> Set(charlie),
+        exerciseId -> Set(charlie),
+        childCreateId1 -> Set(alice, charlie),
+        childCreateId2 -> Set(bob, charlie),
+      ),
+    )
+  }
+
+  /** Creates a transactions with multiple top-level creates.
+    *
+    * Every contract will be signed by a fixed "operator" and each contract will have a
+    * further signatory and a template as defined by signatoriesAndTemplates.
+    *
+    * @throws IllegalArgumentException if signatoryAndTemplate is empty
+    */
+  protected def multipleCreates(
+      operator: String,
+      signatoriesAndTemplates: Seq[(Party, Identifier, LfValue[ContractId])],
+  ): (Offset, LedgerEntry.Transaction) = {
+    require(signatoriesAndTemplates.nonEmpty, "multipleCreates cannot create empty transactions")
+    val txBuilder = TransactionBuilder()
+    val disclosure = for {
+      entry <- signatoriesAndTemplates
+      (signatory, template, argument) = entry
+      contract = create(txBuilder.newCid, Set(signatory), template, argument)
+      parties = Set[Party](operator, signatory)
+      nodeId = txBuilder.add(contract)
+    } yield nodeId -> parties
+    nextOffset() -> LedgerEntry.Transaction(
+      commandId = Some(UUID.randomUUID().toString),
+      transactionId = UUID.randomUUID.toString,
+      applicationId = Some("appID1"),
+      actAs = List(operator),
+      workflowId = Some("workflowId"),
+      ledgerEffectiveTime = Instant.now,
+      recordedAt = Instant.now,
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = disclosure.toMap,
+    )
+  }
+
+  protected final def prepareInsert(
+      submitterInfo: Option[SubmitterInfo],
+      tx: LedgerEntry.Transaction,
+      offsetStep: OffsetStep,
+      divulgedContracts: List[DivulgedContract] = List.empty,
+      blindingInfo: Option[BlindingInfo] = None,
+  ): TransactionsWriter.PreparedInsert =
+    ledgerDao.prepareTransactionInsert(
+      submitterInfo,
+      tx.workflowId,
+      tx.transactionId,
+      tx.ledgerEffectiveTime,
+      offsetStep.offset,
+      tx.transaction,
+      divulgedContracts,
+      blindingInfo,
+    )
+
+  protected final def store(
+      divulgedContracts: Map[(ContractId, v1.ContractInst), Set[Party]],
+      blindingInfo: Option[BlindingInfo],
+      offsetAndTx: (Offset, LedgerEntry.Transaction),
+  ): Future[(Offset, LedgerEntry.Transaction)] =
+    storeOffsetStepAndTx(
+      divulgedContracts = divulgedContracts,
+      blindingInfo = blindingInfo,
+      offsetStepAndTx = nextOffsetStep(offsetAndTx._1) -> offsetAndTx._2,
+    )
+
+  protected final def storeOffsetStepAndTx(
+      divulgedContracts: Map[(ContractId, v1.ContractInst), Set[Party]],
+      blindingInfo: Option[BlindingInfo],
+      offsetStepAndTx: (OffsetStep, LedgerEntry.Transaction),
+  ): Future[(Offset, LedgerEntry.Transaction)] = {
+    val _ = blindingInfo
+    val (offsetStep, entry) = offsetStepAndTx
+    val maybeSubmitterInfo = submitterInfo(entry)
+    val divulged = divulgedContracts.keysIterator.map(c => v1.DivulgedContract(c._1, c._2)).toList
+
+    store(maybeSubmitterInfo, entry, offsetStep, divulged)
+  }
+
+  protected def submitterInfo(entry: LedgerEntry.Transaction) =
+    for (
+      actAs <- if (entry.actAs.isEmpty) None else Some(entry.actAs); app <- entry.applicationId;
+      cmd <- entry.commandId
+    ) yield v1.SubmitterInfo(actAs, app, cmd, Instant.EPOCH)
+
+  protected final def store(
+      offsetAndTx: (Offset, LedgerEntry.Transaction)
+  ): Future[(Offset, LedgerEntry.Transaction)] =
+    storeOffsetStepAndTx(
+      divulgedContracts = Map.empty,
+      blindingInfo = None,
+      offsetStepAndTx = nextOffsetStep(offsetAndTx._1) -> offsetAndTx._2,
+    )
+
+  protected final def storeSync(
+      commands: Vector[(Offset, LedgerEntry.Transaction)]
+  ): Future[Vector[(Offset, LedgerEntry.Transaction)]] = {
+
+    import JdbcLedgerDaoSuite._
+    import scalaz.std.scalaFuture._
+    import scalaz.std.vector._
+
+    // force synchronous future processing with Free monad
+    // to provide the guarantees that all transactions persisted in the specified order
+    commands traverseFM store
+  }
+
+  /** A transaction that creates the given key */
+  protected final def txCreateContractWithKey(
+      party: Party,
+      key: String,
+      txUuid: Option[String] = None,
+  ): (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val createNodeId = txBuilder.add(
+      NodeCreate(
+        coid = txBuilder.newCid,
+        templateId = someTemplateId,
+        arg = someContractArgument,
+        agreementText = someAgreement,
+        optLocation = None,
+        signatories = Set(party),
+        stakeholders = Set(party),
+        key = Some(KeyWithMaintainers(someContractKey(party, key), Set(party))),
+        version = TransactionVersion.minVersion,
+      )
+    )
+    nextOffset() ->
+      LedgerEntry.Transaction(
+        commandId = Some(UUID.randomUUID().toString),
+        transactionId = txUuid.getOrElse(UUID.randomUUID.toString),
+        applicationId = Some(defaultAppId),
+        actAs = List(party),
+        workflowId = Some(defaultWorkflowId),
+        ledgerEffectiveTime = Instant.now,
+        recordedAt = Instant.now,
+        transaction = txBuilder.buildCommitted(),
+        explicitDisclosure = Map(createNodeId -> Set(party)),
+      )
+  }
+
+  /** A transaction that archives the given contract with the given key */
+  protected final def txArchiveContract(
+      party: Party,
+      contract: (ContractId, Option[String]),
+  ): (Offset, LedgerEntry.Transaction) = {
+    val (contractId, maybeKey) = contract
+    val txBuilder = TransactionBuilder()
+    val archiveNodeId = txBuilder.add(
+      NodeExercises(
+        targetCoid = contractId,
+        templateId = someTemplateId,
+        choiceId = Ref.ChoiceName.assertFromString("Archive"),
+        optLocation = None,
+        consuming = true,
+        actingParties = Set(party),
+        chosenValue = LfValue.ValueUnit,
+        stakeholders = Set(party),
+        signatories = Set(party),
+        choiceObservers = Set.empty,
+        children = ImmArray.empty,
+        exerciseResult = Some(LfValue.ValueUnit),
+        key = maybeKey.map(k => KeyWithMaintainers(someContractKey(party, k), Set(party))),
+        byKey = false,
+        version = TransactionVersion.minVersion,
+      )
+    )
+    nextOffset() -> LedgerEntry.Transaction(
+      commandId = Some(UUID.randomUUID().toString),
+      transactionId = UUID.randomUUID.toString,
+      applicationId = Some(defaultAppId),
+      actAs = List(party),
+      workflowId = Some(defaultWorkflowId),
+      ledgerEffectiveTime = Instant.now,
+      recordedAt = Instant.now,
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = Map(archiveNodeId -> Set(party)),
+    )
+  }
+
+  /** A transaction that looks up a key */
+  protected final def txLookupByKey(
+      party: Party,
+      key: String,
+      result: Option[ContractId],
+  ): (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val lookupByKeyNodeId = txBuilder.add(
+      NodeLookupByKey(
+        someTemplateId,
+        None,
+        KeyWithMaintainers(someContractKey(party, key), Set(party)),
+        result,
+        version = TransactionVersion.minVersion,
+      )
+    )
+    nextOffset() -> LedgerEntry.Transaction(
+      commandId = Some(UUID.randomUUID().toString),
+      transactionId = UUID.randomUUID.toString,
+      applicationId = Some(defaultAppId),
+      actAs = List(party),
+      workflowId = Some(defaultWorkflowId),
+      ledgerEffectiveTime = Instant.now(),
+      recordedAt = Instant.now(),
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = Map(lookupByKeyNodeId -> Set(party)),
+    )
+  }
+
+  protected final def txFetch(
+      party: Party,
+      contractId: ContractId,
+  ): (Offset, LedgerEntry.Transaction) = {
+    val txBuilder = TransactionBuilder()
+    val fetchNodeId = txBuilder.add(
+      NodeFetch(
+        coid = contractId,
+        templateId = someTemplateId,
+        optLocation = None,
+        actingParties = Set(party),
+        signatories = Set(party),
+        stakeholders = Set(party),
+        None,
+        byKey = false,
+        version = TransactionVersion.minVersion,
+      )
+    )
+    nextOffset() -> LedgerEntry.Transaction(
+      commandId = Some(UUID.randomUUID().toString),
+      transactionId = UUID.randomUUID.toString,
+      applicationId = Some(defaultAppId),
+      actAs = List(party),
+      workflowId = Some(defaultWorkflowId),
+      ledgerEffectiveTime = Instant.now(),
+      recordedAt = Instant.now(),
+      transaction = txBuilder.buildCommitted(),
+      explicitDisclosure = Map(fetchNodeId -> Set(party)),
+    )
+  }
+
+  protected final def emptyTransaction(party: Party): (Offset, LedgerEntry.Transaction) =
+    nextOffset() -> LedgerEntry.Transaction(
+      commandId = Some(UUID.randomUUID().toString),
+      transactionId = UUID.randomUUID.toString,
+      applicationId = Some(defaultAppId),
+      actAs = List(party),
+      workflowId = Some(defaultWorkflowId),
+      ledgerEffectiveTime = Instant.now(),
+      recordedAt = Instant.now(),
+      transaction = TransactionBuilder.EmptyCommitted,
+      explicitDisclosure = Map.empty,
+    )
+
+  // Returns the command ids and status of completed commands between two offsets
+  protected def getCompletions(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      applicationId: String,
+      parties: Set[Party],
+  ): Future[Seq[(String, Int)]] =
+    ledgerDao.completions
+      .getCommandCompletions(startExclusive, endInclusive, applicationId, parties)
+      .map(_._2.completions.head)
+      .map(c => c.commandId -> c.status.get.code)
+      .runWith(Sink.seq)
+
+  def nextOffsetStep(offset: Offset): OffsetStep =
+    OffsetStep(previousOffset.getAndSet(Some(offset)), offset)
+}
+
+object JdbcLedgerDaoSuite {
+
+  import scalaz.syntax.traverse._
+  import scalaz.{Free, Monad, NaturalTransformation, Traverse}
+
+  implicit final class `TraverseFM Ops`[T[_], A](private val self: T[A]) extends AnyVal {
+
+    /** Like `traverse`, but guarantees that
+      *
+      *  - `f` is evaluated left-to-right, and
+      *  - `B` from the preceding element is evaluated before `f` is invoked for
+      * the subsequent `A`.
+      */
+    def traverseFM[F[_]: Monad, B](f: A => F[B])(implicit T: Traverse[T]): F[T[B]] =
+      self
+        .traverse(a => Free suspend (Free liftF f(a)))
+        .foldMap(NaturalTransformation.refl)
+  }
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoTransactionTreesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoTransactionTreesSpec.scala
@@ -1,0 +1,316 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import akka.NotUsed
+import akka.stream.scaladsl.{Sink, Source}
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.lf.data.Ref.Party
+import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
+import com.daml.lf.transaction.NodeId
+import com.daml.lf.value.Value.ContractId
+import com.daml.ledger.EventId
+import com.daml.ledger.api.v1.transaction.TransactionTree
+import com.daml.ledger.api.v1.transaction_service.GetTransactionTreesResponse
+import com.daml.platform.ApiOffset
+import com.daml.platform.api.v1.event.EventOps.TreeEventOps
+import com.daml.platform.store.entries.LedgerEntry
+import org.scalatest._
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.compat._
+import scala.concurrent.Future
+
+private[appendonlydao] trait JdbcLedgerDaoTransactionTreesSpec
+    extends OptionValues
+    with Inside
+    with LoneElement {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (lookupTransactionTreeById)"
+
+  it should "return nothing for a mismatching transaction id" in {
+    for {
+      (_, tx) <- store(singleCreate)
+      result <- ledgerDao.transactionsReader
+        .lookupTransactionTreeById(transactionId = "WRONG", tx.actAs.toSet)
+    } yield {
+      result shouldBe None
+    }
+  }
+
+  it should "return nothing for a mismatching party" in {
+    for {
+      (_, tx) <- store(singleCreate)
+      result <- ledgerDao.transactionsReader
+        .lookupTransactionTreeById(tx.transactionId, Set("WRONG"))
+    } yield {
+      result shouldBe None
+    }
+  }
+
+  it should "return the expected transaction tree for a correct request (create)" in {
+    for {
+      (offset, tx) <- store(singleCreate)
+      result <- ledgerDao.transactionsReader
+        .lookupTransactionTreeById(tx.transactionId, tx.actAs.toSet)
+    } yield {
+      inside(result.value.transaction) { case Some(transaction) =>
+        val (nodeId, createNode: NodeCreate[ContractId]) =
+          tx.transaction.nodes.head
+        transaction.commandId shouldBe tx.commandId.get
+        transaction.offset shouldBe ApiOffset.toApiString(offset)
+        transaction.effectiveAt.value.seconds shouldBe tx.ledgerEffectiveTime.getEpochSecond
+        transaction.effectiveAt.value.nanos shouldBe tx.ledgerEffectiveTime.getNano
+        transaction.transactionId shouldBe tx.transactionId
+        transaction.workflowId shouldBe tx.workflowId.getOrElse("")
+        val created = transaction.eventsById.values.loneElement.getCreated
+        transaction.rootEventIds.loneElement shouldEqual created.eventId
+        created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
+        created.witnessParties should contain only (tx.actAs: _*)
+        created.agreementText.getOrElse("") shouldBe createNode.coinst.agreementText
+        created.contractKey shouldBe None
+        created.createArguments shouldNot be(None)
+        created.signatories should contain theSameElementsAs createNode.signatories
+        created.observers should contain theSameElementsAs createNode.stakeholders.diff(
+          createNode.signatories
+        )
+        created.templateId shouldNot be(None)
+      }
+    }
+  }
+
+  it should "return the expected transaction tree for a correct request (exercise)" in {
+    for {
+      (_, create) <- store(singleCreate)
+      (offset, exercise) <- store(singleExercise(nonTransient(create).loneElement))
+      result <- ledgerDao.transactionsReader
+        .lookupTransactionTreeById(exercise.transactionId, exercise.actAs.toSet)
+    } yield {
+      inside(result.value.transaction) { case Some(transaction) =>
+        val (nodeId, exerciseNode: NodeExercises[NodeId, ContractId]) =
+          exercise.transaction.nodes.head
+        transaction.commandId shouldBe exercise.commandId.get
+        transaction.offset shouldBe ApiOffset.toApiString(offset)
+        transaction.effectiveAt.value.seconds shouldBe exercise.ledgerEffectiveTime.getEpochSecond
+        transaction.effectiveAt.value.nanos shouldBe exercise.ledgerEffectiveTime.getNano
+        transaction.transactionId shouldBe exercise.transactionId
+        transaction.workflowId shouldBe exercise.workflowId.getOrElse("")
+        val exercised = transaction.eventsById.values.loneElement.getExercised
+        transaction.rootEventIds.loneElement shouldEqual exercised.eventId
+        exercised.eventId shouldBe EventId(transaction.transactionId, nodeId).toLedgerString
+        exercised.witnessParties should contain only (exercise.actAs: _*)
+        exercised.contractId shouldBe exerciseNode.targetCoid.coid
+        exercised.templateId shouldNot be(None)
+        exercised.actingParties should contain theSameElementsAs exerciseNode.actingParties
+        exercised.childEventIds shouldBe Seq.empty
+        exercised.choice shouldBe exerciseNode.choiceId
+        exercised.choiceArgument shouldNot be(None)
+        exercised.consuming shouldBe true
+        exercised.exerciseResult shouldNot be(None)
+      }
+    }
+  }
+
+  it should "return the expected transaction tree for a correct request (create, exercise)" in {
+    for {
+      (offset, tx) <- store(fullyTransient)
+      result <- ledgerDao.transactionsReader
+        .lookupTransactionTreeById(tx.transactionId, tx.actAs.toSet)
+    } yield {
+      inside(result.value.transaction) { case Some(transaction) =>
+        val (createNodeId, createNode) =
+          tx.transaction.nodes.collectFirst { case (nodeId, node: NodeCreate[ContractId]) =>
+            nodeId -> node
+          }.get
+        val (exerciseNodeId, exerciseNode) =
+          tx.transaction.nodes.collectFirst {
+            case (nodeId, node: NodeExercises[NodeId, ContractId]) =>
+              nodeId -> node
+          }.get
+
+        transaction.commandId shouldBe tx.commandId.get
+        transaction.offset shouldBe ApiOffset.toApiString(offset)
+        transaction.transactionId shouldBe tx.transactionId
+        transaction.workflowId shouldBe tx.workflowId.getOrElse("")
+        transaction.effectiveAt.value.seconds shouldBe tx.ledgerEffectiveTime.getEpochSecond
+        transaction.effectiveAt.value.nanos shouldBe tx.ledgerEffectiveTime.getNano
+
+        transaction.rootEventIds should have size 2
+        transaction.rootEventIds(0) shouldBe EventId(
+          transaction.transactionId,
+          createNodeId,
+        ).toLedgerString
+        transaction.rootEventIds(1) shouldBe EventId(
+          transaction.transactionId,
+          exerciseNodeId,
+        ).toLedgerString
+
+        val created = transaction
+          .eventsById(EventId(transaction.transactionId, createNodeId).toLedgerString)
+          .getCreated
+        val exercised = transaction
+          .eventsById(EventId(transaction.transactionId, exerciseNodeId).toLedgerString)
+          .getExercised
+
+        created.eventId shouldBe EventId(transaction.transactionId, createNodeId).toLedgerString
+        created.witnessParties should contain only (tx.actAs: _*)
+        created.agreementText.getOrElse("") shouldBe createNode.coinst.agreementText
+        created.contractKey shouldBe None
+        created.createArguments shouldNot be(None)
+        created.signatories should contain theSameElementsAs createNode.signatories
+        created.observers should contain theSameElementsAs createNode.stakeholders.diff(
+          createNode.signatories
+        )
+        created.templateId shouldNot be(None)
+
+        exercised.eventId shouldBe EventId(transaction.transactionId, exerciseNodeId).toLedgerString
+        exercised.witnessParties should contain only (tx.actAs: _*)
+        exercised.contractId shouldBe exerciseNode.targetCoid.coid
+        exercised.templateId shouldNot be(None)
+        exercised.actingParties should contain theSameElementsAs exerciseNode.actingParties
+        exercised.childEventIds shouldBe Seq.empty
+        exercised.choice shouldBe exerciseNode.choiceId
+        exercised.choiceArgument shouldNot be(None)
+        exercised.consuming shouldBe true
+        exercised.exerciseResult shouldNot be(None)
+      }
+    }
+  }
+
+  it should "return a transaction tree with the expected shape for a partially visible transaction" in {
+    for {
+      (_, tx) <- store(partiallyVisible)
+      result <- ledgerDao.transactionsReader
+        .lookupTransactionTreeById(
+          tx.transactionId,
+          Set(alice),
+        ) // only two children are visible to Alice
+    } yield {
+      inside(result.value.transaction) { case Some(transaction) =>
+        transaction.eventsById should have size 2
+
+        transaction.rootEventIds should have size 2
+        transaction.rootEventIds(0) shouldBe EventId(
+          transaction.transactionId,
+          NodeId(2),
+        ).toLedgerString
+        transaction.rootEventIds(1) shouldBe EventId(
+          transaction.transactionId,
+          NodeId(3),
+        ).toLedgerString
+      }
+    }
+  }
+
+  behavior of "JdbcLedgerDao (getTransactionTrees)"
+
+  it should "match the results of lookupTransactionTreeById" in {
+    for {
+      (from, to, transactions) <- storeTestFixture()
+      lookups <- lookupIndividually(transactions, Set(alice, bob, charlie))
+      result <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getTransactionTrees(
+            startExclusive = from,
+            endInclusive = to,
+            requestingParties = Set(alice, bob, charlie),
+            verbose = true,
+          )
+      )
+    } yield {
+      comparable(result) should contain theSameElementsInOrderAs comparable(lookups)
+    }
+  }
+
+  it should "filter correctly by party" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (_, tx) <- store(
+        multipleCreates(
+          charlie,
+          Seq(
+            (alice, someTemplateId, someContractArgument),
+            (bob, someTemplateId, someContractArgument),
+          ),
+        )
+      )
+      to <- ledgerDao.lookupLedgerEnd()
+      individualLookupForAlice <- lookupIndividually(Seq(tx), as = Set(alice))
+      individualLookupForBob <- lookupIndividually(Seq(tx), as = Set(bob))
+      individualLookupForCharlie <- lookupIndividually(Seq(tx), as = Set(charlie))
+      resultForAlice <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getTransactionTrees(
+            startExclusive = from,
+            endInclusive = to,
+            requestingParties = Set(alice),
+            verbose = true,
+          )
+      )
+      resultForBob <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getTransactionTrees(
+            startExclusive = from,
+            endInclusive = to,
+            requestingParties = Set(bob),
+            verbose = true,
+          )
+      )
+      resultForCharlie <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getTransactionTrees(
+            startExclusive = from,
+            endInclusive = to,
+            requestingParties = Set(charlie),
+            verbose = true,
+          )
+      )
+    } yield {
+      individualLookupForAlice should contain theSameElementsInOrderAs resultForAlice
+      individualLookupForBob should contain theSameElementsInOrderAs resultForBob
+      individualLookupForCharlie should contain theSameElementsInOrderAs resultForCharlie
+    }
+  }
+
+  private def storeTestFixture(): Future[(Offset, Offset, Seq[LedgerEntry.Transaction])] =
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (_, t1) <- store(singleCreate)
+      (_, t2) <- store(singleCreate)
+      (_, t3) <- store(singleExercise(nonTransient(t2).loneElement))
+      (_, t4) <- store(fullyTransient)
+      to <- ledgerDao.lookupLedgerEnd()
+    } yield (from, to, Seq(t1, t2, t3, t4))
+
+  private def lookupIndividually(
+      transactions: Seq[LedgerEntry.Transaction],
+      as: Set[Party],
+  ): Future[Seq[TransactionTree]] =
+    Future
+      .sequence(
+        transactions.map(tx =>
+          ledgerDao.transactionsReader
+            .lookupTransactionTreeById(tx.transactionId, as)
+        )
+      )
+      .map(_.flatMap(_.toList.flatMap(_.transaction.toList)))
+
+  private def transactionsOf(
+      source: Source[(Offset, GetTransactionTreesResponse), NotUsed]
+  ): Future[Seq[TransactionTree]] =
+    source
+      .map(_._2)
+      .runWith(Sink.seq)
+      .map(_.flatMap(_.transactions))
+
+  // Ensure two sequences of transaction trees are comparable:
+  // - witnesses do not have to appear in a specific order
+  private def comparable(txs: Seq[TransactionTree]): Seq[TransactionTree] =
+    txs.map(tx =>
+      tx.copy(eventsById = tx.eventsById.view.mapValues(_.modifyWitnessParties(_.sorted)).toMap)
+    )
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoTransactionsSpec.scala
@@ -1,0 +1,713 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import akka.NotUsed
+import akka.stream.scaladsl.{Sink, Source}
+import com.daml.ledger.EventId
+import com.daml.ledger.api.v1.transaction.Transaction
+import com.daml.ledger.api.v1.transaction_service.GetTransactionsResponse
+import com.daml.ledger.api.{v1 => lav1}
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger.resources.ResourceContext
+import com.daml.lf.data.Ref.{Identifier, Party}
+import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
+import com.daml.lf.transaction.NodeId
+import com.daml.lf.value.Value.ContractId
+import com.daml.logging.LoggingContext
+import com.daml.platform.ApiOffset
+import com.daml.platform.api.v1.event.EventOps.EventOps
+import com.daml.platform.participant.util.LfEngineToApi
+import com.daml.platform.store.entries.LedgerEntry
+import org.scalacheck.Gen
+import org.scalatest.{Inside, LoneElement, OptionValues}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.Future
+
+private[appendonlydao] trait JdbcLedgerDaoTransactionsSpec
+    extends OptionValues
+    with Inside
+    with LoneElement {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  import JdbcLedgerDaoTransactionsSpec._
+
+  behavior of "JdbcLedgerDao (lookupFlatTransactionById)"
+
+  it should "return nothing for a mismatching transaction id" in {
+    for {
+      (_, tx) <- store(singleCreate)
+      result <- ledgerDao.transactionsReader
+        .lookupFlatTransactionById(transactionId = "WRONG", tx.actAs.toSet)
+    } yield {
+      result shouldBe None
+    }
+  }
+
+  it should "return nothing for a mismatching party" in {
+    for {
+      (_, tx) <- store(singleCreate)
+      result <- ledgerDao.transactionsReader
+        .lookupFlatTransactionById(tx.transactionId, Set("WRONG"))
+    } yield {
+      result shouldBe None
+    }
+  }
+
+  it should "return the expected flat transaction for a correct request (create)" in {
+    for {
+      (offset, tx) <- store(singleCreate)
+      result <- ledgerDao.transactionsReader
+        .lookupFlatTransactionById(tx.transactionId, tx.actAs.toSet)
+    } yield {
+      inside(result.value.transaction) { case Some(transaction) =>
+        transaction.commandId shouldBe tx.commandId.get
+        transaction.offset shouldBe ApiOffset.toApiString(offset)
+        transaction.effectiveAt.value.seconds shouldBe tx.ledgerEffectiveTime.getEpochSecond
+        transaction.effectiveAt.value.nanos shouldBe tx.ledgerEffectiveTime.getNano
+        transaction.transactionId shouldBe tx.transactionId
+        transaction.workflowId shouldBe tx.workflowId.getOrElse("")
+        inside(transaction.events.loneElement.event.created) { case Some(created) =>
+          val (nodeId, createNode: NodeCreate[ContractId]) =
+            tx.transaction.nodes.head
+          created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
+          created.witnessParties should contain only (tx.actAs: _*)
+          created.agreementText.getOrElse("") shouldBe createNode.coinst.agreementText
+          created.contractKey shouldBe None
+          created.createArguments shouldNot be(None)
+          created.signatories should contain theSameElementsAs createNode.signatories
+          created.observers should contain theSameElementsAs createNode.stakeholders.diff(
+            createNode.signatories
+          )
+          created.templateId shouldNot be(None)
+        }
+      }
+    }
+  }
+
+  it should "return the expected flat transaction for a correct request (exercise)" in {
+    for {
+      (_, create) <- store(singleCreate)
+      (offset, exercise) <- store(singleExercise(nonTransient(create).loneElement))
+      result <- ledgerDao.transactionsReader
+        .lookupFlatTransactionById(exercise.transactionId, exercise.actAs.toSet)
+    } yield {
+      inside(result.value.transaction) { case Some(transaction) =>
+        transaction.commandId shouldBe exercise.commandId.get
+        transaction.offset shouldBe ApiOffset.toApiString(offset)
+        transaction.transactionId shouldBe exercise.transactionId
+        transaction.effectiveAt.value.seconds shouldBe exercise.ledgerEffectiveTime.getEpochSecond
+        transaction.effectiveAt.value.nanos shouldBe exercise.ledgerEffectiveTime.getNano
+        transaction.workflowId shouldBe exercise.workflowId.getOrElse("")
+        inside(transaction.events.loneElement.event.archived) { case Some(archived) =>
+          val (nodeId, exerciseNode: NodeExercises[NodeId, ContractId]) =
+            exercise.transaction.nodes.head
+          archived.eventId shouldBe EventId(transaction.transactionId, nodeId).toLedgerString
+          archived.witnessParties should contain only (exercise.actAs: _*)
+          archived.contractId shouldBe exerciseNode.targetCoid.coid
+          archived.templateId shouldNot be(None)
+        }
+      }
+    }
+  }
+
+  it should "show command IDs to the original submitters" in {
+    val signatories = Set(alice, bob)
+    val stakeholders = Set(alice, bob, charlie) // Charlie is only stakeholder
+    val actAs = List(alice, bob, david) // David is submitter but not signatory
+    for {
+      (_, tx) <- store(singleCreate(createNode(_, signatories, stakeholders), actAs))
+      // Response 1: querying as all submitters
+      result1 <- ledgerDao.transactionsReader
+        .lookupFlatTransactionById(tx.transactionId, Set(alice, bob, david))
+      // Response 2: querying as a proper subset of all submitters
+      result2 <- ledgerDao.transactionsReader
+        .lookupFlatTransactionById(tx.transactionId, Set(alice, david))
+      // Response 3: querying as a proper superset of all submitters
+      result3 <- ledgerDao.transactionsReader
+        .lookupFlatTransactionById(tx.transactionId, Set(alice, bob, charlie, david))
+    } yield {
+      result1.value.transaction.value.commandId shouldBe tx.commandId.get
+      result2.value.transaction.value.commandId shouldBe tx.commandId.get
+      result3.value.transaction.value.commandId shouldBe tx.commandId.get
+    }
+  }
+
+  it should "hide command IDs from non-submitters" in {
+    val signatories = Set(alice, bob)
+    val stakeholders = Set(alice, bob, charlie) // Charlie is only stakeholder
+    val actAs = List(alice, bob, david) // David is submitter but not signatory
+    for {
+      (_, tx) <- store(singleCreate(createNode(_, signatories, stakeholders), actAs))
+      result <- ledgerDao.transactionsReader
+        .lookupFlatTransactionById(tx.transactionId, Set(charlie))
+    } yield {
+      result.value.transaction.value.commandId shouldBe ""
+    }
+  }
+
+  it should "hide events on transient contracts to the original submitter" in {
+    for {
+      (offset, tx) <- store(fullyTransient)
+      result <- ledgerDao.transactionsReader
+        .lookupFlatTransactionById(tx.transactionId, tx.actAs.toSet)
+    } yield {
+      inside(result.value.transaction) { case Some(transaction) =>
+        transaction.commandId shouldBe tx.commandId.get
+        transaction.offset shouldBe ApiOffset.toApiString(offset)
+        transaction.transactionId shouldBe tx.transactionId
+        transaction.effectiveAt.value.seconds shouldBe tx.ledgerEffectiveTime.getEpochSecond
+        transaction.effectiveAt.value.nanos shouldBe tx.ledgerEffectiveTime.getNano
+        transaction.workflowId shouldBe tx.workflowId.getOrElse("")
+        transaction.events shouldBe Seq.empty
+      }
+    }
+  }
+
+  behavior of "JdbcLedgerDao (getFlatTransactions)"
+
+  it should "match the results of lookupFlatTransactionById" in {
+    for {
+      (from, to, transactions) <- storeTestFixture()
+      lookups <- lookupIndividually(transactions, Set(alice, bob, charlie))
+      result <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(
+            startExclusive = from,
+            endInclusive = to,
+            filter = Map(alice -> Set.empty, bob -> Set.empty, charlie -> Set.empty),
+            verbose = true,
+          )
+      )
+    } yield {
+      comparable(result) should contain theSameElementsInOrderAs comparable(lookups)
+    }
+  }
+
+  it should "filter correctly by party" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (_, tx) <- store(
+        multipleCreates(
+          charlie,
+          Seq(
+            (alice, someTemplateId, someContractArgument),
+            (bob, someTemplateId, someContractArgument),
+          ),
+        )
+      )
+      to <- ledgerDao.lookupLedgerEnd()
+      individualLookupForAlice <- lookupIndividually(Seq(tx), as = Set(alice))
+      individualLookupForBob <- lookupIndividually(Seq(tx), as = Set(bob))
+      individualLookupForCharlie <- lookupIndividually(Seq(tx), as = Set(charlie))
+      resultForAlice <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(
+            startExclusive = from,
+            endInclusive = to,
+            filter = Map(alice -> Set.empty),
+            verbose = true,
+          )
+      )
+      resultForBob <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(
+            startExclusive = from,
+            endInclusive = to,
+            filter = Map(bob -> Set.empty),
+            verbose = true,
+          )
+      )
+      resultForCharlie <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(
+            startExclusive = from,
+            endInclusive = to,
+            filter = Map(charlie -> Set.empty),
+            verbose = true,
+          )
+      )
+    } yield {
+      individualLookupForAlice should contain theSameElementsInOrderAs resultForAlice
+      individualLookupForBob should contain theSameElementsInOrderAs resultForBob
+      individualLookupForCharlie should contain theSameElementsInOrderAs resultForCharlie
+    }
+  }
+
+  it should "filter correctly for a single party" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      _ <- store(
+        multipleCreates(
+          operator = "operator",
+          signatoriesAndTemplates = Seq(
+            (alice, someTemplateId, someContractArgument),
+            (bob, otherTemplateId, otherContractArgument),
+            (alice, otherTemplateId, otherContractArgument),
+          ),
+        )
+      )
+      to <- ledgerDao.lookupLedgerEnd()
+      result <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(
+            startExclusive = from,
+            endInclusive = to,
+            filter = Map(alice -> Set(otherTemplateId)),
+            verbose = true,
+          )
+      )
+    } yield {
+      inside(result.loneElement.events.loneElement.event.created) { case Some(create) =>
+        create.witnessParties.loneElement shouldBe alice
+        create.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+      }
+    }
+  }
+
+  it should "filter correctly by multiple parties with the same template" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      _ <- store(
+        multipleCreates(
+          operator = "operator",
+          signatoriesAndTemplates = Seq(
+            (alice, someTemplateId, someContractArgument),
+            (bob, otherTemplateId, otherContractArgument),
+            (alice, otherTemplateId, otherContractArgument),
+          ),
+        )
+      )
+      to <- ledgerDao.lookupLedgerEnd()
+      result <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(
+            startExclusive = from,
+            endInclusive = to,
+            filter = Map(
+              alice -> Set(otherTemplateId),
+              bob -> Set(otherTemplateId),
+            ),
+            verbose = true,
+          )
+      )
+    } yield {
+      val events = result.loneElement.events.toArray
+      events should have length 2
+      inside(events(0).event.created) { case Some(create) =>
+        create.witnessParties.loneElement shouldBe bob
+        create.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+      }
+      inside(events(1).event.created) { case Some(create) =>
+        create.witnessParties.loneElement shouldBe alice
+        create.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+      }
+    }
+  }
+
+  it should "filter correctly by multiple parties with different templates" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      _ <- store(
+        multipleCreates(
+          operator = "operator",
+          signatoriesAndTemplates = Seq(
+            (alice, someTemplateId, someContractArgument),
+            (bob, otherTemplateId, otherContractArgument),
+            (alice, otherTemplateId, otherContractArgument),
+          ),
+        )
+      )
+      to <- ledgerDao.lookupLedgerEnd()
+      result <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(
+            startExclusive = from,
+            endInclusive = to,
+            filter = Map(
+              alice -> Set(someTemplateId),
+              bob -> Set(otherTemplateId),
+            ),
+            verbose = true,
+          )
+      )
+    } yield {
+      val events = result.loneElement.events.toArray
+      events should have length 2
+      inside(events(0).event.created) { case Some(create) =>
+        create.witnessParties.loneElement shouldBe alice
+        create.templateId.value shouldBe LfEngineToApi.toApiIdentifier(someTemplateId)
+      }
+      inside(events(1).event.created) { case Some(create) =>
+        create.witnessParties.loneElement shouldBe bob
+        create.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+      }
+    }
+  }
+
+  it should "filter correctly by multiple parties with different template and wildcards" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (_, _) <- store(
+        multipleCreates(
+          operator = "operator",
+          signatoriesAndTemplates = Seq(
+            (alice, someTemplateId, someContractArgument),
+            (bob, otherTemplateId, otherContractArgument),
+            (alice, otherTemplateId, otherContractArgument),
+          ),
+        )
+      )
+      to <- ledgerDao.lookupLedgerEnd()
+      result <- transactionsOf(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(
+            startExclusive = from,
+            endInclusive = to,
+            filter = Map(
+              alice -> Set(otherTemplateId),
+              bob -> Set.empty,
+            ),
+            verbose = true,
+          )
+      )
+    } yield {
+      val events = result.loneElement.events.toArray
+      events should have length 2
+      inside(events(0).event.created) { case Some(create) =>
+        create.witnessParties.loneElement shouldBe bob
+        create.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+      }
+      inside(events(1).event.created) { case Some(create) =>
+        create.witnessParties.loneElement shouldBe alice
+        create.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
+      }
+    }
+  }
+
+  it should "return all events in the expected order" in {
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (_, create) <- store(singleCreate)
+      firstContractId = nonTransient(create).loneElement
+      (offset, exercise) <- store(exerciseWithChild(firstContractId))
+      result <- ledgerDao.transactionsReader
+        .getFlatTransactions(
+          from,
+          offset,
+          exercise.actAs.map(submitter => submitter -> Set.empty[Identifier]).toMap,
+          verbose = true,
+        )
+        .runWith(Sink.seq)
+    } yield {
+      import com.daml.ledger.api.v1.event.Event
+      import com.daml.ledger.api.v1.event.Event.Event.{Archived, Created}
+
+      val txs = extractAllTransactions(result)
+
+      inside(txs) { case Vector(tx1, tx2) =>
+        tx1.transactionId shouldBe create.transactionId
+        tx2.transactionId shouldBe exercise.transactionId
+        inside(tx1.events) { case Seq(Event(Created(createdEvent))) =>
+          createdEvent.contractId shouldBe firstContractId.coid
+        }
+        inside(tx2.events) { case Seq(Event(Archived(archivedEvent)), Event(Created(_))) =>
+          archivedEvent.contractId shouldBe firstContractId.coid
+        }
+      }
+    }
+  }
+
+  it should "return the expected flat transaction for the specified offset range" in {
+    for {
+      (_, create1) <- store(singleCreate)
+      (offset1, exercise) <- store(singleExercise(nonTransient(create1).loneElement))
+      (offset2, create2) <- store(singleCreate)
+      result <- ledgerDao.transactionsReader
+        .getFlatTransactions(
+          offset1,
+          offset2,
+          exercise.actAs.map(submitter => submitter -> Set.empty[Identifier]).toMap,
+          verbose = true,
+        )
+        .runWith(Sink.seq)
+
+    } yield {
+      import com.daml.ledger.api.v1.event.Event
+      import com.daml.ledger.api.v1.event.Event.Event.Created
+
+      inside(extractAllTransactions(result)) { case Vector(tx) =>
+        tx.transactionId shouldBe create2.transactionId
+        inside(tx.events) { case Seq(Event(Created(createdEvent))) =>
+          createdEvent.contractId shouldBe nonTransient(create2).loneElement.coid
+        }
+      }
+    }
+  }
+
+  it should "return empty source when offset range is from the future" in {
+    val commands: Vector[(Offset, LedgerEntry.Transaction)] = Vector.fill(3)(singleCreate)
+    val beginOffsetFromTheFuture = nextOffset()
+    val endOffsetFromTheFuture = nextOffset()
+
+    for {
+      _ <- storeSync(commands)
+
+      result <- ledgerDao.transactionsReader
+        .getFlatTransactions(
+          beginOffsetFromTheFuture,
+          endOffsetFromTheFuture,
+          Map(alice -> Set.empty[Identifier]),
+          verbose = true,
+        )
+        .runWith(Sink.seq)
+
+    } yield {
+      extractAllTransactions(result) shouldBe empty
+    }
+  }
+
+  // TODO(Leo): this should be converted to scalacheck test with random offset gaps and pageSize
+  it should "return all transactions in the specified offset range when iterating with gaps in the offsets assigned to events and a page size that ensures a page ends in such a gap" in {
+    // Simulates a gap in the offsets assigned to events, as they
+    // can be assigned to party allocation, package uploads and
+    // configuration updates as well
+    def offsetGap(): Vector[(Offset, LedgerEntry.Transaction)] = {
+      nextOffset()
+      Vector.empty[(Offset, LedgerEntry.Transaction)]
+    }
+
+    // the order of `nextOffset()` calls is important
+    val beginOffset = nextOffset()
+
+    val commandsWithOffsetGaps: Vector[(Offset, LedgerEntry.Transaction)] =
+      Vector(singleCreate) ++ offsetGap() ++
+        Vector.fill(2)(singleCreate) ++ offsetGap() ++
+        Vector.fill(3)(singleCreate) ++ offsetGap() ++ offsetGap() ++
+        Vector.fill(5)(singleCreate)
+
+    val endOffset = nextOffset()
+
+    commandsWithOffsetGaps should have length 11L
+
+    for {
+      _ <- storeSync(commandsWithOffsetGaps)
+
+      // `pageSize = 2` and the offset gaps in the `commandWithOffsetGaps` above are to make sure
+      // that streaming works with event pages separated by offsets that don't have events in the store
+      ledgerDao <- createLedgerDao(pageSize = 2)
+
+      response <- ledgerDao.transactionsReader
+        .getFlatTransactions(
+          beginOffset,
+          endOffset,
+          Map(alice -> Set.empty[Identifier]),
+          verbose = true,
+        )
+        .runWith(Sink.seq)
+
+      readTxs = extractAllTransactions(response)
+    } yield {
+      val readTxOffsets: Vector[String] = readTxs.map(_.offset)
+      readTxOffsets shouldBe readTxOffsets.sorted
+      readTxOffsets shouldBe commandsWithOffsetGaps.map(_._1.toHexString)
+    }
+  }
+
+  it should "fall back to limit-based query with consistent results" in {
+    val txSeqLength = 1000
+    txSeqTrial(
+      trials = 10,
+      txSeq = unfilteredTxSeq(length = txSeqLength),
+      codePath = Gen oneOf getFlatTransactionCodePaths,
+    )
+  }
+
+  private[this] def txSeqTrial(
+      trials: Int,
+      txSeq: Gen[Vector[Boolean]],
+      codePath: Gen[FlatTransactionCodePath],
+  ) = {
+    import JdbcLedgerDaoSuite._
+    import scalaz.std.list._
+    import scalaz.std.scalaFuture._
+
+    val trialData = Gen
+      .listOfN(trials, Gen.zip(txSeq, codePath))
+      .sample getOrElse sys.error("impossible Gen failure")
+
+    trialData
+      .traverseFM { case (boolSeq, cp) =>
+        for {
+          from <- ledgerDao.lookupLedgerEnd()
+          commands <- storeSync(boolSeq map (if (_) cp.makeMatching() else cp.makeNonMatching()))
+          matchingOffsets = commands zip boolSeq collect { case ((off, _), true) =>
+            off.toHexString
+          }
+          to <- ledgerDao.lookupLedgerEnd()
+          response <- ledgerDao.transactionsReader
+            .getFlatTransactions(from, to, cp.filter, verbose = false)
+            .runWith(Sink.seq)
+          readOffsets = response flatMap { case (_, gtr) => gtr.transactions map (_.offset) }
+          readCreates = extractAllTransactions(response) flatMap (_.events)
+        } yield try {
+          readCreates.size should ===(boolSeq count identity)
+          // we check that the offsets from the DB match the ones we had before
+          // submission as a substitute for actually inspecting the events (indeed,
+          // so many of the events are = as written that this would not be useful)
+          readOffsets should ===(matchingOffsets)
+        } catch {
+          case ae: org.scalatest.exceptions.TestFailedException =>
+            throw ae modifyMessage (_ map { msg: String =>
+              msg +
+                "\n  Random parameters:" +
+                s"\n    actual frequency: ${boolSeq.count(identity)}/${boolSeq.size}" +
+                s"\n    code path: ${cp.label}" +
+                s"\n  Please copy the above 4 lines to https://github.com/digital-asset/daml/issues/7521" +
+                s"\n  along with which of (JdbcLedgerDaoPostgresqlSpec, JdbcLedgerDaoH2DatabaseSpec) failed"
+            })
+        }
+      }
+      .map(_.foldLeft(succeed)((_, r) => r))
+  }
+
+  /*
+  it should "get all transactions in order, 48%, onlyWildcardParties" in {
+    val frequency = 48
+    val txSeqLength = 1000
+    val path = "onlyWildcardParties"
+    txSeqTrial(
+      250,
+      unfilteredTxFrequencySeq(txSeqLength, frequencyPct = frequency),
+      getFlatTransactionCodePaths find (_.label == path) getOrElse fail(s"$path not found"))
+  }
+   */
+
+  private def storeTestFixture(): Future[(Offset, Offset, Seq[LedgerEntry.Transaction])] =
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (_, t1) <- store(singleCreate)
+      (_, t2) <- store(singleCreate)
+      (_, t3) <- store(singleExercise(nonTransient(t2).loneElement))
+      (_, t4) <- store(fullyTransient)
+      to <- ledgerDao.lookupLedgerEnd()
+    } yield (from, to, Seq(t1, t2, t3, t4))
+
+  private def lookupIndividually(
+      transactions: Seq[LedgerEntry.Transaction],
+      as: Set[Party],
+  ): Future[Seq[Transaction]] =
+    Future
+      .sequence(
+        transactions.map(tx =>
+          ledgerDao.transactionsReader
+            .lookupFlatTransactionById(tx.transactionId, as)
+        )
+      )
+      .map(_.flatMap(_.toList.flatMap(_.transaction.toList)))
+
+  private def transactionsOf(
+      source: Source[(Offset, GetTransactionsResponse), NotUsed]
+  ): Future[Seq[Transaction]] =
+    source
+      .map(_._2)
+      .runWith(Sink.seq)
+      .map(_.flatMap(_.transactions))
+
+  // Ensure two sequences of transactions are comparable:
+  // - witnesses do not have to appear in a specific order
+  private def comparable(txs: Seq[Transaction]): Seq[Transaction] =
+    txs.map(tx => tx.copy(events = tx.events.map(_.modifyWitnessParties(_.sorted))))
+
+  private def extractAllTransactions(
+      responses: Seq[(Offset, GetTransactionsResponse)]
+  ): Vector[Transaction] =
+    responses.foldLeft(Vector.empty[Transaction])((b, a) => b ++ a._2.transactions.toVector)
+
+  private def createLedgerDao(pageSize: Int) =
+    LoggingContext.newLoggingContext { implicit loggingContext =>
+      daoOwner(eventsPageSize = pageSize).acquire()(ResourceContext(executionContext))
+    }.asFuture
+
+  // XXX SC much of this is repeated because we're more concerned here
+  // with whether each query is tested than whether the specifics of the
+  // predicate are accurate. To test the latter, the creation would have
+  // to have much more detail and should be a pair of Gen[Offset => LedgerEntry.Transaction]
+  // rather than a pair of simple side-effecting procedures that always
+  // produce more or less the same data.  If we aren't interested in testing
+  // the latter at any point, we can remove most of this.
+  private val getFlatTransactionCodePaths: Seq[FlatTransactionCodePath] = {
+    import JdbcLedgerDaoTransactionsSpec.{FlatTransactionCodePath => Mk}
+    Seq(
+      Mk(
+        "singleWildcardParty",
+        Map(alice -> Set.empty),
+        () => singleCreate(create(_, signatories = Set(alice))),
+        () => singleCreate(create(_, signatories = Set(bob))),
+        ce => (ce.signatories ++ ce.observers) contains alice,
+      ),
+      Mk(
+        "singlePartyWithTemplates",
+        Map(alice -> Set(someTemplateId)),
+        () => singleCreate(create(_, signatories = Set(alice))),
+        () => singleCreate(create(_, signatories = Set(bob))),
+        ce =>
+          ((ce.signatories ++ ce.observers) contains alice), /*TODO && ce.templateId == Some(someTemplateId.toString)*/
+      ),
+      Mk(
+        "onlyWildcardParties",
+        Map(alice -> Set.empty, bob -> Set.empty),
+        () => singleCreate(create(_, signatories = Set(alice))),
+        () => singleCreate(create(_, signatories = Set(charlie))),
+        ce => (ce.signatories ++ ce.observers) exists Set(alice, bob),
+      ),
+      Mk(
+        "sameTemplates",
+        Map(alice -> Set(someTemplateId), bob -> Set(someTemplateId)),
+        () => singleCreate(create(_, signatories = Set(alice))),
+        () => singleCreate(create(_, signatories = Set(charlie))),
+        ce => (ce.signatories ++ ce.observers) exists Set(alice, bob),
+      ),
+      Mk(
+        "mixedTemplates",
+        Map(alice -> Set(someTemplateId), bob -> Set(otherTemplateId)),
+        () => singleCreate(create(_, signatories = Set(alice))),
+        () => singleCreate(create(_, signatories = Set(charlie))),
+        ce => (ce.signatories ++ ce.observers) exists Set(alice, bob),
+      ),
+      Mk(
+        "mixedTemplatesWithWildcardParties",
+        Map(alice -> Set(someTemplateId), bob -> Set.empty),
+        () => singleCreate(create(_, signatories = Set(alice))),
+        () => singleCreate(create(_, signatories = Set(charlie))),
+        ce => (ce.signatories ++ ce.observers) exists Set(alice, bob),
+      ),
+    )
+  }
+}
+
+private[appendonlydao] object JdbcLedgerDaoTransactionsSpec {
+  private final case class FlatTransactionCodePath(
+      label: String,
+      filter: events.FilterRelation,
+      makeMatching: () => (Offset, LedgerEntry.Transaction),
+      makeNonMatching: () => (Offset, LedgerEntry.Transaction),
+      // XXX SC we don't need discriminate unless we test the event contents
+      // instead of just the offsets
+      discriminate: lav1.event.CreatedEvent => Boolean = _ => false,
+  )
+
+  private def unfilteredTxSeq(length: Int): Gen[Vector[Boolean]] =
+    Gen.oneOf(1, 2, 5, 10, 20, 50, 100) flatMap { invFreq =>
+      unfilteredTxFrequencySeq(length, frequencyPct = 100 / invFreq)
+    }
+
+  private def unfilteredTxFrequencySeq(length: Int, frequencyPct: Int): Gen[Vector[Boolean]] =
+    Gen.containerOfN[Vector, Boolean](
+      length,
+      Gen.frequency((frequencyPct, true), (100 - frequencyPct, false)),
+    )
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoTransactionsWriterSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/appendonlydao/JdbcLedgerDaoTransactionsWriterSpec.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import org.scalatest.LoneElement
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+private[appendonlydao] trait JdbcLedgerDaoTransactionsWriterSpec extends LoneElement {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  private val ok = io.grpc.Status.Code.OK.value()
+
+  behavior of "JdbcLedgerDao (TransactionsWriter)"
+
+  it should "serialize a valid positive lookupByKey" in {
+    val keyValue = "positive-lookup-by-key"
+
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (_, create) <- store(txCreateContractWithKey(alice, keyValue))
+      createdContractId = nonTransient(create).loneElement
+      (_, lookup) <- store(txLookupByKey(alice, keyValue, Some(createdContractId)))
+      to <- ledgerDao.lookupLedgerEnd()
+      completions <- getCompletions(from, to, defaultAppId, Set(alice))
+    } yield {
+      completions should contain.allOf(
+        create.commandId.get -> ok,
+        lookup.commandId.get -> ok,
+      )
+    }
+  }
+
+  it should "serialize a valid fetch" in {
+    val keyValue = "valid-fetch"
+
+    for {
+      from <- ledgerDao.lookupLedgerEnd()
+      (_, create) <- store(txCreateContractWithKey(alice, keyValue))
+      createdContractId = nonTransient(create).loneElement
+      (_, fetch) <- store(txFetch(alice, createdContractId))
+      to <- ledgerDao.lookupLedgerEnd()
+      completions <- getCompletions(from, to, defaultAppId, Set(alice))
+    } yield {
+      completions should contain.allOf(
+        create.commandId.get -> ok,
+        fetch.commandId.get -> ok,
+      )
+    }
+  }
+
+  // TODO Remove once decided that we don't need to assert blinding info since it is not used with the SqlLedger
+//  it should "prefer pre-computed blinding info" in {
+//    val mismatchingBlindingInfo =
+//      BlindingInfo(Map(NodeId(0) -> Set(Ref.Party.assertFromString("zoe"))), Map())
+//    for {
+//      (_, tx) <- store(
+//        offsetAndTx = singleCreate,
+//        blindingInfo = Some(mismatchingBlindingInfo),
+//        divulgedContracts = Map.empty,
+//      )
+//      result <- ledgerDao.lookupActiveOrDivulgedContract(nonTransient(tx).loneElement, Set(alice))
+//    } yield {
+//      result shouldBe None
+//    }
+//  }
+
+  // TODO do we need incremental offset checks for append-only?
+//  it should "fail trying to store transactions with non-incremental offsets" in {
+//    val (offset, tx) = singleCreate
+//    recoverToSucceededIf[LedgerEndUpdateError](
+//      storeOffsetStepAndTx(
+//        offsetStepAndTx = IncrementalOffsetStep(nextOffset(), offset) -> tx,
+//        blindingInfo = None,
+//        divulgedContracts = Map.empty,
+//      )
+//    )
+//  }
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcAtomicTransactionInsertion.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcAtomicTransactionInsertion.scala
@@ -41,6 +41,7 @@ trait JdbcAtomicTransactionInsertion {
         offsetStep = offsetStep,
         divulged = divulgedContracts,
         ledgerEffectiveTime = tx.ledgerEffectiveTime,
+        workflowId = tx.workflowId,
       )
     } yield offsetStep.offset -> tx
   }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ExecuteUpdateSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ExecuteUpdateSpec.scala
@@ -130,6 +130,7 @@ final class ExecuteUpdateSpec
         offsetStep = eqTo(CurrentOffset(offset)),
         transaction = eqTo(txMock),
         divulged = eqTo(List.empty[DivulgedContract]),
+        workflowId = None,
       )(any[LoggingContext])
     ).thenReturn(Future.successful(PersistenceResponse.Ok))
     dao
@@ -318,6 +319,7 @@ final class ExecuteUpdateSpec
                     offsetStep = eqTo(CurrentOffset(offset)),
                     transaction = eqTo(txMock),
                     divulged = eqTo(List.empty[DivulgedContract]),
+                    workflowId = None,
                   )(any[LoggingContext])
                 orderedEvents
                   .verify(ledgerDaoMock)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/JdbcLedgerDaoPostgresqlSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/JdbcLedgerDaoPostgresqlSpec.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao
+
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+// Aggregate all specs in a single run to not start a new database fixture for each one
+final class JdbcLedgerDaoPostgresqlSpec
+    extends AsyncFlatSpec
+    with Matchers
+    with JdbcLedgerDaoSuite
+    with JdbcLedgerDaoBackendPostgresql
+    with JdbcLedgerDaoPackagesSpec
+    with JdbcLedgerDaoActiveContractsSpec
+    with JdbcLedgerDaoCompletionsSpec
+    with JdbcLedgerDaoConfigurationSpec
+    with JdbcLedgerDaoContractsSpec
+    with JdbcLedgerDaoDivulgenceSpec
+    with JdbcLedgerDaoPartiesSpec
+    with JdbcLedgerDaoTransactionsSpec
+    with JdbcLedgerDaoTransactionTreesSpec
+    with JdbcLedgerDaoTransactionsWriterSpec

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -411,6 +411,7 @@ private final class SqlLedger(
               CurrentOffset(offset),
               transactionCommitter.commitTransaction(transactionId, transaction),
               divulgedContracts,
+              transactionMeta.workflowId,
             )
           },
         )


### PR DESCRIPTION
Implemented ingestion methods for append-only backed JdbcLedgerDao. These changes were needed in order to allow testing the append-only schema with the existing JdbcLedgerDao test suite.

**Important changes**
* Update PostgreSQL nix to 11.
* Pass `workflowId` through `LedgerDao.storeTransaction`.
* Implement all ingestion methods with one exception (see below) in `appendonly.JdbcLedgerDao` similarly to `dao.JdbcLedgerDao`. 

Not implemented yet in `JdbcLedgerDao`, but required for DAML-on-SQL:
* `storeInitialState`
* Post-commit validation in `storeTransaction`

_Hint: For time-effective reviews, one can mostly ignore the test classes in appendonlydao since they are almost fully-copied versions of their dao counterparts_
### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
