### PR TITLE
Fix scala version in quickstart-scala

### DIFF
--- a/language-support/scala/examples/BUILD.bazel
+++ b/language-support/scala/examples/BUILD.bazel
@@ -9,6 +9,7 @@ load(
 )
 load("//rules_daml:daml.bzl", "daml_compile")
 load("//language-support/scala/codegen:codegen.bzl", "dar_to_scala")
+load("@scala_version//:index.bzl", "scala_version")
 
 filegroup(
     name = "quickstart-scala-src",
@@ -23,21 +24,28 @@ filegroup(
 )
 
 genrule(
-    name = "quickstart-scala-dir",
+    name = "quickstart-scala",
     srcs = [
         ":quickstart-scala-src",
         "//docs:daml-assistant-iou-setup",
     ],
-    outs = ["quickstart-scala"],
+    outs = ["quickstart-scala.tar"],
     cmd = """
-        mkdir -p $@
-        cp -rL $(SRCS) $@
+        DIR=$$(mktemp -d)
+        mkdir $$DIR/quickstart-scala
+        trap "rm -rf $$DIR" EXIT
+        cp -rL $(SRCS) $$DIR/quickstart-scala/
+        sed -i 's/SCALA_VERSION/{scala_version}/' $$DIR/quickstart-scala/build.sbt
         rm -rf $@/target
         rm -rf $@/project/target
         rm -rf $@/application/target
         rm -rf $@/scala-codegen/target
-    """,
-    tools = [":quickstart-scala-bin"],  # this is to make sure that quickstart-scala compiles
+        $(execpath //bazel_tools/sh:mktar) $@ -C $$DIR quickstart-scala
+    """.format(scala_version = scala_version),
+    tools = [
+        ":quickstart-scala-bin",
+        "//bazel_tools/sh:mktar",
+    ],  # this is to make sure that quickstart-scala compiles
     visibility = ["//visibility:public"],
 )
 

--- a/language-support/scala/examples/quickstart-scala/build.sbt
+++ b/language-support/scala/examples/quickstart-scala/build.sbt
@@ -3,7 +3,7 @@ import sbt._
 import Versions._
 
 version in ThisBuild := "0.0.1"
-scalaVersion in ThisBuild := "2.12.8"
+scalaVersion in ThisBuild := "SCALA_VERSION"
 isSnapshot := true
 
 lazy val parent = project

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -57,7 +57,7 @@ genrule(
         "//docs:daml-patterns",
         "//docs:copy-trigger-template",
         "//docs:script-example-template",
-        "//language-support/scala/examples:quickstart-scala-dir",
+        "//language-support/scala/examples:quickstart-scala.tar",
     ],
     outs = ["templates-tarball.tar.gz"],
     cmd = """
@@ -90,7 +90,7 @@ EOF
         tar xf $(location //docs:quickstart-java.tar.gz) --strip-components=1 -C $$OUT/quickstart-java
 
         # quickstart-scala template
-        cp -r $(location //language-support/scala/examples:quickstart-scala-dir)/* $$OUT/quickstart-scala/
+        tar xf $(location //language-support/scala/examples:quickstart-scala.tar) --strip-components=1 -C $$OUT/quickstart-scala/
 
         # daml intro templates
         tar xf $(location //docs:daml-intro-templates) -C $$OUT


### PR DESCRIPTION
Setting this manually has resulted in #9397 where we use a scala
version that doesn’t have a silencer version. This PR changes the
quickstart template to use the scala version we also use in our builds
which should avoid them getting out of sync in the future.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
