### PR TITLE
`ledger-api-bench-tool` - min consumption speed SLO [DPP-401]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/Cli.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/Cli.scala
@@ -74,8 +74,14 @@ object Cli {
         def optionalStringField(fieldName: String): Either[String, Option[String]] =
           Right(m.get(fieldName))
 
-        def optionalLongField(fieldName: String): Either[String, Option[Long]] = {
-          Try(m.get(fieldName).map(_.toLong)) match {
+        def optionalLongField(fieldName: String): Either[String, Option[Long]] =
+          optionalField[Long](fieldName, _.toLong)
+
+        def optionalDoubleField(fieldName: String): Either[String, Option[Double]] =
+          optionalField[Double](fieldName, _.toDouble)
+
+        def optionalField[T](fieldName: String, f: String => T): Either[String, Option[T]] = {
+          Try(m.get(fieldName).map(f)) match {
             case Success(value) => Right(value)
             case Failure(_) => Left(s"Invalid value for field name: $fieldName")
           }
@@ -99,6 +105,7 @@ object Cli {
           beginOffset <- optionalStringField("begin-offset").map(_.map(offset))
           endOffset <- optionalStringField("end-offset").map(_.map(offset))
           maxDelaySeconds <- optionalLongField("max-delay")
+          minConsumptionSpeed <- optionalDoubleField("min-consumption-speed")
         } yield Config.StreamConfig(
           name = name,
           streamType = streamType,
@@ -107,7 +114,8 @@ object Cli {
           beginOffset = beginOffset,
           endOffset = endOffset,
           objectives = Config.StreamConfig.Objectives(
-            maxDelaySeconds = maxDelaySeconds
+            maxDelaySeconds = maxDelaySeconds,
+            minConsumptionSpeed = minConsumptionSpeed,
           ),
         )
 

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/Config.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/Config.scala
@@ -33,7 +33,10 @@ object Config {
       case object TransactionTrees extends StreamType
     }
 
-    case class Objectives(maxDelaySeconds: Option[Long])
+    case class Objectives(
+        maxDelaySeconds: Option[Long],
+        minConsumptionSpeed: Option[Double],
+    )
   }
 
   case class Ledger(

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/ConsumptionSpeedMetric.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/ConsumptionSpeedMetric.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.api.benchtool.metrics
 
 import com.daml.ledger.api.benchtool.metrics.Metric.rounded
+import com.daml.ledger.api.benchtool.metrics.objectives.ServiceLevelObjective
 import com.google.protobuf.timestamp.Timestamp
 
 import java.time.Instant
@@ -114,17 +115,6 @@ object ConsumptionSpeedMetric {
         case (None, None) => 0
       }
     }
-  }
-
-  // TODO: add warm-up parameter
-  final case class MinConsumptionSpeed(minSpeed: Double) extends ServiceLevelObjective[Value] {
-    override def isViolatedBy(metricValue: Value): Boolean =
-      Ordering[Value].lt(metricValue, v)
-
-    override def formatted: String =
-      s"min allowed speed: $minSpeed [-]"
-
-    private val v = Value(Some(minSpeed))
   }
 
 }

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/CountMetric.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/CountMetric.scala
@@ -12,7 +12,7 @@ final case class CountMetric[T](
     lastCount: Int = 0,
 ) extends Metric[T] {
 
-  override type Value = CountMetric.Value
+  override type V = CountMetric.Value
 
   override def onNext(value: T): CountMetric[T] =
     this.copy(counter = counter + countingFunction(value))

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/DelayMetric.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/DelayMetric.scala
@@ -111,5 +111,4 @@ object DelayMetric {
       }
     }
   }
-
 }

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/DelayMetric.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/DelayMetric.scala
@@ -14,7 +14,7 @@ final case class DelayMetric[T](
     delaysInCurrentInterval: List[Duration] = List.empty,
 ) extends Metric[T] {
 
-  override type Value = DelayMetric.Value
+  override type V = DelayMetric.Value
   override type Objective = ServiceLevelObjective[DelayMetric.Value]
 
   override def onNext(value: T): DelayMetric[T] = {
@@ -43,7 +43,7 @@ final case class DelayMetric[T](
             case Some(currentValue) =>
               // if the new value violates objective's requirements and there is already a value that violates
               // requirements, record the maximum value of the two
-              objective -> Some(Ordering[Value].max(currentValue, newValue))
+              objective -> Some(Ordering[V].max(currentValue, newValue))
           }
         } else {
           objective -> currentViolatingValue

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/DelayMetric.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/DelayMetric.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.benchtool.metrics
 
+import com.daml.ledger.api.benchtool.metrics.objectives.ServiceLevelObjective
 import com.google.protobuf.timestamp.Timestamp
 
 import java.time.{Clock, Duration, Instant}

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/Metric.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/Metric.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.api.benchtool.metrics
 
+import com.daml.ledger.api.benchtool.metrics.objectives.ServiceLevelObjective
+
 trait Metric[Elem] {
 
   type V <: MetricValue

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/Metric.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/Metric.scala
@@ -5,17 +5,17 @@ package com.daml.ledger.api.benchtool.metrics
 
 trait Metric[Elem] {
 
-  type Value <: MetricValue
+  type V <: MetricValue
 
-  type Objective <: ServiceLevelObjective[Value]
+  type Objective <: ServiceLevelObjective[V]
 
   def onNext(value: Elem): Metric[Elem]
 
-  def periodicValue(): (Metric[Elem], Value)
+  def periodicValue(): (Metric[Elem], V)
 
-  def finalValue(totalDurationSeconds: Double): Value
+  def finalValue(totalDurationSeconds: Double): V
 
-  def violatedObjectives: Map[Objective, Value] = Map.empty
+  def violatedObjectives: Map[Objective, V] = Map.empty
 
   def name: String = getClass.getSimpleName
 

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/MetricsManager.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/MetricsManager.scala
@@ -75,7 +75,7 @@ class MetricsManager[T](
 
   // TODO: move to a separate util
   private def summary(metrics: List[Metric[T]], durationSeconds: Double): String = {
-    def indented(str: String, spaces: Int = 2): String = s"${" " * spaces}$str"
+    def indented(str: String, spaces: Int = 4): String = s"${" " * spaces}$str"
     val reports = metrics.map { metric =>
       val metricValues: List[String] = metric
         .finalValue(totalDurationSeconds)

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/SizeMetric.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/SizeMetric.scala
@@ -12,7 +12,7 @@ final case class SizeMetric[T](
     sizeRateList: List[Double] = List.empty,
 ) extends Metric[T] {
 
-  override type Value = SizeMetric.Value
+  override type V = SizeMetric.Value
 
   override def onNext(value: T): SizeMetric[T] =
     this.copy(currentSizeBytesBucket = currentSizeBytesBucket + sizingBytesFunction(value))

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/TransactionMetrics.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/TransactionMetrics.scala
@@ -100,11 +100,14 @@ object TransactionMetrics {
     val reportingPeriodMillis = reportingPeriod.toMillis
     val delayObjectives =
       objectives.maxDelaySeconds.map(MaxDelay).toList
+    val consumptionSpeedObjectives =
+      objectives.minConsumptionSpeed.map(ConsumptionSpeedMetric.MinConsumptionSpeed).toList
     List[Metric[T]](
       CountMetric.empty[T](reportingPeriodMillis, countingFunction),
       SizeMetric.empty[T](reportingPeriodMillis, sizingFunction),
       DelayMetric.empty[T](recordTimeFunction, delayObjectives, Clock.systemUTC()),
-      ConsumptionSpeedMetric.empty[T](reportingPeriodMillis, recordTimeFunction),
+      ConsumptionSpeedMetric
+        .empty[T](reportingPeriodMillis, recordTimeFunction, consumptionSpeedObjectives),
     )
   }
 }

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/TransactionMetrics.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/TransactionMetrics.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.api.benchtool.metrics
 import akka.actor.typed.{ActorRef, ActorSystem, Props, SpawnProtocol}
 import akka.util.Timeout
 import com.daml.ledger.api.benchtool.Config.StreamConfig.Objectives
+import com.daml.ledger.api.benchtool.metrics.objectives.{MaxDelay, MinConsumptionSpeed}
 import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse,
@@ -101,7 +102,7 @@ object TransactionMetrics {
     val delayObjectives =
       objectives.maxDelaySeconds.map(MaxDelay).toList
     val consumptionSpeedObjectives =
-      objectives.minConsumptionSpeed.map(ConsumptionSpeedMetric.MinConsumptionSpeed).toList
+      objectives.minConsumptionSpeed.map(MinConsumptionSpeed).toList
     List[Metric[T]](
       CountMetric.empty[T](reportingPeriodMillis, countingFunction),
       SizeMetric.empty[T](reportingPeriodMillis, sizingFunction),

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/objectives/MaxDelay.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/objectives/MaxDelay.scala
@@ -1,7 +1,9 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.benchtool.metrics
+package com.daml.ledger.api.benchtool.metrics.objectives
+
+import com.daml.ledger.api.benchtool.metrics.DelayMetric
 
 final case class MaxDelay(maxDelaySeconds: Long) extends ServiceLevelObjective[DelayMetric.Value] {
   override def isViolatedBy(metricValue: DelayMetric.Value): Boolean =

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/objectives/MinConsumptionSpeed.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/objectives/MinConsumptionSpeed.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.metrics.objectives
+
+import com.daml.ledger.api.benchtool.metrics.ConsumptionSpeedMetric
+
+// TODO: add warm-up parameter
+final case class MinConsumptionSpeed(minSpeed: Double)
+    extends ServiceLevelObjective[ConsumptionSpeedMetric.Value] {
+  override def isViolatedBy(metricValue: ConsumptionSpeedMetric.Value): Boolean =
+    Ordering[ConsumptionSpeedMetric.Value].lt(metricValue, v)
+
+  override def formatted: String =
+    s"min allowed speed: $minSpeed [-]"
+
+  private val v = ConsumptionSpeedMetric.Value(Some(minSpeed))
+}

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/objectives/ServiceLevelObjective.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/objectives/ServiceLevelObjective.scala
@@ -1,7 +1,9 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.benchtool.metrics
+package com.daml.ledger.api.benchtool.metrics.objectives
+
+import com.daml.ledger.api.benchtool.metrics.MetricValue
 
 trait ServiceLevelObjective[MetricValueType <: MetricValue] {
   def isViolatedBy(metricValue: MetricValueType): Boolean

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/ConsumptionSpeedMetricSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/ConsumptionSpeedMetricSpec.scala
@@ -11,10 +11,12 @@ import org.scalatest.wordspec.AnyWordSpec
 import java.time.{Clock, Instant}
 import scala.util.Random
 
+import scala.language.existentials
+
 class ConsumptionSpeedMetricSpec extends AnyWordSpec with Matchers {
   ConsumptionSpeedMetric.getClass.getSimpleName should {
     "correctly handle initial state" in {
-      val metric = ConsumptionSpeedMetric.empty[String](100, dummyRecordTimesFunction)
+      val metric = ConsumptionSpeedMetric.empty[String](100, dummyRecordTimesFunction, List.empty)
 
       val (_, periodicValue) = metric.periodicValue()
       val finalValue = metric.finalValue(1.0)
@@ -42,6 +44,7 @@ class ConsumptionSpeedMetricSpec extends AnyWordSpec with Matchers {
       val metric = ConsumptionSpeedMetric.empty[String](
         periodMillis = periodMillis,
         recordTimeFunction = testRecordTimeFunction,
+        objectives = List.empty,
       )
 
       val (newMetric, periodicValue) = metric
@@ -75,6 +78,7 @@ class ConsumptionSpeedMetricSpec extends AnyWordSpec with Matchers {
       val metric = ConsumptionSpeedMetric.empty[String](
         periodMillis = periodMillis,
         recordTimeFunction = testRecordTimeFunction,
+        objectives = List.empty,
       )
 
       val (newMetric, periodicValue) = metric
@@ -105,6 +109,7 @@ class ConsumptionSpeedMetricSpec extends AnyWordSpec with Matchers {
       val metric = ConsumptionSpeedMetric.empty[String](
         periodMillis = periodMillis,
         recordTimeFunction = testRecordTimeFunction,
+        objectives = List.empty,
       )
 
       val (newMetric, periodicValue) = metric
@@ -141,6 +146,7 @@ class ConsumptionSpeedMetricSpec extends AnyWordSpec with Matchers {
       val metric = ConsumptionSpeedMetric.empty[String](
         periodMillis = periodMillis,
         recordTimeFunction = testRecordTimeFunction,
+        objectives = List.empty,
       )
 
       val (newMetric, periodicValue) = metric
@@ -161,6 +167,59 @@ class ConsumptionSpeedMetricSpec extends AnyWordSpec with Matchers {
 
       periodicValue shouldBe ConsumptionSpeedMetric.Value(Some(expectedSpeed))
       finalValue shouldBe ConsumptionSpeedMetric.Value(None)
+    }
+
+    "compute violated min speed SLO and the minimum speed" in {
+      val testNow = Clock.systemUTC().instant()
+      val minAllowedSpeed = 2.0
+      val periodMillis = 100L
+      val elem1 = "a"
+      val elem2 = "b"
+      val elem3 = "c"
+      def testRecordTimeFunction: String => List[Timestamp] = recordTimeFunctionFromMap(
+        Map(
+          elem1 -> List(
+            testNow.minusMillis(5000),
+            testNow.minusMillis(4500),
+            testNow.minusMillis(4000),
+          ), // ok, speed = 10.0
+          elem2 -> List(
+            testNow.minusMillis(3000),
+            testNow.minusMillis(2950),
+            testNow.minusMillis(2920), // not ok, speed 0.8
+          ),
+          elem3 -> List(
+            testNow.minusMillis(2000),
+            testNow.minusMillis(1950),
+            testNow.minusMillis(1850), // not ok, speed 1.5
+          ),
+        )
+      )
+
+      val objective = ConsumptionSpeedMetric.MinConsumptionSpeed(minAllowedSpeed)
+      val metric: ConsumptionSpeedMetric[String] =
+        ConsumptionSpeedMetric.empty[String](
+          periodMillis = periodMillis,
+          recordTimeFunction = testRecordTimeFunction,
+          objectives = List(objective),
+        )
+
+      val violatedObjectives =
+        metric
+          .onNext(elem1)
+          .periodicValue()
+          ._1
+          .onNext(elem2)
+          .periodicValue()
+          ._1
+          .onNext(elem3)
+          .periodicValue()
+          ._1
+          .violatedObjectives
+
+      violatedObjectives shouldBe Map(
+        objective -> ConsumptionSpeedMetric.Value(Some(0.8))
+      )
     }
   }
 

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/ConsumptionSpeedMetricSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/ConsumptionSpeedMetricSpec.scala
@@ -4,12 +4,12 @@
 package com.daml.ledger.api.benchtool
 
 import com.daml.ledger.api.benchtool.metrics.ConsumptionSpeedMetric
+import com.daml.ledger.api.benchtool.metrics.objectives.MinConsumptionSpeed
 import com.google.protobuf.timestamp.Timestamp
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.time.{Clock, Instant}
-
 import scala.language.existentials
 
 class ConsumptionSpeedMetricSpec extends AnyWordSpec with Matchers {
@@ -250,7 +250,7 @@ class ConsumptionSpeedMetricSpec extends AnyWordSpec with Matchers {
         )
       )
 
-      val objective = ConsumptionSpeedMetric.MinConsumptionSpeed(minAllowedSpeed)
+      val objective = MinConsumptionSpeed(minAllowedSpeed)
       val metric: ConsumptionSpeedMetric[String] =
         ConsumptionSpeedMetric.empty[String](
           periodMillis = periodMillis,

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/DelayMetricSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/DelayMetricSpec.scala
@@ -3,13 +3,13 @@
 
 package com.daml.ledger.api.benchtool
 
-import com.daml.ledger.api.benchtool.metrics.{DelayMetric, MaxDelay}
+import com.daml.ledger.api.benchtool.metrics.DelayMetric
+import com.daml.ledger.api.benchtool.metrics.objectives.MaxDelay
 import com.google.protobuf.timestamp.Timestamp
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.time.{Clock, Duration, Instant, ZoneId}
-
 import scala.language.existentials
 
 class DelayMetricSpec extends AnyWordSpec with Matchers {

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/MetricsManagerSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/MetricsManagerSpec.scala
@@ -12,12 +12,8 @@ import akka.actor.testkit.typed.scaladsl.{
 }
 import akka.actor.typed.{ActorRef, Behavior}
 import com.daml.ledger.api.benchtool.metrics.MetricsManager.Message
-import com.daml.ledger.api.benchtool.metrics.{
-  Metric,
-  MetricValue,
-  MetricsManager,
-  ServiceLevelObjective,
-}
+import com.daml.ledger.api.benchtool.metrics.objectives.ServiceLevelObjective
+import com.daml.ledger.api.benchtool.metrics.{Metric, MetricValue, MetricsManager}
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.duration._

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/MetricsManagerSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/MetricsManagerSpec.scala
@@ -116,7 +116,7 @@ class MetricsManagerSpec extends ScalaTestWithActorTestKit(ManualTime.config) wi
   private case class TestMetric(
       processedElems: List[String] = List.empty
   ) extends Metric[String] {
-    override type Value = TestMetricValue
+    override type V = TestMetricValue
     override type Objective = TestObjective.type
 
     override def onNext(value: String): Metric[String] = {

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/ServiceLevelObjectiveSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/ServiceLevelObjectiveSpec.scala
@@ -3,7 +3,8 @@
 
 package com.daml.ledger.api.benchtool
 
-import com.daml.ledger.api.benchtool.metrics.{ConsumptionSpeedMetric, DelayMetric, MaxDelay}
+import com.daml.ledger.api.benchtool.metrics.objectives.{MaxDelay, MinConsumptionSpeed}
+import com.daml.ledger.api.benchtool.metrics.{ConsumptionSpeedMetric, DelayMetric}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
@@ -54,7 +55,7 @@ class ServiceLevelObjectiveSpec extends AnyWordSpec with Matchers with TableDriv
     "correctly report violation" in {
       import ConsumptionSpeedMetric.Value
       val objectiveSpeed = Random.nextDouble()
-      val objective = ConsumptionSpeedMetric.MinConsumptionSpeed(objectiveSpeed)
+      val objective = MinConsumptionSpeed(objectiveSpeed)
       val lowerSpeed = objectiveSpeed - 1.0
       val higherSpeed = objectiveSpeed + 1.0
       val cases = Table(

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/ServiceLevelObjectiveSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/metrics/ServiceLevelObjectiveSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api.benchtool
 
-import com.daml.ledger.api.benchtool.metrics.{DelayMetric, MaxDelay}
+import com.daml.ledger.api.benchtool.metrics.{ConsumptionSpeedMetric, DelayMetric, MaxDelay}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
@@ -46,6 +46,27 @@ class ServiceLevelObjectiveSpec extends AnyWordSpec with Matchers with TableDriv
 
       forAll(cases) { (first, second, expected) =>
         Ordering[Value].max(first, second) shouldBe expected
+      }
+    }
+  }
+
+  "Min consumption speed SLO" should {
+    "correctly report violation" in {
+      import ConsumptionSpeedMetric.Value
+      val objectiveSpeed = Random.nextDouble()
+      val objective = ConsumptionSpeedMetric.MinConsumptionSpeed(objectiveSpeed)
+      val lowerSpeed = objectiveSpeed - 1.0
+      val higherSpeed = objectiveSpeed + 1.0
+      val cases = Table(
+        ("Metric value", "Expected violated"),
+        (Value(None), true),
+        (Value(Some(lowerSpeed)), true),
+        (Value(Some(objectiveSpeed)), false),
+        (Value(Some(higherSpeed)), false),
+      )
+
+      forAll(cases) { (metricValue, expectedViolated) =>
+        objective.isViolatedBy(metricValue) shouldBe expectedViolated
       }
     }
   }


### PR DESCRIPTION
### Changes
- new service level objective for minimum consumption speed, configurable with `min-consumption-speed` parameter
- redefined definition of the consumption speed metric to be more meaningful

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
