### PR TITLE
rank-based-deduplication: add draft of kv_utils.proto changes

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -66,7 +66,7 @@ message DamlSubmission {
     // that triggers the deduplication logic and generates a completion with
     // its own offset. This entry is either added to the ledger as-is or
     // converted to a 'Duplicate' rejection in case it is deduplicated.
-    DamlTransactionRejectionEntry transaction_rejection_entry = 6;
+    DamlTransactionRejectionEntry transaction_rejection_entry = 7;
   }
   bytes submission_seed = 6;
 }

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -133,11 +133,31 @@ message DamlLogEntryId {
 }
 
 message DamlSubmitterInfo {
+  // Parties authorizing the command submitted together with this
+  // DamlSubmitterInfo
   repeated string submitters = 1;
+
+  // Identifier of the intent, which SHOULD be reused when retrying executing
+  // the same intended change.
   string command_id = 2;
+
+  // Opaque reference to application submitting this command. May be used for
+  // request routing and response filtering.
   string application_id = 3;
+
   reserved 4; // was maximum_record_time
+
+  // Timestamp until which the ledger SHOULD deduplicate this submission.
+  // Measured against the ledger's clock.
   google.protobuf.Timestamp deduplicate_until = 5;
+
+  // Identity of the submission. This should always be freshly allocated by
+  // Ledger API clients.
+  string submission_id = 6;
+
+  // Rank of the submission, which is used to allow for safe retries. See
+  // DamlCommandDedupValue for details on the deduplication logic.
+  bytes submission_rank = 7;
 }
 
 // Daml transaction entry, used in both `DamlSubmission` and `DamlLogEntry`.
@@ -392,18 +412,66 @@ message DamlStateValue {
   }
 }
 
+// These keys identify intents to change the Daml ledger using a Daml
+// transaction built from a DamlCommand.
 message DamlCommandDedupKey {
+  // Intents are namespaced to the list of submitting parties.
   repeated string submitters = 1;
   reserved 2; // was application_id
+
+  // An identifier for the intent.
   string command_id = 3;
 }
 
+// The DamlCommand deduplication logic ensures that Ledger API clients can
+// implement exactly-once submission of DamlCommands even when retrying.
+// The logic, called rank-based deduplication, works on a
+// per-DamlCommandDedupKey basis. It stores the rank and result of the last
+// submission that was validated, and cancels any further submissions with the
+// same rank instead of executing them.
+//
+// See TODO: add link to docs for
+// guidance on how applications should manage submission ranks when retrying.
+//
+// DamlCommandDedupValues are tagged with an expiry date to allow ledgers to
+// reclaim storage space by deleting them, at the cost of providing a
+// limited-time deduplication guarantee to applications.
 message DamlCommandDedupValue {
   reserved 1; // was record_time
-  // the time until when future commands with the same
-  // deduplication key will be rejected due to a duplicate submission
+
+  // The time until which ledgers MUST keep this DamlCommandDedupValue around.
+  // Ledgers MAY delete them after this time measured against their local
+  // clock.
+  // Note: we exploit that Ledger API clients are advised to not reuse
+  // DamlCommandDedupKeys, as they cannot assume that their timely removal.
   google.protobuf.Timestamp deduplicated_until = 2;
+
+  // The identity of the submission whose rank and result is stored.
+  // This identity is typically a UUID provided by Ledger API clients.
+  string submission_id = 5;
+  // The rank of the submission whose result is stored. Ranks are compared in
+  // lexicographic order.
+  bytes submission_rank = 4;
+  // The result of the submission.
+  CommandSubmissionResult submission_result = 3;
 }
+
+enum CommandSubmissionResult {
+  // Used for DamlCommandDedupValues that were created before switching to
+  // the rank-based deduplication logic.
+  COMMAND_SUBMSSION_RESULT_UNSPECIFIED = 0;
+  // The submission was executed, but did not pass validation, and was
+  // rejected with a reason other than 'Duplicate'. The rank-based command
+  // deduplication logic guarantees that all further submissions with the same
+  // rank will be rejected as 'Duplicate'.
+  COMMAND_SUBMSSION_RESULT_REJECTED = 1;
+  // The submission was executed and accepted. The rank-based command
+  // deduplication logic guarantees that all further submission, independent
+  // of their rank, will be rejected as 'Duplicate'.
+  COMMAND_SUBMSSION_RESULT_ACCEPTED = 2;
+}
+
+
 
 message DamlSubmissionDedupKey {
   enum SubmissionKind {
@@ -552,7 +620,28 @@ message InvalidLedgerTime {
 // The committer has already seen a command/submission with the same deduplication
 // key during its implementation specific deduplication window.
 message Duplicate {
+  // Error details are only set for methods that do not provide a
+  // duplicate_info.
   string details = 1;
+
+  oneof duplicate_info {
+    RankBasedDuplicateInfo rank_based_duplicate_info = 2;
+  }
+}
+
+// Info on a duplicate determined using rank-based deduplication. See
+// DamlCommandDedupValue for more information.
+message RankBasedDuplicateInfo {
+  // Identity and rank of the submission whose execution got cancelled by the
+  // deduplication logic.
+  string cancelled_submission_id = 1;
+  bytes cancelled_submission_rank = 2;
+
+  // Identity, rank, and result of the submission which was executed in the
+  // past, and which caused the cancellation.
+  string executed_submission_id = 3;
+  bytes executed_submission_rank = 4;
+  CommandSubmissionResult executed_submission_result = 5;
 }
 
 // A party mentioned as a stakeholder or actor has not been on-boarded on

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -137,8 +137,8 @@ message DamlSubmitterInfo {
   // DamlSubmitterInfo
   repeated string submitters = 1;
 
-  // Identifier of the intent, which SHOULD be reused when retrying executing
-  // the same intended change.
+  // Identifier of the intent, which is expected be reused when retrying
+  // executing the same intended change.
   string command_id = 2;
 
   // Opaque reference to application submitting this command. May be used for
@@ -424,7 +424,7 @@ message DamlCommandDedupKey {
 }
 
 // The DamlCommand deduplication logic ensures that Ledger API clients can
-// implement exactly-once submission of DamlCommands even when retrying.
+// implement exactly-once submission of DamlCommands using retries.
 // The logic, called rank-based deduplication, works on a
 // per-DamlCommandDedupKey basis. It stores the rank and result of the last
 // submission that was validated, and cancels any further submissions with the
@@ -434,8 +434,10 @@ message DamlCommandDedupKey {
 // guidance on how applications should manage submission ranks when retrying.
 //
 // DamlCommandDedupValues are tagged with an expiry date to allow ledgers to
-// reclaim storage space by deleting them, at the cost of providing a
-// limited-time deduplication guarantee to applications.
+// reclaim storage space by deleting them. The expiry date is provided either
+// directly or indirectly by Ledger API clients. They are expected to provide
+// a close, but not too close expiry data, so that ledger can reclaim storage
+// space quickly without the clients experiencing duplicate submissions.
 message DamlCommandDedupValue {
   reserved 1; // was record_time
 
@@ -459,16 +461,16 @@ message DamlCommandDedupValue {
 enum CommandSubmissionResult {
   // Used for DamlCommandDedupValues that were created before switching to
   // the rank-based deduplication logic.
-  COMMAND_SUBMSSION_RESULT_UNSPECIFIED = 0;
+  COMMAND_SUBMISSION_RESULT_UNSPECIFIED = 0;
   // The submission was executed, but did not pass validation, and was
   // rejected with a reason other than 'Duplicate'. The rank-based command
   // deduplication logic guarantees that all further submissions with the same
   // rank will be rejected as 'Duplicate'.
-  COMMAND_SUBMSSION_RESULT_REJECTED = 1;
+  COMMAND_SUBMISSION_RESULT_REJECTED = 1;
   // The submission was executed and accepted. The rank-based command
   // deduplication logic guarantees that all further submission, independent
   // of their rank, will be rejected as 'Duplicate'.
-  COMMAND_SUBMSSION_RESULT_ACCEPTED = 2;
+  COMMAND_SUBMISSION_RESULT_ACCEPTED = 2;
 }
 
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -61,6 +61,12 @@ message DamlSubmission {
     DamlPackageUploadEntry package_upload_entry = 3;
     DamlConfigurationSubmission configuration_submission = 4;
     DamlPartyAllocationEntry party_allocation_entry = 5;
+
+    // Report the rejection of a command by the Ledger API server in a way
+    // that triggers the deduplication logic and generates a completion with
+    // its own offset. This entry is either added to the ledger as-is or
+    // converted to a 'Duplicate' rejection in case it is deduplicated.
+    DamlTransactionRejectionEntry transaction_rejection_entry = 6;
   }
   bytes submission_seed = 6;
 }

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -498,7 +498,7 @@ message DamlCommandDedupValue {
   // Ledgers MAY delete them after this time measured against their local
   // clock.
   // Note: we exploit that Ledger API clients are advised to not reuse
-  // DamlCommandDedupKeys, as they cannot assume that their timely removal.
+  // DamlCommandDedupKeys, as they cannot assume their timely removal.
   google.protobuf.Timestamp deduplicated_until = 2;
 
   // The identity of the submission whose rank and result is stored.

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -522,7 +522,7 @@ enum CommandSubmissionResult {
   COMMAND_SUBMISSION_RESULT_UNSPECIFIED = 0;
   // The submission was executed, but did not pass validation, and was
   // rejected with a reason other than 'Duplicate'. The rank-based command
-  // deduplication logic guarantees that all further submissions with the same
+  // deduplication logic guarantees that all further submissions with the same or lower
   // rank will be rejected as 'Duplicate'.
   COMMAND_SUBMISSION_RESULT_REJECTED = 1;
   // The submission was executed and accepted. The rank-based command

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -249,6 +249,14 @@ message DamlTransactionRejectionEntry {
 
   reserved 5; // was reason.maximum_record_time_exceeded
 
+  // Whether this rejection should be considered a definite answer
+  // as defined in rank-based deduplication; i.e., whether this rejection
+  // signals that no other transaction with the same change-id and equal or lower submission_rank
+  // can be accepted or rejected.
+  //
+  // False for all rejections before rank-based deduplication was implemented.
+  bool definite_answer = 11;
+
   oneof reason {
     Inconsistent inconsistent = 2;
     Disputed disputed = 3;

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -123,10 +123,10 @@ message DamlLogEntry {
     // A rejection of a pre-executed submission because of out-of-time-bounds.
     DamlOutOfTimeBoundsEntry out_of_time_bounds_entry = 10;
 
-    // A generic rejection from the Ledger API server that stores a gRPC Status Code
+    // A generic rejection from the Ledger API server.
     DamlRejectSubmissionEntry reject_submission_entry = 11;
 
-    // A rejection by the committer of a rejection submission entry.
+    // A rejection by the committer of a reject submission entry.
     DamlRejectSubmissionRejectionEntry reject_submission_rejection_entry = 12;
 
     // A log entry whose purpose is to transmit a current record time for pre-executed submissions.
@@ -159,28 +159,28 @@ message DamlSubmitterInfo {
   string application_id = 3;
 
   reserved 4; // was maximum_record_time
-
-  // Timestamp until which the ledger MUST deduplicate against this submission.
-  // Measured against the ledger's clock.
-  google.protobuf.Timestamp deduplicate_until = 5;
+  reserved 5; // was deduplicate_until
 
   // Duration that determines the range of existing DamlLogEntries against which this
-  // submission is expected to be deduplicated. More concretely, the expectation is that the
-  // ledger guarantees that for any existing entry e0 and the entry e1 created from this submission
+  // submission deduplicated.
+  //  
+  // The ledger guarantees that for any existing entry e0 the deduplicate_until field of
+  // its associated DamlCommandDedupValue cdv0 and the entry e1 created from this submission
   // it holds that 
   //
-  //    if (e0.record_time >= e1.record_time - e1.deduplication_duration) AND
+  //    if (e1.record_time >= e0.record_time >= e1.record_time - e1.deduplication_duration) AND
   //       (e0.command_id, e0.application_id, e0.submitters) == 
   //       (e1.command_id, e1.application_id, e1.submitters)
-  //    then e0.record_time + e0.deduplicate_until >= e1.record_time
+  //    then e0.record_time + cdv0.deduplicate_until >= e1.record_time
   //
-  // This fields is intended to be used for auditing and testing purposes.
+  // Note that the ledger MAY extend the deduplication_duration; e.g., to the 
+  // LedgerConfiguration.max_deduplication_time.
   google.protobuf.Duration deduplication_duration = 6;
 
   // The generation of the ledger configuration used to build this submission.
   // Used to reject submissions if the configuration at commit time is different
   // from the one of the configuration at submission time.
-  // Optional.
+  // Optional for historic submissions.
   uint64 ledger_configuration_generation = 7;
 
   // Identity of the submission. This should always be freshly allocated by
@@ -278,7 +278,8 @@ message DamlTransactionRejectionEntry {
     PartyNotKnownOnLedger party_not_known_on_ledger = 7;
     SubmitterCannotActViaParticipant submitter_cannot_act_via_participant = 8;
     InvalidLedgerTime invalid_ledger_time = 9;
-    GenerationMismatch generation_mismatch = 10;
+    DeduplicationDurationTooLarge deduplication_duration_too_large = 10;
+    GenerationMismatch generation_mismatch = 11;
   }
 }
 
@@ -338,6 +339,15 @@ message DamlConfigurationSubmission {
 
   // The new configuration that replaces the current configuration.
   com.daml.ledger.participant.state.LedgerConfiguration configuration = 4;
+
+  // The time at which this configuration submission is expected to be committed.
+  //
+  // This submission time is bounded by this configuration's time_model to its record time ``rt`` 
+  // such that ``rt - time_model.min_skew <= submission_time <= rt + time_model.max_skew``.
+  //
+  // Note that it is bound to the new configuration's bounds, as otherwise too tight 
+  // bounds on a configuration cannot be widened anymore.
+  google.protobuf.Timestamp submission_time = 5;
 }
 
 // A log entry describing a rejected configuration change.
@@ -355,13 +365,14 @@ message DamlConfigurationRejectionEntry {
   oneof reason {
     ParticipantNotAuthorized participant_not_authorized = 4;
 
-    // The existing configuration's generation not equal to the new
+    // The existing configuration's generation is not equal to the new
     // configuration generation minus one.
     GenerationMismatch generation_mismatch = 5;
 
     Invalid invalid_configuration = 6;
     TimedOut timed_out = 7;
     Duplicate duplicate_submission = 8;
+    InvalidLedgerTime invalid_ledger_time = 9;
   }
 }
 
@@ -378,6 +389,17 @@ message DamlConfigurationEntry {
 
   // The ledger configuration.
   com.daml.ledger.participant.state.LedgerConfiguration configuration = 3;
+
+  // The time at which this configuration was submitted.
+  //
+  // This submission time is bounded by this configuration's time_model to its record time ``rt`` 
+  // such that ``rt - time_model.min_skew <= submission_time <= rt + time_model.max_skew``.
+  google.protobuf.Timestamp submission_time = 4;
+
+  // The uppper bound on the ``deduplication_duration`` parameter of command submissions
+  // induced by past configurations that were in effect before this configuration.
+  // Used for checking whether a requested deduplication duration can be guaranteed.
+  google.protobuf.Duration past_deduplication_time_upper_bound = 5;
 }
 
 // An allocation of party name and assignment of a party to a given
@@ -440,6 +462,10 @@ message DamlOutOfTimeBoundsEntry {
 message DamlRejectSubmissionEntry {
   DamlSubmitterInfo submitter_info = 1;
   google.rpc.Status status = 2;
+
+  // The time at which this submission is expected to be committed.
+  // Subject to the time model bounds.
+  google.protobuf.Timestamp submission_time = 3;
 }
 
 // A committer-generated rejection of a Ledger API server's DamlRejectSubmissionEntry request to generate a
@@ -453,7 +479,8 @@ message DamlRejectSubmissionRejectionEntry {
   oneof reason {
     Duplicate duplicate_submission = 2;
     InvalidLedgerTime invalid_ledger_time = 3;
-    GenerationMismatch generation_mismatch = 4;
+    DeduplicationDurationTooLarge deduplication_duration_too_large = 4;
+    GenerationMismatch generation_mismatch = 5;
   } 
 }
 
@@ -495,7 +522,7 @@ message DamlCommandDedupKey {
 
   // Submitter provided application identifiers.
   // Optional. Provided for rank-based deduplication.
-  reserved string application_id = 2;
+  string application_id = 2;
 
   // An identifier for the intent.
   string command_id = 3;
@@ -743,6 +770,11 @@ message Invalid {
 
 // Participant not authorized to submit the request.
 message ParticipantNotAuthorized {
+  string details = 1;
+}
+
+// The requested deduplication duration is too large.
+message DeduplicationDurationTooLarge {
   string details = 1;
 }
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -527,7 +527,7 @@ enum CommandSubmissionResult {
   COMMAND_SUBMISSION_RESULT_REJECTED = 1;
   // The submission was executed and accepted. The rank-based command
   // deduplication logic guarantees that all further submission, independent
-  // of their rank, will be rejected as 'Duplicate'.
+  // of their rank, will be rejected as 'Duplicate' until the DamlCommandDedupKey is deleted.
   COMMAND_SUBMISSION_RESULT_ACCEPTED = 2;
 }
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -160,23 +160,36 @@ message DamlSubmitterInfo {
 
   reserved 4; // was maximum_record_time
 
-  // Timestamp until which the ledger MUST deduplicate this submission.
+  // Timestamp until which the ledger MUST deduplicate against this submission.
   // Measured against the ledger's clock.
   google.protobuf.Timestamp deduplicate_until = 5;
+
+  // Duration that determines the range of existing DamlLogEntries against which this
+  // submission is expected to be deduplicated. More concretely, the expectation is that the
+  // ledger guarantees that for any existing entry e0 and the entry e1 created from this submission
+  // it holds that 
+  //
+  //    if (e0.record_time >= e1.record_time - e1.deduplication_duration) AND
+  //       (e0.command_id, e0.application_id, e0.submitters) == 
+  //       (e1.command_id, e1.application_id, e1.submitters)
+  //    then e0.record_time + e0.deduplicate_until >= e1.record_time
+  //
+  // This fields is intended to be used for auditing and testing purposes.
+  google.protobuf.Duration deduplication_duration = 6;
 
   // The generation of the ledger configuration used to build this submission.
   // Used to reject submissions if the configuration at commit time is different
   // from the one of the configuration at submission time.
   // Optional.
-  uint64 ledger_configuration_generation = 6;
+  uint64 ledger_configuration_generation = 7;
 
   // Identity of the submission. This should always be freshly allocated by
   // Ledger API clients.
-  string submission_id = 7;
+  string submission_id = 8;
 
   // Rank of the submission, which is used to allow for safely stopping retrying. See
   // DamlCommandDedupValue for details on the deduplication logic.
-  bytes submission_rank = 8;
+  bytes submission_rank = 9;
 }
 
 // Daml transaction entry, used in both `DamlSubmission` and `DamlLogEntry`.
@@ -436,10 +449,11 @@ message DamlRejectSubmissionEntry {
 // Effectively, this message changes the rejection reason of the Ledger-API-server-submitted rejection.
 message DamlRejectSubmissionRejectionEntry {
   DamlSubmitterInfo submitter_info = 1;
-
+  
   oneof reason {
     Duplicate duplicate_submission = 2;
-    GenerationMismatch generation_mismatch = 3;
+    InvalidLedgerTime invalid_ledger_time = 3;
+    GenerationMismatch generation_mismatch = 4;
   } 
 }
 
@@ -678,7 +692,7 @@ message MaximumRecordTimeExceeded {
   string details = 1;
 }
 
-// The ledger time of the transaction submission violates some constraint.
+// The submission's ledger time or submission time violates the time model constraints.
 message InvalidLedgerTime {
   string details = 1;
 }

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -169,8 +169,8 @@ message DamlSubmitterInfo {
   // it holds that 
   //
   //    if (e1.record_time >= e0.record_time >= e1.record_time - e1.deduplication_duration) AND
-  //       (e0.command_id, e0.application_id, e0.submitters) == 
-  //       (e1.command_id, e1.application_id, e1.submitters)
+  //       (e0.command_id, e0.application_id, e0.submitters.toSet) == 
+  //       (e1.command_id, e1.application_id, e1.submitters.toSet)
   //    then e0.record_time + cdv0.deduplicate_until >= e1.record_time
   //
   // Note that the ledger MAY extend the deduplication_duration; e.g., to the 
@@ -477,10 +477,10 @@ message DamlRejectSubmissionRejectionEntry {
   DamlSubmitterInfo submitter_info = 1;
   
   oneof reason {
-    Duplicate duplicate_submission = 2;
+    GenerationMismatch generation_mismatch = 2;
     InvalidLedgerTime invalid_ledger_time = 3;
     DeduplicationDurationTooLarge deduplication_duration_too_large = 4;
-    GenerationMismatch generation_mismatch = 5;
+    Duplicate duplicate_submission = 5;
   } 
 }
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -508,7 +508,7 @@ message DamlCommandDedupValue {
 
   // The rank of the submission whose result is stored. Ranks are compared in
   // lexicographic order.
-  // Optional.Provided for rank-based deduplication.
+  // Optional. Provided for rank-based deduplication.
   bytes submission_rank = 4;
 
   // The result of the submission.

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -489,7 +489,7 @@ message DamlCommandDedupKey {
 // DamlCommandDedupValues are tagged with an expiry date to allow ledgers to
 // reclaim storage space by deleting them. The expiry date is provided either
 // directly or indirectly by Ledger API clients. They are expected to provide
-// a close, but not too close expiry data, so that ledger can reclaim storage
+// a close, but not too close expiry date, so that ledger can reclaim storage
 // space timely without the clients experiencing duplicate submissions.
 message DamlCommandDedupValue {
   reserved 1; // was record_time

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -64,8 +64,7 @@ message DamlSubmission {
 
     // Report the rejection of a command by the Ledger API server in a way
     // that triggers the deduplication logic and generates a completion with
-    // its own offset. This entry is either added to the ledger as-is or
-    // converted to a 'Duplicate' rejection in case it is deduplicated.
+    // its own offset.
     DamlTransactionRejectionEntry transaction_rejection_entry = 7;
   }
   bytes submission_seed = 6;
@@ -153,7 +152,7 @@ message DamlSubmitterInfo {
 
   reserved 4; // was maximum_record_time
 
-  // Timestamp until which the ledger SHOULD deduplicate this submission.
+  // Timestamp until which the ledger MUST deduplicate this submission.
   // Measured against the ledger's clock.
   google.protobuf.Timestamp deduplicate_until = 5;
 
@@ -161,7 +160,7 @@ message DamlSubmitterInfo {
   // Ledger API clients.
   string submission_id = 6;
 
-  // Rank of the submission, which is used to allow for safe retries. See
+  // Rank of the submission, which is used to allow for safely stopping retrying. See
   // DamlCommandDedupValue for details on the deduplication logic.
   bytes submission_rank = 7;
 }
@@ -436,14 +435,11 @@ message DamlCommandDedupKey {
 // submission that was validated, and cancels any further submissions with the
 // same rank instead of executing them.
 //
-// See TODO: add link to docs for
-// guidance on how applications should manage submission ranks when retrying.
-//
 // DamlCommandDedupValues are tagged with an expiry date to allow ledgers to
 // reclaim storage space by deleting them. The expiry date is provided either
 // directly or indirectly by Ledger API clients. They are expected to provide
 // a close, but not too close expiry data, so that ledger can reclaim storage
-// space quickly without the clients experiencing duplicate submissions.
+// space timely without the clients experiencing duplicate submissions.
 message DamlCommandDedupValue {
   reserved 1; // was record_time
 
@@ -478,7 +474,6 @@ enum CommandSubmissionResult {
   // of their rank, will be rejected as 'Duplicate'.
   COMMAND_SUBMISSION_RESULT_ACCEPTED = 2;
 }
-
 
 
 message DamlSubmissionDedupKey {
@@ -628,11 +623,11 @@ message InvalidLedgerTime {
 // The committer has already seen a command/submission with the same deduplication
 // key during its implementation specific deduplication window.
 message Duplicate {
-  // Error details are only set for methods that do not provide a
-  // duplicate_info.
-  string details = 1;
-
   oneof duplicate_info {
+    // Error details for deduplication provided by the legacy deduplication method.
+    string legacy_deduplication_details = 1; // was 'details'
+    
+    // Error information provided by the rank-based deduplication method.
     RankBasedDuplicateInfo rank_based_duplicate_info = 2;
   }
 }

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -16,6 +16,7 @@ option csharp_namespace = "Com.Daml.Ledger.Participant.State.KVUtils";
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
+import "google/rpc/status.proto";
 import "com/daml/daml_lf_dev/daml_lf.proto";
 import "com/daml/lf/transaction.proto";
 import "com/daml/lf/value.proto";
@@ -62,10 +63,11 @@ message DamlSubmission {
     DamlConfigurationSubmission configuration_submission = 4;
     DamlPartyAllocationEntry party_allocation_entry = 5;
 
-    // Report the rejection of a command by the Ledger API server in a way
+    // Report the rejection of a submission by the Ledger API server in a way
     // that triggers the deduplication logic and generates a completion with
-    // its own offset.
-    DamlTransactionRejectionEntry transaction_rejection_entry = 7;
+    // its own offset. Note that this entry in itself can be rejected by the 
+    // committer due to deduplication or config generation checks.
+    DamlRejectSubmissionEntry reject_submission_entry = ;
   }
   bytes submission_seed = 6;
 }
@@ -121,6 +123,12 @@ message DamlLogEntry {
     // A rejection of a pre-executed submission because of out-of-time-bounds.
     DamlOutOfTimeBoundsEntry out_of_time_bounds_entry = 10;
 
+    // A generic rejection from the Ledger API server that stores a gRPC Status Code
+    DamlRejectSubmissionEntry reject_submission_entry = 11;
+
+    // A rejection by the committer of a rejection submission entry.
+    DamlRejectSubmissionRejectionEntry reject_submission_rejection_entry = 12;
+
     // A log entry whose purpose is to transmit a current record time for pre-executed submissions.
     google.protobuf.Empty time_update_entry = 101;
   }
@@ -156,13 +164,19 @@ message DamlSubmitterInfo {
   // Measured against the ledger's clock.
   google.protobuf.Timestamp deduplicate_until = 5;
 
+  // The generation of the ledger configuration used to build this submission.
+  // Used to reject submissions if the configuration at commit time is different
+  // from the one of the configuration at submission time.
+  // Optional.
+  uint64 ledger_configuration_generation = 6;
+
   // Identity of the submission. This should always be freshly allocated by
   // Ledger API clients.
-  string submission_id = 6;
+  string submission_id = 7;
 
   // Rank of the submission, which is used to allow for safely stopping retrying. See
   // DamlCommandDedupValue for details on the deduplication logic.
-  bytes submission_rank = 7;
+  bytes submission_rank = 8;
 }
 
 // Daml transaction entry, used in both `DamlSubmission` and `DamlLogEntry`.
@@ -243,6 +257,7 @@ message DamlTransactionRejectionEntry {
     PartyNotKnownOnLedger party_not_known_on_ledger = 7;
     SubmitterCannotActViaParticipant submitter_cannot_act_via_participant = 8;
     InvalidLedgerTime invalid_ledger_time = 9;
+    GenerationMismatch generation_mismatch = 10;
   }
 }
 
@@ -318,7 +333,11 @@ message DamlConfigurationRejectionEntry {
 
   oneof reason {
     ParticipantNotAuthorized participant_not_authorized = 4;
+
+    // The existing configuration's generation not equal to the new
+    // configuration generation minus one.
     GenerationMismatch generation_mismatch = 5;
+
     Invalid invalid_configuration = 6;
     TimedOut timed_out = 7;
     Duplicate duplicate_submission = 8;
@@ -382,9 +401,38 @@ message DamlPartyAllocationRejectionEntry {
 message DamlOutOfTimeBoundsEntry {
   // We don't expect entry.recordTime to be present.
   DamlLogEntry entry = 1;
+
+  // Optional. Only set for the legacy deduplication code.
   google.protobuf.Timestamp duplicate_until = 2;
+
   google.protobuf.Timestamp too_early_until = 3;
   google.protobuf.Timestamp too_late_from = 4;
+}
+
+// A generic rejection entry that is used by the Ledger API server to reject
+// commands with an explicit completion that satisfies the rank-based deduplication
+// guarantees.
+//
+// Do not use this entry to signal rejections raised by the KV utils code, as otherwise
+// we risk loosing control over the different status codes that can be encountered
+// in historic log entries.
+message DamlRejectSubmissionEntry {
+  DamlSubmitterInfo submitter_info = 1;
+  google.rpc.Status status = 2;
+}
+
+// A committer-generated rejection of a Ledger API server's DamlRejectSubmissionEntry request to generate a
+// LogEntry to reject a submission.
+// We use DamlRejectSubmissionRejectionEntry to signal committer issued rejections due to rank-based deduplication 
+// and configuration generation checks.
+// Effectively, this message changes the rejection reason of the Ledger-API-server-submitted rejection.
+message DamlRejectSubmissionRejectionEntry {
+  DamlSubmitterInfo submitter_info = 1;
+
+  oneof reason {
+    Duplicate duplicate_submission = 2;
+    GenerationMismatch generation_mismatch = 3;
+  } 
 }
 
 // Daml state key. [[KeyValueCommitting]] produces effects that are committed
@@ -422,7 +470,10 @@ message DamlStateValue {
 message DamlCommandDedupKey {
   // Intents are namespaced to the list of submitting parties.
   repeated string submitters = 1;
-  reserved 2; // was application_id
+
+  // Submitter provided application identifiers.
+  // Optional. Provided for rank-based deduplication.
+  reserved string application_id = 2;
 
   // An identifier for the intent.
   string command_id = 3;
@@ -452,11 +503,16 @@ message DamlCommandDedupValue {
 
   // The identity of the submission whose rank and result is stored.
   // This identity is typically a UUID provided by Ledger API clients.
+  // Optional. Provided for rank-based deduplication.
   string submission_id = 5;
+
   // The rank of the submission whose result is stored. Ranks are compared in
   // lexicographic order.
+  // Optional.Provided for rank-based deduplication.
   bytes submission_rank = 4;
+
   // The result of the submission.
+  // Optional. Provided for rank-based deduplication.
   CommandSubmissionResult submission_result = 3;
 }
 
@@ -669,9 +725,7 @@ message ParticipantNotAuthorized {
   string details = 1;
 }
 
-// A mismatch in the configuration generation, that is, the
-// new configuration did not carry a generation that was one
-// larger than previous generation.
+// A mismatch in the configuration generation.
 message GenerationMismatch {
   int64 expected_generation = 1;
 }

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -487,10 +487,9 @@ message DamlCommandDedupKey {
 // same rank instead of executing them.
 //
 // DamlCommandDedupValues are tagged with an expiry date to allow ledgers to
-// reclaim storage space by deleting them. The expiry date is provided either
-// directly or indirectly by Ledger API clients. They are expected to provide
-// a close, but not too close expiry date, so that ledger can reclaim storage
-// space timely without the clients experiencing duplicate submissions.
+// reclaim storage space by deleting them. The expiry date is computed by the 
+// submitting participant based on the `LedgerConfiguration.max_deduplicate_until` 
+// of the configuration active at the time of submission.
 message DamlCommandDedupValue {
   reserved 1; // was record_time
 
@@ -502,7 +501,7 @@ message DamlCommandDedupValue {
   google.protobuf.Timestamp deduplicated_until = 2;
 
   // The identity of the submission whose rank and result is stored.
-  // This identity is typically a UUID provided by Ledger API clients.
+  // This identity is ledger string provided by Ledger API clients.
   // Optional. Provided for rank-based deduplication.
   string submission_id = 5;
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -164,17 +164,15 @@ message DamlSubmitterInfo {
   // Duration that determines the range of existing DamlLogEntries against which this
   // submission deduplicated.
   //  
-  // The ledger guarantees that for any existing entry e0 the deduplicate_until field of
+  // The Committer guarantees that for any existing entry e0 the deduplicate_until field of
   // its associated DamlCommandDedupValue cdv0 and the entry e1 created from this submission
   // it holds that 
   //
-  //    if (e1.record_time >= e0.record_time >= e1.record_time - e1.deduplication_duration) AND
-  //       (e0.command_id, e0.application_id, e0.submitters.toSet) == 
-  //       (e1.command_id, e1.application_id, e1.submitters.toSet)
+  //    if (e1.record_time >= e0.record_time >= e1.record_time - e1.deduplication_duration)
   //    then e0.record_time + cdv0.deduplicate_until >= e1.record_time
   //
-  // Note that the ledger MAY extend the deduplication_duration; e.g., to the 
-  // LedgerConfiguration.max_deduplication_time.
+  // Note that the Ledger API allows extending the deduplication_duration, which our
+  // Committer uses liberally to always extend it to LedgerConfiguration.max_deduplication_time.
   google.protobuf.Duration deduplication_duration = 6;
 
   // The generation of the ledger configuration used to build this submission.

--- a/ledger/participant-state/protobuf/com/daml/ledger/participant/state/ledger_configuration.proto
+++ b/ledger/participant-state/protobuf/com/daml/ledger/participant/state/ledger_configuration.proto
@@ -17,7 +17,6 @@ option java_multiple_files = true;
 option csharp_namespace = "Com.Daml.Ledger.Participant.State.Protobuf";
 
 import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
 
 message LedgerConfiguration {
   // The version of the configuration message. Defines the semantics
@@ -37,16 +36,6 @@ message LedgerConfiguration {
   // (as described in ``commands.proto``). This defines the maximum time window during which
   // commands can be deduplicated.
   google.protobuf.Duration max_deduplication_time = 4;
-
-  // The time at which this configuration was submitted.
-  //
-  // This submission time is bounded by this configuration's time_model to its record time ``rt`` 
-  // such that ``rt - time_model.min_skew <= submission_time <= rt + time_model.max_skew``.
-  google.protobuf.Timestamp submission_time = 5;
-
-  // The uppper bound on the ``deduplication_duration`` parameter of command submissions
-  // induced by past configurations that were in effect before this configuration.
-  google.protobuf.Duration past_deduplication_time_upper_bound = 6;
 }
 
 message LedgerTimeModel {


### PR DESCRIPTION
This PR serves as a draft to aid the design discussion around rank-based command deduplication.

FYI: @andreaslochbihler-da 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
