### PR TITLE
Additional metrics for mutable contract state cache

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -53,10 +53,6 @@ final class Metrics(val registry: MetricRegistry) {
     object execution {
       private val Prefix: MetricName = daml.Prefix :+ "execution"
 
-      val keyStateCache: CacheMetrics = new CacheMetrics(registry, Prefix :+ "key_state_cache")
-      val contractStateCache: CacheMetrics =
-        new CacheMetrics(registry, Prefix :+ "contract_state_cache")
-
       val lookupActiveContract: Timer = registry.timer(Prefix :+ "lookup_active_contract")
       val lookupActiveContractPerExecution: Timer =
         registry.timer(Prefix :+ "lookup_active_contract_per_execution")
@@ -76,6 +72,24 @@ final class Metrics(val registry: MetricRegistry) {
 
       // Commands being executed by the engine (not currently fetching data)
       val engineRunning: Meter = registry.meter(Prefix :+ "engine_running")
+
+      object cache {
+        private val Prefix: MetricName = execution.Prefix :+ "cache"
+
+        val keyState: CacheMetrics = new CacheMetrics(registry, Prefix :+ "key_state")
+        val contractState: CacheMetrics =
+          new CacheMetrics(registry, Prefix :+ "contract_state")
+
+        val registerCacheUpdate: Timer = registry.timer(Prefix :+ "register_update")
+
+        val dispatcherLag: Timer = registry.timer(Prefix :+ "dispatcher_lag")
+
+        val indexSequentialId = new VarGauge[Long](0L)
+        registry.register(
+          Prefix :+ "index_sequential_id",
+          indexSequentialId,
+        )
+      }
     }
 
     object kvutils {
@@ -527,11 +541,8 @@ final class Metrics(val registry: MetricRegistry) {
 
       val stateUpdateProcessing: Timer = registry.timer(Prefix :+ "processed_state_updates")
 
-      val currentStateCacheSequentialIdGauge = new VarGauge[Long](0L)
-      registry.register(
-        Prefix :+ "current_state_cache_sequential_id",
-        currentStateCacheSequentialIdGauge,
-      )
+      val ledgerEndSequentialId = new VarGauge[Long](0L)
+      registry.register(Prefix :+ "ledger_end_sequential_id", ledgerEndSequentialId)
     }
 
     // TODO append-only: streamline metrics upon cleanup

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
@@ -3,9 +3,12 @@
 
 package com.daml.platform.index
 
+import java.util.concurrent.TimeUnit
+
 import akka.stream._
 import akka.stream.scaladsl.{Keep, RestartSource, Sink, Source}
 import akka.{Done, NotUsed}
+import com.codahale.metrics.Timer
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.participant.state.v1.Offset
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
@@ -13,10 +16,14 @@ import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.akkastreams.dispatcher.SubSource.RangeSource
+import com.daml.platform.index.ReadOnlySqlLedgerWithMutableCache.DispatcherLagMeter
 import com.daml.platform.store.appendonlydao.EventSequentialId
 import com.daml.platform.store.cache.MutableCacheBackedContractStore
+import com.daml.platform.store.cache.MutableCacheBackedContractStore.SignalNewLedgerHead
 import com.daml.platform.store.dao.LedgerReadDao
+import com.daml.scalautil.Statement.discard
 
+import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
@@ -42,8 +49,18 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
           ledgerEndSequentialId,
         ).acquire()
         generalDispatcher <- dispatcherOwner(ledgerEndOffset).acquire()
-        contractStore <- contractStoreOwner(generalDispatcher, contractStateEventsDispatcher)
-        ledger <- ledgerOwner(contractStateEventsDispatcher, generalDispatcher, contractStore)
+        dispatcherLagMeter <- Resource.successful(
+          new DispatcherLagMeter(generalDispatcher.signalNewHead)(
+            metrics.daml.execution.cache.dispatcherLag
+          )
+        )
+        contractStore <- contractStoreOwner(dispatcherLagMeter, contractStateEventsDispatcher)
+        ledger <- ledgerOwner(
+          contractStateEventsDispatcher,
+          generalDispatcher,
+          contractStore,
+          dispatcherLagMeter,
+        )
           .acquire()
       } yield ledger
 
@@ -51,6 +68,7 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
         contractStateEventsDispatcher: Dispatcher[(Offset, Long)],
         generalDispatcher: Dispatcher[Offset],
         contractStore: MutableCacheBackedContractStore,
+        dispatcherLagger: DispatcherLagMeter,
     ) = {
       ResourceOwner
         .forCloseable(() =>
@@ -60,19 +78,20 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
             contractStore,
             contractStateEventsDispatcher,
             generalDispatcher,
+            dispatcherLagger,
           )
         )
     }
 
     private def contractStoreOwner(
-        generalDispatcher: Dispatcher[Offset],
+        signalNewLedgerHead: SignalNewLedgerHead,
         contractStateEventsDispatcher: Dispatcher[(Offset, Long)],
     )(implicit
         context: ResourceContext
     ) =
       MutableCacheBackedContractStore.owner(
         contractsReader = ledgerDao.contractsReader,
-        signalNewLedgerHead = generalDispatcher.signalNewHead,
+        signalNewLedgerHead = signalNewLedgerHead,
         subscribeToContractStateEvents = (offset: Offset, eventSequentialId: Long) =>
           contractStateEventsDispatcher
             .startingAt(
@@ -102,6 +121,41 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
         headAtInitialization = ledgerEnd,
       )
   }
+
+  /** Computes the lag between the contract state events dispatcher and the general dispatcher.
+    *
+    * Internally uses a size bound for preventing memory leaks if misused.
+    *
+    * @param delegate The ledger head dispatcher delegate.
+    * @param timer The timer measuring the delta.
+    */
+  private class DispatcherLagMeter(delegate: SignalNewLedgerHead, maxSize: Long = 1000L)(
+      timer: Timer
+  ) extends SignalNewLedgerHead {
+    private val ledgerHeads = mutable.Map.empty[Offset, Long]
+
+    override def apply(offset: Offset): Unit = {
+      delegate(offset)
+      ledgerHeads.synchronized {
+        ledgerHeads.remove(offset).foreach { startNanos =>
+          val endNanos = System.nanoTime()
+          timer.update(endNanos - startNanos, TimeUnit.NANOSECONDS)
+        }
+      }
+    }
+
+    private[ReadOnlySqlLedgerWithMutableCache] def startTimer(head: Offset): Unit =
+      ledgerHeads.synchronized {
+        ensureBounded()
+        discard(ledgerHeads.getOrElseUpdate(head, System.nanoTime()))
+      }
+
+    private def ensureBounded(): Unit =
+      if (ledgerHeads.size > maxSize) {
+        // If maxSize is reached, remove randomly ANY element.
+        ledgerHeads.headOption.foreach(head => ledgerHeads.remove(head._1))
+      } else ()
+  }
 }
 
 private final class ReadOnlySqlLedgerWithMutableCache(
@@ -110,6 +164,7 @@ private final class ReadOnlySqlLedgerWithMutableCache(
     contractStore: MutableCacheBackedContractStore,
     contractStateEventsDispatcher: Dispatcher[(Offset, Long)],
     dispatcher: Dispatcher[Offset],
+    dispatcherLagger: DispatcherLagMeter,
 )(implicit mat: Materializer, loggingContext: LoggingContext)
     extends ReadOnlySqlLedger(ledgerId, ledgerDao, contractStore, dispatcher) {
 
@@ -123,7 +178,10 @@ private final class ReadOnlySqlLedgerWithMutableCache(
           .mapAsync(1)(_ => ledgerDao.lookupLedgerEndOffsetAndSequentialId())
       )
       .viaMat(KillSwitches.single)(Keep.right[NotUsed, UniqueKillSwitch])
-      .toMat(Sink.foreach(contractStateEventsDispatcher.signalNewHead))(
+      .toMat(Sink.foreach { case newLedgerHead @ (offset, _) =>
+        dispatcherLagger.startTimer(offset)
+        contractStateEventsDispatcher.signalNewHead(newLedgerHead)
+      })(
         Keep.both[UniqueKillSwitch, Future[Done]]
       )
       .run()

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -96,6 +96,8 @@ object ParallelIndexerFactory {
               tailingRateLimitPerSecond = tailingRateLimitPerSecond,
               ingestTail = postgresDaoPool.execute[RunningDBBatch, RunningDBBatch](
                 (batch: RunningDBBatch, dao: PostgresDAO) => {
+                  metrics.daml.indexer.ledgerEndSequentialId
+                    .updateValue(batch.lastSeqEventId)
                   dao.updateParams(
                     ledgerEnd = batch.lastOffset,
                     eventSeqId = batch.lastSeqEventId,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractKeyStateCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractKeyStateCache.scala
@@ -16,9 +16,9 @@ object ContractKeyStateCache {
     StateCache(
       cache = SizedCache.from[GlobalKey, ContractKeyStateValue](
         SizedCache.Configuration(cacheSize),
-        metrics.daml.execution.keyStateCache,
+        metrics.daml.execution.cache.keyState,
       ),
-      metrics = metrics,
+      registerUpdateTimer = metrics.daml.execution.cache.registerCacheUpdate,
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractsStateCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractsStateCache.scala
@@ -16,9 +16,9 @@ object ContractsStateCache {
     StateCache(
       cache = SizedCache.from[ContractId, ContractStateValue](
         SizedCache.Configuration(cacheSize),
-        metrics.daml.execution.contractStateCache,
+        metrics.daml.execution.cache.contractState,
       ),
-      metrics = metrics,
+      registerUpdateTimer = metrics.daml.execution.cache.registerCacheUpdate,
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -18,13 +18,7 @@ import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.appendonlydao.EventSequentialId
 import com.daml.platform.store.cache.ContractKeyStateValue._
 import com.daml.platform.store.cache.ContractStateValue._
-import com.daml.platform.store.cache.MutableCacheBackedContractStore.{
-  CacheIndex,
-  ContractNotFound,
-  EmptyContractIds,
-  SignalNewLedgerHead,
-  SubscribeToContractStateEvents,
-}
+import com.daml.platform.store.cache.MutableCacheBackedContractStore._
 import com.daml.platform.store.dao.events.ContractStateEvent
 import com.daml.platform.store.dao.events.ContractStateEvent.LedgerEndMarker
 import com.daml.platform.store.interfaces.LedgerDaoContractsReader
@@ -223,7 +217,8 @@ class MutableCacheBackedContractStore(
 
   private def updateOffsets(event: ContractStateEvent): Unit = {
     cacheIndex.set(event.eventOffset, event.eventSequentialId)
-    metrics.daml.indexer.currentStateCacheSequentialIdGauge.updateValue(event.eventSequentialId)
+    metrics.daml.execution.cache.indexSequentialId
+      .updateValue(event.eventSequentialId)
     event match {
       case LedgerEndMarker(eventOffset, _) => signalNewLedgerHead(eventOffset)
       case _ => ()

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/StateCacheSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/StateCacheSpec.scala
@@ -22,7 +22,9 @@ import scala.util.Success
 
 class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Eventually {
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
-  private val metrics = new Metrics(new MetricRegistry)
+  private val cacheUpdateTimer = new Metrics(
+    new MetricRegistry
+  ).daml.execution.cache.registerCacheUpdate
 
   behavior of s"${classOf[StateCache[_, _]].getSimpleName}.putAsync"
 
@@ -30,7 +32,7 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
     implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
 
     val cache = mock[ConcurrentCache[String, String]]
-    val stateCache = StateCache[String, String](cache, metrics)
+    val stateCache = StateCache[String, String](cache, cacheUpdateTimer)
 
     val asyncUpdatePromise = Promise[String]()
     val putAsyncResult = stateCache.putAsync("key", 1L, asyncUpdatePromise.future)
@@ -102,7 +104,7 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
     implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
 
     val cache = mock[ConcurrentCache[String, String]]
-    val stateCache = StateCache[String, String](cache, metrics)
+    val stateCache = StateCache[String, String](cache, cacheUpdateTimer)
 
     val asyncUpdatePromise = Promise[String]()
     val putAsyncResult = stateCache.putAsync("key", 1L, asyncUpdatePromise.future)
@@ -123,7 +125,7 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
     implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
 
     val cache = mock[ConcurrentCache[String, String]]
-    val stateCache = StateCache[String, String](cache, metrics)
+    val stateCache = StateCache[String, String](cache, cacheUpdateTimer)
 
     val asyncUpdatePromise = Promise[String]()
     val putAsyncResult = stateCache.putAsync("key", 2L, asyncUpdatePromise.future)
@@ -148,7 +150,7 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
           .maximumSize(cacheSize),
         None,
       ),
-      metrics = metrics,
+      registerUpdateTimer = cacheUpdateTimer,
     )(scala.concurrent.ExecutionContext.global)
 
   private def prepare(


### PR DESCRIPTION
Additional metrics for mutable contract state cache
* Time lag between contract state events and general dispatcher
* Emit current event sequential id from the indexer.
* Time update registering metric

Additionally, all caching metrics have been moved under `daml.execution.cache` in the daml metric registry. 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
