### PR TITLE
fix release PR notifications

### DIFF
--- a/ci/prs.yml
+++ b/ci/prs.yml
@@ -79,7 +79,8 @@ jobs:
 
 - job: notify_release_pr
   condition: and(not(canceled()),
-                 startsWith(variables['Build.SourceBranchName'], 'auto-release-pr-'),
+                 or(startsWith(variables['Build.SourceBranchName'], 'auto-release-pr-'),
+                    startsWith(variables['System.PullRequest.SourceBranch'], 'auto-release-pr-')),
                  eq(dependencies.check_for_release.outputs['out.is_release'], 'true'))
   dependsOn:
     - git_sha


### PR DESCRIPTION
In the automated process, the Azure build is triggered on the branch directly, which will be named `auto-release-pr-$(date -I)`. But if a manual change needs to be made, and people subsequently use the `/azp run` feature of Azure, the build then runs for the PR, which means it actually runs on the merge commit of the branch and `main`, not on the branch itself. In that case, the branch that we run the build on is called `merge` and is thus not starting with `auto-release-pr-`.

This change should get us the notification back on manual PR builds too.

CHANGELOG_BEGIN
CHANGELOG_END