### PR TITLE
Fix client_server_build/test with port file

### DIFF
--- a/bazel_tools/client_server/runner/BUILD.bazel
+++ b/bazel_tools/client_server/runner/BUILD.bazel
@@ -9,6 +9,7 @@ da_haskell_binary(
     hackage_deps = [
         "base",
         "extra",
+        "filepath",
         "process",
         "async",
         "text",

--- a/bazel_tools/client_server/runner/Main.hs
+++ b/bazel_tools/client_server/runner/Main.hs
@@ -5,17 +5,19 @@ module Main(main) where
 
 import DA.PortFile
 import System.Environment
+import System.FilePath ((</>))
 import System.Process
-import System.IO.Extra (withTempFile)
+import System.IO.Extra (withTempDir)
 import Data.List.Split (splitOn)
 
 
 main :: IO ()
 main = do
   [clientExe, clientArgs, serverExe, serverArgs, _runnerArgs] <- getArgs
-  withTempFile $ \tempFile -> do
+  withTempDir $ \tempDir -> do
     let splitArgs = filter (/= "") . splitOn " "
-    let serverProc = proc serverExe $ ["--port-file", tempFile] <> splitArgs serverArgs
+    let portFile = tempDir </> "portfile"
+    let serverProc = proc serverExe $ ["--port-file", portFile] <> splitArgs serverArgs
     withCreateProcess serverProc $ \_stdin _stdout _stderr _ph -> do
-      port <- readPortFile maxRetries tempFile
+      port <- readPortFile maxRetries portFile
       callProcess clientExe (["--target-port", show port] <> splitArgs clientArgs)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -30,10 +30,12 @@ import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.services.time.TimeProviderType
 import com.daml.platform.store.LfValueTranslationCache
 import com.daml.ports.{Port, PortFiles}
+import com.daml.resources.FutureResourceOwner
 import io.grpc.{BindableService, ServerInterceptor}
+import scalaz.{-\/, \/-}
 
 import scala.collection.immutable
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContextExecutor, Future}
 
 // Main entry point to start an index server that also hosts the ledger API.
 // See v2.ReferenceServer on how it is used.
@@ -121,8 +123,8 @@ final class StandaloneApiServer(
         servicesExecutionContext,
         metrics,
       )
+      _ <- new FutureResourceOwner[ResourceContext, Unit](() => writePortFile(apiServer.port))
     } yield {
-      writePortFile(apiServer.port)
       logger.info(
         s"Initialized API server version ${BuildInfo.Version} with ledger-id = $ledgerId, port = ${apiServer.port}, dar file = ${config.archiveFiles}"
       )
@@ -165,8 +167,15 @@ final class StandaloneApiServer(
       .fold({ case (err, file) => sys.error(s"Could not load package $file: $err") }, identity)
   }
 
-  private def writePortFile(port: Port): Unit =
-    config.portFile.foreach { path =>
-      PortFiles.write(path, port)
+  private def writePortFile(port: Port): Future[Unit] = {
+    config.portFile match {
+      case Some(path) =>
+        PortFiles.write(path, port) match {
+          case -\/(err) => Future.failed(new RuntimeException(err.toString))
+          case \/-(()) => Future.successful(())
+        }
+      case None =>
+        Future.successful(())
     }
+  }
 }


### PR DESCRIPTION
The default runner created the port-file for sandbox to write it's port into. (Relevant with dynamic port, i.e. `--port 0`). However, sandbox will not overwrite an existing port-file. Sandbox silently ignored this error and left the port-file untouched.

This PR
- Changes the `client_server_*` runner to create a temporary directory instead of a file and lets sandbox create a fresh port file within that directory.
- Changes sandbox such that it fails if the port-file cannot be written to, instead of silently ignoring the error.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
