### PR TITLE
daml-sdk-head speed improvement proposal

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -381,9 +381,10 @@ rm -f {jar_output}
 def _scaladoc_jar_impl(ctx):
     # Detect an actual scala source file rather than a srcjar or other label
     srcFiles = [
-        src.path
-        for src in ctx.files.srcs
-        if src.is_source or src in ctx.files.generated_srcs
+# TODO: add a config param to omit the below
+#        src.path
+#        for src in ctx.files.srcs
+#        if src.is_source or src in ctx.files.generated_srcs
     ]
 
     if srcFiles != []:


### PR DESCRIPTION
Recently, I had to switch between the sdk repo and the integration kit repo a lot. Therefore, I had to constantly run `daml-sdk-head` which, initially, was taking ~15 min on my machine:
```
Done installing JARs as 0.0.0.

________________________________________________________
Executed in   17.75 mins    fish           external
   usr time   14.82 secs    0.32 millis   14.82 secs
   sys time    9.12 secs    2.01 millis    9.11 secs
```
It's a bit long feedback loop.

This change reduces the time to ~5 min, as most of the time is spent generating scaladocs:
```
Done installing JARs as 0.0.0.

________________________________________________________
Executed in  289.21 secs    fish           external
   usr time   12.67 secs    0.24 millis   12.67 secs
   sys time    7.50 secs    1.34 millis    7.50 secs
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
