### PR TITLE
Speed up daml-sdk-head Maven installation

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -19,7 +19,10 @@ fi
 NUKE=0
 PROFILING=0
 SKIP_JARS=0
+SKIP_JAR_DOCS=0
+SKIP_SDK=1
 JUST_DAMLC=0
+SCALA_VERSIONS=()
 SHA=0
 EE=0
 for opt in "$@"; do
@@ -32,6 +35,16 @@ for opt in "$@"; do
       ;;
     "--skip-jars")
       SKIP_JARS=1
+      ;;
+    "--skip-jar-docs")
+      SKIP_JAR_DOCS=1
+      ;;
+    "--scala-version="*)
+      VERSION="${opt#*=}"
+      SCALA_VERSIONS+=($VERSION)
+      ;;
+    "--skip-sdk")
+      SKIP_SDK=1
       ;;
     "--damlc")
       JUST_DAMLC=1
@@ -48,6 +61,9 @@ for opt in "$@"; do
       echo "  --nuke  Remove existing daml installation before installing daml-head."
       echo "  --profiling  Build Haskell executables with profiling enabled."
       echo "  --skip-jars  Skip building and installing the JARs."
+      echo "  --skip-jar-docs Skips docs builds & installation for jars."
+      echo "  --skip-sdk  Skip building and installing the SDK."
+      echo "  --scala-version=$VERSION Only build for scala version $VERSION, can be specified multiple times. Note that you need an equal sign not spaces."
       echo "  --damlc  Update damlc only, if daml-head is already installed."
       echo "  --sha Include SHA information in version number."
       echo "  --ee Build the EE edition."
@@ -94,90 +110,93 @@ else
     export DAML_SDK_RELEASE_VERSION=$(sha_version)
 fi
 
-readonly DAML_HEAD_SDK="$DAML_HOME/sdk/$DAML_SDK_RELEASE_VERSION"
-if [[ -d "$DAML_HEAD_SDK" && "$JUST_DAMLC" -eq 0 ]]; then
-  echo "$(tput setaf 3)Removing existing daml-head installation.$(tput sgr 0)"
-  rm -f "${DAML_HOME}/bin/daml-head"
-  chmod -R u+w "$DAML_HEAD_SDK"
-  rm -rf "$DAML_HEAD_SDK"
-fi
+if [[ "$SKIP_SDK" -eq 0 ]]; then
+    readonly DAML_HEAD_SDK="$DAML_HOME/sdk/$DAML_SDK_RELEASE_VERSION"
+    if [[ -d "$DAML_HEAD_SDK" && "$JUST_DAMLC" -eq 0 ]]; then
+      echo "$(tput setaf 3)Removing existing daml-head installation.$(tput sgr 0)"
+      rm -f "${DAML_HOME}/bin/daml-head"
+      chmod -R u+w "$DAML_HEAD_SDK"
+      rm -rf "$DAML_HEAD_SDK"
+    fi
 
-if [[ -d "$DAML_HEAD_SDK" && "$JUST_DAMLC" -ne 0 ]]; then
-  # daml-head is installed, so just replace damlc
-  echo "$(tput setaf 3)Existing daml-head installation found."
-  echo "Building damlc version $DAML_SDK_RELEASE_VERSION, this may take a while ...$(tput sgr 0)"
-  echo ""
+    if [[ -d "$DAML_HEAD_SDK" && "$JUST_DAMLC" -ne 0 ]]; then
+      # daml-head is installed, so just replace damlc
+      echo "$(tput setaf 3)Existing daml-head installation found."
+      echo "Building damlc version $DAML_SDK_RELEASE_VERSION, this may take a while ...$(tput sgr 0)"
+      echo ""
 
-  function cleanup() {
-    echo "damlc $DAML_SDK_RELEASE_VERSION failed to build/install; if you need help ask on https://discuss.daml.com"
-    echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
-  }
-  trap cleanup EXIT
+      function cleanup() {
+        echo "damlc $DAML_SDK_RELEASE_VERSION failed to build/install; if you need help ask on https://discuss.daml.com"
+        echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
+      }
+      trap cleanup EXIT
 
-  bazel build ${BAZEL_MODE_FLAGS[@]:-} //compiler/damlc:damlc-dist.tar.gz
+      bazel build ${BAZEL_MODE_FLAGS[@]:-} //compiler/damlc:damlc-dist.tar.gz
 
-  readonly TARBALL="$(bazel info bazel-bin ${BAZEL_MODE_FLAGS[@]:-})/compiler/damlc/damlc-dist.tar.gz"
-  chmod -R u+w "$DAML_HEAD_SDK"
-  rm -rf "${DAML_HEAD_SDK}/damlc"
-  mkdir -p "${DAML_HEAD_SDK}/damlc"
-  tar xzf "$TARBALL" -C "${DAML_HEAD_SDK}/damlc" --strip-components 1
+      readonly TARBALL="$(bazel info bazel-bin ${BAZEL_MODE_FLAGS[@]:-})/compiler/damlc/damlc-dist.tar.gz"
+      chmod -R u+w "$DAML_HEAD_SDK"
+      rm -rf "${DAML_HEAD_SDK}/damlc"
+      mkdir -p "${DAML_HEAD_SDK}/damlc"
+      tar xzf "$TARBALL" -C "${DAML_HEAD_SDK}/damlc" --strip-components 1
 
-  trap - EXIT
-  echo "$(tput setaf 3)Done installing damlc $DAML_SDK_RELEASE_VERSION$(tput sgr 0)"
-  exit 0
-fi
+      trap - EXIT
+      echo "$(tput setaf 3)Done installing damlc $DAML_SDK_RELEASE_VERSION$(tput sgr 0)"
+      exit 0
+    fi
 
-echo "$(tput setaf 3)Building version $DAML_SDK_RELEASE_VERSION - this may take a while ...$(tput sgr 0)"
-echo ""
+    echo "$(tput setaf 3)Building version $DAML_SDK_RELEASE_VERSION - this may take a while ...$(tput sgr 0)"
+    echo ""
 
-function cleanup() {
-  echo "SDK $DAML_SDK_RELEASE_VERSION failed to build/install - if you need help ask on"
-  echo "https://discuss.daml.com"
-  echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
+    function cleanup() {
+      echo "SDK $DAML_SDK_RELEASE_VERSION failed to build/install - if you need help ask on"
+      echo "https://discuss.daml.com"
+      echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
 
-  if [[ -n "${SDK_TEMP_DIR+x}" && -d "$SDK_TEMP_DIR" ]]; then
-    rm -rf "$SDK_TEMP_DIR"
-  fi
-}
-trap cleanup EXIT
+      if [[ -n "${SDK_TEMP_DIR+x}" && -d "$SDK_TEMP_DIR" ]]; then
+        rm -rf "$SDK_TEMP_DIR"
+      fi
+    }
+    trap cleanup EXIT
 
-SDK_RELEASE_TARBALL="sdk-release-tarball-ce.tar.gz"
-if [ $EE = 1 ]; then
-    SDK_RELEASE_TARBALL="sdk-release-tarball-ee.tar.gz"
-fi
+    SDK_RELEASE_TARBALL="sdk-release-tarball-ce.tar.gz"
+    if [ $EE = 1 ]; then
+        SDK_RELEASE_TARBALL="sdk-release-tarball-ee.tar.gz"
+    fi
 
-# Building here separately so the user can see the build process which could take a while
-bazel build ${BAZEL_MODE_FLAGS[@]:-} //release:$SDK_RELEASE_TARBALL
+    # Building here separately so the user can see the build process which could take a while
+    bazel build ${BAZEL_MODE_FLAGS[@]:-} //release:$SDK_RELEASE_TARBALL
 
-readonly TARBALL="$(bazel info bazel-bin ${BAZEL_MODE_FLAGS[@]:-})/release/$SDK_RELEASE_TARBALL"
-readonly SDK_TEMP_DIR="$(mktemp -d)"
-readonly SDK_DIR="${SDK_TEMP_DIR}/sdk-head"
-mkdir -p "$SDK_DIR"
+    readonly TARBALL="$(bazel info bazel-bin ${BAZEL_MODE_FLAGS[@]:-})/release/$SDK_RELEASE_TARBALL"
+    readonly SDK_TEMP_DIR="$(mktemp -d)"
+    readonly SDK_DIR="${SDK_TEMP_DIR}/sdk-head"
+    mkdir -p "$SDK_DIR"
 
-tar xzf "$TARBALL" -C "$SDK_DIR" --strip-components 1
+    tar xzf "$TARBALL" -C "$SDK_DIR" --strip-components 1
 
-readonly DAML_CMD="$(command -v daml)"
-if [[ -x "$DAML_CMD" && "$DAML_CMD" == "$DAML_HOME/bin/daml" ]]; then
-  # A daml installation already exists, so just install SDK version $DAML_SDK_RELEASE_VERSION.
-  "${DAML_HOME}/bin/daml" install "$SDK_DIR" --force --set-path=no
-else
-  # No daml installation detected, so install the tarball normally but disable auto-install.
-  "${SDK_DIR}/install.sh" --force --set-path=no
-  echo "auto-install: false" > "${DAML_HOME}/daml-config.yaml"
-fi
+    readonly DAML_CMD="$(command -v daml)"
+    if [[ -x "$DAML_CMD" && "$DAML_CMD" == "$DAML_HOME/bin/daml" ]]; then
+      # A daml installation already exists, so just install SDK version $DAML_SDK_RELEASE_VERSION.
+      "${DAML_HOME}/bin/daml" install "$SDK_DIR" --force --set-path=no
+    else
+      # No daml installation detected, so install the tarball normally but disable auto-install.
+      "${SDK_DIR}/install.sh" --force --set-path=no
+      echo "auto-install: false" > "${DAML_HOME}/daml-config.yaml"
+    fi
 
-if [[ -d "$SDK_TEMP_DIR" ]]; then
-  rm -rf "$SDK_TEMP_DIR"
-fi
+    if [[ -d "$SDK_TEMP_DIR" ]]; then
+      rm -rf "$SDK_TEMP_DIR"
+    fi
 
-cat > "${DAML_HOME}/bin/daml-head" << EOF
+    cat > "${DAML_HOME}/bin/daml-head" << EOF
 #!/bin/sh
 exec env DAML_SDK_VERSION=$DAML_SDK_RELEASE_VERSION "${DAML_HEAD_SDK}/daml/daml" "\$@"
 EOF
-chmod +x "${DAML_HOME}/bin/daml-head"
+    chmod +x "${DAML_HOME}/bin/daml-head"
 
-trap - EXIT
-echo "$(tput setaf 3)Successfully installed daml-head command pointing to $DAML_SDK_RELEASE_VERSION.$(tput sgr 0)"
+    trap - EXIT
+    echo "$(tput setaf 3)Successfully installed daml-head command pointing to $DAML_SDK_RELEASE_VERSION.$(tput sgr 0)"
+
+fi
 
 if [[ "$SKIP_JARS" -eq 0 ]]; then
     echo "$(tput setaf 3)Installing JARs as $DAML_SDK_RELEASE_VERSION...$(tput sgr 0)"
@@ -189,7 +208,15 @@ if [[ "$SKIP_JARS" -eq 0 ]]; then
 
     bazel build //release:release
     tmp="$(mktemp -d)"
-    "${REPO_ROOT}/bazel-bin/release/release" --release-dir "$tmp" --install-head-jars
+    RELEASE_ARGS=(--release-dir "$tmp" --install-head-jars --no-ts)
+    if [[ "$SKIP_JAR_DOCS" -eq 1 ]]; then
+        RELEASE_ARGS+=(--no-docs)
+    fi
+    for version in ${SCALA_VERSIONS[@]}; do
+        RELEASE_ARGS+=("--scala-version=$version")
+    done
+
+    "${REPO_ROOT}/bazel-bin/release/release" ${RELEASE_ARGS[@]}
 
     trap - EXIT
 

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -36,10 +36,6 @@ import Util
 
 import qualified SdkVersion
 
--- Keep in sync with /bazel_tools/scala_version.bzl and /nix/nixpkgs.nix
-scalaVersions :: [T.Text]
-scalaVersions = ["2.12.13", "2.13.5"]
-
 -- Hack: the logic that looks for missing transitive dependencies is broken, as it checks all build-time dependencies with `bazel query`
 depsToExclude :: T.Text
 depsToExclude = T.intercalate " + " [
@@ -47,13 +43,13 @@ depsToExclude = T.intercalate " + " [
    "//compiler/repl-service/protos:repl_service_java_proto",
    "//daml-script/runner:script-runner-lib-ce"]
 
-buildAndCopyArtifacts :: (MonadLogger m, MonadIO m, E.MonadThrow m) => SemVer.Version -> BazelLocations -> Path Abs Dir -> [Artifact (Maybe ArtifactLocation)] -> m [Artifact PomData]
-buildAndCopyArtifacts mvnVersion bazelLocations releaseDir artifacts = do
-      let targets = concatMap buildTargets artifacts
+buildAndCopyArtifacts :: (MonadLogger m, MonadIO m, E.MonadThrow m) => IncludeDocs -> SemVer.Version -> BazelLocations -> Path Abs Dir -> [Artifact (Maybe ArtifactLocation)] -> m [Artifact PomData]
+buildAndCopyArtifacts includeDocs mvnVersion bazelLocations releaseDir artifacts = do
+      let targets = concatMap (buildTargets includeDocs) artifacts
       liftIO $ callProcess "bazel" ("build" : map (T.unpack . getBazelTarget) targets)
       $logInfo "Reading metadata from pom files"
       as <- liftIO $ mapM (resolvePomData bazelLocations mvnVersion) artifacts
-      copyArtifacts bazelLocations releaseDir as
+      copyArtifacts includeDocs bazelLocations releaseDir as
       pure as
 
 checkForMissingDeps :: (MonadLogger m, MonadIO m) => [Artifact c] -> m ()
@@ -82,11 +78,11 @@ checkForMissingDeps jars = do
       let query = "kind(\"(java|scala)_library\", deps(" <> target <> ")) intersect //... except (" <> T.unpack depsToExclude <> ")"
       in liftIO $ lines <$> readCreateProcess (proc "bazel" ["query", query]) ""
 
-copyArtifacts :: (MonadIO m, MonadLogger m, E.MonadThrow m) => BazelLocations -> Path Abs Dir -> [Artifact PomData] -> m ()
-copyArtifacts bazelLocations releaseDir as = do
+copyArtifacts :: (MonadIO m, MonadLogger m, E.MonadThrow m) => IncludeDocs -> BazelLocations -> Path Abs Dir -> [Artifact PomData] -> m ()
+copyArtifacts includeDocs bazelLocations releaseDir as = do
   mvnFiles <-
     fmap concat $ forM as $ \artifact ->
-    map (artifact,) . toList <$> artifactFiles artifact
+    map (artifact,) . toList <$> artifactFiles includeDocs artifact
   forM_ mvnFiles $ \(_, (inp, outp)) ->
     copyToReleaseDir bazelLocations releaseDir inp outp
 
@@ -107,10 +103,10 @@ main = do
       -- we don't check dependencies for deploy jars as they are single-executable-jars
       let nonDeployJars = filter (not . isDeployJar . artReleaseType) mvnArtifacts
 
-      nonScalaArtifacts <- buildAndCopyArtifacts mvnVersion bazelLocations releaseDir nonScalaArtifacts
+      nonScalaArtifacts <- buildAndCopyArtifacts optIncludeDocs mvnVersion bazelLocations releaseDir nonScalaArtifacts
 
-      scalaArtifacts <- forM scalaVersions $ \ver -> withEnv [("DAML_SCALA_VERSION", Just (T.unpack ver))] $ do
-          as <- buildAndCopyArtifacts mvnVersion bazelLocations releaseDir scalaArtifacts
+      scalaArtifacts <- forM optScalaVersions $ \ver -> withEnv [("DAML_SCALA_VERSION", Just (T.unpack ver))] $ do
+          as <- buildAndCopyArtifacts optIncludeDocs mvnVersion bazelLocations releaseDir scalaArtifacts
           -- Check for missing deps once per Scala version since bazel query depends on DAML_SCALA_VERSION.
           checkForMissingDeps (nonDeployJars ++ scalaArtifacts)
           pure as
@@ -136,7 +132,7 @@ main = do
                   $logError ("\t- "# getBazelTarget (artTarget artifact))
           liftIO exitFailure
 
-      mvnUploadArtifacts <- concatMapM mavenArtifactCoords allArtifacts
+      mvnUploadArtifacts <- concatMapM (mavenArtifactCoords optIncludeDocs) allArtifacts
       validateMavenArtifacts releaseDir mvnUploadArtifacts
 
       -- NPM packages we want to publish
@@ -145,9 +141,12 @@ main = do
               , "//language-support/ts/daml-ledger"
               , "//language-support/ts/daml-react"
               ]
-      -- make sure the NPM packages can be built
-      $logInfo "Building language-support TypeScript packages"
-      liftIO $ callProcess "bazel" $ ["build"] ++ npmPackages
+
+      when (getIncludeTypescript optIncludeTypescript) $ do
+
+        -- make sure the NPM packages can be built
+        $logInfo "Building language-support TypeScript packages"
+        liftIO $ callProcess "bazel" $ ["build"] ++ npmPackages
 
       if  | getPerformUpload optsPerformUpload -> do
               $logInfo "Uploading to Maven Central"
@@ -158,21 +157,23 @@ main = do
                   else
                     $logInfo "No artifacts to upload to Maven Central"
 
-              $logDebug "Uploading npm packages"
-              -- We can't put an .npmrc file in the root of the directory because other bazel npm
-              -- code picks it up and looks for the token which is not yet set before the release
-              -- phase.
-              let npmrcPath = ".npmrc"
-              liftIO $ bracket_
-                (writeFile npmrcPath "//registry.npmjs.org/:_authToken=${NPM_TOKEN}")
-                (Dir.removeFile npmrcPath)
-                (forM_ npmPackages
-                  $ \rule -> liftIO $ callCommand $ unwords $
-                      ["bazel", "run", rule <> ":npm_package.publish", "--", "--access", "public"] <>
-                      [ x | isSnapshot mvnVersion, x <- ["--tag", "next"] ])
+              when (getIncludeTypescript optIncludeTypescript) $ do
+
+                $logDebug "Uploading npm packages"
+                -- We can't put an .npmrc file in the root of the directory because other bazel npm
+                -- code picks it up and looks for the token which is not yet set before the release
+                -- phase.
+                let npmrcPath = ".npmrc"
+                liftIO $ bracket_
+                  (writeFile npmrcPath "//registry.npmjs.org/:_authToken=${NPM_TOKEN}")
+                  (Dir.removeFile npmrcPath)
+                  (forM_ npmPackages
+                    $ \rule -> liftIO $ callCommand $ unwords $
+                        ["bazel", "run", rule <> ":npm_package.publish", "--", "--access", "public"] <>
+                        [ x | isSnapshot mvnVersion, x <- ["--tag", "next"] ])
 
           | optsLocallyInstallJars -> do
-              pom <- generateAggregatePom releaseDir allArtifacts
+              pom <- generateAggregatePom optIncludeDocs releaseDir allArtifacts
               pomPath <- (releaseDir </>) <$> parseRelFile "pom.xml"
               liftIO $ T.IO.writeFile (toFilePath pomPath) pom
               exitCode <- liftIO $ withCreateProcess ((proc "mvn" ["initialize"]) { cwd = Just (toFilePath releaseDir) }) $ \_ _ _ mvnHandle ->

--- a/release/src/Maven.hs
+++ b/release/src/Maven.hs
@@ -30,14 +30,14 @@ validateMavenArtifacts releaseDir artifacts =
             $logError $ T.pack $ show file <> " is required for publishing to Maven"
             liftIO exitFailure
 
-generateAggregatePom :: (MonadFail m, E.MonadThrow m) => Path Abs Dir -> [Artifact PomData] -> m Text
-generateAggregatePom releaseDir artifacts = do
+generateAggregatePom :: (MonadFail m, E.MonadThrow m) => IncludeDocs -> Path Abs Dir -> [Artifact PomData] -> m Text
+generateAggregatePom includeDocs releaseDir artifacts = do
     executions <- T.concat <$> mapM execution artifacts
     return (aggregatePomStart <> executions <> aggregatePomEnd)
     where
     execution :: (MonadFail m, E.MonadThrow m) => Artifact PomData -> m Text
     execution artifact = do
-        ArtifactFiles{..} <- fmap snd <$> artifactFiles artifact
+        ArtifactFiles{..} <- fmap snd <$> artifactFiles includeDocs artifact
         let configuration =
                 map (\(name, value) -> (name, pathToText (releaseDir </> value))) $
                     Maybe.catMaybes

--- a/release/src/Options.hs
+++ b/release/src/Options.hs
@@ -6,6 +6,7 @@ module Options (
     parseOptions,
   ) where
 
+import qualified Data.Text as T
 import Options.Applicative
 
 import Types
@@ -18,6 +19,9 @@ data Options = Options
   { optsPerformUpload :: PerformUpload
   , optsReleaseDir :: FilePath
   , optsLocallyInstallJars :: Bool
+  , optIncludeTypescript :: IncludeTypescript
+  , optScalaVersions :: [T.Text]
+  , optIncludeDocs :: IncludeDocs
   } deriving (Eq, Show)
 
 optsParser :: Parser Options
@@ -25,3 +29,10 @@ optsParser = Options
   <$> (PerformUpload <$> switch (long "upload" <> help "upload java/scala artifacts to Maven Central and typescript artifacts to the npm registry."))
   <*> option str (long "release-dir" <> help "specify full path to release directory")
   <*> switch (long "install-head-jars" <> help "install jars to ~/.m2")
+  <*> fmap (IncludeTypescript . not) (switch (long "no-ts" <> help "Do not build and upload typescript packages"))
+  <*> (some (strOption (long "scala-version" <> help "Scala version to build JARs for")) <|> pure defaultScalaVersions)
+  <*> fmap (IncludeDocs . not) (switch (long "no-docs" <> help "Do not build and install documentation"))
+
+-- Keep in sync with /bazel_tools/scala_version.bzl and /nix/nixpkgs.nix
+defaultScalaVersions :: [T.Text]
+defaultScalaVersions = ["2.12.13", "2.13.5"]

--- a/release/src/Types.hs
+++ b/release/src/Types.hs
@@ -13,7 +13,8 @@ module Types (
     MavenCoords(..),
     MavenUploadConfig(..),
     MonadCI,
-    OnlyScala(..),
+    IncludeDocs(..),
+    IncludeTypescript(..),
     OS(..),
     PerformUpload(..),
     (#),
@@ -109,7 +110,10 @@ type GitRev = Text
 newtype PerformUpload = PerformUpload{getPerformUpload :: Bool}
     deriving (Eq, Show)
 
-newtype OnlyScala = OnlyScala{getOnlyScala :: Bool}
+-- | Whether documentation should be included as well.
+-- This is useful to disable if you run this via daml-sdk-head where you often
+-- don’t care about documentation.
+newtype IncludeDocs = IncludeDocs{includeDocs :: Bool}
     deriving (Eq, Show)
 
 newtype MavenAllowUnsecureTls = MavenAllowUnsecureTls { getAllowUnsecureTls :: Bool }
@@ -132,3 +136,7 @@ instance FromJSON MavenUploadConfig where
         <*> o .: "password"
         <*> (fromMaybe (MavenAllowUnsecureTls False) <$> o .:? "allowUnsecureTls")
         <*> o .: "signingKey"
+
+-- | Whether typescript packages should also be built and uploaded.
+newtype IncludeTypescript = IncludeTypescript { getIncludeTypescript :: Bool}
+  deriving (Eq, Show)


### PR DESCRIPTION
This PR speeds up the Maven installation by doing 4 things:

1. Disable TS builds. This doesn’t make sense since we never install
them.
2. Add a --skip-sdk option that skips the SDK installation.
3. Add a --skip-jar-docs option that skips javadoc and more
importantly scaladoc.
4. Add a --scala-version=$VERSION option to only build against the
given version.

Unfortunately there are no tests and the CLI is a bit messy (you need
--scala-version=$VERSION and not --scala-version $VERSION).

Both are not great but this is a development only tool and it is bash
so my motivation for fixing it is rather low.

Given that this is growing in complexity a fair bit, I think we might
be better off as a long-term solution to move this towards at least
python or maybe even Haskell or Scala. But definitely nothing for this
PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
