### PR TITLE
Handle rollback nodes in protoNodeInfo

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -49,7 +49,7 @@ object Node {
   /** action nodes parametrized over identifier type */
   sealed abstract class GenActionNode[+Nid, +Cid]
       extends GenNode[Nid, Cid]
-      with NodeInfo
+      with ActionNodeInfo
       with CidContainer[GenActionNode[Nid, Cid]] {
 
     def templateId: TypeConName
@@ -231,7 +231,7 @@ object Node {
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
   ) extends LeafOnlyActionNode[Cid]
-      with NodeInfo.Create {
+      with ActionNodeInfo.Create {
 
     override def byKey: Boolean = false
 
@@ -261,7 +261,7 @@ object Node {
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
   ) extends LeafOnlyActionNode[Cid]
-      with NodeInfo.Fetch {
+      with ActionNodeInfo.Fetch {
 
     override private[lf] def updateVersion(version: TransactionVersion): NodeFetch[Cid] =
       copy(version = version)
@@ -293,7 +293,7 @@ object Node {
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
   ) extends GenActionNode[Nid, Cid]
-      with NodeInfo.Exercise {
+      with ActionNodeInfo.Exercise {
     @deprecated("use actingParties instead", since = "1.1.2")
     private[daml] def controllers: actingParties.type = actingParties
 
@@ -320,7 +320,7 @@ object Node {
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
   ) extends LeafOnlyActionNode[Cid]
-      with NodeInfo.LookupByKey {
+      with ActionNodeInfo.LookupByKey {
 
     override def keyMaintainers: Set[Party] = key.maintainers
     override def hasResult: Boolean = result.isDefined

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/NodeInfo.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/NodeInfo.scala
@@ -5,15 +5,15 @@ package com.daml.lf.transaction
 
 import com.daml.lf.data.Ref.Party
 
-/** Trait for extracting information from an abstract node.
+/** Trait for extracting information from an abstract action node.
   * Used for sharing the implementation of common computations
   * over nodes and transactions.
   *
   * External codebases use these utilities on transaction and
-  * node implementations that are not the one defined by [[Node]]
+  * node implementations that are not the one defined by [[ActionNode]]
   * and hence the need for the indirection.
   */
-trait NodeInfo {
+trait ActionNodeInfo {
 
   /** Compute the informees of a node based on the ledger model definition.
     *
@@ -33,9 +33,9 @@ trait NodeInfo {
   def requiredAuthorizers: Set[Party]
 }
 
-object NodeInfo {
+object ActionNodeInfo {
 
-  trait Create extends NodeInfo {
+  trait Create extends ActionNodeInfo {
     def signatories: Set[Party]
     def stakeholders: Set[Party]
 
@@ -43,7 +43,7 @@ object NodeInfo {
     final def informeesOfNode: Set[Party] = stakeholders
   }
 
-  trait Fetch extends NodeInfo {
+  trait Fetch extends ActionNodeInfo {
     def signatories: Set[Party]
     def stakeholders: Set[Party]
     def actingParties: Set[Party]
@@ -55,7 +55,7 @@ object NodeInfo {
 
   }
 
-  trait Exercise extends NodeInfo {
+  trait Exercise extends ActionNodeInfo {
 
     def consuming: Boolean
     def signatories: Set[Party]
@@ -72,7 +72,7 @@ object NodeInfo {
         signatories | actingParties | choiceObservers
   }
 
-  trait LookupByKey extends NodeInfo {
+  trait LookupByKey extends ActionNodeInfo {
     def keyMaintainers: Set[Party]
     def hasResult: Boolean
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -787,28 +787,33 @@ object TransactionCoder {
     else
       decodeVersion(node.getVersion)
 
-  /** Node information for a serialized transaction node. Used to compute
+  /** Action node information for a serialized transaction node. Used to compute
     * informees when deserialization is too costly.
     * This method is not supported for transaction version <5 (as NodeInfo does not support it).
     * We're not using e.g. "implicit class" in order to keep the decoding errors explicit.
     * NOTE(JM): Currently used only externally, but kept here to keep in sync
     * with the implementation.
+    * Note that this can only be applied to action nodes and will return Left on
+    * rollback nodes.
     */
-  def protoNodeInfo(
+  def protoActionNodeInfo(
       txVersion: TransactionVersion,
       protoNode: TransactionOuterClass.Node,
-  ): Either[DecodeError, NodeInfo] =
+  ): Either[DecodeError, ActionNodeInfo] =
     protoNode.getNodeTypeCase match {
       case NodeTypeCase.ROLLBACK =>
-        // TODO https://github.com/digital-asset/daml/issues/8020
-        sys.error("protoNodeInfo, rollback nodes are not supported")
+        Left(
+          DecodeError(
+            "protoActionNodeInfo only supports action nodes but was applied to a rollback node"
+          )
+        )
       case NodeTypeCase.CREATE =>
         val protoCreate = protoNode.getCreate
         for {
           signatories_ <- toPartySet(protoCreate.getSignatoriesList)
           stakeholders_ <- toPartySet(protoCreate.getStakeholdersList)
         } yield {
-          new NodeInfo.Create {
+          new ActionNodeInfo.Create {
             def signatories = signatories_
             def stakeholders = stakeholders_
           }
@@ -820,7 +825,7 @@ object TransactionCoder {
           stakeholders_ <- toPartySet(protoFetch.getStakeholdersList)
           signatories_ <- toPartySet(protoFetch.getSignatoriesList)
         } yield {
-          new NodeInfo.Fetch {
+          new ActionNodeInfo.Fetch {
             def signatories = signatories_
             def stakeholders = stakeholders_
             def actingParties = actingParties_
@@ -839,7 +844,7 @@ object TransactionCoder {
             else
               toPartySet(protoExe.getObserversList)
         } yield {
-          new NodeInfo.Exercise {
+          new ActionNodeInfo.Exercise {
             def signatories = signatories_
             def stakeholders = stakeholders_
             def actingParties = actingParties_
@@ -853,7 +858,7 @@ object TransactionCoder {
         for {
           maintainers <- toPartySet(protoLookupByKey.getKeyWithMaintainers.getMaintainersList)
         } yield {
-          new NodeInfo.LookupByKey {
+          new ActionNodeInfo.LookupByKey {
             def hasResult = protoLookupByKey.hasContractIdStruct
             def keyMaintainers = maintainers
           }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -71,7 +71,7 @@ class TransactionCoderSpec
 
           Right(createNode.informeesOfNode) shouldEqual
             TransactionCoder
-              .protoNodeInfo(txVersion, encodedNode)
+              .protoActionNodeInfo(txVersion, encodedNode)
               .map(_.informeesOfNode)
       }
     }
@@ -100,7 +100,7 @@ class TransactionCoderSpec
             ) shouldBe Right((NodeId(0), normalizeFetch(versionedNode)))
           Right(fetchNode.informeesOfNode) shouldEqual
             TransactionCoder
-              .protoNodeInfo(txVersion, encodedNode)
+              .protoActionNodeInfo(txVersion, encodedNode)
               .map(_.informeesOfNode)
       }
     }
@@ -128,7 +128,7 @@ class TransactionCoderSpec
 
           Right(normalizedNode.informeesOfNode) shouldEqual
             TransactionCoder
-              .protoNodeInfo(txVersion, encodedNode)
+              .protoActionNodeInfo(txVersion, encodedNode)
               .map(_.informeesOfNode)
       }
     }


### PR DESCRIPTION
This PR clarifies that NodeInfo is only intended for actions by
renaming it to ActionNodeInfo and correspondingly also changes
protoNodeInfo to protoActionNodeInfo and makes it return a `Left` for
rollback nodes.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
