### PR TITLE
Extend Transaction proto format for rollback nodes.

### DIFF
--- a/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/TransactionNormalizerSpec.scala
+++ b/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/TransactionNormalizerSpec.scala
@@ -19,7 +19,7 @@ class TransactionNormalizerSpec
   "normalizerTransaction" should {
 
     "only keeps Create and Exercise nodes" in {
-      forAll(noDanglingRefGenVersionedTransaction(allowRollback = true)) { tx =>
+      forAll(noDanglingRefGenVersionedTransaction) { tx =>
         val normalized = TransactionNormalizer.normalize(CommittedTransaction(tx))
 
         val nidsBefore: Set[NodeId] = tx.nodes.keySet

--- a/daml-lf/transaction/src/main/protobuf/com/daml/lf/transaction.proto
+++ b/daml-lf/transaction/src/main/protobuf/com/daml/lf/transaction.proto
@@ -45,6 +45,7 @@ message Node {
         NodeFetch fetch = 4;
         NodeExercise exercise = 5;
         NodeLookupByKey lookup_by_key = 6;
+        NodeRollback rollback = 7;
     }
 
     string version = 63; // *since 11*, optional
@@ -110,6 +111,10 @@ message NodeLookupByKey {
     KeyWithMaintainers key_with_maintainers = 2;
     reserved 3; // was contract_id
     com.daml.lf.value.ContractId contract_id_struct = 4;
+}
+
+message NodeRollback {
+    repeated string children = 1; // node ids
 }
 
 // architecture-handbook-entry-end: Nodes

--- a/daml-lf/transaction/src/main/protobuf/com/daml/lf/transaction.proto
+++ b/daml-lf/transaction/src/main/protobuf/com/daml/lf/transaction.proto
@@ -45,7 +45,8 @@ message Node {
         NodeFetch fetch = 4;
         NodeExercise exercise = 5;
         NodeLookupByKey lookup_by_key = 6;
-        NodeRollback rollback = 7;
+        // TODO https://github.com/digital-asset/daml/issues/8020
+        NodeRollback rollback = 7; //*since DEV* // TODO: update to version when exceptions land
     }
 
     string version = 63; // *since 11*, optional
@@ -113,7 +114,8 @@ message NodeLookupByKey {
     com.daml.lf.value.ContractId contract_id_struct = 4;
 }
 
-message NodeRollback {
+// TODO https://github.com/digital-asset/daml/issues/8020
+message NodeRollback { // *since DEV* // TODO: update to version when exceptions land
     repeated string children = 1; // node ids
 }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -49,6 +49,7 @@ object TransactionVersion {
   private[lf] val minNodeVersion = V11
   private[lf] val minNoVersionValue = V12
   private[lf] val minTypeErasure = V12
+  //nothing was added in V13, so there are no vals: "minSomething = V13"
   private[lf] val minExceptions = VDev
 
   private[lf] val assignNodeVersion: LanguageVersion => TransactionVersion = {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -224,6 +224,10 @@ object KeyValueCommitting {
 
       node.getNodeTypeCase match {
 
+        case TransactionOuterClass.Node.NodeTypeCase.ROLLBACK =>
+          // TODO https://github.com/digital-asset/daml/issues/8020
+          sys.error("rollback nodes are not supported")
+
         case TransactionOuterClass.Node.NodeTypeCase.CREATE =>
           val protoCreate = node.getCreate
           TransactionCoder.nodeKey(nodeVersion, protoCreate) match {


### PR DESCRIPTION
Part of #8020.

Extend Transaction proto format for rollback nodes.

- proto format
- encode/decode
- testcase
- always `allowRollback` from scalagen testing; and so remove control flag
- two more `8020` TODOs, for other code which decodes the proto

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
