### PR TITLE
Accept a comma-separated list of parties for daml ledger export

### DIFF
--- a/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 final case class Config(
     ledgerHost: String,
     ledgerPort: Int,
-    parties: List[String],
+    parties: Seq[String],
     start: LedgerOffset,
     end: LedgerOffset,
     exportType: Option[ExportType],
@@ -50,10 +50,10 @@ object Config {
       .required()
       .action((x, c) => c.copy(ledgerPort = x))
       .text("Daml ledger port to connect to.")
-    opt[String]("party")
+    opt[Seq[String]]("party")
       .required()
       .unbounded()
-      .action((x, c) => c.copy(parties = x.split(",").toList ++ c.parties))
+      .action((x, c) => c.copy(parties = c.parties ++ x.toList))
       .text(
         "Export ledger state as seen by these parties. " +
           "Pass --party multiple times or use a comma-separated list of party names to specify multiple parties."

--- a/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
@@ -63,7 +63,7 @@ object Config {
       )
     opt[String]("end")
       .optional()
-      .action((x, c) => c.copy(start = parseLedgerOffset(x)))
+      .action((x, c) => c.copy(end = parseLedgerOffset(x)))
       .text(
         "The transaction offset (inclusive) for the end position of the export. Optional, by default the export includes the current end of the ledger."
       )

--- a/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
@@ -53,8 +53,11 @@ object Config {
     opt[String]("party")
       .required()
       .unbounded()
-      .action((x, c) => c.copy(parties = x :: c.parties))
-      .text("Export ledger state as seen by these parties.")
+      .action((x, c) => c.copy(parties = x.split(",").toList ++ c.parties))
+      .text(
+        "Export ledger state as seen by these parties. " +
+          "Pass --party multiple times or use a comma-separated list of party names to specify multiple parties."
+      )
     opt[String]("start")
       .optional()
       .action((x, c) => c.copy(start = parseLedgerOffset(x)))

--- a/daml-script/export/src/main/scala/com/daml/script/export/LedgerUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/LedgerUtils.scala
@@ -24,7 +24,7 @@ object LedgerUtils {
     */
   def getACS(
       client: LedgerClient,
-      parties: List[String],
+      parties: Seq[String],
       offset: LedgerOffset,
   )(implicit
       mat: Materializer
@@ -57,7 +57,7 @@ object LedgerUtils {
     */
   def getTransactionTrees(
       client: LedgerClient,
-      parties: List[String],
+      parties: Seq[String],
       start: LedgerOffset,
       end: LedgerOffset,
   )(implicit
@@ -72,6 +72,6 @@ object LedgerUtils {
     }
   }
 
-  private def filter(parties: List[String]): TransactionFilter =
+  private def filter(parties: Seq[String]): TransactionFilter =
     TransactionFilter(parties.map(p => p -> Filters()).toMap)
 }

--- a/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
@@ -59,5 +59,23 @@ class ConfigSpec extends AnyFreeSpec with Matchers with OptionValues {
         optConfig.value.end shouldBe LedgerOffset().withAbsolute("00100")
       }
     }
+    "--party" - {
+      val defaultRequiredArgs = outputTypeArgs ++ outputArgs ++ sdkVersionArgs ++ ledgerArgs
+      "--party Alice" in {
+        val args = defaultRequiredArgs ++ Array("--party", "Alice")
+        val optConfig = Config.parse(args)
+        optConfig.value.parties should contain only ("Alice")
+      }
+      "--party Alice --party Bob" in {
+        val args = defaultRequiredArgs ++ Array("--party", "Alice", "--party", "Bob")
+        val optConfig = Config.parse(args)
+        optConfig.value.parties should contain only ("Alice", "Bob")
+      }
+      "--party Alice,Bob" in {
+        val args = defaultRequiredArgs ++ Array("--party", "Alice,Bob")
+        val optConfig = Config.parse(args)
+        optConfig.value.parties should contain only ("Alice", "Bob")
+      }
+    }
   }
 }

--- a/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.export
+
+import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+class ConfigSpec extends AnyFreeSpec with Matchers with OptionValues {
+  private val outputTypeArgs = Array("script")
+  private val outputArgs = Array("--output", "/tmp/out")
+  private val sdkVersionArgs = Array("--sdk-version", "0.0.0")
+  private val ledgerArgs = Array("--host", "localhost", "--port", "6865")
+  private val partyArgs = Array("--party", "Alice")
+  private val defaultRequiredArgs =
+    outputTypeArgs ++ outputArgs ++ sdkVersionArgs ++ ledgerArgs ++ partyArgs
+  "command-line options" - {
+    "--start" - {
+      "--start begin" in {
+        val args = defaultRequiredArgs ++ Array("--start", "begin")
+        val optConfig = Config.parse(args)
+        optConfig.value.start shouldBe LedgerOffset().withBoundary(
+          LedgerOffset.LedgerBoundary.LEDGER_BEGIN
+        )
+      }
+      "--start end" in {
+        val args = defaultRequiredArgs ++ Array("--start", "end")
+        val optConfig = Config.parse(args)
+        optConfig.value.start shouldBe LedgerOffset().withBoundary(
+          LedgerOffset.LedgerBoundary.LEDGER_END
+        )
+      }
+      "--start offset" in {
+        val args = defaultRequiredArgs ++ Array("--start", "00100")
+        val optConfig = Config.parse(args)
+        optConfig.value.start shouldBe LedgerOffset().withAbsolute("00100")
+      }
+    }
+    "--end" - {
+      "--end begin" in {
+        val args = defaultRequiredArgs ++ Array("--end", "begin")
+        val optConfig = Config.parse(args)
+        optConfig.value.end shouldBe LedgerOffset().withBoundary(
+          LedgerOffset.LedgerBoundary.LEDGER_BEGIN
+        )
+      }
+      "--end end" in {
+        val args = defaultRequiredArgs ++ Array("--end", "end")
+        val optConfig = Config.parse(args)
+        optConfig.value.end shouldBe LedgerOffset().withBoundary(
+          LedgerOffset.LedgerBoundary.LEDGER_END
+        )
+      }
+      "--end offset" in {
+        val args = defaultRequiredArgs ++ Array("--end", "00100")
+        val optConfig = Config.parse(args)
+        optConfig.value.end shouldBe LedgerOffset().withAbsolute("00100")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/digital-asset/daml/pull/9446/files/9de406ba6858f37c3c40baf3c6a3cf64d4ef36c4#r616379478

- Users can specify multiple parties using either `--party Alice,Bob` or `--party Alice --party Bob`.
- Adds a test-suite for command-line flag parsing.
- The test-suite highlighted that the `--end` flag was not implemented correctly. This PR fixes that as well.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
