### PR TITLE
Set supported jdbc driver names at compile time

### DIFF
--- a/daml-assistant/daml-sdk/util.bzl
+++ b/daml-assistant/daml-sdk/util.bzl
@@ -12,7 +12,7 @@ def deps(edition):
         "//navigator/backend:navigator-library",
         "//daml-script/export",
         "//triggers/runner:trigger-runner-lib",
-        "//triggers/service:trigger-service",
+        "//triggers/service:trigger-service-binary-{}".format(edition),
         "//triggers/service/auth:oauth2-middleware",
         "//navigator/backend:backend-resources",
         "//navigator/backend:frontend-resources",

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -51,6 +51,7 @@ hj_scalacopts = lf_scalacopts + [
             "@maven//:ch_qos_logback_logback_classic",
         ],
         deps = [
+            "//runtime-components/jdbc-drivers:jdbc-drivers-{}".format(edition),
             "//daml-lf/data",
             "//daml-lf/interface",
             "//daml-lf/transaction",

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
 import akka.stream.Materializer
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
+import com.daml.runtime.JdbcDrivers
 import com.daml.scalautil.Statement.discard
 import com.daml.http.dbbackend.ContractDao
 import com.typesafe.scalalogging.StrictLogging
@@ -30,7 +31,7 @@ object Main extends StrictLogging {
   }
 
   def main(args: Array[String]): Unit =
-    Cli.parseConfig(args, ContractDao.supportedJdbcDriverNames) match {
+    Cli.parseConfig(args, JdbcDrivers.supportedJdbcDriverNames) match {
       case Some(config) =>
         main(config)
       case None =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -31,7 +31,10 @@ object Main extends StrictLogging {
   }
 
   def main(args: Array[String]): Unit =
-    Cli.parseConfig(args, JdbcDrivers.supportedJdbcDriverNames) match {
+    Cli.parseConfig(
+      args,
+      ContractDao.supportedJdbcDriverNames(JdbcDrivers.availableJdbcDriverNames),
+    ) match {
       case Some(config) =>
         main(config)
       case None =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -36,6 +36,9 @@ object ContractDao {
     "oracle.jdbc.OracleDriver" -> SupportedJdbcDriver.Oracle,
   )
 
+  def supportedJdbcDriverNames(available: Set[String]): Set[String] =
+    supportedJdbcDrivers.keySet intersect available
+
   def apply(jdbcDriver: String, jdbcUrl: String, username: String, password: String)(implicit
       ec: ExecutionContext
   ): ContractDao = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -36,10 +36,6 @@ object ContractDao {
     "oracle.jdbc.OracleDriver" -> SupportedJdbcDriver.Oracle,
   )
 
-  lazy val supportedJdbcDriverNames = supportedJdbcDrivers.keySet filter { d =>
-    scala.util.Try(Class forName d).isSuccess
-  }
-
   def apply(jdbcDriver: String, jdbcUrl: String, username: String, password: String)(implicit
       ec: ExecutionContext
   ): ContractDao = {

--- a/runtime-components/jdbc-drivers/BUILD.bazel
+++ b/runtime-components/jdbc-drivers/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test",
+)
+
+[
+    da_scala_library(
+        name = "jdbc-drivers-{}".format(edition),
+        srcs = glob(["src/main/{}/scala/**/*.scala".format(edition)]),
+        scala_deps = [
+        ],
+        visibility = [
+            "//:__subpackages__",
+        ],
+        deps = [
+        ],
+    )
+    for edition in [
+        "ce",
+        "ee",
+    ]
+]

--- a/runtime-components/jdbc-drivers/src/main/ce/scala/com/daml/runtime/JdbcDrivers.scala
+++ b/runtime-components/jdbc-drivers/src/main/ce/scala/com/daml/runtime/JdbcDrivers.scala
@@ -1,0 +1,5 @@
+package com.daml.runtime
+
+object JdbcDrivers {
+  val supportedJdbcDriverNames: Set[String] = Set("org.postgresql.Driver")
+}

--- a/runtime-components/jdbc-drivers/src/main/ce/scala/com/daml/runtime/JdbcDrivers.scala
+++ b/runtime-components/jdbc-drivers/src/main/ce/scala/com/daml/runtime/JdbcDrivers.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.runtime
 
 object JdbcDrivers {

--- a/runtime-components/jdbc-drivers/src/main/ce/scala/com/daml/runtime/JdbcDrivers.scala
+++ b/runtime-components/jdbc-drivers/src/main/ce/scala/com/daml/runtime/JdbcDrivers.scala
@@ -4,5 +4,5 @@
 package com.daml.runtime
 
 object JdbcDrivers {
-  val supportedJdbcDriverNames: Set[String] = Set("org.postgresql.Driver")
+  val availableJdbcDriverNames: Set[String] = Set("org.postgresql.Driver")
 }

--- a/runtime-components/jdbc-drivers/src/main/ee/scala/com/daml/runtime/JdbcDrivers.scala
+++ b/runtime-components/jdbc-drivers/src/main/ee/scala/com/daml/runtime/JdbcDrivers.scala
@@ -1,5 +1,9 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.runtime
 
 object JdbcDrivers {
-  val supportedJdbcDriverNames: Set[String] = Set("org.postgresql.Driver", "oracle.jdbc.OracleDriver")
+  val supportedJdbcDriverNames: Set[String] =
+    Set("org.postgresql.Driver", "oracle.jdbc.OracleDriver")
 }

--- a/runtime-components/jdbc-drivers/src/main/ee/scala/com/daml/runtime/JdbcDrivers.scala
+++ b/runtime-components/jdbc-drivers/src/main/ee/scala/com/daml/runtime/JdbcDrivers.scala
@@ -1,0 +1,5 @@
+package com.daml.runtime
+
+object JdbcDrivers {
+  val supportedJdbcDriverNames: Set[String] = Set("org.postgresql.Driver", "oracle.jdbc.OracleDriver")
+}

--- a/runtime-components/jdbc-drivers/src/main/ee/scala/com/daml/runtime/JdbcDrivers.scala
+++ b/runtime-components/jdbc-drivers/src/main/ee/scala/com/daml/runtime/JdbcDrivers.scala
@@ -4,6 +4,6 @@
 package com.daml.runtime
 
 object JdbcDrivers {
-  val supportedJdbcDriverNames: Set[String] =
+  val availableJdbcDriverNames: Set[String] =
     Set("org.postgresql.Driver", "oracle.jdbc.OracleDriver")
 }

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -18,9 +18,14 @@ tsvc_main_scalacopts = [
     ]
 ]
 
+triggerMain = "src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala"
+
 da_scala_library(
     name = "trigger-service",
-    srcs = glob(["src/main/scala/**/*.scala"]),
+    srcs = glob(
+        ["src/main/scala/**/*.scala"],
+        exclude = [triggerMain],
+    ),
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [
         "@maven//:com_chuusai_shapeless",
@@ -71,10 +76,8 @@ da_scala_library(
         "//ledger-service/utils",
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
-        "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",
         "//libs-scala/doobie-slf4j",
-        "//libs-scala/ports",
         "//libs-scala/scala-utils",
         "//triggers/runner:trigger-runner-lib",
         "//triggers/service/auth:middleware-api",
@@ -85,24 +88,51 @@ da_scala_library(
     ],
 )
 
+scala_binary_deps = [
+    "@maven//:com_typesafe_akka_akka_actor",
+    "@maven//:com_typesafe_akka_akka_actor_typed",
+    "@maven//:com_typesafe_akka_akka_http_core",
+    "@maven//:com_typesafe_scala_logging_scala_logging",
+    "@maven//:org_scalaz_scalaz_core",
+]
+
+binary_deps = [
+    ":trigger-service",
+    "//libs-scala/ports",
+    "//libs-scala/concurrent",
+    "//daml-lf/archive:daml_lf_archive_reader",
+    "//daml-lf/archive:daml_lf_dev_archive_proto_java",
+    "//daml-lf/data",
+    "//language-support/scala/bindings",
+    "//ledger/ledger-api-common",
+    "//libs-scala/contextualized-logging",
+    "//libs-scala/scala-utils",
+    "//triggers/service/auth:middleware-api",
+    "@maven//:org_slf4j_slf4j_api",
+]
+
 da_scala_binary(
     name = "trigger-service-binary-ce",
+    srcs = [triggerMain],
     main_class = "com.daml.lf.engine.trigger.ServiceMain",
+    scala_deps = scala_binary_deps,
     visibility = ["//visibility:public"],
-    deps = [
-        ":trigger-service",
+    deps = binary_deps + [
+        "//runtime-components/jdbc-drivers:jdbc-drivers-ce",
     ],
 )
 
 da_scala_binary(
     name = "trigger-service-binary-ee",
+    srcs = [triggerMain],
     main_class = "com.daml.lf.engine.trigger.ServiceMain",
+    scala_deps = scala_binary_deps,
     visibility = ["//visibility:public"],
     runtime_deps = [
         "@maven//:com_oracle_database_jdbc_ojdbc8",
     ],
-    deps = [
-        ":trigger-service",
+    deps = binary_deps + [
+        "//runtime-components/jdbc-drivers:jdbc-drivers-ee",
     ],
 )
 
@@ -130,6 +160,7 @@ da_scala_library(
     ],
     deps = [
         ":trigger-service",
+        ":trigger-service-binary-ce",
         "//bazel_tools/runfiles:scala_runfiles",
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_proto_java",
@@ -165,14 +196,13 @@ da_scala_library(
 
 test_deps = [
     ":trigger-service",
+    "//ledger-api/testing-utils",
+    "//ledger-api/rs-grpc-bridge",
     ":trigger-service-tests",
     "//daml-lf/archive:daml_lf_archive_reader",
     "//daml-lf/archive:daml_lf_dev_archive_proto_java",
     "//daml-lf/data",
     "//language-support/scala/bindings-akka",
-    "//ledger-api/rs-grpc-bridge",
-    "//ledger-api/testing-utils",
-    "//ledger-service/cli-opts",
     "//ledger-service/jwt",
     "//ledger/ledger-api-auth",
     "//ledger/ledger-api-common",
@@ -188,11 +218,12 @@ test_deps = [
     "//triggers/service/auth:oauth2-test-server",
     "@maven//:eu_rekawek_toxiproxy_toxiproxy_java_2_1_3",
     "@maven//:org_flywaydb_flyway_core",
+    "//ledger-service/cli-opts",
 ]
 
 scala_test_deps = [
-    "@maven//:com_typesafe_akka_akka_http_core",
     "@maven//:io_spray_spray_json",
+    "@maven//:com_typesafe_akka_akka_http_core",
     "@maven//:org_scalatest_scalatest",
     "@maven//:org_scalaz_scalaz_core",
     "@maven//:com_github_scopt_scopt",

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -82,7 +82,10 @@ object ServiceMain {
   }
 
   def main(args: Array[String]): Unit = {
-    ServiceConfig.parse(args, JdbcDrivers.supportedJdbcDriverNames) match {
+    ServiceConfig.parse(
+      args,
+      DbTriggerDao.supportedJdbcDriverNames(JdbcDrivers.availableJdbcDriverNames),
+    ) match {
       case None => sys.exit(1)
       case Some(config) =>
         val logger = ContextualizedLogger.get(this.getClass)

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -19,6 +19,7 @@ import com.daml.lf.engine.trigger.dao.DbTriggerDao
 import com.daml.logging.ContextualizedLogger
 import com.daml.ports.{Port, PortFiles}
 import com.daml.scalautil.Statement.discard
+import com.daml.runtime.JdbcDrivers
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -81,7 +82,7 @@ object ServiceMain {
   }
 
   def main(args: Array[String]): Unit = {
-    ServiceConfig.parse(args, DbTriggerDao.supportedJdbcDriverNames) match {
+    ServiceConfig.parse(args, JdbcDrivers.supportedJdbcDriverNames) match {
       case None => sys.exit(1)
       case Some(config) =>
         val logger = ContextualizedLogger.get(this.getClass)

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
@@ -332,6 +332,9 @@ object DbTriggerDao {
     "oracle.jdbc.OracleDriver" -> ((d, xa) => new DbTriggerDaoOracle(d, xa)),
   )
 
+  def supportedJdbcDriverNames(available: Set[String]): Set[String] =
+    supportedJdbcDrivers.keySet intersect available
+
   def apply(c: JdbcConfig, poolSize: PoolSize = Production)(implicit
       ec: ExecutionContext
   ): DbTriggerDao = {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
@@ -332,10 +332,6 @@ object DbTriggerDao {
     "oracle.jdbc.OracleDriver" -> ((d, xa) => new DbTriggerDaoOracle(d, xa)),
   )
 
-  lazy val supportedJdbcDriverNames = supportedJdbcDrivers.keySet filter { d =>
-    scala.util.Try(Class forName d).isSuccess
-  }
-
   def apply(c: JdbcConfig, poolSize: PoolSize = Production)(implicit
       ec: ExecutionContext
   ): DbTriggerDao = {


### PR DESCRIPTION
This is mainly to unblock the work on Oracle support in the Ledger API
but I think it’s a sensible thing in general. For the Ledger API,
moving the dependency to the top-level is apparently rather
tricky. Because the SDK bundles everything into a single megajar,
Sandbox depending on the oracle library does also result in the JSON
API and the trigger service will also have the oracle library in scope
and will support Oracle in CE which they should not.

This PR simply hardcodes the list of supported drivers to address
that. Not pretty but does the job.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
