### PR TITLE
Pattern matching for RoundingMode

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -204,14 +204,15 @@ instance Pretty PartyLiteral where
   pPrint = quotes . text . unPartyLiteral
 
 prettyRounding :: RoundingModeLiteral -> String
-prettyRounding LitRoundingUp = "ROUNDING_UP"
-prettyRounding LitRoundingDown = "ROUNDING_DOWN"
-prettyRounding LitRoundingCeiling = "ROUNDING_CEILING"
-prettyRounding LitRoundingFloor = "ROUNDING_FLOOR"
-prettyRounding LitRoundingHalfUp = "ROUNDING_HALF_UP"
-prettyRounding LitRoundingHalfDown = "ROUNDING_HALF_DOWN"
-prettyRounding LitRoundingHalfEven = "ROUNDING_HALF_EVEN"
-prettyRounding LitRoundingUnnecessary = "ROUNDING_UNNECESSARY"
+prettyRounding = \case
+  LitRoundingUp -> "ROUNDING_UP"
+  LitRoundingDown -> "ROUNDING_DOWN"
+  LitRoundingCeiling -> "ROUNDING_CEILING"
+  LitRoundingFloor -> "ROUNDING_FLOOR"
+  LitRoundingHalfUp -> "ROUNDING_HALF_UP"
+  LitRoundingHalfDown -> "ROUNDING_HALF_DOWN"
+  LitRoundingHalfEven -> "ROUNDING_HALF_EVEN"
+  LitRoundingUnnecessary -> "ROUNDING_UNNECESSARY"
 
 instance Pretty BuiltinExpr where
   pPrintPrec lvl prec = \case

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -770,8 +770,8 @@ decodePrimLit (LF1.PrimLit mbSum) = mayDecode "primLitSum" mbSum $ \case
     Proto.Enumerated (Right mode) -> pure $ case mode of
        LF1.PrimLit_RoundingModeUP -> BERoundingMode LitRoundingUp
        LF1.PrimLit_RoundingModeDOWN -> BERoundingMode LitRoundingDown
-       LF1.PrimLit_RoundingModeFLOOR -> BERoundingMode LitRoundingFloor
        LF1.PrimLit_RoundingModeCEILING -> BERoundingMode LitRoundingCeiling
+       LF1.PrimLit_RoundingModeFLOOR -> BERoundingMode LitRoundingFloor
        LF1.PrimLit_RoundingModeHALF_UP -> BERoundingMode LitRoundingHalfUp
        LF1.PrimLit_RoundingModeHALF_DOWN -> BERoundingMode LitRoundingHalfDown
        LF1.PrimLit_RoundingModeHALF_EVEN -> BERoundingMode LitRoundingHalfEven

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1301,10 +1301,10 @@ mkCase env scrutineeType resultType scrutinee galts =
             CaseAlternative CPDefault _ -> Right [alt]
             _ -> Right [alt, CaseAlternative CPDefault e]
     addCaseAlternative (GCAEquality EqualityAlternative{..}) elseBranch =
-        Left (mkIf (mkScrutineEquality eqaltPattern) eqaltBody (finalize elseBranch))
+        Left (mkIf (mkScrutineeEquality eqaltPattern) eqaltBody (finalize elseBranch))
 
-    mkScrutineEquality :: LF.Expr -> LF.Expr
-    mkScrutineEquality pattern
+    mkScrutineeEquality :: LF.Expr -> LF.Expr
+    mkScrutineeEquality pattern
         | TBuiltin scrutineeBuiltinType <- scrutineeType
         = mkBuiltinEqual (envLfVersion env) scrutineeBuiltinType `ETmApp` scrutinee `ETmApp` pattern
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1258,29 +1258,14 @@ data GeneralisedCasePattern
     deriving (Eq, Ord)
 
 -- | Generalised case alternative
-data GeneralisedCaseAlternative = GCA
-    { gcaPattern :: GeneralisedCasePattern
-    , gcaRHS :: LF.Expr
-        -- ^ Right-hand side of case alternative.
-    } deriving (Eq, Ord)
+data GeneralisedCaseAlternative = GCA GeneralisedCasePattern LF.Expr
+    deriving (Eq, Ord)
 
 -- | Is this a normal case alternative?
 isNormalCaseAlternative :: GeneralisedCaseAlternative -> Bool
 isNormalCaseAlternative = \case
     GCA (GCPNormal _) _ -> True
     _ -> False
-
--- | Represents a case alternative that is not directly supported
--- by LF's CaseAlternative syntax. In particular the pattern here
--- is some expression that we want to use the built-in equality
--- to match.
-data EqualityAlternative = EqualityAlternative
-    { eqaltPattern :: LF.Expr
-        -- ^ Pattern expression to test against. This is an inert
-        -- expression (can't raise errors, e.g. a constructor).
-    , eqaltBody :: LF.Expr
-        -- ^ Right-hand side of case alternative. Potentially divergent.
-    } deriving (Eq, Ord)
 
 -- | Represents the body of a generalised case expression.
 data GeneralisedCaseBody

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -437,31 +437,6 @@ convertPrim _ "UTryCatch" ((TUnit :-> TUpdate t1) :-> (TBuiltin BTAnyException :
             (mkVar "x")
             (EVar (mkVar "c") `ETmApp` EVar (mkVar "x"))
 
-convertPrim version "BERoundingUp" TRoundingMode =
-    whenRuntimeSupports version featureBigNumeric TRoundingMode $
-      EBuiltin $ BERoundingMode LitRoundingUp
-convertPrim version "BERoundingDown" TRoundingMode =
-    whenRuntimeSupports version featureBigNumeric TRoundingMode $
-      EBuiltin $ BERoundingMode LitRoundingDown
-convertPrim version "BERoundingCeiling" TRoundingMode =
-    whenRuntimeSupports version featureBigNumeric TRoundingMode $
-      EBuiltin $ BERoundingMode LitRoundingCeiling
-convertPrim version "BERoundingFloor" TRoundingMode =
-    whenRuntimeSupports version featureBigNumeric TRoundingMode $
-      EBuiltin $ BERoundingMode LitRoundingFloor
-convertPrim version "BERoundingHalfUp" TRoundingMode =
-    whenRuntimeSupports version featureBigNumeric TRoundingMode $
-      EBuiltin $ BERoundingMode LitRoundingHalfUp
-convertPrim version "BERoundingHalfDown" TRoundingMode =
-    whenRuntimeSupports version featureBigNumeric TRoundingMode $
-      EBuiltin $ BERoundingMode LitRoundingHalfDown
-convertPrim version "BERoundingHalfEven" TRoundingMode =
-    whenRuntimeSupports version featureBigNumeric TRoundingMode $
-      EBuiltin $ BERoundingMode LitRoundingHalfEven
-convertPrim version "BERoundingUnnecessary" TRoundingMode =
-    whenRuntimeSupports version featureBigNumeric TRoundingMode $
-      EBuiltin $ BERoundingMode LitRoundingUnnecessary
-
 convertPrim (V1 PointDev) (L.stripPrefix "$" -> Just builtin) typ =
     EExperimental (T.pack builtin) typ
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
@@ -199,13 +199,13 @@ toRoundingModeLiteral x = MS.lookup x roundingModeLiteralMap
 
 roundingModeLiteralMap :: MS.Map T.Text LF.RoundingModeLiteral
 roundingModeLiteralMap = MS.fromList
-    [ ("RoundingCeiling", LF.LitRoundingCeiling)
-    , ("RoundingFloor", LF.LitRoundingFloor)
+    [ ("RoundingUp", LF.LitRoundingUp)
     , ("RoundingDown", LF.LitRoundingDown)
-    , ("RoundingUp", LF.LitRoundingUp)
+    , ("RoundingCeiling", LF.LitRoundingCeiling)
+    , ("RoundingFloor", LF.LitRoundingFloor)
+    , ("RoundingHalfUp", LF.LitRoundingHalfUp)
     , ("RoundingHalfDown", LF.LitRoundingHalfDown)
     , ("RoundingHalfEven", LF.LitRoundingHalfEven)
-    , ("RoundingHalfUp", LF.LitRoundingHalfUp)
     , ("RoundingUnnecessary", LF.LitRoundingUnnecessary)
     ]
 

--- a/compiler/damlc/daml-prim-src/GHC/Num.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Num.daml
@@ -25,7 +25,6 @@ import GHC.CString (fromString)
 import GHC.Err (error)
 import GHC.Integer.Type
 import GHC.Real
-import GHC.Show
 import GHC.Types
 
 default ()              -- Double isn't available yet,
@@ -176,9 +175,6 @@ instance Number BigNumeric
 instance Signed BigNumeric where
     signum x = if x == aunit then aunit else if x <= aunit then negate munit else munit
     abs x = if x <= aunit then negate x else x
-
-instance Show BigNumeric where
-    show = primitive @"BEToTextBigNumeric"
 
 #endif
 

--- a/compiler/damlc/daml-prim-src/GHC/Show.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Show.daml
@@ -122,6 +122,21 @@ instance Show Decimal where
   show = primitive @"BEToText"
 #endif
 
+#ifdef DAML_BIGNUMERIC
+instance Show BigNumeric where
+  show = primitive @"BEToTextBigNumeric"
+instance Show RoundingMode where
+  show = \case
+    RoundingUp -> "RoundingUp"
+    RoundingDown -> "RoundingDown"
+    RoundingCeiling -> "RoundingCeiling"
+    RoundingFloor -> "RoundingFloor"
+    RoundingHalfUp -> "RoundingHalfUp"
+    RoundingHalfDown -> "RoundingHalfDown"
+    RoundingHalfEven -> "RoundingHalfEven"
+    RoundingUnnecessary -> "RoundingUnnecessary"
+#endif
+
 instance Show Text where
   show x = "\"" ++ x ++ "\""
 

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -224,19 +224,19 @@ data BigNumeric =
 
 -- | Rounding modes for `BigNumeric` operations like `div` and `round` from `DA.BigNumeric`.
 data RoundingMode
-  = RoundingCeiling -- ^ Round towards positive infinity.
-  | RoundingFloor -- ^ Round towards negative infinity.
+  = RoundingUp -- ^ Round away from zero.
   | RoundingDown -- ^ Round towards zero.
-  | RoundingUp -- ^ Round away from zero.
+  | RoundingCeiling -- ^ Round towards positive infinity.
+  | RoundingFloor -- ^ Round towards negative infinity.
+  | RoundingHalfUp
+      -- ^ Round towards the nearest neighbor unless both neighbors
+      -- are equidistant, in which case round away from zero.
   | RoundingHalfDown
       -- ^ Round towards the nearest neighbor unless both neighbors
       -- are equidistant, in which case round towards zero.
   | RoundingHalfEven
       -- ^ Round towards the nearest neighbor unless both neighbors
       -- are equidistant, in which case round towards the even neighbor.
-  | RoundingHalfUp
-      -- ^ Round towards the nearest neighbor unless both neighbors
-      -- are equidistant, in which case round away from zero.
   | RoundingUnnecessary
       -- ^ Do not round. Raises an error if the result cannot
       -- be represented without rounding at the targeted scale.

--- a/compiler/damlc/tests/daml-test-files/RoundingModeMatch.daml
+++ b/compiler/damlc/tests/daml-test-files/RoundingModeMatch.daml
@@ -3,10 +3,28 @@
 
 -- @SINCE-LF 1.13
 
--- | Test that you get errors when trying to pattern match on rounding mode.
+-- | Test that pattern matching for RoundingMode works.
 module RoundingModeMatch where
 
--- @ERROR Pattern matching on RoundingMode is not currently supported
+import DA.Assert ((===))
+
 foo : RoundingMode -> Int
-foo RoundingCeiling = 10
-foo _ = 20
+foo = \case
+    RoundingUp -> 1
+    RoundingDown -> 2
+    RoundingCeiling -> 3
+    RoundingFloor -> 4
+    RoundingHalfUp -> 5
+    RoundingHalfDown -> 6
+    RoundingHalfEven -> 7
+    RoundingUnnecessary -> 8
+
+test = scenario do
+    foo RoundingUp === 1
+    foo RoundingDown === 2
+    foo RoundingCeiling === 3
+    foo RoundingFloor === 4
+    foo RoundingHalfUp === 5
+    foo RoundingHalfDown === 6
+    foo RoundingHalfEven === 7
+    foo RoundingUnnecessary === 8

--- a/compiler/damlc/tests/daml-test-files/RoundingModeOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/RoundingModeOrder.daml
@@ -1,0 +1,28 @@
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @SINCE-LF 1.13
+
+-- | Test that rounding mode order matches the order in GHC.Types
+module RoundingModeOrder where
+
+import DA.Assert ((===))
+import qualified DA.List
+import qualified DA.List.BuiltinOrder
+
+roundingModes =
+    [ RoundingUp
+    , RoundingDown
+    , RoundingCeiling
+    , RoundingFloor
+    , RoundingHalfUp
+    , RoundingHalfDown
+    , RoundingHalfEven
+    , RoundingUnnecessary
+    ]
+
+test1 = scenario do
+    roundingModes === DA.List.sort roundingModes
+
+test2 = scenario do
+    roundingModes === DA.List.BuiltinOrder.sort roundingModes

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -3807,13 +3807,17 @@ BigNumeric functions
   the given scale, the result is rounded accordingly the
   ``roundingMode`` as follows:
 
+  - ``'ROUNDING_UP'`` : Round away from zero
+
+  - ``'ROUNDING_DOWN'`` : Rounds towards zero
+
   - ``'ROUNDING_CEILING'`` : Rounds towards positive infinity.
 
   - ``'ROUNDING_FLOOR'`` : Rounds towards negative infinity
 
-  - ``'ROUNDING_DOWN'`` : Rounds towards towards zero
-
-  - ``'ROUNDING_UP'`` : Round towards away from zero
+  - ``'ROUNDING_HALF_UP'`` : Round towards the nearest neighbor unless
+    both neighbors are equidistant, in which case round away from
+    zero.
 
   - ``'ROUNDING_HALF_DOWN'`` : Round towards the nearest neighbor
     unless both neighbors are equidistant, in which case round towards
@@ -3822,10 +3826,6 @@ BigNumeric functions
   - ``'ROUNDING_HALF_EVEN'`` : Rounds towards the nearest neighbor
     unless both neighbors are equidistant, in which case round towards
     the even neighbor.
-
-  - ``'ROUNDING_HALF_UP'`` : Round towards the nearest neighbor unless
-    both neighbors are equidistant, in which case round away from
-    zero.
 
   - ``'ROUNDING_UNNECESSARY'`` : Throw `ArithmeticError` if the exact result cannot be
     represented.


### PR DESCRIPTION
- Fix the order of RoundingMode constructors in GHC.Types to match the LF built-in order. Try to match this order across all code and documentation, and added a test for this order.
- Implements pattern matching for RoundingMode. The added machinery could also be useful for solving #5753 in the future.
- Implements Show instance for RoundingMode. (Mainly so we can use them in tests via DA.Assert. Nice to have either way.) Moved BigNumeric Show instance to GHC.Show.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
