### PR TITLE
Collect build-event-stream

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -55,10 +55,20 @@ bazel shutdown
 # It isn’t clear where exactly those errors are coming from.
 bazel fetch @nodejs_dev_env//...
 
-bazel build `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/build_execution_windows.log //...
+bazel build //... `
+  `-`-profile build-profile.json `
+  `-`-experimental_profile_include_target_label `
+  `-`-build_event_json_file build-events.json `
+  `-`-build_event_publish_all_actions `
+  `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/build_execution_windows.log
 
 bazel shutdown
 
 if ($env:SKIP_TESTS -ceq "False") {
-    bazel test `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/test_execution_windows.log //...
+    bazel test //... `
+      `-`-profile test-profile.json `
+      `-`-experimental_profile_include_target_label `
+      `-`-build_event_json_file test-events.json `
+      `-`-build_event_publish_all_actions `
+      `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/test_execution_windows.log
 }

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,12 @@ fi
 rm -rf compiler/daml-extension/node_modules
 
 # Bazel test only builds targets that are dependencies of a test suite so do a full build first.
-bazel build //... --build_tag_filters "$tag_filter"
+bazel build //... \
+  --build_tag_filters "$tag_filter" \
+  --profile build-profile.json \
+  --experimental_profile_include_target_label \
+  --build_event_json_file build-events.json \
+  --build_event_publish_all_actions
 
 # Set up a shared PostgreSQL instance.
 export POSTGRESQL_ROOT_DIR="${TMPDIR:-/tmp}/daml/postgresql"
@@ -71,6 +76,10 @@ bazel test //... \
   --test_env "POSTGRESQL_PORT=${POSTGRESQL_PORT}" \
   --test_env "POSTGRESQL_USERNAME=${POSTGRESQL_USERNAME}" \
   --test_env "POSTGRESQL_PASSWORD=${POSTGRESQL_PASSWORD}" \
+  --profile test-profile.json \
+  --experimental_profile_include_target_label \
+  --build_event_json_file test-events.json \
+  --build_event_publish_all_actions \
   --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
 
 # Make sure that Bazel query works.

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -65,11 +65,23 @@ jobs:
   dependsOn:
     - da_ghc_lib
     - check_for_release
+    - git_sha
   variables:
-    release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
-    release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
-    trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
-    is_release: $[ dependencies.check_for_release.outputs['out.is_release'] ]
+    - name: release_sha
+      value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
+    - name: release_tag
+      value: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
+    - name: trigger_sha
+      value: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
+    - name: is_release
+      value: $[ dependencies.check_for_release.outputs['out.is_release'] ]
+    - name: git_branch_sha
+      value: $[ dependencies.git_sha.outputs['out.branch'] ]
+    - name: git_main_sha
+      value: $[ dependencies.git_sha.outputs['out.main'] ]
+    - name: git_fork_point_sha
+      value: $[ dependencies.git_sha.outputs['out.fork_point'] ]
+    - template: job-variables.yml
   timeoutInMinutes: 360
   pool:
     name: 'ubuntu_20_04'
@@ -88,6 +100,7 @@ jobs:
         release_tag: $(release_tag)
         name: 'linux'
         is_release: variables.is_release
+    - template: upload-bazel-metrics.yml
     - bash: |
         set -euo pipefail
         eval "$(./dev-env/bin/dade-assist)"
@@ -114,11 +127,23 @@ jobs:
   dependsOn:
     - da_ghc_lib
     - check_for_release
+    - git_sha
   variables:
-    release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
-    release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
-    trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
-    is_release: $[ eq(dependencies.check_for_release.outputs['out.is_release'], 'true') ]
+    - name: release_sha
+      value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
+    - name: release_tag
+      value: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
+    - name: trigger_sha
+      value: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
+    - name: is_release
+      value: $[ eq(dependencies.check_for_release.outputs['out.is_release'], 'true') ]
+    - name: git_branch_sha
+      value: $[ dependencies.git_sha.outputs['out.branch'] ]
+    - name: git_main_sha
+      value: $[ dependencies.git_sha.outputs['out.main'] ]
+    - name: git_fork_point_sha
+      value: $[ dependencies.git_sha.outputs['out.fork_point'] ]
+    - template: job-variables.yml
   timeoutInMinutes: 360
   pool:
     name: 'ubuntu_20_04'
@@ -138,6 +163,7 @@ jobs:
         name: 'linux-scala-2.12'
         is_release: variables.is_release
         scala_version: "2.12.13"
+    - template: upload-bazel-metrics.yml
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'
@@ -147,15 +173,27 @@ jobs:
   dependsOn:
     - da_ghc_lib
     - check_for_release
+    - git_sha
   timeoutInMinutes: 360
   pool:
     name: macOS-pool
     demands: assignment -equals default
   variables:
-    release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
-    release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
-    trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
-    is_release: $[ dependencies.check_for_release.outputs['out.is_release'] ]
+    - name: release_sha
+      value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
+    - name: release_tag
+      value: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
+    - name: trigger_sha
+      value: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
+    - name: is_release
+      value: $[ dependencies.check_for_release.outputs['out.is_release'] ]
+    - name: git_branch_sha
+      value: $[ dependencies.git_sha.outputs['out.branch'] ]
+    - name: git_main_sha
+      value: $[ dependencies.git_sha.outputs['out.main'] ]
+    - name: git_fork_point_sha
+      value: $[ dependencies.git_sha.outputs['out.fork_point'] ]
+    - template: job-variables.yml
   steps:
     - template: report-start.yml
     - template: clear-shared-segments-macos.yml
@@ -171,6 +209,7 @@ jobs:
         release_tag: $(release_tag)
         name: macos
         is_release: variables.is_release
+    - template: upload-bazel-metrics.yml
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'
@@ -185,13 +224,26 @@ jobs:
     - da_ghc_lib
     - check_for_release
     - patch_bazel_windows
+    - git_sha
   variables:
-    release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
-    release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
-    trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
-    is_release: $[ dependencies.check_for_release.outputs['out.is_release'] ]
-    skip_tests: $[ and(eq(variables.is_release, 'true'),
+    - name: release_sha
+      value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
+    - name: release_tag
+      value: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
+    - name: trigger_sha
+      value: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
+    - name: is_release
+      value: $[ dependencies.check_for_release.outputs['out.is_release'] ]
+    - name: skip_tests
+      value: $[ and(eq(variables.is_release, 'true'),
                        eq(variables['Build.SourceBranchName'], 'main')) ]
+    - name: git_branch_sha
+      value: $[ dependencies.git_sha.outputs['out.branch'] ]
+    - name: git_main_sha
+      value: $[ dependencies.git_sha.outputs['out.main'] ]
+    - name: git_fork_point_sha
+      value: $[ dependencies.git_sha.outputs['out.fork_point'] ]
+    - template: job-variables.yml
   timeoutInMinutes: 360
   pool:
     name: 'windows-pool'
@@ -215,6 +267,7 @@ jobs:
         # and then splice that in via a template parameter.
         skip_tests: $(skip_tests)
         is_release: variables.is_release
+    - template: upload-bazel-metrics.yml
     - task: PublishBuildArtifacts@1
       condition: succeededOrFailed()
       inputs:

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -75,12 +75,6 @@ jobs:
       value: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
     - name: is_release
       value: $[ dependencies.check_for_release.outputs['out.is_release'] ]
-    - name: git_branch_sha
-      value: $[ dependencies.git_sha.outputs['out.branch'] ]
-    - name: git_main_sha
-      value: $[ dependencies.git_sha.outputs['out.main'] ]
-    - name: git_fork_point_sha
-      value: $[ dependencies.git_sha.outputs['out.fork_point'] ]
     - template: job-variables.yml
   timeoutInMinutes: 360
   pool:
@@ -137,12 +131,6 @@ jobs:
       value: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
     - name: is_release
       value: $[ eq(dependencies.check_for_release.outputs['out.is_release'], 'true') ]
-    - name: git_branch_sha
-      value: $[ dependencies.git_sha.outputs['out.branch'] ]
-    - name: git_main_sha
-      value: $[ dependencies.git_sha.outputs['out.main'] ]
-    - name: git_fork_point_sha
-      value: $[ dependencies.git_sha.outputs['out.fork_point'] ]
     - template: job-variables.yml
   timeoutInMinutes: 360
   pool:
@@ -187,12 +175,6 @@ jobs:
       value: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
     - name: is_release
       value: $[ dependencies.check_for_release.outputs['out.is_release'] ]
-    - name: git_branch_sha
-      value: $[ dependencies.git_sha.outputs['out.branch'] ]
-    - name: git_main_sha
-      value: $[ dependencies.git_sha.outputs['out.main'] ]
-    - name: git_fork_point_sha
-      value: $[ dependencies.git_sha.outputs['out.fork_point'] ]
     - template: job-variables.yml
   steps:
     - template: report-start.yml
@@ -237,12 +219,6 @@ jobs:
     - name: skip_tests
       value: $[ and(eq(variables.is_release, 'true'),
                        eq(variables['Build.SourceBranchName'], 'main')) ]
-    - name: git_branch_sha
-      value: $[ dependencies.git_sha.outputs['out.branch'] ]
-    - name: git_main_sha
-      value: $[ dependencies.git_sha.outputs['out.main'] ]
-    - name: git_fork_point_sha
-      value: $[ dependencies.git_sha.outputs['out.fork_point'] ]
     - template: job-variables.yml
   timeoutInMinutes: 360
   pool:

--- a/ci/job-variables.yml
+++ b/ci/job-variables.yml
@@ -6,3 +6,9 @@ variables:
     value: $[ format('{0:yyyy}-{0:MM}-{0:dd}T{0:HH}:{0:mm}:{0:ss}.{0:fffffff}', pipeline.startTime) ]
   - name: pipeline_id
     value: $(pipeline_timestamp)-$(System.JobDisplayName)-$(System.JobId)-$(System.JobAttempt)
+  - name: git_branch_sha
+    value: $[ dependencies.git_sha.outputs['out.branch'] ]
+  - name: git_main_sha
+    value: $[ dependencies.git_sha.outputs['out.main'] ]
+  - name: git_fork_point_sha
+    value: $[ dependencies.git_sha.outputs['out.fork_point'] ]

--- a/ci/job-variables.yml
+++ b/ci/job-variables.yml
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+variables:
+  - name: pipeline_timestamp
+    value: $[ format('{0:yyyy}-{0:MM}-{0:dd}T{0:HH}:{0:mm}:{0:ss}.{0:fffffff}', pipeline.startTime) ]
+  - name: pipeline_id
+    value: $(pipeline_timestamp)-$(System.JobDisplayName)-$(System.JobId)-$(System.JobAttempt)

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -1,0 +1,58 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+steps:
+  - template: bash-lib.yml
+    parameters:
+      var_name: bash_lib
+  - bash: |
+      set -euo pipefail
+      if [[ $(Agent.OS) = Windows* ]]; then
+        export PATH="$PATH:$(cygpath "$(powershell "./dev-env/windows/bin/dadew.ps1 enable >\$2; dadew where")/scoop/shims")"
+      else
+        eval "$(dev-env/bin/dade assist)"
+      fi
+      source $(bash_lib)
+      jq -nc >job-md.json '{
+        timestamp: "$(pipeline_timestamp)",
+        id: "$(pipeline_id)",
+        agent_id: "$(Agent.Id)",
+        agent_job_name: "$(Agent.JobName)",
+        agent_machine_name: "$(Agent.MachineName)",
+        agent_name: "$(Agent.Name)",
+        agent_os: "$(Agent.OS)",
+        agent_os_architecture: "$(Agent.OSArchitecture)",
+        build_build_id: "$(Build.BuildId)",
+        build_build_number: "$(Build.BuildNumber)",
+        build_definition_name: "$(Build.DefinitionName)",
+        build_source_branch: "$(Build.SourceBranch)",
+        build_source_branch_name: "$(Build.SourceBranchName)",
+        build_source_version: "$(Build.SourceVersion)",
+        system_job_attempt: "$(System.JobAttempt)",
+        system_job_display_name: "$(System.JobDisplayName)",
+        system_job_id: "$(System.JobId)",
+        system_job_name: "$(System.JobName)",
+        system_pullRequest_pullRequestId: "'"${SYSTEM_PULLREQUEST_PULLREQUESTID:-}"'",
+        system_pullRequest_pullRequestNumber: "'"${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-}"'",
+        system_pullRequest_mergedAt: "'"${SYSTEM_PULLREQUEST_MERGEDAT:-}"'",
+        system_pullRequest_sourceBranch: "'"${SYSTEM_PULLREQUEST_SOURCEBRANCH:-}"'",
+        system_pullRequest_targetBranch: "'"${SYSTEM_PULLREQUEST_TARGETBRANCH:-}"'",
+        system_pullRequest_sourceRepositoryUri: "'"${SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI:-}"'",
+        system_pullRequest_sourceCommitId: "'"${SYSTEM_PULLREQUEST_SOURCECOMMITID:-}"'",
+        git_branch_sha: "$(git_branch_sha)",
+        git_main_sha: "$(git_main_sha)",
+        git_fork_point: "$(git_fork_point_sha)",
+        git_current_branch: "'"$(git branch --show-current)"'",
+        git_current_commit: "'"$(git rev-parse HEAD)"'",
+        git_current_tree: "'"$(git rev-parse HEAD:./)"'",
+      }'
+      jq <job-md.json .
+      gcs "$GCRED" cp "job-md.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/job-md.json"
+      [[ -f "build-profile.json" ]] && gcs "$GCRED" cp "build-profile.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/build-profile.json" || echo "build-profile.json not found"
+      [[ -f "build-events.json" ]] && gcs "$GCRED" cp "build-events.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/build-events.json" || echo "build-events.json not found"
+      [[ -f "test-profile.json" ]] && gcs "$GCRED" cp "test-profile.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/test-profile.json" || echo "test-profile.json not found"
+      [[ -f "test-events.json" ]] && gcs "$GCRED" cp "test-events.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/test-events.json" || echo "test-events.json not found"
+    condition: succeededOrFailed()
+    displayName: 'Upload Bazel metrics'
+    env:
+      GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)


### PR DESCRIPTION
Collect Bazel metrics and copy the data to a GCS bucket.

- Collects Bazel metrics and build metadata:
  - [build event stream](https://docs.bazel.build/versions/main/build-event-protocol.html) as JSON dump from the `bazel build` and `bazel test` steps in `build.sh` and `build.ps1`
  - [JSON profile](https://docs.bazel.build/versions/main/skylark/performance.html#performance-profiling) from the `bazel build` and `bazel test` steps in `build.sh` and `build.ps1`
  - Metadata about the current job
- Uploads this data to the GCS bucket `gs://daml-data/bazel-metrics` under a directory of the form `TIMESTAMP-JOBNAME-JOBID-JOBATTEMPT` 
- Installs `jq` in Windows dev-env

The uploaded data ranges between 20M to 50M in size per CI Job.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
