### PR TITLE
Enable sandbox tests for append-only schema

### DIFF
--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
@@ -95,6 +95,7 @@ private[sandbox] object LedgerResource {
           engine = new Engine(),
           enableAppendOnlySchema = enableAppendOnlySchema,
         )
-      } yield ledger
+      } yield ledger,
+      acquisitionTimeout = 1.minute,
     )
 }

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
@@ -62,6 +62,7 @@ private[sandbox] object LedgerResource {
       timeProvider: TimeProvider,
       metrics: MetricRegistry,
       packages: InMemoryPackageStore = InMemoryPackageStore.empty,
+      enableAppendOnlySchema: Boolean = false,
   )(implicit
       resourceContext: ResourceContext,
       materializer: Materializer,
@@ -92,6 +93,7 @@ private[sandbox] object LedgerResource {
           metrics = new Metrics(metrics),
           lfValueTranslationCache = LfValueTranslationCache.Cache.none,
           engine = new Engine(),
+          enableAppendOnlySchema = enableAppendOnlySchema,
         )
       } yield ledger
     )

--- a/ledger/sandbox-classic/src/test/resources/logback-test.xml
+++ b/ledger/sandbox-classic/src/test/resources/logback-test.xml
@@ -9,11 +9,21 @@
         <test>com.daml.platform.sandbox.stores.ledger.sql.SqlLedgerSpec</test>
     </appender>
 
+    <!-- TODO append-only: remove duplicated definitions from this file -->
+    <appender name="SqlLedgerSpecAppendOnlyAppender" class="com.daml.platform.testing.LogCollector">
+        <test>com.daml.platform.sandbox.appendonly.SqlLedgerSpec</test>
+    </appender>
+
     <logger name="com.daml.platform.sandbox.stores.ledger.sql.SqlLedger" level="INFO">
         <appender-ref ref="SqlLedgerSpecAppender" />
+        <appender-ref ref="SqlLedgerSpecAppendOnlyAppender" />
     </logger>
 
     <logger name="com.daml.platform.store.dao.HikariConnection" level="INFO">
         <appender-ref ref="SqlLedgerSpecAppender" />
+    </logger>
+
+    <logger name="com.daml.platform.store.appendonlydao.HikariConnection" level="INFO">
+        <appender-ref ref="SqlLedgerSpecAppendOnlyAppender" />
     </logger>
 </configuration>

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/ScenarioLoadingITDivulgence.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/ScenarioLoadingITDivulgence.scala
@@ -16,7 +16,6 @@ import org.scalatest.time.{Millis, Span}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-@SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
 class ScenarioLoadingITDivulgence
     extends AnyWordSpec
     with Matchers

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITDivulgence.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITDivulgence.scala
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.appendonly
+
+import akka.stream.scaladsl.Sink
+import com.daml.ledger.api.domain.LedgerId
+import com.daml.ledger.api.testing.utils.{SuiteResourceManagementAroundEach, MockMessages => M}
+import com.daml.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc
+import com.daml.ledger.api.v1.transaction_filter._
+import com.daml.ledger.client.services.acs.ActiveContractSetClient
+import com.daml.dec.DirectExecutionContext
+import com.daml.platform.sandbox.config.SandboxConfig
+import com.daml.platform.sandbox.services.{SandboxFixture, TestCommands}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Span}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+// TODO append-only: Remove this class once the mutating schema is removed
+@SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
+class ScenarioLoadingITDivulgence
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with TestCommands
+    with SandboxFixture
+    with SuiteResourceManagementAroundEach {
+
+  override protected def config: SandboxConfig =
+    super.config.copy(
+      enableAppendOnlySchema = true
+    )
+
+  override def scenario: Option[String] = Some("Test:testDivulgenceSuccess")
+
+  private def newACClient(ledgerId: LedgerId) =
+    new ActiveContractSetClient(ledgerId, ActiveContractsServiceGrpc.stub(channel))
+
+  override implicit def patienceConfig: PatienceConfig =
+    PatienceConfig(scaled(Span(15000, Millis)), scaled(Span(150, Millis)))
+
+  private val allTemplatesForParty = M.transactionFilter
+
+  private def getSnapshot(transactionFilter: TransactionFilter = allTemplatesForParty) =
+    newACClient(ledgerId())
+      .getActiveContracts(transactionFilter)
+      .runWith(Sink.seq)
+
+  implicit val ec = DirectExecutionContext
+
+  "ScenarioLoading" when {
+    "running a divulgence scenario" should {
+      "not fail" in {
+        // The testDivulgenceSuccess scenario uses divulgence
+        // This test checks whether the scenario completes without failing
+        whenReady(getSnapshot()) { resp =>
+          resp.size should equal(1)
+        }
+      }
+    }
+  }
+
+}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITDivulgence.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITDivulgence.scala
@@ -17,8 +17,9 @@ import org.scalatest.time.{Millis, Span}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+// This file is identical to com.daml.platform.sandbox.ScenarioLoadingITDivulgence,
+// except that it overrides config such that the append-only schema is used.
 // TODO append-only: Remove this class once the mutating schema is removed
-@SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
 class ScenarioLoadingITDivulgence
     extends AnyWordSpec
     with Matchers

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITNewIdentifier.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITNewIdentifier.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.appendonly
+
+import com.daml.platform.sandbox.ScenarioLoadingITBase
+import com.daml.platform.sandbox.config.SandboxConfig
+
+// TODO append-only: Remove this class once the mutating schema is removed
+class ScenarioLoadingITNewIdentifier extends ScenarioLoadingITBase {
+  override protected def config: SandboxConfig =
+    super.config.copy(
+      enableAppendOnlySchema = true
+    )
+}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITNewIdentifier.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITNewIdentifier.scala
@@ -6,6 +6,8 @@ package com.daml.platform.sandbox.appendonly
 import com.daml.platform.sandbox.ScenarioLoadingITBase
 import com.daml.platform.sandbox.config.SandboxConfig
 
+// This file is identical to com.daml.platform.sandbox.ScenarioLoadingITNewIdentifier,
+// except that it overrides config such that the append-only schema is used.
 // TODO append-only: Remove this class once the mutating schema is removed
 class ScenarioLoadingITNewIdentifier extends ScenarioLoadingITBase {
   override protected def config: SandboxConfig =

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITPostgres.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITPostgres.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.appendonly
+
+import com.daml.platform.sandbox.{SandboxBackend, ScenarioLoadingITBase}
+import com.daml.platform.sandbox.config.SandboxConfig
+
+// TODO append-only: Remove this class once the mutating schema is removed
+final class ScenarioLoadingITPostgres extends ScenarioLoadingITBase with SandboxBackend.Postgresql {
+  override protected def config: SandboxConfig =
+    super.config.copy(
+      enableAppendOnlySchema = true
+    )
+}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITPostgres.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/ScenarioLoadingITPostgres.scala
@@ -6,6 +6,8 @@ package com.daml.platform.sandbox.appendonly
 import com.daml.platform.sandbox.{SandboxBackend, ScenarioLoadingITBase}
 import com.daml.platform.sandbox.config.SandboxConfig
 
+// This file is identical to com.daml.platform.sandbox.ScenarioLoadingITPostgres,
+// except that it overrides config such that the append-only schema is used.
 // TODO append-only: Remove this class once the mutating schema is removed
 final class ScenarioLoadingITPostgres extends ScenarioLoadingITBase with SandboxBackend.Postgresql {
   override protected def config: SandboxConfig =

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/SqlLedgerSpec.scala
@@ -1,0 +1,329 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.stores.ledger.sql
+
+import java.io.File
+import java.time.Instant
+
+import ch.qos.logback.classic.Level
+import com.daml.api.util.TimeProvider
+import com.daml.bazeltools.BazelRunfiles.rlocation
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.api.domain.{LedgerId, ParticipantId}
+import com.daml.ledger.api.health.Healthy
+import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
+import com.daml.ledger.resources.{Resource, ResourceContext, TestResourceContext}
+import com.daml.ledger.test.ModelTestDar
+import com.daml.lf.archive.DarReader
+import com.daml.lf.data.{ImmArray, Ref}
+import com.daml.lf.engine.Engine
+import com.daml.lf.transaction.LegacyTransactionCommitter
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.common.{LedgerIdMode, MismatchException}
+import com.daml.platform.configuration.ServerRole
+import com.daml.platform.packages.InMemoryPackageStore
+import com.daml.platform.sandbox.MetricsAround
+import com.daml.platform.sandbox.config.LedgerName
+import com.daml.platform.sandbox.stores.ledger.Ledger
+import com.daml.platform.sandbox.stores.ledger.sql.SqlLedgerSpec._
+import com.daml.platform.store.{IndexMetadata, LfValueTranslationCache}
+import com.daml.platform.testing.LogCollector
+import com.daml.testing.postgresql.PostgresAroundEach
+import org.scalatest.concurrent.{AsyncTimeLimitedTests, Eventually, ScaledTimeSpans}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Minute, Seconds, Span}
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.collection.mutable
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+import scala.util.{Success, Try}
+
+// TODO append-only: Remove this class once the mutating schema is removed
+final class SqlLedgerSpec
+    extends AsyncWordSpec
+    with Matchers
+    with AsyncTimeLimitedTests
+    with ScaledTimeSpans
+    with Eventually
+    with TestResourceContext
+    with AkkaBeforeAndAfterAll
+    with PostgresAroundEach
+    with MetricsAround {
+
+  protected implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
+
+  override val timeLimit: Span = scaled(Span(1, Minute))
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(10, Seconds)))
+
+  private val createdLedgers = mutable.Buffer[Resource[Ledger]]()
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    createdLedgers.clear()
+  }
+
+  override protected def afterEach(): Unit = {
+    LogCollector.clear[SqlLedgerSpec]
+    for (ledger <- createdLedgers)
+      Await.result(ledger.release(), 2.seconds)
+    super.afterEach()
+  }
+
+  "SQL Ledger" should {
+    "be able to be created from scratch with a random ledger ID" in {
+      for {
+        ledger <- createSqlLedger(validatePartyAllocation = false)
+      } yield {
+        ledger.ledgerId should not be ""
+      }
+    }
+
+    "be able to be created from scratch with a given ledger ID" in {
+      for {
+        ledger <- createSqlLedger(ledgerId, validatePartyAllocation = false)
+      } yield {
+        ledger.ledgerId should be(ledgerId)
+      }
+    }
+
+    "be able to be reused keeping the old ledger ID" in {
+      for {
+        ledger1 <- createSqlLedger(ledgerId, validatePartyAllocation = false)
+        ledger2 <- createSqlLedger(ledgerId, validatePartyAllocation = false)
+        ledger3 <- createSqlLedger(validatePartyAllocation = false)
+      } yield {
+        ledger1.ledgerId should not be LedgerId
+        ledger1.ledgerId should be(ledger2.ledgerId)
+        ledger2.ledgerId should be(ledger3.ledgerId)
+      }
+    }
+
+    "refuse to create a new ledger when there is already one with a different ledger ID" in {
+      for {
+        _ <- createSqlLedger(ledgerId = "TheLedger", validatePartyAllocation = false)
+        throwable <- createSqlLedger(
+          ledgerId = "AnotherLedger",
+          validatePartyAllocation = false,
+        ).failed
+      } yield {
+        throwable.getMessage should be(
+          "The provided ledger id does not match the existing one. Existing: \"TheLedger\", Provided: \"AnotherLedger\"."
+        )
+      }
+    }
+
+    "correctly initialized the participant ID" in {
+      val participantId = makeParticipantId("TheOnlyParticipant")
+      for {
+        _ <- createSqlLedgerWithParticipantId(participantId, validatePartyAllocation = false)
+        metadata <- IndexMetadata.read(postgresDatabase.url)
+      } yield {
+        metadata.participantId shouldEqual participantId
+      }
+    }
+
+    "allow to resume on an existing participant ID" in {
+      val participantId = makeParticipantId("TheParticipant")
+      for {
+        _ <- createSqlLedgerWithParticipantId(participantId, validatePartyAllocation = false)
+        _ <- createSqlLedgerWithParticipantId(participantId, validatePartyAllocation = false)
+        metadata <- IndexMetadata.read(postgresDatabase.url)
+      } yield {
+        metadata.participantId shouldEqual participantId
+      }
+    }
+
+    "refuse to create a new ledger when there is already one with a different participant ID" in {
+      val expectedExisting = makeParticipantId("TheParticipant")
+      val expectedProvided = makeParticipantId("AnotherParticipant")
+      for {
+        _ <- createSqlLedgerWithParticipantId(expectedExisting, validatePartyAllocation = false)
+        throwable <- createSqlLedgerWithParticipantId(
+          expectedProvided,
+          validatePartyAllocation = false,
+        ).failed
+      } yield {
+        throwable match {
+          case mismatch: MismatchException.ParticipantId =>
+            mismatch.existing shouldEqual expectedExisting
+            mismatch.provided shouldEqual expectedProvided
+          case _ =>
+            fail("Did not get the expected exception type", throwable)
+        }
+      }
+    }
+
+    "load no packages by default" in {
+      for {
+        ledger <- createSqlLedger(validatePartyAllocation = false)
+        packages <- ledger.listLfPackages()
+      } yield {
+        packages should have size 0
+      }
+    }
+
+    "load packages if provided with a dynamic ledger ID" in {
+      for {
+        ledger <- createSqlLedger(
+          packages = testDar.all,
+          validatePartyAllocation = false,
+        )
+        packages <- ledger.listLfPackages()
+      } yield {
+        packages should have size testDar.all.length.toLong
+      }
+    }
+
+    "load packages if provided with a static ledger ID" in {
+      for {
+        ledger <- createSqlLedger(
+          ledgerId = "TheLedger",
+          packages = testDar.all,
+          validatePartyAllocation = false,
+        )
+        packages <- ledger.listLfPackages()
+      } yield {
+        packages should have size testDar.all.length.toLong
+      }
+    }
+
+    "load no packages if the ledger already exists" in {
+      for {
+        _ <- createSqlLedger(ledgerId = "TheLedger", validatePartyAllocation = false)
+        ledger <- createSqlLedger(
+          ledgerId = "TheLedger",
+          packages = testDar.all,
+          validatePartyAllocation = false,
+        )
+        packages <- ledger.listLfPackages()
+      } yield {
+        packages should have size 0
+      }
+    }
+
+    "be healthy" in {
+      for {
+        ledger <- createSqlLedger(validatePartyAllocation = false)
+      } yield {
+        ledger.currentHealth() should be(Healthy)
+      }
+    }
+
+    /** Workaround test for asserting that PostgreSQL asynchronous commits are disabled in
+      * [[com.daml.platform.store.dao.JdbcLedgerDao]] transactions when used from [[SqlLedger]].
+      *
+      * NOTE: This is needed for ensuring durability guarantees of Daml-on-SQL.
+      */
+    "does not use async commit when building JdbcLedgerDao" in {
+      for {
+        _ <- createSqlLedger(validatePartyAllocation = false)
+      } yield {
+        val hikariDataSourceLogs =
+          LogCollector.read[this.type]("com.daml.platform.store.dao.HikariConnection")
+        hikariDataSourceLogs should contain(
+          Level.INFO -> "Creating Hikari connections with synchronous commit ON"
+        )
+      }
+    }
+  }
+
+  private def createSqlLedger(validatePartyAllocation: Boolean): Future[Ledger] =
+    createSqlLedger(None, None, List.empty, validatePartyAllocation)
+
+  private def createSqlLedger(
+      ledgerId: String,
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(ledgerId, List.empty, validatePartyAllocation)
+
+  private def createSqlLedger(
+      ledgerId: LedgerId,
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(ledgerId, List.empty, validatePartyAllocation)
+
+  private def createSqlLedger(
+      packages: List[DamlLf.Archive],
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(None, None, packages, validatePartyAllocation)
+
+  private def createSqlLedger(
+      ledgerId: String,
+      packages: List[DamlLf.Archive],
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] = {
+    val assertedLedgerId: LedgerId = LedgerId(Ref.LedgerString.assertFromString(ledgerId))
+    createSqlLedger(assertedLedgerId, packages, validatePartyAllocation)
+  }
+
+  private def createSqlLedger(
+      ledgerId: LedgerId,
+      packages: List[DamlLf.Archive],
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(Some(ledgerId), None, packages, validatePartyAllocation)
+
+  private def createSqlLedgerWithParticipantId(
+      participantId: ParticipantId,
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(None, Some(participantId), List.empty, validatePartyAllocation)
+
+  private def makeParticipantId(id: String): ParticipantId =
+    ParticipantId(Ref.ParticipantId.assertFromString(id))
+
+  private val DefaultParticipantId = makeParticipantId("test-participant-id")
+
+  private def createSqlLedger(
+      ledgerId: Option[LedgerId],
+      participantId: Option[ParticipantId],
+      packages: List[DamlLf.Archive],
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] = {
+    metrics.getNames.forEach(name => { val _ = metrics.remove(name) })
+    val ledger =
+      new SqlLedger.Owner(
+        name = LedgerName(getClass.getSimpleName),
+        serverRole = ServerRole.Testing(getClass),
+        jdbcUrl = postgresDatabase.url,
+        databaseConnectionPoolSize = 16,
+        databaseConnectionTimeout = 250.millis,
+        providedLedgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
+        participantId = participantId.getOrElse(DefaultParticipantId),
+        timeProvider = TimeProvider.UTC,
+        packages = InMemoryPackageStore.empty
+          .withPackages(Instant.EPOCH, None, packages)
+          .fold(sys.error, identity),
+        initialLedgerEntries = ImmArray.empty,
+        queueDepth = queueDepth,
+        transactionCommitter = LegacyTransactionCommitter,
+        startMode = SqlStartMode.MigrateAndStart,
+        eventsPageSize = 100,
+        servicesExecutionContext = executionContext,
+        metrics = new Metrics(metrics),
+        lfValueTranslationCache = LfValueTranslationCache.Cache.none,
+        engine = new Engine(),
+        validatePartyAllocation = validatePartyAllocation,
+        enableAppendOnlySchema = true,
+      ).acquire()(ResourceContext(system.dispatcher))
+    createdLedgers += ledger
+    ledger.asFuture
+  }
+}
+
+object SqlLedgerSpec {
+  private val queueDepth = 128
+
+  private val ledgerId: LedgerId = LedgerId(Ref.LedgerString.assertFromString("TheLedger"))
+
+  private val Success(testDar) = {
+    val reader = DarReader { (_, stream) => Try(DamlLf.Archive.parseFrom(stream)) }
+    val fileName = new File(rlocation(ModelTestDar.path))
+    reader.readArchiveFromFile(fileName)
+  }
+}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/SqlLedgerSpec.scala
@@ -226,7 +226,7 @@ final class SqlLedgerSpec
         _ <- createSqlLedger(validatePartyAllocation = false)
       } yield {
         val hikariDataSourceLogs =
-          LogCollector.read[this.type]("com.daml.platform.store.dao.HikariConnection")
+          LogCollector.read[this.type]("com.daml.platform.store.appendonlydao.HikariConnection")
         hikariDataSourceLogs should contain(
           Level.INFO -> "Creating Hikari connections with synchronous commit ON"
         )

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/SqlLedgerSpec.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.platform.sandbox.stores.ledger.sql
+package com.daml.platform.sandbox.appendonly
 
 import java.io.File
 import java.time.Instant
@@ -27,7 +27,8 @@ import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.sandbox.MetricsAround
 import com.daml.platform.sandbox.config.LedgerName
 import com.daml.platform.sandbox.stores.ledger.Ledger
-import com.daml.platform.sandbox.stores.ledger.sql.SqlLedgerSpec._
+import com.daml.platform.sandbox.appendonly.SqlLedgerSpec._
+import com.daml.platform.sandbox.stores.ledger.sql.{SqlLedger, SqlStartMode}
 import com.daml.platform.store.{IndexMetadata, LfValueTranslationCache}
 import com.daml.platform.testing.LogCollector
 import com.daml.testing.postgresql.PostgresAroundEach
@@ -41,6 +42,8 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.util.{Success, Try}
 
+// This file is identical to com.daml.platform.sandbox.stores.ledger.sql.SqlLedgerSpec,
+// except that it changes createSqlLedger() such that the append-only schema is used.
 // TODO append-only: Remove this class once the mutating schema is removed
 final class SqlLedgerSpec
     extends AsyncWordSpec

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/TransactionTimeModelComplianceIT.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.platform.sandbox.stores.ledger
+package com.daml.platform.sandbox.appendonly
 
 import java.time.{Instant, Duration => JDuration}
 import java.util.UUID
@@ -27,7 +27,8 @@ import com.daml.ledger.resources.ResourceContext
 import com.daml.lf.crypto
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.test.TransactionBuilder
-import com.daml.platform.sandbox.stores.ledger.TransactionTimeModelComplianceIT._
+import com.daml.platform.sandbox.stores.ledger.Ledger
+import com.daml.platform.sandbox.appendonly.TransactionTimeModelComplianceIT._
 import com.daml.platform.sandbox.{LedgerResource, MetricsAround}
 import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
 import org.scalatest.time.Span
@@ -37,6 +38,9 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
+// This file is identical to com.daml.platform.sandbox.stores.ledger.TransactionTimeModelComplianceIT,
+// except that it changes fixtureIdsEnabled and constructResource() such that only the append-only schema is used.
+// TODO append-only: Remove this class once the mutating schema is removed
 class TransactionTimeModelComplianceIT
     extends AsyncWordSpec
     with AkkaBeforeAndAfterAll
@@ -52,7 +56,7 @@ class TransactionTimeModelComplianceIT
 
   /** Overriding this provides an easy way to narrow down testing to a single implementation. */
   override protected def fixtureIdsEnabled: Set[BackendType] =
-    Set(BackendType.InMemory, BackendType.Postgres)
+    Set(BackendType.Postgres)
 
   override protected def constructResource(index: Int, fixtureId: BackendType): Resource[Ledger] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/TransactionTimeModelComplianceIT.scala
@@ -38,7 +38,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class TransactionTimeModelComplianceIT
-    extends AsyncWordSpec
+  extends AsyncWordSpec
     with AkkaBeforeAndAfterAll
     with MultiResourceBase[BackendType, Ledger]
     with SuiteResourceManagementAroundEach
@@ -48,7 +48,7 @@ class TransactionTimeModelComplianceIT
     with OptionValues
     with MetricsAround {
 
-  override def timeLimit: Span = scaled(30.seconds)
+  override def timeLimit: Span = scaled(1.minute)
 
   /** Overriding this provides an easy way to narrow down testing to a single implementation. */
   override protected def fixtureIdsEnabled: Set[BackendType] =
@@ -60,18 +60,24 @@ class TransactionTimeModelComplianceIT
       case BackendType.InMemory =>
         LedgerResource.inMemory(ledgerId, timeProvider)
       case BackendType.Postgres =>
-        LedgerResource.postgres(getClass, ledgerId, timeProvider, metrics)
+        LedgerResource.postgres(
+          getClass,
+          ledgerId,
+          timeProvider,
+          metrics,
+          enableAppendOnlySchema = true,
+        )
     }
   }
 
   private[this] val submissionSeed = crypto.Hash.hashPrivateKey(this.getClass.getName)
 
   private[this] def publishConfig(
-      ledger: Ledger,
-      recordTime: Instant,
-      generation: Long,
-      minSkew: JDuration,
-      maxSkew: JDuration,
+    ledger: Ledger,
+    recordTime: Instant,
+    generation: Long,
+    minSkew: JDuration,
+    maxSkew: JDuration,
   ) = {
     val config = Configuration(
       generation = generation,

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/appendonly/TransactionTimeModelComplianceIT.scala
@@ -38,7 +38,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class TransactionTimeModelComplianceIT
-  extends AsyncWordSpec
+    extends AsyncWordSpec
     with AkkaBeforeAndAfterAll
     with MultiResourceBase[BackendType, Ledger]
     with SuiteResourceManagementAroundEach
@@ -73,11 +73,11 @@ class TransactionTimeModelComplianceIT
   private[this] val submissionSeed = crypto.Hash.hashPrivateKey(this.getClass.getName)
 
   private[this] def publishConfig(
-    ledger: Ledger,
-    recordTime: Instant,
-    generation: Long,
-    minSkew: JDuration,
-    maxSkew: JDuration,
+      ledger: Ledger,
+      recordTime: Instant,
+      generation: Long,
+      minSkew: JDuration,
+      maxSkew: JDuration,
   ) = {
     val config = Configuration(
       generation = generation,

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/reset/ResetServicePostgresqlAppendonlyIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/reset/ResetServicePostgresqlAppendonlyIT.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.services.reset
+
+import com.daml.platform.sandbox.SandboxBackend
+import com.daml.platform.sandbox.config.SandboxConfig
+import com.daml.platform.sandbox.services.SandboxFixture
+
+// TODO append-only: Remove this class once the mutating schema is removed
+final class ResetServicePostgresqlAppendonlyIT
+    extends ResetServiceDatabaseIT
+    with SandboxFixture
+    with SandboxBackend.Postgresql {
+  override protected def config: SandboxConfig =
+    super.config.copy(
+      enableAppendOnlySchema = true
+    )
+}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -48,7 +48,7 @@ class TransactionTimeModelComplianceIT
     with OptionValues
     with MetricsAround {
 
-  override def timeLimit: Span = scaled(60.seconds)
+  override def timeLimit: Span = scaled(1.minute)
 
   /** Overriding this provides an easy way to narrow down testing to a single implementation. */
   override protected def fixtureIdsEnabled: Set[BackendType] =

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -52,7 +52,7 @@ class TransactionTimeModelComplianceIT
 
   /** Overriding this provides an easy way to narrow down testing to a single implementation. */
   override protected def fixtureIdsEnabled: Set[BackendType] =
-    Set(BackendType.InMemory, BackendType.Postgres)
+    Set(BackendType.InMemory, BackendType.Postgres, BackendType.PostgresAppendOnly)
 
   override protected def constructResource(index: Int, fixtureId: BackendType): Resource[Ledger] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
@@ -61,6 +61,14 @@ class TransactionTimeModelComplianceIT
         LedgerResource.inMemory(ledgerId, timeProvider)
       case BackendType.Postgres =>
         LedgerResource.postgres(getClass, ledgerId, timeProvider, metrics)
+      case BackendType.PostgresAppendOnly =>
+        LedgerResource.postgres(
+          getClass,
+          ledgerId,
+          timeProvider,
+          metrics,
+          enableAppendOnlySchema = true,
+        )
     }
   }
 
@@ -211,6 +219,9 @@ object TransactionTimeModelComplianceIT {
     case object InMemory extends BackendType
 
     case object Postgres extends BackendType
+
+    // TODO append-only: remove one of Postgres and PostgresAppendOnly
+    case object PostgresAppendOnly extends BackendType
 
   }
 


### PR DESCRIPTION
This PR runs some selected sandbox classic tests on the append-only schema.

Included tests:
- `SqlLedgerSpec`
- `ScenarioLoadingIT*`
- `TransactionTimeModelComplianceIT`
- `ResetServicePostgresqlIT`

Excluded tests:
- `com.daml.platform.sandbox.auth.*`: these only test Ledger API authentication, and not the index DB
- `CliSpec`, `EngineModeIT`, `TlsIT` these also do not test the index DB
- `com.daml.platform.sandbox.services.*`: these talk to the sandbox over the Ledger API, and therefore overlap with the ledger conformance tests
- `TransactionStreamTerminationIT`: this test only uses the H2 database