### PR TITLE
Add a REPL for each Scala target, for debugging.

### DIFF
--- a/BAZEL.md
+++ b/BAZEL.md
@@ -464,6 +464,15 @@ detailed information.
     bazel run //ledger/sandbox:sandbox-binary -- --help
     ```
 
+### Running a REPL
+
+- Run a Scala REPL which has the library on the classpath:
+
+    ```
+    bazel build //ledger/ledger-on-memory:ledger-on-memory_repl
+    ./bazel-bin/ledger/ledger-on-memory/ledger-on-memory_repl
+    ```
+
 ### Querying Targets
 
 The Bazel query language is described in detail in the [official Bazel


### PR DESCRIPTION
For each Scala library target, this adds a `*_repl` target that can be
built and run to provide a Scala REPL with access to the library and all
its dependencies.

To use:

```
$ bazel build //ledger/ledger-on-memory:ledger-on-memory_repl
INFO: Invocation ID: f1c4ec07-68e7-4bc2-a182-40f6ea035110
INFO: Analyzed target //ledger/ledger-on-memory:ledger-on-memory_repl (32 packages loaded, 714 targets configured).
INFO: Found 1 target...
Target //ledger/ledger-on-memory:ledger-on-memory_repl up-to-date:
  bazel-bin/ledger/ledger-on-memory/ledger-on-memory_repl.jar
  bazel-bin/ledger/ledger-on-memory/ledger-on-memory_repl
INFO: Build completed successfully, 7 total actions

$ ./bazel-bin/ledger/ledger-on-memory/ledger-on-memory_repl
Welcome to Scala 2.12.13 (OpenJDK 64-Bit Server VM, Java 1.8.0_272).
Type in expressions for evaluation. Or try :help.

scala> import scala.concurrent.ExecutionContext.Implicits.global
scala> import com.google.protobuf.ByteString
scala> import com.daml.ledger.on.memory._
scala> import com.daml.ledger.participant.state.kvutils.OffsetBuilder
scala> import com.daml.ledger.participant.state.kvutils.Raw
scala> import com.daml.ledger.participant.state.kvutils.api.LedgerRecord

scala> val state = InMemoryState.empty
state: com.daml.ledger.on.memory.InMemoryState = com.daml.ledger.on.memory.InMemoryState@ff21443

scala> state.write { (log, state) => Future { log += LedgerRecord(OffsetBuilder.fromLong(1), Raw.LogEntryId(ByteString.copyFromUtf8("A")), Raw.Envelope(ByteString.EMPTY)) } }
```

The REPL target has the tag "manual", so will only be built on demand.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
