### PR TITLE
First draw of an interface separating ingestion and storage

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -23,6 +23,7 @@ case class IndexerConfig(
     enableAppendOnlySchema: Boolean = false,
     asyncCommitMode: DbType.AsyncCommitMode = DefaultAsyncCommitMode,
     inputMappingParallelism: Int = DefaultInputMappingParallelism,
+    batchingParallelism: Int = DefaultBatchingParallelism,
     ingestionParallelism: Int = DefaultIngestionParallelism,
     submissionBatchSize: Long = DefaultSubmissionBatchSize,
     tailingRateLimitPerSecond: Int = DefaultTailingRateLimitPerSecond,
@@ -39,6 +40,7 @@ object IndexerConfig {
   val DefaultAsyncCommitMode: DbType.AsyncCommitMode = DbType.AsynchronousCommit
 
   val DefaultInputMappingParallelism: Int = 16
+  val DefaultBatchingParallelism: Int = 4
   val DefaultIngestionParallelism: Int = 16
   val DefaultSubmissionBatchSize: Long = 50L
   val DefaultTailingRateLimitPerSecond: Int = 20

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -19,7 +19,7 @@ import com.daml.platform.ApiOffset.ApiOffsetConverter
 import com.daml.platform.common
 import com.daml.platform.common.MismatchException
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.indexer.parallel.ParallelIndexerFactory
+import com.daml.platform.indexer.parallel.{ParallelIndexerFactory, PostgresStorageBackend}
 import com.daml.platform.store.appendonlydao.events.{CompressionStrategy, LfValueTranslation}
 import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao}
 import com.daml.platform.store.{DbType, FlywayMigrations, LfValueTranslationCache}
@@ -138,6 +138,7 @@ object JdbcIndexer {
         )
         indexer <- ParallelIndexerFactory(
           jdbcUrl = config.jdbcUrl,
+          storageBackend = PostgresStorageBackend, // TODO append-only: factory mechanism
           participantId = config.participantId,
           translation = new LfValueTranslation(
             cache = lfValueTranslationCache,
@@ -150,6 +151,7 @@ object JdbcIndexer {
             else CompressionStrategy.none(metrics),
           mat = materializer,
           inputMappingParallelism = config.inputMappingParallelism,
+          batchingParallelism = config.batchingParallelism,
           ingestionParallelism = config.ingestionParallelism,
           submissionBatchSize = config.submissionBatchSize,
           tailingRateLimitPerSecond = config.tailingRateLimitPerSecond,

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/BatchingParallelIngestionPipe.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/BatchingParallelIngestionPipe.scala
@@ -5,26 +5,26 @@ package com.daml.platform.indexer.parallel
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.v1.{Offset, Update}
-import com.daml.platform.store.appendonlydao.JdbcLedgerDao
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 object BatchingParallelIngestionPipe {
 
-  def apply[IN, RUNBATCH](
+  def apply[IN, IN_BATCH, DB_BATCH](
       submissionBatchSize: Long,
       batchWithinMillis: Long,
       inputMappingParallelism: Int,
-      inputMapper: Iterable[IN] => Future[RUNBATCH],
-      seqMapperZero: RUNBATCH,
-      seqMapper: (RUNBATCH, RUNBATCH) => RUNBATCH,
+      inputMapper: Iterable[IN] => Future[IN_BATCH],
+      seqMapperZero: IN_BATCH,
+      seqMapper: (IN_BATCH, IN_BATCH) => IN_BATCH,
+      batchingParallelism: Int,
+      batcher: IN_BATCH => Future[DB_BATCH],
       ingestingParallelism: Int,
-      ingester: RUNBATCH => Future[RUNBATCH],
-      tailer: (RUNBATCH, RUNBATCH) => RUNBATCH,
+      ingester: DB_BATCH => Future[DB_BATCH],
+      tailer: (DB_BATCH, DB_BATCH) => DB_BATCH,
       tailingRateLimitPerSecond: Int,
-      ingestTail: RUNBATCH => Future[RUNBATCH],
+      ingestTail: DB_BATCH => Future[DB_BATCH],
   )(source: Source[IN, NotUsed]): Source[Unit, NotUsed] =
     // Stage 1: the stream coming from ReadService, involves deserialization and translation to Update-s
     source
@@ -37,86 +37,19 @@ object BatchingParallelIngestionPipe {
       // Stage 3: Encapsulates sequential/stateful computation (generation of sequential IDs for events)
       .scan(seqMapperZero)(seqMapper)
       .drop(1) // remove the zero element from the beginning of the stream
-      // Stage 4: Inserting data into the database. Almost no CPU load here, threads are executing SQL commands over JDBC, and waiting for the result. This defines the parallelism on the SQL database side, same amount of PostgreSQL Backend processes will do the ingestion work.
+      // Stage 4: Mapping to Database specific representation, encapsulates all database specific preparation of the data. Executed in parallel.
+      .async
+      .mapAsync(batchingParallelism)(batcher)
+      // Stage 5: Inserting data into the database. Almost no CPU load here, threads are executing SQL commands over JDBC, and waiting for the result. This defines the parallelism on the SQL database side, same amount of PostgreSQL Backend processes will do the ingestion work.
       .async
       .mapAsync(ingestingParallelism)(ingester)
-      // Stage 5: Preparing data sequentially for throttled mutations in database (tracking the ledger-end, corresponding sequential event ids and latest-at-the-time configurations)
+      // Stage 6: Preparing data sequentially for throttled mutations in database (tracking the ledger-end, corresponding sequential event ids and latest-at-the-time configurations)
       .conflate(tailer)
       .throttle(tailingRateLimitPerSecond, FiniteDuration(1, "seconds"))
-      // Stage 6: Updating ledger-end and related data in database (this stage completion demarcates the consistent point-in-time)
+      // Stage 7: Updating ledger-end and related data in database (this stage completion demarcates the consistent point-in-time)
       .mapAsync(1)(ingestTail)
       .map(_ =>
         ()
       ) // TODO append-only: linking to consumers that depend on the moving ledger end, such as in-memory fan-out
 
-}
-
-case class RunningDBBatch(
-    lastOffset: Offset,
-    lastSeqEventId: Long,
-    lastConfig: Option[Array[Byte]],
-    batch: RawDBBatchPostgreSQLV1,
-    batchSize: Int,
-    averageStartTime: Long,
-)
-
-object RunningDBBatch {
-
-  def inputMapper(
-      toDbDto: Offset => Update => Iterator[DBDTOV1],
-      averageStartTime: Long,
-  )(input: Iterable[(Offset, Update)]): RunningDBBatch = {
-    val batchBuilder = RawDBBatchPostgreSQLV1.Builder()
-    var lastOffset: Offset = null
-    var lastConfiguration: Array[Byte] = null
-    input.foreach { case (offset, update) =>
-      val dbDtos = toDbDto(offset)(update)
-      lastOffset = offset
-      dbDtos.foreach { dbDto =>
-        dbDto match {
-          case c: DBDTOV1.ConfigurationEntry if c.typ == JdbcLedgerDao.acceptType =>
-            lastConfiguration = c.configuration
-          case _ =>
-            ()
-        }
-        batchBuilder.add(dbDto)
-      }
-    }
-    val batch = batchBuilder.build()
-    RunningDBBatch(
-      lastOffset = lastOffset,
-      lastSeqEventId = 0L, // will be populated later
-      lastConfig = Option(lastConfiguration),
-      batch = batch,
-      batchSize = input.size,
-      averageStartTime = averageStartTime,
-    )
-  }
-
-  def seqMapperZero(initialSeqEventId: Long): RunningDBBatch =
-    RunningDBBatch(
-      lastOffset = null,
-      lastSeqEventId = initialSeqEventId,
-      lastConfig = None,
-      batch = nullBatch,
-      batchSize = 0,
-      averageStartTime = 0,
-    )
-
-  def seqMapper(prev: RunningDBBatch, curr: RunningDBBatch): RunningDBBatch = {
-    val idsUsed = curr.batch.offsetSequentialEventIds(prev.lastSeqEventId + 1)
-    curr.copy(lastSeqEventId = prev.lastSeqEventId + idsUsed)
-  }
-
-  private val nullBatch = RawDBBatchPostgreSQLV1.Builder().build()
-
-  def tailer(prev: RunningDBBatch, curr: RunningDBBatch): RunningDBBatch =
-    RunningDBBatch(
-      lastOffset = curr.lastOffset,
-      lastSeqEventId = curr.lastSeqEventId,
-      lastConfig = curr.lastConfig.orElse(prev.lastConfig),
-      batch = nullBatch,
-      batchSize = 0,
-      averageStartTime = 0,
-    )
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/DBDTOV1.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/DBDTOV1.scala
@@ -20,7 +20,7 @@ object DBDTOV1 {
       tree_event_witnesses: Set[String],
       create_argument: Option[Array[Byte]],
       create_argument_compression: Option[Int],
-      // missing: event_sequential_id: Long - this will be assigned only at batches
+      event_sequential_id: Long,
   ) extends DBDTOV1
 
   case class EventCreate(
@@ -45,7 +45,7 @@ object DBDTOV1 {
       create_key_hash: Option[String],
       create_argument_compression: Option[Int],
       create_key_value_compression: Option[Int],
-      // missing: event_sequential_id: Long - this will be assigned only at batches
+      event_sequential_id: Long,
   ) extends DBDTOV1
 
   case class EventExercise(
@@ -72,7 +72,7 @@ object DBDTOV1 {
       create_key_value_compression: Option[Int],
       exercise_argument_compression: Option[Int],
       exercise_result_compression: Option[Int],
-      // missing: event_sequential_id: Long - this will be assigned only at batches
+      event_sequential_id: Long,
   ) extends DBDTOV1
 
   // TODO wartremover complained about having Array-s in case classes. I would prefer case classes. can we work that somehow around? Similarly in other DTO cases...

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -3,6 +3,7 @@
 
 package com.daml.platform.indexer.parallel
 
+import java.sql.Connection
 import java.util.concurrent.TimeUnit
 
 import akka.NotUsed
@@ -10,102 +11,85 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.{KillSwitch, KillSwitches, Materializer, UniqueKillSwitch}
 import com.daml.ledger.participant.state.v1.{Offset, ParticipantId, ReadService, Update}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
+import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
+import com.daml.platform.configuration.ServerRole
 import com.daml.platform.indexer.parallel.AsyncSupport._
 import com.daml.platform.indexer.parallel.PerfSupport._
 import com.daml.platform.indexer.{IndexFeedHandle, Indexer}
+import com.daml.platform.store.DbType
+import com.daml.platform.store.appendonlydao.{DbDispatcher, JdbcLedgerDao}
 import com.daml.platform.store.appendonlydao.events.{CompressionStrategy, LfValueTranslation}
 import com.daml.resources
 
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
 object ParallelIndexerFactory {
 
   // TODO append-only: migrate code for mutable initialisation
-  def apply(
-      jdbcUrl: String,
+  def apply[DB_BATCH](
+      jdbcUrl: String, // TODO maybe inject the whole dispatcher instead, and let a higher level factory create that alongside with StorageBackend
+      storageBackend: StorageBackend[DB_BATCH],
       participantId: ParticipantId,
       translation: LfValueTranslation,
       compressionStrategy: CompressionStrategy,
       mat: Materializer,
       inputMappingParallelism: Int,
+      batchingParallelism: Int,
       ingestionParallelism: Int,
       submissionBatchSize: Long,
       tailingRateLimitPerSecond: Int,
       batchWithinMillis: Long,
       metrics: Metrics,
-  ): ResourceOwner[Indexer] = {
+  )(implicit loggingContext: LoggingContext): ResourceOwner[Indexer] = {
     for {
       inputMapperExecutor <- asyncPool(
         inputMappingParallelism,
         Some(metrics.daml.parallelIndexer.inputMapping.executor -> metrics.registry),
       )
-      postgresDaoPool <- asyncResourcePool(
-        () => JDBCPostgresDAO(jdbcUrl),
-        size = ingestionParallelism + 1,
-        Some(metrics.daml.parallelIndexer.ingestion.executor -> metrics.registry),
+      batcherExecutor <- asyncPool(
+        batchingParallelism,
+        Some(metrics.daml.parallelIndexer.batching.executor -> metrics.registry),
+      )
+      dbDispatcher <- DbDispatcher
+        .owner( // TODO append-only: do we need to wire health status here somehow?
+          serverRole = ServerRole.Indexer,
+          jdbcUrl = jdbcUrl,
+          connectionPoolSize = ingestionParallelism + 1, // + 1 for the tailing ledger_end updates
+          connectionTimeout = FiniteDuration(
+            250,
+            "millis",
+          ), // TODO append-only: verify why would we need here a timeout, in this case (amount of parallelism aligned) it should not happen by design
+          metrics = metrics,
+          connectionAsyncCommitMode = DbType.AsynchronousCommit,
+        )
+      toDbDto = UpdateToDBDTOV1(
+        participantId = participantId,
+        translation = translation,
+        compressionStrategy = compressionStrategy,
       )
     } yield {
       val ingest: Long => Source[(Offset, Update), NotUsed] => Source[Unit, NotUsed] =
         initialSeqId =>
           source =>
-            BatchingParallelIngestionPipe(
+            BatchingParallelIngestionPipe[((Offset, Update), Long), Batch[
+              Vector[DBDTOV1]
+            ], Batch[DB_BATCH]]( // TODO explicit type parameters meeeh: it should be able to figure out from the fully typed params, but...
               submissionBatchSize = submissionBatchSize,
               batchWithinMillis = batchWithinMillis,
               inputMappingParallelism = inputMappingParallelism,
-              inputMapper =
-                inputMapperExecutor.execute((input: Iterable[((Offset, Update), Long)]) => {
-                  val (data, started) = input.unzip
-                  val averageStartTime = started.view.map(_ / input.size).sum
-                  metrics.daml.parallelIndexer.inputMapping.batchSize.update(input.size)
-                  RunningDBBatch.inputMapper(
-                    UpdateToDBDTOV1(
-                      participantId = participantId,
-                      translation = translation,
-                      compressionStrategy = compressionStrategy,
-                    ),
-                    averageStartTime,
-                  )(data)
-                }),
-              seqMapperZero = RunningDBBatch.seqMapperZero(initialSeqId),
-              seqMapper = (prev: RunningDBBatch, curr: RunningDBBatch) => {
-                val nowNanos = System.nanoTime()
-                metrics.daml.parallelIndexer.inputMapping.duration.update(
-                  (nowNanos - curr.averageStartTime) / curr.batchSize,
-                  TimeUnit.NANOSECONDS,
-                )
-                RunningDBBatch.seqMapper(prev, curr).copy(averageStartTime = nowNanos)
-              },
+              inputMapper = inputMapperExecutor.execute(inputMapper(metrics, toDbDto)),
+              seqMapperZero = seqMapperZero(initialSeqId),
+              seqMapper = seqMapper(metrics),
+              batchingParallelism = batchingParallelism,
+              batcher = batcherExecutor.execute(batcher(storageBackend.batch, metrics)),
               ingestingParallelism = ingestionParallelism,
-              ingester = postgresDaoPool.execute[RunningDBBatch, RunningDBBatch](
-                (batch: RunningDBBatch, dao: PostgresDAO) => {
-                  dao.insertBatch(batch.batch)
-                  metrics.daml.parallelIndexer.updates.inc(batch.batchSize.toLong)
-                  batch
-                }
-              ),
-              tailer = (prev: RunningDBBatch, curr: RunningDBBatch) => {
-                val nowNanos = System.nanoTime()
-                metrics.daml.parallelIndexer.ingestion.duration.update(
-                  (nowNanos - curr.averageStartTime) / curr.batchSize,
-                  TimeUnit.NANOSECONDS,
-                )
-                RunningDBBatch.tailer(prev, curr)
-              },
+              ingester = ingester(storageBackend.insertBatch, dbDispatcher, metrics),
+              tailer = tailer,
               tailingRateLimitPerSecond = tailingRateLimitPerSecond,
-              ingestTail = postgresDaoPool.execute[RunningDBBatch, RunningDBBatch](
-                (batch: RunningDBBatch, dao: PostgresDAO) => {
-                  metrics.daml.indexer.ledgerEndSequentialId
-                    .updateValue(batch.lastSeqEventId)
-                  dao.updateParams(
-                    ledgerEnd = batch.lastOffset,
-                    eventSeqId = batch.lastSeqEventId,
-                    configuration = batch.lastConfig,
-                  )
-                  batch
-                }
-              ),
+              ingestTail = ingestTail(storageBackend.updateParams, dbDispatcher, metrics),
             )(
               instrumentedBufferedSource(
                 original = source,
@@ -115,15 +99,168 @@ object ParallelIndexerFactory {
             ).map(_ => ())
 
       def subscribe(readService: ReadService): Future[Source[Unit, NotUsed]] =
-        postgresDaoPool
-          .execute(_.initialize)
-          .map { case (offset, eventSeqId) =>
-            ingest(eventSeqId.getOrElse(0L))(readService.stateUpdates(beginAfter = offset))
-          }(scala.concurrent.ExecutionContext.global)
+        dbDispatcher
+          .executeSql(metrics.daml.parallelIndexer.initialization)(
+            storageBackend.initialize
+          ) // TODO here is an implicit LoggingContext injected from the factory apply implicit param, is that good this way? shouldn't we create here something for the purpose?
+          .map(initialized =>
+            ingest(initialized.lastEventSeqId.getOrElse(0L))(
+              readService.stateUpdates(beginAfter = initialized.lastOffset)
+            )
+          )(scala.concurrent.ExecutionContext.global)
 
       toIndexer(subscribe)(mat)
     }
   }
+
+  /** Batch wraps around a T-typed batch, enriching it with processing relevant information.
+    *
+    * @param lastOffset The latest offset available in the batch. Needed for tail ingestion.
+    * @param lastSeqEventId The latest sequential-event-id in the batch, or if none present there, then the latest from before. Needed for tail ingestion.
+    * @param lastConfig The latest successful accepted configuration in the batch, if available.
+    * @param batch The batch of variable type.
+    * @param batchSize Size of the batch measured in number of updates. Needed for metrics population.
+    * @param averageStartTime The nanosecond timestamp of the start of the previous processing stage. Needed for metrics population: how much time is spend by a particular update in a certain stage.
+    */
+  case class Batch[T](
+      lastOffset: Offset,
+      lastSeqEventId: Long,
+      lastConfig: Option[Array[Byte]],
+      batch: T,
+      batchSize: Int,
+      averageStartTime: Long,
+  )
+
+  def inputMapper(
+      metrics: Metrics,
+      toDbDto: Offset => Update => Iterator[DBDTOV1],
+  ): Iterable[((Offset, Update), Long)] => Batch[Vector[DBDTOV1]] = { input =>
+    metrics.daml.parallelIndexer.inputMapping.batchSize.update(input.size)
+    val batch = input.iterator.flatMap { case ((offset, update), _) =>
+      toDbDto(offset)(update)
+    }.toVector
+    Batch(
+      lastOffset = input.last._1._1,
+      lastSeqEventId = 0, // will be filled later in the sequential step
+      lastConfig = batch.reverseIterator.collectFirst {
+        case c: DBDTOV1.ConfigurationEntry if c.typ == JdbcLedgerDao.acceptType => c.configuration
+      },
+      batch = batch,
+      batchSize = input.size,
+      averageStartTime = input.view.map(_._2 / input.size).sum,
+    )
+  }
+
+  def seqMapperZero(initialSeqId: Long): Batch[Vector[DBDTOV1]] =
+    Batch(
+      lastOffset = null,
+      lastSeqEventId = initialSeqId, // this is the only property of interest in the zero element
+      lastConfig = None,
+      batch = Vector.empty,
+      batchSize = 0,
+      averageStartTime = 0,
+    )
+
+  def seqMapper(metrics: Metrics)(
+      previous: Batch[Vector[DBDTOV1]],
+      current: Batch[Vector[DBDTOV1]],
+  ): Batch[Vector[DBDTOV1]] = {
+    var eventSeqId = previous.lastSeqEventId
+    val batchWithSeqIds = current.batch.map {
+      case dbDto: DBDTOV1.EventCreate =>
+        eventSeqId += 1
+        dbDto.copy(event_sequential_id = eventSeqId)
+
+      case dbDto: DBDTOV1.EventExercise =>
+        eventSeqId += 1
+        dbDto.copy(event_sequential_id = eventSeqId)
+
+      case dbDto: DBDTOV1.EventDivulgence =>
+        eventSeqId += 1
+        dbDto.copy(event_sequential_id = eventSeqId)
+
+      case notEvent => notEvent
+    }
+    val nowNanos = System.nanoTime()
+    metrics.daml.parallelIndexer.inputMapping.duration.update(
+      (nowNanos - current.averageStartTime) / current.batchSize,
+      TimeUnit.NANOSECONDS,
+    )
+    current.copy(
+      lastSeqEventId = eventSeqId,
+      batch = batchWithSeqIds,
+      averageStartTime = nowNanos, // setting start time to the start of the next stage
+    )
+  }
+
+  def batcher[DB_BATCH](
+      batchF: Vector[DBDTOV1] => DB_BATCH,
+      metrics: Metrics,
+  ): Batch[Vector[DBDTOV1]] => Batch[DB_BATCH] = { inBatch =>
+    val dbBatch = batchF(inBatch.batch)
+    val nowNanos = System.nanoTime()
+    metrics.daml.parallelIndexer.batching.duration.update(
+      (nowNanos - inBatch.averageStartTime) / inBatch.batchSize,
+      TimeUnit.NANOSECONDS,
+    )
+    inBatch.copy(
+      batch = dbBatch,
+      averageStartTime = nowNanos,
+    )
+  }
+
+  def ingester[DB_BATCH](
+      ingestFunction: (Connection, DB_BATCH) => Unit,
+      dbDispatcher: DbDispatcher,
+      metrics: Metrics,
+  )(implicit
+      loggingContext: LoggingContext // TODO is that right so? shouldn't we prep something here?
+  ): Batch[DB_BATCH] => Future[Batch[DB_BATCH]] =
+    batch =>
+      dbDispatcher.executeSql(metrics.daml.parallelIndexer.ingestion) { connection =>
+        metrics.daml.parallelIndexer.updates.inc(batch.batchSize.toLong)
+        ingestFunction(connection, batch.batch)
+        val nowNanos = System.nanoTime()
+        metrics.daml.parallelIndexer.ingestion.duration.update(
+          (nowNanos - batch.averageStartTime) / batch.batchSize,
+          TimeUnit.NANOSECONDS,
+        )
+        batch
+      }
+
+  def tailer[DB_BATCH]: (Batch[DB_BATCH], Batch[DB_BATCH]) => Batch[DB_BATCH] =
+    (prev, curr) =>
+      Batch[DB_BATCH](
+        lastOffset = curr.lastOffset,
+        lastSeqEventId = curr.lastSeqEventId,
+        lastConfig = curr.lastConfig.orElse(prev.lastConfig),
+        batch =
+          null.asInstanceOf[DB_BATCH], // not used anymore TODO figure something nicer than ClassCastException upon DB_BATCH is AnyVal
+        batchSize = 0, // not used anymore
+        averageStartTime = 0, // not used anymore
+      )
+
+  def ingestTail[DB_BATCH](
+      ingestTailFunction: (Connection, StorageBackend.Params) => Unit,
+      dbDispatcher: DbDispatcher,
+      metrics: Metrics,
+  )(implicit
+      loggingContext: LoggingContext // TODO is that right so? shouldn't we prep something here?
+  ): Batch[DB_BATCH] => Future[Batch[DB_BATCH]] =
+    batch =>
+      dbDispatcher.executeSql(metrics.daml.parallelIndexer.tailIngestion) { connection =>
+        metrics.daml.parallelIndexer.updates.inc(batch.batchSize.toLong)
+        ingestTailFunction(
+          connection,
+          StorageBackend.Params(
+            ledgerEnd = batch.lastOffset,
+            eventSeqId = batch.lastSeqEventId,
+            configuration = batch.lastConfig,
+          ),
+        )
+        metrics.daml.indexer.ledgerEndSequentialId.updateValue(batch.lastSeqEventId)
+        batch
+      }
 
   def toIndexer(
       ingestionPipeOn: ReadService => Future[Source[Unit, NotUsed]]

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/PostgresStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/PostgresStorageBackend.scala
@@ -3,38 +3,18 @@
 
 package com.daml.platform.indexer.parallel
 
-import java.sql.{DriverManager, PreparedStatement, ResultSet}
+import java.sql.{Connection, PreparedStatement, ResultSet}
 
 import com.daml.lf.data.Ref
 import com.daml.ledger.participant.state.v1.Offset
 
 import scala.collection.mutable
-import scala.util.{Failure, Success, Try}
 
-trait PostgresDAO {
-  def insertBatch(batch: RawDBBatchPostgreSQLV1): Unit
+object PostgresStorageBackend extends StorageBackend[RawDBBatchPostgreSQLV1] {
 
-  def updateParams(ledgerEnd: Offset, eventSeqId: Long, configuration: Option[Array[Byte]]): Unit
-
-  def initialize: (Option[Offset], Option[Long])
-}
-
-case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseable {
-
-  private val connection = {
-    val c = DriverManager.getConnection(jdbcUrl)
-    c.setAutoCommit(false)
-
-    val stmnt = c.createStatement()
-    stmnt.execute("SET synchronous_commit TO OFF;")
-    c.commit()
-    stmnt.close()
-
-    c
-  }
-
-  private val preparedInsertEventsBatchDivulgence = connection.prepareStatement(
-    """
+  private val preparedInsertEventsBatchDivulgence: Connection => PreparedStatement =
+    _.prepareStatement(
+      """
       |INSERT INTO participant_events_divulgence
       | (
       |   event_offset,
@@ -77,9 +57,9 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       | );
       |
       |""".stripMargin
-  )
+    )
 
-  private val preparedInsertEventsBatchCreate = connection.prepareStatement(
+  private val preparedInsertEventsBatchCreate: Connection => PreparedStatement = _.prepareStatement(
     """
       |INSERT INTO participant_events_create
       | (
@@ -158,8 +138,9 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       |""".stripMargin
   )
 
-  private val preparedInsertEventsBatchConsumingExercise = connection.prepareStatement(
-    """
+  private val preparedInsertEventsBatchConsumingExercise: Connection => PreparedStatement =
+    _.prepareStatement(
+      """
       |INSERT INTO participant_events_consuming_exercise
       | (
       |   event_id,
@@ -238,10 +219,11 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       | );
       |
       |""".stripMargin
-  )
+    )
 
-  private val preparedInsertEventsBatchNonConsumingExercise = connection.prepareStatement(
-    """
+  private val preparedInsertEventsBatchNonConsumingExercise: Connection => PreparedStatement =
+    _.prepareStatement(
+      """
       |INSERT INTO participant_events_non_consuming_exercise
       | (
       |   event_id,
@@ -320,10 +302,11 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       | );
       |
       |""".stripMargin
-  )
+    )
 
-  private val preparedInsertConfigurationEntryBatch = connection.prepareStatement(
-    """
+  private val preparedInsertConfigurationEntryBatch: Connection => PreparedStatement =
+    _.prepareStatement(
+      """
       |INSERT INTO configuration_entries
       | (
       |   ledger_offset,
@@ -351,9 +334,9 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       | );
       |
       |""".stripMargin
-  )
+    )
 
-  private val preparedInsertPackageEntryBatch = connection.prepareStatement(
+  private val preparedInsertPackageEntryBatch: Connection => PreparedStatement = _.prepareStatement(
     """
       |INSERT INTO package_entries
       | (
@@ -381,7 +364,7 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       |""".stripMargin
   )
 
-  private val preparedInsertPackageBatch = connection.prepareStatement(
+  private val preparedInsertPackageBatch: Connection => PreparedStatement = _.prepareStatement(
     """
       |INSERT INTO packages
       | (
@@ -416,7 +399,7 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       |""".stripMargin
   )
 
-  private val preparedInsertPartyEntryBatch = connection.prepareStatement(
+  private val preparedInsertPartyEntryBatch: Connection => PreparedStatement = _.prepareStatement(
     """
       |INSERT INTO party_entries
       | (
@@ -453,7 +436,7 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       |""".stripMargin
   )
 
-  private val preparedInsertPartyBatch: PreparedStatement = connection.prepareStatement(
+  private val preparedInsertPartyBatch: Connection => PreparedStatement = _.prepareStatement(
     """
       |INSERT INTO parties
       | (
@@ -481,8 +464,9 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       |""".stripMargin
   )
 
-  private val preparedInsertCommandCompletionBatch = connection.prepareStatement(
-    """
+  private val preparedInsertCommandCompletionBatch: Connection => PreparedStatement =
+    _.prepareStatement(
+      """
       |INSERT INTO participant_command_completions
       | (
       |   completion_offset,
@@ -516,10 +500,11 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       | );
       |
       |""".stripMargin
-  )
+    )
 
-  private val preparedDeleteCommandSubmissionBatch = connection.prepareStatement(
-    """
+  private val preparedDeleteCommandSubmissionBatch: Connection => PreparedStatement =
+    _.prepareStatement(
+      """
       |DELETE FROM participant_command_submissions
       |WHERE deduplication_key IN (
       |  SELECT deduplication_key_in
@@ -528,10 +513,14 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       |)
       |
       |""".stripMargin
-  )
+    )
 
-  override def insertBatch(rawDBBatchPostgreSQLV1: RawDBBatchPostgreSQLV1): Unit = {
-    def execute(preparedStatement: PreparedStatement, params: Any*): Unit = {
+  override def insertBatch(
+      connection: Connection,
+      rawDBBatchPostgreSQLV1: RawDBBatchPostgreSQLV1,
+  ): Unit = {
+    def execute(preparedStatementFactory: Connection => PreparedStatement, params: Any*): Unit = {
+      val preparedStatement = preparedStatementFactory(connection)
       params.view.zipWithIndex.foreach { case (param, zeroBasedIndex) =>
         preparedStatement.setObject(zeroBasedIndex + 1, param)
       }
@@ -720,11 +709,9 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
     rawDBBatchPostgreSQLV1.commandDeduplicationBatch.foreach(batch =>
       execute(preparedDeleteCommandSubmissionBatch, batch.deduplication_key)
     )
-
-    connection.commit()
   }
 
-  private val preparedUpdateLedgerEnd = connection.prepareStatement(
+  private val preparedUpdateLedgerEnd: Connection => PreparedStatement = _.prepareStatement(
     """
       |UPDATE
       |  parameters
@@ -735,8 +722,9 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       |""".stripMargin
   )
 
-  private val preparedUpdateLedgerEndWithConfig = connection.prepareStatement(
-    """
+  private val preparedUpdateLedgerEndWithConfig: Connection => PreparedStatement =
+    _.prepareStatement(
+      """
       |UPDATE
       |  parameters
       |SET
@@ -745,48 +733,50 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
       |  configuration = ?
       |
       |""".stripMargin
-  )
+    )
 
-  override def updateParams(
-      ledgerEnd: Offset,
-      eventSeqId: Long,
-      configuration: Option[Array[Byte]],
-  ): Unit = {
-    configuration match {
+  override def updateParams(connection: Connection, params: StorageBackend.Params): Unit = {
+    params.configuration match {
       case Some(configBytes) =>
         // TODO append-only: just a shortcut, proper solution: reading config with a temporal query
-        preparedUpdateLedgerEndWithConfig.setString(1, ledgerEnd.toHexString)
-        preparedUpdateLedgerEndWithConfig.setLong(2, eventSeqId)
-        preparedUpdateLedgerEndWithConfig.setBytes(3, configBytes)
-        preparedUpdateLedgerEndWithConfig.execute()
+        val preparedStatement = preparedUpdateLedgerEndWithConfig(connection)
+        preparedStatement.setString(1, params.ledgerEnd.toHexString)
+        preparedStatement.setLong(2, params.eventSeqId)
+        preparedStatement.setBytes(3, configBytes)
+        preparedStatement.execute()
 
       case None =>
-        preparedUpdateLedgerEnd.setString(1, ledgerEnd.toHexString)
-        preparedUpdateLedgerEnd.setLong(2, eventSeqId)
-        preparedUpdateLedgerEnd.execute()
+        val preparedStatement = preparedUpdateLedgerEnd(connection)
+        preparedStatement.setString(1, params.ledgerEnd.toHexString)
+        preparedStatement.setLong(2, params.eventSeqId)
+        preparedStatement.execute()
 
     }
-    connection.commit()
+    ()
   }
 
-  override def initialize: (Option[Offset], Option[Long]) = {
-    val result @ (offset, _) = queryLedgerAndAndEventSeqId()
+  override def initialize(connection: Connection): StorageBackend.Initialized = {
+    val (offset, eventSeqId) = queryLedgerEndAndEventSeqId(connection)
 
     // TODO append-only: verify default isolation level is enough to maintain consistency here (eg the fact of selecting these values at the beginning ensures data changes to the params are postponed until purging finishes). Alternatively: if single indexer instance to db access otherwise ensured, atomicity here is not an issue.
 
     offset.foreach { existingOffset =>
+      val preparedStatement = preparedDeleteIngestionOverspillEntries(connection)
       List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).foreach(
-        preparedDeleteIngestionOverspillEntries.setString(_, existingOffset.toHexString)
+        preparedStatement.setString(_, existingOffset.toHexString)
       )
-      preparedDeleteIngestionOverspillEntries.execute()
+      preparedStatement.execute()
     }
 
-    connection.commit()
-
-    result
+    StorageBackend.Initialized(
+      lastOffset = offset,
+      lastEventSeqId = eventSeqId,
+    )
   }
 
-  private def queryLedgerAndAndEventSeqId(): (Option[Offset], Option[Long]) = {
+  private def queryLedgerEndAndEventSeqId(
+      connection: Connection
+  ): (Option[Offset], Option[Long]) = {
     val queryStatement = connection.createStatement()
     val params = fetch(
       queryStatement.executeQuery(
@@ -811,8 +801,8 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
     params.head
   }
 
-  private val preparedDeleteIngestionOverspillEntries: PreparedStatement =
-    connection.prepareStatement(
+  private val preparedDeleteIngestionOverspillEntries: Connection => PreparedStatement =
+    _.prepareStatement(
       """
       |DELETE
       |FROM configuration_entries
@@ -868,45 +858,9 @@ case class JDBCPostgresDAO(jdbcUrl: String) extends PostgresDAO with AutoCloseab
     buffer.toVector
   }
 
-  override def close(): Unit = connection.close()
-
-}
-
-object PostgresDAO {
-
-  case class ResourcePool[T <: AutoCloseable](create: () => T, size: Int) extends AutoCloseable {
-    assert(size > 0)
-
-    private val pool = mutable.Queue.empty[T]
-    pool ++= List.fill(size)(create())
-
-    def borrow[U](block: T => U): U = {
-      val resource = synchronized {
-        if (pool.isEmpty) None
-        else Some(pool.dequeue())
-      } match {
-        case None => throw new Exception("non-growing pool exhausted, please tune pool size")
-        case Some(resource) => resource
-      }
-
-      Try(block(resource)) match {
-        case Success(result) =>
-          synchronized {
-            pool.enqueue(resource)
-          }
-          result
-
-        case Failure(exception) =>
-          synchronized {
-            pool.enqueue(create())
-          }
-          Try(resource.close())
-          throw exception
-      }
-    }
-
-    override def close(): Unit =
-      pool.foreach(_.close())
+  override def batch(dbDtos: Vector[DBDTOV1]): RawDBBatchPostgreSQLV1 = {
+    val builder = RawDBBatchPostgreSQLV1.Builder()
+    dbDtos.foreach(builder.add)
+    builder.build()
   }
-
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/RawDBBatchPostgreSQLV1.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/RawDBBatchPostgreSQLV1.scala
@@ -353,15 +353,6 @@ object RawDBBatchPostgreSQLV1 {
     private[this] var commandCompletionsBatchBuilder: CommandCompletionsBatchBuilder = _
     private[this] var commandDeduplicationBatchBuilder: CommandDeduplicationBatchBuilder = _
 
-    // Sequential ID within this batch. These local sequential IDs are converted to global IDs at a later stage.
-    // See RawDBBatch.offsetSequentialEventIds()
-    private[this] var eventSequentialId: Long = 0
-    private[this] def nextEventSequentialId() = {
-      val result = eventSequentialId
-      eventSequentialId = eventSequentialId + 1
-      result
-    }
-
     def add(entry: DBDTOV1): Unit = {
       entry match {
         case e: EventDivulgence =>
@@ -381,7 +372,7 @@ object RawDBBatchPostgreSQLV1 {
           eventsBatchBuilder.template_id += e.template_id.orNull
           eventsBatchBuilder.tree_event_witnesses += encodeTextArray(e.tree_event_witnesses)
           eventsBatchBuilder.create_argument += e.create_argument.orNull
-          eventsBatchBuilder.event_sequential_id += nextEventSequentialId()
+          eventsBatchBuilder.event_sequential_id += e.event_sequential_id
           eventsBatchBuilder.create_argument_compression += e.create_argument_compression
             .map(x => x: java.lang.Integer)
             .orNull
@@ -415,7 +406,7 @@ object RawDBBatchPostgreSQLV1 {
           eventsBatchBuilder.create_agreement_text += e.create_agreement_text.orNull
           eventsBatchBuilder.create_key_value += e.create_key_value.orNull
           eventsBatchBuilder.create_key_hash += e.create_key_hash.orNull
-          eventsBatchBuilder.event_sequential_id += nextEventSequentialId()
+          eventsBatchBuilder.event_sequential_id += e.event_sequential_id
           eventsBatchBuilder.create_argument_compression += e.create_argument_compression
             .map(x => x: java.lang.Integer)
             .orNull
@@ -463,7 +454,7 @@ object RawDBBatchPostgreSQLV1 {
           eventsBatchBuilder.exercise_child_event_ids += e.exercise_child_event_ids
             .map(encodeTextArray)
             .orNull
-          eventsBatchBuilder.event_sequential_id += nextEventSequentialId()
+          eventsBatchBuilder.event_sequential_id += e.event_sequential_id
           eventsBatchBuilder.exercise_argument_compression += e.exercise_argument_compression
             .map(x => x: java.lang.Integer)
             .orNull
@@ -554,7 +545,7 @@ object RawDBBatchPostgreSQLV1 {
           template_id = b.template_id.result(),
           tree_event_witnesses = b.tree_event_witnesses.result(),
           create_argument = b.create_argument.result(),
-          event_sequential_id = b.event_sequential_id.result(), // will be populated later
+          event_sequential_id = b.event_sequential_id.result(),
           create_argument_compression = b.create_argument_compression.result(),
         )
       ),
@@ -579,7 +570,7 @@ object RawDBBatchPostgreSQLV1 {
           create_agreement_text = b.create_agreement_text.result(),
           create_key_value = b.create_key_value.result(),
           create_key_hash = b.create_key_hash.result(),
-          event_sequential_id = b.event_sequential_id.result(), // will be populated later
+          event_sequential_id = b.event_sequential_id.result(),
           create_argument_compression = b.create_argument_compression.result(),
           create_key_value_compression = b.create_key_value_compression.result(),
         )
@@ -605,7 +596,7 @@ object RawDBBatchPostgreSQLV1 {
           exercise_result = b.exercise_result.result(),
           exercise_actors = b.exercise_actors.result(),
           exercise_child_event_ids = b.exercise_child_event_ids.result(),
-          event_sequential_id = b.event_sequential_id.result(), // will be populated later
+          event_sequential_id = b.event_sequential_id.result(),
           create_key_value_compression = b.create_key_value_compression.result(),
           exercise_argument_compression = b.exercise_argument_compression.result(),
           exercise_result_compression = b.exercise_result_compression.result(),
@@ -632,7 +623,7 @@ object RawDBBatchPostgreSQLV1 {
           exercise_result = b.exercise_result.result(),
           exercise_actors = b.exercise_actors.result(),
           exercise_child_event_ids = b.exercise_child_event_ids.result(),
-          event_sequential_id = b.event_sequential_id.result(), // will be populated later
+          event_sequential_id = b.event_sequential_id.result(),
           create_key_value_compression = b.create_key_value_compression.result(),
           exercise_argument_compression = b.exercise_argument_compression.result(),
           exercise_result_compression = b.exercise_result_compression.result(),

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/StorageBackend.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.indexer.parallel
+
+import java.sql.Connection
+
+import com.daml.ledger.participant.state.v1.Offset
+
+trait StorageBackend[DB_BATCH] {
+  def batch(dbDtos: Vector[DBDTOV1]): DB_BATCH
+  def insertBatch(connection: Connection, batch: DB_BATCH): Unit
+  def updateParams(connection: Connection, params: StorageBackend.Params): Unit
+  def initialize(connection: Connection): StorageBackend.Initialized
+}
+
+object StorageBackend {
+  case class Params(ledgerEnd: Offset, eventSeqId: Long, configuration: Option[Array[Byte]])
+
+  case class Initialized(lastOffset: Option[Offset], lastEventSeqId: Option[Long])
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/UpdateToDBDTOV1.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/UpdateToDBDTOV1.scala
@@ -181,6 +181,7 @@ object UpdateToDBDTOV1 {
                   compressionStrategy.createKeyValueCompression.id.filter(_ =>
                     createKeyValue.isDefined
                   ),
+                event_sequential_id = 0, // this is filled later
               )
 
             case (nodeId, exercise: Exercise) =>
@@ -220,6 +221,7 @@ object UpdateToDBDTOV1 {
                 create_key_value_compression = compressionStrategy.createKeyValueCompression.id,
                 exercise_argument_compression = compressionStrategy.exerciseArgumentCompression.id,
                 exercise_result_compression = compressionStrategy.exerciseResultCompression.id,
+                event_sequential_id = 0, // this is filled later
               )
           }
 
@@ -242,6 +244,7 @@ object UpdateToDBDTOV1 {
               .map(translation.serialize(contractId, _))
               .map(compressionStrategy.createArgumentCompression.compress),
             create_argument_compression = compressionStrategy.createArgumentCompression.id,
+            event_sequential_id = 0, // this is filled later
           )
         }
 

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -202,6 +202,10 @@ object Config {
               .get("indexer-input-mapping-parallelism")
               .map(_.toInt)
               .getOrElse(ParticipantIndexerConfig.DefaultInputMappingParallelism)
+            val indexerBatchingParallelism = kv
+              .get("indexer-batching-parallelism")
+              .map(_.toInt)
+              .getOrElse(ParticipantIndexerConfig.DefaultBatchingParallelism)
             val indexerIngestionParallelism = kv
               .get("indexer-ingestion-parallelism")
               .map(_.toInt)
@@ -250,6 +254,7 @@ object Config {
                 databaseConnectionPoolSize = indexerConnectionPoolSize,
                 allowExistingSchema = false,
                 inputMappingParallelism = indexerInputMappingParallelism,
+                batchingParallelism = indexerBatchingParallelism,
                 ingestionParallelism = indexerIngestionParallelism,
                 submissionBatchSize = indexerSubmissionBatchSize,
                 tailingRateLimitPerSecond = indexerTailingRateLimitPerSecond,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -46,6 +46,7 @@ trait ConfigProvider[ExtraConfig] {
       allowExistingSchema = participantConfig.indexerConfig.allowExistingSchema,
       enableAppendOnlySchema = config.enableAppendOnlySchema,
       inputMappingParallelism = participantConfig.indexerConfig.ingestionParallelism,
+      batchingParallelism = participantConfig.indexerConfig.batchingParallelism,
       submissionBatchSize = participantConfig.indexerConfig.submissionBatchSize,
       tailingRateLimitPerSecond = participantConfig.indexerConfig.tailingRateLimitPerSecond,
       batchWithinMillis = participantConfig.indexerConfig.batchWithinMillis,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantIndexerConfig.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantIndexerConfig.scala
@@ -14,6 +14,7 @@ final case class ParticipantIndexerConfig(
     allowExistingSchema: Boolean,
     databaseConnectionPoolSize: Int = ParticipantIndexerConfig.DefaultDatabaseConnectionPoolSize,
     inputMappingParallelism: Int = ParticipantIndexerConfig.DefaultInputMappingParallelism,
+    batchingParallelism: Int = ParticipantIndexerConfig.DefaultBatchingParallelism,
     ingestionParallelism: Int = ParticipantIndexerConfig.DefaultIngestionParallelism,
     submissionBatchSize: Long = ParticipantIndexerConfig.DefaultSubmissionBatchSize,
     tailingRateLimitPerSecond: Int = ParticipantIndexerConfig.DefaultTailingRateLimitPerSecond,
@@ -24,6 +25,7 @@ final case class ParticipantIndexerConfig(
 object ParticipantIndexerConfig {
   val DefaultDatabaseConnectionPoolSize: Int = IndexerConfig.DefaultDatabaseConnectionPoolSize
   val DefaultInputMappingParallelism: Int = IndexerConfig.DefaultInputMappingParallelism
+  val DefaultBatchingParallelism: Int = IndexerConfig.DefaultBatchingParallelism
   val DefaultIngestionParallelism: Int = IndexerConfig.DefaultIngestionParallelism
   val DefaultSubmissionBatchSize: Long = IndexerConfig.DefaultSubmissionBatchSize
   val DefaultTailingRateLimitPerSecond: Int = IndexerConfig.DefaultTailingRateLimitPerSecond


### PR DESCRIPTION
The intent of this change is to make the first step in this direction
in order to support dpp-336 work of sanbdox-classic integration by
injecting DAO functionality via this interface.
Level of quality is still pre-production, hence TODO comments.
Planned next step: move StorageBackend interface, and implementation
to platform/store, to it's final place.

* Introduce StorageBackend interface
* Decouple event-seq-id assignment logic from storage specific batching
* Pull out of batching step from input mapping, execution too
* Switch to stateless DAO functions
* Switch to DBDispatcher instead of custom JDBC Connection pool
* Introduce/adapt metrics
* Naturally extend configuration
* Move RunningBatch layer to ParallelIndexerFactory
* Remove dead code

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
