### PR TITLE
Fix behavior of Math.sqrt at 0 (#9818)

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Math.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Math.daml
@@ -27,6 +27,7 @@ infixr 8 **
 (**) : Decimal -> Decimal -> Decimal
 x ** y
   | y == 0.0 = 1.0
+  | x == 0.0 = 0.0
   | otherwise = exp (y * log x)
 
 -- | Calculate the square root of a Decimal.

--- a/compiler/damlc/daml-stdlib-src/DA/Math.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Math.daml
@@ -37,7 +37,9 @@ x ** y
 -- 1.2
 -- ```
 sqrt : Decimal -> Decimal
-sqrt x = x ** 0.5
+sqrt x
+  | x < 0.0 = error "sqrt is defined only for non-negative numbers"
+  | otherwise = x ** 0.5
 
 -- | The exponential function. Example: `exp 0.0 == 1.0`
 exp : Decimal -> Decimal
@@ -50,7 +52,9 @@ exp x
 
 -- | The natural logarithm. Example: `log 10.0 == 2.30258509299`
 log : Decimal -> Decimal
-log x = logt10k x / 10000.0
+log x
+  | x <= 0.0 = error "logarithm is defined only for positive numbers"
+  | otherwise = logt10k x / 10000.0
 
 -- | The logarithm of a number to a given base. Example: `log 10.0 100.0 == 2.0`
 logBase : Decimal -> Decimal -> Decimal

--- a/compiler/damlc/daml-stdlib-src/DA/Math.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Math.daml
@@ -25,7 +25,9 @@ infixr 8 **
 
 -- | Take a power of a number Example: `2.0 ** 3.0 == 8.0`.
 (**) : Decimal -> Decimal -> Decimal
-x ** y = exp (y * log x)
+x ** y
+  | y == 0.0 = 1.0
+  | otherwise = exp (y * log x)
 
 -- | Calculate the square root of a Decimal.
 --

--- a/compiler/damlc/tests/daml-test-files/Math.daml
+++ b/compiler/damlc/tests/daml-test-files/Math.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- @INFO range=47:22-47:32; Use sqrt
--- @INFO range=57:15-57:25; Use sqrt
+-- @INFO range=65:15-65:25; Use sqrt
 
 
 module Math where

--- a/compiler/damlc/tests/daml-test-files/Math.daml
+++ b/compiler/damlc/tests/daml-test-files/Math.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- @INFO range=47:22-47:32; Use sqrt
--- @INFO range=65:15-65:25; Use sqrt
+-- @INFO range=66:15-66:25; Use sqrt
 
 
 module Math where
@@ -46,6 +46,7 @@ powerTest = scenario do
     sqrt2 = 1.4142135623 : Decimal
   assert(abs(sqrt2 - 2.0 ** 0.5) <= 0.0000000001)
   0.0 ** 0.0 === 1.0
+  0.0 ** 1.0 === 0.0
   42.0 ** 0.0 === 1.0
 
 sqrtTest = scenario do

--- a/compiler/damlc/tests/daml-test-files/Math.daml
+++ b/compiler/damlc/tests/daml-test-files/Math.daml
@@ -45,6 +45,14 @@ powerTest = scenario do
   let
     sqrt2 = 1.4142135623 : Decimal
   assert(abs(sqrt2 - 2.0 ** 0.5) <= 0.0000000001)
+  assert(abs(0 ** 0) == 1.0)
+  assert(abs(42 ** 0) == 1.0)
+
+sqrtTest = scenario do
+  let
+    sqrt2 = 1.4142135623 : Decimal
+  assert(abs(sqrt2 - sqrt(2.0)) <= 0.0000000001)
+  assert(sqrt(0.0) == 0.0)
 
 trigTest = scenario do
   let

--- a/compiler/damlc/tests/daml-test-files/Math.daml
+++ b/compiler/damlc/tests/daml-test-files/Math.daml
@@ -45,14 +45,14 @@ powerTest = scenario do
   let
     sqrt2 = 1.4142135623 : Decimal
   assert(abs(sqrt2 - 2.0 ** 0.5) <= 0.0000000001)
-  assert(abs(0 ** 0) == 1.0)
-  assert(abs(42 ** 0) == 1.0)
+  0.0 ** 0.0 === 1.0
+  42.0 ** 0.0 === 1.0
 
 sqrtTest = scenario do
   let
     sqrt2 = 1.4142135623 : Decimal
-  assert(abs(sqrt2 - sqrt(2.0)) <= 0.0000000001)
-  assert(sqrt(0.0) == 0.0)
+  assert(abs(sqrt2 - sqrt 2.0) <= 0.0000000001)
+  sqrt 0.0 === 0.0
 
 trigTest = scenario do
   let


### PR DESCRIPTION
Changed the exponent function so that `x ** 0` yields 1 regardless of x. This remove the crash when calling `sqrt 0`.

CHANGELOG_BEGIN
[Daml Compiler] Ensure that sqrt(0.0) == 0 and 0 ** 0 == 1
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
