### PR TITLE
Add race condition tests for exceptions

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/dummy/ExceptionRaceConditionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/dummy/ExceptionRaceConditionIT.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.suites
+
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
+
+// Empty dummy suite for LF versions that do not support exceptions.
+final class ExceptionRaceConditionIT extends LedgerTestSuite {}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionRaceConditionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionRaceConditionIT.scala
@@ -10,11 +10,8 @@ import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestCo
 import com.daml.ledger.api.testtool.infrastructure.RaceConditionTests._
 import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.test.semantic.ExceptionRaceTests._
-// import com.daml.timer.Delayed
 
-// import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-// import scala.util.Success
 
 final class ExceptionRaceConditionIT extends LedgerTestSuite {
   raceConditionTest(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionRaceConditionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionRaceConditionIT.scala
@@ -1,0 +1,178 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.suites
+
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
+import com.daml.ledger.api.testtool.infrastructure.Assertions._
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
+import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
+import com.daml.ledger.api.testtool.infrastructure.RaceConditionTests._
+import com.daml.ledger.client.binding.Primitive
+import com.daml.ledger.test.semantic.ExceptionRaceTests._
+// import com.daml.timer.Delayed
+
+// import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+// import scala.util.Success
+
+final class ExceptionRaceConditionIT extends LedgerTestSuite {
+  raceConditionTest(
+    "RWRollbackCreateVsNonTransientCreate",
+    "Cannot create a contract in a rollback and a non-transient contract with the same key",
+  ) { implicit ec => ledger => alice =>
+    for {
+      wrapper <- ledger.create(alice, CreateWrapper(alice))
+      _ <- executeRepeatedlyWithRandomDelay(
+        numberOfAttempts = 20,
+        once = ledger.create(alice, ContractWithKey(alice)).map(_ => ()),
+        repeated = ledger.exercise(alice, wrapper.exerciseCreateWrapper_CreateRollback).map(_ => ()),
+      )
+      transactions <- transactions(ledger, alice)
+    } yield {
+      import TransactionUtil._
+
+      // We deliberately allow situations where no non-transient contract is created and verify the transactions
+      // order when such contract is actually created.
+      transactions.find(isCreateNonTransient).foreach { nonTransientCreateTransaction =>
+        transactions
+          .filter(isTransientCreate)
+          .foreach(assertTransactionOrder(_, nonTransientCreateTransaction))
+      }
+    }
+  }
+
+  raceConditionTest(
+    "RWArchiveVsRollbackNonConsumingChoice",
+    "Cannot exercise a non-consuming choice in a rollback after a contract archival",
+  ) { implicit ec => ledger => alice =>
+    for {
+      wrapper <- ledger.create(alice, ExerciseWrapper(alice))
+      contract <- ledger.create(alice, ContractWithKey(alice))
+      _ <- executeRepeatedlyWithRandomDelay(
+        numberOfAttempts = 10,
+        once = ledger.exercise(alice, contract.exerciseContractWithKey_Archive),
+        repeated = ledger.exercise(
+          alice,
+          wrapper.exerciseExerciseWrapper_ExerciseNonConsumingRollback(_, contract),
+        ),
+      )
+      transactions <- transactions(ledger, alice)
+    } yield {
+      import TransactionUtil._
+      val archivalTransaction = assertSingleton("archivals", transactions.filter(isArchival))
+      transactions
+        .filter(isNonConsumingExercise)
+        .foreach(assertTransactionOrder(_, archivalTransaction))
+    }
+  }
+
+  raceConditionTest(
+    "RWArchiveVsRollbackConsumingChoice",
+    "Cannot exercise a consuming choice in a rollback after a contract archival",
+  ) { implicit ec => ledger => alice =>
+    for {
+      wrapper <- ledger.create(alice, ExerciseWrapper(alice))
+      contract <- ledger.create(alice, ContractWithKey(alice))
+      _ <- executeRepeatedlyWithRandomDelay(
+        numberOfAttempts = 10,
+        once = ledger.exercise(alice, contract.exerciseContractWithKey_Archive),
+        repeated = ledger.exercise(
+          alice,
+          wrapper.exerciseExerciseWrapper_ExerciseConsumingRollback(_, contract),
+        ),
+      )
+      transactions <- transactions(ledger, alice)
+    } yield {
+      import TransactionUtil._
+      val archivalTransaction = assertSingleton("archivals", transactions.filter(isArchival))
+      transactions
+        .filter(isNonConsumingExercise)
+        .foreach(assertTransactionOrder(_, archivalTransaction))
+    }
+  }
+
+  raceConditionTest(
+    "RWArchiveVsRollbackFetch",
+    "Cannot fetch in a rollback after a contract archival",
+  ) { implicit ec => ledger => alice =>
+    for {
+      contract <- ledger.create(alice, ContractWithKey(alice))
+      fetchConract <- ledger.create(alice, FetchWrapper(alice, contract))
+      _ <- executeRepeatedlyWithRandomDelay(
+        numberOfAttempts = 10,
+        once = ledger.exercise(alice, contract.exerciseContractWithKey_Archive),
+        repeated = ledger.exercise(alice, fetchConract.exerciseFetchWrapper_Fetch),
+      )
+      transactions <- transactions(ledger, alice)
+    } yield {
+      import TransactionUtil._
+      val archivalTransaction = assertSingleton("archivals", transactions.filter(isArchival))
+      transactions
+        .filter(isFetch)
+        .foreach(assertTransactionOrder(_, archivalTransaction))
+    }
+  }
+
+  raceConditionTest(
+    "RWArchiveVsRollbackLookupByKey",
+    "Cannot successfully lookup by key in a rollback after a contract archival",
+  ) { implicit ec => ledger => alice =>
+    for {
+      contract <- ledger.create(alice, ContractWithKey(alice))
+      looker <- ledger.create(alice, LookupWrapper(alice))
+      _ <- executeRepeatedlyWithRandomDelay(
+        numberOfAttempts = 20,
+        once = ledger.exercise(alice, contract.exerciseContractWithKey_Archive),
+        repeated = ledger.exercise(alice, looker.exerciseLookupWrapper_Lookup),
+      )
+      transactions <- transactions(ledger, alice)
+    } yield {
+      import TransactionUtil._
+      val archivalTransaction = assertSingleton("archivals", transactions.filter(isArchival))
+      transactions
+        .filter(isContractLookup(success = true))
+        .foreach(assertTransactionOrder(_, archivalTransaction))
+    }
+  }
+
+  raceConditionTest(
+    "RWArchiveVsRollbackFailedLookupByKey",
+    "Lookup by key in a rollback cannot fail after a contract creation",
+  ) { implicit ec => ledger => alice =>
+    for {
+      looker <- ledger.create(alice, LookupWrapper(alice))
+      _ <- executeRepeatedlyWithRandomDelay(
+        numberOfAttempts = 5,
+        once = ledger.create(alice, ContractWithKey(alice)),
+        repeated = ledger.exercise(alice, looker.exerciseLookupWrapper_Lookup),
+      )
+      transactions <- transactions(ledger, alice)
+    } yield {
+      import TransactionUtil._
+      val createNonTransientTransaction = assertSingleton(
+        "create-non-transient transactions",
+        transactions.filter(isCreateNonTransient),
+      )
+      transactions
+        .filter(isContractLookup(success = false))
+        .foreach(assertTransactionOrder(_, createNonTransientTransaction))
+    }
+  }
+
+  private def raceConditionTest(
+      shortIdentifier: String,
+      description: String,
+      repeated: Int = DefaultRepetitionsNumber,
+      runConcurrently: Boolean = false,
+  )(testCase: ExecutionContext => ParticipantTestContext => Primitive.Party => Future[Unit]): Unit =
+    test(
+      shortIdentifier = shortIdentifier,
+      description = description,
+      participants = allocate(SingleParty),
+      repeated = repeated,
+      runConcurrently = runConcurrently,
+    )(implicit ec => { case Participants(Participant(ledger, party)) =>
+      testCase(ec)(ledger)(party)
+    })
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionsIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionsIT.scala
@@ -109,7 +109,7 @@ final class ExceptionsIT extends LedgerTestSuite {
 
   test(
     "ExRolledbackArchiveConsuming",
-    "Rolledback archive does not block consuming exercise",
+    "Rolled back archive does not block consuming exercise",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
     for {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Tests.scala
@@ -45,7 +45,8 @@ object Tests {
       new ValueLimitsIT,
       new WitnessesIT,
       new WronglyTypedContractIdIT,
-    ) ++ (if (supportsExceptions) Vector(new ExceptionsIT) else Vector.empty)
+    ) ++ (if (supportsExceptions) Vector(new ExceptionsIT, new ExceptionRaceConditionIT)
+          else Vector.empty)
 
   val optional: Vector[LedgerTestSuite] =
     Vector(

--- a/ledger/ledger-api-test-tool/util.bzl
+++ b/ledger/ledger-api-test-tool/util.bzl
@@ -6,19 +6,25 @@ load(
     "versions",
 )
 
-exceptions_suite = "src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionsIT.scala"
-exceptions_dummy_suite = "src/main/scala/com/daml/ledger/api/testtool/dummy/ExceptionsIT.scala"
+exceptions_suites = [
+    "src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionsIT.scala",
+    "src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionRaceConditionIT.scala",
+]
+exceptions_dummy_suites = [
+    "src/main/scala/com/daml/ledger/api/testtool/dummy/ExceptionsIT.scala",
+    "src/main/scala/com/daml/ledger/api/testtool/dummy/ExceptionRaceConditionIT.scala",
+]
 
 def suites_sources(version):
     suites = native.glob(
         ["src/main/scala/com/daml/ledger/api/testtool/suites/**/*.scala"],
-        exclude = [exceptions_suite],
+        exclude = exceptions_suites,
     )
 
     # TODO https://github.com/digital-asset/daml/issues/8020
     # Switch to a stable LF version.
     if versions.gte(version, "1.dev"):
-        suites += [exceptions_suite]
+        suites += exceptions_suites
     else:
-        suites += [exceptions_dummy_suite]
+        suites += exceptions_dummy_suites
     return suites

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -407,6 +407,10 @@ server_conformance_test(
         "--contract-id-seeding=testing-weak",
     ],
     servers = SERVERS,
+    test_tool_args = [
+        "--open-world",
+        "--exclude=ClosedWorldIT",
+    ],
 )
 
 # TODO https://github.com/digital-asset/daml/issues/8020
@@ -421,4 +425,8 @@ server_conformance_test(
         "--enable-append-only-schema",
     ],
     servers = ONLY_POSTGRES_SERVER,
+    test_tool_args = [
+        "--open-world",
+        "--exclude=ClosedWorldIT",
+    ],
 )

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -407,9 +407,6 @@ server_conformance_test(
         "--contract-id-seeding=testing-weak",
     ],
     servers = SERVERS,
-    test_tool_args = [
-        "--include=ExceptionsIT",
-    ],
 )
 
 # TODO https://github.com/digital-asset/daml/issues/8020
@@ -424,7 +421,4 @@ server_conformance_test(
         "--enable-append-only-schema",
     ],
     servers = ONLY_POSTGRES_SERVER,
-    test_tool_args = [
-        "--include=ExceptionsIT",
-    ],
 )

--- a/ledger/test-common/src/main/daml/semantic/ExceptionRaceTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/ExceptionRaceTests.daml
@@ -1,0 +1,116 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE CPP #-}
+module ExceptionRaceTests where
+
+#ifdef DAML_EXCEPTIONS
+import DA.Exception
+import DA.Optional (isSome)
+
+exception E
+  where
+    message "E"
+
+exception LookupException
+  with
+    found : Bool
+  where
+    message "LookupException"
+
+type RaceKey = Text
+
+template DummyContract with
+    owner : Party
+  where
+    signatory owner
+
+template ContractWithKey with
+    owner : Party
+  where
+    signatory owner
+    key owner: Party
+    maintainer key
+
+    controller owner can
+      ContractWithKey_Archive : ()
+        do
+          return ()
+
+    controller owner can
+      nonconsuming ContractWithKey_Exercise : ()
+        do
+          return ()
+
+template FetchWrapper with
+    fetcher : Party
+    contractId : ContractId ContractWithKey
+  where 
+    signatory fetcher
+    controller fetcher can
+      nonconsuming FetchWrapper_Fetch: ()
+        do try do
+             _ <- fetch contractId
+             throw E
+           catch
+             E -> pure ()
+
+template LookupResult with
+    owner : Party
+    found : Bool
+  where
+    signatory owner
+
+template LookupWrapper with
+    owner : Party
+  where
+    signatory owner
+
+    controller owner can
+      nonconsuming LookupWrapper_Lookup : ()
+        do try do
+             optionalContractId <- lookupByKey @ContractWithKey owner
+             throw (LookupException (isSome optionalContractId))
+           catch
+             (LookupException successful) -> do
+               create LookupResult with owner = owner, found = successful
+               pure ()
+
+template CreateWrapper with
+    owner : Party
+  where
+    signatory owner
+    controller owner can
+      nonconsuming CreateWrapper_CreateRollback : ()
+        do
+          try do
+            contract <- create ContractWithKey with owner
+            throw E
+          catch
+            E -> pure ()
+
+template ExerciseWrapper
+  with
+    owner : Party
+  where
+    signatory owner
+    controller owner can
+      nonconsuming ExerciseWrapper_ExerciseConsumingRollback : ()
+        with
+          cid : ContractId ContractWithKey
+        do
+          try do
+            contract <- exercise cid Archive
+            throw E
+          catch
+            E -> pure ()
+      nonconsuming ExerciseWrapper_ExerciseNonConsumingRollback : ()
+        with
+          cid : ContractId ContractWithKey
+        do
+          try do
+            contract <- exercise cid ContractWithKey_Exercise
+            throw E
+          catch
+            E -> pure ()
+#endif


### PR DESCRIPTION
This PR addresses
https://github.com/digital-asset/daml/pull/9400#pullrequestreview-634770251
and adds tests that match RaceConditionTests but to the read side in a
rollback (we cannot do writes in rollbacks, they are rolled back :)).

The tests are as close as possible to the other race condition tests
to ease maintenance and reduce confusion.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
