### PR TITLE
Support rollback nodes in scenario service

### DIFF
--- a/compiler/damlc/tests/daml-test-files/ExceptionDesugared.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionDesugared.daml
@@ -29,9 +29,7 @@ instance DA.Internal.Desugar.HasToAnyException MyException where
 instance DA.Internal.Desugar.HasFromAnyException MyException where
     fromAnyException = GHC.Types.primitive @"EFromAnyException"
 
--- TODO https://github.com/digital-asset/daml/issues/8020
---  Reactivate the test
-tryCatchExample () = scenario do
+tryCatchExample = scenario do
     p <- getParty "Alice"
     x <- submit p do
         DA.Internal.Desugar._tryCatch

--- a/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
@@ -1,0 +1,134 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF 1.dev
+module ExceptionSemantics where
+
+import DA.Exception (throw)
+
+exception E
+  where
+    message "E"
+
+template K
+  with
+    p : Party
+    v : Int
+  where
+    signatory p
+    key (p, v) : (Party, Int)
+    maintainer key._1
+
+template T
+  with
+    p : Party
+  where
+    signatory p
+    nonconsuming choice Throw : ()
+      controller p
+      do throw E
+    nonconsuming choice Catch : ()
+      controller p
+      do try (exercise self Throw)
+         catch
+           E -> pure ()
+
+    nonconsuming choice TransientDuplicate : ()
+      with
+        i : Int
+      controller p
+      do try do
+           create (K p i)
+           create (K p i)
+           throw E
+         catch
+           E -> pure ()
+    nonconsuming choice NonTransientDuplicate : ()
+      with
+        i : Int
+      controller p
+      do try do
+           create (K p i)
+           throw E
+         catch
+           E -> pure ()
+    nonconsuming choice RollbackKey : ()
+      with
+        i : Int
+      controller p
+      do try do
+           create (K p i)
+           throw E
+         catch
+           E -> create (K p i) >> pure ()
+
+    nonconsuming choice RollbackArchive : ()
+      with
+        i : Int
+      controller p
+      do cid <- create (K p i)
+         try (archive cid >> throw E)
+         catch
+           E -> archive cid
+
+    nonconsuming choice NonRollbackArchive : ()
+      with
+        i : Int
+      controller p
+      do cid <- create (K p i)
+         try (archive cid)
+         catch
+           E -> pure ()
+         archive cid
+
+template Fetcher
+  with
+    sig : Party
+    obs : Party
+  where
+    signatory sig
+    observer obs
+    choice Fetch : K
+      with
+        cid : ContractId K
+      controller obs
+      do fetch cid
+    choice RollbackFetch : ()
+      with
+        cid : ContractId K
+      controller obs
+      do try (fetch cid >> throw E)
+         catch
+           E -> pure ()
+
+unhandledException = scenario do
+  p <- getParty "p"
+  submitMustFail p $ createAndExercise (T p) Throw
+  pure ()
+
+duplicateKey = scenario do
+  p <- getParty "p"
+  -- transient duplicate key in rollback
+  submitMustFail p $ createAndExercise (T p) (TransientDuplicate 0)
+  submit p $ create (K p 1)
+  -- duplicate key error with contract created outside of rollback
+  submitMustFail p $ createAndExercise (T p) (NonTransientDuplicate 1)
+  -- no duplicate key error if key creation got rolled back
+  submit p $ createAndExercise (T p) (RollbackKey 2)
+  pure ()
+
+rollbackArchive = scenario do
+  p <- getParty "p"
+  submit p $ createAndExercise (T p) (RollbackArchive 0)
+  submitMustFail p $ createAndExercise (T p) (NonRollbackArchive 0)
+
+divulgence = scenario do
+  p1 <- getParty "p1"
+  p2 <- getParty "p2"
+  cid <- submit p1 $ create (K p1 0)
+  divulger <- submit p2 $ create (Fetcher p2 p1)
+  fetcher <- submit p1 $ create (Fetcher p1 p2)
+  submitMustFail p2 $ exercise fetcher (Fetch cid)
+  submit p1 $ exercise divulger (RollbackFetch cid)
+  submit p2 $ exercise fetcher (Fetch cid)
+  pure ()

--- a/compiler/damlc/tests/daml-test-files/ExceptionSyntax.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSyntax.daml
@@ -17,9 +17,7 @@ exception MyException
     where
         message m
 
--- TODO https://github.com/digital-asset/daml/issues/8020
---  Reactivate the test
-tryCatchExample () = scenario do
+tryCatchExample = scenario do
     p <- getParty "Alice"
     x <- submit p do
         try do

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -26,7 +26,8 @@ import           Control.Monad.IO.Class
 import           DA.Daml.LF.Proto3.EncodeV1
 import           DA.Pretty hiding (first)
 import qualified DA.Daml.LF.ScenarioServiceClient as SS
-import qualified DA.Service.Logger.Impl.Pure as Logger
+import qualified DA.Service.Logger as Logger
+import qualified DA.Service.Logger.Impl.IO as Logger
 import Development.IDE.Core.Compile
 import Development.IDE.Core.Debouncer
 import qualified Development.IDE.Types.Logger as IdeLogger
@@ -108,7 +109,8 @@ main = do
  LfVersionOpt lfVer <- do
      let parser = optionCLParser <* many (strArgument @String mempty)
      execParser (info parser forwardOptions)
- SS.withScenarioService lfVer Logger.makeNopHandle scenarioConf $ \scenarioService -> do
+ scenarioLogger <- Logger.newStderrLogger Logger.Warning "scenario"
+ SS.withScenarioService lfVer scenarioLogger scenarioConf $ \scenarioService -> do
   hSetEncoding stdout utf8
   setEnv "TASTY_NUM_THREADS" "1" True
   todoRef <- newIORef DList.empty

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -214,6 +214,7 @@ prettyScenarioErrorError (Just err) =  do
   case err of
     ScenarioErrorErrorCrash reason -> pure $ text "CRASH:" <-> ltext reason
     ScenarioErrorErrorUserError reason -> pure $ text "Aborted: " <-> ltext reason
+    ScenarioErrorErrorUnhandledException exc -> pure $ text "Unhandled exception: " <-> prettyValue' True 0 world exc
     ScenarioErrorErrorTemplatePrecondViolated ScenarioError_TemplatePreconditionViolated{..} -> do
       pure $
         "Template pre-condition violated in:"
@@ -545,6 +546,13 @@ ltext = text . TL.toStrict
 mapV :: (a -> b) -> V.Vector a -> [b]
 mapV f = map f . V.toList
 
+prettyChildren :: V.Vector NodeId -> M (Doc SyntaxClass)
+prettyChildren cs
+  | V.null cs = pure mempty
+  | otherwise = do
+        children <- mapM (lookupNode >=> prettyNode) (V.toList cs)
+        pure $ keyword_ "children:" $$ vsep children
+
 prettyNodeNode :: NodeNode -> M (Doc SyntaxClass)
 prettyNodeNode nn = do
   world <- askWorld
@@ -571,13 +579,7 @@ prettyNodeNode nn = do
                   node_FetchTemplateId
 
     NodeNodeExercise Node_Exercise{..} -> do
-      ppChildren <-
-        if V.null node_ExerciseChildren
-        then pure mempty
-        else
-              (keyword_ "children:" $$) . vsep
-          <$> mapM (lookupNode >=> prettyNode) (V.toList node_ExerciseChildren)
-
+      ppChildren <- prettyChildren node_ExerciseChildren
       pure
         $   fcommasep (mapV prettyParty node_ExerciseActingParties)
         <-> ( -- group to align "exercises" and "with"
@@ -610,6 +612,10 @@ prettyNodeNode nn = do
           $$ if TL.null node_LookupByKeyContractId
             then text "not found"
             else text "found:" <-> text (TL.toStrict node_LookupByKeyContractId)
+
+    NodeNodeRollback Node_Rollback{..} -> do
+        ppChildren <- prettyChildren node_RollbackChildren
+        pure $ keyword_ "rollback" $$ ppChildren
 
 isUnitValue :: Maybe Value -> Bool
 isUnitValue (Just (Value (Just ValueSumUnit{}))) = True

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -240,6 +240,9 @@ message ScenarioError {
     // Error was raised via the error builtin
     string user_error = 13;
 
+    // Unhandled exception
+    Value unhandled_exception = 26;
+
     // Errors related to update interpretation.
     TemplatePreconditionViolated template_precond_violated = 14;
     ContractNotActive update_local_contract_not_active = 15;
@@ -559,6 +562,10 @@ message Node {
     string contract_id = 3; // optional, if empty, we haven't found a contract
   }
 
+  message Rollback {
+    repeated NodeId children = 1;
+  }
+
   NodeId node_id = 1;
   sfixed64 effective_at = 2;
   repeated Disclosure disclosures = 3;
@@ -574,5 +581,6 @@ message Node {
     Fetch fetch = 9;
     Exercise exercise = 10;
     LookupByKey lookup_by_key = 11;
+    Rollback rollback = 12;
   }
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -62,7 +62,7 @@ object BlindingTransaction {
         case Some(action: Node.GenActionNode[NodeId, ContractId]) =>
           val witnesses = parentExerciseWitnesses union action.informeesOfNode
 
-          // nodes of every type are disclosed to their witnesses
+          // actions of every type are disclosed to their witnesses
           val state = state0.discloseNode(witnesses, nodeId)
 
           action match {


### PR DESCRIPTION
This focuses on the semantics rather than the display in Daml Studio
which needs more work (and seems not all that important at this
stage).

This already uncovered a bug which also applies outside of scenarios:

The consumedBy field was not affected by rollbacks which breaks the
mustBeActive check in partial transactions. This PR fixes this by
caching on try and restoring on rollback.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
