### PR TITLE
Filter divulgence to an empty set of parties

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/BlindingSpec.scala
@@ -81,13 +81,13 @@ class BlindingSpec extends AnyFreeSpec with Matchers {
   }
   "fetch" in {
     val builder = TransactionBuilder()
-    val (cid, createNode) = create(builder)
+    val (_, createNode) = create(builder)
     val fetch = builder.fetch(createNode)
     val nodeId = builder.add(fetch)
     val blindingInfo = Blinding.blind(builder.build())
     blindingInfo shouldBe BlindingInfo(
       disclosure = Map(nodeId -> Set("Bob", "Alice")),
-      divulgence = Map(cid -> Set()),
+      divulgence = Map.empty,
     )
   }
   "lookupByKey found" in {
@@ -188,8 +188,7 @@ class BlindingSpec extends AnyFreeSpec with Matchers {
         c4Id -> Set("A", "B", "D"),
       ),
       divulgence = Map(
-        create1.coid -> Set(),
-        create2.coid -> Set("A"),
+        create2.coid -> Set("A")
       ),
     )
   }
@@ -232,8 +231,7 @@ class BlindingSpec extends AnyFreeSpec with Matchers {
         ex2 -> Set("A", "B", "C", "D", "F"),
       ),
       divulgence = Map(
-        cid1 -> Set(),
-        cid2 -> Set("A", "B", "C"),
+        cid2 -> Set("A", "B", "C")
       ),
     )
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -33,7 +33,6 @@ object BlindingTransaction {
       if (disclosures.contains(nid))
         crash(s"discloseNode: nodeId already processed '$nid'.")
       // Each node should be visible to someone
-      assert(witnesses.nonEmpty, s"No witnesses for $nid")
       copy(
         disclosures = disclosures.updated(nid, witnesses)
       )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -32,16 +32,22 @@ object BlindingTransaction {
     ): BlindState = {
       if (disclosures.contains(nid))
         crash(s"discloseNode: nodeId already processed '$nid'.")
+      // Each node should be visible to someone
+      assert(witnesses.nonEmpty, s"No witnesses for $nid")
       copy(
         disclosures = disclosures.updated(nid, witnesses)
       )
     }
 
     def divulgeCoidTo(witnesses: Set[Party], acoid: ContractId): BlindState = {
-      copy(
-        divulgences = divulgences
-          .updated(acoid, witnesses union divulgences.getOrElse(acoid, Set.empty))
-      )
+      if (witnesses.nonEmpty) {
+        copy(
+          divulgences = divulgences
+            .updated(acoid, witnesses union divulgences.getOrElse(acoid, Set.empty))
+        )
+      } else {
+        this
+      }
     }
 
   }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
@@ -24,7 +24,11 @@ import com.daml.lf.value.Value.ContractId
   * See also https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
   *
   * @param disclosure Disclosure, specified in terms of local transaction node IDs
-  *  Each node in the transaction will be mapped to a non-empty set of witnesses.
+  *  Each node in the transaction will be mapped to a non-empty set of witnesses
+  *  for ledger API transactions.
+  *  Scenarios unfortunately break this invariant and we can have rollback nodes
+  *  at the top with an empty set of witnesses. We still include those
+  *  in the map here.
   * @param divulgence
   *     Divulgence, specified in terms of contract IDs.
   *     Note that if this info was produced by blinding a transaction

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
@@ -24,11 +24,15 @@ import com.daml.lf.value.Value.ContractId
   * See also https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
   *
   * @param disclosure Disclosure, specified in terms of local transaction node IDs
+  *  Each node in the transaction will be mapped to a non-empty set of witnesses.
   * @param divulgence
   *     Divulgence, specified in terms of contract IDs.
   *     Note that if this info was produced by blinding a transaction
   *     containing only contract ids, this map may also
   *     contain contracts produced in the same transaction.
+  *     We only include contracts that are divulged to a
+  *     non-empty set of parties since there is no difference
+  *     between not divulging a contract and divulging it to no one.
   */
 final case class BlindingInfo(
     disclosure: Relation[NodeId, Party],

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/TransactionConversionSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/TransactionConversionSpec.scala
@@ -130,7 +130,8 @@ final class TransactionConversionSpec extends AnyWordSpec with Matchers {
     "remove rollback nodes" in {
       val builder = TransactionBuilder()
       builder.add(create(builder, "#1"))
-      val rollback = builder.add(builder.rollback())
+      val rollbackParent = builder.add(exercise(builder, "#0"))
+      val rollback = builder.add(builder.rollback(), rollbackParent)
       builder.add(create(builder, "#2"), rollback)
       builder.add(exercise(builder, "#1"), rollback)
       val ex = builder.add(exercise(builder, "#1"))
@@ -146,8 +147,9 @@ final class TransactionConversionSpec extends AnyWordSpec with Matchers {
         .get
         .eventsById shouldBe Map(
         "#transactionId:0" -> createdEv("0", "#1"),
-        "#transactionId:4" -> exercisedEv("4", "#1", Seq("5")),
-        "#transactionId:5" -> createdEv("5", "#3"),
+        "#transactionId:1" -> exercisedEv("1", "#0", Seq.empty),
+        "#transactionId:5" -> exercisedEv("5", "#1", Seq("6")),
+        "#transactionId:6" -> createdEv("6", "#3"),
       )
     }
   }


### PR DESCRIPTION
As @nmarton-da noticed painfully, we currently include divulgence to
an empty set of parties. While this is arguably not wrong it is at
least confusing and useless. The whole point of divulgence is to track
visibility. Divulging to an empty set of parties does not affect
visibility so it is not meaningfully different from no
divulgence. Therefore this PR filters it out and adds a doc comment
that the list of divulgees is always non-empty.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
