### PR TITLE
Use sequential id for contract and key activeness checks

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -180,6 +180,7 @@ class MutableCacheBackedContractStore(
           forParties,
           contractId,
           contract.arg,
+          Some(cacheIndex.getSequentialId),
         )
       case _: Archived =>
         // We need to fetch the contract here since the archival
@@ -187,6 +188,7 @@ class MutableCacheBackedContractStore(
         contractsReader.lookupActiveContractAndLoadArgument(
           forParties,
           contractId,
+          Some(cacheIndex.getSequentialId),
         )
     }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.transaction.GlobalKey
 import com.daml.logging.LoggingContext
+import com.daml.platform.store.cache.MutableCacheBackedContractStore.EventSequentialId
 import com.daml.platform.store.interfaces.LedgerDaoContractsReader._
 
 import scala.concurrent.Future
@@ -25,28 +26,36 @@ private[platform] trait LedgerDaoContractsReader {
 
   /** Looks up an active or divulged contract if it is visible for the given party.
     *
+    * TODO append-only: Remove optionality of `ledgerEndSequentialId` when it's no longer needed for compatibility with the legacy `dao`
+    *
     * @param readers a set of parties for one of which the contract must be visible
     * @param contractId the contract id to query
+    * @param ledgerEndSequentialId optionally, the ledger end sequential id against which the query should be executed
     * @return the optional [[Contract]] value
     */
   def lookupActiveContractAndLoadArgument(
       readers: Set[Party],
       contractId: ContractId,
+      ledgerEndSequentialId: Option[EventSequentialId] = None,
   )(implicit loggingContext: LoggingContext): Future[Option[Contract]]
 
   /** Looks up an active or divulged contract if it is visible for the given party.
     * This method uses the provided create argument for building the [[Contract]] value
     * instead of decoding it again.
     *
+    * TODO append-only: Remove optionality of `ledgerEndSequentialId` when it's no longer needed for compatibility with the legacy `dao`
+    *
     * @param readers a set of parties for one of which the contract must be visible
     * @param contractId the contract id to query
     * @param createArgument the contract create argument
+    * @param ledgerEndSequentialId optionally, the ledger end sequential id against which the query should be executed
     * @return the optional [[Contract]] value
     */
   def lookupActiveContractWithCachedArgument(
       readers: Set[Party],
       contractId: ContractId,
       createArgument: Value,
+      ledgerEndSequentialId: Option[EventSequentialId] = None,
   )(implicit loggingContext: LoggingContext): Future[Option[Contract]]
 
   /** Looks up a Contract given a contract key and a party

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
@@ -434,6 +434,7 @@ object MutableCacheBackedContractStoreSpec {
     override def lookupActiveContractAndLoadArgument(
         forParties: Set[Party],
         contractId: ContractId,
+        ledgerEndSequentialId: Option[EventSequentialId] = None,
     )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
       (contractId, forParties) match {
         case (`cId_2`, parties) if parties.contains(charlie) =>
@@ -449,13 +450,18 @@ object MutableCacheBackedContractStoreSpec {
         forParties: Set[Party],
         contractId: ContractId,
         createArgument: Value,
+        ledgerEndSequentialId: Option[EventSequentialId] = None,
     )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
       (contractId, forParties) match {
         case (`cId_2`, parties) if parties.contains(charlie) => Future.successful(Some(contract2))
         case _ => Future.successful(Option.empty)
       }
 
-    override def lookupContractKey(key: Key, forParties: Set[Party])(implicit
+    override def lookupContractKey(
+        key: Key,
+        forParties: Set[Party],
+        ledgerEndSequentialId: Option[EventSequentialId] = None,
+    )(implicit
         loggingContext: LoggingContext
     ): Future[Option[ContractId]] = throw new RuntimeException("This method should not be called")
   }


### PR DESCRIPTION
This PR optimizes activeness checks for contracts and keys performed by the `ContractsReader` against the index db, by using the current cache index (from `MutableCacheBackedContractStore`) as the ledger end bound in SQL queries.

**NOTE**: The optimization is targeted at the mutable contract state cache. The legacy `dao` schema and the translation cache do not leverage this optimization.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
