### PR TITLE
sandbox-on-x: Support `beginAfter` in state updates.

### DIFF
--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
@@ -112,9 +112,9 @@ case class ReadWriteServiceBridge(
   var stateUpdatesWasCalledAlready = false
   override def stateUpdates(beginAfter: Option[Offset]): Source[(Offset, Update), NotUsed] = {
     // TODO for PoC purposes:
-    //   no beginAfter supported
-    //   neither multiple subscriptions
-    //   neither bootstrapping the bridge from indexer persistence
+    //   This method may only be called once, either with `beginAfter` set or unset.
+    //   A second call will result in an error unless the server is restarted.
+    //   Bootstrapping the bridge from indexer persistence is supported.
     synchronized {
       if (stateUpdatesWasCalledAlready)
         throw new IllegalStateException("not allowed to call this twice")


### PR DESCRIPTION
Because @kamil-da needs it.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
