### PR TITLE
Check visibility for by-key operation of local contracts

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -226,6 +226,15 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        "start": "1.13.0-snapshot.20210419.6730.1.8c3a8c04",
+        "platform_ranges": [
+            {
+                "end": "1.13.0-snapshot.20210419.6730.0.8c3a8c04",
+                "exclusions": ["ContractKeysIT:CKLocalKeyVisibility"],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
+++ b/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
@@ -1,6 +1,8 @@
--- @ERROR Attempt to fetch, lookup or exercise a key associated with a contract
--- @ERROR Attempt to fetch, lookup or exercise a key associated with a contract
--- @ERROR Attempt to fetch, lookup or exercise a key associated with a contract
+-- @ERROR range=18:1-18:10; Attempt to fetch, lookup or exercise a key associated with a contract
+-- @ERROR range=63:1-63:15; Attempt to fetch, lookup or exercise a key associated with a contract
+-- @ERROR range=81:1-81:12; Attempt to fetch, lookup or exercise a key associated with a contract
+-- @ERROR range=111:1-111:12; Attempt to fetch, lookup or exercise a key associated with a contract
+-- @ERROR range=117:1-117:11;  Attempt to fetch, lookup or exercise a key associated with a contract
 module ContractKeyNotVisible where
 
 import DA.Optional
@@ -70,8 +72,9 @@ divulgeeLookup = scenario do
   -- which means the error message changes. The reason is that the
   -- assertion is checked at interpretation time, before the lookup
   -- is checked at validation time.
+  delegationCid <- submit sig $ create (Delegation sig divulgee)
   submit divulgee do
-    mcid <- createAndExercise (Delegation sig divulgee) LookupKeyed
+    mcid <- exercise delegationCid LookupKeyed
     assert (isNone mcid)
     pure ()
 
@@ -80,7 +83,46 @@ blindLookup = scenario do
   blind <- getParty "b" -- Blind
   _ <- submit sig do create Keyed with ..
   -- Blind party can't do positive lookup with maintainer authority.
+  cid <- submit sig $ create (Delegation sig blind)
   submit blind do
-    mcid <- createAndExercise (Delegation sig blind) LookupKeyed
+    mcid <- exercise cid LookupKeyed
     assert (isNone mcid)
     pure ()
+
+template LocalKeyVisibility
+  with
+    sig : Party
+    obs : Party
+  where
+    signatory sig
+    observer obs
+    choice LocalLookup : ()
+      controller obs
+      do create (Keyed sig)
+         Some _ <- lookupByKey @Keyed sig
+         pure ()
+
+    choice LocalFetch : ()
+      controller obs
+      do create (Keyed sig)
+         _ <- fetchByKey @Keyed sig
+         pure ()
+
+localLookup = scenario do
+  p1 <- getParty "p1"
+  p2 <- getParty "p2"
+  cid <- submit p1 $ create (LocalKeyVisibility p1 p2)
+  submit p2 $ exercise cid LocalLookup
+
+localFetch = scenario do
+  p1 <- getParty "p1"
+  p2 <- getParty "p2"
+  cid <- submit p1 $ create (LocalKeyVisibility p1 p2)
+  submit p2 $ exercise cid LocalLookup
+
+localLookupFetchMustFail = scenario do
+  p1 <- getParty "p1"
+  p2 <- getParty "p2"
+  cid <- submit p1 $ create (LocalKeyVisibility p1 p2)
+  submitMustFail p2 $ exercise cid LocalLookup
+  submitMustFail p2 $ exercise cid LocalFetch

--- a/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
+++ b/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
@@ -118,7 +118,7 @@ localFetch = scenario do
   p1 <- getParty "p1"
   p2 <- getParty "p2"
   cid <- submit p1 $ create (LocalKeyVisibility p1 p2)
-  submit p2 $ exercise cid LocalLookup
+  submit p2 $ exercise cid LocalFetch
 
 localLookupFetchMustFail = scenario do
   p1 <- getParty "p1"

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -742,7 +742,7 @@ main =
                     , "  p1 <- allocateParty \"p1\""
                     , "  p2 <- allocateParty \"p2\""
                     , "  cid <- submit p1 $ createCmd (LocalKeyVisibility p1 p2)"
-                    , "  submit p2 $ exerciseCmd cid LocalLookup"
+                    , "  submit p2 $ exerciseCmd cid LocalFetch"
                     , "localLookupFetchMustFail = do"
                     , "  p1 <- allocateParty \"p1\""
                     , "  p2 <- allocateParty \"p2\""

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -161,6 +161,16 @@ final class Conversions(
             .build
         )
 
+      case SError.DamlELocalContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
+        builder.setScenarioContractKeyNotVisible(
+          proto.ScenarioError.ContractKeyNotVisible.newBuilder
+            .setContractRef(mkContractRef(coid, gk.templateId))
+            .addAllActAs(actAs.map(convertParty(_)).asJava)
+            .addAllReadAs(readAs.map(convertParty(_)).asJava)
+            .addAllStakeholders(stakeholders.map(convertParty).asJava)
+            .build
+        )
+
       case SError.ScenarioErrorContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
         builder.setScenarioContractKeyNotVisible(
           proto.ScenarioError.ContractKeyNotVisible.newBuilder

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -334,6 +334,15 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
                 ResultError(Error(s"dependency error: couldn't find key ${gk.globalKey}")),
           )
 
+        case SResultNeedLocalKeyVisible(stakeholders, _, cb) =>
+          return ResultNeedLocalKeyVisible(
+            stakeholders,
+            result => {
+              cb(result.toSVisibleByKey)
+              interpretLoop(machine, time)
+            },
+          )
+
         case _: SResultScenarioCommit =>
           return ResultError(Error("unexpected ScenarioCommit"))
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -6,6 +6,7 @@ package com.daml.lf.engine
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{BackStack, ImmArray, ImmArrayCons}
 import com.daml.lf.language.Ast._
+import com.daml.lf.speedy.SResult.SVisibleByKey
 import com.daml.lf.transaction.GlobalKeyWithMaintainers
 import com.daml.lf.value.Value._
 import scalaz.Monad
@@ -26,6 +27,8 @@ sealed trait Result[+A] extends Product with Serializable {
       ResultNeedPackage(pkgId, mbPkg => resume(mbPkg).map(f))
     case ResultNeedKey(gk, resume) =>
       ResultNeedKey(gk, mbAcoid => resume(mbAcoid).map(f))
+    case ResultNeedLocalKeyVisible(stakeholders, resume) =>
+      ResultNeedLocalKeyVisible(stakeholders, visible => resume(visible).map(f))
   }
 
   def flatMap[B](f: A => Result[B]): Result[B] = this match {
@@ -37,12 +40,15 @@ sealed trait Result[+A] extends Product with Serializable {
       ResultNeedPackage(pkgId, mbPkg => resume(mbPkg).flatMap(f))
     case ResultNeedKey(gk, resume) =>
       ResultNeedKey(gk, mbAcoid => resume(mbAcoid).flatMap(f))
+    case ResultNeedLocalKeyVisible(stakeholders, resume) =>
+      ResultNeedLocalKeyVisible(stakeholders, visible => resume(visible).flatMap(f))
   }
 
   def consume(
       pcs: ContractId => Option[ContractInst[VersionedValue[ContractId]]],
       packages: PackageId => Option[Package],
       keys: GlobalKeyWithMaintainers => Option[ContractId],
+      localKeyVisible: Set[Party] => VisibleByKey,
   ): Either[Error, A] = {
     @tailrec
     def go(res: Result[A]): Either[Error, A] =
@@ -52,6 +58,8 @@ sealed trait Result[+A] extends Product with Serializable {
         case ResultNeedContract(acoid, resume) => go(resume(pcs(acoid)))
         case ResultNeedPackage(pkgId, resume) => go(resume(packages(pkgId)))
         case ResultNeedKey(key, resume) => go(resume(keys(key)))
+        case ResultNeedLocalKeyVisible(stakeholders, resume) =>
+          go(resume(localKeyVisible(stakeholders)))
       }
     go(this)
   }
@@ -88,6 +96,45 @@ final case class ResultNeedPackage[A](packageId: PackageId, resume: Option[Packa
 final case class ResultNeedKey[A](
     key: GlobalKeyWithMaintainers,
     resume: Option[ContractId] => Result[A],
+) extends Result[A]
+
+/** Whether a given contract can be fetched by key, i.e., actAs union readAs
+  *    contains at least one stakeholder.
+  */
+sealed trait VisibleByKey {
+  private[engine] def toSVisibleByKey: SVisibleByKey
+}
+object VisibleByKey {
+
+  /** Contract is not visible, includes actAs and readAs for error reporting
+    */
+  final case class NotVisible(actAs: Set[Party], readAs: Set[Party]) extends VisibleByKey {
+    override def toSVisibleByKey = SVisibleByKey.NotVisible(actAs, readAs)
+  }
+  final case object Visible extends VisibleByKey {
+    override val toSVisibleByKey = SVisibleByKey.Visible
+  }
+
+  def fromSubmitters(
+      actAs: Set[Party],
+      readAs: Set[Party] = Set.empty,
+  ): Set[Party] => VisibleByKey = {
+    val readers = actAs union readAs
+    stakeholders =>
+      if (readers.intersect(stakeholders).nonEmpty) {
+        VisibleByKey.Visible
+      } else {
+        VisibleByKey.NotVisible(actAs, readAs)
+      }
+  }
+}
+
+/** Check that a local contract with the given stakeholders
+  *    can be fetched by key.
+  */
+final case class ResultNeedLocalKeyVisible[A](
+    stakeholders: Set[Party],
+    resume: VisibleByKey => Result[A],
 ) extends Result[A]
 
 object Result {
@@ -150,6 +197,14 @@ object Result {
                     Result
                       .sequence(results_)
                       .map(otherResults => (okResults :+ x) :++ otherResults)
+                  ),
+              )
+            case ResultNeedLocalKeyVisible(stakeholders, resume) =>
+              ResultNeedLocalKeyVisible(
+                stakeholders,
+                visible =>
+                  resume(visible).flatMap(x =>
+                    Result.sequence(results_).map(otherResults => (okResults :+ x) :++ otherResults)
                   ),
               )
           }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
@@ -143,7 +143,12 @@ class ContractDiscriminatorFreshnessCheckSpec
         participantId = participant,
         submissionSeed = submissionSeed,
       )
-      .consume(pcs, pkgs, keyWithMaintainers => keys(keyWithMaintainers.globalKey))
+      .consume(
+        pcs,
+        pkgs,
+        keyWithMaintainers => keys(keyWithMaintainers.globalKey),
+        VisibleByKey.fromSubmitters(Set(alice)),
+      )
 
   val engine = Engine.DevEngine()
 
@@ -326,7 +331,7 @@ class ContractDiscriminatorFreshnessCheckSpec
       val result =
         new preprocessing.Preprocessor(ConcurrentCompiledPackages(speedy.Compiler.Config.Dev))
           .translateTransactionRoots(GenTransaction(newNodes, tx.roots))
-          .consume(_ => None, pkgs, _ => None)
+          .consume(_ => None, pkgs, _ => None, _ => VisibleByKey.Visible)
 
       inside(result) { case Left(err) =>
         err.msg should include("Conflicting discriminators")

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -192,7 +192,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Right[_, _]]
 
     }
@@ -204,7 +204,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Right[_, _]]
     }
 
@@ -218,7 +218,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Left[_, _]]
     }
 
@@ -234,7 +234,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Right[_, _]]
     }
 
@@ -250,7 +250,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Right[_, _]]
     }
 
@@ -265,7 +265,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Right[_, _]]
     }
 
@@ -280,7 +280,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Right[_, _]]
     }
 
@@ -295,7 +295,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res.left.value.msg should startWith("Missing record label n for record")
     }
 
@@ -310,7 +310,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res.left.value.msg should startWith(
         "Impossible to exercise by key, no key is defined for template"
       )
@@ -327,7 +327,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res.left.value.msg should startWith("mismatching type")
     }
 
@@ -349,7 +349,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Right[_, _]]
 
     }
@@ -369,7 +369,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Right[_, _]]
     }
 
@@ -391,7 +391,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Left[_, _]]
     }
 
@@ -410,7 +410,7 @@ class EngineTest
 
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Left[_, _]]
     }
 
@@ -433,12 +433,12 @@ class EngineTest
 
       translator
         .translateValue(typ, someValue)
-        .consume(lookupContract, allOptionalPackages.get, lookupKey) shouldEqual
+        .consume(lookupContract, allOptionalPackages.get, lookupKey, allKeysVisible) shouldEqual
         Right(SRecord(id, ImmArray("recField"), ArrayList(SOptional(Some(SText("foo"))))))
 
       translator
         .translateValue(typ, noneValue)
-        .consume(lookupContract, allOptionalPackages.get, lookupKey) shouldEqual
+        .consume(lookupContract, allOptionalPackages.get, lookupKey, allKeysVisible) shouldEqual
         Right(SRecord(id, ImmArray("recField"), ArrayList(SOptional(None))))
 
     }
@@ -454,7 +454,7 @@ class EngineTest
           TTyConApp(id, ImmArray.empty),
           wrongRecord,
         )
-        .consume(lookupContract, lookupPackage, lookupKey) shouldBe a[Left[_, _]]
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible) shouldBe a[Left[_, _]]
     }
   }
 
@@ -464,13 +464,14 @@ class EngineTest
     val command =
       CreateCommand(id, ValueRecord(Some(id), ImmArray((Some[Name]("p"), ValueParty(party)))))
     val submissionSeed = hash("minimal create command")
+    val submitters = Set(party)
     val res = preprocessor
       .preprocessCommands(ImmArray(command))
-      .consume(lookupContract, lookupPackage, lookupKey)
+      .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
     res shouldBe a[Right[_, _]]
     val interpretResult = engine
-      .submit(Set(party), Commands(ImmArray(command), let, "test"), participant, submissionSeed)
-      .consume(lookupContract, lookupPackage, lookupKey)
+      .submit(submitters, Commands(ImmArray(command), let, "test"), participant, submissionSeed)
+      .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
     "be translated" in {
       interpretResult shouldBe a[Right[_, _]]
@@ -495,9 +496,10 @@ class EngineTest
     "be validated" in {
       val Right((tx, meta)) = interpretResult
       val Right(submitter) = tx.guessSubmitter
+      val submitters = Set(submitter)
       val validated = engine
-        .validate(Set(submitter), tx, let, participant, meta.submissionTime, submissionSeed)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .validate(submitters, tx, let, participant, meta.submissionTime, submissionSeed)
+        .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
       validated match {
         case Left(e) =>
           fail(e.msg)
@@ -545,12 +547,12 @@ class EngineTest
       val cmd = command(templateId, signatories)
       val res = preprocessor
         .preprocessCommands(ImmArray(cmd))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(actAs))
       withClue("Preprocessing result: ")(res shouldBe a[Right[_, _]])
 
       engine
         .submit(actAs, Commands(ImmArray(cmd), let, "test"), participant, submissionSeed)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(actAs))
     }
 
     "be translated" in {
@@ -582,7 +584,12 @@ class EngineTest
         val Right((tx, meta)) = interpretResult(templateId, signatories, submitters)
         val validated = engine
           .validate(submitters, tx, let, participant, meta.submissionTime, submissionSeed)
-          .consume(lookupContract, lookupPackage, lookupKey)
+          .consume(
+            lookupContract,
+            lookupPackage,
+            lookupKey,
+            VisibleByKey.fromSubmitters(submitters),
+          )
         validated match {
           case Left(e) =>
             fail(e.msg)
@@ -637,10 +644,11 @@ class EngineTest
     val cid = toContractId("#BasicTests:Simple:1")
     val command =
       ExerciseCommand(templateId, cid, "Hello", ValueRecord(Some(hello), ImmArray.empty))
+    val submitters = Set(party)
 
     val res = preprocessor
       .preprocessCommands(ImmArray(command))
-      .consume(lookupContract, lookupPackage, lookupKey)
+      .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
     res shouldBe a[Right[_, _]]
     val interpretResult =
       res
@@ -655,7 +663,12 @@ class EngineTest
               seeding = seeding,
               globalCids = globalCids,
             )
-            .consume(lookupContract, lookupPackage, lookupKey)
+            .consume(
+              lookupContract,
+              lookupPackage,
+              lookupKey,
+              VisibleByKey.fromSubmitters(submitters),
+            )
         }
     val Right((tx, txMeta)) = interpretResult
     val Right(submitter) = tx.guessSubmitter
@@ -663,7 +676,12 @@ class EngineTest
     "be translated" in {
       val Right((rtx, _)) = engine
         .submit(Set(party), Commands(ImmArray(command), let, "test"), participant, submissionSeed)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(
+          lookupContract,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(Set(submitter)),
+        )
       isReplayedBy(tx, rtx) shouldBe Right(())
     }
 
@@ -685,7 +703,12 @@ class EngineTest
     "be validated" in {
       val validated = engine
         .validate(Set(submitter), tx, let, participant, let, submissionSeed)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(
+          lookupContract,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(Set(submitter)),
+        )
       validated match {
         case Left(e) =>
           fail(e.msg)
@@ -715,16 +738,17 @@ class EngineTest
       "SumToK",
       ValueRecord(None, ImmArray((None, ValueInt64(5)))),
     )
+    val submitters = Set(alice)
 
     val res = preprocessor
       .preprocessCommands(ImmArray(command))
-      .consume(lookupContract, lookupPackage, lookupKey)
+      .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
     res shouldBe a[Right[_, _]]
 
     "fail at submission" in {
       val submitResult = engine
-        .submit(Set(alice), Commands(ImmArray(command), let, "test"), participant, submissionSeed)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .submit(submitters, Commands(ImmArray(command), let, "test"), participant, submissionSeed)
+        .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
       submitResult.left.value.msg should startWith("dependency error: couldn't find key")
     }
   }
@@ -740,10 +764,11 @@ class EngineTest
       "SumToK",
       ValueRecord(None, ImmArray((None, ValueInt64(5)))),
     )
+    val submitters = Set(alice)
 
     val res = preprocessor
       .preprocessCommands(ImmArray(command))
-      .consume(lookupContract, lookupPackage, lookupKey)
+      .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
     res shouldBe a[Right[_, _]]
     val result =
       res
@@ -751,22 +776,32 @@ class EngineTest
           engine
             .interpretCommands(
               validating = false,
-              submitters = Set(alice),
+              submitters = submitters,
               commands = cmds,
               ledgerTime = let,
               submissionTime = let,
               seeding = seeding,
               globalCids = globalCids,
             )
-            .consume(lookupContract, lookupPackage, lookupKey)
+            .consume(
+              lookupContract,
+              lookupPackage,
+              lookupKey,
+              VisibleByKey.fromSubmitters(submitters),
+            )
         }
     val Right((tx, txMeta)) = result
     val Right(submitter) = tx.guessSubmitter
 
     "be translated" in {
       val submitResult = engine
-        .submit(Set(alice), Commands(ImmArray(command), let, "test"), participant, submissionSeed)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .submit(submitters, Commands(ImmArray(command), let, "test"), participant, submissionSeed)
+        .consume(
+          lookupContract,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(Set(submitter)),
+        )
         .map(_._1)
       (result.map(_._1) |@| submitResult)((tx, rtx) => isReplayedBy(tx, rtx)) shouldBe Right(
         Right(())
@@ -785,8 +820,13 @@ class EngineTest
 
     "be validated" in {
       val validated = engine
-        .validate(Set(submitter), tx, let, participant, let, submissionSeed)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .validate(submitters, tx, let, participant, let, submissionSeed)
+        .consume(
+          lookupContract,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(Set(submitter)),
+        )
       validated match {
         case Left(e) =>
           fail(e.msg)
@@ -832,18 +872,19 @@ class EngineTest
           argument = SValue.SUnit,
         )
       )
+      val submitters = Set(alice)
 
       val result = engine
         .interpretCommands(
           validating = false,
-          submitters = Set(alice),
+          submitters = submitters,
           commands = cmds,
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(seed),
           globalCids = Set.empty,
         )
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       inside(result) { case Left(err) =>
         err.msg should include(
@@ -869,17 +910,19 @@ class EngineTest
         )
       )
 
+      val submitters = Set(alice)
+
       val result = engine
         .interpretCommands(
           validating = false,
-          submitters = Set(alice),
+          submitters = submitters,
           commands = cmds,
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(seed),
           globalCids = Set.empty,
         )
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       inside(result) { case Left(err) =>
         err.msg should include(
@@ -902,17 +945,19 @@ class EngineTest
         )
       )
 
+      val submitters = Set(alice)
+
       val result = engine
         .interpretCommands(
           validating = false,
-          submitters = Set(alice),
+          submitters = submitters,
           commands = cmds,
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(seed),
           globalCids = Set.empty,
         )
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       inside(result) { case Left(err) =>
         err.msg should include(
@@ -936,9 +981,11 @@ class EngineTest
         ValueRecord(Some(hello), ImmArray.empty),
       )
 
+    val submitters = Set(party)
+
     val res = preprocessor
       .preprocessCommands(ImmArray(command))
-      .consume(lookupContract, lookupPackage, lookupKey)
+      .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
     res shouldBe a[Right[_, _]]
     val interpretResult =
       res
@@ -946,14 +993,19 @@ class EngineTest
           engine
             .interpretCommands(
               validating = false,
-              submitters = Set(party),
+              submitters = submitters,
               commands = cmds,
               ledgerTime = let,
               submissionTime = let,
               seeding = InitialSeeding.TransactionSeed(txSeed),
               globalCids = globalCids,
             )
-            .consume(lookupContract, lookupPackage, lookupKey)
+            .consume(
+              lookupContract,
+              lookupPackage,
+              lookupKey,
+              VisibleByKey.fromSubmitters(submitters),
+            )
         }
 
     val Right((tx, txMeta)) = interpretResult
@@ -980,7 +1032,12 @@ class EngineTest
     "be validated" in {
       val validated = engine
         .validate(Set(submitter), tx, let, participant, let, submissionSeed)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(
+          lookupContract,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(Set(submitter)),
+        )
       validated match {
         case Left(e) =>
           fail(e.msg)
@@ -998,7 +1055,7 @@ class EngineTest
       val list = ValueNil
       val res = preprocessor
         .translateValue(TList(TBuiltin(BTInt64)), list)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
 
       res shouldEqual Right(SList(FrontStack.empty))
     }
@@ -1007,7 +1064,7 @@ class EngineTest
       val list = ValueList(FrontStack(ValueInt64(1)))
       val res = preprocessor
         .translateValue(TList(TBuiltin(BTInt64)), list)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
 
       res shouldEqual Right(SList(FrontStack(ImmArray(SInt64(1)))))
     }
@@ -1018,7 +1075,7 @@ class EngineTest
       )
       val res = preprocessor
         .translateValue(TList(TBuiltin(BTInt64)), list)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
 
       res shouldEqual Right(
         SValue.SList(FrontStack(ImmArray(SInt64(1), SInt64(2), SInt64(3), SInt64(4), SInt64(5))))
@@ -1034,7 +1091,7 @@ class EngineTest
           TTyConApp(TypeConName(basicTestsPkgId, "BasicTests:Nesting0"), ImmArray.empty),
           nested,
         )
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
         .swap
         .toOption
         .get
@@ -1067,7 +1124,7 @@ class EngineTest
           TTyConApp(Identifier(basicTestsPkgId, "BasicTests:MyNestedRec"), ImmArray.empty),
           rec,
         )
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
       res shouldBe a[Right[_, _]]
     }
 
@@ -1087,7 +1144,7 @@ class EngineTest
           TTyConApp(Identifier(basicTestsPkgId, "BasicTests:TypeWithParameters"), ImmArray.empty),
           rec,
         )
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
 
       res shouldBe a[Right[_, _]]
     }
@@ -1108,7 +1165,7 @@ class EngineTest
           TTyConApp(Identifier(basicTestsPkgId, "BasicTests:TypeWithParameters"), ImmArray.empty),
           rec,
         )
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
 
       res shouldBe a[Right[_, _]]
     }
@@ -1126,7 +1183,7 @@ class EngineTest
           TTyConApp(Identifier(basicTestsPkgId, "BasicTests:TypeWithParameters"), ImmArray.empty),
           rec,
         )
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
 
       res shouldBe a[Left[_, _]]
     }
@@ -1144,7 +1201,7 @@ class EngineTest
           TTyConApp(Identifier(basicTestsPkgId, "BasicTests:TypeWithParameters"), ImmArray.empty),
           rec,
         )
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
 
       res shouldBe a[Right[_, _]]
     }
@@ -1162,7 +1219,7 @@ class EngineTest
           TTyConApp(Identifier(basicTestsPkgId, "BasicTests:TypeWithParameters"), ImmArray.empty),
           rec,
         )
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, allKeysVisible)
 
       res shouldBe a[Left[_, _]]
     }
@@ -1182,9 +1239,11 @@ class EngineTest
       ValueRecord(None, ImmArray((Some[Name]("newReceiver"), ValueParty(clara)))),
     )
 
+    val submitters = Set(bob)
+
     val Right((tx, txMeta)) = engine
-      .submit(Set(bob), Commands(ImmArray(command), let, "test"), participant, submissionSeed)
-      .consume(lookupContract, lookupPackage, lookupKey)
+      .submit(submitters, Commands(ImmArray(command), let, "test"), participant, submissionSeed)
+      .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
     val submissionTime = txMeta.submissionTime
 
@@ -1192,18 +1251,18 @@ class EngineTest
       crypto.Hash.deriveTransactionSeed(submissionSeed, participant, submissionTime)
     val Right((cmds, globalCids)) = preprocessor
       .preprocessCommands(ImmArray(command))
-      .consume(lookupContract, lookupPackage, lookupKey)
+      .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
     val Right((rtx, _)) = engine
       .interpretCommands(
         validating = false,
-        submitters = Set(bob),
+        submitters = submitters,
         commands = cmds,
         ledgerTime = let,
         submissionTime = submissionTime,
         seeding = InitialSeeding.TransactionSeed(txSeed),
         globalCids = globalCids,
       )
-      .consume(lookupContract, lookupPackage, lookupKey)
+      .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
     "be translated" in {
       isReplayedBy(tx, rtx) shouldBe Right(())
@@ -1284,18 +1343,24 @@ class EngineTest
       val transactionSeed =
         crypto.Hash.deriveTransactionSeed(submissionSeed, participant, submissionTime)
 
+      val submitters = Set(bob)
       val Right((tx, _)) =
         engine
           .interpretCommands(
             validating = false,
-            submitters = Set(bob),
+            submitters = submitters,
             commands = cmds,
             ledgerTime = let,
             submissionTime = submissionTime,
             seeding = InitialSeeding.TransactionSeed(transactionSeed),
             globalCids,
           )
-          .consume(lookupContract, lookupPackage, lookupKey)
+          .consume(
+            lookupContract,
+            lookupPackage,
+            lookupKey,
+            VisibleByKey.fromSubmitters(submitters),
+          )
       val Seq(_, noid1) = tx.transaction.nodes.keys.toSeq.sortBy(_.index)
       val blindingInfo = Blinding.blind(tx)
       val events = Event.collectEvents(tx.transaction, blindingInfo.disclosure)
@@ -1415,23 +1480,30 @@ class EngineTest
         ValueRecord(None, ImmArray((Some[Name]("cid"), ValueContractId(fetchedCid)))),
       )
 
+      val submitters = Set(exerciseActor)
+
       val res = preprocessor
         .preprocessCommands(ImmArray(command))
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       res
         .flatMap { case (cmds, globalCids) =>
           engine
             .interpretCommands(
               validating = false,
-              submitters = Set(exerciseActor),
+              submitters = submitters,
               commands = cmds,
               ledgerTime = let,
               submissionTime = let,
               seeding = seeding,
               globalCids = globalCids,
             )
-            .consume(lookupContract, lookupPackage, lookupKey)
+            .consume(
+              lookupContract,
+              lookupPackage,
+              lookupKey,
+              VisibleByKey.fromSubmitters(submitters),
+            )
         }
 
     }
@@ -1465,7 +1537,12 @@ class EngineTest
               txMeta.submissionTime,
               let,
             )
-            .consume(lookupContract, lookupPackage, lookupKey)
+            .consume(
+              lookupContract,
+              lookupPackage,
+              lookupKey,
+              VisibleByKey.fromSubmitters(n.requiredAuthorizers),
+            )
         isReplayedBy(fetchTx, reinterpreted) shouldBe Right(())
       }
     }
@@ -1520,10 +1597,17 @@ class EngineTest
 
       val let = Time.Timestamp.now()
 
+      val submitters = Set(alice)
+
       val reinterpreted =
         engine
-          .reinterpret(Set(alice), fetchNode, None, let, let)
-          .consume(lookupContract, lookupPackage, lookupKey)
+          .reinterpret(submitters, fetchNode, None, let, let)
+          .consume(
+            lookupContract,
+            lookupPackage,
+            lookupKey,
+            VisibleByKey.fromSubmitters(submitters),
+          )
 
       reinterpreted shouldBe a[Right[_, _]]
     }
@@ -1581,7 +1665,12 @@ class EngineTest
       )
       val Right((tx, _)) = engine
         .submit(Set(alice), Commands(ImmArray(exerciseCmd), now, "test"), participant, seed)
-        .consume(lookupContractMap.get, lookupPackage, lookupKey)
+        .consume(
+          lookupContractMap.get,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(Set(alice)),
+        )
 
       val expectedByKeyNodes = tx.transaction.nodes.collect {
         case (id, _: Node.NodeLookupByKey[_]) => id
@@ -1598,9 +1687,16 @@ class EngineTest
         "Lookup",
         ValueRecord(None, ImmArray((Some[Name]("n"), ValueInt64(42)))),
       )
+      val submitters = Set(alice)
+
       val Right((tx, txMeta)) = engine
         .submit(Set(alice), Commands(ImmArray(exerciseCmd), now, "test"), participant, seed)
-        .consume(lookupContractMap.get, lookupPackage, lookupKey)
+        .consume(
+          lookupContractMap.get,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(submitters),
+        )
       val nodeSeedMap = HashMap(txMeta.nodeSeeds.toSeq: _*)
 
       val Some((nid, lookupNode)) = firstLookupNode(tx.transaction)
@@ -1610,13 +1706,18 @@ class EngineTest
         Engine
           .DevEngine()
           .reinterpret(
-            Set(alice),
+            submitters,
             lookupNode,
             nodeSeedMap.get(nid),
             txMeta.submissionTime,
             now,
           )
-          .consume(lookupContract, lookupPackage, lookupKey)
+          .consume(
+            lookupContract,
+            lookupPackage,
+            lookupKey,
+            VisibleByKey.fromSubmitters(submitters),
+          )
 
       firstLookupNode(reinterpreted.transaction).map(_._2) shouldEqual Some(lookupNode)
     }
@@ -1630,18 +1731,30 @@ class EngineTest
       )
       val Right((tx, txMeta)) = engine
         .submit(Set(alice), Commands(ImmArray(exerciseCmd), now, "test"), participant, seed)
-        .consume(lookupContractMap.get, lookupPackage, lookupKey)
+        .consume(
+          lookupContractMap.get,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(Set(alice)),
+        )
 
       val nodeSeedMap = HashMap(txMeta.nodeSeeds.toSeq: _*)
 
       val Some((nid, lookupNode)) = firstLookupNode(tx.transaction)
       lookupNode.result shouldBe None
 
+      val submitters = Set(alice)
+
       val Right((reinterpreted, _)) =
         Engine
           .DevEngine()
-          .reinterpret(Set(alice), lookupNode, nodeSeedMap.get(nid), txMeta.submissionTime, now)
-          .consume(lookupContract, lookupPackage, lookupKey)
+          .reinterpret(submitters, lookupNode, nodeSeedMap.get(nid), txMeta.submissionTime, now)
+          .consume(
+            lookupContract,
+            lookupPackage,
+            lookupKey,
+            VisibleByKey.fromSubmitters(submitters),
+          )
 
       firstLookupNode(reinterpreted.transaction).map(_._2) shouldEqual Some(lookupNode)
     }
@@ -1654,17 +1767,19 @@ class EngineTest
         speedy.Command.LookupByKey(templateId, SParty(alice))
       )
 
+      val submitters = Set(alice)
+
       val result = engine
         .interpretCommands(
           validating = false,
-          submitters = Set(alice),
+          submitters = submitters,
           commands = cmds,
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(seed),
           globalCids = Set.empty,
         )
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       inside(result) { case Left(err) =>
         err.msg should include(
@@ -1685,14 +1800,15 @@ class EngineTest
           choiceId = choiceName,
           choiceArgument = ValueRecord(None, ImmArray.empty),
         )
+      val submitters = Set(party)
       engine
         .submit(
-          Set(party),
+          submitters,
           Commands(ImmArray(command), Time.Timestamp.now(), "test"),
           participant,
           submissionSeed,
         )
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
     }
 
     run("FactorialOfThree").map(_._2.dependsOnTime) shouldBe Right(false)
@@ -1715,17 +1831,24 @@ class EngineTest
 
       val cmd = speedy.Command.Fetch(BasicTests_WithKey, SValue.SContractId(fetchedCid))
 
+      val submitters = Set(alice)
+
       val Right((tx, _)) = engine
         .interpretCommands(
           validating = false,
-          submitters = Set(alice),
+          submitters = submitters,
           commands = ImmArray(cmd),
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
           globalCids = Set(fetchedCid),
         )
-        .consume(lookupContractMap.get, lookupPackage, lookupKey)
+        .consume(
+          lookupContractMap.get,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(submitters),
+        )
 
       tx.transaction.nodes.values.headOption match {
         case Some(Node.NodeFetch(_, _, _, _, _, _, key, _, _)) =>
@@ -1765,6 +1888,8 @@ class EngineTest
 
       val lookupContractMap = Map(fetchedCid -> withKeyContractInst, fetcherCid -> fetcherInst)
 
+      val submitters = Set(alice)
+
       val Right((cmds, globalCids)) = preprocessor
         .preprocessCommands(
           ImmArray(
@@ -1776,19 +1901,29 @@ class EngineTest
             )
           )
         )
-        .consume(lookupContractMap.get, lookupPackage, lookupKey)
+        .consume(
+          lookupContractMap.get,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(submitters),
+        )
 
       val Right((tx, _)) = engine
         .interpretCommands(
           validating = false,
-          submitters = Set(alice),
+          submitters = submitters,
           commands = cmds,
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
           globalCids = globalCids,
         )
-        .consume(lookupContractMap.get, lookupPackage, lookupKey)
+        .consume(
+          lookupContractMap.get,
+          lookupPackage,
+          lookupKey,
+          VisibleByKey.fromSubmitters(submitters),
+        )
 
       tx.transaction.nodes
         .collectFirst { case (id, nf: Node.NodeFetch[_]) =>
@@ -1839,7 +1974,7 @@ class EngineTest
     def run(cmds: ImmArray[Command]) =
       engine
         .submit(Set(alice), Commands(cmds, now, ""), participant, submissionSeed)
-        .consume(lookupContract, lookupPackage, lookupKey)
+        .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(Set(alice)))
 
     "error on fetch" in {
       val result = run(ImmArray(incorrectFetch))
@@ -1886,7 +2021,7 @@ class EngineTest
       )
       engine
         .submit(Set(party), Commands(ImmArray(command), let, "test"), participant, submissionSeed)
-        .consume(_ => None, lookupPackage, _ => None)
+        .consume(_ => None, lookupPackage, _ => None, VisibleByKey.fromSubmitters(Set(party)))
     }
 
     "produce a quadratic number of nodes" in {
@@ -1902,7 +2037,12 @@ class EngineTest
           submitter <- tx.guessSubmitter.left.map(ValidationError)
           res <- engine
             .validate(Set(submitter), tx, let, participant, metaData.submissionTime, submissionSeed)
-            .consume(_ => None, lookupPackage, _ => None)
+            .consume(
+              _ => None,
+              lookupPackage,
+              _ => None,
+              VisibleByKey.fromSubmitters(Set(submitter)),
+            )
         } yield res
 
       run(0).flatMap { case (tx, metaData) => validate(tx, metaData) } shouldBe Right(())
@@ -1948,13 +2088,15 @@ class EngineTest
           ImmArray.empty,
         )
 
+      val submitters = Set(alice)
+
       val Right((cmds, globalCids)) = preprocessor
         .preprocessCommands(
           ImmArray(
             CreateAndExerciseCommand(templateId, createArg, "DontExecuteCreate", exerciseArg)
           )
         )
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       val result = engine
         .interpretCommands(
@@ -1966,7 +2108,7 @@ class EngineTest
           seeding = InitialSeeding.TransactionSeed(txSeed),
           globalCids = globalCids,
         )
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
       result shouldBe a[Right[_, _]]
     }
 
@@ -1979,21 +2121,23 @@ class EngineTest
           ImmArray((Some[Name]("owner"), ValueParty(alice))),
         )
 
+      val submitters = Set(alice)
+
       val Right((cmds, globalCids)) = preprocessor
         .preprocessCommands(ImmArray(CreateCommand(templateId, createArg)))
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       val result = engine
         .interpretCommands(
           validating = false,
-          submitters = Set(alice),
+          submitters = submitters,
           commands = cmds,
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
           globalCids = globalCids,
         )
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
       result shouldBe a[Left[_, _]]
       val Left(err) = result
       err.msg should not include ("Boom")
@@ -2009,20 +2153,22 @@ class EngineTest
           ImmArray((Some[Name]("sig"), ValueParty(alice))),
         )
 
+      val submitters = Set(alice)
+
       val Right((cmds, globalCids)) = preprocessor
         .preprocessCommands(ImmArray(CreateCommand(templateId, createArg)))
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
       val result = engine
         .interpretCommands(
           validating = false,
-          submitters = Set(alice),
+          submitters = submitters,
           commands = cmds,
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
           globalCids = globalCids,
         )
-        .consume(_ => None, lookupPackage, lookupKey)
+        .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       inside(result) { case Left(err) =>
         err.msg should include(
@@ -2061,20 +2207,31 @@ class EngineTest
             None
         }
       def run(cmd: Command) = {
+        val submitters = Set(party)
         val Right((cmds, globalCids)) = preprocessor
           .preprocessCommands(ImmArray(cmd))
-          .consume(lookupContract, lookupPackage, lookupKey)
+          .consume(
+            lookupContract,
+            lookupPackage,
+            lookupKey,
+            VisibleByKey.fromSubmitters(submitters),
+          )
         engine
           .interpretCommands(
             validating = false,
-            submitters = Set(party),
+            submitters = submitters,
             commands = cmds,
             ledgerTime = let,
             submissionTime = let,
             seeding = seeding,
             globalCids = globalCids,
           )
-          .consume(lookupContract, lookupPackage, lookupKey)
+          .consume(
+            lookupContract,
+            lookupPackage,
+            lookupKey,
+            VisibleByKey.fromSubmitters(submitters),
+          )
       }
       "rolled-back archive of transient contract does not prevent consuming choice after rollback" in {
         val command = CreateAndExerciseCommand(
@@ -2186,6 +2343,8 @@ class EngineTest
 
 object EngineTest {
 
+  val allKeysVisible = (_: Set[Party]) => VisibleByKey.Visible
+
   private implicit def qualifiedNameStr(s: String): QualifiedName =
     QualifiedName.assertFromString(s)
 
@@ -2247,7 +2406,12 @@ object EngineTest {
               txMeta.submissionTime,
               ledgerEffectiveTime,
             )
-            .consume(contracts0.get, lookupPackages, k => keys0.get(k.globalKey))
+            .consume(
+              contracts0.get,
+              lookupPackages,
+              k => keys0.get(k.globalKey),
+              VisibleByKey.fromSubmitters(submitters),
+            )
           (tr1, meta1) = currentStep
           (contracts1, keys1) = tr1.transaction.fold((contracts0, keys0)) {
             case (

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -232,6 +232,9 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
         { _ =>
           sys.error("TODO keys for LargeTransactionTest")
         },
+        { _ =>
+          sys.error("TODO keys for LargeTransactionTest")
+        },
       ) match {
       case Left(err) =>
         fail(s"Unexpected error: $err")

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueEnricherSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueEnricherSpec.scala
@@ -76,7 +76,9 @@ class ValueEnricherSpec extends AnyWordSpec with Matchers with TableDrivenProper
   val keyCon = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Mod:Key"))
 
   private[this] val engine = Engine.DevEngine()
-  engine.preloadPackage(pkgId, pkg).consume(_ => None, _ => None, _ => None)
+  engine
+    .preloadPackage(pkgId, pkg)
+    .consume(_ => None, _ => None, _ => None, _ => VisibleByKey.Visible)
 
   private[this] val enricher = new ValueEnricher(engine)
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -84,6 +84,22 @@ private[lf] object Pretty {
               (line + prettyPartialTransactionNode(node)).nested(4)
           })
 
+      case DamlELocalContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
+        text(
+          "Update failed due to a fetch, lookup or exercise by key of contract not visible to the reading parties"
+        ) & prettyContractId(coid) &
+          char('(') + (prettyIdentifier(gk.templateId)) + text(") associated with key ") +
+          prettyValue(false)(gk.key) &
+          text("No reading party is a stakeholder:") &
+          text("actAs:") & intercalate(comma + space, actAs.map(prettyParty))
+            .tightBracketBy(char('{'), char('}')) &
+          text("readAs:") & intercalate(comma + space, readAs.map(prettyParty))
+            .tightBracketBy(char('{'), char('}')) +
+          char('.') / text("Stakeholders:") & intercalate(
+            comma + space,
+            stakeholders.map(prettyParty),
+          ) + char('.')
+
       case DamlEWronglyTypedContract(coid, expected, actual) =>
         text("Update failed due to wrongly typed contract id") & prettyContractId(coid) /
           text("Expected contract of type") & prettyTypeConName(expected) & text(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -77,6 +77,14 @@ object SError {
       consumedBy: NodeId,
   ) extends SErrorDamlException
 
+  final case class DamlELocalContractKeyNotVisible(
+      coid: ContractId,
+      key: GlobalKey,
+      actAs: Set[Party],
+      readAs: Set[Party],
+      stakeholders: Set[Party],
+  ) extends SErrorDamlException
+
   /** Error during an operation on the update transaction. */
   final case class DamlETransactionError(
       reason: String

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -102,6 +102,11 @@ final case class ScenarioRunner(
         case SResultNeedKey(keyWithMaintainers, committers, cb) =>
           // We never have readAs parties in scenarios.
           lookupKeyUnsafe(keyWithMaintainers.globalKey, committers, Set.empty, cb)
+
+        case SResultNeedLocalKeyVisible(stakeholders, committers, cb) =>
+          // We never have readAs parties in scenarios.
+          val visible = SVisibleByKey.fromSubmitters(committers, Set.empty)(stakeholders)
+          cb(visible)
       }
     }
     val endTime = System.nanoTime()

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -171,6 +171,9 @@ class IdeLedgerClient(val compiledPackages: CompiledPackages) extends ScriptLedg
               .lookupKey(keyWithMaintainers.globalKey, actAs.toSet, readAs, cb)
               .toTry
               .get
+          case SResultNeedLocalKeyVisible(stakeholders, committers @ _, cb) =>
+            val visible = SVisibleByKey.fromSubmitters(actAs.toSet, readAs)(stakeholders)
+            cb(visible)
           case SResultFinalValue(SUnit) =>
             onLedger.ptx.finish match {
               case PartialTransaction.CompleteTransaction(tx) =>

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -119,7 +119,8 @@ conformance_test(
         "--include=ContractKeysIT" +
         ",RaceConditionIT",
         # Some of gRPC status codes changed from INVALID_ARGUMENT to ABORTED (see https://github.com/digital-asset/daml/pull/9218):
-        "--exclude=ContractKeysIT:CKFetchOrLookup,ContractKeysIT:CKNoFetchUndisclosed,ContractKeysIT:CKMaintainerScoped",
+        # LocalKeyVisibility can be reenabled on the next canton update.
+        "--exclude=ContractKeysIT:CKFetchOrLookup,ContractKeysIT:CKNoFetchUndisclosed,ContractKeysIT:CKMaintainerScoped,ContractKeysIT:CKLocalKeyVisibility",
     ],
 ) if not is_windows else None
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -147,6 +147,9 @@ final class StandaloneApiServer(
           { _ =>
             sys.error("Unexpected request of contract key")
           },
+          { _ =>
+            sys.error("Unexpected request of local contract key visibility")
+          },
         )
       ()
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -101,6 +101,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
       loggingContext: LoggingContext,
   ): Future[Either[DamlLfError, A]] = {
     val readers = actAs ++ readAs
+    val isVisible = VisibleByKey.fromSubmitters(actAs, readAs)
 
     val lookupActiveContractTime = new AtomicLong(0L)
     val lookupActiveContractCount = new AtomicLong(0L)
@@ -145,7 +146,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
             }
 
         case ResultNeedLocalKeyVisible(stakeholders, resume) =>
-          val visible = VisibleByKey.fromSubmitters(actAs, readAs)(stakeholders)
+          val visible = isVisible(stakeholders)
           resolveStep(Timed.trackedValue(metrics.daml.execution.engineRunning, resume(visible)))
 
         case ResultNeedPackage(packageId, resume) =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -17,7 +17,7 @@ import com.daml.lf
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.engine.Engine
+import com.daml.lf.engine.{Engine, VisibleByKey}
 import com.daml.lf.language.Ast
 import com.daml.metrics.Metrics
 import com.google.protobuf.ByteString
@@ -265,7 +265,7 @@ final private[kvutils] class PackageCommitter(
       val errors = pkgs.flatMap { case (pkgId, pkg) =>
         engine
           .preloadPackage(pkgId, pkg)
-          .consume(_ => None, pkgs.get, _ => None)
+          .consume(_ => None, pkgs.get, _ => None, _ => VisibleByKey.Visible)
           .fold(err => List(err.detailMsg), _ => List.empty)
       }.toList
       metrics.daml.kvutils.committer.packageUpload.loadedPackages(() =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -19,7 +19,7 @@ import com.daml.lf.archive.Reader.ParseError
 import com.daml.lf.crypto
 import com.daml.lf.data.Ref.{PackageId, Party}
 import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.engine.{Blinding, Engine, ReplayMismatch}
+import com.daml.lf.engine.{Blinding, Engine, ReplayMismatch, VisibleByKey}
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.{
   BlindingInfo,
@@ -263,6 +263,8 @@ private[kvutils] class TransactionCommitter(
               lookupContract(transactionEntry, commitContext),
               lookupPackage(transactionEntry, commitContext),
               lookupKey(commitContext, knownKeys),
+              // No check for key visibility during validation
+              _ => VisibleByKey.Visible,
             )
             .fold(
               err =>

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -15,7 +15,7 @@ import com.daml.lf.command.{Command, Commands}
 import com.daml.lf.crypto
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.{ImmArray, Ref}
-import com.daml.lf.engine.Engine
+import com.daml.lf.engine.{Engine, VisibleByKey}
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.Transaction
 import com.daml.metrics.Metrics
@@ -198,6 +198,7 @@ object KVTest {
             state.damlState
               .get(Conversions.globalKeyToStateKey(globalKey.globalKey))
               .map(value => Conversions.decodeContractId(value.getContractKeyState.getContractId)),
+          localKeyVisible = VisibleByKey.fromSubmitters(Set(submitter)),
         )
         .fold(error => throw new RuntimeException(error.detailMsg), identity)
     }

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Replay.scala
@@ -16,7 +16,7 @@ import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.daml.lf.crypto
 import com.daml.lf.data._
-import com.daml.lf.engine.{Engine, EngineConfig, Error}
+import com.daml.lf.engine.{Engine, EngineConfig, Error, VisibleByKey}
 import com.daml.lf.language.{Ast, LanguageVersion, Util => AstUtil}
 import com.daml.lf.transaction.{
   GlobalKey,
@@ -65,7 +65,7 @@ final case class BenchmarkState(
         transaction.submissionTime,
         transaction.submissionSeed,
       )
-      .consume(getContract, Replay.unexpectedError, getContractKey)
+      .consume(getContract, Replay.unexpectedError, getContractKey, _ => VisibleByKey.Visible)
       .map(_ => ())
 
   def validate(engine: Engine): Either[Error, Unit] =
@@ -78,7 +78,7 @@ final case class BenchmarkState(
         transaction.submissionTime,
         transaction.submissionSeed,
       )
-      .consume(getContract, Replay.unexpectedError, getContractKey)
+      .consume(getContract, Replay.unexpectedError, getContractKey, _ => VisibleByKey.Visible)
 }
 
 class Benchmarks(private val benchmarks: Map[String, Vector[BenchmarkState]]) {
@@ -122,7 +122,7 @@ private[replay] object Replay {
     AstUtil.dependenciesInTopologicalOrder(pkgs.keys.toList, pkgs).foreach { pkgId =>
       val r = engine
         .preloadPackage(pkgId, pkgs(pkgId))
-        .consume(unexpectedError, unexpectedError, unexpectedError)
+        .consume(unexpectedError, unexpectedError, unexpectedError, unexpectedError)
       assert(r.isRight)
     }
     engine

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -246,6 +246,9 @@ final class SandboxServer(
             keys = { _ =>
               sys.error("Unexpected request of contract key")
             },
+            localKeyVisible = { _ =>
+              sys.error("Unexpected request of local contract key visibility")
+            },
           )
           .left
           .foreach(err => sys.error(err.detailMsg))

--- a/ledger/test-common/src/main/daml/model/Test.daml
+++ b/ledger/test-common/src/main/daml/model/Test.daml
@@ -373,6 +373,26 @@ template TextKeyOperations
           cid2 <- create TextKey with tkParty = contract.tkParty, tkKey = contract.tkKey, tkDisclosedTo = contract.tkDisclosedTo
           return ()
 
+template LocalKeyVisibilityOperations
+  with
+    sig : Party
+    obs : Party
+  where
+    signatory sig
+    observer obs
+
+    nonconsuming choice LocalLookup : ()
+      controller obs
+      do cid <- create (TextKey sig "" [])
+         Some _ <- lookupByKey @TextKey (sig, "")
+         archive cid
+
+    nonconsuming choice LocalFetch : ()
+      controller obs
+      do cid <- create (TextKey sig "" [])
+         _ <- fetchByKey @TextKey (sig, "")
+         archive cid
+
 -- dummy contract to be divulged out-of-band
 template Divulgence1
   with


### PR DESCRIPTION
fixes #9454

I tried out two approaches for this:

1. The one here where we add a new callback. This has the advantage
   that the engine remains oblivious to visibility checks. They are all
   done outside and the engine doesn’t even know about the reading
   parties.
2. Make the engine aware of the reading parties. A start of that is in
   #9458.

Both work in principle but I ended up going for 1 in the end. Doing
half of the visibility checks outside the engine and half inside just
seems worse than the current state.

changelog_begin

- [Daml Engine] Fix a bug where it was possible to
  fetch/lookup/exercise a local contract by key even if the reading parties
  are not stakeholders. See #9454 for details.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
