### PR TITLE
Add logging command line option to ledger http service, fixes #7198

### DIFF
--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -152,6 +152,7 @@ trait JsonApiFixture
                 override val accessTokenFile = Some(jsonAccessTokenFile)
                 override val allowNonHttps = true
                 override val nonRepudiation = nonrepudiation.Configuration.Cli.Empty
+                override val logLevel = None
               }
               HttpService
                 .start(config)(

--- a/ledger-service/http-json-cli/BUILD.bazel
+++ b/ledger-service/http-json-cli/BUILD.bazel
@@ -20,6 +20,7 @@ da_scala_library(
         "//ledger-service/cli-opts",
         "//ledger-service/utils",
         "//ledger/ledger-api-common",
+        "@maven//:ch_qos_logback_logback_classic",
         "@maven//:io_netty_netty_handler",
         "@maven//:org_slf4j_slf4j_api",
     ],

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
@@ -17,6 +17,8 @@ import scalaz.{Show, \/}
 import scala.concurrent.duration._
 import scala.util.Try
 
+import ch.qos.logback.classic.{Level => LogLevel}
+
 // The internal transient scopt structure *and* StartSettings; external `start`
 // users should extend StartSettings or DefaultStartSettings themselves
 private[http] final case class Config(
@@ -36,6 +38,7 @@ private[http] final case class Config(
     accessTokenFile: Option[Path] = None,
     wsConfig: Option[WebsocketConfig] = None,
     nonRepudiation: nonrepudiation.Configuration.Cli = nonrepudiation.Configuration.Cli.Empty,
+    logLevel: Option[LogLevel] = None, // the default is in logback.xml
 ) extends StartSettings
 
 private[http] object Config {

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/StartSettings.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/StartSettings.scala
@@ -9,6 +9,8 @@ import com.daml.ledger.api.tls.TlsConfiguration
 
 import scala.concurrent.duration.FiniteDuration
 
+import ch.qos.logback.classic.{Level => LogLevel}
+
 // defined separately from Config so
 //  1. it is absolutely lexically apparent what `import startSettings._` means
 //  2. avoid incorporating other Config'd things into "the shared args to start"
@@ -28,6 +30,7 @@ trait StartSettings {
   val maxInboundMessageSize: Int
   val healthTimeoutSeconds: Int
   val nonRepudiation: nonrepudiation.Configuration.Cli
+  val logLevel: Option[LogLevel]
 }
 
 object StartSettings {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -30,6 +30,23 @@ object Main extends StrictLogging {
     val StartupError = 101
   }
 
+  // TODO: Refactor out as this is duplicated from the sandbox code
+  object Logging {
+
+    import ch.qos.logback.classic.{Level => LogLevel}
+    import org.slf4j.{Logger, LoggerFactory}
+
+    def setGlobalLogLevel(verbosity: LogLevel): Unit = {
+      LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) match {
+        case rootLogger: ch.qos.logback.classic.Logger =>
+          rootLogger.setLevel(verbosity)
+          rootLogger.info(s"Verbosity changed to $verbosity")
+        case _ =>
+          logger.warn(s"Verbosity cannot be set to requested $verbosity")
+      }
+    }
+  }
+
   def main(args: Array[String]): Unit =
     Cli.parseConfig(
       args,
@@ -43,6 +60,7 @@ object Main extends StrictLogging {
     }
 
   private def main(config: Config): Unit = {
+    config.logLevel.foreach(Logging.setGlobalLogLevel(_))
     logger.info(
       s"Config(ledgerHost=${config.ledgerHost: String}, ledgerPort=${config.ledgerPort: Int}" +
         s", address=${config.address: String}, httpPort=${config.httpPort: Int}" +

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
@@ -27,6 +27,48 @@ final class CliSpec extends AnyFreeSpec with Matchers {
   val sharedOptions =
     Seq("--ledger-host", "localhost", "--ledger-port", "6865", "--http-port", "7500")
 
+  "LogLevel" - {
+    import ch.qos.logback.classic.{Level => LogLevel}
+
+    def logLevelArgs(level: String) = Seq("--log-level", level)
+
+    def checkLogLevelWorks(level: String, expected: LogLevel) = {
+      val config = configParser(logLevelArgs(level) ++ sharedOptions)
+        .getOrElse(fail())
+      config.logLevel shouldBe Some(expected)
+    }
+
+    "should get the error log level from the command line argument when provided" in {
+      checkLogLevelWorks("error", LogLevel.ERROR)
+    }
+
+    "should get the warn log level from the command line argument when provided" in {
+      checkLogLevelWorks("warn", LogLevel.WARN)
+    }
+
+    "should get the info log level from the command line argument when provided" in {
+      checkLogLevelWorks("info", LogLevel.INFO)
+    }
+
+    "should get the debug log level from the command line argument when provided" in {
+      checkLogLevelWorks("debug", LogLevel.DEBUG)
+    }
+
+    "should get the trace log level from the command line argument when provided" in {
+      checkLogLevelWorks("trace", LogLevel.TRACE)
+    }
+
+    "shouldn't get a config parser result if an invalid log level is provided via a command line argument" in {
+      val config = configParser(logLevelArgs("SUPERFANCYLOGLEVEL") ++ sharedOptions)
+      config shouldBe None
+    }
+
+    "should get a config parser result if no log level is provided via a command line argument" in {
+      val config = configParser(sharedOptions).getOrElse(fail())
+      config.logLevel shouldBe None
+    }
+  }
+
   "JdbcConfig" - {
     "should get the jdbc string from the command line argument when provided" in {
       val config = configParser(Seq("--query-store-jdbc-config", jdbcConfigString) ++ sharedOptions)


### PR DESCRIPTION
May solve #7198.

This adds the `--log-level` cli argument to the http json ledger service, which allows configuring the log level. Valid values are `error`, `warn`, `info` (default), `debug`, `trace`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [x] If necessary, did you manually test?

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
