### PR TITLE
fix flaky test in RecoveringIndexer

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
@@ -83,12 +83,10 @@ private[indexer] final class RecoveringIndexer(
             logger.info("Restarting Indexer Server")
             val newSubscription = subscribe()
             if (subscription.compareAndSet(oldSubscription, newSubscription)) {
-              resubscribeOnFailure(
-                newSubscription, {
-                  updateHealthStatus(HealthStatus.healthy)
-                  logger.info("Restarted Indexer Server")
-                },
-              )
+              resubscribeOnFailure(newSubscription) {
+                updateHealthStatus(HealthStatus.healthy)
+                logger.info("Restarted Indexer Server")
+              }
               Future.unit
             } else { // we must have stopped the server during the restart
               logger.info("Indexer Server was stopped; cancelling the restart")

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
@@ -83,11 +83,12 @@ private[indexer] final class RecoveringIndexer(
             logger.info("Restarting Indexer Server")
             val newSubscription = subscribe()
             if (subscription.compareAndSet(oldSubscription, newSubscription)) {
-              resubscribeOnFailure(newSubscription)
               newSubscription.asFuture.map { _ =>
                 updateHealthStatus(Healthy)
                 logger.info("Restarted Indexer Server")
               }
+              resubscribeOnFailure(newSubscription)
+              Future.unit
             } else { // we must have stopped the server during the restart
               logger.info("Indexer Server was stopped; cancelling the restart")
               newSubscription.release().flatMap { _ =>

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
@@ -51,7 +51,7 @@ private[indexer] final class RecoveringIndexer(
       handle
     })
     subscription.set(firstSubscription)
-    resubscribeOnFailure(firstSubscription)
+    resubscribeOnFailure(firstSubscription, ())
 
     def waitForRestart(
         delayUntil: Instant = clock.instant().plusMillis(restartDelay.toMillis)
@@ -83,11 +83,12 @@ private[indexer] final class RecoveringIndexer(
             logger.info("Restarting Indexer Server")
             val newSubscription = subscribe()
             if (subscription.compareAndSet(oldSubscription, newSubscription)) {
-              newSubscription.asFuture.map { _ =>
-                updateHealthStatus(Healthy)
-                logger.info("Restarted Indexer Server")
-              }
-              resubscribeOnFailure(newSubscription)
+              resubscribeOnFailure(
+                newSubscription, {
+                  updateHealthStatus(HealthStatus.healthy)
+                  logger.info("Restarted Indexer Server")
+                },
+              )
               Future.unit
             } else { // we must have stopped the server during the restart
               logger.info("Indexer Server was stopped; cancelling the restart")
@@ -103,9 +104,13 @@ private[indexer] final class RecoveringIndexer(
         }
       } yield ()
 
-    def resubscribeOnFailure(currentSubscription: Resource[IndexFeedHandle]): Unit =
+    def resubscribeOnFailure(
+        currentSubscription: Resource[IndexFeedHandle],
+        actOnSuccess: => Unit,
+    ): Unit =
       currentSubscription.asFuture.onComplete {
         case Success(handle) =>
+          actOnSuccess
           handle.completed().onComplete {
             case Success(()) =>
               logger.info("Successfully finished processing state updates")

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
@@ -51,7 +51,7 @@ private[indexer] final class RecoveringIndexer(
       handle
     })
     subscription.set(firstSubscription)
-    resubscribeOnFailure(firstSubscription, ())
+    resubscribeOnFailure(firstSubscription) {}
 
     def waitForRestart(
         delayUntil: Instant = clock.instant().plusMillis(restartDelay.toMillis)
@@ -105,9 +105,8 @@ private[indexer] final class RecoveringIndexer(
       } yield ()
 
     def resubscribeOnFailure(
-        currentSubscription: Resource[IndexFeedHandle],
-        actOnSuccess: => Unit,
-    ): Unit =
+        currentSubscription: Resource[IndexFeedHandle]
+    )(actOnSuccess: => Unit): Unit =
       currentSubscription.asFuture.onComplete {
         case Success(handle) =>
           actOnSuccess


### PR DESCRIPTION
Move the log "Restarted Indexer Server" up to ascertain that this log action happens before re-subscription action and race is avoided.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
