### PR TITLE
Handle curl failures in vscode publish process

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -99,9 +99,9 @@ jobs:
           chmod 600 ~/.docker/da_automation.key
           docker trust key load ~/.docker/da_automation.key --name $DOCKER_CONTENT_TRUST_USERNAME
 
-          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '.[] | .tag_name')
+          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -sSfL | jq -r '.[] | .tag_name')
           DIR=$(pwd)
-          VERSIONS=$(curl 'https://hub.docker.com/v2/repositories/digitalasset/daml-sdk/tags/?page_size=10000' -s)
+          VERSIONS=$(curl 'https://hub.docker.com/v2/repositories/digitalasset/daml-sdk/tags/?page_size=10000' -sSfL)
           # Our docker tags should be stable. Therefore, we only build the image if it has not already
           # been built before and we checkout the Dockerfile for the release tag.
           # We do not update docker images for older releases so only docker images for SDK releases
@@ -149,7 +149,7 @@ jobs:
           AUTH=$(echo -n "OAuth:${MARKETPLACE_TOKEN}" | base64 -w0)
           MARKET=$(curl -H "Authorization: Basic $AUTH" \
                         -H "Accept: application/json;api-version=5.0-preview.2" \
-                        -s \
+                        -sSfL \
                         "https://marketplace.visualstudio.com/_apis/gallery/publishers/DigitalAssetHoldingsLLC/extensions/daml?flags=1" \
                         | jq -r '.versions[0].version')
           # This jq expression should ensure that we always upload the
@@ -171,7 +171,7 @@ jobs:
           # _a_ version number, it doesn't handle versions at all: we can only
           # have one version on the marketplace at any given time, and any
           # upload replaces the existing version.
-          GITHUB=$(curl https://api.github.com/repos/digital-asset/daml/releases -s \
+          GITHUB=$(curl https://api.github.com/repos/digital-asset/daml/releases -sSfL \
                    | jq -r '. | map(select(.prerelease == false)
                                     | .tag_name
                                     | .[1:]
@@ -214,7 +214,7 @@ jobs:
           eval "$(dev-env/bin/dade-assist)"
 
           STATS=$(mktemp)
-          curl https://api.github.com/repos/digital-asset/daml/releases -s | gzip -9 > $STATS
+          curl https://api.github.com/repos/digital-asset/daml/releases -sSfL | gzip -9 > $STATS
 
           GCS_KEY=$(mktemp)
           cleanup () {


### PR DESCRIPTION
Currently CI is failing with a 401. Confusingly, it doesn’t fail
during this step but fails during the upload below later because
$MARKET ends up pointing to garbage. This does not solve the failure
but it produces a more sensible error.

EDIT: The CI failure has been fixed in the meantime but I’d still like to get a more sensible error next time.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
