### PR TITLE
Revert to using natural join instead of cross join in ContractsReader

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -57,9 +57,9 @@ private[dao] sealed class ContractsReader(
 
         dispatcher.executeSql(metrics.daml.index.db.lookupContractByKeyDbMetrics) {
           implicit connection =>
-            SQL"""select pc.contract_id from #$contractsTable
-                 where #$stakeholdersWhere and pcw.contract_witness in ($readers)
-                 and pc.create_key_hash = ${key.hash}
+            SQL"""select contract_id from #$contractsTable
+                 where #$stakeholdersWhere and contract_witness in ($readers)
+                 and create_key_hash = ${key.hash}
                  #${sqlFunctions.limitClause(1)}"""
               .as(contractId("contract_id").singleOpt)
         }
@@ -74,10 +74,9 @@ private[dao] sealed class ContractsReader(
       metrics.daml.index.db.lookupActiveContract,
       dispatcher
         .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
-          SQL"""select pc.contract_id, pc.template_id, pc.create_argument, pc.create_argument_compression from #$contractsTable
+          SQL"""select contract_id, template_id, create_argument, create_argument_compression from #$contractsTable
                where
-               pc.contract_id = pcw.contract_id and
-               pcw.contract_witness in ($readers) and pc.contract_id = $contractId #${sqlFunctions
+               contract_witness in ($readers) and contract_id = $contractId #${sqlFunctions
             .limitClause(1)}"""
             .as(contractRowParser.singleOpt)
         }
@@ -105,7 +104,7 @@ private[dao] sealed class ContractsReader(
       metrics.daml.index.db.lookupActiveContract,
       dispatcher
         .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
-          SQL"select pc.contract_id, pc.template_id from #$contractsTable where pcw.contract_witness in ($readers) and pc.contract_id = $contractId #${sqlFunctions
+          SQL"select contract_id, template_id from #$contractsTable where contract_witness in ($readers) and participant_contracts.contract_id = $contractId #${sqlFunctions
             .limitClause(1)}"
             .as(contractWithoutValueRowParser.singleOpt)
         }
@@ -136,7 +135,7 @@ private[dao] sealed class ContractsReader(
 
 private[dao] object ContractsReader {
   private val contractsTable =
-    "participant_contracts pc, participant_contract_witnesses pcw"
+    "participant_contracts natural join participant_contract_witnesses"
   private val contractWithoutValueRowParser: RowParser[String] =
     str("template_id")
   private val contractRowParser: RowParser[(String, InputStream, Option[Int])] =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -74,7 +74,8 @@ private[dao] sealed class ContractsReader(
       metrics.daml.index.db.lookupActiveContract,
       dispatcher
         .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
-          SQL"""select pc.contract_id, template_id, create_argument, create_argument_compression from #$contractsTable where contract_witness in ($readers) and pc.contract_id = $contractId #${sqlFunctions.limitClause(1)}"""
+          SQL"""select pc.contract_id, template_id, create_argument, create_argument_compression from #$contractsTable where contract_witness in ($readers) and pc.contract_id = $contractId #${sqlFunctions
+            .limitClause(1)}"""
             .as(contractRowParser.singleOpt)
         }
         .map(_.map { case (templateId, createArgument, createArgumentCompression) =>


### PR DESCRIPTION
The existing cross-join in the `contractsTable` relation is slow when running contracts/keys lookups against PostgreSQL. This PR addresses the issue, by reverting back to the `natural join` relation in the `from` clause.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
