### PR TITLE
restore natural join and avoid table aliasing in participant contracts queries

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -57,9 +57,9 @@ private[dao] sealed class ContractsReader(
 
         dispatcher.executeSql(metrics.daml.index.db.lookupContractByKeyDbMetrics) {
           implicit connection =>
-            SQL"""select pc.contract_id from #$contractsTable
-                 where #$stakeholdersWhere and pcw.contract_witness in ($readers)
-                 and pc.create_key_hash = ${key.hash}
+            SQL"""select contract_id from #$contractsTable
+                 where #$stakeholdersWhere and contract_witness in ($readers)
+                 and create_key_hash = ${key.hash}
                  #${sqlFunctions.limitClause(1)}"""
               .as(contractId("contract_id").singleOpt)
         }
@@ -74,10 +74,9 @@ private[dao] sealed class ContractsReader(
       metrics.daml.index.db.lookupActiveContract,
       dispatcher
         .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
-          SQL"""select pc.contract_id, pc.template_id, pc.create_argument, pc.create_argument_compression from #$contractsTable
+          SQL"""select contract_id, template_id, create_argument, create_argument_compression from #$contractsTable
                where
-               pc.contract_id = pcw.contract_id and
-               pcw.contract_witness in ($readers) and pc.contract_id = $contractId #${sqlFunctions
+               contract_witness in ($readers) and contract_id = $contractId #${sqlFunctions
             .limitClause(1)}"""
             .as(contractRowParser.singleOpt)
         }
@@ -105,7 +104,7 @@ private[dao] sealed class ContractsReader(
       metrics.daml.index.db.lookupActiveContract,
       dispatcher
         .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
-          SQL"select pc.contract_id, pc.template_id from #$contractsTable where pcw.contract_witness in ($readers) and pc.contract_id = $contractId #${sqlFunctions
+          SQL"select contract_id, template_id from #$contractsTable where contract_witness in ($readers) and participant_contracts.contract_id = $contractId #${sqlFunctions
             .limitClause(1)}"
             .as(contractWithoutValueRowParser.singleOpt)
         }
@@ -136,7 +135,7 @@ private[dao] sealed class ContractsReader(
 
 private[dao] object ContractsReader {
   private val contractsTable =
-    "participant_contracts pc, participant_contract_witnesses pcw"
+    "participant_contracts natural join participant_contract_witnesses"
   private val contractWithoutValueRowParser: RowParser[String] =
     str("template_id")
   private val contractRowParser: RowParser[(String, InputStream, Option[Int])] =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -74,7 +74,8 @@ private[dao] sealed class ContractsReader(
       metrics.daml.index.db.lookupActiveContract,
       dispatcher
         .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
-          SQL"""select pc.contract_id, template_id, create_argument, create_argument_compression from #$contractsTable where contract_witness in ($readers) and pc.contract_id = $contractId #${sqlFunctions.limitClause(1)}"""
+          SQL"""select pc.contract_id, template_id, create_argument, create_argument_compression from #$contractsTable where contract_witness in ($readers) and pc.contract_id = $contractId #${sqlFunctions
+            .limitClause(1)}"""
             .as(contractRowParser.singleOpt)
         }
         .map(_.map { case (templateId, createArgument, createArgumentCompression) =>


### PR DESCRIPTION
A regression was found in daml on sql that causes high load on postgres.
This was due to what becomes a cross join when syntax `select ... from participant_contracts pc, participant_contract_witnesses pcw` is used without a column on which to join on.

The following action was taken to fix the regression.  This approach allows for cross-platform syntax which works equivalently on Postgres, Oracle and H2

- Use join for active contracts queries (equivalent to inner join) specifying the column to match on
- Explicitly specify the table from which the contract_id column should be referenced
- Remove references to other columns with table alias as they are not ambiguous and the alias is therefore unnecessary


We have avoided the use of natural join as the column referencing required for natural join is contradictory between H2 and Oracle

- H2 treats natural join as an equivalent to an inner join with an implied `on` on the matching column(s) between the tables, but still requires you to specifically disambiguate the source table for the column in your select and where clauses
- Oracle will use a natural join to collapse common columns between the joined tables, but prevents you from referencing these columns with their source table alias (as it internally takes care of collapsing to a disambiguated 3rd joined table)