### PR TITLE
Parallelize daml-assistant integration tests.

### DIFF
--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -106,7 +106,6 @@ da_haskell_library(
 da_haskell_test(
     name = "integration-tests",
     timeout = "long",
-    tags = ["cpu:2"]
     srcs = [
         "src/DA/Daml/Assistant/FreePort.hs",
         "src/DA/Daml/Assistant/IntegrationTests.hs",
@@ -155,6 +154,7 @@ da_haskell_test(
         "vector",
     ],
     main_function = "DA.Daml.Assistant.IntegrationTests.main",
+    tags = ["cpu:2"],
     visibility = ["//visibility:public"],
     deps = [
         ":integration-test-utils",

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -106,6 +106,7 @@ da_haskell_library(
 da_haskell_test(
     name = "integration-tests",
     timeout = "long",
+    tags = ["cpu:2"]
     srcs = [
         "src/DA/Daml/Assistant/FreePort.hs",
         "src/DA/Daml/Assistant/IntegrationTests.hs",

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -35,7 +35,7 @@ import DA.Daml.Assistant.IntegrationTestUtils
 import DA.Daml.Helper.Util (waitForConnectionOnPort, waitForHttpServer, tokenFor)
 -- import DA.PortFile
 import DA.Test.Daml2jsUtils
-import DA.Test.Process (callCommandSilent)
+import DA.Test.Process (callCommandSilent, callCommandSilentIn, callCommandSilentWithEnvIn, subprocessEnv)
 import DA.Test.Util
 import DA.PortFile
 import SdkVersion
@@ -44,20 +44,20 @@ main :: IO ()
 main = do
     yarn : args <- getArgs
     withTempDir $ \tmpDir -> do
-    oldPath <- getSearchPath
-    javaPath <- locateRunfiles "local_jdk/bin"
-    mvnPath <- locateRunfiles "mvn_dev_env/bin"
-    tarPath <- locateRunfiles "tar_dev_env/bin"
-    yarnPath <- takeDirectory <$> locateRunfiles (mainWorkspace </> yarn)
-    -- NOTE: `COMSPEC` env. variable on Windows points to cmd.exe, which is required to be present
-    -- on the PATH as mvn.cmd executes cmd.exe
-    mbComSpec <- getEnv "COMSPEC"
-    let mbCmdDir = takeDirectory <$> mbComSpec
-    limitJvmMemory defaultJvmMemoryLimits
-    withArgs args (withEnv
-        [ ("PATH", Just $ intercalate [searchPathSeparator] $ (tarPath : javaPath : mvnPath : yarnPath : oldPath) ++ maybeToList mbCmdDir)
-        , ("TASTY_NUM_THREADS", Just "1")
-        ] $ defaultMain (tests tmpDir))
+        oldPath <- getSearchPath
+        javaPath <- locateRunfiles "local_jdk/bin"
+        mvnPath <- locateRunfiles "mvn_dev_env/bin"
+        tarPath <- locateRunfiles "tar_dev_env/bin"
+        yarnPath <- takeDirectory <$> locateRunfiles (mainWorkspace </> yarn)
+        -- NOTE: `COMSPEC` env. variable on Windows points to cmd.exe, which is required to be present
+        -- on the PATH as mvn.cmd executes cmd.exe
+        mbComSpec <- getEnv "COMSPEC"
+        let mbCmdDir = takeDirectory <$> mbComSpec
+        limitJvmMemory defaultJvmMemoryLimits
+        withArgs args (withEnv
+            [ ("PATH", Just $ intercalate [searchPathSeparator] $ (tarPath : javaPath : mvnPath : yarnPath : oldPath) ++ maybeToList mbCmdDir)
+            , ("TASTY_NUM_THREADS", Just "2")
+            ] $ defaultMain (tests tmpDir))
 
 hardcodedToken :: T.Text
 hardcodedToken = tokenFor ["Alice"] "MyLedger" "AssistantIntegrationTests"
@@ -65,11 +65,12 @@ hardcodedToken = tokenFor ["Alice"] "MyLedger" "AssistantIntegrationTests"
 authorizationHeaders :: RequestHeaders
 authorizationHeaders = [("Authorization", "Bearer " <> T.encodeUtf8 hardcodedToken)]
 
-withDamlService :: String -> [String] -> IO a -> IO a
-withDamlService command args act = withDevNull $ \devNull -> do
+withDamlServiceIn :: FilePath -> String -> [String] -> IO a -> IO a
+withDamlServiceIn path command args act = withDevNull $ \devNull -> do
     let proc' = (shell $ unwords $ ["daml", command] <> args)
           { std_out = UseHandle devNull
           , create_group = True
+          , cwd = Just path
           }
     withCreateProcess proc' $ \_ _ _ ph -> do
         r <- act
@@ -142,10 +143,11 @@ damlStart startCwd tmpDir = do
     let cwd
           | ProjDir <- startCwd = projDir
           | otherwise = tmpDir
-    let env
+    let envChanges
           | ProjDir <- startCwd = []
-          | EnvRelativeDir <- startCwd = [("DAML_PROJECT", Just "assistant-integration-tests")]
-          | EnvAbsoluteDir <- startCwd = [("DAML_PROJECT", Just projDir)]
+          | EnvRelativeDir <- startCwd = [("DAML_PROJECT", "assistant-integration-tests")]
+          | EnvAbsoluteDir <- startCwd = [("DAML_PROJECT", projDir)]
+    env <- subprocessEnv envChanges
     let startProc =
             (shell $
              unwords
@@ -158,29 +160,28 @@ damlStart startCwd tmpDir = do
                  , "--json-api-port"
                  , show jsonApiPort
                  ])
-                {std_in = CreatePipe, std_out = CreatePipe, cwd = Just cwd, create_group = True}
-    withEnv env $ do
-      (Just startStdin, Just startStdout, _, startPh) <- createProcess startProc
-      outChan <- newBroadcastTChanIO
-      outReader <- forkIO $ forever $ do
-          line <- hGetLine startStdout
-          atomically $ writeTChan outChan line
-      waitForHttpServer
-          (threadDelay 100000)
-          ("http://localhost:" <> show jsonApiPort <> "/v1/query")
-          authorizationHeaders
-      pure $
-          DamlStartResource
-              { projDir = projDir
-              , tmpDir = tmpDir
-              , sandboxPort = sandboxPort
-              , jsonApiPort = jsonApiPort
-              , startStdin = startStdin
-              , stop = do
-                  interruptProcessGroupOf startPh
-                  killThread outReader
-              , stdoutChan = outChan
-              }
+                {std_in = CreatePipe, std_out = CreatePipe, cwd = Just cwd, create_group = True, env = Just env}
+    (Just startStdin, Just startStdout, _, startPh) <- createProcess startProc
+    outChan <- newBroadcastTChanIO
+    outReader <- forkIO $ forever $ do
+        line <- hGetLine startStdout
+        atomically $ writeTChan outChan line
+    waitForHttpServer
+        (threadDelay 100000)
+        ("http://localhost:" <> show jsonApiPort <> "/v1/query")
+        authorizationHeaders
+    pure $
+        DamlStartResource
+            { projDir = projDir
+            , tmpDir = tmpDir
+            , sandboxPort = sandboxPort
+            , jsonApiPort = jsonApiPort
+            , startStdin = startStdin
+            , stop = do
+                interruptProcessGroupOf startPh
+                killThread outReader
+            , stdoutChan = outChan
+            }
 
 data QuickSandboxResource = QuickSandboxResource
     { quickSandboxPort :: PortNumber
@@ -193,31 +194,30 @@ quickSandbox :: FilePath -> IO QuickSandboxResource
 quickSandbox projDir = do
     withDevNull $ \devNull -> do
         callCommandSilent $ unwords ["daml", "new", projDir, "--template=quickstart-java"]
-        withCurrentDirectory projDir $ do
-            callCommandSilent "daml build"
-            sandboxPort <- getFreePort
-            let sandboxProc =
-                    (shell $
-                     unwords
-                         [ "daml"
-                         , "sandbox"
-                         , "--"
-                         , "--port"
-                         , show sandboxPort
-                         , "--"
-                         , "--static-time"
-                         , ".daml/dist/quickstart-0.0.1.dar"
-                         ])
-                        {std_out = UseHandle devNull, create_group = True}
-            (_, _, _, sandboxPh) <- createProcess sandboxProc
-            waitForConnectionOnPort (threadDelay 500000) $ fromIntegral sandboxPort
-            pure $
-                QuickSandboxResource
-                    { quickProjDir = projDir
-                    , quickSandboxPort = sandboxPort
-                    , quickSandboxPh = sandboxPh
-                    , quickDar = projDir </> ".daml" </> "dist" </> "quickstart-0.0.1.dar"
-                    }
+        callCommandSilentIn projDir "daml build"
+        sandboxPort <- getFreePort
+        let sandboxProc =
+                (shell $
+                    unwords
+                        [ "daml"
+                        , "sandbox"
+                        , "--"
+                        , "--port"
+                        , show sandboxPort
+                        , "--"
+                        , "--static-time"
+                        , ".daml/dist/quickstart-0.0.1.dar"
+                        ])
+                    {std_out = UseHandle devNull, create_group = True, cwd = Just projDir}
+        (_, _, _, sandboxPh) <- createProcess sandboxProc
+        waitForConnectionOnPort (threadDelay 500000) $ fromIntegral sandboxPort
+        pure $
+            QuickSandboxResource
+                { quickProjDir = projDir
+                , quickSandboxPort = sandboxPort
+                , quickSandboxPh = sandboxPh
+                , quickDar = projDir </> ".daml" </> "dist" </> "quickstart-0.0.1.dar"
+                }
 
 tests :: FilePath -> TestTree
 tests tmpDir =
@@ -225,10 +225,11 @@ tests tmpDir =
         testGroup
             "Integration tests"
             [ testCase "daml version" $
-              withCurrentDirectory tmpDir $ callCommandSilent "daml version"
-            , testCase "daml --help" $ withCurrentDirectory tmpDir $ callCommandSilent "daml --help"
+                callCommandSilentIn tmpDir "daml version"
+            , testCase "daml --help" $
+                callCommandSilentIn tmpDir "daml --help"
             , testCase "daml new --list" $
-              withCurrentDirectory tmpDir $ callCommandSilent "daml new --list"
+                callCommandSilentIn tmpDir "daml new --list"
             , packagingTests tmpDir
             , damlToolTests
             , withResource (damlStart ProjDir tmpDir) stop damlStartTests
@@ -254,13 +255,13 @@ packagingTests tmpDir =
         [ testCase "Build copy trigger" $ do
               let projDir = tmpDir </> "copy-trigger1"
               callCommandSilent $ unwords ["daml", "new", projDir, "--template=copy-trigger"]
-              withCurrentDirectory projDir $ callCommandSilent "daml build"
+              callCommandSilentIn projDir "daml build"
               let dar = projDir </> ".daml" </> "dist" </> "copy-trigger-0.0.1.dar"
               assertFileExists dar
         , testCase "Build copy trigger with LF version 1.dev" $ do
               let projDir = tmpDir </> "copy-trigger2"
               callCommandSilent $ unwords ["daml", "new", projDir, "--template=copy-trigger"]
-              withCurrentDirectory projDir $ callCommandSilent "daml build --target 1.dev"
+              callCommandSilentIn projDir "daml build --target 1.dev"
               let dar = projDir </> ".daml" </> "dist" </> "copy-trigger-0.0.1.dar"
               assertFileExists dar
         , testCase "Build trigger with extra dependency" $ do
@@ -277,7 +278,7 @@ packagingTests tmpDir =
                       , "  - daml-stdlib"
                       ]
               writeFileUTF8 (myDepDir </> "daml" </> "MyDep.daml") $ unlines ["module MyDep where"]
-              withCurrentDirectory myDepDir $ callCommandSilent "daml build -o mydep.dar"
+              callCommandSilentIn myDepDir "daml build -o mydep.dar"
               let myTriggerDir = tmpDir </> "mytrigger"
               createDirectoryIfMissing True (myTriggerDir </> "daml")
               writeFileUTF8 (myTriggerDir </> "daml.yaml") $
@@ -294,25 +295,24 @@ packagingTests tmpDir =
                       ]
               writeFileUTF8 (myTriggerDir </> "daml/Main.daml") $
                   unlines ["module Main where", "import MyDep ()", "import Daml.Trigger ()"]
-              withCurrentDirectory myTriggerDir $ callCommandSilent "daml build -o mytrigger.dar"
+              callCommandSilentIn myTriggerDir "daml build -o mytrigger.dar"
               let dar = myTriggerDir </> "mytrigger.dar"
               assertFileExists dar
         , testCase "Build DAML script example" $ do
               let projDir = tmpDir </> "script-example"
               callCommandSilent $ unwords ["daml", "new", projDir, "--template=script-example"]
-              withCurrentDirectory projDir $ callCommandSilent "daml build"
+              callCommandSilentIn projDir "daml build"
               let dar = projDir </> ".daml/dist/script-example-0.0.1.dar"
               assertFileExists dar
         , testCase "Build DAML script example with LF version 1.dev" $ do
               let projDir = tmpDir </> "script-example1"
               callCommandSilent $ unwords ["daml", "new", projDir, "--template=script-example"]
-              withCurrentDirectory projDir $ callCommandSilent "daml build --target 1.dev"
+              callCommandSilentIn projDir "daml build --target 1.dev"
               let dar = projDir </> ".daml/dist/script-example-0.0.1.dar"
               assertFileExists dar
         , testCase "Package depending on daml-script and daml-trigger can use data-dependencies" $ do
               callCommandSilent $ unwords ["daml", "new", tmpDir </> "data-dependency"]
-              withCurrentDirectory (tmpDir </> "data-dependency") $
-                  callCommandSilent "daml build -o data-dependency.dar"
+              callCommandSilentIn (tmpDir </> "data-dependency") "daml build -o data-dependency.dar"
               createDirectoryIfMissing True (tmpDir </> "proj")
               writeFileUTF8 (tmpDir </> "proj" </> "daml.yaml") $
                   unlines
@@ -333,7 +333,7 @@ packagingTests tmpDir =
                       , "f = setup >> allocateParty \"foobar\""
           -- This also checks that we get the same Script type within an SDK version.
                       ]
-              withCurrentDirectory (tmpDir </> "proj") $ callCommandSilent "daml build"
+              callCommandSilentIn (tmpDir </> "proj") "daml build"
         ]
 
 -- Test tools that can run outside a daml project
@@ -342,433 +342,403 @@ damlToolTests =
     testGroup
         "daml tools"
         [ testCase "OAuth 2.0 middleware startup" $ do
-              middlewarePort <- getFreePort
-              withDamlService "oauth2-middleware"
-                  [ "--address"
-                  , "localhost"
-                  , "--http-port"
-                  , show middlewarePort
-                  , "--oauth-auth"
-                  , "http://localhost:0/authorize"
-                  , "--oauth-token"
-                  , "http://localhost:0/token"
-                  , "--auth-jwt-hs256-unsafe"
-                  , "jwt-secret"
-                  , "--id"
-                  , "client-id"
-                  , "--secret"
-                  , "client-secret"
-                  ] $ do
-                  let endpoint =
-                          "http://localhost:" <> show middlewarePort <> "/livez"
-                  waitForHttpServer (threadDelay 100000) endpoint []
-                  req <- parseRequest endpoint
-                  manager <- newManager defaultManagerSettings
-                  resp <- httpLbs req manager
-                  responseBody resp @?= "{\"status\":\"pass\"}"
+            withTempDir $ \tmpDir -> do
+                middlewarePort <- getFreePort
+                withDamlServiceIn tmpDir "oauth2-middleware"
+                    [ "--address"
+                    , "localhost"
+                    , "--http-port"
+                    , show middlewarePort
+                    , "--oauth-auth"
+                    , "http://localhost:0/authorize"
+                    , "--oauth-token"
+                    , "http://localhost:0/token"
+                    , "--auth-jwt-hs256-unsafe"
+                    , "jwt-secret"
+                    , "--id"
+                    , "client-id"
+                    , "--secret"
+                    , "client-secret"
+                    ] $ do
+                        let endpoint =
+                                "http://localhost:" <> show middlewarePort <> "/livez"
+                        waitForHttpServer (threadDelay 100000) endpoint []
+                        req <- parseRequest endpoint
+                        manager <- newManager defaultManagerSettings
+                        resp <- httpLbs req manager
+                        responseBody resp @?= "{\"status\":\"pass\"}"
         ]
 
 -- We are trying to run as many tests with the same `daml start` process as possible to safe time.
 damlStartTests :: IO DamlStartResource -> TestTree
 damlStartTests getDamlStart =
-    testGroup
-        "daml start"
-          -- If the ledger id or wall clock time is not picked or project dir was not found, this
-          -- would fail.
-        [ testCase "sandbox and json-api come up" $ do
-              DamlStartResource {jsonApiPort} <- getDamlStart
-              manager <- newManager defaultManagerSettings
-              initialRequest <-
-                  parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/create"
-              let createRequest =
-                      initialRequest
-                          { method = "POST"
-                          , requestHeaders = authorizationHeaders
-                          , requestBody =
-                                RequestBodyLBS $
-                                Aeson.encode $
-                                Aeson.object
-                                    [ "templateId" Aeson..= Aeson.String "Main:T"
-                                    , "payload" Aeson..= [Aeson.String "Alice"]
-                                    ]
-                          }
-              createResponse <- httpLbs createRequest manager
-              statusCode (responseStatus createResponse) @?= 200
-        , testCase "daml start invokes codegen" $ do
-              DamlStartResource {projDir} <- getDamlStart
-              withCurrentDirectory projDir $ do
-                  didGenerateJsCode <-
-                      doesFileExist
-                          ("ui" </> "daml.js" </> "assistant-integration-tests-1.0" </>
-                           "package.json")
-                  didGenerateJavaCode <-
-                      doesFileExist
-                          ("ui" </> "java" </> "da" </> "internal" </> "template" </> "Archive.java")
-                  didGenerateScalaCode <-
-                      doesFileExist
-                          ("ui" </> "scala" </> "com" </> "digitalasset" </> "PackageIDs.scala")
-                  didGenerateJsCode @?= True
-                  didGenerateJavaCode @?= True
-                  didGenerateScalaCode @?= True
-        , testCase "run a daml ledger command" $ do
-              DamlStartResource {projDir, sandboxPort} <- getDamlStart
-              withCurrentDirectory projDir $
-                  callCommand $
-                  unwords ["daml", "ledger", "allocate-party", "--port", show sandboxPort, "Bob"]
-        , testCase "Run init-script" $ do
-              DamlStartResource {projDir, jsonApiPort} <- getDamlStart
-              withCurrentDirectory projDir $ do
-                  initialRequest <-
-                      parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
-                  let queryRequest =
-                          initialRequest
-                              { method = "POST"
-                              , requestHeaders = authorizationHeaders
-                              , requestBody =
-                                    RequestBodyLBS $
-                                    Aeson.encode $
-                                    Aeson.object ["templateIds" Aeson..= [Aeson.String "Main:T"]]
-                              }
-                  manager <- newManager defaultManagerSettings
-                  queryResponse <- httpLbs queryRequest manager
-                  statusCode (responseStatus queryResponse) @?= 200
-                  preview (key "result" . _Array . to Vector.length) (responseBody queryResponse) @?=
-                      Just 2
-        , testCase "DAML Script --input-file and --output-file" $ do
-              DamlStartResource {projDir, sandboxPort} <- getDamlStart
-              withCurrentDirectory projDir $ do
-                  let dar = projDir </> ".daml" </> "dist" </> "assistant-integration-tests-1.0.dar"
-                  writeFileUTF8 (projDir </> "input.json") "0"
-                  callCommand $
-                      unwords
-                          [ "daml script"
-                          , "--dar " <> dar <> " --script-name Main:test"
-                          , "--input-file input.json --output-file output.json"
-                          , "--ledger-host localhost --ledger-port " <> show sandboxPort
-                          ]
-                  contents <- readFileUTF8 (projDir </> "output.json")
-                  lines contents @?= ["{", "  \"_1\": 0,", "  \"_2\": 1", "}"]
-        , testCase "daml export script" $ do
-              DamlStartResource {projDir, sandboxPort} <- getDamlStart
-              withTempDir $ \exportDir -> do
-                  withCurrentDirectory projDir $ do
-                      callCommand $ unwords
-                          [ "daml ledger export script"
-                          , "--host localhost --port " <> show sandboxPort
-                          , "--party Alice"
-                          , "--output " <> exportDir <> " --sdk-version " <> sdkVersion
-                          ]
-                  withCurrentDirectory exportDir $ do
-                      didGenerateExportDaml <- doesFileExist "Export.daml"
-                      didGenerateDamlYaml <- doesFileExist "daml.yaml"
-                      didGenerateExportDaml @?= True
-                      didGenerateDamlYaml @?= True
-        , testCase "trigger service startup" $ do
-              DamlStartResource {sandboxPort} <- getDamlStart
-              triggerServicePort <- getFreePort
-              withDamlService "trigger-service"
-                  [ "--ledger-host"
-                  , "localhost"
-                  , "--ledger-port"
-                  , show sandboxPort
-                  , "--http-port"
-                  , show triggerServicePort
-                  , "--wall-clock-time"
-                  ] $ do
-                  let endpoint =
-                          "http://localhost:" <> show triggerServicePort <> "/livez"
-                  waitForHttpServer (threadDelay 100000) endpoint []
-                  req <- parseRequest endpoint
-                  manager <- newManager defaultManagerSettings
-                  resp <- httpLbs req manager
-                  responseBody resp @?= "{\"status\":\"pass\"}"
-        , testCase "Navigator startup" $ do
-              DamlStartResource {projDir, sandboxPort} <- getDamlStart
-              navigatorPort :: Int <- fromIntegral <$> getFreePort
-              withCurrentDirectory projDir $
-                  -- This test just checks that navigator starts up and returns a 200 response.
-                  -- Nevertheless this would have caught a few issues on rules_nodejs upgrades
-                  -- where we got a 404 instead.
-                  withDamlService "navigator"
-                      [ "server"
-                      , "localhost"
-                      , show sandboxPort
-                      , "--port"
-                      , show navigatorPort
-                      ] $
-                      waitForHttpServer
-                          (threadDelay 100000)
-                          ("http://localhost:" <> show navigatorPort)
-                          []
-        , testCase "Navigator startup via daml ledger outside project directory" $ do
-              DamlStartResource {sandboxPort} <- getDamlStart
-              withTempDir $ \tmpDir -> do
-              navigatorPort :: Int <- fromIntegral <$> getFreePort
-              withCurrentDirectory tmpDir $
-                  withDamlService "ledger navigator"
-                      ["--host"
-                      , "localhost"
-                      , "--port"
-                      , show sandboxPort
-                      , "--port"
-                      , show navigatorPort
-                      ] $
-                      -- waitForHttpServer will only return once we get a 200 response so we
-                      -- don’t need to do anything else.
-                      waitForHttpServer
-                          (threadDelay 100000)
-                          ("http://localhost:" <> show navigatorPort)
-                          []
-        , testCase "hot-reload" $ do
-              DamlStartResource {projDir, jsonApiPort, startStdin, stdoutChan} <- getDamlStart
-              stdoutReadChan <- atomically $ dupTChan stdoutChan
-              withCurrentDirectory projDir $ do
-                  writeFileUTF8 (projDir </> "daml/Main.daml") $
-                      unlines
-                          [ "module Main where"
-                          , "import Daml.Script"
-                          , "template S with newFieldName : Party where signatory newFieldName"
-                          , "init : Script ()"
-                          , "init = do"
-                          , "  [aliceDetails,_bob] <- listKnownParties"
-                          , "  let alice = party aliceDetails"
-                          , "  alice `submit` createCmd (S alice)"
-                          , "  pure ()"
-                          ]
-                  hPutChar startStdin 'r'
-                  hFlush startStdin
-                  untilM_ (pure ()) $ do
-                      line <- atomically $ readTChan stdoutReadChan
-                      pure ("Rebuild complete" `isInfixOf` line)
-                  initialRequest <-
-                      parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
-                  manager <- newManager defaultManagerSettings
-                  let queryRequestT =
-                          initialRequest
-                              { method = "POST"
-                              , requestHeaders = authorizationHeaders
-                              , requestBody =
-                                    RequestBodyLBS $
-                                    Aeson.encode $
-                                    Aeson.object ["templateIds" Aeson..= [Aeson.String "Main:T"]]
-                              }
-                  let queryRequestS =
-                          initialRequest
-                              { method = "POST"
-                              , requestHeaders = authorizationHeaders
-                              , requestBody =
-                                    RequestBodyLBS $
-                                    Aeson.encode $
-                                    Aeson.object ["templateIds" Aeson..= [Aeson.String "Main:S"]]
-                              }
-                  queryResponseT <- httpLbs queryRequestT manager
-                  queryResponseS <- httpLbs queryRequestS manager
-                  -- check that there are no more active contracts of template T
-                  statusCode (responseStatus queryResponseT) @?= 200
-                  preview (key "result" . _Array) (responseBody queryResponseT) @?= Just Vector.empty
-                  -- check that a new contract of template S was created
-                  statusCode (responseStatus queryResponseS) @?= 200
-                  preview
-                      (key "result" . nth 0 . key "payload" . key "newFieldName")
-                      (responseBody queryResponseS) @?=
-                      Just "Alice"
-        , testCase "daml start --sandbox-port=0" $
-          withTempDir $ \tmpDir -> do
-              writeFileUTF8 (tmpDir </> "daml.yaml") $
-                  unlines
-                      [ "sdk-version: " <> sdkVersion
-                      , "name: sandbox-options"
-                      , "version: \"1.0\""
-                      , "source: ."
-                      , "dependencies:"
-                      , "  - daml-prim"
-                      , "  - daml-stdlib"
-                      , "start-navigator: false"
-                      ]
-              withCurrentDirectory tmpDir $
-                  withDamlService "start"
-                      [ "--sandbox-port=0"
-                      , "--sandbox-option=--ledgerid=MyLedger"
-                      , "--json-api-port=0"
-                      , "--json-api-option=--port-file=jsonapi.port"
-                      ] $ do
-                      jsonApiPort <- readPortFile maxRetries "jsonapi.port"
-                      initialRequest <-
-                          parseRequest $
-                          "http://localhost:" <> show jsonApiPort <> "/v1/parties/allocate"
-                      let queryRequest =
-                              initialRequest
-                                  { method = "POST"
-                                  , requestHeaders = authorizationHeaders
-                                  , requestBody =
-                                        RequestBodyLBS $
-                                        Aeson.encode $
-                                        Aeson.object ["identifierHint" Aeson..= ("Alice" :: String)]
-                                  }
-                      manager <- newManager defaultManagerSettings
-                      queryResponse <- httpLbs queryRequest manager
-                      responseBody queryResponse @?=
-                          "{\"result\":{\"identifier\":\"Alice\",\"isLocal\":true},\"status\":200}"
-        , testCase "daml start --sandbox-option --port=X" $
-          withTempDir $ \tmpDir -> do
-              p :: Int <- fromIntegral <$> getFreePort
-              writeFileUTF8 (tmpDir </> "daml.yaml") $
-                  unlines
-                      [ "sdk-version: " <> sdkVersion
-                      , "name: sandbox-options"
-                      , "version: \"1.0\""
-                      , "source: ."
-                      , "dependencies:"
-                      , "  - daml-prim"
-                      , "  - daml-stdlib"
-                      , "start-navigator: false"
-                      ]
-              withCurrentDirectory tmpDir $
-                  withDamlService "start"
-                      [ "--sandbox-option=--port=" <> show p
-                      , "--sandbox-option=--ledgerid=MyLedger"
-                      , "--json-api-port=0"
-                      , "--json-api-option=--port-file=jsonapi.port"
-                      ] $ do
-                      jsonApiPort <- readPortFile maxRetries "jsonapi.port"
-                      initialRequest <-
-                          parseRequest $
-                          "http://localhost:" <> show jsonApiPort <> "/v1/parties/allocate"
-                      let queryRequest =
-                              initialRequest
-                                  { method = "POST"
-                                  , requestHeaders = authorizationHeaders
-                                  , requestBody =
-                                        RequestBodyLBS $
-                                        Aeson.encode $
-                                        Aeson.object ["identifierHint" Aeson..= ("Alice" :: String)]
-                                  }
-                      manager <- newManager defaultManagerSettings
-                      queryResponse <- httpLbs queryRequest manager
-                      responseBody queryResponse @?=
-                          "{\"result\":{\"identifier\":\"Alice\",\"isLocal\":true},\"status\":200}"
-        , testCase "daml start with relative project dir" $
-          withTempDir $ \tmpDir -> do
-            DamlStartResource{stop} <- damlStart EnvRelativeDir tmpDir
-            stop
-        , testCase "daml start absolut path" $
-          withTempDir $ \tmpDir -> do
-            DamlStartResource{stop} <- damlStart EnvAbsoluteDir tmpDir
-            stop
-        , testCase "run a daml deploy without project parties" $ do
-              DamlStartResource {projDir, sandboxPort} <- getDamlStart
-              withCurrentDirectory projDir $ do
-                  copyFile "daml.yaml" "daml.yaml.back"
-                  writeFileUTF8 "daml.yaml" $ unlines
-                      [ "sdk-version: " <> sdkVersion
-                      , "name: proj1"
-                      , "version: 0.0.1"
-                      , "source: daml"
-                      , "dependencies:"
-                      , "  - daml-prim"
-                      , "  - daml-stdlib"
-                      , "  - daml-script"
-                      ]
-                  callCommand $
-                    unwords ["daml", "deploy", "--host localhost", "--port", show sandboxPort]
-                  copyFile "daml.yaml.back" "daml.yaml"
-        ]
+    -- We use testCaseSteps to make sure each of these tests runs in sequence, not in parallel.
+    testCaseSteps "daml start" $ \step -> do
+        let subtest :: forall t. String -> IO t -> IO t
+            subtest m p = step m >> p
+        subtest "sandbox and json-api come up" $ do
+            DamlStartResource {jsonApiPort} <- getDamlStart
+            manager <- newManager defaultManagerSettings
+            initialRequest <-
+                parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/create"
+            let createRequest =
+                    initialRequest
+                        { method = "POST"
+                        , requestHeaders = authorizationHeaders
+                        , requestBody =
+                            RequestBodyLBS $
+                            Aeson.encode $
+                            Aeson.object
+                                [ "templateId" Aeson..= Aeson.String "Main:T"
+                                , "payload" Aeson..= [Aeson.String "Alice"]
+                                ]
+                        }
+            createResponse <- httpLbs createRequest manager
+            statusCode (responseStatus createResponse) @?= 200
+        subtest "daml start invokes codegen" $ do
+            DamlStartResource {projDir} <- getDamlStart
+            didGenerateJsCode <- doesFileExist (projDir </> "ui" </> "daml.js" </> "assistant-integration-tests-1.0" </> "package.json")
+            didGenerateJavaCode <- doesFileExist (projDir </> "ui" </> "java" </> "da" </> "internal" </> "template" </> "Archive.java")
+            didGenerateScalaCode <- doesFileExist (projDir </> "ui" </> "scala" </> "com" </> "digitalasset" </> "PackageIDs.scala")
+            didGenerateJsCode @?= True
+            didGenerateJavaCode @?= True
+            didGenerateScalaCode @?= True
+        subtest "run a daml ledger command" $ do
+            DamlStartResource {projDir, sandboxPort} <- getDamlStart
+            callCommandSilentIn projDir $ unwords
+                ["daml", "ledger", "allocate-party", "--port", show sandboxPort, "Bob"]
+        subtest "Run init-script" $ do
+            DamlStartResource {jsonApiPort} <- getDamlStart
+            initialRequest <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
+            let queryRequest = initialRequest
+                    { method = "POST"
+                    , requestHeaders = authorizationHeaders
+                    , requestBody =
+                        RequestBodyLBS $
+                        Aeson.encode $
+                        Aeson.object ["templateIds" Aeson..= [Aeson.String "Main:T"]]
+                    }
+            manager <- newManager defaultManagerSettings
+            queryResponse <- httpLbs queryRequest manager
+            statusCode (responseStatus queryResponse) @?= 200
+            preview (key "result" . _Array . to Vector.length) (responseBody queryResponse) @?= Just 2
+        subtest "DAML Script --input-file and --output-file" $ do
+            DamlStartResource {projDir, sandboxPort} <- getDamlStart
+            let dar = projDir </> ".daml" </> "dist" </> "assistant-integration-tests-1.0.dar"
+            writeFileUTF8 (projDir </> "input.json") "0"
+            callCommandSilentIn projDir $ unwords
+                [ "daml script"
+                , "--dar " <> dar <> " --script-name Main:test"
+                , "--input-file input.json --output-file output.json"
+                , "--ledger-host localhost --ledger-port " <> show sandboxPort
+                ]
+            contents <- readFileUTF8 (projDir </> "output.json")
+            lines contents @?= ["{", "  \"_1\": 0,", "  \"_2\": 1", "}"]
+        subtest "daml export script" $ do
+            DamlStartResource {projDir, sandboxPort} <- getDamlStart
+            withTempDir $ \exportDir -> do
+                callCommandSilentIn projDir $ unwords
+                    [ "daml ledger export script"
+                    , "--host localhost --port " <> show sandboxPort
+                    , "--party Alice"
+                    , "--output " <> exportDir <> " --sdk-version " <> sdkVersion
+                    ]
+                didGenerateExportDaml <- doesFileExist (exportDir </> "Export.daml")
+                didGenerateDamlYaml <- doesFileExist (exportDir </> "daml.yaml")
+                didGenerateExportDaml @?= True
+                didGenerateDamlYaml @?= True
+        subtest "trigger service startup" $ do
+            DamlStartResource {projDir, sandboxPort} <- getDamlStart
+            triggerServicePort <- getFreePort
+            withDamlServiceIn projDir "trigger-service"
+                [ "--ledger-host"
+                , "localhost"
+                , "--ledger-port"
+                , show sandboxPort
+                , "--http-port"
+                , show triggerServicePort
+                , "--wall-clock-time"
+                ] $ do
+                    let endpoint = "http://localhost:" <> show triggerServicePort <> "/livez"
+                    waitForHttpServer (threadDelay 100000) endpoint []
+                    req <- parseRequest endpoint
+                    manager <- newManager defaultManagerSettings
+                    resp <- httpLbs req manager
+                    responseBody resp @?= "{\"status\":\"pass\"}"
+        subtest "Navigator startup" $ do
+            DamlStartResource {projDir, sandboxPort} <- getDamlStart
+            navigatorPort :: Int <- fromIntegral <$> getFreePort
+            -- This test just checks that navigator starts up and returns a 200 response.
+            -- Nevertheless this would have caught a few issues on rules_nodejs upgrades
+            -- where we got a 404 instead.
+            withDamlServiceIn projDir "navigator"
+                [ "server"
+                , "localhost"
+                , show sandboxPort
+                , "--port"
+                , show navigatorPort
+                ] $ do
+                    waitForHttpServer
+                        (threadDelay 100000)
+                        ("http://localhost:" <> show navigatorPort)
+                        []
+        subtest "Navigator startup via daml ledger outside project directory" $ do
+            DamlStartResource {sandboxPort} <- getDamlStart
+            withTempDir $ \tmpDir -> do
+                navigatorPort :: Int <- fromIntegral <$> getFreePort
+                withDamlServiceIn tmpDir "ledger navigator"
+                    ["--host"
+                    , "localhost"
+                    , "--port"
+                    , show sandboxPort
+                    , "--port"
+                    , show navigatorPort
+                    ] $ do
+                        -- waitForHttpServer will only return once we get a 200 response so we
+                        -- don’t need to do anything else.
+                        waitForHttpServer
+                            (threadDelay 100000)
+                            ("http://localhost:" <> show navigatorPort)
+                            []
+        subtest "hot-reload" $ do
+            DamlStartResource {projDir, jsonApiPort, startStdin, stdoutChan} <- getDamlStart
+            stdoutReadChan <- atomically $ dupTChan stdoutChan
+            writeFileUTF8 (projDir </> "daml/Main.daml") $
+                unlines
+                    [ "module Main where"
+                    , "import Daml.Script"
+                    , "template S with newFieldName : Party where signatory newFieldName"
+                    , "init : Script ()"
+                    , "init = do"
+                    , "  [aliceDetails,_bob] <- listKnownParties"
+                    , "  let alice = party aliceDetails"
+                    , "  alice `submit` createCmd (S alice)"
+                    , "  pure ()"
+                    ]
+            hPutChar startStdin 'r'
+            hFlush startStdin
+            untilM_ (pure ()) $ do
+                line <- atomically $ readTChan stdoutReadChan
+                pure ("Rebuild complete" `isInfixOf` line)
+            initialRequest <-
+                parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
+            manager <- newManager defaultManagerSettings
+            let queryRequestT =
+                    initialRequest
+                        { method = "POST"
+                        , requestHeaders = authorizationHeaders
+                        , requestBody =
+                            RequestBodyLBS $
+                            Aeson.encode $
+                            Aeson.object ["templateIds" Aeson..= [Aeson.String "Main:T"]]
+                        }
+            let queryRequestS =
+                    initialRequest
+                        { method = "POST"
+                        , requestHeaders = authorizationHeaders
+                        , requestBody =
+                            RequestBodyLBS $
+                            Aeson.encode $
+                            Aeson.object ["templateIds" Aeson..= [Aeson.String "Main:S"]]
+                        }
+            queryResponseT <- httpLbs queryRequestT manager
+            queryResponseS <- httpLbs queryRequestS manager
+            -- check that there are no more active contracts of template T
+            statusCode (responseStatus queryResponseT) @?= 200
+            preview (key "result" . _Array) (responseBody queryResponseT) @?= Just Vector.empty
+            -- check that a new contract of template S was created
+            statusCode (responseStatus queryResponseS) @?= 200
+            preview
+                (key "result" . nth 0 . key "payload" . key "newFieldName")
+                (responseBody queryResponseS) @?=
+                Just "Alice"
+        subtest "daml start --sandbox-port=0" $
+            withTempDir $ \tmpDir -> do
+                writeFileUTF8 (tmpDir </> "daml.yaml") $
+                    unlines
+                        [ "sdk-version: " <> sdkVersion
+                        , "name: sandbox-options"
+                        , "version: \"1.0\""
+                        , "source: ."
+                        , "dependencies:"
+                        , "  - daml-prim"
+                        , "  - daml-stdlib"
+                        , "start-navigator: false"
+                        ]
+                withDamlServiceIn tmpDir "start"
+                    [ "--sandbox-port=0"
+                    , "--sandbox-option=--ledgerid=MyLedger"
+                    , "--json-api-port=0"
+                    , "--json-api-option=--port-file=jsonapi.port"
+                    ] $ do
+                        jsonApiPort <- readPortFile maxRetries (tmpDir </> "jsonapi.port")
+                        initialRequest <-
+                            parseRequest $
+                            "http://localhost:" <> show jsonApiPort <> "/v1/parties/allocate"
+                        let queryRequest =
+                                initialRequest
+                                    { method = "POST"
+                                    , requestHeaders = authorizationHeaders
+                                    , requestBody =
+                                            RequestBodyLBS $
+                                            Aeson.encode $
+                                            Aeson.object ["identifierHint" Aeson..= ("Alice" :: String)]
+                                    }
+                        manager <- newManager defaultManagerSettings
+                        queryResponse <- httpLbs queryRequest manager
+                        responseBody queryResponse @?=
+                            "{\"result\":{\"identifier\":\"Alice\",\"isLocal\":true},\"status\":200}"
+        subtest "daml start --sandbox-option --port=X" $
+            withTempDir $ \tmpDir -> do
+                p :: Int <- fromIntegral <$> getFreePort
+                writeFileUTF8 (tmpDir </> "daml.yaml") $
+                    unlines
+                        [ "sdk-version: " <> sdkVersion
+                        , "name: sandbox-options"
+                        , "version: \"1.0\""
+                        , "source: ."
+                        , "dependencies:"
+                        , "  - daml-prim"
+                        , "  - daml-stdlib"
+                        , "start-navigator: false"
+                        ]
+                withDamlServiceIn tmpDir "start"
+                    [ "--sandbox-option=--port=" <> show p
+                    , "--sandbox-option=--ledgerid=MyLedger"
+                    , "--json-api-port=0"
+                    , "--json-api-option=--port-file=jsonapi.port"
+                    ] $ do
+                        jsonApiPort <- readPortFile maxRetries (tmpDir </> "jsonapi.port")
+                        initialRequest <-
+                            parseRequest $
+                            "http://localhost:" <> show jsonApiPort <> "/v1/parties/allocate"
+                        let queryRequest =
+                                initialRequest
+                                    { method = "POST"
+                                    , requestHeaders = authorizationHeaders
+                                    , requestBody =
+                                            RequestBodyLBS $
+                                            Aeson.encode $
+                                            Aeson.object ["identifierHint" Aeson..= ("Alice" :: String)]
+                                    }
+                        manager <- newManager defaultManagerSettings
+                        queryResponse <- httpLbs queryRequest manager
+                        responseBody queryResponse @?=
+                            "{\"result\":{\"identifier\":\"Alice\",\"isLocal\":true},\"status\":200}"
+        subtest "daml start with relative project dir" $
+            withTempDir $ \tmpDir -> do
+                DamlStartResource{stop} <- damlStart EnvRelativeDir tmpDir
+                stop
+        subtest "daml start absolute path" $
+            withTempDir $ \tmpDir -> do
+                DamlStartResource{stop} <- damlStart EnvAbsoluteDir tmpDir
+                stop
+        subtest "run a daml deploy without project parties" $ do
+            DamlStartResource {projDir, sandboxPort} <- getDamlStart
+            copyFile (projDir </> "daml.yaml") (projDir </> "daml.yaml.back")
+            writeFileUTF8 (projDir </> "daml.yaml") $ unlines
+                [ "sdk-version: " <> sdkVersion
+                , "name: proj1"
+                , "version: 0.0.1"
+                , "source: daml"
+                , "dependencies:"
+                , "  - daml-prim"
+                , "  - daml-stdlib"
+                , "  - daml-script"
+                ]
+            callCommandSilentIn projDir $ unwords ["daml", "deploy", "--host localhost", "--port", show sandboxPort]
+            copyFile (projDir </> "daml.yaml.back") (projDir </> "daml.yaml")
 
 quickstartTests :: FilePath -> FilePath -> IO QuickSandboxResource -> TestTree
 quickstartTests quickstartDir mvnDir getSandbox =
-    testGroup
-        "quickstart"
-        [ testCase "daml test" $ withCurrentDirectory quickstartDir $ callCommandSilent "daml test"
+    testCaseSteps "quickstart" $ \step -> do
+        let subtest :: forall t. String -> IO t -> IO t
+            subtest m p = step m >> p
+        subtest "daml test" $
+            callCommandSilentIn quickstartDir "daml test"
         -- Testing `daml new` and `daml build` is done when the QuickSandboxResource is build.
-        , testCase "daml damlc test --files" $
-          withCurrentDirectory quickstartDir $
-          callCommandSilent "daml damlc test --files daml/Main.daml"
-        , testCase "daml damlc visual-web" $
-          withCurrentDirectory quickstartDir $
-          callCommandSilent $
-          unwords ["daml damlc visual-web .daml/dist/quickstart-0.0.1.dar -o visual.html -b"]
-        , testCase "mvn compile" $
-          withCurrentDirectory quickstartDir $ do
-              mvnDbTarball <-
-                  locateRunfiles
-                      (mainWorkspace </> "daml-assistant" </> "integration-tests" </>
-                       "integration-tests-mvn.tar")
-              runConduitRes $
-                  sourceFileBS mvnDbTarball .|
-                  Tar.Conduit.Extra.untar (Tar.Conduit.Extra.restoreFile throwError mvnDir)
-              callCommand "daml codegen java"
-              callCommand $ unwords ["mvn", mvnRepoFlag, "-q", "compile"]
-        , testCase "Sandbox Classic startup" $
-          withCurrentDirectory quickstartDir $ do
-              p :: Int <- fromIntegral <$> getFreePort
-              withDamlService "sandbox-classic"
-                  [ "--wall-clock-time"
-                  , "--port"
-                  , show p
-                  , ".daml/dist/quickstart-0.0.1.dar"
-                  ] $ do
-                  waitForConnectionOnPort (threadDelay 100000) p
-                  addr:_ <- getAddrInfo (Just socketHints) (Just "127.0.0.1") (Just $ show p)
-                  bracket
-                      (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
-                      close
-                      (\s -> connect s (addrAddress addr))
-        , testCase "mvn exec:java@run-quickstart" $ do
-              QuickSandboxResource {quickProjDir, quickSandboxPort, quickDar} <- getSandbox
-              withCurrentDirectory quickProjDir $
-                  withDevNull $ \devNull -> do
-                      callCommandSilent $
-                          unwords
-                              [ "daml script"
-                              , "--dar " <> quickDar
-                              , "--script-name Main:initialize"
-                              , "--static-time"
-                              , "--ledger-host localhost"
-                              , "--ledger-port"
-                              , show quickSandboxPort
-                              ]
-                      restPort :: Int <- fromIntegral <$> getFreePort
-                      let mavenProc =
-                              (shell $
-                               unwords
-                                   [ "mvn"
-                                   , mvnRepoFlag
-                                   , "-Dledgerport=" <> show quickSandboxPort
-                                   , "-Drestport=" <> show restPort
-                                   , "exec:java@run-quickstart"
-                                   ])
-                                  {std_out = UseHandle devNull}
-                      withCreateProcess mavenProc $ \_ _ _ mavenPh -> do
-                          let url = "http://localhost:" <> show restPort <> "/iou"
-                          waitForHttpServer (threadDelay 1000000) url []
-                          threadDelay 5000000
-                          manager <- newManager defaultManagerSettings
-                          req <- parseRequest url
-                          req <-
-                              pure req {requestHeaders = [(hContentType, "application/json")]}
-                          resp <- httpLbs req manager
-                          responseBody resp @?=
-                              "{\"0\":{\"issuer\":\"EUR_Bank\",\"owner\":\"Alice\",\"currency\":\"EUR\",\"amount\":100.0000000000,\"observers\":[]}}"
-                          -- Note (MK) You might be tempted to suggest using
-                          -- create_group and interruptProcessGroupOf
-                          -- or alternatively use_process_jobs here.
-                          -- However, that is a trap. It will block forever
-                          -- trying to terminate the process on Windows. I have absolutely
-                          -- no idea why that is the case and I stopped trying
-                          -- to figure out.
-                          -- Luckily, it doesn’t seem like maven actually creates
-                          -- child processes or at least none that
-                          -- block us from cleaning up the SDK installation and
-                          -- Bazel will tear down everything at the end anyway.
-                          terminateProcess mavenPh
-        , testCase "daml codegen java with DAML_PROJECT" $
-              withTempDir $ \dir -> do
-                callCommandSilent $ unwords ["daml", "new", dir </> "quickstart", "--template=quickstart-java"]
-                withEnv [ ("DAML_PROJECT", Just $ dir </> "quickstart") ] $ do
-                    callCommandSilent $ unwords ["daml", "build"]
-                    callCommandSilent $ unwords ["daml", "codegen", "java"]
+        subtest "daml damlc test --files" $
+            callCommandSilentIn quickstartDir "daml damlc test --files daml/Main.daml"
+        subtest "daml damlc visual-web" $
+            callCommandSilentIn quickstartDir
+                "daml damlc visual-web .daml/dist/quickstart-0.0.1.dar -o visual.html -b"
+        subtest "mvn compile" $ do
+            mvnDbTarball <-
+                locateRunfiles
+                    (mainWorkspace </> "daml-assistant" </> "integration-tests" </>
+                    "integration-tests-mvn.tar")
+            runConduitRes $
+                sourceFileBS mvnDbTarball .|
+                Tar.Conduit.Extra.untar (Tar.Conduit.Extra.restoreFile throwError mvnDir)
+            callCommandSilentIn quickstartDir "daml codegen java"
+            callCommandSilentIn quickstartDir $ unwords ["mvn", mvnRepoFlag, "-q", "compile"]
+        subtest "Sandbox Classic startup" $ do
+            p :: Int <- fromIntegral <$> getFreePort
+            withDamlServiceIn quickstartDir "sandbox-classic"
+                [ "--wall-clock-time"
+                , "--port"
+                , show p
+                , ".daml/dist/quickstart-0.0.1.dar"
+                ] $ do
+                    waitForConnectionOnPort (threadDelay 100000) p
+                    addr:_ <- getAddrInfo (Just socketHints) (Just "127.0.0.1") (Just $ show p)
+                    bracket
+                        (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+                        close
+                        (\s -> connect s (addrAddress addr))
+        subtest "mvn exec:java@run-quickstart" $ do
+            QuickSandboxResource {quickProjDir, quickSandboxPort, quickDar} <- getSandbox
+            withDevNull $ \devNull -> do
+                callCommandSilentIn quickProjDir $
+                    unwords
+                        [ "daml script"
+                        , "--dar " <> quickDar
+                        , "--script-name Main:initialize"
+                        , "--static-time"
+                        , "--ledger-host localhost"
+                        , "--ledger-port"
+                        , show quickSandboxPort
+                        ]
+                restPort :: Int <- fromIntegral <$> getFreePort
+                let mavenProc = (shell $ unwords
+                        [ "mvn"
+                        , mvnRepoFlag
+                        , "-Dledgerport=" <> show quickSandboxPort
+                        , "-Drestport=" <> show restPort
+                        , "exec:java@run-quickstart"
+                        ])
+                        { std_out = UseHandle devNull
+                        , cwd = Just quickProjDir }
+                withCreateProcess mavenProc $ \_ _ _ mavenPh -> do
+                    let url = "http://localhost:" <> show restPort <> "/iou"
+                    waitForHttpServer (threadDelay 1000000) url []
+                    threadDelay 5000000
+                    manager <- newManager defaultManagerSettings
+                    req <- parseRequest url
+                    req <-
+                        pure req {requestHeaders = [(hContentType, "application/json")]}
+                    resp <- httpLbs req manager
+                    responseBody resp @?=
+                        "{\"0\":{\"issuer\":\"EUR_Bank\",\"owner\":\"Alice\",\"currency\":\"EUR\",\"amount\":100.0000000000,\"observers\":[]}}"
+                    -- Note (MK) You might be tempted to suggest using
+                    -- create_group and interruptProcessGroupOf
+                    -- or alternatively use_process_jobs here.
+                    -- However, that is a trap. It will block forever
+                    -- trying to terminate the process on Windows. I have absolutely
+                    -- no idea why that is the case and I stopped trying
+                    -- to figure out.
+                    -- Luckily, it doesn’t seem like maven actually creates
+                    -- child processes or at least none that
+                    -- block us from cleaning up the SDK installation and
+                    -- Bazel will tear down everything at the end anyway.
+                    terminateProcess mavenPh
+        subtest "daml codegen java with DAML_PROJECT" $ do
+            withTempDir $ \dir -> do
+                callCommandSilentIn dir $ unwords ["daml", "new", dir </> "quickstart", "--template=quickstart-java"]
+                let projEnv = [("DAML_PROJECT", dir </> "quickstart")]
+                callCommandSilentWithEnvIn dir projEnv "daml build"
+                callCommandSilentWithEnvIn dir projEnv "daml codegen java"
                 pure ()
-        ]
   where
     mvnRepoFlag = "-Dmaven.repo.local=" <> mvnDir
 
@@ -784,40 +754,37 @@ cleanTests baseDir = testGroup "daml clean"
         cleanTestFor templateName =
             testCase ("daml clean test for " <> templateName <> " template") $ do
                 createDirectoryIfMissing True baseDir
-                withCurrentDirectory baseDir $ do
-                    let projectDir = baseDir </> ("proj-" <> templateName)
-                    callCommandSilent $ unwords ["daml", "new", projectDir, "--template", templateName]
-                    withCurrentDirectory projectDir $ do
-                        filesAtStart <- sort <$> listFilesRecursive "."
-                        callCommandSilent "daml build"
-                        callCommandSilent "daml clean"
-                        filesAtEnd <- sort <$> listFilesRecursive "."
-                        when (filesAtStart /= filesAtEnd) $
-                            fail $ unlines
-                                [ "daml clean did not remove all files produced by daml build."
-                                , ""
-                                , "    files at start:"
-                                , unlines (map ("       "++) filesAtStart)
-                                , "    files at end:"
-                                , unlines (map ("       "++) filesAtEnd)
-                                ]
+                let projectDir = baseDir </> ("proj-" <> templateName)
+                callCommandSilentIn baseDir $ unwords ["daml", "new", projectDir, "--template", templateName]
+                filesAtStart <- sort <$> listFilesRecursive projectDir
+                callCommandSilentIn projectDir "daml build"
+                callCommandSilentIn projectDir "daml clean"
+                filesAtEnd <- sort <$> listFilesRecursive projectDir
+                when (filesAtStart /= filesAtEnd) $ fail $ unlines
+                    [ "daml clean did not remove all files produced by daml build."
+                    , ""
+                    , "    files at start:"
+                    , unlines (map ("       "++) filesAtStart)
+                    , "    files at end:"
+                    , unlines (map ("       "++) filesAtEnd)
+                    ]
 
 templateTests :: TestTree
 templateTests = testGroup "templates" $
     [ testCase name $ do
-          withTempDir $ \tmpDir -> do
-          let dir = tmpDir </> "foobar"
-          callCommandSilent $ unwords ["daml", "new", dir, "--template", name]
-          withCurrentDirectory dir $ callCommandSilent "daml build"
+        withTempDir $ \tmpDir -> do
+            let dir = tmpDir </> "foobar"
+            callCommandSilentIn tmpDir $ unwords ["daml", "new", dir, "--template", name]
+            callCommandSilentIn dir "daml build"
     | name <- templateNames
     ] <>
     [ testCase "quickstart-java, positional template" $ do
-          withTempDir $ \tmpDir -> do
-          let dir = tmpDir </> "foobar"
-          -- Verify that the old syntax for `daml new` still works.
-          callCommandSilent $ unwords ["daml","new", dir, "quickstart-java"]
-          contents <- readFileUTF8 $ dir </> "daml.yaml"
-          assertInfixOf "name: quickstart" contents
+        withTempDir $ \tmpDir -> do
+            let dir = tmpDir </> "foobar"
+            -- Verify that the old syntax for `daml new` still works.
+            callCommandSilentIn tmpDir $ unwords ["daml","new", dir, "quickstart-java"]
+            contents <- readFileUTF8 $ dir </> "daml.yaml"
+            assertInfixOf "name: quickstart" contents
     ]
   -- NOTE (MK) We might want to autogenerate this list at some point but for now
   -- this should be good enough.
@@ -848,19 +815,17 @@ codegenTests codegenDir = testGroup "daml codegen" (
         codegenTestFor lang namespace =
             testCase lang $ do
                 createDirectoryIfMissing True codegenDir
-                withCurrentDirectory codegenDir $ do
-                    let projectDir = codegenDir </> ("proj-" ++ lang)
-                    callCommandSilent $ unwords ["daml new", projectDir, "--template=skeleton"]
-                    withCurrentDirectory projectDir $ do
-                        callCommandSilent "daml build"
-                        let darFile = projectDir </> ".daml/dist/proj-" ++ lang ++ "-0.0.1.dar"
-                            outDir  = projectDir </> "generated" </> lang
-                        when (lang == "js") $ do
-                            let workspaces = Workspaces [makeRelative codegenDir outDir]
-                            setupYarnEnv codegenDir workspaces [DamlTypes, DamlLedger]
-                        callCommandSilent $
-                          unwords [ "daml", "codegen", lang
-                                  , darFile ++ maybe "" ("=" ++) namespace
-                                  , "-o", outDir]
-                        contents <- listDirectory outDir
-                        assertBool "bindings were written" (not $ null contents)
+                let projectDir = codegenDir </> ("proj-" ++ lang)
+                callCommandSilentIn codegenDir $ unwords ["daml new", projectDir, "--template=skeleton"]
+                callCommandSilentIn projectDir "daml build"
+                let darFile = projectDir </> ".daml/dist/proj-" ++ lang ++ "-0.0.1.dar"
+                    outDir  = projectDir </> "generated" </> lang
+                when (lang == "js") $ do
+                    let workspaces = Workspaces [makeRelative codegenDir outDir]
+                    setupYarnEnv codegenDir workspaces [DamlTypes, DamlLedger]
+                callCommandSilentIn projectDir $
+                    unwords [ "daml", "codegen", lang
+                            , darFile ++ maybe "" ("=" ++) namespace
+                            , "-o", outDir]
+                contents <- listDirectory (projectDir </> outDir)
+                assertBool "bindings were written" (not $ null contents)

--- a/libs-haskell/test-utils/DA/Test/Process.hs
+++ b/libs-haskell/test-utils/DA/Test/Process.hs
@@ -7,12 +7,17 @@ module DA.Test.Process
   , callProcessSilentError
   , callProcessForStdout
   , callCommandSilent
+  , callCommandSilentIn
+  , callCommandSilentWithEnvIn
+  , subprocessEnv
   ) where
 
 import Control.Monad (unless,void)
 import System.IO.Extra (hPutStrLn,stderr)
 import System.Exit (ExitCode(ExitSuccess),exitFailure)
-import System.Process (CreateProcess,proc,shell,readCreateProcessWithExitCode)
+import System.Process (CreateProcess,proc,shell,readCreateProcessWithExitCode,cwd,env)
+import System.Environment.Blank (getEnvironment)
+import qualified Data.Set as S
 
 newtype ShouldSucceed = ShouldSucceed Bool
 
@@ -31,6 +36,22 @@ callProcessForStdout cmd args =
 callCommandSilent :: String -> IO ()
 callCommandSilent cmd =
   void $ run (ShouldSucceed True) (shell cmd)
+
+callCommandSilentIn :: FilePath -> String -> IO ()
+callCommandSilentIn path cmd =
+  void $ run (ShouldSucceed True) (shell cmd) { cwd = Just path }
+
+callCommandSilentWithEnvIn :: FilePath -> [(String, String)] -> String -> IO ()
+callCommandSilentWithEnvIn path envChanges cmd = do
+  newEnv <- subprocessEnv envChanges
+  void $ run (ShouldSucceed True) (shell cmd) { cwd = Just path, env = Just newEnv }
+
+subprocessEnv :: [(String, String)] -> IO [(String, String)]
+subprocessEnv envChanges = do
+  oldEnv <- getEnvironment
+  let changedVars = S.fromList (map fst envChanges)
+  let newEnv = filter (\(v,_) -> v `S.notMember` changedVars) oldEnv ++ envChanges
+  pure newEnv
 
 run :: ShouldSucceed -> CreateProcess -> IO String
 run (ShouldSucceed shouldSucceed) cp = do


### PR DESCRIPTION
This mainly involves avoiding changing the working directory or the environment while inside tests.

AFAIK the daml start tests can't be parallelized without starting up a sandbox instance each time, which seems bad. These tests could be separated from the rest...

The magic number "2" was picked via experimentation:

```
1 threads -> 306 s
2 threads -> 199 s
3 threads -> 198 s
4 threads -> 195 s
```

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
