### PR TITLE
check whether collection.compat is unused when compiling for Scala 2.12

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -30,6 +30,11 @@ load("@scala_version//:index.bzl", "scala_major_version", "scala_major_version_s
 def resolve_scala_deps(deps, scala_deps = [], versioned_scala_deps = {}):
     return deps + ["{}_{}".format(d, scala_major_version_suffix) for d in scala_deps + versioned_scala_deps.get(scala_major_version, [])]
 
+def extra_scalacopts(scala_deps, plugins):
+    return (["-P:silencer:lineContentFilters=import scala.collection.compat._"] if (scala_major_version != "2.12" and
+                                                                                    silencer_plugin in plugins and
+                                                                                    "@maven//:org_scala_lang_modules_scala_collection_compat" in scala_deps) else [])
+
 version_specific = {
     "2.12": [
         # these two flags turn on source-incompatible enhancements that are always
@@ -213,9 +218,10 @@ def _wrap_rule(
     exports = resolve_scala_deps(exports, scala_exports)
     if (len(exports) > 0):
         kwargs["exports"] = exports
+    compat_scalacopts = extra_scalacopts(scala_deps = scala_deps, plugins = plugins)
     rule(
         name = name,
-        scalacopts = common_scalacopts + plugin_scalacopts + scalacopts,
+        scalacopts = common_scalacopts + plugin_scalacopts + compat_scalacopts + scalacopts,
         plugins = common_plugins + plugins,
         deps = deps,
         runtime_deps = runtime_deps,
@@ -497,15 +503,15 @@ Arguments:
 """
 
 def _create_scaladoc_jar(name, srcs, plugins = [], deps = [], scala_deps = [], versioned_scala_deps = {}, scalacopts = [], generated_srcs = [], **kwargs):
-    deps = resolve_scala_deps(deps, scala_deps, versioned_scala_deps)
-
     # Limit execution to Linux and MacOS
     if is_windows == False:
+        deps = resolve_scala_deps(deps, scala_deps, versioned_scala_deps)
+        compat_scalacopts = extra_scalacopts(scala_deps = scala_deps, plugins = plugins)
         scaladoc_jar(
             name = name + "_scaladoc",
             deps = deps,
             srcs = srcs,
-            scalacopts = common_scalacopts + plugin_scalacopts + scalacopts,
+            scalacopts = common_scalacopts + plugin_scalacopts + compat_scalacopts + scalacopts,
             plugins = common_plugins + plugins,
             generated_srcs = generated_srcs,
             tags = ["scaladoc"],

--- a/compiler/scenario-service/server/BUILD.bazel
+++ b/compiler/scenario-service/server/BUILD.bazel
@@ -24,9 +24,6 @@ da_scala_binary(
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     runtime_deps = [
         "@maven//:ch_qos_logback_logback_classic",
     ],

--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -104,9 +104,7 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = lf_scalacopts + [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
+    scalacopts = lf_scalacopts,
     tags = ["maven_coordinates=com.daml:daml-lf-archive-reader:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [

--- a/daml-lf/data/BUILD.bazel
+++ b/daml-lf/data/BUILD.bazel
@@ -25,7 +25,6 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
     ],
     scalacopts = lf_scalacopts + [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
         "-P:silencer:lineContentFilters=import ImmArraySeq.Implicits._",
     ],
     tags = ["maven_coordinates=com.daml:daml-lf-data:__VERSION__"],
@@ -54,7 +53,6 @@ da_scala_test(
     ],
     scalacopts = lf_scalacopts + [
         "-P:silencer:lineContentFilters=import ImmArraySeq.Implicits._",
-        "-P:silencer:lineContentFilters=import scala.collection.compat._",
         "-P:silencer:lineContentFilters=signum",
     ],
     deps = [

--- a/daml-lf/data/src/main/2.12/com/daml/lf/data/AbstractImmArraySeq.scala
+++ b/daml-lf/data/src/main/2.12/com/daml/lf/data/AbstractImmArraySeq.scala
@@ -4,7 +4,6 @@
 package com.daml.lf.data
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.compat.immutable.ArraySeq
 import scala.collection.generic.{
   CanBuildFrom,
   GenericCompanion,

--- a/daml-lf/interface/BUILD.bazel
+++ b/daml-lf/interface/BUILD.bazel
@@ -19,9 +19,7 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = lf_scalacopts + [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
+    scalacopts = lf_scalacopts,
     tags = ["maven_coordinates=com.daml:daml-lf-interface:__VERSION__"],
     visibility = [
         "//daml-assistant/daml-sdk:__subpackages__",

--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -53,9 +53,7 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = lf_scalacopts + [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
+    scalacopts = lf_scalacopts,
     tags = ["maven_coordinates=com.daml:daml-lf-transaction:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [
@@ -82,9 +80,7 @@ da_scala_test(
         "@maven//:org_scalaz_scalaz_scalacheck_binding",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = lf_scalacopts + [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
+    scalacopts = lf_scalacopts,
     deps = [
         ":transaction",
         ":transaction_proto_java",

--- a/daml-script/export/BUILD.bazel
+++ b/daml-script/export/BUILD.bazel
@@ -26,9 +26,6 @@ da_scala_binary(
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_typelevel_paiges_core",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat.",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         "//daml-lf/archive:daml_lf_archive_reader",

--- a/extractor/BUILD.bazel
+++ b/extractor/BUILD.bazel
@@ -103,9 +103,6 @@ da_scala_library(
     scala_runtime_deps = [
         "@maven//:org_tpolecat_doobie_postgres",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat.",
-    ],
     visibility = ["//visibility:public"],
     runtime_deps = [
         "@maven//:ch_qos_logback_logback_classic",

--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -117,9 +117,6 @@ da_scala_test_suite(
         "@maven//:org_scalatestplus_scalacheck_1_14",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     deps = [
         ":bindings-java",
         ":bindings-java-tests-lib",

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -54,9 +54,6 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     tags = ["maven_coordinates=com.daml:codegen-java-lib:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [

--- a/language-support/scala/bindings-akka/BUILD.bazel
+++ b/language-support/scala/bindings-akka/BUILD.bazel
@@ -35,9 +35,6 @@ da_scala_library(
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     tags = ["maven_coordinates=com.daml:bindings-akka:__VERSION__"],
     visibility = [
         "//visibility:public",

--- a/language-support/scala/codegen-testing/BUILD.bazel
+++ b/language-support/scala/codegen-testing/BUILD.bazel
@@ -93,9 +93,6 @@ da_scala_test_suite(
         "@maven//:org_scalatestplus_scalacheck_1_14",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     deps = [
         ":codegen-testing",
         ":codegen-testing-testing",

--- a/language-support/scala/codegen/BUILD.bazel
+++ b/language-support/scala/codegen/BUILD.bazel
@@ -36,9 +36,7 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = common_scalacopts + [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
+    scalacopts = common_scalacopts,
     tags = ["maven_coordinates=com.daml:codegen-scala:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -94,9 +92,7 @@ da_scala_test_suite(
         "@maven//:org_scalatestplus_scalacheck_1_14",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = common_scalacopts + [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
+    scalacopts = common_scalacopts,
     deps = [
         ":codegen",
         "//daml-lf/archive:daml_lf_archive_reader",

--- a/ledger-api/perf-testing/BUILD.bazel
+++ b/ledger-api/perf-testing/BUILD.bazel
@@ -20,9 +20,6 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     visibility = [
         "//visibility:public",
     ],

--- a/ledger-api/testing-utils/BUILD.bazel
+++ b/ledger-api/testing-utils/BUILD.bazel
@@ -21,9 +21,6 @@ da_scala_library(
         "@maven//:org_scalatest_scalatest",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     tags = ["maven_coordinates=com.daml:testing-utils:__VERSION__"],
     visibility = [
         "//visibility:public",

--- a/ledger-service/http-json-testing/BUILD.bazel
+++ b/ledger-service/http-json-testing/BUILD.bazel
@@ -36,9 +36,7 @@ hj_scalacopts = lf_scalacopts + [
             "@maven//:org_typelevel_cats_effect",
             "@maven//:org_typelevel_cats_free",
         ],
-        scalacopts = hj_scalacopts + [
-            "-P:silencer:lineContentFilters=import scala.collection.compat",
-        ],
+        scalacopts = hj_scalacopts,
         tags = ["maven_coordinates=com.daml:http-json-testing:__VERSION__"],
         visibility = ["//visibility:public"],
         runtime_deps = [

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -42,9 +42,7 @@ hj_scalacopts = lf_scalacopts + [
             "@maven//:org_typelevel_cats_free",
             "@maven//:org_typelevel_cats_kernel",
         ],
-        scalacopts = hj_scalacopts + [
-            "-P:silencer:lineContentFilters=import scala.collection.compat",
-        ],
+        scalacopts = hj_scalacopts,
         tags = ["maven_coordinates=com.daml:http-json:__VERSION__"],
         visibility = ["//visibility:public"],
         runtime_deps = [
@@ -197,9 +195,7 @@ daml_compile(
             "@maven//:org_typelevel_cats_free",
             "@maven//:org_typelevel_cats_kernel",
         ],
-        scalacopts = hj_scalacopts + [
-            "-P:silencer:lineContentFilters=import scala.collection.compat",
-        ],
+        scalacopts = hj_scalacopts,
         deps = [
             ":http-json-{}".format(edition),
             "//daml-lf/data",

--- a/ledger/ledger-api-client/BUILD.bazel
+++ b/ledger/ledger-api-client/BUILD.bazel
@@ -20,9 +20,6 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     tags = ["maven_coordinates=com.daml:ledger-api-client:__VERSION__"],
     visibility = [
         "//visibility:public",

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -90,7 +90,6 @@ da_scala_test_suite(
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat._",
         "-P:silencer:lineContentFilters=import scala.collection.parallel.CollectionConverters._",
     ],
     versioned_scala_deps = {

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -116,9 +116,6 @@ da_scala_binary(
                 "@maven//:com_softwaremill_diffx_diffx_core",
                 "@maven//:org_scala_lang_modules_scala_collection_compat",
             ],
-            scalacopts = [
-                "-P:silencer:lineContentFilters=import scala.collection.compat._",
-            ],
             scaladoc = False,
             visibility = [
                 "//:__subpackages__",
@@ -165,9 +162,6 @@ da_scala_binary(
             scala_deps = [
                 "@maven//:org_scala_lang_modules_scala_collection_compat",
                 "@maven//:com_github_scopt_scopt",
-            ],
-            scalacopts = [
-                "-P:silencer:lineContentFilters=import scala.collection.compat._",
             ],
             visibility = ["//visibility:public"],
             runtime_deps = [

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -88,9 +88,6 @@ da_scala_library(
         "@maven//:org_playframework_anorm_anorm_tokenizer",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     tags = ["maven_coordinates=com.daml:ledger-on-sql:__VERSION__"],
     visibility = [
         "//visibility:public",

--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -102,9 +102,6 @@ da_scala_library(
     scala_deps = scala_compile_deps + [
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     tags = ["maven_coordinates=com.daml:participant-integration-api:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -127,9 +124,6 @@ da_scala_library(
             exclude = ["src/main/resources/logback.xml"],
         ),
     scala_deps = scala_compile_deps,
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     tags = ["maven_coordinates=com.daml:ledger-api-server:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -153,9 +147,6 @@ da_scala_library(
     ],
     scala_runtime_deps = [
         "@maven//:com_typesafe_akka_akka_slf4j",
-    ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat._",
     ],
     visibility = ["//visibility:public"],
     runtime_deps = [
@@ -354,7 +345,6 @@ scaladoc_jar(
     root_content = "rootdoc.txt",
     scalacopts = [
         "-P:silencer:checkUnused",
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
     ],
     visibility = [
         "//visibility:public",

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -34,9 +34,6 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     tags = ["maven_coordinates=com.daml:participant-state-kvutils:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -91,9 +88,6 @@ da_scala_library(
         "@maven//:org_scalatest_scalatest",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
-    ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
     ],
     tags = ["maven_coordinates=com.daml:kvutils-tests-lib:__VERSION__"],
     visibility = [
@@ -151,9 +145,6 @@ da_scala_test_suite(
         "@maven//:org_scalactic_scalactic",
         "@maven//:org_scalatest_scalatest",
         "@maven//:org_scalaz_scalaz_core",
-    ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
     ],
     deps = [
         ":daml_kvutils_proto_java",

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -140,9 +140,6 @@ da_scala_library(
         "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     deps = [
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_proto_java",

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -42,7 +42,6 @@ alias(
             "@maven//:org_scalaz_scalaz_core",
         ],
         scalacopts = [
-            "-P:silencer:lineContentFilters=import scala.collection.compat",
             # retain is deprecated in 2.13 but the replacement filterInPlace
             # does not exist in 2.12.
             "-P:silencer:lineContentFilters=retain",

--- a/libs-scala/gatling-utils/BUILD.bazel
+++ b/libs-scala/gatling-utils/BUILD.bazel
@@ -27,9 +27,7 @@ da_scala_library(
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = scalacopts + [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
+    scalacopts = scalacopts,
     tags = ["maven_coordinates=com.daml:gatling-utils:__VERSION__"],
     visibility = ["//visibility:public"],
     runtime_deps = [

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -74,9 +74,7 @@ da_scala_library(
         "@maven//:io_spray_spray_json",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = scalacopts + [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
+    scalacopts = scalacopts,
     visibility = ["//visibility:public"],
     deps = [
         ":middleware-api",

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -88,9 +88,6 @@ da_scala_library(
         "@maven//:org_scalatest_scalatest",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.compat",
-    ],
     deps = [
         "//bazel_tools/runfiles:scala_runfiles",
         "//daml-lf/archive:daml_lf_archive_reader",


### PR DESCRIPTION
Instead of always suppressing warnings for `collection.compat._`, we should only do it for Scala 2.13.

We also reduce boilerplate by automatically adding this option when both silencer_plugin and collection-compat are present.  There are a few other possible approaches, such as adding silencer_plugin when collection-compat is present, or having a special `collection_compat = True` option to `da_scala_library` et al; this one just happens to be the smallest change that eliminates the flags.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
