### PR TITLE
Fix authorization in try contexts

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -12,7 +12,6 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.language.{Util => AstUtil}
 import com.daml.lf.ledger.Authorize
 import com.daml.lf.speedy.Compiler.{CompilationError, PackageNotFound}
-import com.daml.lf.speedy.PartialTransaction.ExercisesContextInfo
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
@@ -320,12 +319,7 @@ private[lf] object Speedy {
 
     private[lf] def contextActors: Set[Party] =
       withOnLedger("ptx") { onLedger =>
-        onLedger.ptx.context.info match {
-          case ctx: ExercisesContextInfo =>
-            ctx.actingParties union ctx.signatories
-          case _ =>
-            onLedger.committers
-        }
+        onLedger.ptx.context.info.authorizers.getOrElse(onLedger.committers)
       }
 
     private[lf] def auth: Authorize = Authorize(this.contextActors)

--- a/daml-lf/tests/scenario/dev/exception-auth/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/dev/exception-auth/EXPECTED.ledger
@@ -1,0 +1,38 @@
+transactions:
+TX #0 1970-01-01T00:00:00Z [Test:42] version: dev
+#0:0 version: dev
+│   referenced by #1:0, #2:0
+│   known to (since): a (#0), b (#0)
+└─> create Test:Tester@XXXXXXXX
+    with: { a = 'a', b = 'b' }
+
+TX #1 1970-01-01T00:00:00Z [Test:44] version: dev
+#1:0 version: dev
+│   known to (since): a (#1), b (#1)
+└─> b exercises CreateInTry:Test:Tester@XXXXXXXX on 009877e9c7e647b905ba9185add7af1b24e664508899260672b7e21c59ad9168d1
+    with {  }
+    children:
+    #1:1 no-version
+    │   known to (since): a (#1), b (#1)
+    └─> rollback:
+    #1:2 version: dev
+    │   known to (since): a (#1), b (#1)
+    └─> create Test:T@XXXXXXXX
+        with: { ps = ['a', 'b'] }
+
+TX #2 1970-01-01T00:00:00Z [Test:47] version: dev
+#2:0 version: dev
+│   known to (since): a (#2), b (#2)
+└─> b exercises CreateInNestedTry:Test:Tester@XXXXXXXX on 009877e9c7e647b905ba9185add7af1b24e664508899260672b7e21c59ad9168d1
+    with {  }
+    children:
+    #2:1 no-version
+    │   known to (since): a (#2), b (#2)
+    └─> rollback:
+    #2:2 version: dev
+    │   known to (since): a (#2), b (#2)
+    └─> create Test:T@XXXXXXXX
+        with: { ps = ['a', 'b'] }
+
+active contracts:
+   009877e9c7e647b905ba9185add7af1b24e664508899260672b7e21c59ad9168d1

--- a/daml-lf/tests/scenario/dev/exception-auth/Test.daml
+++ b/daml-lf/tests/scenario/dev/exception-auth/Test.daml
@@ -1,0 +1,47 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module Test where
+
+import DA.Exception
+
+template T
+  with
+    ps : [Party]
+  where
+    signatory ps
+
+template Tester
+  with
+    a : Party
+    b : Party
+  where
+    signatory a
+    observer b
+    nonconsuming choice CreateInTry : ()
+      controller b
+      do try do
+           create (T [a, b])
+           abort ""
+         catch
+           GeneralError _ -> pure ()
+
+    nonconsuming choice CreateInNestedTry : ()
+      controller b
+      do try try do create (T [a, b])
+                    abort ""
+             catch
+               GeneralError _ -> pure ()
+         catch
+           GeneralError _ -> pure ()
+
+run = scenario do
+  a <- getParty "a"
+  b <- getParty "b"
+  cid <- submit a $ create (Tester a b)
+  -- Tests that we have the authorization from the parent exercise.
+  submit b $ exercise cid CreateInTry
+  -- Tests that we have the authorization from the parent exercise
+  -- even if there is another rollback in between.
+  submit b $ exercise cid CreateInNestedTry


### PR DESCRIPTION
wildcard pattern matches bite once again. We clearly do not want to
use the committers here.

I tried to move most of the logic to PartialTransaction but
unfortunately moving the submitters to PartialTransaction doesn’t
quite work since as usual scenarios make things difficult because
submitters change at weird places and we reset the partial transaction
in weird places.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
