### PR TITLE
Split daml test-script code into a separate library

### DIFF
--- a/daml-assistant/daml-sdk/util.bzl
+++ b/daml-assistant/daml-sdk/util.bzl
@@ -3,7 +3,8 @@
 
 def deps(edition):
     return [
-        "//daml-script/runner:script-runner-lib-{}".format(edition),
+        "//daml-script/runner:script-runner-lib",
+        "//daml-script/runner:script-test-lib-{}".format(edition),
         "//extractor",
         "//language-support/codegen-main:codegen-main-lib",
         "//ledger-service/http-json:http-json-{}".format(edition),

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -11,47 +11,79 @@ script_scalacopts = ["-P:wartremover:traverser:org.wartremover.warts.%s" % wart 
     "NonUnitStatements",
 ]]
 
-alias(
+test_script_sources = [
+    "src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala",
+]
+
+da_scala_library(
     name = "script-runner-lib",
-    actual = "script-runner-lib-ce",
+    srcs = glob(
+        ["src/main/scala/**/*.scala"],
+        exclude = test_script_sources,
+    ),
+    scala_deps = [
+        "@maven//:com_github_scopt_scopt",
+        "@maven//:com_typesafe_akka_akka_http",
+        "@maven//:com_typesafe_akka_akka_http_core",
+        "@maven//:com_typesafe_akka_akka_http_spray_json",
+        "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:com_typesafe_akka_akka_parsing",
+        "@maven//:io_spray_spray_json",
+        "@maven//:org_scala_lang_modules_scala_collection_compat",
+        "@maven//:org_scalaz_scalaz_core",
+        "@maven//:org_typelevel_paiges_core",
+    ],
+    scalacopts = script_scalacopts,
     visibility = ["//visibility:public"],
+    deps = [
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/archive:daml_lf_dev_archive_proto_java",
+        "//daml-lf/data",
+        "//daml-lf/engine",
+        "//daml-lf/interface",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
+        "//daml-lf/scenario-interpreter",
+        "//daml-lf/transaction",
+        "//daml-script/converter",
+        "//language-support/scala/bindings",
+        "//language-support/scala/bindings-akka",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-service/cli-opts",
+        "//ledger-service/jwt",
+        "//ledger-service/lf-value-json",
+        "//ledger/ledger-api-auth",
+        "//ledger/ledger-api-client",
+        "//ledger/ledger-api-common",
+        "//libs-scala/auth-utils",
+        "//libs-scala/scala-utils",
+    ],
 )
 
+# Spun out into a separate library to avoid pulling in a sandbox
+# dependency where we don’t need it.
 [
     da_scala_library(
-        name = "script-runner-lib-{}".format(edition),
-        srcs = glob(["src/main/scala/**/*.scala"]),
+        name = "script-test-lib-{}".format(edition),
+        srcs = test_script_sources,
         scala_deps = [
-            "@maven//:com_github_scopt_scopt",
-            "@maven//:com_typesafe_akka_akka_http",
-            "@maven//:com_typesafe_akka_akka_http_core",
-            "@maven//:com_typesafe_akka_akka_http_spray_json",
             "@maven//:com_typesafe_akka_akka_stream",
-            "@maven//:com_typesafe_akka_akka_parsing",
             "@maven//:io_spray_spray_json",
-            "@maven//:org_scala_lang_modules_scala_collection_compat",
             "@maven//:org_scalaz_scalaz_core",
-            "@maven//:org_typelevel_paiges_core",
         ],
         scalacopts = script_scalacopts,
         visibility = ["//visibility:public"],
         deps = [
+            ":script-runner-lib",
             "//daml-lf/archive:daml_lf_archive_reader",
             "//daml-lf/archive:daml_lf_dev_archive_proto_java",
             "//daml-lf/data",
-            "//daml-lf/engine",
-            "//daml-lf/interface",
             "//daml-lf/interpreter",
             "//daml-lf/language",
-            "//daml-lf/scenario-interpreter",
             "//daml-lf/transaction",
-            "//daml-script/converter",
             "//language-support/scala/bindings",
             "//language-support/scala/bindings-akka",
             "//ledger-api/rs-grpc-bridge",
-            "//ledger-service/cli-opts",
-            "//ledger-service/jwt",
-            "//ledger-service/lf-value-json",
             "//ledger/caching",
             "//ledger/ledger-api-auth",
             "//ledger/ledger-api-client",
@@ -61,10 +93,8 @@ alias(
             "//ledger/participant-state",
             "//ledger/sandbox-classic:sandbox-classic-{}".format(edition),
             "//ledger/sandbox-common",
-            "//libs-scala/auth-utils",
             "//libs-scala/ports",
             "//libs-scala/resources",
-            "//libs-scala/scala-utils",
         ],
     )
     for edition in [
@@ -88,7 +118,7 @@ da_scala_binary(
     resources = glob(["src/main/resources/**/*"]),
     scalacopts = script_scalacopts,
     visibility = ["//visibility:public"],
-    deps = [":script-runner-lib"],
+    deps = [":script-test-lib-ce"],
 )
 
 exports_files(["src/main/resources/logback.xml"])

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -41,7 +41,7 @@ depsToExclude :: T.Text
 depsToExclude = T.intercalate " + " [
    "//compiler/scenario-service/protos:scenario_service_java_proto",
    "//compiler/repl-service/protos:repl_service_java_proto",
-   "//daml-script/runner:script-runner-lib-ce"]
+   "//daml-script/runner:script-runner-lib"]
 
 buildAndCopyArtifacts :: (MonadLogger m, MonadIO m, E.MonadThrow m) => IncludeDocs -> SemVer.Version -> BazelLocations -> Path Abs Dir -> [Artifact (Maybe ArtifactLocation)] -> m [Artifact PomData]
 buildAndCopyArtifacts includeDocs mvnVersion bazelLocations releaseDir artifacts = do


### PR DESCRIPTION
Currently we have the following dependency chain:

1. The compiler depends on the scenario service for daml test
2. The scenario service depends on Daml Script
3. Daml Script depends on the Sandbox code only for daml test-script

The last one can easily be split. The scenario service does not care
about this code.

This means that now if we change ledger code, at least not all
compiler tests are going to rerun.

Verified that this actually breaks the dependency fully via

```
bazel query 'somepath(//compiler/damlc/tests:packaging, //ledger/participant-integration-api/...)'
```

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
