### PR TITLE
Share code between SBUFetchKey and SBULookupKey

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1174,7 +1174,7 @@ private[lf] object SBuiltin {
         args: util.ArrayList[SValue],
         machine: Machine,
         onLedger: OnLedger,
-    ): Unit = lookupKey(args, machine, onLedger)
+    ): Unit = handleKey(args, machine, onLedger, Lookup)
   }
 
   /** $insertLookup[T]
@@ -1250,21 +1250,7 @@ private[lf] object SBuiltin {
         SBSome(SEImportValue(typ, V.ValueContractId(cid)))
     }
 
-    protected final def lookupKey(
-        args: util.ArrayList[SValue],
-        machine: Machine,
-        onLedger: OnLedger,
-    ) =
-      handleKey(args, machine, onLedger, Lookup)
-
-    protected final def fetchKey(
-        args: util.ArrayList[SValue],
-        machine: Machine,
-        onLedger: OnLedger,
-    ) =
-      handleKey(args, machine, onLedger, Fetch)
-
-    private def handleKey(
+    protected final def handleKey(
         args: util.ArrayList[SValue],
         machine: Machine,
         onLedger: OnLedger,
@@ -1335,7 +1321,7 @@ private[lf] object SBuiltin {
         args: util.ArrayList[SValue],
         machine: Machine,
         onLedger: OnLedger,
-    ): Unit = fetchKey(args, machine, onLedger)
+    ): Unit = handleKey(args, machine, onLedger, Fetch)
   }
 
   /** $getTime :: Token -> Timestamp */

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1169,66 +1169,12 @@ private[lf] object SBuiltin {
     *   :: { key: key, maintainers: List Party }
     *   -> Maybe (ContractId T)
     */
-  final case class SBULookupKey(templateId: TypeConName) extends OnLedgerBuiltin(1) {
-    private[this] val typ = AstUtil.TContractId(Ast.TTyCon(templateId))
+  final case class SBULookupKey(templateId: TypeConName) extends SBUKeyBuiltin(templateId) {
     override protected final def execute(
         args: util.ArrayList[SValue],
         machine: Machine,
         onLedger: OnLedger,
-    ): Unit = {
-      val keyWithMaintainers = extractKeyWithMaintainers(args.get(0))
-      if (keyWithMaintainers.maintainers.isEmpty)
-        throw DamlEFetchEmptyContractKeyMaintainers(templateId, keyWithMaintainers.key)
-      val gkey = GlobalKey(templateId, keyWithMaintainers.key)
-      // check if we find it locally
-      onLedger.ptx.keys.get(gkey) match {
-        case Some(Some(coid)) if onLedger.ptx.localContracts.contains(coid) =>
-          val cachedContract = onLedger.cachedContracts
-            .get(coid)
-            .getOrElse(crash(s"Local contract $coid not in cachedContracts"))
-          val stakeholders = cachedContract.signatories union cachedContract.observers
-          throw SpeedyHungry(
-            SResultNeedLocalKeyVisible(
-              stakeholders,
-              onLedger.committers,
-              {
-                case SVisibleByKey.Visible =>
-                  machine.returnValue = SOptional(Some(SContractId(coid)))
-                case SVisibleByKey.NotVisible(actAs, readAs) =>
-                  machine.ctrl = SEDamlException(
-                    DamlELocalContractKeyNotVisible(coid, gkey, actAs, readAs, stakeholders)
-                  )
-              },
-            )
-          )
-        case Some(mbCoid) =>
-          machine.returnValue = SOptional(mbCoid.map(SContractId))
-        case None =>
-          // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
-          // that.
-          throw SpeedyHungry(
-            SResultNeedKey(
-              GlobalKeyWithMaintainers(gkey, keyWithMaintainers.maintainers),
-              onLedger.committers,
-              {
-                case SKeyLookupResult.Found(cid) =>
-                  onLedger.ptx = onLedger.ptx.copy(keys = onLedger.ptx.keys + (gkey -> Some(cid)))
-                  // We have to check that the discriminator of cid does not conflict with a local ones
-                  // however we cannot raise an exception in case of failure here.
-                  // We delegate to CtrlImportValue the task to check cid.
-                  machine.ctrl = SBSome(SEImportValue(typ, V.ValueContractId(cid)))
-                  true
-                case SKeyLookupResult.NotFound =>
-                  onLedger.ptx = onLedger.ptx.copy(keys = onLedger.ptx.keys + (gkey -> None))
-                  machine.returnValue = SV.None
-                  true
-                case SKeyLookupResult.NotVisible =>
-                  machine.tryHandleSubmitMustFail()
-              },
-            )
-          )
-      }
-    }
+    ): Unit = lookupKey(args, machine, onLedger)
   }
 
   /** $insertLookup[T]
@@ -1267,16 +1213,62 @@ private[lf] object SBuiltin {
     }
   }
 
-  /** $fetchKey[T]
-    *   :: { key: key, maintainers: List Party }
-    *   -> ContractId T
-    */
-  final case class SBUFetchKey(templateId: TypeConName) extends OnLedgerBuiltin(1) {
+  private[speedy] sealed abstract class SBUKeyBuiltin(templateId: TypeConName)
+      extends OnLedgerBuiltin(1) {
     private[this] val typ = AstUtil.TContractId(Ast.TTyCon(templateId))
-    override protected final def execute(
+
+    sealed trait KeyOperation {
+      // Callback from the engine returned NotFound
+      def handleKeyNotFound(machine: Machine): Boolean
+      // We saw an archive of this key.
+      def handleKeyArchived(machine: Machine, key: GlobalKey): Unit
+      def cidToSValue(cid: V.ContractId): SValue
+      def cidToSExpr(cid: V.ContractId): SExpr
+    }
+    final case object Fetch extends KeyOperation {
+      override def handleKeyNotFound(machine: Machine): Boolean =
+        machine.tryHandleSubmitMustFail()
+      override def handleKeyArchived(machine: Machine, key: GlobalKey): Unit =
+        // TODO (MK) Produce a proper error here.
+        crash(s"Could not find key $key")
+      override def cidToSValue(cid: V.ContractId) =
+        SContractId(cid)
+      override def cidToSExpr(cid: V.ContractId) =
+        SEImportValue(typ, V.ValueContractId(cid))
+    }
+    final case object Lookup extends KeyOperation {
+      override def handleKeyNotFound(machine: Machine): Boolean = {
+        machine.returnValue = SV.None
+        true
+      }
+      override def handleKeyArchived(machine: Machine, key: GlobalKey): Unit = {
+        machine.returnValue = SV.None
+      }
+      override def cidToSValue(cid: V.ContractId) =
+        SOptional(Some(SContractId(cid)))
+      override def cidToSExpr(cid: V.ContractId) =
+        SBSome(SEImportValue(typ, V.ValueContractId(cid)))
+    }
+
+    protected final def lookupKey(
         args: util.ArrayList[SValue],
         machine: Machine,
         onLedger: OnLedger,
+    ) =
+      handleKey(args, machine, onLedger, Lookup)
+
+    protected final def fetchKey(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+        onLedger: OnLedger,
+    ) =
+      handleKey(args, machine, onLedger, Fetch)
+
+    private def handleKey(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+        onLedger: OnLedger,
+        operation: KeyOperation,
     ): Unit = {
       val keyWithMaintainers = extractKeyWithMaintainers(args.get(0))
       if (keyWithMaintainers.maintainers.isEmpty)
@@ -1284,8 +1276,6 @@ private[lf] object SBuiltin {
       val gkey = GlobalKey(templateId, keyWithMaintainers.key)
       // check if we find it locally
       onLedger.ptx.keys.get(gkey) match {
-        case Some(None) =>
-          crash(s"Could not find key $gkey")
         case Some(Some(coid)) if onLedger.ptx.localContracts.contains(coid) =>
           val cachedContract = onLedger.cachedContracts
             .get(coid)
@@ -1297,7 +1287,7 @@ private[lf] object SBuiltin {
               onLedger.committers,
               {
                 case SVisibleByKey.Visible =>
-                  machine.returnValue = SContractId(coid)
+                  machine.returnValue = operation.cidToSValue(coid)
                 case SVisibleByKey.NotVisible(actAs, readAs) =>
                   machine.ctrl = SEDamlException(
                     DamlELocalContractKeyNotVisible(coid, gkey, actAs, readAs, stakeholders)
@@ -1306,7 +1296,9 @@ private[lf] object SBuiltin {
             )
           )
         case Some(Some(coid)) =>
-          machine.returnValue = SContractId(coid)
+          machine.returnValue = operation.cidToSValue(coid)
+        case Some(None) =>
+          operation.handleKeyArchived(machine, gkey)
         case None =>
           // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
           // that.
@@ -1320,16 +1312,30 @@ private[lf] object SBuiltin {
                   // We have to check that the discriminator of cid does not conflict with a local ones
                   // however we cannot raise an exception in case of failure here.
                   // We delegate to CtrlImportValue the task to check cid.
-                  machine.ctrl = SEImportValue(typ, V.ValueContractId(cid))
+                  machine.ctrl = operation.cidToSExpr(cid)
                   true
-                case SKeyLookupResult.NotFound | SKeyLookupResult.NotVisible =>
+                case SKeyLookupResult.NotFound =>
                   onLedger.ptx = onLedger.ptx.copy(keys = onLedger.ptx.keys + (gkey -> None))
+                  operation.handleKeyNotFound(machine)
+                case SKeyLookupResult.NotVisible =>
                   machine.tryHandleSubmitMustFail()
               },
             )
           )
       }
     }
+  }
+
+  /** $fetchKey[T]
+    *   :: { key: key, maintainers: List Party }
+    *   -> ContractId T
+    */
+  final case class SBUFetchKey(templateId: TypeConName) extends SBUKeyBuiltin(templateId) {
+    override protected final def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+        onLedger: OnLedger,
+    ): Unit = fetchKey(args, machine, onLedger)
   }
 
   /** $getTime :: Token -> Timestamp */


### PR DESCRIPTION
Those do almost the same and the logic is growing increasingly complex
so I really want to share it. This also makes it easier to see the
things that are different.

Along the way I’ve also discovered a bug:
SBUFetchKey called crash where it should produce a proper error that
can be caught by submitMustFail. Not going to resolve that in this PR
though so I just added a TODO.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
