### PR TITLE
Only archive a key if it was brought into scope before

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2468,10 +2468,10 @@ class EngineTest
           ("LookupAfterCreate", emptyArg, 0),
           ("LookupAfterCreateArchive", emptyArg, 0),
           ("LookupAfterFetch", cidArg, 1),
-          // TODO (MK) An archive should not bring a key in scope.
-          ("LookupAfterArchive", cidArg, 0),
+          ("LookupAfterArchive", cidArg, 1),
           ("LookupAfterRollbackCreate", emptyArg, 0),
           ("LookupAfterRollbackLookup", emptyArg, 1),
+          ("LookupAfterArchiveAfterRollbackLookup", cidArg, 1),
         )
         forAll(cases) { case (choice, argument, lookups) =>
           val command = CreateAndExerciseCommand(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1319,8 +1319,9 @@ private[lf] object SBuiltin {
                     // already brought into scope.
                     val activeResult = result match {
                       case SKeyLookupResult.Found(cid) if onLedger.ptx.consumedBy.contains(cid) =>
-                          SKeyLookupResult.NotFound
-                      case SKeyLookupResult.Found(_) | SKeyLookupResult.NotFound | SKeyLookupResult.NotVisible =>
+                        SKeyLookupResult.NotFound
+                      case SKeyLookupResult.Found(_) | SKeyLookupResult.NotFound |
+                          SKeyLookupResult.NotVisible =>
                         result
                     }
                     activeResult match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -165,12 +165,7 @@ private[lf] object PartialTransaction {
   final case class CompleteTransaction(tx: SubmittedTransaction) extends Result
   final case class IncompleteTransaction(ptx: PartialTransaction) extends Result
 
-  sealed abstract class KeyMapping extends Product with Serializable {
-    final def flatMap(f: Value.ContractId => KeyMapping): KeyMapping = this match {
-      case KeyInactive => KeyInactive
-      case KeyActive(cid) => f(cid)
-    }
-  }
+  sealed abstract class KeyMapping extends Product with Serializable
   // There is no active contract with the given key.
   final case object KeyInactive extends KeyMapping
   // The contract with the given cid is active and has the given key.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -165,7 +165,12 @@ private[lf] object PartialTransaction {
   final case class CompleteTransaction(tx: SubmittedTransaction) extends Result
   final case class IncompleteTransaction(ptx: PartialTransaction) extends Result
 
-  sealed abstract class KeyMapping
+  sealed abstract class KeyMapping extends Product with Serializable {
+    final def flatMap(f: Value.ContractId => KeyMapping): KeyMapping = this match {
+      case KeyInactive => KeyInactive
+      case KeyActive(cid) => f(cid)
+    }
+  }
   // There is no active contract with the given key.
   final case object KeyInactive extends KeyMapping
   // The contract with the given cid is active and has the given key.
@@ -196,7 +201,11 @@ private[lf] object PartialTransaction {
   *                 an entry in the map if there wasn’t already one (i.e., if they queried the ledger).
   *              2. ACS mutating operations if the corresponding contract has a key. Specifically,
   *                 2.1. A create will set the corresponding map entry to KeyActive(cid) if the contract has a key.
-  *                 2.2. A consuming choice will set the corresponding map entry to KeyInactive if the contract has a key.
+  *                 2.2. A consuming choice on cid will set the corresponding map entry to KeyInactive
+  *                      iff we had a KeyActive(cid) entry for the same key before. If not, keys
+  *                      will not be modified. Later lookups have an activeness check
+  *                      that can then set this to KeyInactive if the result of the
+  *                      lookup was already archived.
   *
   *              On a rollback, we restore the state at the beginning of the rollback. However,
   *              we preserve globalKeyInputs so we will not ask the ledger again for a key lookup
@@ -481,7 +490,15 @@ private[lf] case class PartialTransaction(
             consumedBy = if (consuming) consumedBy.updated(targetId, nid) else consumedBy,
             keys = mbKey match {
               case Some(kWithM) if consuming =>
-                keys.updated(GlobalKey(templateId, kWithM.key), KeyInactive)
+                val gkey = GlobalKey(templateId, kWithM.key)
+                keys.get(gkey) match {
+                  // An archive can only mark a key as inactive
+                  // if it was brought into scope before.
+                  case Some(KeyActive(cid)) if cid == targetId => keys.updated(gkey, KeyInactive)
+                  // If the key was not in scope or mapped to a different cid, we don’t change keys. Instead we will do
+                  // an activeness check when looking it up later.
+                  case _ => keys
+                }
               case _ => keys
             },
           ),

--- a/daml-lf/tests/Exceptions.daml
+++ b/daml-lf/tests/Exceptions.daml
@@ -166,3 +166,22 @@ template GlobalLookups
            E -> pure ()
          Some _ <- lookupByKey @K k
          pure ()
+
+    choice LookupAfterArchiveAfterRollbackLookup : ()
+      with
+        cid : ContractId K
+      controller p
+      do try do
+           -- this updates globalKeyInputs
+           Some cid' <- lookupByKey @K k
+           cid === cid'
+           throw E
+         catch
+           E -> pure ()
+         c <- fetch cid
+         key c === k
+         -- keys is empty here so archive does not drop it.
+         archive cid
+         -- this one needs to check activeness for an entry in globalKeyInputs
+         None <- lookupByKey @K k
+         pure ()

--- a/daml-lf/tests/MultiKeys.daml
+++ b/daml-lf/tests/MultiKeys.daml
@@ -130,7 +130,9 @@ template KeyOperations
          (keyCid, _) <- fetchByKey @Keyed p
          assert (keyCid `elem` [cid1, cid2])
          archive (fromSome (find (/= keyCid) [cid1, cid2]))
-         None <- lookupByKey @Keyed p
+         -- archive can only influence result for a contract fetched by key before.
+         Some keyCid' <- lookupByKey @Keyed p
+         keyCid' === keyCid
          pure ()
 
     -- should be accepted in uck


### PR DESCRIPTION
This PR implements the semantics we agreed on in
https://github.com/digital-asset/daml/pull/9472#discussion_r620097844.

Before, archive always marked the key as inactive in `keys`. This is
weirdly inconsistent with other operations. For example, a regular
fetch does not bring a key in scope in `keys`. This PR changes this to
a more consistent model where `keys` is modified exactly under the
following circumstances:

1. A create with a key always overwrites.
2. An archive will only mark a key as inactive if there was an entry
   in `keys` with the same contract id.
3. Lookup/fetch by key first check if we currently have an entry in `keys`.
   If so, we use that.
   If not, we need to ask the ledger. We first check if we have a
   ceched entry in `globalKeyInputs`. If we do use that.
   If we don’t, we ask the ledger.
   If the result is not active or not visible we proceed updating `keys`
   and `globalKeyInputs`.
   If the result was a cid, we check if it’s still active.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
