### PR TITLE
KVL-920 Propagate trace context for configuration submission

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/telemetry/SpanName.scala
+++ b/ledger/metrics/src/main/scala/com/daml/telemetry/SpanName.scala
@@ -4,5 +4,6 @@
 package com.daml.telemetry
 
 object SpanName {
-  val RunnerUploadDar: String = "daml.runner.upload-dar"
+  val LedgerConfigProviderInitialConfig = "daml.ledger.config-provider.initial-config"
+  val RunnerUploadDar = "daml.runner.upload-dar"
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/LedgerConfigProviderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/LedgerConfigProviderSpec.scala
@@ -26,6 +26,7 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
 import com.daml.platform.apiserver.services.LedgerConfigProviderSpec._
 import com.daml.platform.configuration.LedgerConfiguration
+import com.daml.telemetry.TelemetryContext
 import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
@@ -162,7 +163,7 @@ object LedgerConfigProviderSpec {
         maxRecordTime: Timestamp,
         submissionId: SubmissionId,
         config: Configuration,
-    ): CompletionStage[SubmissionResult] =
+    )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
       CompletableFuture.supplyAsync { () =>
         Thread.sleep(delay.toMillis)
         currentOffset += 1

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
@@ -55,7 +55,7 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       maxRecordTime: Time.Timestamp,
       submissionId: SubmissionId,
       config: Configuration,
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     Timed.completionStage(
       metrics.daml.services.write.submitConfiguration,
       delegate.submitConfiguration(maxRecordTime, submissionId, config),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
@@ -59,7 +59,7 @@ class KeyValueParticipantState(
       maxRecordTime: Time.Timestamp,
       submissionId: SubmissionId,
       config: Configuration,
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     writerAdapter.submitConfiguration(maxRecordTime, submissionId, config)
 
   override def uploadPackages(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -60,7 +60,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
       maxRecordTime: Time.Timestamp,
       submissionId: SubmissionId,
       config: Configuration,
-  ): CompletionStage[SubmissionResult] = {
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
     val submission =
       keyValueSubmission
         .configurationToSubmission(maxRecordTime, submissionId, writer.participantId, config)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteConfigService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteConfigService.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.participant.state.v1
 import java.util.concurrent.CompletionStage
 
 import com.daml.lf.data.Time.Timestamp
+import com.daml.telemetry.TelemetryContext
 
 trait WriteConfigService {
 
@@ -23,11 +24,12 @@ trait WriteConfigService {
     * @param maxRecordTime: The maximum record time after which the request is rejected.
     * @param submissionId: Client picked submission identifier for matching the responses with the request.
     * @param config: The new ledger configuration.
+    * @param telemetryContext: An implicit context for tracing.
     * @return an async result of a SubmissionResult
     */
   def submitConfiguration(
       maxRecordTime: Timestamp,
       submissionId: SubmissionId,
       config: Configuration,
-  ): CompletionStage[SubmissionResult]
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult]
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -91,7 +91,7 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
       maxRecordTime: Time.Timestamp,
       submissionId: SubmissionId,
       config: Configuration,
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     withEnrichedLoggingContext(
       "maxRecordTime" -> maxRecordTime.toInstant.toString,
       "submissionId" -> submissionId,

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
@@ -50,7 +50,7 @@ case class ReadWriteServiceBridge(
       maxRecordTime: Time.Timestamp,
       submissionId: SubmissionId,
       config: Configuration,
-  ): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     submit(
       Submission.Config(
         maxRecordTime = maxRecordTime,


### PR DESCRIPTION
Introduces a breaking change (adding implicit `TelemetryContext`) to `WriteConfigService` which according to the discussion in the previous PR should be fine: #9436 (comment)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
