### PR TITLE
Move activeness check of globalKeyInputs into archive

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1298,9 +1298,9 @@ private[lf] object SBuiltin {
         case None =>
           // Check if we have a cached global key result.
           onLedger.ptx.globalKeyInputs.get(gkey) match {
-            case Some(optCid) =>
-              onLedger.ptx = onLedger.ptx.copy(keys = onLedger.ptx.keys.updated(gkey, optCid))
-              operation.handleKnownInputKey(machine, gkey, optCid)
+            case Some(keyMapping) =>
+              onLedger.ptx = onLedger.ptx.copy(keys = onLedger.ptx.keys.updated(gkey, keyMapping))
+              operation.handleKnownInputKey(machine, gkey, keyMapping)
             case None =>
               // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
               // that.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1299,12 +1299,8 @@ private[lf] object SBuiltin {
           // Check if we have a cached global key result.
           onLedger.ptx.globalKeyInputs.get(gkey) match {
             case Some(optCid) =>
-              val optActiveCid = optCid match {
-                case KeyActive(cid) if onLedger.ptx.consumedBy.contains(cid) => KeyInactive
-                case _ => optCid
-              }
-              onLedger.ptx = onLedger.ptx.copy(keys = onLedger.ptx.keys.updated(gkey, optActiveCid))
-              operation.handleKnownInputKey(machine, gkey, optActiveCid)
+              onLedger.ptx = onLedger.ptx.copy(keys = onLedger.ptx.keys.updated(gkey, optCid))
+              operation.handleKnownInputKey(machine, gkey, optCid)
             case None =>
               // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
               // that.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -486,12 +486,10 @@ private[lf] case class PartialTransaction(
             keys = mbKey match {
               case Some(kWithM) if consuming =>
                 val gkey = GlobalKey(templateId, kWithM.key)
-                (keys.get(gkey), globalKeyInputs.get(gkey)) match {
+                keys.get(gkey).orElse(globalKeyInputs.get(gkey)) match {
                   // An archive can only mark a key as inactive
                   // if it was brought into scope before.
-                  case (Some(KeyActive(cid)), _) if cid == targetId =>
-                    keys.updated(gkey, KeyInactive)
-                  case (None, Some(KeyActive(cid))) if cid == targetId =>
+                  case Some(KeyActive(cid)) if cid == targetId =>
                     keys.updated(gkey, KeyInactive)
                   // If the key was not in scope or mapped to a different cid, we don’t change keys. Instead we will do
                   // an activeness check when looking it up later.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -486,10 +486,13 @@ private[lf] case class PartialTransaction(
             keys = mbKey match {
               case Some(kWithM) if consuming =>
                 val gkey = GlobalKey(templateId, kWithM.key)
-                keys.get(gkey) match {
+                (keys.get(gkey), globalKeyInputs.get(gkey)) match {
                   // An archive can only mark a key as inactive
                   // if it was brought into scope before.
-                  case Some(KeyActive(cid)) if cid == targetId => keys.updated(gkey, KeyInactive)
+                  case (Some(KeyActive(cid)), _) if cid == targetId =>
+                    keys.updated(gkey, KeyInactive)
+                  case (None, Some(KeyActive(cid))) if cid == targetId =>
+                    keys.updated(gkey, KeyInactive)
                   // If the key was not in scope or mapped to a different cid, we don’t change keys. Instead we will do
                   // an activeness check when looking it up later.
                   case _ => keys


### PR DESCRIPTION
This is semantically equivalent but it seems slightly simpler and more
importantly it leads to slightly nicer semantics by reducing the
number of cases where we have to worry about accidentally skipping an
activeness check.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
