### PR TITLE
KVL-918 Propagate trace context for party allocation

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -203,7 +203,10 @@ private[apiserver] final class ApiSubmissionService private[services] (
   // Takes the whole transaction to ensure to traverse it only if necessary
   private[services] def allocateMissingInformees(
       transaction: SubmittedTransaction
-  )(implicit loggingContext: LoggingContext): Future[Seq[SubmissionResult]] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): Future[Seq[SubmissionResult]] =
     if (configuration.implicitPartyAllocation) {
       val partiesInTransaction = transaction.informees.toSeq
       for {
@@ -214,7 +217,9 @@ private[apiserver] final class ApiSubmissionService private[services] (
       } yield submissionResults
     } else Future.successful(Seq.empty)
 
-  private def allocateParty(name: Party) = {
+  private def allocateParty(
+      name: Party
+  )(implicit telemetryContext: TelemetryContext): Future[SubmissionResult] = {
     val submissionId = v1.SubmissionId.assertFromString(UUID.randomUUID().toString)
     withEnrichedLoggingContext(logging.party(name), logging.submissionId(submissionId)) {
       implicit loggingContext =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -21,12 +21,13 @@ import com.daml.ledger.participant.state.index.v2.{
 import com.daml.ledger.participant.state.v1.{SubmissionId, SubmissionResult, WritePackagesService}
 import com.daml.lf.archive.{Dar, DarReader, Decode}
 import com.daml.lf.engine.Engine
-import com.daml.logging.{ContextualizedLogger, LoggingContext}
-import com.daml.platform.apiserver.services.logging
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.apiserver.services.admin.ApiPackageManagementService._
+import com.daml.platform.apiserver.services.logging
 import com.daml.platform.server.api.validation.ErrorFactories
+import com.daml.telemetry.{NoOpTelemetryContext, TelemetryContext}
 import com.google.protobuf.timestamp.Timestamp
 import io.grpc.{ServerServiceDefinition, StatusRuntimeException}
 
@@ -112,7 +113,11 @@ private[apiserver] final class ApiPackageManagementService private (
             err => Future.failed(ErrorFactories.invalidArgument(err.getMessage)),
             Future.successful,
           )
-          _ <- synchronousResponse.submitAndWait(submissionId, dar)(executionContext, materializer)
+          _ <- synchronousResponse.submitAndWait(submissionId, dar)(
+            NoOpTelemetryContext,
+            executionContext,
+            materializer,
+          )
         } yield {
           for (archive <- dar.all) {
             logger.info(s"Package ${archive.getHash} successfully uploaded")
@@ -160,7 +165,9 @@ private[apiserver] object ApiPackageManagementService {
     override def currentLedgerEnd(): Future[Option[LedgerOffset.Absolute]] =
       ledgerEndService.currentLedgerEnd().map(Some(_))
 
-    override def submit(submissionId: SubmissionId, dar: Dar[Archive]): Future[SubmissionResult] =
+    override def submit(submissionId: SubmissionId, dar: Dar[Archive])(implicit
+        telemetryContext: TelemetryContext
+    ): Future[SubmissionResult] =
       packagesWrite.uploadPackages(submissionId, dar.all, None).toScala
 
     override def entries(offset: Option[LedgerOffset.Absolute]): Source[PackageEntry, _] =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
@@ -12,6 +12,7 @@ import com.daml.ledger.api.domain.LedgerOffset
 import com.daml.ledger.participant.state.v1.{SubmissionId, SubmissionResult}
 import com.daml.platform.apiserver.services.admin.SynchronousResponse.{Accepted, Rejected}
 import com.daml.platform.server.api.validation.ErrorFactories
+import com.daml.telemetry.TelemetryContext
 import io.grpc.StatusRuntimeException
 
 import scala.concurrent.duration.FiniteDuration
@@ -28,6 +29,7 @@ class SynchronousResponse[Input, Entry, AcceptedEntry](
 ) {
 
   def submitAndWait(submissionId: SubmissionId, input: Input)(implicit
+      telemetryContext: TelemetryContext,
       executionContext: ExecutionContext,
       materializer: Materializer,
   ): Future[AcceptedEntry] = {
@@ -70,7 +72,9 @@ object SynchronousResponse {
     def currentLedgerEnd(): Future[Option[LedgerOffset.Absolute]]
 
     /** Submits a request to the ledger. */
-    def submit(submissionId: SubmissionId, input: Input): Future[SubmissionResult]
+    def submit(submissionId: SubmissionId, input: Input)(implicit
+        telemetryContext: TelemetryContext
+    ): Future[SubmissionResult]
 
     /** Opens a stream of entries from before the submission. */
     def entries(offset: Option[LedgerOffset.Absolute]): Source[Entry, _]

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
@@ -89,7 +89,11 @@ class ApiSubmissionServiceSpec
     submissionService(writeService, partyManagementService, implicitPartyAllocation = true)
 
   before {
-    when(writeService.allocateParty(any[Option[Party]], any[Option[Party]], any[SubmissionId]))
+    when(
+      writeService.allocateParty(any[Option[Party]], any[Option[Party]], any[SubmissionId])(
+        any[TelemetryContext]
+      )
+    )
       .thenReturn(CompletableFuture.completedFuture(SubmissionResult.Acknowledged))
   }
 
@@ -120,7 +124,7 @@ class ApiSubmissionServiceSpec
           eqTo(Some(Ref.Party.assertFromString(party))),
           eqTo(Some(Ref.Party.assertFromString(party))),
           any[SubmissionId],
-        )
+        )(any[TelemetryContext])
       )
       verifyNoMoreInteractions(writeService)
       succeed
@@ -155,8 +159,11 @@ class ApiSubmissionServiceSpec
     val party = "party-1"
     val typedParty = Ref.Party.assertFromString(party)
     val submissionFailure = SubmissionResult.InternalError(s"failed to allocate $party")
-    when(writeService.allocateParty(eqTo(Some(typedParty)), eqTo(Some(party)), any[SubmissionId]))
-      .thenReturn(CompletableFuture.completedFuture(submissionFailure))
+    when(
+      writeService.allocateParty(eqTo(Some(typedParty)), eqTo(Some(party)), any[SubmissionId])(
+        any[TelemetryContext]
+      )
+    ).thenReturn(CompletableFuture.completedFuture(submissionFailure))
     when(partyManagementService.getParties(eqTo(Seq(typedParty)))(any[LoggingContext])).thenAnswer(
       Future(List.empty[PartyDetails])
     )

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
@@ -45,7 +45,7 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       hint: Option[Party],
       displayName: Option[String],
       submissionId: SubmissionId,
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     Timed.completionStage(
       metrics.daml.services.write.allocateParty,
       delegate.allocateParty(hint, displayName, submissionId),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
@@ -73,7 +73,7 @@ class KeyValueParticipantState(
       hint: Option[Party],
       displayName: Option[String],
       submissionId: SubmissionId,
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     writerAdapter.allocateParty(hint, displayName, submissionId)
 
   override def prune(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -71,7 +71,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
       hint: Option[Party],
       displayName: Option[String],
       submissionId: SubmissionId,
-  ): CompletionStage[SubmissionResult] = {
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
     val party = hint.getOrElse(generateRandomParty())
     val submission =
       keyValueSubmission.partyToSubmission(
@@ -80,7 +80,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
         displayName,
         writer.participantId,
       )
-    commit(submissionId, submission)(NoOpTelemetryContext)
+    commit(submissionId, submission)
   }
 
   override def currentHealth(): HealthStatus = writer.currentHealth()

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
@@ -23,9 +23,10 @@ trait LedgerWriter extends ReportsHealth {
 
   /** Sends a submission to be committed to the ledger.
     *
-    * @param correlationId correlation ID to be used for logging purposes
-    * @param envelope      opaque submission; may be compressed
-    * @param metadata      metadata associated to this particular commit
+    * @param correlationId    correlation ID to be used for logging purposes
+    * @param envelope         opaque submission; may be compressed
+    * @param metadata         metadata associated to this particular commit
+    * @param telemetryContext an implicit context for tracing
     * @return future for sending the submission; for possible results see
     *         [[com.daml.ledger.participant.state.v1.SubmissionResult]]
     */

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePartyService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePartyService.scala
@@ -5,6 +5,8 @@ package com.daml.ledger.participant.state.v1
 
 import java.util.concurrent.CompletionStage
 
+import com.daml.telemetry.TelemetryContext
+
 /** An interface for on-boarding parties via a participant. */
 trait WritePartyService {
 
@@ -22,11 +24,10 @@ trait WritePartyService {
     * message. See the comments on [[ReadService.stateUpdates]] and [[Update]] for
     * further details.
     *
-    * @param hint         : A party identifier suggestion
-    *
-    * @param displayName  : A human readable name of the new party
-    *
-    * @param submissionId: Client picked submission identifier for matching the responses with the request.
+    * @param hint             A party identifier suggestion
+    * @param displayName      A human readable name of the new party
+    * @param submissionId     Client picked submission identifier for matching the responses with the request.
+    * @param telemetryContext An implicit context for tracing.
     *
     * @return an async result of a SubmissionResult
     */
@@ -34,5 +35,5 @@ trait WritePartyService {
       hint: Option[Party],
       displayName: Option[String],
       submissionId: SubmissionId,
-  ): CompletionStage[SubmissionResult]
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult]
 }

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -29,6 +29,7 @@ import com.daml.platform.indexer.RecoveringIndexerIntegrationSpec._
 import com.daml.platform.store.{DbType, LfValueTranslationCache}
 import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao}
 import com.daml.platform.testing.LogCollector
+import com.daml.telemetry.{NoOpTelemetryContext, TelemetryContext}
 import com.daml.timer.RetryStrategy
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
@@ -47,6 +48,8 @@ class RecoveringIndexerIntegrationSpec
     with TestResourceContext
     with BeforeAndAfterEach {
   private[this] var testId: UUID = _
+
+  private implicit val telemetryContext: TelemetryContext = NoOpTelemetryContext
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -23,8 +23,8 @@ import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Time
 import com.daml.logging.LoggingContext
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
-import com.daml.telemetry.TelemetryContext
 import com.daml.platform.sandbox.stores.ledger.{Ledger, PartyIdGenerator}
+import com.daml.telemetry.TelemetryContext
 import io.grpc.Status
 
 import scala.compat.java8.FutureConverters
@@ -59,7 +59,7 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
       hint: Option[Party],
       displayName: Option[String],
       submissionId: SubmissionId,
-  ): CompletionStage[SubmissionResult] = {
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
     val party = hint.getOrElse(PartyIdGenerator.generateRandomId())
     withEnrichedLoggingContext(
       "party" -> party,

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
@@ -65,7 +65,7 @@ case class ReadWriteServiceBridge(
       hint: Option[Party],
       displayName: Option[String],
       submissionId: SubmissionId,
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     submit(
       Submission.AllocateParty(
         hint = hint,


### PR DESCRIPTION
Introduces a breaking change (adding implicit `TelemetryContext`) to `WritePartyService` which according to the discussion in the previous PR should be fine: https://github.com/digital-asset/daml/pull/9436#discussion_r619072079

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
