### PR TITLE
Throw on internal errors instead of setting ptx to aborted

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1863,10 +1863,6 @@ private[lf] object SBuiltin {
         throw DamlELocalContractNotActive(coid, tid, consumedBy)
       case Some(Tx.DuplicateContractKey(key)) =>
         throw DamlEDuplicateContractKey(key)
-      case Some(Tx.NonExerciseContext) =>
-        crash("internal error: end exercise in non exercise context")
-      case Some(Tx.NonCatchContext) =>
-        crash("internal error: end catch in non catch context")
       case None =>
         ()
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -440,6 +440,11 @@ private[lf] object Speedy {
           popKont() match {
             case handler: KCatchSubmitMustFail =>
               handler
+            case _: KTryCatchHandler =>
+              withOnLedger("tryHandleSubmitMustFail/KCloseExercise") { onLedger =>
+                onLedger.ptx = onLedger.ptx.abortTry
+              }
+              unwind()
             case _: KCloseExercise =>
               withOnLedger("tryHandleSubmitMustFail/KCloseExercise") { onLedger =>
                 onLedger.ptx = onLedger.ptx.abortExercises
@@ -1396,7 +1401,6 @@ private[lf] object Speedy {
           case _: KCloseExercise =>
             machine.withOnLedger("unwindToHandler/KCloseExercise") { onLedger =>
               onLedger.ptx = onLedger.ptx.abortExercises
-              checkAborted(onLedger.ptx)
             }
             unwind()
           case _ =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -573,8 +573,7 @@ private[lf] case class PartialTransaction(
           nodes = nodes.updated(nodeId, exerciseNode),
           actionNodeSeeds = actionNodeSeeds :+ (nodeId -> ec.actionNodeSeed),
         )
-      case _ =>
-        noteAbort(Tx.NonExerciseContext)
+      case _ => throw new RuntimeException("endExercises called in non-exercise context")
     }
 
   /** Close a abruptly an exercise context du to an uncaught exception.
@@ -607,8 +606,7 @@ private[lf] case class PartialTransaction(
           nodes = nodes.updated(nodeId, exerciseNode),
           actionNodeSeeds = actionNodeSeeds :+ (nodeId -> actionNodeSeed),
         )
-      case _ =>
-        noteAbort(Tx.NonExerciseContext)
+      case _ => throw new RuntimeException("abortExercises called in non-exercise context")
     }
 
   /** Open a Try context.
@@ -636,7 +634,7 @@ private[lf] case class PartialTransaction(
           )
         )
       case _ =>
-        noteAbort(Tx.NonCatchContext)
+        throw new RuntimeException("endTry called in non-catch context")
     }
 
   /** Close abruptly a try context, due to an uncaught exception,
@@ -664,8 +662,7 @@ private[lf] case class PartialTransaction(
           context = info.parent.addRollbackChild(info.nodeId, context.nextActionChildIdx),
           nodes = nodes.updated(info.nodeId, rollbackNode),
         ).resetActiveState(info.beginState)
-      case _ =>
-        noteAbort(Tx.NonCatchContext)
+      case _ => throw new RuntimeException("rollbackTry called in non-catch context")
     }
 
   /** Note that the transaction building failed due to an authorization failure */

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -873,16 +873,6 @@ object Transaction {
   /** Errors that can happen during building transactions. */
   sealed abstract class TransactionError extends Product with Serializable
 
-  /** Signal that a 'endExercise' was called in a non exercise-context; i.e.,
-    * without a matching 'beginExercise'.
-    */
-  case object NonExerciseContext extends TransactionError
-
-  /** Signal that a 'endCatch' or a 'rollback`` was called in a non catch-context; i.e.,
-    * without a matching 'beginCatch'.
-    */
-  case object NonCatchContext extends TransactionError
-
   /** Signals that the contract-id `coid` was expected to be active, but
     * is not.
     */


### PR DESCRIPTION
The main purpose of aborted is to be able to get out a ptx in the
scenario service. However, for internal errors that makes no
sense. Users should never encounter them. And the use of `aborted`
here has swallowed these errors silently in a few places before which
is clearly bad.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
