### PR TITLE
Damlification of metrics prefix

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/MetricName.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/MetricName.scala
@@ -15,7 +15,7 @@ final class MetricName(private val segments: Vector[String]) extends AnyVal {
 
 object MetricName {
 
-  val DAML: MetricName = MetricName("daml")
+  val Daml: MetricName = MetricName("daml")
 
   def apply(segments: String*): MetricName =
     new MetricName(segments.toVector)

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -20,7 +20,7 @@ final class Metrics(val registry: MetricRegistry) {
   }
 
   object daml {
-    private val Prefix: MetricName = MetricName.DAML
+    private val Prefix: MetricName = MetricName.Daml
 
     object commands {
       private val Prefix: MetricName = daml.Prefix :+ "commands"

--- a/ledger/metrics/src/test/suite/scala/com/daml/metrics/PackageSpec.scala
+++ b/ledger/metrics/src/test/suite/scala/com/daml/metrics/PackageSpec.scala
@@ -14,7 +14,7 @@ class PackageSpec extends AsyncWordSpec with Matchers {
     "succeed on multiple threads in parallel for the same metric name" in {
       val registry = new MetricRegistry
       implicit val executionContext: ExecutionContext = ExecutionContext.global
-      val metricName = MetricName.DAML :+ "a" :+ "test"
+      val metricName = MetricName.Daml :+ "a" :+ "test"
       val instances =
         (1 to 1000).map(_ => Future(registerGauge(metricName, () => () => 1.0, registry)))
       Future.sequence(instances).map { _ =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -32,6 +32,6 @@ package object kvutils {
 
   type CorrelationId = String
 
-  val MetricPrefix: MetricName = MetricName.DAML :+ "kvutils"
+  val MetricPrefix: MetricName = MetricName.Daml :+ "kvutils"
 
 }


### PR DESCRIPTION
Changed the metrics prefix to follow our product naming conventions.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
