### PR TITLE
Authorization for daml script exports

### DIFF
--- a/daml-script/export/BUILD.bazel
+++ b/daml-script/export/BUILD.bazel
@@ -64,6 +64,7 @@ da_scala_test(
         "//daml-lf/language",
         "//language-support/scala/bindings",
         "//ledger/ledger-api-common",
+        "//libs-scala/auth-utils",
     ],
 )
 

--- a/daml-script/export/BUILD.bazel
+++ b/daml-script/export/BUILD.bazel
@@ -41,6 +41,7 @@ da_scala_binary(
         "//ledger-service/cli-opts",
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
+        "//libs-scala/auth-utils",
         "@maven//:org_apache_commons_commons_text",
     ],
 )

--- a/daml-script/export/src/it/scala/com/daml/script/export/IT.scala
+++ b/daml-script/export/src/it/scala/com/daml/script/export/IT.scala
@@ -148,6 +148,7 @@ final class IT
         ledgerHost = "localhost",
         ledgerPort = serverPort.value,
         tlsConfig = TlsConfiguration(false, None, None, None),
+        accessToken = None,
         parties = parties,
         start = offset,
         end = ledgerEnd,

--- a/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
@@ -3,9 +3,10 @@
 
 package com.daml.script.export
 
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 import java.io.File
 
+import com.daml.auth.TokenHolder
 import com.daml.ledger.api.tls.{TlsConfiguration, TlsConfigurationCli}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 
@@ -13,6 +14,7 @@ final case class Config(
     ledgerHost: String,
     ledgerPort: Int,
     tlsConfig: TlsConfiguration,
+    accessToken: Option[TokenHolder],
     parties: Seq[String],
     start: LedgerOffset,
     end: LedgerOffset,
@@ -55,6 +57,11 @@ object Config {
     TlsConfigurationCli.parse(this, colSpacer = "        ")((f, c) =>
       c.copy(tlsConfig = f(c.tlsConfig))
     )
+    opt[String]("access-token-file")
+      .action((f, c) => c.copy(accessToken = Some(new TokenHolder(Paths.get(f)))))
+      .text(
+        "File from which the access token will be read, required to interact with an authenticated ledger."
+      )
     opt[Seq[String]]("party")
       .required()
       .unbounded()
@@ -132,6 +139,7 @@ object Config {
     ledgerHost = "",
     ledgerPort = -1,
     tlsConfig = TlsConfiguration(false, None, None, None),
+    accessToken = None,
     parties = List(),
     start = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)),
     end = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END)),

--- a/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
@@ -82,5 +82,6 @@ object Main {
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
     sslContext = config.tlsConfig.client,
+    token = config.accessToken.flatMap(_.token),
   )
 }

--- a/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
@@ -3,13 +3,14 @@
 
 package com.daml.script.export
 
-import java.nio.file.{Files, Paths}
+import java.io.PrintWriter
+import java.nio.file.{Files, Path, Paths}
 
 import com.daml.bazeltools.BazelRunfiles.rlocation
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.OptionValues
+import org.scalatest.{Assertion, OptionValues}
 
 class ConfigSpec extends AnyFreeSpec with Matchers with OptionValues {
   private val outputTypeArgs = Array("script")
@@ -93,6 +94,28 @@ class ConfigSpec extends AnyFreeSpec with Matchers with OptionValues {
             Paths.get(crtPath),
           )
         )
+      }
+    }
+    "Auth" - {
+      val token = "test-token"
+      def withTokenFile(f: Path => Assertion): Assertion = {
+        val tokenFile: Path = Files.createTempFile("token", ".jwt")
+        try {
+          val writer = new PrintWriter(tokenFile.toFile)
+          try {
+            writer.print(token)
+          } finally {
+            writer.close
+          }
+          f(tokenFile)
+        } finally {
+          Files.delete(tokenFile)
+        }
+      }
+      "--access-token-file" in withTokenFile { tokenFile =>
+        val args = defaultRequiredArgs ++ Array("--access-token-file", tokenFile.toString)
+        val optConfig = Config.parse(args)
+        optConfig.value.accessToken.value.token.value shouldBe token
       }
     }
   }


### PR DESCRIPTION
Closes #9585

- Adds an `--access-token-file` flag analogous to other tools like `daml script`.
- Adds a test-case for the CLI flag.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
