### PR TITLE
Determine rollback node version from non-empty children

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -574,7 +574,11 @@ private[lf] case class PartialTransaction(
         // TODO https://github.com/digital-asset/daml/issues/8020
         //  the version of a rollback node should be determined from its children.
         //  in the case of there being no children we can simple drop the entire rollback node.
-        val rollbackNode = Node.NodeRollback(context.children.toImmArray, TxVersion.VDev)
+        // NICK - drop node when no there are no children
+        val rollbackNode = Node.NodeRollback(
+          context.children.toImmArray,
+          TxVersion.VDev, // NICK: determine version as max of non-empty child version.
+        )
         copy(
           context = info.parent.addRollbackChild(info.nodeId, context.nextActionChildIdx),
           nodes = nodes.updated(info.nodeId, rollbackNode),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -573,16 +573,19 @@ private[lf] case class PartialTransaction(
       case info: TryContextInfo =>
         // TODO https://github.com/digital-asset/daml/issues/8020
         //  the version of a rollback node should be determined from its children.
-        //  in the case of there being no children we can simple drop the entire rollback node.
-        // NICK - drop node when no there are no children
-        val rollbackNode = Node.NodeRollback(
-          context.children.toImmArray,
-          TxVersion.VDev, // NICK: determine version as max of non-empty child version.
-        )
-        copy(
-          context = info.parent.addRollbackChild(info.nodeId, context.nextActionChildIdx),
-          nodes = nodes.updated(info.nodeId, rollbackNode),
-        ).resetActiveState(info.beginState)
+        if (context.children.isEmpty) {
+          // in the case of there being no children, we drop the entire rollback node.
+          endTry
+        } else {
+          val rollbackNode = Node.NodeRollback(
+            context.children.toImmArray,
+            TxVersion.VDev, // NICK: determine version as max of non-empty child version.
+          )
+          copy(
+            context = info.parent.addRollbackChild(info.nodeId, context.nextActionChildIdx),
+            nodes = nodes.updated(info.nodeId, rollbackNode),
+          ).resetActiveState(info.beginState)
+        }
       case _ =>
         noteAbort(Tx.NonCatchContext)
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -222,7 +222,7 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
     ("create3throwAndOuterCatch", List[Tree](R(List(C(100), C(200))), C(300))),
     ("exer1", List[Tree](C(100), X(List(C(400), C(500))), C(200), C(300))),
     ("exer2", List[Tree](C(100), R(List(X(List(C(400))))), C(300))),
-    ("emptyRollback", List[Tree](C(100), R(List()), C(300))),
+    ("emptyRollback", List[Tree](C(100), C(300))),
   )
 
   forEvery(testCases) { (exp: String, expected: List[Tree]) =>

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -201,11 +201,11 @@ final class TransactionBuilder(
 
   def rollback(): Rollback =
     Rollback(
-      children = ImmArray.empty,
+      children = ImmArray.empty, //NICK, breaks invariant; matters? should we add a child?
       // TODO https://github.com/digital-asset/daml/issues/8020
       //  the version of a rollback node should be determined from its children.
       //  in the case of there being no children we can simple drop the entire rollback node.
-      version = TransactionVersion.VDev,
+      version = TransactionVersion.VDev, // NICK: determine correct version here?
     )
 }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -372,6 +372,9 @@ object Node {
       children: ImmArray[Nid],
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
+      // Invariants.
+      // -- There must be at least one child node.
+      // -- The version must equal the maximum of the versions of the children.
   ) extends GenNode[Nid, Nothing] {
 
     override private[lf] def updateVersion(version: TransactionVersion): NodeRollback[Nid] =

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -270,7 +270,7 @@ object TransactionCoder {
             _ <- Either.cond(
               test = nr.children.nonEmpty,
               right = (),
-              left = EncodeError("rollback node with no children"), //NICK, test this check
+              left = EncodeError("rollback node with no children"),
             )
             _ <- Either.cond(
               test = nr.version >= TransactionVersion.minExceptions || disableVersionCheck,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -268,6 +268,11 @@ object TransactionCoder {
           nr.children.foreach { id => builder.addChildren(encodeNid.asString(id)); () }
           for {
             _ <- Either.cond(
+              test = nr.children.nonEmpty,
+              right = (),
+              left = EncodeError("rollback node with no children"), //NICK, test this check
+            )
+            _ <- Either.cond(
               test = nr.version >= TransactionVersion.minExceptions || disableVersionCheck,
               right = (),
               left = EncodeError(node.version, isTooOldFor = "rollback nodes"),
@@ -470,6 +475,7 @@ object TransactionCoder {
         for {
           _ <- Either.cond(
             test = nodeVersion >= TransactionVersion.minExceptions,
+            // NICK, check version matches max of children & test
             right = (),
             left = DecodeError(
               s"rollback node (supported since ${TransactionVersion.minExceptions}) unexpected in transaction of version $nodeVersion"


### PR DESCRIPTION
Done
- invariant: rollback nodes have non-empty children
- check this invariant on encode/decode & test the checks
- adapt scalacheck generators so existing tests continue to pass
- don't create empty rollback nodes when constructing a transaction from speedy; and test

TODO:
- invariant: rollback node version is the max version of its children
- encode/decode checks
- tests


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
