### PR TITLE
Stop leaking Sdk installations from assistant integration tests

### DIFF
--- a/libs-haskell/test-utils/DA/Test/Util.hs
+++ b/libs-haskell/test-utils/DA/Test/Util.hs
@@ -21,7 +21,6 @@ module DA.Test.Util (
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift (MonadUnliftIO)
-import Control.Exception.Safe
 import Data.List.Extra (isInfixOf)
 import qualified Data.Text as T
 import System.Directory
@@ -51,18 +50,7 @@ withTempFileResource f = withResource newTempFile snd (f . fmap fst)
 
 withTempDirResource :: (IO FilePath -> TestTree) -> TestTree
 withTempDirResource f = withResource newTempDir delete (f . fmap fst)
-  -- The delete action provided by `newTempDir` calls `removeDirectoryRecursively`
-  -- and silently swallows errors. SDK installations are marked read-only
-  -- which means that they don’t end up being removed which is obviously
-  -- not what we intend.
-  -- As usual Windows is terrible and doesn’t let you remove the SDK
-  -- if there is a process running. Simultaneously it is also terrible
-  -- at process management so we end up with running processes
-  -- since child processes aren’t torn down properly
-  -- (Bazel will kill them later when the test finishes). Therefore,
-  -- we ignore exceptions and hope for the best. On Windows that
-  -- means we still leak directories :(
-  where delete (d, _delete) = void $ tryIO $ removePathForcibly d
+  where delete (d, _delete) = removePathForcibly d
 
 nullDevice :: FilePath
 nullDevice


### PR DESCRIPTION
Each of these installations is about 1gb so it’s not that unlikely
that this plays a significant factor in our out of disk space errors.

Although I think we cleanup partially so I’m not sure how large the
part of the SDK installation is that gets leftover.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
