### PR TITLE
Added maxlength information to id string

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
@@ -211,7 +211,7 @@ private final class ConcatenableMatchingStringModule(
     if (s.length == 0)
       throw new IllegalArgumentException(s"""$description is empty""")
     if (s.length > maxLength)
-      throw new IllegalArgumentException(s"""$description is too long""")
+      throw new IllegalArgumentException(s"""$description is too long (max: $maxLength)""")
     var i = 0
     while (i < s.length) {
       val c = s(i).toInt


### PR DESCRIPTION
Before this change, when converting a string that exceeds the max
length, the application would return the error "too long" without saying what
the bounds are, requiring a user to lookup the bounds in the source code. Now, the
user gets the actual length that is enforced as part of the error message.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
