### PR TITLE
kvutils: Log a missing input state warning without the stack trace. [KVL-796]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
@@ -18,21 +18,25 @@ object Err {
   final case class InvalidSubmission(message: String) extends Err {
     override def getMessage: String = s"Invalid submission: $message"
   }
+
   final case class MissingInputState(key: DamlStateKey) extends Err {
     override def getMessage: String =
       s"Missing input state for key $key. Hint: the referenced contract might have been archived."
   }
+
   final case class ArchiveDecodingFailed(packageId: PackageId, reason: String) extends Err {
     override def getMessage: String = s"Decoding of DAML-LF archive $packageId failed: $reason"
   }
+
   final case class DecodeError(kind: String, message: String) extends Err {
     override def getMessage: String = s"Decoding $kind failed: $message"
   }
+
   final case class EncodeError(kind: String, message: String) extends Err {
     override def getMessage: String = s"Encoding $kind failed: $message"
   }
+
   final case class InternalError(message: String) extends Err {
     override def getMessage: String = s"Internal error: $message"
   }
-
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -276,7 +276,9 @@ private[kvutils] class TransactionCommitter(
             )
         } catch {
           case err: Err.MissingInputState =>
-            logger.warn("Exception during model conformance validation.", err)
+            logger.warn(
+              s"Model conformance validation failed due to a missing input state (most likely due to invalid state on the partcipant), correlationId=${transactionEntry.commandId}"
+            )
             reject(
               commitContext.recordTime,
               buildRejectionLogEntry(transactionEntry, RejectionReason.Disputed(err.getMessage)),


### PR DESCRIPTION
Missing input state is the fault of the participant, not the ledger.
Logging it as a warning, with a stack trace, makes it look like the
ledger itself failed, when actually the participant failed to provide
the correct keys (potentially due to data corruption, but it could also
be malicious).

This drops the stack trace to make the error less scary. We still log at
WARN level because this sort of thing shouldn't happen very often, and
at the very least, the participant operator should be informed, and the
participant should be refreshed with the correct data somehow.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
