### PR TITLE
Simplify opt-in/out of Oracle when building

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,8 @@ fetch:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 query:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 sync:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 
+test:oracle --test_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
+
 # Improve remote cache hit rate by exluding environment variables from the
 # sandbox that are not whitelisted using --action_env.
 # This will become the default in a future Bazel release.

--- a/.bazelrc
+++ b/.bazelrc
@@ -21,7 +21,7 @@ fetch:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 query:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 sync:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 
-test:oracle --test_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
+test:oracle --repo_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
 
 # Improve remote cache hit rate by exluding environment variables from the
 # sandbox that are not whitelisted using --action_env.

--- a/.envrc
+++ b/.envrc
@@ -3,3 +3,4 @@ eval "$(dev-env/bin/dade assist)"
 
 # Load private overrides
 [[ -f .envrc.private ]] && source_env .envrc.private
+

--- a/.envrc
+++ b/.envrc
@@ -3,4 +3,3 @@ eval "$(dev-env/bin/dade assist)"
 
 # Load private overrides
 [[ -f .envrc.private ]] && source_env .envrc.private
-

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -228,7 +228,7 @@ jobs:
         }
         trap cleanup EXIT
         testConnection() {
-            docker exec oracle bash -c 'sqlplus -L system/'"$ORACLE_PWD"'@//localhost:'"$ORACLE_PORT"'/ORCLPDB1 <<< "select * from dba_users;"; exit $?' >/dev/null
+            docker exec oracle bash -c 'sqlplus -L '"$ORACLE_USERNAME"'/'"$ORACLE_PWD"'@//localhost:'"$ORACLE_PORT"'/ORCLPDB1 <<< "select * from dba_users;"; exit $?' >/dev/null
         }
         until testConnection
         do

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -212,8 +212,6 @@ jobs:
     - bash: |
         set -euo pipefail
         eval "$(./dev-env/bin/dade-assist)"
-        export ORACLE_PORT=1521
-        export ORACLE_PWD=hunter2
         docker login --username "$DOCKER_LOGIN" --password "$DOCKER_PASSWORD"
         IMAGE=digitalasset/oracle:enterprise-19.3.0-preloaded-20210325-22-be14fb7
         docker pull $IMAGE
@@ -230,7 +228,7 @@ jobs:
         }
         trap cleanup EXIT
         testConnection() {
-            docker exec oracle bash -c 'sqlplus -L system/'"$ORACLE_PWD"'@//localhost:1521/ORCLPDB1 <<< "select * from dba_users;"; exit $?' >/dev/null
+            docker exec oracle bash -c 'sqlplus -L system/'"$ORACLE_PWD"'@//localhost:'"$ORACLE_PORT"'/ORCLPDB1 <<< "select * from dba_users;"; exit $?' >/dev/null
         }
         until testConnection
         do
@@ -238,8 +236,8 @@ jobs:
           sleep 1
         done
         # Actually run some tests
-        DAML_ORACLE_TESTING=true bazel test \
-          --test_env ORACLE_USERNAME=system --test_env ORACLE_PORT --test_env ORACLE_PWD \
+        bazel test \
+          --config=oracle \
           //ledger-service/http-json-oracle/... \
           //triggers/service:test-oracle \
           //ledger/participant-integration-api:participant-integration-api-tests-oracle

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -21,6 +21,8 @@ fetch:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 query:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 sync:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 
+test:oracle --test_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
+
 # Improve remote cache hit rate by exluding environment variables from the
 # sandbox that are not whitelisted using --action_env.
 # This will become the default in a future Bazel release.

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -21,7 +21,7 @@ fetch:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 query:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 sync:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.3
 
-test:oracle --test_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
+test:oracle --repo_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
 
 # Improve remote cache hit rate by exluding environment variables from the
 # sandbox that are not whitelisted using --action_env.

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -128,3 +128,8 @@ fi
 echo "export LC_ALL=en_US.UTF-8"
 echo "export LANG=en_US.UTF-8"
 
+echo "# Used when running Bazel commands with --config=oracle"
+echo "export ORACLE_USERNAME=system"
+echo "export ORACLE_PWD=hunter2"
+echo "export ORACLE_PORT=1521"
+


### PR DESCRIPTION
- defines Oracle-related environment variables as part of dev-env so that it's the same across CI and dev
- adds a Bazel 'oracle' configuration so that --config=oracle pulls all required environment

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
