### PR TITLE
Fix typeclass detection in data-dependencies

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -613,6 +613,9 @@ getTypeClassFields :: LF.Type -> Maybe [(LF.FieldName, LF.Type)]
 getTypeClassFields = \case
     LF.TStruct fields | all isTypeClassField fields -> Just fields
     LF.TUnit -> Just []
+        -- Type classes with no fields are translated to TUnit
+        -- since LF structs need to have a non-zero number of
+        -- fields.
     _ -> Nothing
 
 isTypeClassField :: (LF.FieldName, LF.Type) -> Bool

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -229,8 +229,17 @@ emitHsDecl decl = Gen $ modify' (\gs -> gs { gsExtraDecls = decl : gsExtraDecls 
 freshInt :: Gen Int
 freshInt = Gen $ state (\gs -> (gsFreshCounter gs, gs { gsFreshCounter = gsFreshCounter gs + 1 }))
 
-freshTypeName :: Gen (Located RdrName)
-freshTypeName = mkRdrName . ("T__DataDependencies__" <>) . T.pack . show <$> freshInt
+freshTypeName :: Env -> Gen (Located RdrName)
+freshTypeName env = mkRdrName . (prefix <>) . T.pack . show <$> freshInt
+    where
+        prefix :: T.Text
+        prefix = T.concat
+            [ "T__DataDependencies__"
+            , LF.unPackageId (configSelfPkgId (envConfig env))
+            , "__"
+            , T.intercalate "_" (LF.unModuleName (LF.moduleName (envMod env)))
+            , "__"
+            ]
 
 -- | Extract all data definitions from a daml-lf module and generate
 -- a haskell source file from it.
@@ -297,13 +306,7 @@ generateSrcFromLf env = noLoc mod
     classReexportMap :: MS.Map LF.TypeSynName (LF.PackageId, Gen (LIE GhcPs))
     classReexportMap = MS.fromList $ do
         synDef@LF.DefTypeSyn{..} <- NM.toList . LF.moduleSynonyms $ envMod env
-        guard $ case synType of
-            LF.TStruct _ -> True
-            -- Type classes with no fields are translated to TUnit
-            -- since LF structs need to have a non-zero number of
-            -- fields.
-            LF.TUnit -> True
-            _ -> False
+        guard $ isJust (getTypeClassFields synType)
         LF.TypeSynName [name] <- [synName]
         Just (pkgId, depDef) <- [envLookupDepClass synName env]
         guard (safeToReexport env synDef depDef)
@@ -320,10 +323,7 @@ generateSrcFromLf env = noLoc mod
     classDecls :: [Gen (LHsDecl GhcPs)]
     classDecls = do
         defTypeSyn@LF.DefTypeSyn{..} <- NM.toList . LF.moduleSynonyms $ envMod env
-        fields <- case synType of
-            LF.TStruct fields -> [fields]
-            LF.TUnit -> [[]]
-            _ -> []
+        Just fields <- [getTypeClassFields synType]
         LF.TypeSynName [name] <- [synName]
         guard (synName `MS.notMember` classReexportMap)
         guard (shouldExposeDefTypeSyn defTypeSyn)
@@ -395,10 +395,7 @@ generateSrcFromLf env = noLoc mod
     synonymDecls :: [Gen (LHsDecl GhcPs)]
     synonymDecls = do
         defTypeSyn@LF.DefTypeSyn{..} <- NM.toList . LF.moduleSynonyms $ envMod env
-        guard $ case synType of
-            LF.TStruct _ -> False
-            LF.TUnit -> False
-            _ -> True
+        Nothing <- [getTypeClassFields synType]
         LF.TypeSynName [name] <- [synName]
         guard (shouldExposeDefTypeSyn defTypeSyn)
         let occName = mkOccName tcName (T.unpack name)
@@ -612,6 +609,19 @@ generateSrcFromLf env = noLoc mod
         , modRefModule /= LF.ModuleName ["CurrentSdk", "GHC", "Prim"]
         ]
 
+getTypeClassFields :: LF.Type -> Maybe [(LF.FieldName, LF.Type)]
+getTypeClassFields = \case
+    LF.TStruct fields | all isTypeClassField fields -> Just fields
+    LF.TUnit -> Just []
+    _ -> Nothing
+
+isTypeClassField :: (LF.FieldName, LF.Type) -> Bool
+isTypeClassField = \case
+    (fieldName, LF.TUnit LF.:-> _) ->
+        isSuperClassField fieldName || isJust (getClassMethodName fieldName)
+    _ ->
+        False
+
 mkConRdr :: Env -> Module -> OccName -> RdrName
 mkConRdr env thisModule
  | envQualifyThisModule env = mkOrig thisModule
@@ -760,7 +770,7 @@ convType env reexported =
             HsTyVar noExt NotPromoted $ mkRdrName $ LF.unTypeVarName tyVarName
 
         ty1 LF.:-> ty2 -> do
-            ty1' <- convType env reexported ty1
+            ty1' <- convTypeLiftingConstraintTuples ty1
             ty2' <- convType env reexported ty2
             pure $ if isConstraint ty1
                 then HsQualTy noExt (noLoc [noLoc ty1']) (noLoc ty2')
@@ -803,29 +813,11 @@ convType env reexported =
             binder <- convTyVarBinder env forallBinder
             body <- convType env reexported forallBody
             pure . HsParTy noExt . noLoc $ HsForAllTy noExt [binder] (noLoc body)
+
         ty@(LF.TStruct fls)
             | isConstraint ty -> do
-                -- A constraint tuple. We need to lift it up to a type synonym,
-                -- otherwise GHC will treat it as a regular constraint.
-                -- See issue https://github.com/digital-asset/daml/issues/9663
-                let freeVars = map LF.unTypeVarName . Set.toList $ LF.freeVars ty
-                fieldTys <- mapM (convType env reexported . snd) fls
-                tupleTyName <- freshTypeName
-                emitHsDecl . noLoc . TyClD noExt $ SynDecl
-                    { tcdSExt = noExt
-                    , tcdLName = tupleTyName
-                    , tcdTyVars = HsQTvs noExt $ map mkUserTyVar freeVars
-                    , tcdFixity = Prefix
-                    , tcdRhs = noLoc $ HsTupleTy noExt HsConstraintTuple (map noLoc fieldTys)
-                    }
-                pure $ foldl'
-                    (\ accum freeVar ->
-                        HsParTy noExt
-                        . noLoc . HsAppTy noExt (noLoc accum)
-                        . noLoc . HsTyVar noExt NotPromoted
-                        $ mkRdrName freeVar )
-                    (HsTyVar noExt NotPromoted tupleTyName)
-                    freeVars
+                fieldTys <- mapM (convTypeLiftingConstraintTuples . snd) fls
+                pure $ HsTupleTy noExt HsConstraintTuple (map noLoc fieldTys)
 
             | otherwise ->
                 error ("Unexpected: Bare LF struct type that does not represent constraint tuple in data-dependencies. " <> show ty)
@@ -833,6 +825,35 @@ convType env reexported =
         LF.TNat n -> pure $
             HsTyLit noExt (HsNumTy NoSourceText (LF.fromTypeLevelNat n))
   where
+    convTypeLiftingConstraintTuples :: LF.Type -> Gen (HsType GhcPs)
+    convTypeLiftingConstraintTuples = \case
+        ty@(LF.TStruct fls) | isConstraint ty -> do
+            -- A constraint tuple. We need to lift it up to a type synonym
+            -- when it occurs in a function domain, otherwise GHC will
+            -- expand it out as a regular constraint.
+            -- See issue https://github.com/digital-asset/daml/issues/9663
+            let freeVars = map LF.unTypeVarName . Set.toList $ LF.freeVars ty
+            fieldTys <- mapM (convTypeLiftingConstraintTuples . snd) fls
+            tupleTyName <- freshTypeName env
+            emitHsDecl . noLoc . TyClD noExt $ SynDecl
+                { tcdSExt = noExt
+                , tcdLName = tupleTyName
+                , tcdTyVars = HsQTvs noExt $ map mkUserTyVar freeVars
+                , tcdFixity = Prefix
+                , tcdRhs = noLoc $ HsTupleTy noExt HsConstraintTuple (map noLoc fieldTys)
+                }
+            pure $ foldl'
+                (\ accum freeVar ->
+                    HsParTy noExt
+                    . noLoc . HsAppTy noExt (noLoc accum)
+                    . noLoc . HsTyVar noExt NotPromoted
+                    $ mkRdrName freeVar )
+                (HsTyVar noExt NotPromoted tupleTyName)
+                freeVars
+
+        ty ->
+            convType env reexported ty
+
     mkTuple :: Int -> Gen (HsType GhcPs)
     mkTuple i =
         pure $ HsTyVar noExt NotPromoted $

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -579,6 +579,10 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
               , "type BigConstraint a b c = (Show a, Show b, Show c, Additive c)"
               , "bigConstraintFn : BigConstraint a b c => a -> b -> c -> c -> Text"
               , "bigConstraintFn x y z w = show x <> show y <> show (z + w)"
+              -- nested constraint tuples
+              , "type NestedConstraintTuple a b c d = (BigConstraint a b c, Show d)"
+              , "nestedConstraintTupleFn : NestedConstraintTuple a b c d => a -> b -> c -> d -> Text"
+              , "nestedConstraintTupleFn x y z w = show x <> show y <> show z <> show z"
               ]
           writeFileUTF8 (proja </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion
@@ -598,7 +602,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
           createDirectoryIfMissing True (projb </> "src")
           writeFileUTF8 (projb </> "src" </> "B.daml") $ unlines
               [ "module B where"
-              , "import A ( Foo (foo), Bar (..), usingFoo, Q (..), usingEq, RR(RR), P(P), AnyWrapper(..), FunT(..), OptionalT(..), ActionTrans(..), usesHasField, usesHasFieldEmpty, constraintTupleFn, bigConstraintFn )"
+              , "import A"
               , "import DA.Assert"
               , "import DA.Record"
               , ""
@@ -653,6 +657,17 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
               , "useConstraintTupleFn x = constraintTupleFn x"
               , "useBigConstraintFn : Text"
               , "useBigConstraintFn = bigConstraintFn True \"Hello\" 10 20"
+              -- regression test for issue: https://github.com/digital-asset/daml/issues/9689
+              -- Using constraint synonym defined in data-dependency
+              , "newBigConstraintFn : BigConstraint a b c => a -> b -> c -> Text"
+              , "newBigConstraintFn x y z = show x <> show y <> show z"
+              , "useNewBigConstraintFn : Text"
+              , "useNewBigConstraintFn = newBigConstraintFn 10 \"Hello\" 20"
+              -- Using nested constraint tuple
+              , "useNestedConstraintTupleFn : Text"
+              , "useNestedConstraintTupleFn = nestedConstraintTupleFn 10 20 30 40"
+              , "nestedConstraintTupleFn2 : NestedConstraintTuple a b c d => a -> b -> c -> d -> Text"
+              , "nestedConstraintTupleFn2 x y z w = show x <> show y <> show z <> show z"
               ]
           writeFileUTF8 (projb </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -582,7 +582,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
               -- nested constraint tuples
               , "type NestedConstraintTuple a b c d = (BigConstraint a b c, Show d)"
               , "nestedConstraintTupleFn : NestedConstraintTuple a b c d => a -> b -> c -> d -> Text"
-              , "nestedConstraintTupleFn x y z w = show x <> show y <> show z <> show z"
+              , "nestedConstraintTupleFn x y z w = show x <> show y <> show z <> show w"
               ]
           writeFileUTF8 (proja </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion
@@ -667,7 +667,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
               , "useNestedConstraintTupleFn : Text"
               , "useNestedConstraintTupleFn = nestedConstraintTupleFn 10 20 30 40"
               , "nestedConstraintTupleFn2 : NestedConstraintTuple a b c d => a -> b -> c -> d -> Text"
-              , "nestedConstraintTupleFn2 x y z w = show x <> show y <> show z <> show z"
+              , "nestedConstraintTupleFn2 x y z w = show x <> show y <> show z <> show w"
               ]
           writeFileUTF8 (projb </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion


### PR DESCRIPTION
Fixes #9689 which was actually caused by misinterpreting a constraint
synonym as an empty typeclass.

This PR fixes and deduplicates the logic for detecting typeclass
definitions in data-dependencies. It also tries to avoid lifting
constraint tuples unnecessarily (since constraint synonym
definitions are already lifted). And for any constraint tuples
that are lifted, it picks a more unique name.

The PR adds a regression test, and a test for nested constraint tuples.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
