### PR TITLE
KVL-919 Propagate trace context for package upload

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/telemetry/SpanName.scala
+++ b/ledger/metrics/src/main/scala/com/daml/telemetry/SpanName.scala
@@ -1,0 +1,8 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.telemetry
+
+object SpanName {
+  val RunnerUploadDar: String = "daml.runner.upload-dar"
+}

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
@@ -35,7 +35,7 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       submissionId: SubmissionId,
       archives: List[DamlLf.Archive],
       sourceDescription: Option[String],
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     Timed.completionStage(
       metrics.daml.services.write.uploadPackages,
       delegate.uploadPackages(submissionId, archives, sourceDescription),

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -25,7 +25,7 @@ import com.daml.metrics.JvmMetricSet
 import com.daml.platform.apiserver.StandaloneApiServer
 import com.daml.platform.indexer.StandaloneIndexerServer
 import com.daml.platform.store.{IndexMetadata, LfValueTranslationCache}
-import com.daml.telemetry.{DefaultTelemetry, SpanKind, SpanName, Spans, TelemetryContext}
+import com.daml.telemetry.{DefaultTelemetry, SpanKind, SpanName}
 
 import scala.compat.java8.FutureConverters.CompletionStageOps
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -25,6 +25,7 @@ import com.daml.metrics.JvmMetricSet
 import com.daml.platform.apiserver.StandaloneApiServer
 import com.daml.platform.indexer.StandaloneIndexerServer
 import com.daml.platform.store.{IndexMetadata, LfValueTranslationCache}
+import com.daml.telemetry.{DefaultTelemetry, SpanKind, SpanName, Spans, TelemetryContext}
 
 import scala.compat.java8.FutureConverters.CompletionStageOps
 import scala.concurrent.{ExecutionContext, Future}
@@ -178,15 +179,16 @@ final class Runner[T <: ReadWriteService, Extra](
 
   private def uploadDar(from: Path, to: WritePackagesService)(implicit
       executionContext: ExecutionContext
-  ): Future[Unit] = {
-    val submissionId = SubmissionId.assertFromString(UUID.randomUUID().toString)
-    for {
-      dar <- Future(
-        DarReader[Archive] { case (_, x) => Try(Archive.parseFrom(x)) }
-          .readArchiveFromFile(from.toFile)
-          .get
-      )
-      _ <- to.uploadPackages(submissionId, dar.all, None).toScala
-    } yield ()
+  ): Future[Unit] = DefaultTelemetry.runFutureInSpan(SpanName.RunnerUploadDar, SpanKind.Internal) {
+    implicit telemetryContext =>
+      val submissionId = SubmissionId.assertFromString(UUID.randomUUID().toString)
+      for {
+        dar <- Future(
+          DarReader[Archive] { case (_, x) => Try(Archive.parseFrom(x)) }
+            .readArchiveFromFile(from.toFile)
+            .get
+        )
+        _ <- to.uploadPackages(submissionId, dar.all, None).toScala
+      } yield ()
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
@@ -66,7 +66,7 @@ class KeyValueParticipantState(
       submissionId: SubmissionId,
       archives: List[DamlLf.Archive],
       sourceDescription: Option[String],
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     writerAdapter.uploadPackages(submissionId, archives, sourceDescription)
 
   override def allocateParty(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -45,7 +45,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
       submissionId: SubmissionId,
       archives: List[DamlLf.Archive],
       sourceDescription: Option[String],
-  ): CompletionStage[SubmissionResult] = {
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
     val submission = keyValueSubmission
       .archivesToSubmission(
         submissionId,
@@ -53,7 +53,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
         sourceDescription.getOrElse(""),
         writer.participantId,
       )
-    commit(submissionId, submission)(NoOpTelemetryContext)
+    commit(submissionId, submission)
   }
 
   override def submitConfiguration(

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePackagesService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePackagesService.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.participant.state.v1
 import java.util.concurrent.CompletionStage
 
 import com.daml.daml_lf_dev.DamlLf.Archive
+import com.daml.telemetry.TelemetryContext
 
 /** An interface for uploading packages via a participant. */
 trait WritePackagesService {
@@ -28,11 +29,12 @@ trait WritePackagesService {
     * provide the size, and the size might potentially be different from the
     * original size, which would be quite confusing.
     *
-    * @param submissionId      : Submitter chosen submission identifier.
-    * @param sourceDescription : Description provided by the backing participant
+    * @param submissionId       Submitter chosen submission identifier.
+    * @param sourceDescription  Description provided by the backing participant
     *   describing where it got the package from, e.g., when, where, or by whom
     *   the packages were uploaded.
-    * @param archives           : DAML-LF archives to be uploaded to the ledger.
+    * @param archives           DAML-LF archives to be uploaded to the ledger.
+    * @param telemetryContext   An implicit context for tracing.
     *
     * @return an async result of a [[SubmissionResult]]
     */
@@ -40,5 +42,5 @@ trait WritePackagesService {
       submissionId: SubmissionId,
       archives: List[Archive],
       sourceDescription: Option[String],
-  ): CompletionStage[SubmissionResult]
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult]
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -74,7 +74,7 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
       submissionId: SubmissionId,
       payload: List[Archive],
       sourceDescription: Option[String],
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     withEnrichedLoggingContext(
       "submissionId" -> submissionId,
       "description" -> sourceDescription.getOrElse(""),

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
@@ -78,7 +78,7 @@ case class ReadWriteServiceBridge(
       submissionId: SubmissionId,
       archives: List[Archive],
       sourceDescription: Option[String],
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     submit(
       Submission.UploadPackages(
         submissionId = submissionId,


### PR DESCRIPTION
Introduces a breaking change (adding implicit `TelemetryContext`) to `WritePackagesService` which according to the discussion in the previous PR should be fine: #9436 (comment)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
