### PR TITLE
Patch perf reference Bazel derivation

### DIFF
--- a/ci/cron/perf/BazelExclusiveSandboxing.patch
+++ b/ci/cron/perf/BazelExclusiveSandboxing.patch
@@ -1,0 +1,15 @@
+diff --git a/nix/nixpkgs.nix b/nix/nixpkgs.nix
+index 8c7eb189783..e0b7e1e5534 100644
+--- a/nix/nixpkgs.nix
++++ b/nix/nixpkgs.nix
+@@ -38,8 +38,8 @@ let
+         # for the only change that actually affects the code in this patch. The rest is tests
+         # and/or documentation.
+         (pkgs.fetchurl {
+-          url = "https://patch-diff.githubusercontent.com/raw/bazelbuild/bazel/pull/8983.patch";
+-          sha256 = "1j25bycn9q7536ab3ln6yi6zpzv2b25fwdyxbgnalkpl2dz9idb7";
++          url = "https://github.com/bazelbuild/bazel/commit/0f0a0d58725603cf2f1c175963360b525718a195.patch";
++          sha256 = "1h9sqlcz3nkpppkbk0rilwf7ivhxp9iwircfpm1mbbjwq2pwywqa";
+         })
+       ];
+     });

--- a/ci/cron/perf/compare.sh
+++ b/ci/cron/perf/compare.sh
@@ -18,6 +18,7 @@ main() {
 
   git checkout $BASELINE >&2
   git show ${current}:ci/cron/perf/CollectAuthority.scala.patch | git apply
+  git show ${current}:ci/cron/perf/BazelExclusiveSandboxing.patch | git apply
   local baseline_perf=$(measure)
   if [ "" = "$baseline_perf" ]; then exit 1; fi
 


### PR DESCRIPTION
The patch that it downloads via Nix was taken from a GH PR instead of a commit such that the hash is not fully stable. This adds a patch to download the relevant patch directly from a GitHub commit.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
