### PR TITLE
Extend prometheus metrics with min/mean/max values

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/io/prometheus/client/dropwizard/DropwizardExportsAccess.scala
+++ b/ledger/participant-integration-api/src/main/scala/io/prometheus/client/dropwizard/DropwizardExportsAccess.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.prometheus.client.dropwizard
+
+import com.codahale.metrics.{MetricRegistry, Snapshot}
+import io.prometheus.client.Collector
+import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder
+
+/** This is a work-around to open up package-private `DropwizardExports` methods so that we can expose
+  * min/mean/max metrics. Those values are absent in the official prometheus implementation but are
+  * an essential part of the ledger performance reporting and feature heavily in other back-end
+  * integrations as well as metrics dashboards.
+  *
+  * @param metricRegistry metric registry instance to wrap
+  */
+class DropwizardExportsAccess(metricRegistry: MetricRegistry)
+    extends DropwizardExports(metricRegistry) {
+
+  final val sampleBuilder = new DefaultSampleBuilder()
+
+  override def fromSnapshotAndCount(
+      dropwizardName: String,
+      snapshot: Snapshot,
+      count: Long,
+      factor: Double,
+      helpMessage: String,
+  ): Collector.MetricFamilySamples =
+    super.fromSnapshotAndCount(dropwizardName, snapshot, count, factor, helpMessage)
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/ExtendedDropwizardExports.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/ExtendedDropwizardExports.scala
@@ -24,7 +24,7 @@ final class ExtendedDropwizardExports(metricRegistry: MetricRegistry)
     val basicMetricFamilySamples =
       super.fromSnapshotAndCount(dropwizardName, snapshot, count, factor, helpMessage)
 
-    val additionalMetrics = basicMetricFamilySamples.samples.asScala ++ List(
+    val extendedMetrics = basicMetricFamilySamples.samples.asScala ++ List(
       sampleBuilder
         .createSample(
           dropwizardName,
@@ -53,7 +53,7 @@ final class ExtendedDropwizardExports(metricRegistry: MetricRegistry)
       basicMetricFamilySamples.name,
       basicMetricFamilySamples.`type`,
       basicMetricFamilySamples.help,
-      additionalMetrics.asJava,
+      extendedMetrics.asJava,
     )
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/ExtendedDropwizardExports.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/ExtendedDropwizardExports.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.configuration
+
+import java.util.Collections
+import scala.jdk.CollectionConverters._
+
+import com.codahale.metrics.{MetricRegistry, Snapshot}
+import io.prometheus.client.Collector.MetricFamilySamples
+import io.prometheus.client.dropwizard.DropwizardExportsAccess
+
+final class ExtendedDropwizardExports(metricRegistry: MetricRegistry)
+    extends DropwizardExportsAccess(metricRegistry) {
+
+  override def fromSnapshotAndCount(
+      dropwizardName: String,
+      snapshot: Snapshot,
+      count: Long,
+      factor: Double,
+      helpMessage: String,
+  ): MetricFamilySamples = {
+
+    val basicMetricFamilySamples =
+      super.fromSnapshotAndCount(dropwizardName, snapshot, count, factor, helpMessage)
+
+    val additionalMetrics = basicMetricFamilySamples.samples.asScala ++ List(
+      sampleBuilder
+        .createSample(
+          dropwizardName,
+          "_min",
+          EmptyJavaList,
+          EmptyJavaList,
+          snapshot.getMin * factor,
+        ),
+      sampleBuilder.createSample(
+        dropwizardName,
+        "_mean",
+        EmptyJavaList,
+        EmptyJavaList,
+        snapshot.getMean * factor,
+      ),
+      sampleBuilder.createSample(
+        dropwizardName,
+        "_max",
+        EmptyJavaList,
+        EmptyJavaList,
+        snapshot.getMax * factor,
+      ),
+    )
+
+    new MetricFamilySamples(
+      basicMetricFamilySamples.name,
+      basicMetricFamilySamples.`type`,
+      basicMetricFamilySamples.help,
+      additionalMetrics.asJava,
+    )
+  }
+
+  private val EmptyJavaList = Collections.emptyList[String]()
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/PrometheusReporter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/PrometheusReporter.scala
@@ -38,7 +38,7 @@ final class PrometheusReporter private (
     ) {
   private val logger = LoggerFactory.getLogger(getClass)
   private val server = new HTTPServer(address.getHostName, address.getPort)
-  private val exports = new DropwizardExports(registry).register[DropwizardExports]()
+  private val exports = new ExtendedDropwizardExports(registry).register[DropwizardExports]()
   logger.info(s"Reporting prometheus metrics on ${address}")
 
   override def report(


### PR DESCRIPTION
This is a work-around to open up package-private `DropwizardExports` methods so that we can expose min/mean/max metrics. Those values are absent in the official prometheus implementation but are an essential part of the ledger performance reporting and feature heavily in other back-end integrations as well as metrics dashboards.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
