### PR TITLE
LF: SBUKeyBuiltin clean up.

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1165,13 +1165,6 @@ private[lf] object SBuiltin {
     }
   }
 
-  /** $lookupKey[T]
-    *   :: { key: key, maintainers: List Party }
-    *   -> Maybe (ContractId T)
-    */
-  final case class SBULookupKey(templateId: TypeConName)
-      extends SBUKeyBuiltin(new KeyOperation.Lookup(templateId))
-
   /** $insertLookup[T]
     *    :: { key : key, maintainers: List Party}
     *    -> Maybe (ContractId T)
@@ -1340,6 +1333,13 @@ private[lf] object SBuiltin {
     */
   final case class SBUFetchKey(templateId: TypeConName)
       extends SBUKeyBuiltin(new KeyOperation.Fetch(templateId))
+
+  /** $lookupKey[T]
+    *   :: { key: key, maintainers: List Party }
+    *   -> Maybe (ContractId T)
+    */
+  final case class SBULookupKey(templateId: TypeConName)
+      extends SBUKeyBuiltin(new KeyOperation.Lookup(templateId))
 
   /** $getTime :: Token -> Timestamp */
   final case object SBGetTime extends SBuiltin(1) {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -165,7 +165,7 @@ private[lf] object PartialTransaction {
   final case class CompleteTransaction(tx: SubmittedTransaction) extends Result
   final case class IncompleteTransaction(ptx: PartialTransaction) extends Result
 
-  sealed trait KeyMapping
+  sealed abstract class KeyMapping
   // There is no active contract with the given key.
   final case object KeyInactive extends KeyMapping
   // The contract with the given cid is active and has the given key.


### PR DESCRIPTION
This PR some minor clean up for #9537 nd #9538.
    
In particular it:
    
- Refactor the class KeyOperation outside SBUKeyBuiltin

- Renames and refactor methods `handleKeyFound`, `handleKeyArchived`,
     `cidToSValue` and `cidToSExpr` to gave them a more obvious meaning.
    
- Replaces `immutable.Map#+` by `immutable.Map#updated` (cosmetic)
    
- Replaces `trait` by `abstract class` (cosmetic)

- Replaces 'get(???).getOrElse(???)' by `getOrElse(???, ???)` (cosmetic)

CHANGELOG_BEGIN
CHANGELOG_END


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
