### PR TITLE
prepare for EV Windows signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,46 @@ jobs:
       fi
     displayName: check perf changes
 
+- job: test-windows-signing
+  dependsOn: [ "check_for_release", "Windows" ]
+  condition: and(succeeded(),
+                 eq(variables['Build.SourceBranchName'], 'main'))
+  pool:
+    name: 'windows-pool'
+    demands: assignment -equals windows-signing
+  steps:
+  - checkout: none
+  - bash: |
+      mkdir $(Build.StagingDirectory)/test-signing
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      artifactName: test-signing
+      targetPath: $(Build.StagingDirectory)/test-signing
+  - bash: |
+      azuresigntool sign \
+        --azure-key-vault-url "$AZURE_KEY_VAULT_URL" \
+        --azure-key-vault-client-id "$AZURE_CLIENT_ID" \
+        --azure-key-vault-client-secret "$AZURE_CLIENT_SECRET" \
+        --azure-key-vault-tenant-id "$AZURE_TENANT_ID"\
+        --azure-key-vault-certificate "$AZURE_KEY_VAULT_CERTIFICATE" \
+        --description "Daml SDK installer" \
+        --description-url "https://daml.com" \
+        --timestamp-rfc3161 "http://timestamp.digicert.com" \
+        --file-digest sha256 \
+        --verbose \
+        $(Build.StagingDirectory)/test-signing/installer.exe
+      exit 0
+    env:
+      AZURE_KEY_VAULT_URL: $(AZURE_KEY_VAULT_URL)
+      AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+      AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+      AZURE_KEY_VAULT_CERTIFICATE: $(AZURE_KEY_VAULT_CERTIFICATE)
+  - task: PublishPipelineArtifact@0
+    inputs:
+      targetPath: $(Build.StagingDirectory)/test-signing/installer.exe
+      artifactName: test-signing-signed
+
 - job: release
   dependsOn: [ "check_for_release", "Linux", "Linux_scala_2_12", "macOS", "Windows" ]
   condition: and(succeeded(),

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -43,6 +43,16 @@ steps:
     parameters:
       var_name: bash-lib
 
+  # TODO: remove once new signing is working (see #9758)
+  - bash: |
+      OUTPUT_DIR=$(Build.StagingDirectory)/test-signing
+      mkdir -p $OUTPUT_DIR
+      cp "bazel-bin/release/windows-installer/daml-sdk-installer-ce.exe" "$OUTPUT_DIR/installer.exe"
+  - task: PublishPipelineArtifact@0
+    inputs:
+      targetPath: $(Build.StagingDirectory)/test-signing
+      artifactName: test-signing
+
   - bash: |
       set -euo pipefail
       mkdir -p '$(Build.StagingDirectory)'/release

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -45,8 +45,7 @@ steps:
 
   # TODO: remove once new signing is working (see #9758)
   - bash: |
-      set -x
-      OUTPUT_DIR=$(Build.StagingDirectory)/test-signing
+      OUTPUT_DIR='$(Build.StagingDirectory)'/test-signing
       mkdir -p $OUTPUT_DIR
       cp "bazel-bin/release/windows-installer/daml-sdk-installer-ce.exe" "$OUTPUT_DIR/installer.exe"
   - task: PublishPipelineArtifact@0

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -45,6 +45,7 @@ steps:
 
   # TODO: remove once new signing is working (see #9758)
   - bash: |
+      set -x
       OUTPUT_DIR=$(Build.StagingDirectory)/test-signing
       mkdir -p $OUTPUT_DIR
       cp "bazel-bin/release/windows-installer/daml-sdk-installer-ce.exe" "$OUTPUT_DIR/installer.exe"

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -7,20 +7,41 @@ locals {
   vsts_pool    = "windows-pool"
 }
 
+locals {
+  w = [
+    {
+      suffix     = "",
+      size       = 6,
+      assignment = "default",
+      install    = "",
+    },
+    {
+      suffix     = "-sign"
+      size       = 1,
+      assignment = "windows-signing",
+      install    = <<INSTALL
+choco install dotnetcore-2.1-sdk
+"C:\Program Files\dotnet\dotnet.exe" tool install --global AzureSignTool
+INSTALL
+    }
+  ]
+}
+
 resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
+  count    = length(local.w)
   provider = google-beta
-  name     = "vsts-agent-windows"
+  name     = "vsts-agent-windows${local.w[count.index].suffix}"
 
   # keep the name short. windows hostnames are limited to 12(?) chars.
   # -5 for the random postfix:
-  base_instance_name = "vsts-win"
+  base_instance_name = "vsts-win${local.w[count.index].suffix}"
 
   region      = "us-east1"
-  target_size = 6
+  target_size = local.w[count.index].size
 
   version {
-    name              = "vsts-agent-windows"
-    instance_template = google_compute_instance_template.vsts-agent-windows.self_link
+    name              = "vsts-agent-windows${local.w[count.index].suffix}"
+    instance_template = google_compute_instance_template.vsts-agent-windows[count.index].self_link
   }
 
   update_policy {
@@ -37,7 +58,8 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
 }
 
 resource "google_compute_instance_template" "vsts-agent-windows" {
-  name_prefix  = "vsts-agent-windows-"
+  count        = length(local.w)
+  name_prefix  = "vsts-agent-windows${local.w[count.index].suffix}-"
   machine_type = "c2-standard-8"
   labels       = local.machine-labels
 
@@ -125,11 +147,11 @@ winrm set winrm/config/service/auth '@{Basic="true"}'
 net stop winrm
 sc.exe config winrm start=auto
 net start winrm
-
+${local.w[count.index].install}
 echo "== Installing the VSTS agent"
 
 New-Item -ItemType Directory -Path 'C:\agent'
-Set-Content -Path 'C:\agent\.capabilities' -Value 'assignment=default'
+Set-Content -Path 'C:\agent\.capabilities' -Value 'assignment=${local.w[count.index].assignment}'
 
 $MachineName = Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object CSName | ForEach{ $_.CSName }
 choco install azure-pipelines-agent --no-progress --yes --params "'/Token:${local.vsts_token} /Pool:${local.vsts_pool} /Url:https://dev.azure.com/${local.vsts_account}/ /LogonAccount:$Account /LogonPassword:$Password /Work:D:\a /AgentName:$MachineName /Replace'"


### PR DESCRIPTION
Setting up a non-disruptive way to test out EV signing of our Windows artifacts.

CHANGELOG_BEGIN
CHANGELOG_END