### PR TITLE
Fix conversion of TryContextInfo in scenario service

### DIFF
--- a/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SINCE-LF-FEATURE DAML_EXCEPTIONS
+-- @ERROR range=145:1-145:11; Attempt to exercise a consumed contract
 module ExceptionSemantics where
 
 import DA.Exception (throw)
@@ -32,6 +33,14 @@ template T
       do try (exercise self Throw)
          catch
            E -> pure ()
+
+    nonconsuming choice UncatchableTry : ()
+      with
+        cid : ContractId K
+      controller p
+      do try (() <$ fetch cid)
+         catch
+           E -> pure()
 
     nonconsuming choice TransientDuplicate : ()
       with
@@ -132,3 +141,12 @@ divulgence = scenario do
   submit p1 $ exercise divulger (RollbackFetch cid)
   submit p2 $ exercise fetcher (Fetch cid)
   pure ()
+
+tryContext = scenario do
+  p <- getParty "p"
+  kCid <- submit p $ create (K p 0)
+  submit p $ archive kCid
+  c <- submit p $ create (T p)
+  -- This will result in a partial transaction with ptx.context.info
+  -- pointing to a TryContextInfo.
+  submit p $ exercise c (UncatchableTry kCid)

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -11,6 +11,7 @@ import com.daml.lf.transaction.{GlobalKey, Node => N, NodeId}
 import com.daml.lf.ledger._
 import com.daml.lf.value.{Value => V}
 
+import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
 
 final class Conversions(
@@ -416,19 +417,23 @@ final class Conversions(
         ptx.context.children.toImmArray.toSeq.sortBy(_.index).map(convertTxNodeId).asJava
       )
 
-    ptx.context.info match {
-      case ctx: SPartialTransaction.ExercisesContextInfo =>
-        val ecBuilder = proto.ExerciseContext.newBuilder
-          .setTargetId(mkContractRef(ctx.targetId, ctx.templateId))
-          .setChoiceId(ctx.choiceId)
-          .setChosenValue(convertValue(ctx.chosenValue))
-        ctx.optLocation.map(loc => ecBuilder.setExerciseLocation(convertLocation(loc)))
-        builder.setExerciseContext(ecBuilder.build)
-      case _: SPartialTransaction.TryContextInfo =>
-        // TODO: https://github.com/digital-asset/daml/issues/8020
-        //  handle catch context
-        sys.error("exception not supported")
-      case _: SPartialTransaction.RootContextInfo =>
+    @tailrec
+    def unwindToExercise(
+        contextInfo: SPartialTransaction.ContextInfo
+    ): Option[SPartialTransaction.ExercisesContextInfo] = contextInfo match {
+      case ctx: SPartialTransaction.ExercisesContextInfo => Some(ctx)
+      case ctx: SPartialTransaction.TryContextInfo =>
+        unwindToExercise(ctx.parent.info)
+      case _: SPartialTransaction.RootContextInfo => None
+    }
+
+    unwindToExercise(ptx.context.info).foreach { ctx =>
+      val ecBuilder = proto.ExerciseContext.newBuilder
+        .setTargetId(mkContractRef(ctx.targetId, ctx.templateId))
+        .setChoiceId(ctx.choiceId)
+        .setChosenValue(convertValue(ctx.chosenValue))
+      ctx.optLocation.map(loc => ecBuilder.setExerciseLocation(convertLocation(loc)))
+      builder.setExerciseContext(ecBuilder.build)
     }
     builder.build
   }


### PR DESCRIPTION
There are two options here:

1. We unwind to the nearest parent exercise. This is what I
implemented.
2. We show the try context. At first it seems like this exposes more
information but really it doesn’t. You cannot locate the try so it’s
fairly meaningless.

A solution here could be to show the full context
stack instead but that’s a separate issue which I do not want to
tackle atm.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
