### PR TITLE
Daml ledger export test - normalize SDK version

### DIFF
--- a/daml-script/export/BUILD.bazel
+++ b/daml-script/export/BUILD.bazel
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@build_environment//:configuration.bzl", "ghc_version")
 load(
     "//bazel_tools/client_server:client_server_build.bzl",
     "client_server_build",
@@ -175,8 +176,8 @@ client_server_build(
 # documentation import markers and normalizes the actual output by adding a
 # newline to the last line if missing.
 #
-# Normalizes the data-dependencies by replacing package-id hashes with a
-# placeholder and Windows path separators by Unix separators.
+# Normalizes the data-dependencies by replacing the SDK version, package-id
+# hashes with a placeholder, and Windows path separators by Unix separators.
 sh_inline_test(
     name = "example-export-compare",
     cmd = """\
@@ -188,21 +189,23 @@ ACTUAL_ARGS=$$(canonicalize_rlocation $(rootpath :example-export/args.json))
 ACTUAL_YAML=$$(canonicalize_rlocation $(rootpath :example-export/daml.yaml))
 # Normalize the expected file by removing the copyright header and any documentation import markers.
 # Normalize the actual output by adding a newline to the last line if missing.
-$(POSIX_DIFF) -Naur --strip-trailing-cr <($(POSIX_SED) '1,3d;/^-- EXPORT/d' $$EXPECTED_EXPORT) <($(POSIX_SED) '$$a\\' $$ACTUAL_EXPORT) || {
+$(POSIX_DIFF) -Naur --strip-trailing-cr <($(POSIX_SED) '1,3d;/^-- EXPORT/d' $$EXPECTED_EXPORT) <($(POSIX_SED) '$$a\\' $$ACTUAL_EXPORT) || {{
   echo "$$EXPECTED_EXPORT did not match $$ACTUAL_EXPORT"
   exit 1
-}
-$(POSIX_DIFF) -Naur --strip-trailing-cr $$EXPECTED_ARGS <($(POSIX_SED) '$$a\\' $$ACTUAL_ARGS) || {
+}}
+$(POSIX_DIFF) -Naur --strip-trailing-cr $$EXPECTED_ARGS <($(POSIX_SED) '$$a\\' $$ACTUAL_ARGS) || {{
   echo "$$EXPECTED_ARGS did not match $$ACTUAL_ARGS"
   exit 1
-}
+}}
 # Normalize the expected file by removing the copyright header and any documentation import markers.
-# Normalize the data-dependencies by replacing package-id hashes with a placeholder and Windows path separators by Unix separators.
-$(POSIX_DIFF) -Naur --strip-trailing-cr <($(POSIX_SED) '1,3d;s/[0-9a-f]\\{64\\}/HASH/' $$EXPECTED_YAML) <($(POSIX_SED) 's/[0-9a-f]\\{64\\}/HASH/;s,\\\\,/,g;$$a\\' $$ACTUAL_YAML) || {
+# Normalize the data-dependencies by replacing the SDK version, package-id hashes with a placeholder, and Windows path separators by Unix separators.
+$(POSIX_DIFF) -Naur --strip-trailing-cr <($(POSIX_SED) '1,3d;s/[0-9a-f]\\{{64\\}}/HASH/;s/daml-\\(script\\|stdlib\\)-0\\.0\\.0/daml-\\1-{ghc_version}/' $$EXPECTED_YAML) <($(POSIX_SED) 's/[0-9a-f]\\{{64\\}}/HASH/;s,\\\\,/,g;$$a\\' $$ACTUAL_YAML) || {{
   echo "$$EXPECTED_YAML did not match $$ACTUAL_YAML"
   exit 1
-}
-""",
+}}
+""".format(
+        ghc_version = ghc_version,
+    ),
     data = [
         ":example-export/Export.daml",
         ":example-export/args.json",


### PR DESCRIPTION

The Daml ledger export golden test compares a generated ledger export against a checked in example. The example assumes the SDK version 0.0.0. This works for regular CI builds, but fails for snapshot/release builds where the version is different. Specifically, https://github.com/digital-asset/daml/pull/9794 failed with the error below.

This PR fixes this by replacing 0.0.0 by the expected version in the example file before comparison.

```
FAIL: //daml-script/export:example-export-compare (see /home/vsts/.cache/bazel/_bazel_vsts/9b01b58e95c1fb4c476c067a6a807d1d/execroot/com_github_digital_asset_daml/bazel-out/k8-opt/testlogs/daml-script/export/example-export-compare/test.log)
INFO: From Testing //daml-script/export:example-export-compare:
==================== Test output for //daml-script/export:example-export-compare:
--- /dev/fd/63	2021-05-26 06:42:59.414702208 +0000
+++ /dev/fd/62	2021-05-26 06:42:59.414702208 +0000
@@ -32,8 +32,8 @@
 - EXPORT_OUT/deps/HASH.dalf
 - EXPORT_OUT/deps/HASH.dalf
 - EXPORT_OUT/deps/daml-prim-0.0.0-HASH.dalf
-- EXPORT_OUT/deps/daml-script-0.0.0-HASH.dalf
-- EXPORT_OUT/deps/daml-stdlib-0.0.0-HASH.dalf
+- EXPORT_OUT/deps/daml-script-1.14.0.20210525.7017.0-HASH.dalf
+- EXPORT_OUT/deps/daml-stdlib-1.14.0.20210525.7017.0-HASH.dalf
 - EXPORT_OUT/deps/daml-stdlib-DA-Set-Types-1.0.0-HASH.dalf
 - EXPORT_OUT/deps/script-test-0.0.1-HASH.dalf
 build-options:
/home/vsts/.cache/bazel/_bazel_vsts/9b01b58e95c1fb4c476c067a6a807d1d/sandbox/linux-sandbox/6355/execroot/com_github_digital_asset_daml/bazel-out/k8-opt/bin/daml-script/export/example-export-compare.runfiles/com_github_digital_asset_daml/docs/source/tools/export/output-root/daml.yaml did not match /home/vsts/.cache/bazel/_bazel_vsts/9b01b58e95c1fb4c476c067a6a807d1d/sandbox/linux-sandbox/6355/execroot/com_github_digital_asset_daml/bazel-out/k8-opt/bin/daml-script/export/example-export-compare.runfiles/com_github_digital_asset_daml/daml-script/export/example-export/daml.yaml
================================================================================
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
