### PR TITLE
Make succ/pred throw an ArithmeticError on overflow.

### DIFF
--- a/compiler/damlc/daml-prim-src/GHC/Enum.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Enum.daml
@@ -22,12 +22,14 @@ import GHC.Err
 import Data.String()
 import GHC.Integer.Type
 import GHC.Num
-import GHC.Show()
 import GHC.Classes
 import GHC.CString (fromString)
 
 #ifdef DAML_EXCEPTIONS
+import GHC.Show(show)
 import DA.Exception.ArithmeticError
+#else
+import GHC.Show()
 #endif
 
 -- | Use the `Bounded` class to name the upper and lower limits of a
@@ -162,10 +164,10 @@ instance  Enum Int  where
 
 #ifdef DAML_EXCEPTIONS
     succ x
-       | x == maxBound  = primitive @"EThrow" (ArithmeticError "ArithmeticError while evaluating (succ @Int " <> show x <> ").")
-       | otherwise      = x + 1
+       | x == maxBound  = primitive @"EThrow" (ArithmeticError ("ArithmeticError while evaluating (succ @Int " ++ show x ++ ")."))
+        | otherwise      = x + 1
     pred x
-       | x == minBound  = primitive @"EThrow" (ArithmeticError "ArithmeticError while evaluating (pred @Int " <> show x <> ").")
+       | x == minBound  = primitive @"EThrow" (ArithmeticError ("ArithmeticError while evaluating (pred @Int " ++ show x ++ ")."))
        | otherwise      = x - 1
 #else
     succ x

--- a/compiler/damlc/daml-prim-src/GHC/Enum.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Enum.daml
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-missing-methods #-}
 
 -- | MOVE Prelude
@@ -24,6 +25,10 @@ import GHC.Num
 import GHC.Show()
 import GHC.Classes
 import GHC.CString (fromString)
+
+#ifdef DAML_EXCEPTIONS
+import DA.Exception.ArithmeticError
+#endif
 
 -- | Use the `Bounded` class to name the upper and lower limits of a
 -- type.
@@ -154,12 +159,22 @@ instance Bounded Int where
     maxBound =  0x7FFFFFFFFFFFFFFF
 
 instance  Enum Int  where
+
+#ifdef DAML_EXCEPTIONS
+    succ x
+       | x == maxBound  = primitive @"EThrow" (ArithmeticError "ArithmeticError while evaluating (succ @Int " <> show x <> ").")
+       | otherwise      = x + 1
+    pred x
+       | x == minBound  = primitive @"EThrow" (ArithmeticError "ArithmeticError while evaluating (pred @Int " <> show x <> ").")
+       | otherwise      = x - 1
+#else
     succ x
        | x == maxBound  = error "Prelude.Enum.succ{Int}: tried to take `succ' of maxBound"
        | otherwise      = x + 1
     pred x
        | x == minBound  = error "Prelude.Enum.pred{Int}: tried to take `pred' of minBound"
        | otherwise      = x - 1
+#endif
 
     toEnum   x = x
     fromEnum x = x


### PR DESCRIPTION
Part of #8020.

I went through all of daml-prim and daml-stdlib, looking for appropriate places to throw exceptions. These are the only two remaining cases that I found where it seems correct to me to throw a different exception type rather than `GeneralError`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
