### PR TITLE
Make sure we don’t start leaking directories in compat tests

### DIFF
--- a/compatibility/assistant/BUILD
+++ b/compatibility/assistant/BUILD
@@ -21,7 +21,6 @@ da_haskell_test(
         "extra",
         "process",
         "typed-process",
-        "safe-exceptions",
         "tasty",
         "tasty-hunit",
         "utf8-string",

--- a/compatibility/assistant/src/DA/Test/PlatformVersion.hs
+++ b/compatibility/assistant/src/DA/Test/PlatformVersion.hs
@@ -5,7 +5,6 @@ module DA.Test.PlatformVersion (main) where
 
 import qualified Bazel.Runfiles
 import Control.Concurrent.STM
-import Control.Exception.Safe
 import Control.Monad
 import Data.ByteString.Lazy.UTF8 (ByteString, toString)
 import Data.Conduit ((.|), runConduitRes)
@@ -131,18 +130,7 @@ withSdkResource f =
 
 withTempDirResource :: (IO FilePath -> TestTree) -> TestTree
 withTempDirResource f = withResource newTempDir delete (f . fmap fst)
-    -- The delete action provided by `newTempDir` calls `removeDirectoryRecursively`
-    -- and silently swallows errors. SDK installations are marked read-only
-    -- which means that they don’t end up being removed which is obviously
-    -- not what we intend.
-    -- As usual Windows is terrible and doesn’t let you remove the SDK
-    -- if there is a process running. Simultaneously it is also terrible
-    -- at process management so we end up with running processes
-    -- since child processes aren’t torn down properly
-    -- (Bazel will kill them later when the test finishes). Therefore,
-    -- we ignore exceptions and hope for the best. On Windows that
-    -- means we still leak directories :(
-    where delete (d, _delete) = void $ tryIO $ removePathForcibly d
+    where delete (d, _delete) = void $ removePathForcibly d
 
 exe :: FilePath -> FilePath
 exe | os == "mingw32" = (<.> "exe")


### PR DESCRIPTION
As evidenced by this change, we don’t actually need the safeguard
here. i think this was just copied over from the main workspace where
we did leak installations. I’d like to know when we start leaking
installations here in the future so this PR removes the catch.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
