### PR TITLE
Support mapping from old to new party ids in daml exports

### DIFF
--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -41,7 +41,7 @@ private[export] object Encode {
       Doc.hardLine +
       encodeContractsType() /
       Doc.hardLine +
-      encodeGetContract() /
+      encodeLookupContract() /
       Doc.hardLine +
       encodeArgsType() /
       Doc.hardLine +
@@ -79,10 +79,10 @@ private[export] object Encode {
         Doc.text("parties : Parties") /
         Doc.text("contracts : Contracts")).nested(2)
 
-  private def encodeGetContract(): Doc =
+  private def encodeLookupContract(): Doc =
     Doc.text("-- | Look-up a replacement for a missing contract id. Fails if none is found.") /
-      Doc.text("getContract : DA.Stack.HasCallStack => Text -> Contracts -> ContractId a") /
-      (Doc.text("getContract old contracts =") /
+      Doc.text("lookupContract : DA.Stack.HasCallStack => Text -> Contracts -> ContractId a") /
+      (Doc.text("lookupContract old contracts =") /
         (Doc.text("case DA.TextMap.lookup old contracts of") /
           Doc.text("None -> error (\"Missing contract id \" <> old)") /
           Doc.text("Some new -> coerceContractId new")).nested(2)).nested(2)
@@ -256,7 +256,7 @@ private[export] object Encode {
     // LedgerStrings are strings that match the regexp ``[A-Za-z0-9#:\-_/ ]+
     cidMap.get(cid) match {
       case Some(value) => Doc.text(value)
-      case None => parens("getContract" &: quotes(Doc.text(cid.toString)) :& "contracts")
+      case None => parens("lookupContract" &: quotes(Doc.text(cid.toString)) :& "contracts")
     }
   }
 

--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -104,7 +104,7 @@ private[export] object Encode {
   private def encodeAllocateParties(partyMap: Map[Party, String]): Doc =
     Doc.text("-- | Allocates fresh parties from the party management service.") /
       Doc.text("allocateParties : Script Parties") /
-      Doc.text("allocateParties = mapA allocateParty (DA.TextMap.fromList") /
+      Doc.text("allocateParties = DA.Traversable.mapA allocateParty (DA.TextMap.fromList") /
       ("[" &: Doc.intercalate(
         Doc.hardLine :+ ", ",
         partyMap.keys.map { case Party(p) =>

--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -21,8 +21,8 @@ private[export] object Encode {
 
   def encodeArgs(export: Export): JsObject = {
     JsObject(
-      "parties" -> JsObject(export.partyMap.map { case (Party(party), binding) =>
-        binding -> JsString(party)
+      "parties" -> JsObject(export.partyMap.keys.map { case Party(party) =>
+        party -> JsString(party)
       }.toMap),
       "contracts" -> JsObject(export.unknownCids.map { case ContractId(c) =>
         c -> JsString(c)

--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -35,7 +35,7 @@ private[export] object Encode {
       Doc.hardLine +
       encodePartyType() /
       Doc.hardLine +
-      encodeGetParty() /
+      encodeLookupParty() /
       Doc.hardLine +
       encodeAllocateParties(export.partyMap) /
       Doc.hardLine +
@@ -62,7 +62,7 @@ private[export] object Encode {
   }
 
   private def encodePartyBinding(party: Party, binding: String): Doc =
-    s"let $binding = getParty" &: quotes(Doc.text(Party.unwrap(party))) :& "parties"
+    s"let $binding = lookupParty" &: quotes(Doc.text(Party.unwrap(party))) :& "parties"
 
   private def encodeTestExport(): Doc =
     Doc.text("-- | Test 'export' with freshly allocated parties and") /
@@ -113,10 +113,10 @@ private[export] object Encode {
         },
       ) :& "])").indent(2)
 
-  private def encodeGetParty(): Doc =
+  private def encodeLookupParty(): Doc =
     Doc.text("-- | Look-up a party based on the party name in the original ledger state.") /
-      Doc.text("getParty : DA.Stack.HasCallStack => Text -> Parties -> Party") /
-      (Doc.text("getParty old parties =") /
+      Doc.text("lookupParty : DA.Stack.HasCallStack => Text -> Parties -> Party") /
+      (Doc.text("lookupParty old parties =") /
         (Doc.text("case DA.TextMap.lookup old parties of") /
           Doc.text("None -> error (\"Missing party \" <> old)") /
           Doc.text("Some new -> new")).nested(2)).nested(2)

--- a/daml-script/export/src/main/scala/com/daml/script/export/Export.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Export.scala
@@ -64,6 +64,7 @@ object Export {
     val usesSetTime = actions.any(_.isInstanceOf[SetTime])
     val timeRefs: Set[String] = if (usesSetTime) { Set("DA.Date", "DA.Time") }
     else { Set.empty }
+    val partiesModuleRefs = Set[String]("DA.Traversable")
     val unknownContractModuleRefs = Set[String]("DA.Stack", "DA.TextMap")
 
     Export(
@@ -71,7 +72,8 @@ object Export {
       cidMap = cidMap,
       unknownCids = cidRefs -- cidMap.keySet,
       cidRefs = cidRefs,
-      moduleRefs = refs.map(_.moduleName).toSet ++ timeRefs ++ unknownContractModuleRefs,
+      moduleRefs =
+        refs.map(_.moduleName).toSet ++ timeRefs ++ partiesModuleRefs ++ unknownContractModuleRefs,
       actions = actions,
     )
   }

--- a/docs/source/tools/export.rst
+++ b/docs/source/tools/export.rst
@@ -59,8 +59,14 @@ Daml Script
 
 The generated Daml code in ``Export.daml`` contains the following top-level definitions:
 
-``data Parties``
-  A record that holds the relevant Daml parties.
+``type Parties``
+  A mapping from parties in the original ledger state to parties to be used in
+  the new reconstructed ledger state.
+``lookupParty : Text -> Parties -> Party``
+  A helper function to look up parties in the ``Parties`` mapping.
+``allocateParties : Script Parties``
+  A Daml script that allocates fresh parties on the ledger and returns them in
+  a ``Parties`` mapping.
 ``type Contracts``
   A mapping from unknown contract ids to replacement contract ids,
   see :ref:`unknown contract ids <export-unknown-cids>`.
@@ -73,6 +79,11 @@ The generated Daml code in ``Export.daml`` contains the following top-level defi
   this script will reproduce the ledger state when executed. You can read this
   script to understand the exported ledger state or history, and you can modify
   this script for debugging or testing purposes.
+``testExport : Script ()``
+  A Daml script that will first invoke ``allocateParties`` and then ``export``.
+  It will use an empty ``Contracts`` mapping. This can be useful to test the
+  export in Daml studio. If your export references unknown contract ids then
+  you may need to manually extend the ``Contracts`` mapping.
 
 In most simple cases the generated Daml script will use the functions
 ``submit`` or ``submitMulti`` to issue ledger commands that reproduce a
@@ -115,8 +126,8 @@ state and to map unknown contract ids to themselves. For example:
       "001335..": "001335..."
     },
     "parties": {
-      "alice_0": "Alice",
-      "bob_0": "Bob"
+      "Alice": "Alice",
+      "Bob": "Bob"
     }
   }
 

--- a/docs/source/tools/export.rst
+++ b/docs/source/tools/export.rst
@@ -70,7 +70,7 @@ The generated Daml code in ``Export.daml`` contains the following top-level defi
 ``type Contracts``
   A mapping from unknown contract ids to replacement contract ids,
   see :ref:`unknown contract ids <export-unknown-cids>`.
-``getContract : Text -> Contracts -> ContractId a``
+``lookupContract : Text -> Contracts -> ContractId a``
   A helper function to look up unknown contract ids in the ``Contracts`` mapping.
 ``data Args``
   A record that holds all arguments to the export script.


### PR DESCRIPTION
Closes #9453

- The `Parties` argument is now a `TextMap` mapping from old party names to new party names.
- Defines a helper `lookupParty` in the generated Daml script similar to `getContract`. Uses `lookupParty` instead of `getParty` because the latter would collide with the corresponding function in `Prelude`.
- Renames `getContract` to `lookupContract` for consistency.
- Updates the documentation for daml ledger export

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
