### PR TITLE
Disable migration tests on macos on PRs

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@os_info//:os_info.bzl", "is_windows")
+load("@os_info//:os_info.bzl", "is_linux", "is_windows")
 load("//bazel_tools:testing.bzl", "create_daml_app_codegen", "create_daml_app_dar", "daml_lf_compatible", "sdk_platform_test")
 load(
     "//bazel_tools/daml_script:daml_script.bzl",
@@ -132,8 +132,9 @@ migration_test(
     # Exclusive due to hardcoded postgres ports.
     tags = [
         "exclusive",
-        "head-quick",
-    ],
+    ] +
+    # These tests are fairly slow so on PRs we only run them on Linux
+    (["head-quick"] if is_linux else []),
     versions = stable_versions,
 ) if not is_windows else None
 


### PR DESCRIPTION
We are a bit short on macos nodes and these tests run > 500s so this
should hopefully make things a bit faster. Not necessarily the full
solution, I think we also want to limit the versions here but this is
at least a start.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
