### PR TITLE
Fix MutableCacheBackedContractStoreSpec flakiness

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
@@ -58,7 +58,7 @@ class MutableCacheBackedContractStoreSpec
   private implicit val materializer: Materializer = Materializer(actorSystem)
 
   override implicit val patienceConfig: PatienceConfig =
-    PatienceConfig(timeout = scaled(Span(500, Millis)))
+    PatienceConfig(timeout = scaled(Span(2000, Millis)), interval = scaled(Span(50, Millis)))
 
   "event stream consumption" should {
     "populate the caches from the contract state event stream" in {


### PR DESCRIPTION
Optimistically increase Patience for fixing flakiness in MutableCacheBackedContractStoreSpec.

Failure [example](https://dev.azure.com/digitalasset/daml/_build/results?buildId=77327) 

CHANGELOG_BEING
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
