### PR TITLE
DA.BigNumeric: Split shift, add roundToNumeric.

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
@@ -33,7 +33,7 @@ import GHC.Types (primitive)
 -- ```
 --
 -- ```
--- >>> scale (shift (-2^14) 1.0)
+-- >>> scale (shiftLeft (2^14) 1.0)
 -- -2^14
 -- ```
 scale : BigNumeric -> Int
@@ -73,16 +73,40 @@ div = primitive @"BEDivBigNumeric"
 round : Int -> RoundingMode -> BigNumeric -> BigNumeric
 round scale rounding x = div scale rounding x 1.0
 
--- | Shift a `BigNumeric` number up or down by a power of 10. The value
--- `shift n a` is the value of `a` times `10^(-n)`.
+-- | Shift a `BigNumeric` number to the right by a power of 10. The value
+-- `shiftRight n a` is the value of `a` times `10^(-n)`.
 --
--- This will fail if the resulting `BigNumeric` is out of bounds.
+-- This will fail if the resulting `BigNumeric` is out of bounds,
+-- or if the absolute value of `n` is larger than the maximum
+-- precision (2^16 - 1).
 --
 -- ```
--- >>> shift 2 32.0
+-- >>> shiftRight 2 32.0
 -- 0.32
 -- ```
-shift : Int -> BigNumeric -> BigNumeric
-shift = primitive @"BEShiftBigNumeric"
+shiftRight : Int -> BigNumeric -> BigNumeric
+shiftRight = primitive @"BEShiftBigNumeric"
+
+-- | Shift a `BigNumeric` number to the left by a power of 10. The value
+-- `shiftLeft n a` is the value of `a` times `10^n`.
+--
+-- This will fail if the resulting `BigNumeric` is out of bounds,
+-- or if the absolute value of `n` is larger than the maximum
+-- precision (2^16 - 1).
+--
+-- ```
+-- >>> shiftLeft 2 32.0
+-- 3200.0
+-- ```
+shiftLeft : Int -> BigNumeric -> BigNumeric
+shiftLeft n x = shiftRight (-n) x
+
+-- | Round a `BigNumeric` and cast it to a `Numeric`. This function uses the
+-- scale of the resulting numeric to determine the scale of the rounding.
+--
+-- This will fail when using the `RoundingUnnecessary` mode if the `BigNumeric`
+-- cannot be represented exactly in the requested `Numeric n`.
+roundToNumeric : forall n. NumericScale n => RoundingMode -> BigNumeric -> Numeric n
+roundToNumeric r x = fromBigNumeric (round (numericScale (aunit : Numeric n)) r x)
 
 #endif

--- a/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
@@ -14,6 +14,7 @@ module DA.BigNumeric where
 module DA.BigNumeric where
 
 import GHC.Types (primitive)
+import Prelude hiding (round)
 
 -- | Calculate the scale of a `BigNumeric` number. The `BigNumeric` number is
 -- represented as `n * 10^-s` where `n` is an integer with no trailing zeros,

--- a/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
@@ -77,9 +77,7 @@ round scale rounding x = div scale rounding x 1.0
 -- | Shift a `BigNumeric` number to the right by a power of 10. The value
 -- `shiftRight n a` is the value of `a` times `10^(-n)`.
 --
--- This will fail if the resulting `BigNumeric` is out of bounds,
--- or if the absolute value of `n` is larger than the maximum
--- precision (2^16 - 1).
+-- This will fail if the resulting `BigNumeric` is out of bounds.
 --
 -- ```
 -- >>> shiftRight 2 32.0
@@ -91,9 +89,7 @@ shiftRight = primitive @"BEShiftBigNumeric"
 -- | Shift a `BigNumeric` number to the left by a power of 10. The value
 -- `shiftLeft n a` is the value of `a` times `10^n`.
 --
--- This will fail if the resulting `BigNumeric` is out of bounds,
--- or if the absolute value of `n` is larger than the maximum
--- precision (2^16 - 1).
+-- This will fail if the resulting `BigNumeric` is out of bounds.
 --
 -- ```
 -- >>> shiftLeft 2 32.0
@@ -107,6 +103,11 @@ shiftLeft n x = shiftRight (-n) x
 --
 -- This will fail when using the `RoundingUnnecessary` mode if the `BigNumeric`
 -- cannot be represented exactly in the requested `Numeric n`.
+--
+-- ```
+-- >>> (roundToNumeric RoundingHalfUp 1.23456789 : Numeric 5)
+-- 1.23457
+-- ```
 roundToNumeric : forall n. NumericScale n => RoundingMode -> BigNumeric -> Numeric n
 roundToNumeric r x = fromBigNumeric (round (numericScale (aunit : Numeric n)) r x)
 

--- a/compiler/damlc/tests/daml-test-files/BigNumeric.daml
+++ b/compiler/damlc/tests/daml-test-files/BigNumeric.daml
@@ -9,8 +9,10 @@ import DA.Assert
 import DA.BigNumeric
 
 testShift = scenario do
-     shift 2 32.0 === 0.32
-     shift (-2) 32.0 === 3200.0
+     shiftRight 2 32.0 === 0.32
+     shiftRight (-2) 32.0 === 3200.0
+     shiftLeft 5 (-1.0) === -100000.0
+     shiftLeft (-5) (-1.0) === -0.00001
 
 testPrecision = scenario do
      precision 0.0 === 1
@@ -23,4 +25,29 @@ testScale = scenario do
     scale 1.0 === 0
     scale 1.1 === 1
     scale 1.1 === 1
-    scale (shift (-2^14) 1.0) === -2^14
+    scale (shiftLeft (2^14) 1.0) === -2^14
+
+testRoundToNumeric = scenario do
+     roundToNumeric RoundingUnnecessary 10.0 === (10.0 : Decimal)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.0 : Numeric 0)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.1 : Numeric 1)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.12 : Numeric 2)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.123 : Numeric 3)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.1235 : Numeric 4)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.12346 : Numeric 5)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.123457 : Numeric 6)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.1234568 : Numeric 7)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.12345679 : Numeric 8)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.123456789 : Numeric 9)
+     roundToNumeric RoundingHalfUp 0.123456789 === (0.123456789 : Numeric 10)
+     roundToNumeric RoundingDown 0.123456789 === (0.0 : Numeric 0)
+     roundToNumeric RoundingDown 0.123456789 === (0.1 : Numeric 1)
+     roundToNumeric RoundingDown 0.123456789 === (0.12 : Numeric 2)
+     roundToNumeric RoundingDown 0.123456789 === (0.123 : Numeric 3)
+     roundToNumeric RoundingDown 0.123456789 === (0.1234 : Numeric 4)
+     roundToNumeric RoundingDown 0.123456789 === (0.12345 : Numeric 5)
+     roundToNumeric RoundingDown 0.123456789 === (0.123456 : Numeric 6)
+     roundToNumeric RoundingDown 0.123456789 === (0.1234567 : Numeric 7)
+     roundToNumeric RoundingDown 0.123456789 === (0.12345678 : Numeric 8)
+     roundToNumeric RoundingDown 0.123456789 === (0.123456789 : Numeric 9)
+     roundToNumeric RoundingDown 0.123456789 === (0.123456789 : Numeric 10)


### PR DESCRIPTION
This is based on some feedback we received. The shift direction was
counterintuitive so splitting `shift` into `shiftLeft` and `shiftRight`
makes this more explicit. It's also convenient to have a function that
combines the rounding and casting of BigNumeric to a specific Numeric
scale.

changelog_begin

- [Daml Standard Library] `DA.BigNumeric.shift` has been split into
  `DA.BigNumeric.shiftLeft` and `DA.BigNumeric.shiftRight`.
  `DA.BigNumeric.roundToNumeric` is introduced, for rounding and
  converting a BigNumeric to a Numeric in a single move.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
