### PR TITLE
Normalize rollback nodes when a transaction is constructed

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Trampoline.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Trampoline.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package data
+
+import scala.annotation.tailrec
+
+// Trampolines for stack-safety
+object Trampoline {
+
+  sealed trait Trampoline[A] {
+
+    @tailrec
+    final def bounce: A = this match {
+      case Land(a) => a
+      case Bounce(continue) => continue().bounce
+    }
+
+  }
+
+  final case class Land[A](a: A) extends Trampoline[A]
+  final case class Bounce[A](func: () => Trampoline[A]) extends Trampoline[A]
+
+}

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Trampoline.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Trampoline.scala
@@ -7,9 +7,9 @@ package data
 import scala.annotation.tailrec
 
 // Trampolines for stack-safety
-object Trampoline {
+private[lf] object Trampoline {
 
-  sealed trait Trampoline[A] {
+  private[lf] sealed trait Trampoline[A] {
 
     @tailrec
     final def bounce: A = this match {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2617,8 +2617,10 @@ object EngineTest {
     iterate.map { case (nodes, roots, dependsOnTime, nodeSeeds, _, _) =>
       (
         TxVersions.asVersionedTransaction(
-          roots.toImmArray,
-          nodes,
+          GenTx(
+            nodes,
+            roots.toImmArray,
+          )
         ),
         Tx.Metadata(
           submissionSeed = None,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -22,6 +22,8 @@ package com.daml.lf.speedy
   *  expression forms: SEAppGeneral and SECase are removed, and replaced by the simpler
   *  SEAppAtomic and SECaseAtomic (plus SELet as required).
   */
+
+import com.daml.lf.data.Trampoline.{Bounce, Land, Trampoline}
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.Compiler.CompilationError
 
@@ -112,19 +114,6 @@ private[lf] object Anf {
     val extra = (0 until n).map(i => (env.oldDepth.incr(i), depth.incr(i)))
     Env(absMap = env.absMap ++ extra, oldDepth = env.oldDepth.incr(n))
   }
-
-  // Returning a Bounce object allows a function to evict itself from the
-  // current stack.
-  private[this] sealed abstract class Trampoline[T] {
-    @tailrec
-    final def bounce: T = this match {
-      case Land(x) => x
-      case Bounce(continue) => continue().bounce
-    }
-  }
-
-  private[this] final case class Land[T](x: T) extends Trampoline[T]
-  private[this] final case class Bounce[T](continue: () => Trampoline[T]) extends Trampoline[T]
 
   /** Tx is the type for the stacked transformation functions managed by the ANF
     * transformation, mainly transformExp.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -13,12 +13,12 @@ import scala.annotation.tailrec
 
 private[lf] object NormalizeRollbacks {
 
-  type Nid = NodeId
-  type Cid = Value.ContractId
-  type TX = GenTransaction[Nid, Cid]
-  type Node = GenNode[Nid, Cid]
-  type LeafNode = LeafOnlyActionNode[Cid]
-  type ExeNode = NodeExercises[Nid, Cid]
+  private[this] type Nid = NodeId
+  private[this] type Cid = Value.ContractId
+  private[this] type TX = GenTransaction[Nid, Cid]
+  private[this] type Node = GenNode[Nid, Cid]
+  private[this] type LeafNode = LeafOnlyActionNode[Cid]
+  private[this] type ExeNode = NodeExercises[Nid, Cid]
 
   // Normalize a transaction so rollback nodes satisfy the normalization rules.
   // see `makeRoll` below
@@ -92,7 +92,7 @@ private[lf] object NormalizeRollbacks {
 
   //   rule #2/#3 overlap: ROLL [ ROLL [ xs… ] ] -> ROLL [ xs… ]
 
-  private def makeRoll[R](norms: List[Norm])(k: List[Norm] => Tramp[R]): Tramp[R] = {
+  private[this] def makeRoll[R](norms: List[Norm])(k: List[Norm] => Tramp[R]): Tramp[R] = {
     caseNorms(norms) match {
       case Case.Empty =>
         // normalization rule #1
@@ -134,7 +134,7 @@ private[lf] object NormalizeRollbacks {
 
   // There is no connection between the ids in the original and normalized transaction.
 
-  private case class State(index: Int, nodeMap: Map[Nid, Node]) {
+  private[this] case class State(index: Int, nodeMap: Map[Nid, Node]) {
 
     def next[R](k: (State, Nid) => Tramp[R]): Tramp[R] = {
       k(State(index + 1, nodeMap), NodeId(index))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -1,0 +1,188 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import com.daml.lf.transaction.{NodeId, GenTransaction}
+import com.daml.lf.transaction.Node.{
+  GenNode,
+  GenActionNode,
+  NodeRollback,
+  NodeExercises,
+  LeafOnlyActionNode,
+}
+import com.daml.lf.value.Value
+import com.daml.lf.data.ImmArray
+
+private[lf] object NormalizeRollbacks {
+
+  type Nid = NodeId
+  type Cid = Value.ContractId
+  type TX = GenTransaction[Nid, Cid]
+  type Node = GenNode[Nid, Cid]
+  type ActNode = GenActionNode[Nid, Cid]
+
+  // Normalize a transaction so rollback nodes satisfy the normalization rules.
+  // see `makeRoll` below
+
+  def normalizeTx(txOriginal: TX): TX = {
+
+    // Here we generate fresh node-ids for the normalized transaction.
+    val ids = Iterator.from(0).map(NodeId(_)) // perhaps we could reuse orig nids
+
+    // There is no connection between the ids in the pre and post transaction.
+    // Semantically this is fine: The ids are just of tie the tree structure together.
+    // But perhaps for ease of debugging we might consider trying to reuse existing ids.
+
+    // We accumulate (imperatively!) a nodes-map for the normalized transaction
+    var nodes: Map[Nid, Node] = Map.empty
+
+    def pushNode(node: Node): Nid = {
+      val nodeId = ids.next()
+      nodes += (nodeId -> node)
+      nodeId
+    }
+
+    def pushNodes(nodes: List[Node]): List[Nid] = nodes.map(pushNode)
+
+    import Canonical.{Norm, Case, caseNorms}
+    // The normalization phase works by constructing intermediate values which are
+    // `Canonical` in the sense that only properly normalized nodes can be represented.
+    // Although this doesn't ensure correctness, one class of bugs is avoided.
+
+    // The `force*` functions move from the world of Norms into standard transactions.
+    // This is also where node-ids for the resulting normalized transaction are generated.
+
+    def forceRoll(x: Norm.Roll): Node = {
+      x match {
+        case Norm.Roll1(act) =>
+          val child = pushNode(act.node)
+          NodeRollback(children = ImmArray(List(child)))
+        case Norm.Roll2(h, m, t) =>
+          val nodes = List(h.node) ++ m ++ List(t.node)
+          val children = pushNodes(nodes)
+          NodeRollback(children = ImmArray(children))
+      }
+    }
+
+    def forceNorm(x: Norm): Node = {
+      x match {
+        case Norm.Act(node) => node
+        case roll: Norm.Roll => forceRoll(roll)
+      }
+    }
+
+    def forceNorms(xs: List[Norm]): List[Node] = xs.map(forceNorm)
+
+    // makeRoll: encodes the normalization transformation rules:
+    //   rule #1: R [ ] -> ε
+    //   rule #2: R [ R [ xs… ] , ys… ] -> R [ xs… ] , R [ ys… ]
+    //   rule #3: R [ xs… , R [ ys… ] ] ->  R [ xs… , ys… ]
+
+    def makeRoll(norms: List[Norm]): List[Norm] = {
+      caseNorms(norms) match {
+        case Case.Empty =>
+          // normalization rule #1
+          Nil
+
+        case Case.Single(roll: Norm.Roll) =>
+          // normalization rule #2 or #3
+          List(roll)
+
+        case Case.Single(act: Norm.Act) =>
+          // no rule
+          List(Norm.Roll1(act))
+
+        case Case.Multi(h: Norm.Roll, m, t) =>
+          // normalization rule #2
+          h :: makeRoll(m ++ List(t))
+
+        case Case.Multi(h: Norm.Act, m, t: Norm.Roll) =>
+          // normalization rule #3
+          List(pushIntoRoll(h, forceNorms(m), t))
+
+        case Case.Multi(h: Norm.Act, m, t: Norm.Act) =>
+          // no rule
+          List(Norm.Roll2(h, forceNorms(m), t))
+      }
+    }
+
+    def pushIntoRoll(a1: Norm.Act, xs2: List[Node], t: Norm.Roll): Norm.Roll = {
+      t match {
+        case Norm.Roll1(a3) => Norm.Roll2(a1, xs2, a3)
+        case Norm.Roll2(a3, xs4, a5) => Norm.Roll2(a1, xs2 ++ List(a3.node) ++ xs4, a5)
+      }
+    }
+
+    // Here we traverse the original transaction structure.
+    // During the transformation, an original `Node` is mapped into a List[Norm]
+
+    // The List is necessary because the rules can:
+    // (1) drop nodes; (2) combine nodes (3) lift nodes from a lower level to a higher level.
+
+    // TODO: https://github.com/digital-asset/daml/issues/8020
+    // make this traversal code stack-safe
+
+    txOriginal match {
+      case GenTransaction(nodesOriginal, rootsOriginal) =>
+        def traverseNids(nids: List[Nid]): List[Norm] = nids.flatMap(traverseNid)
+        def traverseNid(nid: Nid): List[Norm] = traverseNode(nodesOriginal(nid))
+
+        def traverseNode(node: Node): List[Norm] = {
+          node match {
+
+            case NodeRollback(children) =>
+              makeRoll(traverseNids(children.toList))
+
+            case ex: NodeExercises[_, _] =>
+              val norms = traverseNids(ex.children.toList)
+              val children = pushNodes(forceNorms(norms))
+              List(Norm.Act(ex.copy(children = ImmArray(children))))
+
+            case act: LeafOnlyActionNode[_] =>
+              List(Norm.Act(act))
+          }
+        }
+        val norms = traverseNids(rootsOriginal.toList)
+        val roots = pushNodes(forceNorms(norms))
+        GenTransaction(nodes, ImmArray(roots))
+    }
+  }
+
+  // Types which ensure we can only represent the properly normalized cases.
+  object Canonical {
+
+    // A properly normalized Tx/node
+    sealed trait Norm
+    object Norm {
+
+      // A non-rollback tx/node
+      final case class Act(node: ActNode) extends Norm
+
+      // A *normalized* rollback tx/node. 2 cases:
+      // - rollback containing a single non-rollback tx/node.
+      // - rollback of 2 or more tx/nodes, such that first and last are not rollbacks.
+      sealed trait Roll extends Norm
+      final case class Roll1(act: Act) extends Roll
+      final case class Roll2(head: Act, middle: List[Node], tail: Act) extends Roll
+    }
+
+    // Case analysis on a list of Norms, distinuishing: Empty, Single and Multi forms
+    // The Multi form separes the head and tail element for the middle-list.
+    sealed trait Case
+    object Case {
+      final case object Empty extends Case
+      final case class Single(n: Norm) extends Case
+      final case class Multi(h: Norm, m: List[Norm], t: Norm) extends Case
+    }
+
+    def caseNorms(xs: List[Norm]): Case = {
+      xs.length match {
+        case 0 => Case.Empty
+        case 1 => Case.Single(xs(0))
+        case n => Case.Multi(xs(0), xs.slice(1, n - 1), xs(n - 1))
+      }
+    }
+  }
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -38,9 +38,6 @@ private[lf] object NormalizeRollbacks {
     // The List is necessary because the rules can:
     // (1) drop nodes; (2) combine nodes (3) lift nodes from a lower level to a higher level.
 
-    // TODO: https://github.com/digital-asset/daml/issues/8020
-    // make this traversal code stack-safe
-
     txOriginal match {
       case GenTransaction(nodesOriginal, rootsOriginal) =>
         def traverseNids[R](xs: List[Nid])(k: List[Norm] => Tramp[R]): Tramp[R] = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -142,7 +142,9 @@ private[lf] object NormalizeRollbacks {
         case x :: xs =>
           pushNorm(s, x) { (s, y) =>
             pushNorms(s, xs) { (s, ys) =>
-              k(s, y :: ys)
+              Bounce { () =>
+                k(s, y :: ys)
+              }
             }
           }
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -84,9 +84,12 @@ private[lf] object NormalizeRollbacks {
 
   }
 
-  private val initialState = State(100, Map.empty)
-
   // The `push*` functions convert the Canonical types to the tx being collected in State.
+  // Ensuring:
+  // - The final tx has increasing node-ids when nodes are listed in pre-order.
+  // - The root node-id is 0 (we have tests that rely on this)
+
+  private val initialState = State(0, Map.empty)
 
   private def pushAct[R](s: State, x: Norm.Act)(k: (State, Nid) => Tramp[R]): Tramp[R] = {
     Bounce { () =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -89,9 +89,11 @@ private[lf] object NormalizeRollbacks {
   }
 
   // makeRoll: encodes the normalization transformation rules:
-  //   rule #1: R [ ] -> ε
-  //   rule #2: R [ R [ xs… ] , ys… ] -> R [ xs… ] , R [ ys… ]
-  //   rule #3: R [ xs… , R [ ys… ] ] ->  R [ xs… , ys… ]
+  //   rule #1: ROLL [ ] -> ε
+  //   rule #2: ROLL [ ROLL [ xs… ] , ys… ] -> ROLL [ xs… ] , ROLL [ ys… ]
+  //   rule #3: ROLL [ xs… , ROLL [ ys… ] ] ->  ROLL [ xs… , ys… ]
+
+  //   rule #2/#3 overlap: ROLL [ ROLL [ xs… ] ] -> ROLL [ xs… ]
 
   private def makeRoll[R](norms: List[Norm])(k: List[Norm] => Tramp[R]): Tramp[R] = {
     caseNorms(norms) match {
@@ -100,7 +102,7 @@ private[lf] object NormalizeRollbacks {
         k(Nil)
 
       case Case.Single(roll: Norm.Roll) =>
-        // normalization rule #2 or #3
+        // normalization rule #2/#3 overlap
         k(List(roll))
 
       case Case.Single(act: Norm.Act) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -306,9 +306,7 @@ private[lf] case class PartialTransaction(
       case _: RootContextInfo if aborted.isEmpty =>
         val roots = context.children.toImmArray
         val tx0 = GenTransaction(nodes, roots)
-        // TODO: https://github.com/digital-asset/daml/issues/8020
-        // enable rollback normalization on the following line when all tests pass
-        val tx = tx0 //NormalizeRollbacks.normalizeTx(tx0)
+        val tx = NormalizeRollbacks.normalizeTx(tx0)
         CompleteTransaction(
           SubmittedTransaction(
             TxVersion.asVersionedTransaction(tx)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -304,9 +304,14 @@ private[lf] case class PartialTransaction(
   def finish: PartialTransaction.Result =
     context.info match {
       case _: RootContextInfo if aborted.isEmpty =>
+        val roots = context.children.toImmArray
+        val tx0 = GenTransaction(nodes, roots)
+        // TODO: https://github.com/digital-asset/daml/issues/8020
+        // enable rollback normalization on the following line when all tests pass
+        val tx = tx0 //NormalizeRollbacks.normalizeTx(tx0)
         CompleteTransaction(
           SubmittedTransaction(
-            TxVersion.asVersionedTransaction(context.children.toImmArray, nodes)
+            TxVersion.asVersionedTransaction(tx)
           )
         )
       case _ =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
@@ -155,6 +155,14 @@ class NormalizeRollbacksSpec extends AnyWordSpec with Matchers with Inside {
     Top(R(R(c1), c2, c3, R(c4))),
     Top(R(c1), R(c2, c3, c4)),
   )
+  test("mixed-extra-1")(
+    Top(R(c1, R(R(c2), c3))),
+    Top(R(c1, R(c2), c3)),
+  )
+  test("mixed-extra-2")(
+    Top(R(R(c1, R(c2)), c3)),
+    Top(R(c1, c2), R(c3)),
+  )
 
 }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
@@ -39,7 +39,7 @@ class NormalizeRollbacksSpec extends AnyWordSpec with Matchers with Inside {
         assert(isNormalized(txN))
       }
       "have increasing node-ids when listed in pre-order" in {
-        assert(preOrderNidsOfTxIsIncreasing(txN))
+        assert(preOrderNidsOfTxIsIncreasingFromZero(txN))
       }
     }
   }
@@ -177,7 +177,7 @@ object NormalizeRollbackSpec {
   type Node = GenNode[Nid, Cid]
   type RB = NodeRollback[Nid]
 
-  def preOrderNidsOfTxIsIncreasing(tx: TX): Boolean = {
+  def preOrderNidsOfTxIsIncreasingFromZero(tx: TX): Boolean = {
     def check(x1: Int, xs: List[Int]): Boolean = {
       xs match {
         case Nil => true
@@ -186,7 +186,7 @@ object NormalizeRollbackSpec {
     }
     preOrderNidsOfTx(tx) match {
       case Nil => true
-      case x :: xs => check(x, xs)
+      case x :: xs => x == 0 && check(x, xs)
     }
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
@@ -1,0 +1,291 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.daml.lf.data.ImmArray
+import com.daml.lf.data.Ref
+import com.daml.lf.transaction.Node.{GenNode, NodeRollback, NodeCreate, NodeExercises}
+import com.daml.lf.transaction.Transaction.LeafNode
+import com.daml.lf.transaction.TransactionVersion
+import com.daml.lf.transaction.{NodeId, GenTransaction}
+import com.daml.lf.value.{Value => V}
+
+class NormalizeRollbacksSpec extends AnyWordSpec with Matchers with Inside {
+
+  import NormalizeRollbackSpec._
+
+  // TODO: https://github.com/digital-asset/daml/issues/8020
+  // Below we test a set of hand-constructed testcases. Hopefully we got all edge cases!
+  // But for more confidence we might consider adding scalacheck based testing.
+
+  // TODO: https://github.com/digital-asset/daml/issues/8020
+  // We should test that the `meaning` of a transaction is preserved by normalization.
+
+  def test(name: String)(orig: Shape.Top, expected: Shape.Top): Unit = {
+    s"normalize: ($orig) -- $name" should {
+      val tx = Shape.toTransaction(orig)
+      val txN = NormalizeRollbacks.normalizeTx(tx) // code under test
+      val shapeN = Shape.ofTransaction(txN)
+      "be as expected" in {
+        assert(shapeN == expected)
+      }
+      "be a normal form" in {
+        assert(isNormalized(txN))
+      }
+    }
+  }
+
+  // multi arg construction for example convenience
+  def Top(xs: Shape*) = Shape.Top(xs.toList)
+  def E(xs: Shape*) = Shape.Exercise(xs.toList)
+  def R(xs: Shape*) = Shape.Rollback(xs.toList)
+
+  val List(c1, c2, c3, c4) = List[Long](1, 2, 3, 4).map(Shape.Create)
+
+  // no normalization required
+  test("empty tx")(
+    Top(),
+    Top(),
+  )
+  test("one create")(
+    Top(c1),
+    Top(c1),
+  )
+  test("two creates")(
+    Top(c1, c2),
+    Top(c1, c2),
+  )
+  test("rollback create")(
+    Top(R(c1)),
+    Top(R(c1)),
+  )
+  test("non empty rollback between creates")(
+    Top(c1, R(c2), c3),
+    Top(c1, R(c2), c3),
+  )
+  test("empty exercise")(
+    Top(E()),
+    Top(E()),
+  )
+  test("exercise and creates")(
+    Top(E(c1, E(), c2)),
+    Top(E(c1, E(), c2)),
+  )
+
+  // normalization rule #1
+  test("empty rollback")(
+    Top(R()),
+    Top(),
+  )
+  test("empty rollback after create")(
+    Top(c1, R()),
+    Top(c1),
+  )
+  test("empty rollback before create")(
+    Top(R(), c1),
+    Top(c1),
+  )
+  test("empty rollback between creates")(
+    Top(c1, R(), c2),
+    Top(c1, c2),
+  )
+  test("sibling empty rollback")(
+    Top(R(), R()),
+    Top(),
+  )
+  test("nested inner empty rollback")(
+    Top(R(c1, R(), c2)),
+    Top(R(c1, c2)),
+  )
+  test("inner empty rollback, within exercise")(
+    Top(E(c1, R(), c2)),
+    Top(E(c1, c2)),
+  )
+  test("nested empty rollback")(
+    Top(R(R())),
+    Top(),
+  )
+  test("nested sibling empty rollback")(
+    Top(R(R(), R())),
+    Top(),
+  )
+
+  // normalization rules #2 or #3
+  test("nested-rollback")(
+    Top(R(R(c1))),
+    Top(R(c1)),
+  )
+
+  // normalization rules #2
+  test("head-nested-rollback")(
+    Top(R(R(c1), c2)),
+    Top(R(c1), R(c2)),
+  )
+  test("head-nested-rollback-cascade")(
+    Top(R(R(R(c1), c2), c3)),
+    Top(R(c1), R(c2), R(c3)),
+  )
+
+  // normalization rules #3
+  test("tail-nested-rollback")(
+    Top(R(c1, R(c2))),
+    Top(R(c1, c2)),
+  )
+  test("tail-nested-rollback-cascade")(
+    Top(R(c1, R(c2, R(c3)))),
+    Top(R(c1, c2, c3)),
+  )
+  test("tail-nested-rollback-cascade-complex")(
+    Top(R(c1, c2, R(c3, R(c4)))),
+    Top(R(c1, c2, c3, c4)),
+  )
+
+  // normalization rules #2 and #3
+  test("mixed-rollback-nesting-A")(
+    Top(R(R(c1), c2, R(c3))),
+    Top(R(c1), R(c2, c3)),
+  )
+  test("mixed-rollback-nesting-B")(
+    Top(R(R(c1), c2, c3, R(c4))),
+    Top(R(c1), R(c2, c3, c4)),
+  )
+
+}
+
+object NormalizeRollbackSpec {
+
+  type Nid = NodeId
+  type Cid = V.ContractId
+  type TX = GenTransaction[Nid, Cid]
+  type Node = GenNode[Nid, Cid]
+  type RB = NodeRollback[Nid]
+
+  def forallNode(tx: TX)(pred: Node => Boolean): Boolean = {
+    tx.fold[Boolean](true) { case (acc, (_, node)) =>
+      acc && pred(node)
+    }
+  }
+
+  def forallRB(tx: TX)(pred: RB => Boolean): Boolean = {
+    forallNode(tx) {
+      case rb: NodeRollback[_] => pred(rb)
+      case _ => true
+    }
+  }
+
+  def isNormalized(tx: TX): Boolean = {
+    tx match {
+      case GenTransaction(nodes, _) =>
+        def isRB(node: Node): Boolean = {
+          node match {
+            case _: NodeRollback[_] => true
+            case _ => false
+          }
+        }
+        def check(rb: RB): Boolean = {
+          val n = rb.children.length
+          (n > 0) && // Normalization rule #1
+          !isRB(nodes(rb.children(0))) && // Normalization rule #2
+          !isRB(nodes(rb.children(n - 1))) // Normalization rule #3
+        }
+        forallRB(tx) { rb =>
+          check(rb)
+        }
+    }
+  }
+
+  // Shape: description of a transaction, with conversions to and from a real tx
+  sealed trait Shape
+  object Shape {
+
+    final case class Top(xs: List[Shape])
+    final case class Create(x: Long) extends Shape
+    final case class Exercise(x: List[Shape]) extends Shape
+    final case class Rollback(x: List[Shape]) extends Shape
+
+    def toTransaction(top: Top): TX = {
+      val ids = Iterator.from(0).map(NodeId(_))
+      var nodes: Map[Nid, Node] = Map.empty
+      def add(node: Node): Nid = {
+        val nodeId = ids.next()
+        nodes += (nodeId -> node)
+        nodeId
+      }
+      def toNid(shape: Shape): Nid = {
+        shape match {
+          case Create(n) => add(dummyCreateNode(n))
+          case Exercise(shapes) =>
+            val children = shapes.map(toNid)
+            add(dummyExerciseNode(ImmArray(children)))
+          case Rollback(shapes) =>
+            val children = shapes.map(toNid)
+            add(NodeRollback[Nid](children = ImmArray(children)))
+        }
+      }
+      val roots: List[Nid] = top.xs.map(toNid)
+      GenTransaction(nodes, ImmArray(roots))
+    }
+
+    def ofTransaction(tx: TX): Top = {
+      def ofNid(nid: NodeId): Shape = {
+        tx.nodes(nid) match {
+          case create: NodeCreate[_] =>
+            create.arg match {
+              case V.ValueInt64(n) => Create(n)
+              case _ => sys.error(s"unexpected create.arg: ${create.arg}")
+            }
+          case leaf: LeafNode => sys.error(s"Shape.ofTransaction, unexpected leaf: $leaf")
+          case node: NodeExercises[_, _] => Exercise(node.children.toList.map(ofNid))
+          case node: NodeRollback[_] => Rollback(node.children.toList.map(ofNid))
+        }
+      }
+      Top(tx.roots.toList.map(nid => ofNid(nid)))
+    }
+  }
+
+  private def toCid(s: String): V.ContractId.V1 =
+    V.ContractId.V1(crypto.Hash.hashPrivateKey(s))
+
+  private def dummyCreateNode(n: Long): NodeCreate[V.ContractId] =
+    NodeCreate(
+      coid = toCid("dummyCid"),
+      templateId = Ref.Identifier.assertFromString("-dummyPkg-:DummyModule:dummyName"),
+      arg = V.ValueInt64(n),
+      agreementText = "dummyAgreement",
+      optLocation = None,
+      signatories = Set.empty,
+      stakeholders = Set.empty,
+      key = None,
+      version = TransactionVersion.minVersion,
+    )
+
+  private def dummyExerciseNode(
+      children: ImmArray[NodeId]
+  ): NodeExercises[NodeId, V.ContractId] =
+    NodeExercises(
+      targetCoid = toCid("dummyTargetCoid"),
+      templateId = Ref.Identifier(
+        Ref.PackageId.assertFromString("-dummyPkg-"),
+        Ref.QualifiedName.assertFromString("DummyModule:dummyName"),
+      ),
+      choiceId = Ref.Name.assertFromString("dummyChoice"),
+      optLocation = None,
+      consuming = true,
+      actingParties = Set.empty,
+      chosenValue = V.ValueUnit,
+      stakeholders = Set.empty,
+      signatories = Set.empty,
+      choiceObservers = Set.empty,
+      children = children,
+      exerciseResult = None,
+      key = None,
+      byKey = false,
+      version = TransactionVersion.minVersion,
+    )
+}

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -235,10 +235,7 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
     ("create3throwAndOuterCatch", List[Tree](R(List(C(100), C(200))), C(300))),
     ("exer1", List[Tree](C(100), X(List(C(400), C(500))), C(200), C(300))),
     ("exer2", List[Tree](C(100), R(List(X(List(C(400))))), C(300))),
-    // TODO: https://github.com/digital-asset/daml/issues/8020
-    // when rollback normalization is enabled, this test needs to be adapted thus:
-    // ("exer3", List[Tree](C(100))),
-    ("exer3", List[Tree](C(100), R(List()))),
+    ("exer3", List[Tree](C(100))),
   )
 
   forEvery(testCases) { (exp: String, expected: List[Tree]) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -235,6 +235,9 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
     ("create3throwAndOuterCatch", List[Tree](R(List(C(100), C(200))), C(300))),
     ("exer1", List[Tree](C(100), X(List(C(400), C(500))), C(200), C(300))),
     ("exer2", List[Tree](C(100), R(List(X(List(C(400))))), C(300))),
+    // TODO: https://github.com/digital-asset/daml/issues/8020
+    // when rollback normalization is enabled, this test needs to be adapted thus:
+    // ("exer3", List[Tree](C(100))),
     ("exer3", List[Tree](C(100), R(List()))),
   )
 


### PR DESCRIPTION
Done:
- Implemented normalization rules as new code pass in `NormalizeRollbacks`
- Fairly extensive tests in `NormalizeRollbacksSpec`
- ensure pre-order traversal of node-ids is in increasing order; and starts from 0, fixes some existing tests which depend on this
- make normalization pass stack-safe (CPS & trampolines)
- enable normalization pass in `PartialTransaction`


part of #8020

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
