### PR TITLE
daml-stdlib: align HasField instance with ghc

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -951,9 +951,9 @@ convertExpr env0 e = do
     go env (VarIn DA_Internal_Record "setFieldPrim") (LType (isStrLitTy -> Just name) : LType record : LType field : args) = do
         record' <- convertType env record
         field' <- convertType env field
-        withTmArg env field' args $ \x1 args ->
-            withTmArg env record' args $ \x2 args ->
-                pure (ERecUpd (fromTCon record') (mkField $ fsToText name) x2 x1, args)
+        withTmArg env record' args $ \x1 args ->
+            withTmArg env field' args $ \x2 args ->
+                pure (ERecUpd (fromTCon record') (mkField $ fsToText name) x1 x2, args)
     -- NOTE(MH): We only inline `getField` for record types. Projections on
     -- sum-of-records types have to through the type class for `getField`.
     go env (VarIn DA_Internal_Record "getField") (LType (isStrLitTy -> Just name) : LType recordType@(TypeCon recordTyCon _) : LType _fieldType : _dict : args)
@@ -967,9 +967,9 @@ convertExpr env0 e = do
         | isSingleConType recordTyCon = do
             record' <- convertType env record
             field' <- convertType env field
-            withTmArg env field' args $ \x1 args ->
-                withTmArg env record' args $ \x2 args ->
-                    pure (ERecUpd (fromTCon record') (mkField $ fsToText name) x2 x1, args)
+            withTmArg env record' args $ \x1 args ->
+                withTmArg env field' args $ \x2 args ->
+                    pure (ERecUpd (fromTCon record') (mkField $ fsToText name) x1 x2, args)
         -- TODO: Also fix evaluation order for sum-of-record types.
     go env (VarIn GHC_Real "fromRational") (LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
         = fmap (, args) $ convertRationalDecimal env top bot

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/Records.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/Records.hs
@@ -89,14 +89,14 @@ instanceTemplate abstract selector record field = ClsInstD noE $ ClsInstDecl noE
         get = funbind var_getField [] $ noL $ HsVar noE $ rdrNameFieldOcc selector
 
         set = funbind var_setField
-            [VarPat noE $ noL vA, VarPat noE $ noL vR] $
+            [VarPat noE $ noL vR, VarPat noE $ noL vA] $
             noL $ RecordUpd noE (noL $ GHC.HsVar noE $ noL vR)
                 [noL $ HsRecField (noL (Unambiguous noE (rdrNameFieldOcc selector))) (noL $ GHC.HsVar noE $ noL vA) False]
 
         getAbstract = funbind var_getField [] $
             noL (HsVar noE $ noL var_getFieldPrim) `mkAppType` fldName `mkAppType` noL record `mkAppType` noL field
         setAbstract = funbind var_setField [] $
-            noL (HsVar noE $ noL var_setFieldPrim) `mkAppType` fldName `mkAppType` noL record `mkAppType` noL field
+            noL (HsVar noE $ noL var_setFieldPrim) `mkAppType` fldName `mkAppType`  noL record `mkAppType` noL field
 
         fldName = mkSelector $ GHC.rdrNameFieldOcc selector
 
@@ -174,7 +174,7 @@ onExp (L o (SectionR _ mid@(isDot -> True) rhs))
 onExp (L o upd@RecordUpd{rupd_expr,rupd_flds=L _ (HsRecField (fmap rdrNameAmbiguousFieldOcc -> lbl) arg pun):flds})
     | let sel = mkSelector lbl
     , let arg2 = if pun then noL $ HsVar noE lbl else arg
-    , let expr = mkParen $ mkVar var_setField `mkAppType` sel `mkApp` arg2 `mkApp` rupd_expr -- 'rupd_expr' never needs bracketing.
+    , let expr = mkParen $ mkVar var_setField `mkAppType` sel `mkApp` rupd_expr `mkApp` arg2 -- 'rupd_expr' never needs bracketing.
     = onExp $ if null flds then expr else L o upd{rupd_expr=expr,rupd_flds=flds}
 
 onExp x = descend onExp x

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Record.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Record.daml
@@ -67,78 +67,78 @@ import GHC.Integer.Type() -- required for Integer primitives
 -- Likewise, if we want to set the value in the field, we can use the `setField` function:
 --
 -- ```
--- setFoo : Int -> MyRecord -> MyRecord
--- setFoo a r = setField @"foo" a r
+-- setFoo : MyRecord -> Int -> MyRecord
+-- setFoo r a = setField @"foo" r a
 --
--- setBar : Text -> MyRecord -> MyRecord
--- setBar a r = setField @"bar" a r
+-- setBar : MyRecord -> Text -> MyRecord
+-- setBar r a = setField @"bar" r a
 -- ```
 class HasField (x : Symbol) r a | x r -> a where
     getField : r -> a
-    setField : a -> r -> r
+    setField : r -> a -> r
 
 -- | HIDE Not re-exported in DA.Record
 getFieldPrim : forall (f : Symbol) rec fld. rec -> fld
 getFieldPrim = getFieldPrim
 
 -- | HIDE Not re-exported in DA.Record
-setFieldPrim : forall (f : Symbol) rec fld. fld -> rec -> rec
+setFieldPrim : forall (f : Symbol) rec fld. rec -> fld -> rec
 setFieldPrim = setFieldPrim
 
 -- we have _1/.. for pairs to quintuples
 
 instance HasField "_1" (a,b) a where
     getField (a,_) = a
-    setField a (_,b) = (a,b)
+    setField (_,b) a = (a,b)
 
 instance HasField "_2" (a,b) b where
     getField (_,b) = b
-    setField b (a,_) = (a,b)
+    setField (a,_) b = (a,b)
 
 instance HasField "_1" (a,b,c) a where
     getField (a,_,_) = a
-    setField a (_,b,c) = (a,b,c)
+    setField (_,b,c) a = (a,b,c)
 
 instance HasField "_2" (a,b,c) b where
     getField (_,b,_) = b
-    setField b (a,_,c) = (a,b,c)
+    setField (a,_,c) b = (a,b,c)
 
 instance HasField "_3" (a,b,c) c where
     getField (_,_,c) = c
-    setField c (a,b,_) = (a,b,c)
+    setField (a,b,_) c = (a,b,c)
 
 instance HasField "_1" (a,b,c,d) a where
     getField (a,_,_,_) = a
-    setField a (_,b,c,d) = (a,b,c,d)
+    setField (_,b,c,d) a = (a,b,c,d)
 
 instance HasField "_2" (a,b,c,d) b where
     getField (_,b,_,_) = b
-    setField b (a,_,c,d) = (a,b,c,d)
+    setField (a,_,c,d) b = (a,b,c,d)
 
 instance HasField "_3" (a,b,c,d) c where
     getField (_,_,c,_) = c
-    setField c (a,b,_,d) = (a,b,c,d)
+    setField (a,b,_,d) c = (a,b,c,d)
 
 instance HasField "_4" (a,b,c,d) d where
     getField (_,_,_,d) = d
-    setField d (a,b,c,_) = (a,b,c,d)
+    setField (a,b,c,_) d = (a,b,c,d)
 
 instance HasField "_1" (a,b,c,d,e) a where
     getField (a,_,_,_,_) = a
-    setField a (_,b,c,d,e) = (a,b,c,d,e)
+    setField (_,b,c,d,e) a = (a,b,c,d,e)
 
 instance HasField "_2" (a,b,c,d,e) b where
     getField (_,b,_,_,_) = b
-    setField b (a,_,c,d,e) = (a,b,c,d,e)
+    setField (a,_,c,d,e) b = (a,b,c,d,e)
 
 instance HasField "_3" (a,b,c,d,e) c where
     getField (_,_,c,_,_) = c
-    setField c (a,b,_,d,e) = (a,b,c,d,e)
+    setField (a,b,_,d,e) c = (a,b,c,d,e)
 
 instance HasField "_4" (a,b,c,d,e) d where
     getField (_,_,_,d,_) = d
-    setField d (a,b,c,_,e) = (a,b,c,d,e)
+    setField (a,b,c,_,e) d = (a,b,c,d,e)
 
 instance HasField "_5" (a,b,c,d,e) e where
     getField (_,_,_,_,e) = e
-    setField e (a,b,c,d,_) = (a,b,c,d,e)
+    setField (a,b,c,d,_) e = (a,b,c,d,e)

--- a/compiler/damlc/daml-stdlib-src/DA/Monoid.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Monoid.daml
@@ -68,12 +68,12 @@ instance Multiplicative a => Monoid (Product a) where
 
 instance DA.Internal.Record.HasField "getAll" All Bool where
   getField (All x) = x
-  setField x _ = All x
+  setField _ x = All x
 
 instance DA.Internal.Record.HasField "getAny" Any Bool where
   getField (Any x) = x
-  setField x _ = Any x
+  setField _ x = Any x
 
 instance DA.Internal.Record.HasField "appEndo" (Endo a) (a -> a) where
   getField (Endo f) = f
-  setField f _ = Endo f
+  setField _ f = Endo f

--- a/compiler/damlc/daml-stdlib-src/DA/NonEmpty.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/NonEmpty.daml
@@ -44,11 +44,11 @@ deriving instance Show a => Show (NonEmpty a)
 
 instance DA.Internal.Record.HasField "hd" (NonEmpty a) a where
     getField (NonEmpty x _) = x
-    setField x (NonEmpty _ xs) = NonEmpty x xs
+    setField (NonEmpty _ xs) x = NonEmpty x xs
 
 instance DA.Internal.Record.HasField "tl" (NonEmpty a) [a] where
     getField (NonEmpty _ xs) = xs
-    setField xs (NonEmpty x _) = NonEmpty x xs
+    setField (NonEmpty x _) xs = NonEmpty x xs
 
 instance Semigroup (NonEmpty a) where
   (<>) = append

--- a/compiler/damlc/daml-stdlib-src/DA/Set.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Set.daml
@@ -148,6 +148,6 @@ instance Ord k => Monoid (Set k) where
 
 instance DA.Internal.Record.HasField "map" (Set k) (Map k ()) where
   getField (Set m) = m
-  setField m _ = Set m
+  setField _ m = Set m
 
 #endif

--- a/ghc-lib/template-desugaring.md
+++ b/ghc-lib/template-desugaring.md
@@ -133,7 +133,7 @@ _choice_IouTransfer
               [toParties (owner)],
      \ self this@Iou {..} arg@Transfer {..}
        -> let
-          in do create (DA.Internal.Record.setField @"owner" newOwner this),
+          in do create (DA.Internal.Record.setField @"owner" this newOwner),
      PreConsuming)
 ```
 


### PR DESCRIPTION
For some reason we ended up with a `setField: a -> r -> r` while ghc has
a `setField: r -> a -> r`. This is a source of confusion and subtile
bugs. This PR aligns our `setField` method with the one of ghc in
preparation of the coming nested record update feature.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
