### PR TITLE
Ledger API Server: Named threadpools

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/AsyncSupport.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/AsyncSupport.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.Executors
 import com.codahale.metrics.{InstrumentedExecutorService, MetricRegistry}
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.metrics.MetricName
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -20,10 +21,14 @@ object AsyncSupport {
 
   def asyncPool(
       size: Int,
+      namePrefix: String,
       withMetric: Option[(MetricName, MetricRegistry)] = None,
   ): ResourceOwner[Executor] =
     ResourceOwner.forCloseable { () =>
-      val executor = Executors.newFixedThreadPool(size)
+      val executor = Executors.newFixedThreadPool(
+        size,
+        new ThreadFactoryBuilder().setNameFormat(s"$namePrefix-%d").build,
+      )
       val workerE = withMetric match {
         case Some((metricName, metricRegistry)) =>
           new InstrumentedExecutorService(

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -48,10 +48,12 @@ object ParallelIndexerFactory {
     for {
       inputMapperExecutor <- asyncPool(
         inputMappingParallelism,
+        "input-mapping-pool",
         Some(metrics.daml.parallelIndexer.inputMapping.executor -> metrics.registry),
       )
       batcherExecutor <- asyncPool(
         batchingParallelism,
+        "batching-pool",
         Some(metrics.daml.parallelIndexer.batching.executor -> metrics.registry),
       )
       dbDispatcher <- DbDispatcher

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -342,6 +342,7 @@ final private[kvutils] class PackageCommitter(
     Executors.newSingleThreadExecutor { (runnable: Runnable) =>
       val t = new Thread(runnable)
       t.setDaemon(true)
+      t.setName("package-preload-executor")
       t
     }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -340,9 +340,8 @@ final private[kvutils] class PackageCommitter(
 
   private lazy val preloadExecutor =
     Executors.newSingleThreadExecutor { (runnable: Runnable) =>
-      val t = new Thread(runnable)
+      val t = new Thread(runnable, "package-preload-executor")
       t.setDaemon(true)
-      t.setName("package-preload-executor")
       t
     }
 

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ProgramResource.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ProgramResource.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.{Executors, TimeUnit}
 import com.daml.logging.ContextualizedLogger
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.resources.ProgramResource._
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -20,7 +21,11 @@ final class ProgramResource[Context: HasExecutionContext, T](
 ) {
   private val logger = ContextualizedLogger.get(getClass)
 
-  private val executorService = Executors.newCachedThreadPool()
+  private val executorService = Executors.newCachedThreadPool(
+    new ThreadFactoryBuilder()
+      .setNameFormat("program-resource-pool-%d")
+      .build()
+  )
 
   def run(newContext: ExecutionContext => Context): Unit = {
     newLoggingContext { implicit loggingContext =>
@@ -72,4 +77,5 @@ object ProgramResource {
   trait SuppressedStartupException {
     self: Exception =>
   }
+
 }


### PR DESCRIPTION
Some cached threadpools weren't given names, meaning at runtime there
are a bunch of pool-x-thread-y threads. This makes it hard to understand
which threads are being used for what.

The following pool names were introduced:

append-only indexer: input-mapping-pool, batching-pool
ProgramResource: program-resource-pool
kvutils PackageCommitter: package-preload-executor

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
