### PR TITLE
Parallelize the data-dependencies test.

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -463,6 +463,9 @@ da_haskell_test(
     ],
     main_function = "DA.Test.DataDependencies.main",
     src_strip_prefix = "src",
+    tags = [
+        "cpu:3",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -15,6 +15,7 @@ import Data.List (sort)
 import qualified Data.NameMap as NM
 import Module (unitIdString)
 import System.Directory.Extra
+import System.Environment.Blank
 import System.FilePath
 import System.Info.Extra
 import System.IO.Extra
@@ -26,6 +27,7 @@ import SdkVersion
 
 main :: IO ()
 main = do
+    setEnv "TASTY_NUM_THREADS" "3" True
     damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
     repl <- locateRunfiles (mainWorkspace </> "daml-lf" </> "repl" </> exe "repl")
     davlDar <- locateRunfiles ("davl-v3" </> "released" </> "davl-v3.dar")


### PR DESCRIPTION
It runs about twice as fast on my laptop (240s -> 120s) when allowed to
run tests in parallel. I'm not sure this will work or make a huge
difference when it comes to timeouts in CI, but it's worth a shot.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
