### PR TITLE
Add a helper for getting all inactive contracts to Transaction

### DIFF
--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -17,7 +17,6 @@ import com.daml.lf.transaction.Node.{
   NodeRollback,
 }
 import com.daml.lf.transaction.{
-  BlindingInfo,
   GenTransaction,
   NodeId,
   TransactionVersion,
@@ -552,20 +551,6 @@ object ValueGenerators {
       }
     } yield VersionedTransaction(txVer, nodes, tx.roots)
 
-  }
-
-  val genBlindingInfo: Gen[BlindingInfo] = {
-    val nodePartiesGen = Gen.mapOf(
-      arbitrary[Int]
-        .map(NodeId(_))
-        .flatMap(n => genMaybeEmptyParties.map(ps => (n, ps)))
-    )
-    for {
-      disclosed <- nodePartiesGen
-      divulged <- Gen.mapOf(
-        cidV0Gen.flatMap(c => genMaybeEmptyParties.map(ps => (c: ContractId) -> ps))
-      )
-    } yield BlindingInfo(disclosed, divulged)
   }
 
   def stringVersionGen: Gen[String] = {

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -421,7 +421,7 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
     builder.add(exercise(builder, create3, parties, true), rollback)
     val (cid4, create4) = create(builder, parties)
     builder.add(create4, rollback)
-    val transaction = builder.build
+    val transaction = builder.build()
 
     "consumedContracs does not include rollbacks" in {
       transaction.consumedContracts shouldBe Set(cid0, cid2)


### PR DESCRIPTION
This comes up in a few places and rather than inlining the
implementation everywhere, I’d rather rely on this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
