### PR TITLE
Drop todo for conversion of exception primitives

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -415,8 +415,6 @@ convertPrim _ "BEArithmeticErrorMessage" (TBuiltin BTArithmeticError :-> TText) 
 convertPrim _ "BEContractErrorMessage" (TBuiltin BTContractError :-> TText) =
     EBuiltin BEContractErrorMessage
 
--- TODO #8020 https://github.com/digital-asset/daml/issues/8020
--- Handle these three in LFConversion.hs and check that ty1 is an exception type.
 convertPrim _ "EThrow" (ty1 :-> ty2) =
     ETmLam (mkVar "x", ty1) (EThrow ty2 ty1 (EVar (mkVar "x")))
 convertPrim _ "EToAnyException" (ty :-> TBuiltin BTAnyException) =


### PR DESCRIPTION
While there might be nicer ways to do this, the current way is
consistent what we do for example with `create` which seems pretty
comparable and the check that `ty1` is an exception type happens in
the LF typechecker (again consistent with how we check for create that
the type is a template type) so this seems fine.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
