### PR TITLE
Make DA.Assert throw AssertionFailed instead of GeneralError

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -589,6 +589,7 @@ generateStablePackages lfVersion fp = do
                     , "DA-Exception-GeneralError.dalf"
                     , "DA-Exception-ArithmeticError.dalf"
                     , "DA-Exception-ContractError.dalf"
+                    , "DA-Exception-AssertionFailed.dalf"
                     , "DA-Types.dalf"
                     , "GHC-Prim.dalf"
                     , "GHC-Tuple.dalf"

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -45,9 +45,6 @@ isInternal (GHC.moduleNameString -> x)
       , "LibraryModules"
       , "DA.Types"
       , "DA.Time.Types"
-      , "DA.Exception.GeneralError"
-      , "DA.Exception.ArithmeticError"
-      , "DA.Exception.ContractError"
       ]
 
 preprocessorExceptions :: Set.Set GHC.ModuleName
@@ -65,6 +62,10 @@ preprocessorExceptions = Set.fromList $ map GHC.mkModuleName
     , "DA.Stack"
     , "DA.BigNumeric"
     , "DA.Exception"
+    , "DA.Exception.GeneralError"
+    , "DA.Exception.ArithmeticError"
+    , "DA.Exception.ContractError"
+    , "DA.Exception.AssertionFailed"
 
     -- These modules need to have the record preprocessor disabled.
     , "DA.NonEmpty.Types"

--- a/compiler/damlc/daml-prim-src/DA/Exception/AssertionFailed.daml
+++ b/compiler/damlc/daml-prim-src/DA/Exception/AssertionFailed.daml
@@ -1,0 +1,24 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+#ifndef DAML_EXCEPTIONS
+
+-- | HIDE
+module DA.Exception.AssertionFailed where
+
+import GHC.Types ()
+
+#else
+
+-- | MOVE DA.Exception
+module DA.Exception.AssertionFailed where
+
+import GHC.Types (Text)
+
+-- | Exception raised by assert functions in DA.Assert
+data AssertionFailed = AssertionFailed { message : Text }
+
+#endif

--- a/compiler/damlc/daml-prim-src/LibraryModules.daml
+++ b/compiler/damlc/daml-prim-src/LibraryModules.daml
@@ -31,4 +31,5 @@ import GHC.Types
 import DA.Exception.GeneralError
 import DA.Exception.ArithmeticError
 import DA.Exception.ContractError
+import DA.Exception.AssertionFailed
 #endif

--- a/compiler/damlc/daml-stdlib-src/DA/Assert.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Assert.daml
@@ -3,6 +3,7 @@
 
 module DA.Assert
   ( module DA.Assert
+  , CanAssert (assertFail)
   , assert
   , assertMsg
   , assertAfter
@@ -14,42 +15,42 @@ infix 4 =/=
 
 -- | Check two values for equality. If they're not equal,
 -- fail with a message.
-assertEq : (CanAbort m, Show a, Eq a) => a -> a -> m ()
+assertEq : (CanAssert m, Show a, Eq a) => a -> a -> m ()
 -- NOTE(MH): We do not define `assertEq` in terms of `assertMsg` to avoid
 -- constructing the error message in the successful case.
 assertEq x y
   | x == y = return ()
-  | otherwise = abort ("Failure, expected " <> show x <> " == " <> show y)
+  | otherwise = assertFail ("Failure, expected " <> show x <> " == " <> show y)
 
 -- | Infix version of `assertEq`.
-(===) : (CanAbort m, Show a, Eq a) => a -> a -> m ()
+(===) : (CanAssert m, Show a, Eq a) => a -> a -> m ()
 (===) = assertEq
 
 -- | Check two values for inequality. If they're equal,
 -- fail with a message.
-assertNotEq : (CanAbort m, Show a, Eq a) => a -> a -> m ()
+assertNotEq : (CanAssert m, Show a, Eq a) => a -> a -> m ()
 assertNotEq x y
   | x /= y = return ()
-  | otherwise = abort ("Failure, expected " <> show x <> " /= " <> show y)
+  | otherwise = assertFail ("Failure, expected " <> show x <> " /= " <> show y)
 
 -- | Infix version of `assertNotEq`.
-(=/=) : (CanAbort m, Show a, Eq a) => a -> a -> m ()
+(=/=) : (CanAssert m, Show a, Eq a) => a -> a -> m ()
 (=/=) = assertNotEq
 
 -- | Check whether the given time is in the future. If it's not,
 -- abort with a message.
-assertAfterMsg : (CanAbort m, HasTime m) => Text -> Time -> m ()
+assertAfterMsg : (CanAssert m, HasTime m) => Text -> Time -> m ()
 assertAfterMsg msg time = do
   now <- getTime
   if time > now
-    then abort msg
+    then assertFail msg
     else return ()
 
 -- | Check whether the given time is in the past. If it's not,
 -- abort with a message.
-assertBeforeMsg : (CanAbort m, HasTime m) => Text -> Time -> m ()
+assertBeforeMsg : (CanAssert m, HasTime m) => Text -> Time -> m ()
 assertBeforeMsg msg time = do
   now <- getTime
   if time < now
-    then abort msg
+    then assertFail msg
     else return ()

--- a/compiler/damlc/daml-stdlib-src/DA/Assert.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Assert.daml
@@ -1,6 +1,8 @@
 -- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE CPP #-}
+
 module DA.Assert
   ( module DA.Assert
   , CanAssert (assertFail)
@@ -8,6 +10,9 @@ module DA.Assert
   , assertMsg
   , assertAfter
   , assertBefore
+#ifdef DAML_EXCEPTIONS
+  , AssertionFailed (AssertionFailed)
+#endif
   ) where
 
 infix 4 ===

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Assert.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Assert.daml
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE CPP #-}
 
 -- | MOVE Prelude
 module DA.Internal.Assert where
@@ -9,29 +10,62 @@ module DA.Internal.Assert where
 import DA.Internal.Prelude
 import DA.Internal.LF
 
+#ifdef DAML_EXCEPTION
+import DA.Internal.Exception
+#endif
+
+-- | Constraint that determines whether an assertion can be made
+-- in this context.
+class Action m => CanAssert m where
+    -- | Abort since an assertion has failed. In an Update, Scenario,
+    -- Script, or Trigger context this will throw an AssertionFailed
+    -- exception. In an `Either Text` context, this will return the
+    -- message as an error.
+    assertFail : Text -> m t
+
+#ifdef DAML_EXCEPTION
+
+instance CanAssert Update where
+    assertFail msg = throw (AssertionFailed msg)
+instance CanAssert Scenario where
+    assertFail msg = throw (AssertionFailed msg)
+instance CanAssert (Either Text) where
+    assertFail = fail
+
+#else
+
+instance CanAssert Update where
+    assertFail = fail
+instance CanAssert Scenario where
+    assertFail = fail
+instance CanAssert (Either Text) where
+    assertFail = fail
+
+#endif
+
 -- | Check whether a condition is true. If it's not, abort the transaction.
-assert : CanAbort m => Bool -> m ()
+assert : CanAssert m => Bool -> m ()
 assert = assertMsg "Assertion failed"
 
 -- | Check whether a condition is true. If it's not, abort the transaction
 -- with a message.
-assertMsg : CanAbort m => Text -> Bool -> m ()
-assertMsg msg b = if b then return () else abort msg
+assertMsg : CanAssert m => Text -> Bool -> m ()
+assertMsg msg b = if b then return () else assertFail msg
 
 -- | Check whether the given time is in the future. If it's not, abort the transaction.
-assertAfter : (CanAbort m, HasTime m) => Time -> m ()
+assertAfter : (CanAssert m, HasTime m) => Time -> m ()
 assertAfter time = do
   now <- getTime
   if time > now
-    then abort ("assertAfter: expected time " <> show time <>
-                " before current ledger time, but ledger time is " <> show now)
+    then assertFail ("assertAfter: expected time " <> show time <>
+                     " before current ledger time, but ledger time is " <> show now)
     else return ()
 
 -- | Check whether the given time is in the past. If it's not, abort the transaction.
-assertBefore : (CanAbort m, HasTime m) => Time -> m ()
+assertBefore : (CanAssert m, HasTime m) => Time -> m ()
 assertBefore time = do
   now <- getTime
   if time < now
-    then abort ("assertBefore: expected time " <> show time <>
-                " after current ledger time, but ledger time is " <> show now)
+    then assertFail ("assertBefore: expected time " <> show time <>
+                     " after current ledger time, but ledger time is " <> show now)
     else return ()

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Assert.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Assert.daml
@@ -5,12 +5,17 @@
 {-# LANGUAGE CPP #-}
 
 -- | MOVE Prelude
-module DA.Internal.Assert where
+module DA.Internal.Assert
+  ( module DA.Internal.Assert
+#ifdef DAML_EXCEPTIONS
+  , AssertionFailed (AssertionFailed)
+#endif
+  ) where
 
 import DA.Internal.Prelude
 import DA.Internal.LF
 
-#ifdef DAML_EXCEPTION
+#ifdef DAML_EXCEPTIONS
 import DA.Internal.Exception
 #endif
 
@@ -23,7 +28,7 @@ class Action m => CanAssert m where
     -- message as an error.
     assertFail : Text -> m t
 
-#ifdef DAML_EXCEPTION
+#ifdef DAML_EXCEPTIONS
 
 instance CanAssert Update where
     assertFail msg = throw (AssertionFailed msg)

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -18,12 +18,14 @@ module DA.Internal.Exception
     , GeneralError    (GeneralError)
     , ArithmeticError (ArithmeticError)
     , ContractError   (ContractError)
+    , AssertionFailed (AssertionFailed)
     ) where
 
 import GHC.Types
 import DA.Exception.GeneralError    ( GeneralError    (GeneralError) )
 import DA.Exception.ArithmeticError ( ArithmeticError (ArithmeticError) )
 import DA.Exception.ContractError   ( ContractError   (ContractError) )
+import DA.Exception.AssertionFailed ( AssertionFailed (AssertionFailed) )
 import DA.Internal.LF
 import DA.Internal.Prelude
 import DA.Internal.Record
@@ -143,6 +145,24 @@ instance HasFromAnyException ContractError where
 
 --------------------------------------------------------------
 
+instance HasField "message" AssertionFailed Text where
+    getField (AssertionFailed m) = m
+    setField m (AssertionFailed _) = AssertionFailed m
+
+instance HasThrow AssertionFailed where
+    throwPure = primitive @"EThrow"
+
+instance HasMessage AssertionFailed where
+    message (AssertionFailed m) = m
+
+instance HasToAnyException AssertionFailed where
+    toAnyException = primitive @"EToAnyException"
+
+instance HasFromAnyException AssertionFailed where
+    fromAnyException = primitive @"EFromAnyException"
+
+--------------------------------------------------------------
+
 -- | Action type in which `throw` is supported.
 class Action m => ActionThrow m where
     throw : Exception e => e -> m t
@@ -159,6 +179,9 @@ instance ActionThrow Update where
 instance ActionCatch Update where
     _tryCatch = primitive @"UTryCatch"
 
---------------------------------------------------------------
+instance ActionThrow Scenario where
+    throw e = pure () >>= \_ -> throwPure e
+
+-- Can't catch in scenarios.
 
 #endif

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -352,6 +352,7 @@ baseImports =
            , "DA.Exception.GeneralError"
            , "DA.Exception.ArithmeticError"
            , "DA.Exception.ContractError"
+           , "DA.Exception.AssertionFailed"
            , "GHC.Err"
            , "Data.String"
            ]

--- a/compiler/damlc/stable-packages/BUILD.bazel
+++ b/compiler/damlc/stable-packages/BUILD.bazel
@@ -53,6 +53,7 @@ genrule(
         "daml-prim/DA-Exception-GeneralError.dalf",
         "daml-prim/DA-Exception-ArithmeticError.dalf",
         "daml-prim/DA-Exception-ContractError.dalf",
+        "daml-prim/DA-Exception-AssertionFailed.dalf",
         "daml-prim/DA-Types.dalf",
         "daml-stdlib/DA-Internal-Template.dalf",
         "daml-stdlib/DA-Internal-Any.dalf",
@@ -75,6 +76,7 @@ genrule(
       $(location :generate-stable-package) --module DA.Exception.GeneralError -o $(location daml-prim/DA-Exception-GeneralError.dalf)
       $(location :generate-stable-package) --module DA.Exception.ArithmeticError -o $(location daml-prim/DA-Exception-ArithmeticError.dalf)
       $(location :generate-stable-package) --module DA.Exception.ContractError -o $(location daml-prim/DA-Exception-ContractError.dalf)
+      $(location :generate-stable-package) --module DA.Exception.AssertionFailed -o $(location daml-prim/DA-Exception-AssertionFailed.dalf)
       $(location :generate-stable-package) --module DA.Types -o $(location daml-prim/DA-Types.dalf)
       $(location :generate-stable-package) --module DA.Time.Types -o $(location daml-stdlib/DA-Time-Types.dalf)
       $(location :generate-stable-package) --module DA.NonEmpty.Types -o $(location daml-stdlib/DA-NonEmpty-Types.dalf)
@@ -97,6 +99,7 @@ genrule(
 filegroup(
     name = "stable-packages",
     srcs = [
+        "daml-prim/DA-Exception-AssertionFailed.dalf",
         "daml-prim/DA-Exception-ArithmeticError.dalf",
         "daml-prim/DA-Exception-ContractError.dalf",
         "daml-prim/DA-Exception-GeneralError.dalf",

--- a/compiler/damlc/stable-packages/BUILD.bazel
+++ b/compiler/damlc/stable-packages/BUILD.bazel
@@ -99,8 +99,8 @@ genrule(
 filegroup(
     name = "stable-packages",
     srcs = [
-        "daml-prim/DA-Exception-AssertionFailed.dalf",
         "daml-prim/DA-Exception-ArithmeticError.dalf",
+        "daml-prim/DA-Exception-AssertionFailed.dalf",
         "daml-prim/DA-Exception-ContractError.dalf",
         "daml-prim/DA-Exception-GeneralError.dalf",
         "daml-prim/DA-Internal-Erased.dalf",

--- a/compiler/damlc/stable-packages/lib/DA/Daml/StablePackages.hs
+++ b/compiler/damlc/stable-packages/lib/DA/Daml/StablePackages.hs
@@ -39,6 +39,7 @@ allStablePackages =
     , daExceptionGeneralError
     , daExceptionArithmeticError
     , daExceptionContractError
+    , daExceptionAssertionFailed
     ]
 
 allStablePackagesForVersion :: Version -> [Package]
@@ -554,6 +555,9 @@ daExceptionArithmeticError = builtinExceptionPackage "ArithmeticError"
 
 daExceptionContractError :: Package
 daExceptionContractError = builtinExceptionPackage "ContractError"
+
+daExceptionAssertionFailed :: Package
+daExceptionAssertionFailed = builtinExceptionPackage "AssertionFailed"
 
 builtinExceptionPackage :: T.Text -> Package
 builtinExceptionPackage name = Package

--- a/compiler/damlc/tests/daml-test-files/ExceptionAssert.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionAssert.daml
@@ -1,0 +1,36 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_EXCEPTIONS
+
+-- | Test that DA.Assert throws AssertionFailed on failure.
+module ExceptionAssert where
+
+import DA.Assert
+
+testAssert = scenario do
+    p <- getParty "Alice"
+    submit p do
+        try do
+            assert False
+        catch
+            AssertionFailed m ->
+                m === "Assertion failed"
+
+testAssertMsg = scenario do
+    p <- getParty "Alice"
+    submit p do
+        try do
+            assertMsg "My message" False
+        catch
+            AssertionFailed m ->
+                m === "My message"
+
+testAssertEq = scenario do
+    p <- getParty "Alice"
+    submit p do
+        try do
+            10 === 20
+        catch
+            AssertionFailed m ->
+                m === "Failure, expected 10 == 20"

--- a/compiler/damlc/tests/daml-test-files/ExceptionCatchError.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionCatchError.daml
@@ -36,12 +36,3 @@ test3 = scenario do
         catch
             GeneralError msg ->
                 msg === "bar"
-
-test4 = scenario do
-    p <- getParty "Alice"
-    submit p do
-        try do
-            1 + 1 === 3
-        catch
-            GeneralError msg ->
-                msg === "Failure, expected 2 == 3"

--- a/compiler/damlc/tests/src/stable-packages.sh
+++ b/compiler/damlc/tests/src/stable-packages.sh
@@ -39,6 +39,7 @@ $DAMLC build --target=1.dev --project-root $DIR -o $DIR/out.dar
 $DIFF -u -b <($DAMLC inspect-dar $DIR/out.dar | sed '1,/following packages/d' | head -n -1) <(cat <<EOF
 
 daml-prim-DA-Exception-ArithmeticError-f1cf1ff41057ce327248684089b106d0a1f27c2f092d30f663c919addf173981 "f1cf1ff41057ce327248684089b106d0a1f27c2f092d30f663c919addf173981"
+daml-prim-DA-Exception-AssertionFailed-0b6d5242cee0f53a6aa39ab7caa8122e3864b200b86338007b334b0ad3c65830 "0b6d5242cee0f53a6aa39ab7caa8122e3864b200b86338007b334b0ad3c65830"
 daml-prim-DA-Exception-ContractError-a4d351c1a14963402c98d9c4ad92ce7e7cea74d81138f4de012df8d65229b78f "a4d351c1a14963402c98d9c4ad92ce7e7cea74d81138f4de012df8d65229b78f"
 daml-prim-DA-Exception-GeneralError-a4c4df2bd621b1bc1ba9fb5d3e633a5ddffb5b59e379bb091a18ce3f7801a7e4 "a4c4df2bd621b1bc1ba9fb5d3e633a5ddffb5b59e379bb091a18ce3f7801a7e4"
 daml-prim-DA-Internal-Erased-76bf0fd12bd945762a01f8fc5bbcdfa4d0ff20f8762af490f8f41d6237c6524f "76bf0fd12bd945762a01f8fc5bbcdfa4d0ff20f8762af490f8f41d6237c6524f"

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -466,6 +466,13 @@ instance CanAbort Script where
 instance ActionFail Script where
   fail = abort
 
+instance CanAssert Script where
+#ifdef DAML_EXCEPTION
+  assertFail m = throw (AssertionFailed m)
+#else
+  assertFail = abort
+#endif
+
 data LedgerValue = LedgerValue {}
 
 fromLedgerValue : LedgerValue -> a

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -467,7 +467,7 @@ instance ActionFail Script where
   fail = abort
 
 instance CanAssert Script where
-#ifdef DAML_EXCEPTION
+#ifdef DAML_EXCEPTIONS
   assertFail m = throw (AssertionFailed m)
 #else
   assertFail = abort

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -44,12 +44,12 @@ ScriptExample:initializeFixed SUCCESS
 ScriptExample:initializeFromQuery SUCCESS
 ScriptExample:queryParties SUCCESS
 ScriptExample:test SUCCESS
-ScriptTest:failingTest FAILURE (com.daml.lf.engine.script.ScriptF$FailedCmd: Command submit failed: INVALID_ARGUMENT: Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:19], partial transaction:
+ScriptTest:failingTest FAILURE (com.daml.lf.engine.script.ScriptF$FailedCmd: Command submit failed: INVALID_ARGUMENT: Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:43], partial transaction:
 ScriptTest:listKnownPartiesTest SUCCESS
 ScriptTest:multiPartySubmission SUCCESS
 ScriptTest:partyIdHintTest SUCCESS
 ScriptTest:sleepTest SUCCESS
-ScriptTest:stackTrace FAILURE (com.daml.lf.engine.script.ScriptF$FailedCmd: Command submit failed: INVALID_ARGUMENT: Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:19], partial transaction:
+ScriptTest:stackTrace FAILURE (com.daml.lf.engine.script.ScriptF$FailedCmd: Command submit failed: INVALID_ARGUMENT: Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:43], partial transaction:
 ScriptTest:test0 SUCCESS
 ScriptTest:test1 SUCCESS
 ScriptTest:test3 SUCCESS

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -44,12 +44,12 @@ ScriptExample:initializeFixed SUCCESS
 ScriptExample:initializeFromQuery SUCCESS
 ScriptExample:queryParties SUCCESS
 ScriptExample:test SUCCESS
-ScriptTest:failingTest FAILURE (com.daml.lf.engine.script.ScriptF$FailedCmd: Command submit failed: INVALID_ARGUMENT: Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:43], partial transaction:
+ScriptTest:failingTest FAILURE (com.daml.lf.engine.script.ScriptF$FailedCmd: Command submit failed: INVALID_ARGUMENT: Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:45], partial transaction:
 ScriptTest:listKnownPartiesTest SUCCESS
 ScriptTest:multiPartySubmission SUCCESS
 ScriptTest:partyIdHintTest SUCCESS
 ScriptTest:sleepTest SUCCESS
-ScriptTest:stackTrace FAILURE (com.daml.lf.engine.script.ScriptF$FailedCmd: Command submit failed: INVALID_ARGUMENT: Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:43], partial transaction:
+ScriptTest:stackTrace FAILURE (com.daml.lf.engine.script.ScriptF$FailedCmd: Command submit failed: INVALID_ARGUMENT: Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:45], partial transaction:
 ScriptTest:test0 SUCCESS
 ScriptTest:test1 SUCCESS
 ScriptTest:test3 SUCCESS

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -36,6 +36,8 @@ instance CanAbort (TriggerA s) where
   abort = error
 instance ActionFail (TriggerA s) where
   fail = error
+instance CanAssert (TriggerA s) where
+  assertFail = error
 
 trigger : Trigger Int
 trigger = Trigger with


### PR DESCRIPTION
changelog_begin

- [Daml Standard Library] `assert`, `(===)`, and other assertion functions (see DA.Assert) now use a new `CanAssert` typeclass constraint instead of `CanAbort`, in preparation for exceptions support.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
