### PR TITLE
Fix flakiness in //daml-lf/transaction

### DIFF
--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -311,6 +311,19 @@ object ValueGenerators {
   val malformedCreateNodeGen: Gen[NodeCreate[Value.ContractId]] = {
     for {
       version <- transactionVersionGen()
+      node <- malformedCreateNodeGenWithVersion(version)
+    } yield node
+  }
+
+  /** Makes create nodes with the given version that violate the rules:
+    *
+    * 1. stakeholders may not be a superset of signatories
+    * 2. key's maintainers may not be a subset of signatories
+    */
+  def malformedCreateNodeGenWithVersion(
+      version: TransactionVersion
+  ): Gen[NodeCreate[Value.ContractId]] = {
+    for {
       coid <- coidGen
       templateId <- idGen
       arg <- valueGen

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -293,10 +293,13 @@ class TransactionCoderSpec
       value.toBuilder.setVersion(version).build()
 
     "fail if try to encode a create node containing value with version different from node" in {
-      forAll(malformedCreateNodeGen, transactionVersionGen(maxVersion = V12), minSuccessful(5)) {
-        (node, version) =>
-          whenever(node.version <= V11 && node.version != version) {
-            val nodeVersion = node.version
+      forAll(
+        transactionVersionGen(maxVersion = V11),
+        transactionVersionGen(maxVersion = V12),
+        minSuccessful(5),
+      ) { (nodeVersion, version) =>
+        whenever(nodeVersion != version) {
+          forAll(malformedCreateNodeGenWithVersion(nodeVersion)) { node =>
             val encodeVersion = ValueCoder.encodeValueVersion(version)
             val Right(encodedNode) = TransactionCoder.encodeNode(
               TransactionCoder.NidEncoder,
@@ -335,6 +338,8 @@ class TransactionCoderSpec
               ) shouldBe a[Left[_, _]]
             )
           }
+
+        }
       }
     }
 


### PR DESCRIPTION
The current generators are a bit too dumb and relatively
frequently (~1/10) fail to generate 5 successful results before
failing forever. This PR changes things slightly to avoid this. We
could be even more clever and draw the second version after having
selected the first one so we cannot even draw the same but that
doesn’t seem worth the complexity for now.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
