### PR TITLE
kvutils: Make `Step` a trait to carry the logging context more easily.

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitStep.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitStep.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer
+
+import com.daml.logging.LoggingContext
+
+private[committer] trait CommitStep[PartialResult] {
+  def apply(
+      context: CommitContext,
+      input: PartialResult,
+  )(implicit loggingContext: LoggingContext): StepResult[PartialResult]
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/package.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+package object committer {
+  private[committer] type StepInfo = String
+
+  private[committer] type Steps[PartialResult] = Iterable[(StepInfo, CommitStep[PartialResult])]
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/DamlTransactionEntrySummary.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/DamlTransactionEntrySummary.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer.transaction
+
+import com.daml.ledger.participant.state.kvutils.Conversions
+import com.daml.ledger.participant.state.kvutils.Conversions.parseTimestamp
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlSubmitterInfo,
+  DamlTransactionEntry,
+}
+import com.daml.lf.crypto
+import com.daml.lf.data.Ref.Party
+import com.daml.lf.data.Time.Timestamp
+import com.daml.lf.transaction.{Transaction => Tx}
+
+import scala.jdk.CollectionConverters._
+
+private[transaction] final class DamlTransactionEntrySummary(
+    val submission: DamlTransactionEntry,
+    tx: => Tx.Transaction,
+) {
+  val ledgerEffectiveTime: Timestamp = parseTimestamp(submission.getLedgerEffectiveTime)
+  val submitterInfo: DamlSubmitterInfo = submission.getSubmitterInfo
+  val commandId: String = submitterInfo.getCommandId
+  val submitters: List[Party] =
+    submitterInfo.getSubmittersList.asScala.toList.map(Party.assertFromString)
+  lazy val transaction: Tx.Transaction = tx
+  val submissionTime: Timestamp =
+    Conversions.parseTimestamp(submission.getSubmissionTime)
+  val submissionSeed: crypto.Hash =
+    Conversions.parseHash(submission.getSubmissionSeed)
+
+  // On copy, avoid decoding the transaction again if not needed
+  def copyPreservingDecodedTransaction(
+      submission: DamlTransactionEntry
+  ): DamlTransactionEntrySummary =
+    new DamlTransactionEntrySummary(submission, transaction)
+}
+
+private[transaction] object DamlTransactionEntrySummary {
+  def apply(
+      submission: DamlTransactionEntry
+  ): DamlTransactionEntrySummary =
+    new DamlTransactionEntrySummary(
+      submission,
+      Conversions.decodeTransaction(submission.getTransaction),
+    )
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/KeyMonotonicityValidation.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/KeyMonotonicityValidation.scala
@@ -5,9 +5,11 @@ package com.daml.ledger.participant.state.kvutils.committer.transaction.keys
 
 import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.committer.transaction.{
+  DamlTransactionEntrySummary,
+  TransactionCommitter,
+}
 import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepResult}
-import com.daml.ledger.participant.state.kvutils.committer.transaction.TransactionCommitter
-import com.daml.ledger.participant.state.kvutils.committer.transaction.TransactionCommitter.DamlTransactionEntrySummary
 import com.daml.ledger.participant.state.v1.RejectionReason
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/package.scala
@@ -5,4 +5,6 @@ package com.daml.ledger.participant.state.kvutils.committer
 
 package object transaction {
   private[transaction] type RawContractId = String
+
+  private[transaction] type Step = CommitStep[DamlTransactionEntrySummary]
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
@@ -33,7 +33,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
       val instance = createConfigCommitter(aRecordTime)
       val context = createCommitContext(recordTime = Some(aRecordTime.addMicros(1)))
 
-      val actual = instance.checkTtl(context, anEmptyResult)(loggingContext)
+      val actual = instance.checkTtl(context, anEmptyResult)
 
       actual match {
         case StepContinue(_) => fail()
@@ -51,7 +51,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
         val instance = createConfigCommitter(maximumRecordTime)
         val context = createCommitContext(recordTime = Some(aRecordTime))
 
-        val actual = instance.checkTtl(context, anEmptyResult)(loggingContext)
+        val actual = instance.checkTtl(context, anEmptyResult)
 
         actual match {
           case StepContinue(_) => succeed
@@ -64,7 +64,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
       val instance = createConfigCommitter(aRecordTime)
       val context = createCommitContext(recordTime = None)
 
-      val actual = instance.checkTtl(context, anEmptyResult)(loggingContext)
+      val actual = instance.checkTtl(context, anEmptyResult)
 
       actual match {
         case StepContinue(_) => succeed
@@ -76,7 +76,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
       val instance = createConfigCommitter(aRecordTime)
       val context = createCommitContext(recordTime = None)
 
-      instance.checkTtl(context, anEmptyResult)(loggingContext)
+      instance.checkTtl(context, anEmptyResult)
 
       context.maximumRecordTime shouldEqual Some(aRecordTime.toInstant)
       context.outOfTimeBoundsLogEntry should not be empty
@@ -94,7 +94,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
       val instance = createConfigCommitter(theRecordTime)
       val context = createCommitContext(recordTime = Some(aRecordTime))
 
-      instance.checkTtl(context, anEmptyResult)(loggingContext)
+      instance.checkTtl(context, anEmptyResult)
 
       context.preExecute shouldBe false
       context.outOfTimeBoundsLogEntry shouldBe empty
@@ -106,7 +106,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
       val instance = createConfigCommitter(theRecordTime.addMicros(1000))
       val context = createCommitContext(recordTime = Some(theRecordTime))
 
-      val actual = instance.buildLogEntry(context, anEmptyResult)(loggingContext)
+      val actual = instance.buildLogEntry(context, anEmptyResult)
 
       actual match {
         case StepContinue(_) => fail()
@@ -120,7 +120,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
       val instance = createConfigCommitter(theRecordTime)
       val context = createCommitContext(recordTime = None)
 
-      val actual = instance.buildLogEntry(context, anEmptyResult)(loggingContext)
+      val actual = instance.buildLogEntry(context, anEmptyResult)
 
       actual match {
         case StepContinue(_) => fail()
@@ -134,7 +134,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
         val instance = createConfigCommitter(theRecordTime)
         val context = createCommitContext(recordTime = recordTimeMaybe)
 
-        val actual = instance.buildLogEntry(context, anEmptyResult)(loggingContext)
+        val actual = instance.buildLogEntry(context, anEmptyResult)
 
         actual match {
           case StepContinue(_) => fail()

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitterSpec.scala
@@ -24,7 +24,7 @@ class PartyAllocationCommitterSpec extends AnyWordSpec with Matchers {
       val instance = new PartyAllocationCommitter(metrics)
       val context = createCommitContext(recordTime = None)
 
-      instance.buildLogEntry(context, aPartyAllocationEntry)(loggingContext)
+      instance.buildLogEntry(context, aPartyAllocationEntry)
 
       context.preExecute shouldBe true
       context.outOfTimeBoundsLogEntry should not be empty
@@ -40,7 +40,7 @@ class PartyAllocationCommitterSpec extends AnyWordSpec with Matchers {
       val instance = new PartyAllocationCommitter(metrics)
       val context = createCommitContext(recordTime = Some(theRecordTime))
 
-      instance.buildLogEntry(context, aPartyAllocationEntry)(loggingContext)
+      instance.buildLogEntry(context, aPartyAllocationEntry)
 
       context.preExecute shouldBe false
       context.outOfTimeBoundsLogEntry shouldBe empty

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -11,7 +11,6 @@ import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, co
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
-import com.daml.ledger.participant.state.kvutils.committer.transaction.TransactionCommitter.DamlTransactionEntrySummary
 import com.daml.ledger.participant.state.kvutils.committer.transaction.keys.ContractKeysValidation
 import com.daml.ledger.participant.state.kvutils.committer.{
   CommitContext,
@@ -135,7 +134,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       val actual = transactionCommitter.trimUnnecessaryNodes(
         context,
         aRichTransactionTreeSummary,
-      )(loggingContext)
+      )
 
       actual match {
         case StepContinue(logEntry) =>
@@ -168,8 +167,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     "continue if record time is not available" in {
       val context = createCommitContext(recordTime = None)
 
-      val actual =
-        transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)(loggingContext)
+      val actual = transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)
 
       actual match {
         case StepContinue(_) => succeed
@@ -182,8 +180,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       val context =
         createCommitContext(recordTime = Some(aRecordTime), inputs = inputs)
 
-      val actual =
-        transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)(loggingContext)
+      val actual = transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)
 
       actual match {
         case StepContinue(_) => succeed
@@ -197,8 +194,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       val context =
         createCommitContext(recordTime = Some(aRecordTime.addMicros(1)), inputs = inputs)
 
-      val actual =
-        transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)(loggingContext)
+      val actual = transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)
 
       actual match {
         case StepContinue(_) => succeed
@@ -218,8 +214,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         val context =
           createCommitContext(recordTime = Some(recordTime), inputs = inputs)
 
-        val actual =
-          transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)(loggingContext)
+        val actual = transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)
 
         actual match {
           case StepContinue(_) => fail()
@@ -236,7 +231,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         val result = transactionCommitter.validateLedgerTime(
           contextWithTimeModelAndEmptyCommandDeduplication(),
           aTransactionEntrySummary,
-        )(loggingContext)
+        )
 
         result match {
           case StepContinue(_) => succeed
@@ -250,7 +245,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         transactionCommitter.validateLedgerTime(
           context,
           aDamlTransactionEntrySummaryWithSubmissionAndLedgerEffectiveTimes,
-        )(loggingContext)
+        )
 
         context.minimumRecordTime shouldEqual Some(Instant.ofEpochSecond(-28))
         context.maximumRecordTime shouldEqual Some(Instant.ofEpochSecond(31))
@@ -268,7 +263,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         transactionCommitter.validateLedgerTime(
           context,
           aDamlTransactionEntrySummaryWithSubmissionAndLedgerEffectiveTimes,
-        )(loggingContext)
+        )
 
         context.minimumRecordTime shouldEqual Some(
           Instant.ofEpochSecond(3).plus(Timestamp.Resolution)
@@ -309,8 +304,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
             )
             .build
         )
-        val actual =
-          transactionCommitter.validateLedgerTime(context, transactionEntrySummary)(loggingContext)
+        val actual = transactionCommitter.validateLedgerTime(context, transactionEntrySummary)
 
         actual match {
           case StepContinue(_) => fail()
@@ -327,7 +321,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       transactionCommitter.validateLedgerTime(
         commitContext,
         aTransactionEntrySummary,
-      )(loggingContext)
+      )
 
       commitContext.getAccessedInputKeys should contain(configurationStateKey)
     }
@@ -337,8 +331,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     "set record time in log entry when it is available" in {
       val context = createCommitContext(recordTime = Some(theRecordTime))
 
-      val actual =
-        transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
+      val actual = transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
 
       actual.hasRecordTime shouldBe true
       actual.getRecordTime shouldBe buildTimestamp(theRecordTime)
@@ -360,8 +353,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     "produce an out-of-time-bounds rejection log entry in case pre-execution is enabled" in {
       val context = createCommitContext(recordTime = None)
 
-      val _ =
-        transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
+      transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
 
       context.preExecute shouldBe true
       context.outOfTimeBoundsLogEntry should not be empty
@@ -375,8 +367,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     "not set an out-of-time-bounds rejection log entry in case pre-execution is disabled" in {
       val context = createCommitContext(recordTime = Some(aRecordTime))
 
-      val _ =
-        transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
+      transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
 
       context.preExecute shouldBe false
       context.outOfTimeBoundsLogEntry shouldBe empty
@@ -387,7 +378,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     "always set blindingInfo" in {
       val context = createCommitContext(recordTime = None)
 
-      val actual = transactionCommitter.blind(context, aTransactionEntrySummary)(loggingContext)
+      val actual = transactionCommitter.blind(context, aTransactionEntrySummary)
 
       actual match {
         case StepContinue(partialResult) =>
@@ -529,7 +520,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       a[MissingInputState] should be thrownBy transactionCommitter.authorizeSubmitters(
         context,
         tx,
-      )(loggingContext)
+      )
     }
 
     "reject a submission when any of the submitters is not known" in {
@@ -543,7 +534,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       )
       val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob)))
 
-      val result = transactionCommitter.authorizeSubmitters(context, tx)(loggingContext)
+      val result = transactionCommitter.authorizeSubmitters(context, tx)
       result shouldBe a[StepStop]
 
       val rejectionReason =
@@ -562,7 +553,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       )
       val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob)))
 
-      val result = transactionCommitter.authorizeSubmitters(context, tx)(loggingContext)
+      val result = transactionCommitter.authorizeSubmitters(context, tx)
       result shouldBe a[StepStop]
 
       val rejectionReason =
@@ -584,8 +575,8 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       )
       val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob, Emma)))
 
-      transactionCommitter
-        .authorizeSubmitters(context, tx)(loggingContext) shouldBe a[StepContinue[_]]
+      val result = transactionCommitter.authorizeSubmitters(context, tx)
+      result shouldBe a[StepContinue[_]]
     }
 
     lazy val Alice = "alice"
@@ -778,11 +769,10 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         ctx: CommitContext,
         transaction: SubmittedTransaction,
     )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] =
-      ContractKeysValidation
-        .validateKeys(transactionCommitter)(
-          ctx,
-          DamlTransactionEntrySummary(createTransactionEntry(List("Alice"), transaction)),
-        )(loggingContext)
+      ContractKeysValidation.validateKeys(transactionCommitter)(
+        ctx,
+        DamlTransactionEntrySummary(createTransactionEntry(List("Alice"), transaction)),
+      )
 
     def contractKeyState(contractId: String): DamlContractKeyState =
       DamlContractKeyState

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/KeyMonotonicityValidationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/KeyMonotonicityValidationSpec.scala
@@ -8,8 +8,10 @@ import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.committer.StepContinue
-import com.daml.ledger.participant.state.kvutils.committer.transaction.TransactionCommitter
-import com.daml.ledger.participant.state.kvutils.committer.transaction.TransactionCommitter.DamlTransactionEntrySummary
+import com.daml.ledger.participant.state.kvutils.committer.transaction.{
+  DamlTransactionEntrySummary,
+  TransactionCommitter,
+}
 import com.daml.ledger.participant.state.v1.RejectionReason
 import com.daml.logging.LoggingContext
 import com.google.protobuf.ByteString
@@ -29,11 +31,10 @@ class KeyMonotonicityValidationSpec
   private val ledgerEffectiveTime =
     ZonedDateTime.of(2021, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC).toInstant
   private val testTransactionEntry = DamlTransactionEntrySummary(
-    DamlTransactionEntry
-      .newBuilder()
+    DamlTransactionEntry.newBuilder
       .setSubmissionSeed(testSubmissionSeed)
       .setLedgerEffectiveTime(Conversions.buildTimestamp(ledgerEffectiveTime))
-      .build()
+      .build
   )
 
   "checkContractKeysCausalMonotonicity" should {
@@ -71,12 +72,10 @@ class KeyMonotonicityValidationSpec
     }
   }
 
-  private def aStateValueActiveAt(activeAt: Instant) = DamlStateValue
-    .newBuilder()
-    .setContractKeyState(
-      DamlContractKeyState
-        .newBuilder()
-        .setActiveAt(Conversions.buildTimestamp(activeAt))
-    )
-    .build()
+  private def aStateValueActiveAt(activeAt: Instant) =
+    DamlStateValue.newBuilder
+      .setContractKeyState(
+        DamlContractKeyState.newBuilder.setActiveAt(Conversions.buildTimestamp(activeAt))
+      )
+      .build
 }


### PR DESCRIPTION
Implicits and lambdas don't work well together.

I don't know if this is a good idea. I find the `Step` definitions a little easier to read, and I appreciate avoid passing `loggingContext` around explicitly (although this mostly happens in tests). That said, there's undeniably more code, and more nesting, which you might find less pleasant.

Let me know what you think.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
