### PR TITLE
[Mutable contract state cache] Tests for contract/key state new methods in ContractsReader

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoContractsAppendOnlySpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoContractsAppendOnlySpec.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao
+
+import com.daml.lf.transaction.GlobalKey
+import com.daml.lf.transaction.Node.KeyWithMaintainers
+import com.daml.lf.value.Value.ValueText
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{LoneElement, OptionValues}
+
+private[dao] trait JdbcLedgerDaoContractsAppendOnlySpec extends LoneElement with OptionValues {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  private def contractsReader = ledgerDao.contractsReader
+
+  behavior of "JdbcLedgerDao (contracts) on append-only schema"
+
+  it should "present the contract state at a specific event sequential id" in {
+    for {
+      (_, tx) <- store(singleCreate(create(_, signatories = Set(alice))))
+      contractId = nonTransient(tx).loneElement
+      _ <- store(singleNonConsumingExercise(contractId))
+      eventSeqIdAtCreate <- ledgerDao.lookupLedgerEndOffsetAndSequentialId()
+      _ <- store(txArchiveContract(alice, (contractId, None)))
+      eventSeqIdAfterArchive <- ledgerDao.lookupLedgerEndOffsetAndSequentialId()
+      queryAfterCreate <- contractsReader.lookupContractState(contractId, eventSeqIdAtCreate._2)
+      queryAfterArchive <- contractsReader.lookupContractState(
+        contractId,
+        eventSeqIdAfterArchive._2,
+      )
+    } yield {
+      queryAfterCreate.value match {
+        case LedgerDaoContractsReader.ActiveContract(contract, stakeholders, _) =>
+          contract shouldBe someVersionedContractInstance.copy(agreementText = "")
+          stakeholders should contain theSameElementsAs Set(alice)
+        case LedgerDaoContractsReader.ArchivedContract(_) =>
+          fail("Contract should appear as active")
+      }
+      queryAfterArchive.value match {
+        case _: LedgerDaoContractsReader.ActiveContract =>
+          fail("Contract should appear as archived")
+        case LedgerDaoContractsReader.ArchivedContract(stakeholders) =>
+          stakeholders should contain theSameElementsAs Set(alice)
+      }
+    }
+  }
+
+  it should "present the contract key state at a specific event sequential id" in {
+    val aTextValue = ValueText(scala.util.Random.nextString(10))
+
+    for {
+      (_, tx) <- createAndStoreContract(
+        submittingParties = Set(alice),
+        signatories = Set(alice, bob),
+        stakeholders = Set(alice, bob),
+        key = Some(KeyWithMaintainers(aTextValue, Set(alice, bob))),
+      )
+      key = GlobalKey.assertBuild(someTemplateId, aTextValue)
+      contractId = nonTransient(tx).loneElement
+      _ <- store(singleNonConsumingExercise(contractId))
+      eventSeqIdAtCreate <- ledgerDao.lookupLedgerEndOffsetAndSequentialId()
+      _ <- store(txArchiveContract(alice, (contractId, None)))
+      eventSeqIdAfterArchive <- ledgerDao.lookupLedgerEndOffsetAndSequentialId()
+      queryAfterCreate <- contractsReader.lookupKeyState(key, eventSeqIdAtCreate._2)
+      queryAfterArchive <- contractsReader.lookupKeyState(key, eventSeqIdAfterArchive._2)
+    } yield {
+      queryAfterCreate match {
+        case LedgerDaoContractsReader.KeyAssigned(fetchedContractId, stakeholders) =>
+          fetchedContractId shouldBe contractId
+          stakeholders shouldBe Set(alice, bob)
+        case _ => fail("Key should be assigned")
+      }
+      queryAfterArchive shouldBe LedgerDaoContractsReader.KeyUnassigned
+    }
+  }
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPostgresqlAppendOnlySpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPostgresqlAppendOnlySpec.scala
@@ -17,6 +17,7 @@ final class JdbcLedgerDaoPostgresqlAppendOnlySpec
     with JdbcLedgerDaoCompletionsSpec
     with JdbcLedgerDaoConfigurationSpec
     with JdbcLedgerDaoContractsSpec
+    with JdbcLedgerDaoContractsAppendOnlySpec
     with JdbcLedgerDaoDivulgenceSpec
     with JdbcLedgerDaoPartiesSpec
     with JdbcLedgerDaoTransactionsSpec


### PR DESCRIPTION
Test cases added for `ContractsReader.lookupKeyState` and `ContractsReader.lookupContractState` in `JdbcLedgerDaoPostgresqlAppendOnlySpec`

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
