### PR TITLE
skip Windows tests on release

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -59,4 +59,6 @@ bazel build `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/build_exec
 
 bazel shutdown
 
-bazel test `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/test_execution_windows.log //...
+if ($env:SKIP_TESTS = "False") {
+    bazel test `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/test_execution_windows.log //...
+}

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -20,6 +20,17 @@ steps:
     displayName: 'Build'
     env:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
+      # On release, we want to skip testing because:
+      # - Caching on Windows is keyed on full path, and full path is somewhat
+      #   random (for a given machine, each pipeline has a its own workdir, but
+      #   they are not the same across machines).
+      # - In the specific case of a release commit on `main`, the exact same
+      #   code has already been tested twice: once as part of the target
+      #   commit's own build (albeit with 0.0.0 as version number), and once as
+      #   part of the release PR that triggered the build (with correct version
+      #   number).
+      SKIP_TESTS: ${{and(eq(parameters.is_release, 'true'),
+                         eq(variables['Build.SourceBranchName'], 'main'))}}
 
   - task: PublishBuildArtifacts@1
     condition: failed()


### PR DESCRIPTION
Caching doesn't seem to work very well here. On a release, we build an old commit, which has already been tested twice (once as a commit on `main`, once as part of the release PR).

CHANGELOG_BEGIN
CHANGELOG_END