### PR TITLE
participant-state: rejection reason abstractions

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
@@ -42,6 +42,7 @@ trait ErrorFactories {
   def unimplemented(description: String): StatusRuntimeException =
     grpcError(Status.UNIMPLEMENTED.withDescription(description))
 
+  // permission denied is intentionally without description to ensure we don't leak security relevant information by accident
   def permissionDenied(): StatusRuntimeException =
     grpcError(Status.PERMISSION_DENIED)
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -300,7 +300,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         Status.Code.INVALID_ARGUMENT,
         Some(
           Pattern.compile(
-            "Command interpretation error in LF-DAMLe: Interpretation error: Error: (User abort: Assertion failed\\.|Unhandled exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"Assertion failed\" \\}\\.) Details: Last location: \\[[^\\]]*\\], partial transaction: root node"
+            "Interpretation error: Error: (User abort: Assertion failed\\.|Unhandled exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"Assertion failed\" \\}\\.) Details: Last location: \\[[^\\]]*\\], partial transaction: root node"
           )
         ),
       )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -16,6 +16,7 @@ import com.daml.ledger.participant.state.v1.SubmissionResult.{
   InternalError,
   NotSupported,
   Overloaded,
+  SynchronousReject,
 }
 import com.daml.ledger.participant.state.v1.{
   Configuration,
@@ -25,7 +26,7 @@ import com.daml.ledger.participant.state.v1.{
 }
 import com.daml.lf.crypto
 import com.daml.lf.data.Ref.Party
-import com.daml.lf.engine.{DuplicateContractKey, ContractNotFound, ReplayMismatch}
+import com.daml.lf.engine.{ContractNotFound, DuplicateContractKey, ReplayMismatch}
 import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -168,6 +169,10 @@ private[apiserver] final class ApiSubmissionService private[services] (
     case Success(InternalError(reason)) =>
       logger.error(s"Internal error: $reason")
       Failure(Status.INTERNAL.augmentDescription(reason).asRuntimeException)
+
+    case Success(SynchronousReject(failure)) =>
+      logger.info(s"Rejected: ${failure.getStatus}")
+      Failure(failure)
 
     case Failure(error) =>
       logger.info(s"Rejected: ${error.getMessage}")

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
@@ -52,6 +52,8 @@ class SynchronousResponse[Input, Entry, AcceptedEntry](
               Future.failed(ErrorFactories.aborted("Request timed out"))
             }
             .flatten
+        case r @ SubmissionResult.SynchronousReject(_) =>
+          Future.failed(r.failure)
         case r @ SubmissionResult.Overloaded =>
           Future.failed(ErrorFactories.resourceExhausted(r.description))
         case r @ SubmissionResult.InternalError(_) =>

--- a/ledger/participant-integration-api/src/main/scala/platform/store/Conversions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/Conversions.scala
@@ -11,8 +11,8 @@ import anorm.Column.nonNull
 import anorm._
 import com.daml.ledger.EventId
 import com.daml.ledger.api.domain
-import com.daml.ledger.participant.state.v1.RejectionReason._
-import com.daml.ledger.participant.state.v1.{Offset, RejectionReason}
+import com.daml.ledger.participant.state.v1.RejectionReasonV0._
+import com.daml.ledger.participant.state.v1.{Offset, RejectionReasonV0}
 import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.Party
@@ -360,26 +360,14 @@ private[platform] object Conversions {
   }
 
   // RejectionReason
-
   implicit def domainRejectionReasonToErrorCode(reason: domain.RejectionReason): Code =
-    participantRejectionReasonToErrorCode(
-      domainRejectionReasonToParticipantRejectionReason(
-        reason
-      )
-    )
-
-  // We _rely_ on the following compiler flags for this to be safe:
-  // * -Xno-patmat-analysis _MUST NOT_ be enabled
-  // * -Xfatal-warnings _MUST_ be enabled
-  implicit def participantRejectionReasonToErrorCode(reason: RejectionReason): Code = reason match {
-    case _: Disputed | _: PartyNotKnownOnLedger => Code.INVALID_ARGUMENT
-    case _: Inconsistent | _: ResourcesExhausted | _: InvalidLedgerTime => Code.ABORTED
-    case _: SubmitterCannotActViaParticipant => Code.PERMISSION_DENIED
-  }
+    domainRejectionReasonToParticipantRejectionReason(
+      reason
+    ).code
 
   implicit def domainRejectionReasonToParticipantRejectionReason(
       reason: domain.RejectionReason
-  ): RejectionReason =
+  ): RejectionReasonV0 =
     reason match {
       case r: domain.RejectionReason.Inconsistent => Inconsistent(r.description)
       case r: domain.RejectionReason.Disputed => Disputed(r.description)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDBDTOV1.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDBDTOV1.scala
@@ -9,7 +9,6 @@ import com.daml.ledger.api.domain
 import com.daml.ledger.participant.state.v1.{Configuration, Offset, ParticipantId, Update}
 import com.daml.lf.engine.Blinding
 import com.daml.lf.ledger.EventId
-import com.daml.platform.store.Conversions
 import com.daml.platform.store.appendonlydao.JdbcLedgerDao
 import com.daml.platform.store.appendonlydao.events._
 import com.daml.platform.store.dao.DeduplicationKeyMaker
@@ -31,7 +30,7 @@ object UpdateToDBDTOV1 {
             submitters = u.submitterInfo.actAs.toSet,
             command_id = u.submitterInfo.commandId,
             transaction_id = None,
-            status_code = Some(Conversions.participantRejectionReasonToErrorCode(u.reason).value()),
+            status_code = Some(u.reason.code.value()),
             status_message = Some(u.reason.description),
           ),
           DBDTOV1.CommandDeduplication(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -1203,7 +1203,7 @@ private[platform] object JdbcLedgerDao {
         reason: RejectionReason,
     ): SimpleSql[Row] = {
       SQL"insert into participant_command_completions(completion_offset, record_time, application_id, submitters, command_id, status_code, status_message) values ($offset, $recordTime, ${submitterInfo.applicationId}, ${submitterInfo.actAs
-        .toArray[String]}, ${submitterInfo.commandId}, ${reason.value()}, ${reason.description})"
+        .toArray[String]}, ${submitterInfo.commandId}, ${reason.code.value}, ${reason.description})"
     }
 
     protected[JdbcLedgerDao] def escapeReservedWord(word: String): String
@@ -1393,7 +1393,7 @@ private[platform] object JdbcLedgerDao {
     ): SimpleSql[Row] = {
       import com.daml.platform.store.OracleArrayConversions._
       SQL"insert into participant_command_completions(completion_offset, record_time, application_id, submitters, command_id, status_code, status_message) values ($offset, $recordTime, ${submitterInfo.applicationId}, ${submitterInfo.actAs
-        .toArray[String]}, ${submitterInfo.commandId}, ${reason.value()}, ${reason.description})"
+        .toArray[String]}, ${submitterInfo.commandId}, ${reason.code.value()}, ${reason.description})"
     }
 
     // spaces which are subsequently trimmed left only for readability

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/PostCommitValidation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/PostCommitValidation.scala
@@ -6,7 +6,7 @@ package com.daml.platform.store.dao.events
 import java.sql.Connection
 import java.time.Instant
 
-import com.daml.ledger.participant.state.v1.{CommittedTransaction, RejectionReason}
+import com.daml.ledger.participant.state.v1.{CommittedTransaction, RejectionReasonV0}
 
 /** Performs post-commit validation on transactions for Sandbox Classic.
   * This is intended exclusively as a temporary replacement for
@@ -29,7 +29,7 @@ private[dao] sealed trait PostCommitValidation {
       transaction: CommittedTransaction,
       transactionLedgerEffectiveTime: Instant,
       divulged: Set[ContractId],
-  )(implicit connection: Connection): Option[RejectionReason]
+  )(implicit connection: Connection): Option[RejectionReasonV0]
 
 }
 
@@ -45,7 +45,7 @@ private[dao] object PostCommitValidation {
         committedTransaction: CommittedTransaction,
         transactionLedgerEffectiveTime: Instant,
         divulged: Set[ContractId],
-    )(implicit connection: Connection): Option[RejectionReason] =
+    )(implicit connection: Connection): Option[RejectionReasonV0] =
       None
   }
 
@@ -56,7 +56,7 @@ private[dao] object PostCommitValidation {
         transaction: CommittedTransaction,
         transactionLedgerEffectiveTime: Instant,
         divulged: Set[ContractId],
-    )(implicit connection: Connection): Option[RejectionReason] = {
+    )(implicit connection: Connection): Option[RejectionReasonV0] = {
 
       val causalMonotonicityViolation =
         validateCausalMonotonicity(transaction, transactionLedgerEffectiveTime, divulged)
@@ -80,7 +80,7 @@ private[dao] object PostCommitValidation {
         transaction: CommittedTransaction,
         transactionLedgerEffectiveTime: Instant,
         divulged: Set[ContractId],
-    )(implicit connection: Connection): Option[RejectionReason] = {
+    )(implicit connection: Connection): Option[RejectionReasonV0] = {
       val referredContracts = collectReferredContracts(transaction, divulged)
       if (referredContracts.isEmpty) {
         None
@@ -95,10 +95,10 @@ private[dao] object PostCommitValidation {
     private def validateCausalMonotonicity(
         maximumLedgerEffectiveTime: Option[Instant],
         transactionLedgerEffectiveTime: Instant,
-    ): Option[RejectionReason] =
+    ): Option[RejectionReasonV0] =
       maximumLedgerEffectiveTime
         .filter(_.isAfter(transactionLedgerEffectiveTime))
-        .fold(Option.empty[RejectionReason])(contractLedgerEffectiveTime => {
+        .fold(Option.empty[RejectionReasonV0])(contractLedgerEffectiveTime => {
           Some(
             CausalMonotonicityViolation(
               contractLedgerEffectiveTime = contractLedgerEffectiveTime,
@@ -109,13 +109,13 @@ private[dao] object PostCommitValidation {
 
     private def validateParties(
         transaction: CommittedTransaction
-    )(implicit connection: Connection): Option[RejectionReason] = {
+    )(implicit connection: Connection): Option[RejectionReasonV0] = {
       val informees = transaction.informees
       val allocatedInformees = data.lookupParties(informees.toSeq).map(_.party)
       if (allocatedInformees.toSet == informees)
         None
       else
-        Some(RejectionReason.PartyNotKnownOnLedger("Some parties are unallocated"))
+        Some(RejectionReasonV0.PartyNotKnownOnLedger("Some parties are unallocated"))
     }
 
     private def collectReferredContracts(
@@ -127,7 +127,7 @@ private[dao] object PostCommitValidation {
 
     private def validateKeyUsages(
         transaction: CommittedTransaction
-    )(implicit connection: Connection): Option[RejectionReason] =
+    )(implicit connection: Connection): Option[RejectionReasonV0] =
       transaction
         .foldInExecutionOrder[Result](Right(State.empty(data)))(
           exerciseBegin = (acc, _, exe) => {
@@ -144,7 +144,7 @@ private[dao] object PostCommitValidation {
     private def validateKeyUsages(
         node: Node,
         state: State,
-    )(implicit connection: Connection): Either[RejectionReason, State] =
+    )(implicit connection: Connection): Either[RejectionReasonV0, State] =
       node match {
         case c: Create =>
           state.validateCreate(c.versionedKey.map(convert(c.versionedCoinst.template, _)), c.coid)
@@ -162,7 +162,7 @@ private[dao] object PostCommitValidation {
 
   }
 
-  private type Result = Either[RejectionReason, State]
+  private type Result = Either[RejectionReasonV0, State]
 
   /** The active ledger key state during validation.
     * After a rollback node, we restore the state at the
@@ -212,18 +212,18 @@ private[dao] object PostCommitValidation {
 
     def validateCreate(maybeKey: Option[Key], id: ContractId)(implicit
         connection: Connection
-    ): Either[RejectionReason, State] =
+    ): Either[RejectionReasonV0, State] =
       maybeKey.fold[Result](Right(this)) { key =>
         lookup(key).fold[Result](Right(add(key, id)))(_ => Left(DuplicateKey))
       }
 
     // `causalMonotonicity` already reports unknown contracts, no need to check it here
-    def removeKeyIfDefined(maybeKey: Option[Key]): Right[RejectionReason, State] =
+    def removeKeyIfDefined(maybeKey: Option[Key]): Right[RejectionReasonV0, State] =
       Right(maybeKey.fold(this)(remove))
 
     def validateLookupByKey(key: Key, expectation: Option[ContractId])(implicit
         connection: Connection
-    ): Either[RejectionReason, State] = {
+    ): Either[RejectionReasonV0, State] = {
       val result = lookup(key)
       if (result == expectation) Right(this)
       else Left(MismatchingLookup(expectation, result))
@@ -265,25 +265,25 @@ private[dao] object PostCommitValidation {
       State(ActiveState(Map.empty, Set.empty), Nil, data)
   }
 
-  private[events] val DuplicateKey: RejectionReason =
-    RejectionReason.Inconsistent("DuplicateKey: contract key is not unique")
+  private[events] val DuplicateKey: RejectionReasonV0 =
+    RejectionReasonV0.Inconsistent("DuplicateKey: contract key is not unique")
 
   private[events] def MismatchingLookup(
       expectation: Option[ContractId],
       result: Option[ContractId],
-  ): RejectionReason =
-    RejectionReason.Inconsistent(
+  ): RejectionReasonV0 =
+    RejectionReasonV0.Inconsistent(
       s"Contract key lookup with different results: expected [$expectation], actual [$result]"
     )
 
-  private[events] val UnknownContract: RejectionReason =
-    RejectionReason.Inconsistent("Unknown contract")
+  private[events] val UnknownContract: RejectionReasonV0 =
+    RejectionReasonV0.Inconsistent("Unknown contract")
 
   private[events] def CausalMonotonicityViolation(
       contractLedgerEffectiveTime: Instant,
       transactionLedgerEffectiveTime: Instant,
-  ): RejectionReason =
-    RejectionReason.InvalidLedgerTime(
+  ): RejectionReasonV0 =
+    RejectionReasonV0.InvalidLedgerTime(
       s"Encountered contract with LET [$contractLedgerEffectiveTime] greater than the LET of the transaction [$transactionLedgerEffectiveTime]"
     )
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
@@ -9,10 +9,9 @@ import java.util.UUID
 import akka.stream.scaladsl.Sink
 import com.daml.ledger.ApplicationId
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
-import com.daml.ledger.participant.state.v1.{Offset, RejectionReason, SubmitterInfo}
+import com.daml.ledger.participant.state.v1.{Offset, RejectionReasonV0, SubmitterInfo}
 import com.daml.lf.data.Ref.Party
 import com.daml.platform.ApiOffset
-import com.daml.platform.store.Conversions.participantRejectionReasonToErrorCode
 import com.daml.platform.store.dao.JdbcLedgerDaoCompletionsSpec._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -72,7 +71,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
     val expectedCmdId = UUID.randomUUID.toString
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      offset <- storeRejection(RejectionReason.Inconsistent(""), expectedCmdId)
+      offset <- storeRejection(RejectionReasonV0.Inconsistent(""), expectedCmdId)
       to <- ledgerDao.lookupLedgerEnd()
       (_, response) <- ledgerDao.completions
         .getCommandCompletions(from, to, applicationId, parties)
@@ -92,7 +91,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
     val expectedCmdId = UUID.randomUUID.toString
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      _ <- storeMultiPartyRejection(RejectionReason.Inconsistent(""), expectedCmdId)
+      _ <- storeMultiPartyRejection(RejectionReasonV0.Inconsistent(""), expectedCmdId)
       to <- ledgerDao.lookupLedgerEnd()
       // Response 1: querying as all submitters
       (_, response1) <- ledgerDao.completions
@@ -116,7 +115,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   it should "not return completions if the application id is wrong" in {
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      _ <- storeRejection(RejectionReason.Inconsistent(""))
+      _ <- storeRejection(RejectionReasonV0.Inconsistent(""))
       to <- ledgerDao.lookupLedgerEnd()
       response <- ledgerDao.completions
         .getCommandCompletions(from, to, applicationId = "WRONG", parties)
@@ -129,7 +128,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   it should "not return completions if the parties do not match" in {
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      _ <- storeRejection(RejectionReason.Inconsistent(""))
+      _ <- storeRejection(RejectionReasonV0.Inconsistent(""))
       to <- ledgerDao.lookupLedgerEnd()
       response1 <- ledgerDao.completions
         .getCommandCompletions(from, to, applicationId, Set("WRONG"))
@@ -146,7 +145,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   it should "not return completions if the parties do not match (multi-party submission)" in {
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      _ <- storeMultiPartyRejection(RejectionReason.Inconsistent(""))
+      _ <- storeMultiPartyRejection(RejectionReasonV0.Inconsistent(""))
       to <- ledgerDao.lookupLedgerEnd()
       response1 <- ledgerDao.completions
         .getCommandCompletions(from, to, applicationId, Set("WRONG"))
@@ -161,14 +160,14 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   }
 
   it should "return the expected status for each rejection reason" in {
-    val reasons = List[RejectionReason](
-      RejectionReason.Disputed(""),
-      RejectionReason.Inconsistent(""),
-      RejectionReason.InvalidLedgerTime(""),
-      RejectionReason.ResourcesExhausted(""),
-      RejectionReason.PartyNotKnownOnLedger(""),
-      RejectionReason.SubmitterCannotActViaParticipant(""),
-      RejectionReason.InvalidLedgerTime(""),
+    val reasons = List[RejectionReasonV0](
+      RejectionReasonV0.Disputed(""),
+      RejectionReasonV0.Inconsistent(""),
+      RejectionReasonV0.InvalidLedgerTime(""),
+      RejectionReasonV0.ResourcesExhausted(""),
+      RejectionReasonV0.PartyNotKnownOnLedger(""),
+      RejectionReasonV0.SubmitterCannotActViaParticipant(""),
+      RejectionReasonV0.InvalidLedgerTime(""),
     )
 
     for {
@@ -183,14 +182,14 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
       responses should have length reasons.length.toLong
       val returnedCodes = responses.flatMap(_.completions.map(_.status.get.code))
       for ((reason, code) <- reasons.zip(returnedCodes)) {
-        code shouldBe participantRejectionReasonToErrorCode(reason).value
+        code shouldBe reason.code.value
       }
       succeed
     }
   }
 
   private def prepareStoreRejection(
-      reason: RejectionReason,
+      reason: RejectionReasonV0,
       commandId: String = UUID.randomUUID().toString,
   ): () => Future[Offset] = () => {
     val offset = nextOffset()
@@ -205,7 +204,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   }
 
   private def storeMultiPartyRejection(
-      reason: RejectionReason,
+      reason: RejectionReasonV0,
       commandId: String = UUID.randomUUID().toString,
   ): Future[Offset] = {
     lazy val offset = nextOffset()
@@ -222,7 +221,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   }
 
   private def storeRejection(
-      reason: RejectionReason,
+      reason: RejectionReasonV0,
       commandId: String = UUID.randomUUID().toString,
   ): Future[Offset] = prepareStoreRejection(reason, commandId)()
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 import java.util.UUID
 
 import com.daml.ledger.api.domain.PartyDetails
-import com.daml.ledger.participant.state.v1.RejectionReason
+import com.daml.ledger.participant.state.v1.RejectionReasonV0
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
 import com.daml.lf.value.Value.ValueText
@@ -543,7 +543,7 @@ final class PostCommitValidationSpec extends AnyWordSpec with Matchers {
             divulged = Set.empty,
           )
 
-        error shouldBe Some(RejectionReason.PartyNotKnownOnLedger("Some parties are unallocated"))
+        error shouldBe Some(RejectionReasonV0.PartyNotKnownOnLedger("Some parties are unallocated"))
       }
       "reject if party is used in rollback" in {
         val createWithKey = genTestCreate()
@@ -557,7 +557,7 @@ final class PostCommitValidationSpec extends AnyWordSpec with Matchers {
             divulged = Set.empty,
           )
 
-        error shouldBe Some(RejectionReason.PartyNotKnownOnLedger("Some parties are unallocated"))
+        error shouldBe Some(RejectionReasonV0.PartyNotKnownOnLedger("Some parties are unallocated"))
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -216,7 +216,7 @@ object KeyValueConsumption {
       recordTime: Timestamp,
       rejEntry: DamlTransactionRejectionEntry,
   ): List[Update] = {
-    def wrap(reason: RejectionReason) =
+    def wrap(reason: RejectionReasonV0) =
       List(
         Update.CommandRejected(
           recordTime = recordTime,
@@ -227,23 +227,23 @@ object KeyValueConsumption {
 
     rejEntry.getReasonCase match {
       case DamlTransactionRejectionEntry.ReasonCase.DISPUTED =>
-        wrap(RejectionReason.Disputed(rejEntry.getDisputed.getDetails))
+        wrap(RejectionReasonV0.Disputed(rejEntry.getDisputed.getDetails))
       case DamlTransactionRejectionEntry.ReasonCase.INCONSISTENT =>
-        wrap(RejectionReason.Inconsistent(rejEntry.getInconsistent.getDetails))
+        wrap(RejectionReasonV0.Inconsistent(rejEntry.getInconsistent.getDetails))
       case DamlTransactionRejectionEntry.ReasonCase.RESOURCES_EXHAUSTED =>
-        wrap(RejectionReason.ResourcesExhausted(rejEntry.getResourcesExhausted.getDetails))
+        wrap(RejectionReasonV0.ResourcesExhausted(rejEntry.getResourcesExhausted.getDetails))
       case DamlTransactionRejectionEntry.ReasonCase.DUPLICATE_COMMAND =>
         List()
       case DamlTransactionRejectionEntry.ReasonCase.PARTY_NOT_KNOWN_ON_LEDGER =>
-        wrap(RejectionReason.PartyNotKnownOnLedger(rejEntry.getPartyNotKnownOnLedger.getDetails))
+        wrap(RejectionReasonV0.PartyNotKnownOnLedger(rejEntry.getPartyNotKnownOnLedger.getDetails))
       case DamlTransactionRejectionEntry.ReasonCase.SUBMITTER_CANNOT_ACT_VIA_PARTICIPANT =>
         wrap(
-          RejectionReason.SubmitterCannotActViaParticipant(
+          RejectionReasonV0.SubmitterCannotActViaParticipant(
             rejEntry.getSubmitterCannotActViaParticipant.getDetails
           )
         )
       case DamlTransactionRejectionEntry.ReasonCase.INVALID_LEDGER_TIME =>
-        wrap(RejectionReason.InvalidLedgerTime(rejEntry.getInvalidLedgerTime.getDetails))
+        wrap(RejectionReasonV0.InvalidLedgerTime(rejEntry.getInvalidLedgerTime.getDetails))
       case DamlTransactionRejectionEntry.ReasonCase.REASON_NOT_SET =>
         //TODO: Replace with "Unknown reason" error code or something similar
         throw Err.InternalError("transactionRejectionEntryToUpdate: REASON_NOT_SET!")
@@ -320,7 +320,7 @@ object KeyValueConsumption {
           case _ =>
             "Record time outside of valid range"
         }
-        val rejectionReason = RejectionReason.InvalidLedgerTime(reason)
+        val rejectionReason = RejectionReasonV0.InvalidLedgerTime(reason)
         Some(
           Update.CommandRejected(
             recordTime = recordTime,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/ContractKeysValidation.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/ContractKeysValidation.scala
@@ -16,7 +16,7 @@ import com.daml.ledger.participant.state.kvutils.committer.transaction.{
 }
 import com.daml.ledger.participant.state.kvutils.committer.transaction.keys.KeyMonotonicityValidation.checkContractKeysCausalMonotonicity
 import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepResult}
-import com.daml.ledger.participant.state.v1.RejectionReason
+import com.daml.ledger.participant.state.v1.RejectionReasonV0
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
 
@@ -114,7 +114,7 @@ private[transaction] object ContractKeysValidation {
           recordTime,
           transactionCommitter.buildRejectionLogEntry(
             transactionEntry,
-            RejectionReason.Inconsistent(message),
+            RejectionReasonV0.Inconsistent(message),
           ),
         )
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/KeyMonotonicityValidation.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/KeyMonotonicityValidation.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   TransactionCommitter,
 }
 import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepResult}
-import com.daml.ledger.participant.state.v1.RejectionReason
+import com.daml.ledger.participant.state.v1.RejectionReasonV0
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
 
@@ -44,7 +44,7 @@ private[keys] object KeyMonotonicityValidation {
         recordTime,
         transactionCommitter.buildRejectionLogEntry(
           transactionEntry,
-          RejectionReason.InvalidLedgerTime("Causal monotonicity violated"),
+          RejectionReasonV0.InvalidLedgerTime("Causal monotonicity violated"),
         ),
       )
   }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -462,7 +462,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)(i
 
           offset2 should be(toOffset(2))
           inside(update2) { case CommandRejected(_, _, reason) =>
-            reason should be(a[RejectionReason.PartyNotKnownOnLedger])
+            reason should be(a[RejectionReasonV0.PartyNotKnownOnLedger])
           }
 
           offset3 should be(toOffset(3))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
@@ -14,7 +14,7 @@ import com.daml.ledger.participant.state.kvutils.KeyValueConsumption.{
   outOfTimeBoundsEntryToUpdate,
 }
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
-import com.daml.ledger.participant.state.v1.{Configuration, RejectionReason, Update}
+import com.daml.ledger.participant.state.v1.{Configuration, RejectionReasonV0, Update}
 import com.daml.lf.data.Time.Timestamp
 import com.google.protobuf.Empty
 import org.scalatest.prop.TableDrivenPropertyChecks._
@@ -116,7 +116,7 @@ class KeyValueConsumptionSpec extends AnyWordSpec with Matchers {
         case Some(Update.CommandRejected(recordTime, submitterInfo, reason)) =>
           recordTime shouldBe aRecordTime
           submitterInfo shouldBe Conversions.parseSubmitterInfo(someSubmitterInfo)
-          reason shouldBe a[RejectionReason.InvalidLedgerTime]
+          reason shouldBe a[RejectionReasonV0.InvalidLedgerTime]
           ()
         case _ => fail()
       }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -19,7 +19,7 @@ import com.daml.ledger.participant.state.kvutils.committer.{
   StepStop,
 }
 import com.daml.ledger.participant.state.kvutils.{Conversions, committer}
-import com.daml.ledger.participant.state.v1.{Configuration, RejectionReason}
+import com.daml.ledger.participant.state.v1.{Configuration, RejectionReason, RejectionReasonV0}
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Engine, ReplayMismatch}
@@ -460,7 +460,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
           mkMismatch(tx1, txNone),
           mkMismatch(txNone, tx2),
         )
-        forEvery(inconsistentLookups)(checkRejectionReason(RejectionReason.Inconsistent))
+        forEvery(inconsistentLookups)(checkRejectionReason(RejectionReasonV0.Inconsistent))
       }
 
       "report Disputed if one of contracts is created in the same transaction" in {
@@ -484,11 +484,11 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
           mkMismatch(txC1, txCNone),
           mkMismatch(tx1C, txNoneC),
         )
-        forEvery(recordedKeyInconsistent)(checkRejectionReason(RejectionReason.Disputed))
+        forEvery(recordedKeyInconsistent)(checkRejectionReason(RejectionReasonV0.Disputed))
       }
 
       "report Disputed if the keys are different" in {
-        checkRejectionReason(RejectionReason.Disputed)(mkMismatch(txOther, tx1))
+        checkRejectionReason(RejectionReasonV0.Disputed)(mkMismatch(txOther, tx1))
       }
     }
 
@@ -510,7 +510,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
           mkRecordedMissing(txExerciseOnly, tx2),
           mkReplayedMissing(tx1, txExerciseOnly),
         )
-        forEvery(miscMismatches)(checkRejectionReason(RejectionReason.Disputed))
+        forEvery(miscMismatches)(checkRejectionReason(RejectionReasonV0.Disputed))
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/KeyMonotonicityValidationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/keys/KeyMonotonicityValidationSpec.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,
   TransactionCommitter,
 }
-import com.daml.ledger.participant.state.v1.RejectionReason
+import com.daml.ledger.participant.state.v1.{RejectionReasonV0}
 import com.daml.logging.LoggingContext
 import com.google.protobuf.ByteString
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
@@ -62,7 +62,7 @@ class KeyMonotonicityValidationSpec
 
       verify(mockTransactionCommitter).buildRejectionLogEntry(
         eqTo(testTransactionEntry),
-        any[RejectionReason.InvalidLedgerTime],
+        any[RejectionReasonV0.InvalidLedgerTime],
       )(any[LoggingContext])
       verify(mockTransactionCommitter).reject(
         eqTo(None),

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -63,7 +63,6 @@ da_scala_test(
         "@maven//:org_scalaz_scalaz_core",
     ],
     deps = [
-        "@maven//:org_mockito_mockito_core",
         "//daml-lf/archive:daml_lf_dev_archive_proto_java",
         "//daml-lf/data",
         "//daml-lf/transaction",
@@ -75,6 +74,7 @@ da_scala_test(
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils/tools",
         "@maven//:io_grpc_grpc_api",
+        "@maven//:org_mockito_mockito_core",
     ] + (["@maven//:com_google_protobuf_protobuf_java"] if scala_major_version == "2.13" else []),
 )
 

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -74,6 +74,7 @@ da_scala_test(
         "//ledger/participant-state",
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils/tools",
+        "@maven//:io_grpc_grpc_api",
     ] + (["@maven//:com_google_protobuf_protobuf_java"] if scala_major_version == "2.13" else []),
 )
 

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
-import com.daml.ledger.participant.state.v1.{RejectionReason, Update}
+import com.daml.ledger.participant.state.v1.{RejectionReasonV0, Update}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.kv.TransactionNormalizer
 import com.daml.lf.transaction.CommittedTransaction
@@ -52,18 +52,20 @@ object RejectionReasonDescriptionNormalizer extends UpdateNormalizer {
   override def normalize(update: Update): Update = update match {
     case commandRejected @ Update.CommandRejected(_, _, reason) =>
       val newReason = reason match {
-        case RejectionReason.Disputed(_) =>
-          RejectionReason.Disputed("")
-        case RejectionReason.Inconsistent(_) =>
-          RejectionReason.Inconsistent("")
-        case RejectionReason.InvalidLedgerTime(_) =>
-          RejectionReason.InvalidLedgerTime("")
-        case RejectionReason.PartyNotKnownOnLedger(_) =>
-          RejectionReason.PartyNotKnownOnLedger("")
-        case RejectionReason.ResourcesExhausted(_) =>
-          RejectionReason.ResourcesExhausted("")
-        case RejectionReason.SubmitterCannotActViaParticipant(_) =>
-          RejectionReason.SubmitterCannotActViaParticipant("")
+        case RejectionReasonV0.Disputed(_) =>
+          RejectionReasonV0.Disputed("")
+        case RejectionReasonV0.Inconsistent(_) =>
+          RejectionReasonV0.Inconsistent("")
+        case RejectionReasonV0.InvalidLedgerTime(_) =>
+          RejectionReasonV0.InvalidLedgerTime("")
+        case RejectionReasonV0.PartyNotKnownOnLedger(_) =>
+          RejectionReasonV0.PartyNotKnownOnLedger("")
+        case RejectionReasonV0.ResourcesExhausted(_) =>
+          RejectionReasonV0.ResourcesExhausted("")
+        case RejectionReasonV0.SubmitterCannotActViaParticipant(_) =>
+          RejectionReasonV0.SubmitterCannotActViaParticipant("")
+        // don't map non V0 errors
+        case x => x
       }
       commandRejected.copy(reason = newReason)
     case _ => update

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparisonSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparisonSpec.scala
@@ -37,12 +37,14 @@ final class StateUpdateComparisonSpec
     "ignore rejection reason for CommandRejected updates" in {
       val rejectionReasons = Table(
         ("Left", "Right"),
-        RejectionReason.Disputed("a") -> RejectionReason.Disputed("b"),
-        RejectionReason.Inconsistent("a") -> RejectionReason.Inconsistent("b"),
-        RejectionReason.InvalidLedgerTime("a") -> RejectionReason.InvalidLedgerTime("b"),
-        RejectionReason.PartyNotKnownOnLedger("a") -> RejectionReason.PartyNotKnownOnLedger("b"),
-        RejectionReason.ResourcesExhausted("a") -> RejectionReason.ResourcesExhausted("b"),
-        RejectionReason.SubmitterCannotActViaParticipant("a") -> RejectionReason
+        RejectionReasonV0.Disputed("a") -> RejectionReasonV0.Disputed("b"),
+        RejectionReasonV0.Inconsistent("a") -> RejectionReasonV0.Inconsistent("b"),
+        RejectionReasonV0.InvalidLedgerTime("a") -> RejectionReasonV0.InvalidLedgerTime("b"),
+        RejectionReasonV0.PartyNotKnownOnLedger("a") -> RejectionReasonV0.PartyNotKnownOnLedger(
+          "b"
+        ),
+        RejectionReasonV0.ResourcesExhausted("a") -> RejectionReasonV0.ResourcesExhausted("b"),
+        RejectionReasonV0.SubmitterCannotActViaParticipant("a") -> RejectionReasonV0
           .SubmitterCannotActViaParticipant("b"),
       )
       forAll(rejectionReasons) { case (left, right) =>
@@ -108,7 +110,7 @@ final class StateUpdateComparisonSpec
       commandId = CommandId.assertFromString("a command ID"),
       deduplicateUntil = Instant.now(),
     ),
-    reason = RejectionReason.Disputed("a rejection reason"),
+    reason = RejectionReasonV0.Disputed("a rejection reason"),
   )
   private lazy val aTransactionAcceptedUpdate =
     TransactionAccepted(

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/RejectionReason.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/RejectionReason.scala
@@ -3,15 +3,20 @@
 
 package com.daml.ledger.participant.state.v1
 
+import io.grpc.Status.Code
+
 /** Reasons for rejections of transaction submission.
   *
   * Used to provide details for [[Update.CommandRejected]].
   */
-sealed abstract class RejectionReason extends Product with Serializable {
+abstract class RejectionReason extends Product with Serializable {
   def description: String
+  def code: Code
 }
 
-object RejectionReason {
+sealed abstract class RejectionReasonV0 extends RejectionReason
+
+object RejectionReasonV0 {
 
   /** The transaction relied on contracts or keys being active that were no longer
     * active at the point where it was sequenced or a contract key was being created
@@ -19,8 +24,10 @@ object RejectionReason {
     * See https://docs.daml.com/concepts/ledger-model/ledger-integrity.html
     * for the definition of ledger consistency.
     */
-  final case class Inconsistent(reason: String) extends RejectionReason {
+  final case class Inconsistent(reason: String) extends RejectionReasonV0 {
     override def description: String = s"Inconsistent: $reason"
+    override def code: Code = Code.ABORTED
+
   }
 
   /** The transaction has been disputed.
@@ -29,15 +36,17 @@ object RejectionReason {
     * considered the transaction potentially invalid. This can be due to a bug
     * in the submission or validation logic, or due to malicious behaviour.
     */
-  final case class Disputed(reason: String) extends RejectionReason {
+  final case class Disputed(reason: String) extends RejectionReasonV0 {
     override def description: String = s"Disputed: $reason"
+    override def code: Code = Code.INVALID_ARGUMENT
   }
 
   /** The Participant node did not have sufficient resources with the
     * ledger to submit the transaction.
     */
-  final case class ResourcesExhausted(reason: String) extends RejectionReason {
+  final case class ResourcesExhausted(reason: String) extends RejectionReasonV0 {
     override def description: String = s"Resources exhausted: $reason"
+    override def code: Code = Code.ABORTED
   }
 
   /** A party mentioned as a stakeholder or actor has not been on-boarded on
@@ -48,8 +57,9 @@ object RejectionReason {
     * material and registering the party with the ledger-wise
     * identity-manager.
     */
-  final case class PartyNotKnownOnLedger(reason: String) extends RejectionReason {
+  final case class PartyNotKnownOnLedger(reason: String) extends RejectionReasonV0 {
     override def description: String = s"Party not known on ledger: $reason"
+    override def code: Code = Code.INVALID_ARGUMENT
   }
 
   /** The submitter cannot act via this participant.
@@ -58,8 +68,9 @@ object RejectionReason {
     *   it is not hosted on the participant or because its write access to
     *   the ledger has been deactivated.
     */
-  final case class SubmitterCannotActViaParticipant(reason: String) extends RejectionReason {
+  final case class SubmitterCannotActViaParticipant(reason: String) extends RejectionReasonV0 {
     override def description: String = s"Submitter cannot act via participant: $reason"
+    override def code: Code = Code.PERMISSION_DENIED
   }
 
   /** The ledger time of the transaction submission violated one of the
@@ -70,7 +81,8 @@ object RejectionReason {
     *  - The ledger time of the transaction must be greater than or equal
     *    to the ledger time of any contract used by the transaction.
     */
-  final case class InvalidLedgerTime(reason: String) extends RejectionReason {
+  final case class InvalidLedgerTime(reason: String) extends RejectionReasonV0 {
     override def description: String = s"Invalid ledger time: $reason"
+    override def code: Code = Code.ABORTED
   }
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmissionResult.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmissionResult.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.participant.state.v1
 
+import io.grpc.StatusRuntimeException
+
 sealed abstract class SubmissionResult extends Product with Serializable {
   def description: String
 }
@@ -28,4 +30,10 @@ object SubmissionResult {
   final case class InternalError(reason: String) extends SubmissionResult {
     override val description: String = s"Failed with an internal error, reason=$reason"
   }
+
+  /** Temporary method to tunnel new error codes through the ledger-api server */
+  final case class SynchronousReject(failure: StatusRuntimeException) extends SubmissionResult {
+    override def description: String = failure.getStatus.getDescription
+  }
+
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -379,16 +379,16 @@ private final class SqlLedger(
   private def checkTimeModel(
       ledgerTime: Instant,
       recordTime: Instant,
-  ): Either[RejectionReason, Unit] = {
+  ): Either[RejectionReasonV0, Unit] = {
     currentConfiguration
       .get()
-      .fold[Either[RejectionReason, Unit]](
+      .fold[Either[RejectionReasonV0, Unit]](
         Left(
-          RejectionReason
+          RejectionReasonV0
             .InvalidLedgerTime("No ledger configuration available, cannot validate ledger time")
         )
       )(
-        _.timeModel.checkTime(ledgerTime, recordTime).left.map(RejectionReason.InvalidLedgerTime)
+        _.timeModel.checkTime(ledgerTime, recordTime).left.map(RejectionReasonV0.InvalidLedgerTime)
       )
   }
 


### PR DESCRIPTION
Before this change, any write-service was restricted to the predefined
set of rejection reasons which couldn't capture the complex canton
rejection reasons.
In order to open up the path for a redesign, I've migrated the current
rejection reasons into a V0 version and opened the abstract class for
customized implementations.
In addition, I added another SubmissionResult which will support synchronous error responses.

CHANGELOG_BEGIN

- Participant-state: Introduced versioned form of rejection reason

CHANGELOG_END

There is a related PR https://github.com/DACH-NY/canton/pull/6177 that is going to leverage these changes, such that we can work out the V1 error responses.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
