### PR TITLE
Add support for daml exceptions for append-only indexer

### DIFF
--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -412,3 +412,20 @@ server_conformance_test(
         "--include=ExceptionsIT",
     ],
 )
+
+# TODO https://github.com/digital-asset/daml/issues/8020
+# TODO append-only: only for temporary testing
+# Drop/modify once exceptions are out of 1.dev
+server_conformance_test(
+    name = "conformance-test-exceptions-append-only",
+    lf_versions = ["dev"],
+    server_args = [
+        "--wall-clock-time",
+        "--contract-id-seeding=testing-weak",
+        "--enable-append-only-schema",
+    ],
+    servers = ONLY_POSTGRES_SERVER,
+    test_tool_args = [
+        "--include=ExceptionsIT",
+    ],
+)


### PR DESCRIPTION
This change adds support for append-only sandbox-classic as well.
Temporarily enabled tests ensure correctness for now
In parallel-ingestion stabilisation epic further unit tests willbe added (hence keeping the TODO for now)

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
