### PR TITLE
Support rollback nodes in KeyValueCommitting.submissionOutputs

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -225,12 +225,13 @@ object KeyValueCommitting {
       node.getNodeTypeCase match {
 
         case TransactionOuterClass.Node.NodeTypeCase.ROLLBACK =>
-        // Rollback nodes themselves do not produce any outputs. However, children
-        // of rollback nodes potentially will, e.g., divulgence.
-        // At the moment, we overapproximate and treat
-        // a node the same regardless of whether it was under a rollback node.
-        // This matches the treatment of transient contracts which could also
-        // be trimmed from the output.
+        // Nodes under rollback will potentially produce outputs such as divulgence.
+        // Actual outputs must be a subset of, or the same as, computed outputs and
+        // we currently relax this check by widening the latter set, treating a node the
+        // same regardless of whether it was under a rollback node or not.
+        // Computed outputs that are not actual outputs can be safely trimmed: examples
+        // are transient contracts and, now, potentially also outputs from nodes under
+        // rollback.
 
         case TransactionOuterClass.Node.NodeTypeCase.CREATE =>
           val protoCreate = node.getCreate

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -225,8 +225,12 @@ object KeyValueCommitting {
       node.getNodeTypeCase match {
 
         case TransactionOuterClass.Node.NodeTypeCase.ROLLBACK =>
-          // TODO https://github.com/digital-asset/daml/issues/8020
-          sys.error("rollback nodes are not supported")
+        // Rollback nodes itself do not produce any outputs. However, children
+        // of rollback nodes potentially will, e.g., divulgence.
+        // At the moment, we overapproximate and treat
+        // a node the same regardless of whether it was under a rollback node.
+        // This matches the treatment of transient contracts which could also
+        // be trimmed from the output.
 
         case TransactionOuterClass.Node.NodeTypeCase.CREATE =>
           val protoCreate = node.getCreate

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -225,7 +225,7 @@ object KeyValueCommitting {
       node.getNodeTypeCase match {
 
         case TransactionOuterClass.Node.NodeTypeCase.ROLLBACK =>
-        // Rollback nodes itself do not produce any outputs. However, children
+        // Rollback nodes themselves do not produce any outputs. However, children
         // of rollback nodes potentially will, e.g., divulgence.
         // At the moment, we overapproximate and treat
         // a node the same regardless of whether it was under a rollback node.

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
@@ -100,6 +100,7 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
   import Conversions.{contractIdToStateKey, contractKeyToStateKey}
 
   "submissionOutputs" should {
+
     "return a single output for a create without a key" in {
       val builder = TransactionBuilder()
       val c = create(builder, "#1")
@@ -110,6 +111,7 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
         key,
       )
     }
+
     "return two outputs for a create with a key" in {
       val builder = TransactionBuilder()
       val c = create(builder, "#1", true)
@@ -122,6 +124,7 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
         contractKeyKey,
       )
     }
+
     "return a single output for a transient contract" in {
       val builder = TransactionBuilder()
       val c = create(builder, "#1", true)
@@ -135,6 +138,7 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
         contractKeyKey,
       )
     }
+
     "return a single output for an exercise without a key" in {
       val builder = TransactionBuilder()
       val e = exercise(builder, "#1")
@@ -145,6 +149,7 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
         contractIdKey,
       )
     }
+
     "return two outputs for an exercise with a key" in {
       val builder = TransactionBuilder()
       val e = exercise(builder, "#1", hasKey = true)
@@ -157,6 +162,7 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
         contractKeyKey,
       )
     }
+
     "return one output per fetch and fetch-by-key" in {
       val builder = TransactionBuilder()
       val f1 = fetch(builder, "#1", byKey = true)
@@ -169,17 +175,20 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
         contractIdToStateKey(f2.coid),
       )
     }
+
     "return no output for a failing lookup-by-key" in {
       val builder = TransactionBuilder()
       builder.add(lookup(builder, "#1", found = false))
       getOutputs(builder) shouldBe Set(dedupKey)
 
     }
+
     "return no output for a successful lookup-by-key" in {
       val builder = TransactionBuilder()
       builder.add(lookup(builder, "#1", found = true))
       getOutputs(builder) shouldBe Set(dedupKey)
     }
+
     "return outputs for nodes under a rollback node" in {
       val builder = TransactionBuilder()
       val rollback = builder.add(builder.rollback())

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import java.time.Instant
 
-class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
+class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
   private val metrics: Metrics = new Metrics(new MetricRegistry)
   private val keyValueSubmission = new KeyValueSubmission(metrics)
 
@@ -35,7 +35,7 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
   private val commandId = CommandId.assertFromString("cmdid")
 
   private def toSubmission(tx: SubmittedTransaction): DamlSubmission = {
-    val timestamp = Time.Timestamp.assertFromInstant(Instant.EPOCH)
+    val timestamp = Time.Timestamp.Epoch
     val meta = TransactionMeta(
       ledgerEffectiveTime = timestamp,
       workflowId = None,
@@ -184,7 +184,6 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
       val builder = TransactionBuilder()
       builder.add(lookup(builder, "#1", found = false))
       KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(dedupKey)
-
     }
 
     "return no output for a successful lookup-by-key" in {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
@@ -103,9 +103,9 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
 
     "return a single output for a create without a key" in {
       val builder = TransactionBuilder()
-      val c = create(builder, "#1")
-      builder.add(c)
-      val key = contractIdToStateKey(c.coid)
+      val createNode = create(builder, "#1")
+      builder.add(createNode)
+      val key = contractIdToStateKey(createNode.coid)
       getOutputs(builder) shouldBe Set(
         dedupKey,
         key,
@@ -114,9 +114,9 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
 
     "return two outputs for a create with a key" in {
       val builder = TransactionBuilder()
-      val c = create(builder, "#1", true)
-      builder.add(c)
-      val contractIdKey = contractIdToStateKey(c.coid)
+      val createNode = create(builder, "#1", true)
+      builder.add(createNode)
+      val contractIdKey = contractIdToStateKey(createNode.coid)
       val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
       getOutputs(builder) shouldBe Set(
         dedupKey,
@@ -127,10 +127,10 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
 
     "return a single output for a transient contract" in {
       val builder = TransactionBuilder()
-      val c = create(builder, "#1", true)
-      builder.add(c)
+      val createNode = create(builder, "#1", true)
+      builder.add(createNode)
       builder.add(exercise(builder, "#1"))
-      val contractIdKey = contractIdToStateKey(c.coid)
+      val contractIdKey = contractIdToStateKey(createNode.coid)
       val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
       getOutputs(builder) shouldBe Set(
         dedupKey,
@@ -141,9 +141,9 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
 
     "return a single output for an exercise without a key" in {
       val builder = TransactionBuilder()
-      val e = exercise(builder, "#1")
-      builder.add(e)
-      val contractIdKey = contractIdToStateKey(e.targetCoid)
+      val exerciseNode = exercise(builder, "#1")
+      builder.add(exerciseNode)
+      val contractIdKey = contractIdToStateKey(exerciseNode.targetCoid)
       getOutputs(builder) shouldBe Set(
         dedupKey,
         contractIdKey,
@@ -152,9 +152,9 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
 
     "return two outputs for an exercise with a key" in {
       val builder = TransactionBuilder()
-      val e = exercise(builder, "#1", hasKey = true)
-      builder.add(e)
-      val contractIdKey = contractIdToStateKey(e.targetCoid)
+      val exerciseNode = exercise(builder, "#1", hasKey = true)
+      builder.add(exerciseNode)
+      val contractIdKey = contractIdToStateKey(exerciseNode.targetCoid)
       val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
       getOutputs(builder) shouldBe Set(
         dedupKey,
@@ -165,14 +165,14 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
 
     "return one output per fetch and fetch-by-key" in {
       val builder = TransactionBuilder()
-      val f1 = fetch(builder, "#1", byKey = true)
-      val f2 = fetch(builder, "#2", byKey = false)
-      builder.add(f1)
-      builder.add(f2)
+      val fetchNode1 = fetch(builder, "#1", byKey = true)
+      val fetchNode2 = fetch(builder, "#2", byKey = false)
+      builder.add(fetchNode1)
+      builder.add(fetchNode2)
       getOutputs(builder) shouldBe Set(
         dedupKey,
-        contractIdToStateKey(f1.coid),
-        contractIdToStateKey(f2.coid),
+        contractIdToStateKey(fetchNode1.coid),
+        contractIdToStateKey(fetchNode2.coid),
       )
     }
 
@@ -192,18 +192,18 @@ class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
     "return outputs for nodes under a rollback node" in {
       val builder = TransactionBuilder()
       val rollback = builder.add(builder.rollback())
-      val c = create(builder, "#1", hasKey = true)
-      builder.add(c, rollback)
-      val e = exercise(builder, "#2", hasKey = true)
-      builder.add(e, rollback)
-      val f = fetch(builder, "#3", byKey = true)
-      builder.add(f, rollback)
+      val createNode = create(builder, "#1", hasKey = true)
+      builder.add(createNode, rollback)
+      val exerciseNode = exercise(builder, "#2", hasKey = true)
+      builder.add(exerciseNode, rollback)
+      val fetchNode = fetch(builder, "#3", byKey = true)
+      builder.add(fetchNode, rollback)
       getOutputs(builder) shouldBe Set(
         dedupKey,
-        contractIdToStateKey(c.coid),
+        contractIdToStateKey(createNode.coid),
         contractKeyToStateKey(templateId, keyValue),
-        contractIdToStateKey(e.targetCoid),
-        contractIdToStateKey(f.coid),
+        contractIdToStateKey(exerciseNode.targetCoid),
+        contractIdToStateKey(fetchNode.coid),
       )
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
@@ -110,7 +110,8 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
       val createNode = create(builder, "#1")
       builder.add(createNode)
       val key = contractIdToStateKey(createNode.coid)
-      KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(
+      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
+      result shouldBe Set(
         dedupKey,
         key,
       )
@@ -122,7 +123,8 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
       builder.add(createNode)
       val contractIdKey = contractIdToStateKey(createNode.coid)
       val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
-      KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(
+      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
+      result shouldBe Set(
         dedupKey,
         contractIdKey,
         contractKeyKey,
@@ -136,7 +138,8 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
       builder.add(exercise(builder, "#1"))
       val contractIdKey = contractIdToStateKey(createNode.coid)
       val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
-      KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(
+      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
+      result shouldBe Set(
         dedupKey,
         contractIdKey,
         contractKeyKey,
@@ -160,7 +163,8 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
       builder.add(exerciseNode)
       val contractIdKey = contractIdToStateKey(exerciseNode.targetCoid)
       val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
-      KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(
+      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
+      result shouldBe Set(
         dedupKey,
         contractIdKey,
         contractKeyKey,
@@ -173,7 +177,8 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
       val fetchNode2 = fetch(builder, "#2", byKey = false)
       builder.add(fetchNode1)
       builder.add(fetchNode2)
-      KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(
+      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
+      result shouldBe Set(
         dedupKey,
         contractIdToStateKey(fetchNode1.coid),
         contractIdToStateKey(fetchNode2.coid),
@@ -183,7 +188,8 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
     "return no output for a failing lookup-by-key" in {
       val builder = TransactionBuilder()
       builder.add(lookup(builder, "#1", found = false))
-      KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(dedupKey)
+      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
+      result shouldBe Set(dedupKey)
     }
 
     "return no output for a successful lookup-by-key" in {
@@ -201,7 +207,8 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
       builder.add(exerciseNode, rollback)
       val fetchNode = fetch(builder, "#3", byKey = true)
       builder.add(fetchNode, rollback)
-      KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(
+      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
+      result shouldBe Set(
         dedupKey,
         contractIdToStateKey(createNode.coid),
         contractKeyToStateKey(templateId, keyValue),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
@@ -1,0 +1,201 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.participant.state.v1.{
+  SubmitterInfo,
+  ApplicationId,
+  CommandId,
+  TransactionMeta,
+}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlCommandDedupKey}
+import com.daml.lf.crypto
+import com.daml.lf.data.Time
+import com.daml.lf.data.Ref.{Party, Identifier}
+import com.daml.lf.data.ImmArray
+import com.daml.lf.transaction.SubmittedTransaction
+import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.value.Value
+import com.daml.metrics.Metrics
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import java.time.Instant
+
+class KeyValueCommitingSpec extends AnyWordSpec with Matchers {
+  private val metrics: Metrics = new Metrics(new MetricRegistry)
+  private val keyValueSubmission = new KeyValueSubmission(metrics)
+
+  private val alice = Party.assertFromString("Alice")
+  private val commandId = CommandId.assertFromString("cmdid")
+
+  private def toSubmission(tx: SubmittedTransaction) = {
+    val timestamp = Time.Timestamp.assertFromInstant(Instant.EPOCH)
+    val meta = TransactionMeta(
+      ledgerEffectiveTime = timestamp,
+      workflowId = None,
+      submissionTime = timestamp,
+      submissionSeed = crypto.Hash.hashPrivateKey(this.getClass.getName),
+      optUsedPackages = Some(Set.empty),
+      optNodeSeeds = None,
+      optByKeyNodes = None,
+    )
+    val submitterInfo = SubmitterInfo(
+      actAs = List(alice),
+      applicationId = ApplicationId.assertFromString("appid"),
+      commandId = commandId,
+      deduplicateUntil = Instant.EPOCH,
+    )
+    keyValueSubmission.transactionToSubmission(
+      submitterInfo = submitterInfo,
+      meta = meta,
+      tx = tx,
+    )
+  }
+
+  def getOutputs(builder: TransactionBuilder) =
+    KeyValueCommitting.submissionOutputs(toSubmission(builder.buildSubmitted()))
+
+  val dedupKey = DamlStateKey.newBuilder
+    .setCommandDedup(
+      DamlCommandDedupKey.newBuilder.addSubmitters(alice).setCommandId(commandId).build
+    )
+    .build
+
+  private val keyValue = Value.ValueUnit
+  private val templateId = Identifier.assertFromString("pkg:M:T")
+
+  private def create(builder: TransactionBuilder, id: String, hasKey: Boolean = false) =
+    builder.create(
+      id = id,
+      template = templateId.toString,
+      argument = Value.ValueRecord(None, ImmArray.empty),
+      signatories = Seq(),
+      observers = Seq(),
+      key = if (hasKey) Some(keyValue) else None,
+    )
+
+  private def exercise(
+      builder: TransactionBuilder,
+      id: String,
+      hasKey: Boolean = false,
+      consuming: Boolean = true,
+  ) =
+    builder.exercise(
+      contract = create(builder, id, hasKey),
+      choice = "Choice",
+      argument = Value.ValueRecord(None, ImmArray.empty),
+      actingParties = Set(),
+      consuming = consuming,
+      result = Some(Value.ValueUnit),
+    )
+
+  private def fetch(builder: TransactionBuilder, id: String, byKey: Boolean) =
+    builder.fetch(contract = create(builder, id, hasKey = true), byKey = byKey)
+
+  private def lookup(builder: TransactionBuilder, id: String, found: Boolean) =
+    builder.lookupByKey(contract = create(builder, id, hasKey = true), found = found)
+
+  import Conversions.{contractIdToStateKey, contractKeyToStateKey}
+
+  "submissionOutputs" should {
+    "return a single output for a create without a key" in {
+      val builder = TransactionBuilder()
+      val c = create(builder, "#1")
+      builder.add(c)
+      val key = contractIdToStateKey(c.coid)
+      getOutputs(builder) shouldBe Set(
+        dedupKey,
+        key,
+      )
+    }
+    "return two outputs for a create with a key" in {
+      val builder = TransactionBuilder()
+      val c = create(builder, "#1", true)
+      builder.add(c)
+      val contractIdKey = contractIdToStateKey(c.coid)
+      val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
+      getOutputs(builder) shouldBe Set(
+        dedupKey,
+        contractIdKey,
+        contractKeyKey,
+      )
+    }
+    "return a single output for a transient contract" in {
+      val builder = TransactionBuilder()
+      val c = create(builder, "#1", true)
+      builder.add(c)
+      builder.add(exercise(builder, "#1"))
+      val contractIdKey = contractIdToStateKey(c.coid)
+      val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
+      getOutputs(builder) shouldBe Set(
+        dedupKey,
+        contractIdKey,
+        contractKeyKey,
+      )
+    }
+    "return a single output for an exercise without a key" in {
+      val builder = TransactionBuilder()
+      val e = exercise(builder, "#1")
+      builder.add(e)
+      val contractIdKey = contractIdToStateKey(e.targetCoid)
+      getOutputs(builder) shouldBe Set(
+        dedupKey,
+        contractIdKey,
+      )
+    }
+    "return two outputs for an exercise with a key" in {
+      val builder = TransactionBuilder()
+      val e = exercise(builder, "#1", hasKey = true)
+      builder.add(e)
+      val contractIdKey = contractIdToStateKey(e.targetCoid)
+      val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
+      getOutputs(builder) shouldBe Set(
+        dedupKey,
+        contractIdKey,
+        contractKeyKey,
+      )
+    }
+    "return one output per fetch and fetch-by-key" in {
+      val builder = TransactionBuilder()
+      val f1 = fetch(builder, "#1", byKey = true)
+      val f2 = fetch(builder, "#2", byKey = false)
+      builder.add(f1)
+      builder.add(f2)
+      getOutputs(builder) shouldBe Set(
+        dedupKey,
+        contractIdToStateKey(f1.coid),
+        contractIdToStateKey(f2.coid),
+      )
+    }
+    "return no output for a failing lookup-by-key" in {
+      val builder = TransactionBuilder()
+      builder.add(lookup(builder, "#1", found = false))
+      getOutputs(builder) shouldBe Set(dedupKey)
+
+    }
+    "return no output for a successful lookup-by-key" in {
+      val builder = TransactionBuilder()
+      builder.add(lookup(builder, "#1", found = true))
+      getOutputs(builder) shouldBe Set(dedupKey)
+    }
+    "return outputs for nodes under a rollback node" in {
+      val builder = TransactionBuilder()
+      val rollback = builder.add(builder.rollback())
+      val c = create(builder, "#1", hasKey = true)
+      builder.add(c, rollback)
+      val e = exercise(builder, "#2", hasKey = true)
+      builder.add(e, rollback)
+      val f = fetch(builder, "#3", byKey = true)
+      builder.add(f, rollback)
+      getOutputs(builder) shouldBe Set(
+        dedupKey,
+        contractIdToStateKey(c.coid),
+        contractKeyToStateKey(templateId, keyValue),
+        contractIdToStateKey(e.targetCoid),
+        contractIdToStateKey(f.coid),
+      )
+    }
+  }
+}


### PR DESCRIPTION
As discussed on Slack overapproximating and thereby not treating nodes
under a rollback special seems like a good first step and matches what
we do for transient contracts.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
