### PR TITLE
more robust macOS cleanup

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -7,29 +7,8 @@ steps:
 
     eval "$(dev-env/bin/dade-assist)"
 
-    exec 1> >(while IFS= read -r line; do echo "$(date -Is) [out]: $line"; done)
-    exec 2> >(while IFS= read -r line; do echo "$(date -Is) [err]: $line"; done >&2)
-
-    # Location of the disk cache for CI servers set in their init files:
-    # infra/macos/2-common-box/init.sh:echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
-    # infra/vsts_agent_linux_startup.sh:echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
-
-    case $(uname) in
-    Linux)
-        cache_1=/home/vsts/.cache/bazel
-        cache_2=/home/vsts/.bazel-cache
-    ;;
-    Darwin)
-        cache_1=/var/tmp/_bazel_vsts
-        cache_2=/Users/vsts/.bazel-cache
-    ;;
-    esac
-
-    for cache in $cache_1 $cache_2; do
-        for pid in $(lsof $cache | sed 1d | awk '{print $2}' | sort -u); do
-            kill -s KILL $pid
-        done
-    done
+    exec 1> >(while IFS= read -r line; do echo "$(date -uIs) [out]: $line"; done)
+    exec 2> >(while IFS= read -r line; do echo "$(date -uIs) [err]: $line"; done >&2)
 
     df -h .
     if [ $(df -m . | sed 1d | awk '{print $4}') -lt 50000 ]; then

--- a/infra/macos/2-common-box/init.sh
+++ b/infra/macos/2-common-box/init.sh
@@ -72,8 +72,6 @@ cat <<'RESET_CACHES' > $CACHE_SCRIPT
 
 set -euo pipefail
 
-set -x
-
 reset_cache() {
     local file mount_point
     file=$1
@@ -85,7 +83,14 @@ reset_cache() {
             echo "Killing $pid..."
             kill -s KILL $pid
         done
-        hdiutil detach "$mount_point"
+        for pid in $(lsof $mount_point | sed 1d | awk '{print $2}' | sort -u); do
+            echo "Killing $pid..."
+            kill -s KILL $pid
+        done
+        if hdiutil info | grep $mount_point; then
+            hdiutil detach "$mount_point"
+        fi
+        rm -rf $mount_point
     fi
 
     rm -f "${file}.sparseimage"

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -117,7 +117,14 @@ reset_cache() {
             echo "Killing $pid..."
             kill -s KILL $pid
         done
-        umount $mount_point
+        for pid in $(lsof $mount_point | sed 1d | awk '{print $2}' | sort -u); do
+            echo "Killing $pid..."
+            kill -s KILL $pid
+        done
+        if mount -l | grep $mount_point; then
+            umount $mount_point
+        fi
+        rm -rf $mount_point
     fi
 
     rm -f $file


### PR DESCRIPTION
We've recently seen a few cases where the macOS nodes ended up not having the cache partition mounted. So far this has only happened on semi-broken nodes (guest VM still up and running but host unable to connect to it), so I haven't been able to actually poke at a broken machine, but I believe this should allow a machine in such a state to recover.

While we haven't observed a similar issue on Linux nodes (as far as I'm aware), I have made similar changes there to keep both scripts in sync.

CHANGELOG_BEGIN
CHANGELOG_END