### PR TITLE
Fix simplifier safety for AnyExceptionMessage

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -84,7 +84,7 @@ safetyStep = \case
       BEBool _            -> Safe 0
       BERoundingMode _    -> Safe 0
       BEError             -> Safe 0
-      BEAnyExceptionMessage -> Safe 0 -- evaluates user-defined code which may crash
+      BEAnyExceptionMessage -> Safe 0 -- evaluates user-defined code which may throw
       BEAnyExceptionIsArithmeticError -> Safe 1
       BEAnyExceptionIsContractError -> Safe 1
       BEEqualGeneric      -> Safe 1 -- may crash if values are incomparable

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -84,7 +84,7 @@ safetyStep = \case
       BEBool _            -> Safe 0
       BERoundingMode _    -> Safe 0
       BEError             -> Safe 0
-      BEAnyExceptionMessage -> Safe 1
+      BEAnyExceptionMessage -> Safe 0 -- evaluates user-defined code which may crash
       BEAnyExceptionIsArithmeticError -> Safe 1
       BEAnyExceptionIsContractError -> Safe 1
       BEEqualGeneric      -> Safe 1 -- may crash if values are incomparable


### PR DESCRIPTION
This highlights the danger of shifting definitions. At some point this safety was correct (AnyException contained the message string directly, "throw" took a message argument), and then we decided to have AnyException call a function associated with the type (to speed up exception throwing & catching), and this safety became incorrect :-(

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
