### PR TITLE
Fix BigNumeric literal validation

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Numeric.hs
@@ -54,7 +54,7 @@ data NumericError
 numericE :: Natural -> Integer -> Either NumericError Numeric
 numericE s m
     | s > numericMaxScale = Left NEScaleTooLarge
-    | m > numericMaxMantissa = Left NEMantissaTooLarge
+    | abs m > numericMaxMantissa = Left NEMantissaTooLarge
     | otherwise = Right . Numeric $ Decimal (fromIntegral s) m
 
 -- | Partial smart constructor for Numeric literals. Returns undefined

--- a/compiler/damlc/daml-lf-conversion/BUILD.bazel
+++ b/compiler/damlc/daml-lf-conversion/BUILD.bazel
@@ -47,8 +47,10 @@ da_haskell_test(
     srcs = glob(["test/**/*.hs"]),
     hackage_deps = [
         "base",
+        "either",
         "ghc-lib-parser",
         "ghc-lib",
+        "ghcide",
         "tasty",
         "tasty-hunit",
         "text",

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -335,18 +335,16 @@ convertRationalNumericMono env scale num denom
 -- values that will fit in a Numeric.
 convertRationalBigNumeric :: Integer -> Integer -> ConvertM LF.Expr
 convertRationalBigNumeric num denom = case numericFromRational rational of
-    Left error -> invalid
+    Left _ -> invalid
     Right n ->
         let scale = numericScale n
         in pure (EBuiltin BEFromNumericBigNumeric
             `ETyApp` TNat (typeLevelNat scale)
-            `ETmApp` EBuiltin (BENumeric $ numeric
-                (fromIntegral scale)
-                ((num * 10^scale) `div` denom)))
+            `ETmApp` EBuiltin (BENumeric n))
 
     where
         rational = num % denom
-        invalid = unsupported "Large BigNumeric (larger than Numeric) literals are not currently supported. Please construct the number from smaller literals." ()
+        invalid = unsupported "Large BigNumeric (larger than Numeric) literals are not currently supported. Please construct the number from smaller literals" ()
 
 data TemplateBinds = TemplateBinds
     { tbTyCon :: Maybe GHC.TyCon

--- a/compiler/damlc/daml-lf-conversion/test/DA/Daml/LFConversion/Tests.hs
+++ b/compiler/damlc/daml-lf-conversion/test/DA/Daml/LFConversion/Tests.hs
@@ -3,10 +3,16 @@
 
 module DA.Daml.LFConversion.Tests (main) where
 
+import Development.IDE.Types.Diagnostics (FileDiagnostic, showDiagnostics)
+import Development.IDE.Types.Location (toNormalizedFilePath')
 import Test.Tasty
 import Test.Tasty.HUnit
+import Data.Either.Combinators (whenLeft, whenRight)
 import Data.Maybe (isNothing)
+import Data.Ratio
+import qualified Data.Text as T
 
+import DA.Daml.LFConversion
 import DA.Daml.LFConversion.MetadataEncoding
 import qualified DA.Daml.LF.Ast as LF
 
@@ -15,7 +21,11 @@ import qualified "ghc-lib-parser" BooleanFormula as BF
 import "ghc-lib-parser" SrcLoc (noLoc)
 
 main :: IO ()
-main = defaultMain metadataEncodingTests
+main = defaultMain $
+  testGroup "LFConversion"
+    [ metadataEncodingTests
+    , bignumericTests
+    ]
 
 metadataEncodingTests :: TestTree
 metadataEncodingTests = testGroup "MetadataEncoding"
@@ -67,3 +77,30 @@ roundtripTestsPartial groupName encode decode negativeExamples positiveExamples 
                 (Just value == (encode value >>= decode))
         | (name, value) <- positiveExamples
         ]
+
+bignumericTests :: TestTree
+bignumericTests = testGroup "BigNumeric"
+  [ valid 0.123457
+  , valid 0.123456
+  , valid 0.0
+  , invalid 123456789012345678901233456789012345678
+  , invalid (-123456789012345678901233456789012345678)
+  ]
+  where
+    valid :: Rational -> TestTree
+    valid r = testCase (show r <> " should be valid") $ do
+      let result = convertLiteral r
+      whenLeft result $ \diag ->
+        assertFailure $ T.unpack $ showDiagnostics [diag]
+    invalid :: Rational -> TestTree
+    invalid r = testCase (show r <> " should be invalid") $ do
+      let result = convertLiteral r
+      whenRight result $ \_ ->
+        assertFailure $ "Expected " <> show r <> " to be an invalid BigNumeric literal but conversion succeeeded"
+    convertLiteral :: Rational -> Either FileDiagnostic LF.Expr
+    convertLiteral r =
+        let dummyEnv = ConversionEnv
+              { convModuleFilePath = toNormalizedFilePath' ""
+              , convRange = Nothing
+              }
+        in runConvertM dummyEnv $ convertRationalBigNumeric (numerator r) (denominator r)

--- a/compiler/damlc/tests/daml-test-files/BigNumericTooBig.daml
+++ b/compiler/damlc/tests/daml-test-files/BigNumericTooBig.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- @SINCE-LF 1.13
--- @ERROR Large BigNumeric literals are not currently supported.
+-- @ERROR Large BigNumeric (larger than Numeric) literals are not currently supported.
 
 module BigNumericTooBig where
 


### PR DESCRIPTION
The calculation of scale is off and fails on
0.123456 which turns into 1929 % 15625.

I don’t really like the implementation here but I’m failing to come up
with a more direct way to calculate it. I blame the fact that I
haven’t had coffee yet.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
