### PR TITLE
Avoid assertFromString in validateParties

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/PostCommitValidation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/PostCommitValidation.scala
@@ -111,14 +111,14 @@ private[appendonlydao] object PostCommitValidation {
         transaction: CommittedTransaction
     )(implicit connection: Connection): Option[RejectionReason] = {
       def foldInformees[T](tx: CommittedTransaction, init: T)(
-          f: (T, String) => T
+          f: (T, Party) => T
       ): T =
         tx.fold(init) { case (accum, (_, node)) =>
           node.informeesOfNode.foldLeft(accum)(f)
         }
 
       val informees = foldInformees(transaction, Seq.empty[Party]) { (informeesSoFar, partyId) =>
-        Party.assertFromString(partyId) +: informeesSoFar
+        partyId +: informeesSoFar
       }
       val allocatedInformees = data.lookupParties(informees).map(_.party)
       if (allocatedInformees.toSet == informees.toSet)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/PostCommitValidation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/PostCommitValidation.scala
@@ -111,14 +111,14 @@ private[dao] object PostCommitValidation {
         transaction: CommittedTransaction
     )(implicit connection: Connection): Option[RejectionReason] = {
       def foldInformees[T](tx: CommittedTransaction, init: T)(
-          f: (T, String) => T
+          f: (T, Party) => T
       ): T =
         tx.fold(init) { case (accum, (_, node)) =>
           node.informeesOfNode.foldLeft(accum)(f)
         }
 
       val informees = foldInformees(transaction, Seq.empty[Party]) { (informeesSoFar, partyId) =>
-        Party.assertFromString(partyId) +: informeesSoFar
+        partyId +: informeesSoFar
       }
       val allocatedInformees = data.lookupParties(informees).map(_.party)
       if (allocatedInformees.toSet == informees.toSet)


### PR DESCRIPTION
Random drive-by PR since I stumbled on this. Dosen’t make much of a
difference but it keeps the code a bit cleaner and you avoid an extra
validation step so it is slightly (although almost certainly not
measurably) faster.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
