### PR TITLE
Integrate mutable state cache layer into ReadOnlySqlLedger

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -389,8 +389,8 @@ final class Metrics(val registry: MetricRegistry) {
         val getLedgerId: DatabaseMetrics = createDbMetrics("get_ledger_id")
         val getParticipantId: DatabaseMetrics = createDbMetrics("get_participant_id")
         val getLedgerEnd: DatabaseMetrics = createDbMetrics("get_ledger_end")
-        val getLedgerEndSequentialId: DatabaseMetrics = createDbMetrics(
-          "get_ledger_end_sequential_id"
+        val getLedgerEndOffsetAndSequentialId: DatabaseMetrics = createDbMetrics(
+          "get_ledger_end_offset_and_sequential_id"
         )
         val getInitialLedgerEnd: DatabaseMetrics = createDbMetrics("get_initial_ledger_end")
         val initializeLedgerParameters: DatabaseMetrics = createDbMetrics(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -21,18 +21,18 @@ import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.common.{LedgerIdNotFoundException, MismatchException}
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.store.dao
 import com.daml.platform.store.dao.LedgerReadDao
-import com.daml.platform.store.{BaseLedger, LfValueTranslationCache}
+import com.daml.platform.store.{BaseLedger, LfValueTranslationCache, appendonlydao, dao}
 import com.daml.resources.ProgramResource.StartupException
 import com.daml.timer.RetryStrategy
-
-import com.daml.platform.store.appendonlydao
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 private[platform] object ReadOnlySqlLedger {
+
+  private val logger = ContextualizedLogger.get(this.getClass)
+
   //jdbcUrl must have the user/password encoded in form of: "jdbc:postgresql://localhost/test?user=fred&password=secret"
   final class Owner(
       serverRole: ServerRole,
@@ -51,8 +51,6 @@ private[platform] object ReadOnlySqlLedger {
       enableMutableContractStateCache: Boolean,
   )(implicit mat: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[ReadOnlySqlLedger] {
-
-    private val logger = ContextualizedLogger.get(this.getClass)
 
     override def acquire()(implicit context: ResourceContext): Resource[ReadOnlySqlLedger] =
       for {

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
@@ -1,0 +1,142 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.index
+
+import akka.stream._
+import akka.stream.scaladsl.{Keep, RestartSource, Sink, Source}
+import akka.{Done, NotUsed}
+import com.daml.ledger.api.domain.LedgerId
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.akkastreams.dispatcher.Dispatcher
+import com.daml.platform.akkastreams.dispatcher.SubSource.RangeSource
+import com.daml.platform.store.appendonlydao.EventSequentialId
+import com.daml.platform.store.cache.MutableCacheBackedContractStore
+import com.daml.platform.store.dao.LedgerReadDao
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+private[index] object ReadOnlySqlLedgerWithMutableCache {
+  final class Owner(
+      ledgerDao: LedgerReadDao,
+      ledgerId: LedgerId,
+      metrics: Metrics,
+      maxContractStateCacheSize: Long,
+      maxContractKeyStateCacheSize: Long,
+  )(implicit mat: Materializer, loggingContext: LoggingContext)
+      extends ResourceOwner[ReadOnlySqlLedgerWithMutableCache] {
+
+    override def acquire()(implicit
+        context: ResourceContext
+    ): Resource[ReadOnlySqlLedgerWithMutableCache] =
+      for {
+        (ledgerEndOffset, ledgerEndSequentialId) <- Resource.fromFuture(
+          ledgerDao.lookupLedgerEndOffsetAndSequentialId()
+        )
+        contractStateEventsDispatcher <- dispatcherOffsetSeqIdOwner(
+          ledgerEndOffset,
+          ledgerEndSequentialId,
+        ).acquire()
+        generalDispatcher <- dispatcherOwner(ledgerEndOffset).acquire()
+        contractStore <- contractStoreOwner(generalDispatcher, contractStateEventsDispatcher)
+        ledger <- ledgerOwner(contractStateEventsDispatcher, generalDispatcher, contractStore)
+          .acquire()
+      } yield ledger
+
+    private def ledgerOwner(
+        contractStateEventsDispatcher: Dispatcher[(Offset, Long)],
+        generalDispatcher: Dispatcher[Offset],
+        contractStore: MutableCacheBackedContractStore,
+    ) = {
+      ResourceOwner
+        .forCloseable(() =>
+          new ReadOnlySqlLedgerWithMutableCache(
+            ledgerId,
+            ledgerDao,
+            contractStore,
+            contractStateEventsDispatcher,
+            generalDispatcher,
+          )
+        )
+    }
+
+    private def contractStoreOwner(
+        generalDispatcher: Dispatcher[Offset],
+        contractStateEventsDispatcher: Dispatcher[(Offset, Long)],
+    )(implicit
+        context: ResourceContext
+    ) =
+      MutableCacheBackedContractStore.owner(
+        contractsReader = ledgerDao.contractsReader,
+        signalNewLedgerHead = generalDispatcher.signalNewHead,
+        subscribeToContractStateEvents = (offset: Offset, eventSequentialId: Long) =>
+          contractStateEventsDispatcher
+            .startingAt(
+              offset -> eventSequentialId,
+              RangeSource(
+                ledgerDao.transactionsReader.getContractStateEvents(_, _)
+              ),
+            )
+            .map(_._2),
+        metrics = metrics,
+        maxContractsCacheSize = maxContractStateCacheSize,
+        maxKeyCacheSize = maxContractKeyStateCacheSize,
+      )
+
+    private def dispatcherOffsetSeqIdOwner(ledgerEnd: Offset, evtSeqId: Long) = {
+      implicit val ordering: Ordering[(Offset, Long)] = Ordering.fromLessThan {
+        case ((fOffset, fSeqId), (sOffset, sSeqId)) =>
+          (fOffset < sOffset) || (fOffset == sOffset && fSeqId < sSeqId)
+      }
+      Dispatcher.owner(
+        name = "contract-state-events",
+        zeroIndex = (Offset.beforeBegin, EventSequentialId.beforeBegin),
+        headAtInitialization = (ledgerEnd, evtSeqId),
+      )
+    }
+
+    private def dispatcherOwner(ledgerEnd: Offset): ResourceOwner[Dispatcher[Offset]] =
+      Dispatcher.owner(
+        name = "sql-ledger",
+        zeroIndex = Offset.beforeBegin,
+        headAtInitialization = ledgerEnd,
+      )
+  }
+}
+
+private final class ReadOnlySqlLedgerWithMutableCache(
+    ledgerId: LedgerId,
+    ledgerDao: LedgerReadDao,
+    contractStore: MutableCacheBackedContractStore,
+    contractStateEventsDispatcher: Dispatcher[(Offset, Long)],
+    dispatcher: Dispatcher[Offset],
+)(implicit mat: Materializer, loggingContext: LoggingContext)
+    extends ReadOnlySqlLedger(ledgerId, ledgerDao, contractStore, dispatcher) {
+
+  protected val (ledgerEndUpdateKillSwitch, ledgerEndUpdateDone) =
+    RestartSource
+      .withBackoff(
+        RestartSettings(minBackoff = 1.second, maxBackoff = 10.seconds, randomFactor = 0.2)
+      )(() =>
+        Source
+          .tick(0.millis, 100.millis, ())
+          .mapAsync(1)(_ => ledgerDao.lookupLedgerEndOffsetAndSequentialId())
+      )
+      .viaMat(KillSwitches.single)(Keep.right[NotUsed, UniqueKillSwitch])
+      .toMat(Sink.foreach(contractStateEventsDispatcher.signalNewHead))(
+        Keep.both[UniqueKillSwitch, Future[Done]]
+      )
+      .run()
+
+  override def close(): Unit = {
+    ledgerEndUpdateKillSwitch.shutdown()
+
+    Await.ready(ledgerEndUpdateDone, 10.seconds)
+
+    super.close()
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
@@ -88,10 +88,6 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
       )
 
     private def dispatcherOffsetSeqIdOwner(ledgerEnd: Offset, evtSeqId: Long) = {
-      implicit val ordering: Ordering[(Offset, Long)] = Ordering.fromLessThan {
-        case ((fOffset, fSeqId), (sOffset, sSeqId)) =>
-          (fOffset < sOffset) || (fOffset == sOffset && fSeqId < sSeqId)
-      }
       Dispatcher.owner(
         name = "contract-state-events",
         zeroIndex = (Offset.beforeBegin, EventSequentialId.beforeBegin),

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithTranslationCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithTranslationCache.scala
@@ -1,0 +1,100 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.index
+
+import akka.stream._
+import akka.stream.scaladsl.{Keep, RestartSource, Sink, Source}
+import akka.{Done, NotUsed}
+import com.daml.ledger.api.domain.LedgerId
+import com.daml.ledger.participant.state.index.v2.ContractStore
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
+import com.daml.logging.LoggingContext
+import com.daml.platform.akkastreams.dispatcher.Dispatcher
+import com.daml.platform.store.LfValueTranslationCache
+import com.daml.platform.store.cache.TranslationCacheBackedContractStore
+import com.daml.platform.store.dao.LedgerReadDao
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+private[index] object ReadOnlySqlLedgerWithTranslationCache {
+
+  final class Owner(
+      ledgerDao: LedgerReadDao,
+      ledgerId: LedgerId,
+      lfValueTranslationCache: LfValueTranslationCache.Cache,
+  )(implicit mat: Materializer, loggingContext: LoggingContext)
+      extends ResourceOwner[ReadOnlySqlLedgerWithTranslationCache] {
+
+    override def acquire()(implicit
+        context: ResourceContext
+    ): Resource[ReadOnlySqlLedgerWithTranslationCache] =
+      for {
+        ledgerEnd <- Resource.fromFuture(ledgerDao.lookupLedgerEnd())
+        dispatcher <- dispatcherOwner(ledgerEnd).acquire()
+        contractsStore <- contractStoreOwner()
+        ledger <- ledgerOwner(dispatcher, contractsStore).acquire()
+      } yield ledger
+
+    private def ledgerOwner(dispatcher: Dispatcher[Offset], contractsStore: ContractStore) =
+      ResourceOwner
+        .forCloseable(() =>
+          new ReadOnlySqlLedgerWithTranslationCache(
+            ledgerId,
+            ledgerDao,
+            contractsStore,
+            dispatcher,
+          )
+        )
+
+    private def contractStoreOwner(): Resource[ContractStore] =
+      TranslationCacheBackedContractStore
+        .owner(lfValueTranslationCache, ledgerDao.contractsReader)
+
+    private def dispatcherOwner(ledgerEnd: Offset): ResourceOwner[Dispatcher[Offset]] =
+      Dispatcher.owner(
+        name = "sql-ledger",
+        zeroIndex = Offset.beforeBegin,
+        headAtInitialization = ledgerEnd,
+      )
+  }
+}
+
+private final class ReadOnlySqlLedgerWithTranslationCache(
+    ledgerId: LedgerId,
+    ledgerDao: LedgerReadDao,
+    contractStore: ContractStore,
+    dispatcher: Dispatcher[Offset],
+)(implicit mat: Materializer, loggingContext: LoggingContext)
+    extends ReadOnlySqlLedger(
+      ledgerId,
+      ledgerDao,
+      contractStore,
+      dispatcher,
+    ) {
+
+  protected val (ledgerEndUpdateKillSwitch, ledgerEndUpdateDone) =
+    RestartSource
+      .withBackoff(
+        RestartSettings(minBackoff = 1.second, maxBackoff = 10.seconds, randomFactor = 0.2)
+      )(() =>
+        Source
+          .tick(0.millis, 100.millis, ())
+          .mapAsync(1)(_ => ledgerDao.lookupLedgerEnd())
+      )
+      .viaMat(KillSwitches.single)(Keep.right[NotUsed, UniqueKillSwitch])
+      .toMat(Sink.foreach(dispatcher.signalNewHead))(
+        Keep.both[UniqueKillSwitch, Future[Done]]
+      )
+      .run()
+
+  override def close(): Unit = {
+    ledgerEndUpdateKillSwitch.shutdown()
+
+    Await.result(ledgerEndUpdateDone, 10.seconds)
+
+    super.close()
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -118,11 +118,11 @@ private class JdbcLedgerDao(
   override def lookupLedgerEnd()(implicit loggingContext: LoggingContext): Future[Offset] =
     dbDispatcher.executeSql(metrics.daml.index.db.getLedgerEnd)(ParametersTable.getLedgerEnd)
 
-  override def lookupLedgerEndSequentialId()(implicit
+  override def lookupLedgerEndOffsetAndSequentialId()(implicit
       loggingContext: LoggingContext
-  ): Future[Long] =
-    dbDispatcher.executeSql(metrics.daml.index.db.getLedgerEndSequentialId)(
-      ParametersTable.getLedgerEndSequentialId
+  ): Future[(Offset, Long)] =
+    dbDispatcher.executeSql(metrics.daml.index.db.getLedgerEndOffsetAndSequentialId)(
+      ParametersTable.getLedgerEndOffsetAndSequentialId
     )
 
   override def lookupInitialLedgerEnd()(implicit

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
@@ -304,6 +304,15 @@ private[appendonlydao] sealed class ContractsReader(
             AND #$tree_event_witnessesWhere
           LIMIT 1 -- limit here to guide planner wrt expected number of results
        ),
+       -- no visibility check, as it is used to backfill missing template_id and create_arguments for divulged contracts
+       create_event_unrestricted AS (
+         SELECT contract_id, template_id
+           FROM participant_events, parameters
+          WHERE contract_id = $contractId
+            AND event_kind = 10  -- create
+            AND event_sequential_id <= parameters.ledger_end_sequential_id
+          LIMIT 1 -- limit here to guide planner wrt expected number of results
+       ),
        divulged_contract AS (
          SELECT divulgence_events.contract_id,
                 -- Note: the divulgance_event.template_id can be NULL

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -122,18 +122,18 @@ class MutableCacheBackedContractStore(
   private def readThroughContractsCache(contractId: ContractId)(implicit
       loggingContext: LoggingContext
   ) = {
-    val currentCacheOffset = cacheIndex.getSequentialId
+    val currentCacheSequentialId = cacheIndex.getSequentialId
     val fetchStateRequest =
       Timed.future(
         metrics.daml.index.lookupContract,
-        contractsReader.lookupContractState(contractId, currentCacheOffset),
+        contractsReader.lookupContractState(contractId, currentCacheSequentialId),
       )
     val eventualValue = fetchStateRequest.map(toContractCacheValue)
 
     for {
       _ <- contractsCache.putAsync(
         key = contractId,
-        validAt = currentCacheOffset,
+        validAt = currentCacheSequentialId,
         eventualValue = eventualValue,
       )
       value <- eventualValue
@@ -208,12 +208,12 @@ class MutableCacheBackedContractStore(
   private def readThroughKeyCache(
       key: GlobalKey
   )(implicit loggingContext: LoggingContext) = {
-    val currentOffset = cacheIndex.getSequentialId
-    val eventualResult = contractsReader.lookupKeyState(key, currentOffset)
+    val currentCacheSequentialId = cacheIndex.getSequentialId
+    val eventualResult = contractsReader.lookupKeyState(key, currentCacheSequentialId)
     val eventualValue = eventualResult.map(toKeyCacheValue)
 
     for {
-      _ <- keyCache.putAsync(key, currentOffset, eventualValue)
+      _ <- keyCache.putAsync(key, currentCacheSequentialId, eventualValue)
       value <- eventualValue
     } yield value
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -118,9 +118,9 @@ private class JdbcLedgerDao(
     * and it will throw if used. Implemented here only for
     * conformance with the common [[LedgerDao]] interface.
     */
-  override def lookupLedgerEndSequentialId()(implicit
+  override def lookupLedgerEndOffsetAndSequentialId()(implicit
       loggingContext: LoggingContext
-  ): Future[Long] =
+  ): Future[(Offset, Long)] =
     throw new UnsupportedOperationException("not supported")
 
   override def lookupInitialLedgerEnd()(implicit

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -108,8 +108,10 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
   /** Looks up the current ledger end */
   def lookupLedgerEnd()(implicit loggingContext: LoggingContext): Future[Offset]
 
-  /** Looks up the current ledger end sequential id */
-  def lookupLedgerEndSequentialId()(implicit loggingContext: LoggingContext): Future[Long]
+  /** Looks up the current ledger end as the offset and event sequential id */
+  def lookupLedgerEndOffsetAndSequentialId()(implicit
+      loggingContext: LoggingContext
+  ): Future[(Offset, Long)]
 
   /** Looks up the current external ledger end offset */
   def lookupInitialLedgerEnd()(implicit loggingContext: LoggingContext): Future[Option[Offset]]

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -47,10 +47,12 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
   override def lookupLedgerEnd()(implicit loggingContext: LoggingContext): Future[Offset] =
     Timed.future(metrics.daml.index.db.lookupLedgerEnd, ledgerDao.lookupLedgerEnd())
 
-  def lookupLedgerEndSequentialId()(implicit loggingContext: LoggingContext): Future[Long] =
+  def lookupLedgerEndOffsetAndSequentialId()(implicit
+      loggingContext: LoggingContext
+  ): Future[(Offset, Long)] =
     Timed.future(
       metrics.daml.index.db.lookupLedgerEndSequentialId,
-      ledgerDao.lookupLedgerEndSequentialId(),
+      ledgerDao.lookupLedgerEndOffsetAndSequentialId(),
     )
 
   override def lookupInitialLedgerEnd()(implicit

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
@@ -6,9 +6,10 @@ package com.daml.platform.store.cache
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.QueueOfferResult.Enqueued
-import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.scaladsl.Source
 import akka.stream.{BoundedSourceQueue, Materializer}
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.v1.Offset
@@ -18,6 +19,7 @@ import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.value.Value.{ContractInst, ValueRecord, ValueText}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
+import com.daml.platform.store.appendonlydao.EventSequentialId
 import com.daml.platform.store.cache.ContractKeyStateValue.{Assigned, Unassigned}
 import com.daml.platform.store.cache.ContractStateValue.{Active, Archived}
 import com.daml.platform.store.cache.MutableCacheBackedContractStore.{
@@ -34,59 +36,138 @@ import com.daml.platform.store.dao.events.ContractStateEvent
 import com.daml.platform.store.interfaces.LedgerDaoContractsReader
 import com.daml.platform.store.interfaces.LedgerDaoContractsReader.{KeyAssigned, KeyUnassigned}
 import org.mockito.MockitoSugar
-import org.scalatest.Assertion
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Span}
 import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest.{Assertion, BeforeAndAfterAll}
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import scala.math.BigInt.long2bigInt
 
 class MutableCacheBackedContractStoreSpec
     extends AsyncWordSpec
     with Matchers
     with Eventually
-    with MockitoSugar {
+    with MockitoSugar
+    with BeforeAndAfterAll {
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
-  "consumeFrom" should {
+  private val actorSystem = ActorSystem("test")
+  private implicit val materializer: Materializer = Materializer(actorSystem)
+
+  override implicit val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(500, Millis)))
+
+  "event stream consumption" should {
     "populate the caches from the contract state event stream" in {
-      val actorSystem = ActorSystem("test")
-      implicit val materializer: Materializer = Materializer(actorSystem)
-      implicit val patienceConfig: PatienceConfig =
-        PatienceConfig(timeout = scaled(Span(500, Millis)))
 
       val lastLedgerHead = new AtomicReference[Offset](Offset.beforeBegin)
       val capture_signalLedgerHead = lastLedgerHead.set _
-      val store = contractStore(cachesSize = 2L, ContractsReaderFixture(), capture_signalLedgerHead)
 
-      implicit val eventsStreamQueue: BoundedSourceQueue[ContractStateEvent] = Source
+      implicit val (
+        queue: BoundedSourceQueue[ContractStateEvent],
+        source: Source[ContractStateEvent, NotUsed],
+      ) = Source
         .queue[ContractStateEvent](16)
-        .via(store.consumeFrom)
-        .toMat(Sink.ignore)(Keep.left)
-        .run()
+        .preMaterialize()
+
+      val store =
+        contractStore(
+          cachesSize = 2L,
+          ContractsReaderFixture(),
+          capture_signalLedgerHead,
+          (_, _) => source,
+        )
 
       for {
         c1 <- createdEvent(cId_1, contract1, Some(someKey), Set(charlie), 1L, t1)
         _ <- eventually {
           store.contractsCache.get(cId_1) shouldBe Some(Active(contract1, Set(charlie), t1))
           store.keyCache.get(someKey) shouldBe Some(Assigned(cId_1, Set(charlie)))
-          store.cacheOffset.get() shouldBe 1L
+          store.cacheIndex.getSequentialId shouldBe 1L
         }
 
         _ <- archivedEvent(c1, eventSequentialId = 2L)
         _ <- eventually {
           store.contractsCache.get(cId_1) shouldBe Some(Archived(Set(charlie)))
           store.keyCache.get(someKey) shouldBe Some(Unassigned)
-          store.cacheOffset.get() shouldBe 2L
+          store.cacheIndex.getSequentialId shouldBe 2L
         }
 
         someOffset = Offset.fromByteArray(1337.toByteArray)
         _ <- ledgerEnd(someOffset, 3L)
         _ <- eventually {
-          store.cacheOffset.get() shouldBe 3L
+          store.cacheIndex.getSequentialId shouldBe 3L
           lastLedgerHead.get() shouldBe someOffset
+        }
+      } yield succeed
+    }
+
+    "resubscribe from the last ingested offset (on failure)" in {
+      val offsetBase = BigInt(1) << 32
+
+      val offset1 = Offset.beforeBegin
+      val offset2 = Offset.fromByteArray((offsetBase + 1L).toByteArray)
+      val offset3 = Offset.fromByteArray((offsetBase + 2L).toByteArray)
+
+      val created = ContractStateEvent.Created(
+        contractId = cId_1,
+        contract = contract1,
+        globalKey = Some(someKey),
+        ledgerEffectiveTime = t1,
+        stakeholders = Set(charlie),
+        eventOffset = offset1,
+        eventSequentialId = 1L,
+      )
+
+      val dummy = created.copy(eventSequentialId = 7L)
+
+      val archived = ContractStateEvent.Archived(
+        contractId = created.contractId,
+        globalKey = created.globalKey,
+        stakeholders = created.stakeholders,
+        eventOffset = offset2,
+        eventSequentialId = 2L,
+      )
+
+      val anotherCreate = ContractStateEvent.Created(
+        contractId = cId_2,
+        contract = contract2,
+        globalKey = Some(someKey),
+        ledgerEffectiveTime = t2,
+        stakeholders = Set(alice),
+        eventOffset = offset3,
+        eventSequentialId = 3L,
+      )
+
+      val sourceSubscriptionFixture
+          : (Offset, EventSequentialId) => Source[ContractStateEvent, NotUsed] = {
+        case (Offset.beforeBegin, EventSequentialId.beforeBegin) =>
+          Source
+            .fromIterator(() => Iterator(created, archived, dummy))
+            // Simulate the source failure at the last event
+            .map(x => if (x == dummy) throw new RuntimeException("some transient failure") else x)
+        case (_, 2L) =>
+          Source.fromIterator(() => Iterator(anotherCreate))
+        case _ => Source.empty
+      }
+
+      val store =
+        contractStore(
+          cachesSize = 2L,
+          ContractsReaderFixture(),
+          _ => (),
+          sourceSubscriptionFixture,
+        )
+
+      for {
+        _ <- eventually {
+          store.contractsCache.get(cId_1) shouldBe Some(Archived(Set(charlie)))
+          store.contractsCache.get(cId_2) shouldBe Some(Active(contract2, Set(alice), t2))
+          store.keyCache.get(someKey) shouldBe Some(Assigned(cId_2, Set(alice)))
+          store.cacheIndex.get shouldBe offset3 -> 3L
         }
       } yield succeed
     }
@@ -96,17 +177,17 @@ class MutableCacheBackedContractStoreSpec
     "read-through the contract state cache" in {
       val spyContractsReader = spy(ContractsReaderFixture())
       val store = contractStore(cachesSize = 1L, spyContractsReader)
-      store.cacheOffset.set(1L)
+      store.cacheIndex.set(unusedOffset, 1L)
 
       for {
         cId2_lookup <- store.lookupActiveContract(Set(alice), cId_2)
         another_cId2_lookup <- store.lookupActiveContract(Set(alice), cId_2)
 
-        _ = store.cacheOffset.incrementAndGet()
+        _ = store.cacheIndex.set(unusedOffset, 2L)
         cId3_lookup <- store.lookupActiveContract(Set(bob), cId_3)
         another_cId3_lookup <- store.lookupActiveContract(Set(bob), cId_3)
 
-        _ = store.cacheOffset.incrementAndGet()
+        _ = store.cacheIndex.set(unusedOffset, 3L)
         nonExistentCId = contractId(5)
         nonExistentCId_lookup <- store.lookupActiveContract(Set.empty, nonExistentCId)
         another_nonExistentCId_lookup <- store.lookupActiveContract(Set.empty, nonExistentCId)
@@ -134,11 +215,11 @@ class MutableCacheBackedContractStoreSpec
         cId1_lookup0 <- store.lookupActiveContract(Set(alice), cId_1)
         cId2_lookup0 <- store.lookupActiveContract(Set(bob), cId_2)
 
-        _ = store.cacheOffset.incrementAndGet()
+        _ = store.cacheIndex.set(unusedOffset, 1L)
         cId1_lookup1 <- store.lookupActiveContract(Set(alice), cId_1)
         cid1_lookup1_archivalNotDivulged <- store.lookupActiveContract(Set(charlie), cId_1)
 
-        _ = store.cacheOffset.incrementAndGet()
+        _ = store.cacheIndex.set(unusedOffset, 2L)
         cId2_lookup2 <- store.lookupActiveContract(Set(bob), cId_2)
         cid2_lookup2_divulged <- store.lookupActiveContract(Set(charlie), cId_2)
         cid2_lookup2_nonVisible <- store.lookupActiveContract(Set(alice), cId_2)
@@ -166,7 +247,7 @@ class MutableCacheBackedContractStoreSpec
         assigned_firstLookup <- store.lookupContractKey(Set(alice), someKey)
         assigned_secondLookup <- store.lookupContractKey(Set(alice), someKey)
 
-        _ = store.cacheOffset.incrementAndGet()
+        _ = store.cacheIndex.set(unusedOffset, 1L)
         unassigned_firstLookup <- store.lookupContractKey(Set(alice), unassignedKey)
         unassigned_secondLookup <- store.lookupContractKey(Set(alice), unassignedKey)
       } yield {
@@ -188,14 +269,14 @@ class MutableCacheBackedContractStoreSpec
       for {
         key_lookup0 <- store.lookupContractKey(Set(alice), someKey)
 
-        _ = store.cacheOffset.incrementAndGet()
+        _ = store.cacheIndex.set(unusedOffset, 1L)
         key_lookup1 <- store.lookupContractKey(Set(alice), someKey)
 
-        _ = store.cacheOffset.incrementAndGet()
+        _ = store.cacheIndex.set(unusedOffset, 2L)
         key_lookup2 <- store.lookupContractKey(Set(bob), someKey)
         key_lookup2_notVisible <- store.lookupContractKey(Set(charlie), someKey)
 
-        _ = store.cacheOffset.incrementAndGet()
+        _ = store.cacheIndex.set(unusedOffset, 3L)
         key_lookup3 <- store.lookupContractKey(Set(bob), someKey)
       } yield {
         key_lookup0 shouldBe Some(cId_1)
@@ -210,7 +291,7 @@ class MutableCacheBackedContractStoreSpec
   "lookupMaximumLedgerTime" should {
     "return the maximum ledger time with cached values" in {
       val store = contractStore(cachesSize = 2L)
-      store.cacheOffset.set(2L)
+      store.cacheIndex.set(unusedOffset, 2L)
       for {
         // populate the cache
         _ <- store.lookupActiveContract(Set(bob), cId_2)
@@ -223,7 +304,7 @@ class MutableCacheBackedContractStoreSpec
 
     "fail if one of the contract ids doesn't have an associated active contract" in {
       val store = contractStore(cachesSize = 0L)
-      store.cacheOffset.set(2L)
+      store.cacheIndex.set(unusedOffset, 2L)
       recoverToSucceededIf[ContractNotFound] {
         store.lookupMaximumLedgerTime(Set(cId_1, cId_2)).map(_ => succeed)
       }
@@ -282,9 +363,15 @@ class MutableCacheBackedContractStoreSpec
     Future {
       queue.offer(ContractStateEvent.LedgerEndMarker(offset, eventSequentialId)) shouldBe Enqueued
     }
+
+  override def afterAll(): Unit = {
+    materializer.shutdown()
+    val _ = actorSystem.terminate()
+  }
 }
 
 object MutableCacheBackedContractStoreSpec {
+  private val unusedOffset = Offset.beforeBegin
   private val Seq(alice, bob, charlie) = Seq("alice", "bob", "charlie").map(party)
   private val (
     Seq(cId_1, cId_2, cId_3, cId_4),
@@ -301,14 +388,18 @@ object MutableCacheBackedContractStoreSpec {
       cachesSize: Long,
       readerFixture: LedgerDaoContractsReader = ContractsReaderFixture(),
       signalNewLedgerHead: Offset => Unit = _ => (),
-  ) =
+      sourceSubscriber: (Offset, EventSequentialId) => Source[ContractStateEvent, NotUsed] =
+        (_: Offset, _: EventSequentialId) => Source.empty,
+  )(implicit loggingContext: LoggingContext, materializer: Materializer) =
     MutableCacheBackedContractStore(
       readerFixture,
       signalNewLedgerHead,
+      sourceSubscriber,
       new Metrics(new MetricRegistry),
       maxContractsCacheSize = cachesSize,
       maxKeyCacheSize = cachesSize,
-    )(scala.concurrent.ExecutionContext.global)
+      minBackoffStreamRestart = 10.millis,
+    )(materializer, scala.concurrent.ExecutionContext.global, loggingContext)
 
   case class ContractsReaderFixture() extends LedgerDaoContractsReader {
     override def lookupKeyState(key: Key, validAt: Long)(implicit


### PR DESCRIPTION
Integrate mutable state cache layer into `ReadOnlySqlLedger`
* Create tiered `ReadOnlySqlLedger` for accommodating both legacy and new caching store wirings behind the feature flag. 
* Integrate event stream lifecycle responsibility into `MutableCacheBackedContractStore`.
* Add contract state events stream resilience test in `MutableCacheBackedContractStoreSpec`.
* Add missing SQL fragment to `ContractsReader` fetch query.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
