### PR TITLE
test_windows_signing: add quotes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
   steps:
   - checkout: none
   - bash: |
-      mkdir $(Build.StagingDirectory)/test-signing
+      mkdir -p '$(Build.StagingDirectory)'/test-signing
   - task: DownloadPipelineArtifact@0
     inputs:
       artifactName: test-signing


### PR DESCRIPTION
Otherwise Bash interprets the baskslashes and it's not a path anymore.

CHANGELOG_BEGIN
CHANGELOG_END