### PR TITLE
Differentiate between negative inputs & errors in contractKeyInputs

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -275,6 +275,16 @@ final case class GenTransaction[Nid, +Cid](
 
 sealed abstract class HasTxNodes[Nid, +Cid] {
 
+  import Transaction.{
+    KeyInput,
+    KeyActive,
+    KeyCreate,
+    NegativeKeyLookup,
+    KeyInputError,
+    DuplicateKeys,
+    InconsistentKeys,
+  }
+
   def nodes: Map[Nid, Node.GenNode[Nid, Cid]]
 
   def roots: ImmArray[Nid]
@@ -485,7 +495,11 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
 
   /** Return the expected contract key inputs (i.e. the state before the transaction)
     * for this transaction or an error if the transaction contains a
-    * duplicate key error or has an inconsistent mapping for a key.
+    * duplicate key error or has an inconsistent mapping for a key. For
+    * KeyCreate and NegativeKeyLookup (both corresponding to the key not being active)
+    * the first required input in execution order wins. So if a create comes first
+    * the input will be set to KeyCreate, if a negative lookup by key comes first
+    * the input will be set to NegativeKeyLookup.
     *
     * Because we do not preserve byKey flags across transaction serialization
     * this method will consider all operations with keys for conflicts
@@ -496,38 +510,42 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
   )
   final def contractKeyInputs(implicit
       evidence: HasTxNodes[Nid, Cid] <:< HasTxNodes[_, Value.ContractId]
-  ): Either[GlobalKey, Map[GlobalKey, Option[Value.ContractId]]] = {
+  ): Either[KeyInputError, Map[GlobalKey, KeyInput]] = {
     val evThis = evidence(this)
     val localContracts = evThis.localContracts
     final case class State(
         keys: Map[GlobalKey, Option[Value.ContractId]],
         rollbackStack: List[Map[GlobalKey, Option[Value.ContractId]]],
-        keyInputs: Map[GlobalKey, Option[Value.ContractId]],
+        keyInputs: Map[GlobalKey, KeyInput],
     ) {
       def setKeyMapping(
           key: GlobalKey,
-          value: Option[Value.ContractId],
-      ): Either[GlobalKey, State] = {
-        keyInputs.get(key) match {
-          case Some(prev) if prev != value => Left(key)
-          case _ => Right(copy(keyInputs = keyInputs.updated(key, value)))
+          value: KeyInput,
+      ): Either[KeyInputError, State] = {
+        (keyInputs.get(key), value) match {
+          case (None, _) =>
+            Right(copy(keyInputs = keyInputs.updated(key, value)))
+          case (Some(KeyCreate | NegativeKeyLookup), KeyActive(_)) => Left(InconsistentKeys(key))
+          case (Some(KeyActive(_)), NegativeKeyLookup) => Left(InconsistentKeys(key))
+          case (Some(KeyActive(_)), KeyCreate) => Left(DuplicateKeys(key))
+          case _ => Right(this)
         }
       }
       def assertKeyMapping(
           templateId: Identifier,
           cid: Value.ContractId,
           optKey: Option[Node.KeyWithMaintainers[Value[Value.ContractId]]],
-      ): Either[GlobalKey, State] =
-        optKey.fold[Either[GlobalKey, State]](Right(this)) { key =>
+      ): Either[KeyInputError, State] =
+        optKey.fold[Either[KeyInputError, State]](Right(this)) { key =>
           val gk = GlobalKey.assertBuild(templateId, key.key)
           keys.get(gk) match {
-            case Some(keyMapping) if Some(cid) != keyMapping => Left(gk)
+            case Some(keyMapping) if Some(cid) != keyMapping => Left(InconsistentKeys(gk))
             case _ =>
               val r = copy(keys = keys.updated(gk, Some(cid)))
               if (localContracts.contains(cid)) {
                 Right(r)
               } else {
-                r.setKeyMapping(gk, Some(cid))
+                r.setKeyMapping(gk, KeyActive(cid))
               }
           }
         }
@@ -546,30 +564,29 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
         }
 
       def handleCreate(create: Node.NodeCreate[Value.ContractId]) =
-        create.key.fold[Either[GlobalKey, State]](Right(this)) { key =>
+        create.key.fold[Either[KeyInputError, State]](Right(this)) { key =>
           val gk = GlobalKey.assertBuild(create.templateId, key.key)
-          keys.get(gk).orElse(keyInputs.get(gk)) match {
+          val next = copy(keys = keys.updated(gk, Some(create.coid)))
+          keys.get(gk) match {
             case None =>
-              Right(
-                copy(
-                  keys = keys.updated(gk, Some(create.coid)),
-                  keyInputs = keyInputs.updated(gk, None),
-                )
-              )
+              next.setKeyMapping(gk, KeyCreate)
             case Some(None) =>
-              Right(copy(keys = keys.updated(gk, Some(create.coid))))
-            case Some(Some(_)) =>
-              Left(gk)
+              Right(next)
+            case Some(Some(_)) => Left(DuplicateKeys(gk))
           }
         }
 
-      def handleLookup(lookup: Node.NodeLookupByKey[Value.ContractId]) = {
+      def handleLookup(
+          lookup: Node.NodeLookupByKey[Value.ContractId]
+      ): Either[KeyInputError, State] = {
         val gk = GlobalKey.assertBuild(lookup.templateId, lookup.key.key)
         keys.get(gk) match {
-          case None => setKeyMapping(gk, lookup.result)
+          case None =>
+            copy(keys = keys.updated(gk, lookup.result))
+              .setKeyMapping(gk, lookup.result.fold[KeyInput](NegativeKeyLookup)(KeyActive(_)))
           case Some(optCid) =>
             if (optCid != lookup.result) {
-              Left(gk)
+              Left(InconsistentKeys(gk))
             } else {
               // No need to update anything, we updated keyInputs when we updated keys.
               Right(this)
@@ -577,7 +594,9 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
         }
       }
 
-      def handleLeaf(leaf: Node.LeafOnlyActionNode[Value.ContractId]): Either[GlobalKey, State] =
+      def handleLeaf(
+          leaf: Node.LeafOnlyActionNode[Value.ContractId]
+      ): Either[KeyInputError, State] =
         leaf match {
           case create: Node.NodeCreate[Value.ContractId] =>
             handleCreate(create)
@@ -597,7 +616,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
         )
     }
     evThis
-      .foldInExecutionOrder[Either[GlobalKey, State]](
+      .foldInExecutionOrder[Either[KeyInputError, State]](
         Right(State(Map.empty, List.empty, Map.empty))
       )(
         exerciseBegin = (acc, _, exe) => (acc.flatMap(_.handleExercise(exe)), true),
@@ -815,7 +834,6 @@ object GenTransaction extends value.CidContainer2[GenTransaction] {
       }
     }.duplicates
   }
-
 }
 
 object Transaction {
@@ -913,4 +931,39 @@ object Transaction {
       replayed: VersionedTransaction[Nid, Cid],
   )(implicit ECid: Equal[Cid]): Either[ReplayMismatch[Nid, Cid], Unit] =
     Validation.isReplayedBy(recorded, replayed)
+
+  /** The state of a key at the beginning of the transaction.
+    */
+  sealed trait KeyInput extends Product with Serializable
+
+  /** No active contract with the given key.
+    */
+  sealed trait KeyInactive extends KeyInput
+
+  /** A contract with the key will be created so the key must be inactive.
+    */
+  final case object KeyCreate extends KeyInactive
+
+  /** Negative key lookup so the key mus tbe inactive.
+    */
+  final case object NegativeKeyLookup extends KeyInactive
+
+  /** Key must be mapped to this active contract.
+    */
+  final case class KeyActive(cid: Value.ContractId) extends KeyInput
+
+  /** contractKeyInputs failed to produce an input due to an error for the given key.
+    */
+  sealed abstract class KeyInputError {
+    def key: GlobalKey
+  }
+
+  /** A create failed because there was already an active contract with the same key.
+    */
+  final case class DuplicateKeys(key: GlobalKey) extends KeyInputError
+
+  /** An exercise, fetch or lookupByKey failed because the mapping of key -> contract id
+    * was inconsistent with earlier nodes (in execution order).
+    */
+  final case class InconsistentKeys(key: GlobalKey) extends KeyInputError
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -18,6 +18,7 @@ import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.test.ValueGenerators.danglingRefGenNode
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.freespec.AnyFreeSpec
 
@@ -25,7 +26,11 @@ import scala.collection.immutable.HashMap
 import scala.language.implicitConversions
 import scala.util.Random
 
-class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class TransactionSpec
+    extends AnyFreeSpec
+    with Matchers
+    with Inside
+    with ScalaCheckDrivenPropertyChecks {
 
   import TransactionSpec._
 
@@ -380,6 +385,7 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
   }
 
   "contractKeyInputs" - {
+    import Transaction._
     // TODO: https://github.com/digital-asset/daml/issues/8020
     // change VDev to  TransactionVersion.StableVersions.max once exception are released
     val dummyBuilder = TransactionBuilder(TransactionVersion.VDev)
@@ -418,7 +424,7 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
       val builder = TransactionBuilder(TransactionVersion.VDev)
       val createNode = create("#0")
       builder.add(createNode)
-      builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> None))
+      builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> KeyCreate))
     }
     "return Some(_) for fetch and fetch-by-key" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
@@ -427,7 +433,10 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
       builder.add(fetchNode0)
       builder.add(fetchNode1)
       builder.build().contractKeyInputs shouldBe Right(
-        Map(globalKey("#0") -> Some(fetchNode0.coid), globalKey("#1") -> Some(fetchNode1.coid))
+        Map(
+          globalKey("#0") -> KeyActive(fetchNode0.coid),
+          globalKey("#1") -> KeyActive(fetchNode1.coid),
+        )
       )
     }
     "return Some(_) for consuming/non-consuming exercise and exercise-by-key" in {
@@ -443,7 +452,7 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
       builder.build().contractKeyInputs shouldBe
         Right(
           Seq(exe0, exe1, exe2, exe3).view
-            .map(exe => globalKey(exe.targetCoid.coid) -> Some(exe.targetCoid))
+            .map(exe => globalKey(exe.targetCoid.coid) -> KeyActive(exe.targetCoid))
             .toMap
         )
     }
@@ -452,15 +461,16 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
       val builder = TransactionBuilder(TransactionVersion.VDev)
       val lookupNode = lookup("#0", found = false)
       builder.add(lookupNode)
-      builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> None))
+      builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> NegativeKeyLookup))
     }
 
     "return Some(_) for negative lookup by key" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
       val lookupNode = lookup("#0", found = true)
       builder.add(lookupNode)
-      lookupNode.result shouldBe a[Some[_]]
-      builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> lookupNode.result))
+      inside(lookupNode.result) { case Some(cid) =>
+        builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> KeyActive(cid)))
+      }
     }
     "returns keys used under rollback nodes" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
@@ -475,10 +485,10 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
       builder.add(lookupNode, rollback)
       builder.build().contractKeyInputs shouldBe Right(
         Map(
-          globalKey("#0") -> None,
-          globalKey("#1") -> Some(exerciseNode.targetCoid),
-          globalKey("#2") -> Some(fetchNode.coid),
-          globalKey("#3") -> None,
+          globalKey("#0") -> KeyCreate,
+          globalKey("#1") -> KeyActive(exerciseNode.targetCoid),
+          globalKey("#2") -> KeyActive(fetchNode.coid),
+          globalKey("#3") -> NegativeKeyLookup,
         )
       )
     }
@@ -486,53 +496,53 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
       val builder = TransactionBuilder(TransactionVersion.VDev)
       builder.add(create("#0"))
       builder.add(create("#0"))
-      builder.build().contractKeyInputs shouldBe Left(globalKey("#0"))
+      builder.build().contractKeyInputs shouldBe Left(DuplicateKeys(globalKey("#0")))
     }
     "two creates do not conflict if interleaved with archive" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
       builder.add(create("#0"))
       builder.add(exe("#0", consuming = true, byKey = false))
       builder.add(create("#0"))
-      builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> None))
+      builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> KeyCreate))
     }
     "two creates do not conflict if one is in rollback" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
       val rollback = builder.add(builder.rollback())
       builder.add(create("#0"), rollback)
       builder.add(create("#0"))
-      builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> None))
+      builder.build().contractKeyInputs shouldBe Right(Map(globalKey("#0") -> KeyCreate))
     }
     "negative lookup after create fails" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
       builder.add(create("#0"))
       builder.add(lookup("#0", found = false))
-      builder.build().contractKeyInputs shouldBe Left(globalKey("#0"))
+      builder.build().contractKeyInputs shouldBe Left(InconsistentKeys(globalKey("#0")))
     }
     "inconsistent lookups conflict" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
       builder.add(lookup("#0", found = true))
       builder.add(lookup("#0", found = false))
-      builder.build().contractKeyInputs shouldBe Left(globalKey("#0"))
+      builder.build().contractKeyInputs shouldBe Left(InconsistentKeys(globalKey("#0")))
     }
     "inconsistent lookups conflict across rollback" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
       val rollback = builder.add(builder.rollback())
       builder.add(lookup("#0", found = true), rollback)
       builder.add(lookup("#0", found = false))
-      builder.build().contractKeyInputs shouldBe Left(globalKey("#0"))
+      builder.build().contractKeyInputs shouldBe Left(InconsistentKeys(globalKey("#0")))
     }
     "positive lookup conflicts with create" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
       builder.add(lookup("#0", found = true))
       builder.add(create("#0"))
-      builder.build().contractKeyInputs shouldBe Left(globalKey("#0"))
+      builder.build().contractKeyInputs shouldBe Left(DuplicateKeys(globalKey("#0")))
     }
     "positive lookup in rollback conflicts with create" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
       val rollback = builder.add(builder.rollback())
       builder.add(lookup("#0", found = true), rollback)
       builder.add(create("#0"))
-      builder.build().contractKeyInputs shouldBe Left(globalKey("#0"))
+      builder.build().contractKeyInputs shouldBe Left(DuplicateKeys(globalKey("#0")))
     }
     "rolled back archive does not prevent conflict" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
@@ -540,7 +550,7 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
       val rollback = builder.add(builder.rollback())
       builder.add(exe("#0", consuming = true, byKey = true), rollback)
       builder.add(create("#0"))
-      builder.build().contractKeyInputs shouldBe Left(globalKey("#0"))
+      builder.build().contractKeyInputs shouldBe Left(DuplicateKeys(globalKey("#0")))
     }
     "successful, inconsistent lookups conflict" in {
       val builder = TransactionBuilder(TransactionVersion.VDev)
@@ -555,7 +565,22 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
       )
       builder.add(builder.lookupByKey(create0, found = true))
       builder.add(builder.lookupByKey(create1, found = true))
-      builder.build().contractKeyInputs shouldBe Left(globalKey("#0"))
+      builder.build().contractKeyInputs shouldBe Left(InconsistentKeys(globalKey("#0")))
+    }
+    "first negative input wins" in {
+      val builder = TransactionBuilder(TransactionVersion.VDev)
+      val rollback = builder.add(builder.rollback())
+      val create0 = create("#0")
+      val lookup0 = builder.lookupByKey(create0, found = false)
+      val create1 = create("#1")
+      val lookup1 = builder.lookupByKey(create1, found = false)
+      builder.add(create0, rollback)
+      builder.add(lookup1, rollback)
+      builder.add(lookup0)
+      builder.add(create1)
+      builder.build().contractKeyInputs shouldBe Right(
+        Map(globalKey("#0") -> KeyCreate, globalKey("#1") -> NegativeKeyLookup)
+      )
     }
   }
 


### PR DESCRIPTION
For better or for worse, kvutils validation insists on treating a
negative input from a create different to a negative key lookup (and
to make things more annoying the first one will never blow up during
submission only during validation).

While, nobody seems to argue all that strongly that the current errors
are very sensible, we agreed to do it in two steps:

1. Expose enough information in `contractKeyInputs` so that we can use
   it in kvutils while preserving the current error semantics.
2. Revisit contract key error handling across ledgers which is
   currently an inconsistent mess.

changelog_begin
changelog_end

.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
