### PR TITLE
participant-integration-api: Avoid the serial EC in integration testing.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -113,7 +113,7 @@ private[daml] object ApiServices {
             optWriteService,
             timeProvider,
             ledgerConfiguration,
-          )(materializer, servicesExecutionContext, loggingContext)
+          )(materializer, loggingContext)
           .acquire()
         services <- Resource(
           Future(createServices(ledgerId, ledgerConfigProvider)(servicesExecutionContext))


### PR DESCRIPTION
The behavior of LedgerConfigProvider is time-sensitive at startup. The test was accidentally supplying the serial execution context, which meant that the initialization process could be blocked by a lack of available threads, causing the wrong result.

Switching to the materializer's execution context avoids this issue in testing, and does not impact production logic.

In general, resource owners should not accept execution contexts implicitly. Looks like I added this one, so everyone else is off the hook. I will punish myself by ordering a pizza. :pizza: 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
