### PR TITLE
Only resolve template id once

### DIFF
--- a/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
+++ b/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
@@ -90,7 +90,6 @@ final class FailureTests
   }
 
   "Command submission timeouts" in withHttpService { (uri, encoder, _, client) =>
-    import encoder.implicits._
     import json.JsonProtocol._
     for {
       p <- allocateParty(client, "Alice")
@@ -103,7 +102,9 @@ final class FailureTests
       _ = status shouldBe StatusCodes.OK
       // Client -> Server connection
       _ = proxy.toxics().timeout("timeout", ToxicDirection.UPSTREAM, 0)
-      body <- FutureUtil.toFuture(SprayJson.encode1(accountCreateCommand(p, "24"))): Future[JsValue]
+      body <- FutureUtil.toFuture(
+        encoder.encodeCreateCommand(accountCreateCommand(p, "24"))
+      ): Future[JsValue]
       (status, output) <- postJsonStringRequestEncoded(
         uri.withPath(Uri.Path("/v1/create")),
         body.compactPrint,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -20,7 +20,7 @@ import com.daml.lf
 import com.daml.http.ContractsService.SearchResult
 import com.daml.http.EndpointsCompanion._
 import com.daml.scalautil.Statement.discard
-import com.daml.http.domain.{JwtPayload, JwtWritePayload}
+import com.daml.http.domain.{JwtPayload, JwtWritePayload, TemplateId}
 import com.daml.http.json._
 import com.daml.http.util.Collections.toNonEmptySet
 import com.daml.http.util.FutureUtil.{either, eitherT}
@@ -126,7 +126,7 @@ class Endpoints(
 
       cmd <- either(
         decoder.decodeCreateCommand(reqBody).liftErr(InvalidUserInput)
-      ): ET[domain.CreateCommand[ApiRecord]]
+      ): ET[domain.CreateCommand[ApiRecord, TemplateId.RequiredPkg]]
 
       ac <- eitherT(
         handleFutureEitherFailure(commandService.create(jwt, jwtPayload, cmd))
@@ -174,7 +174,7 @@ class Endpoints(
 
       cmd <- either(
         decoder.decodeCreateAndExerciseCommand(reqBody).liftErr(InvalidUserInput)
-      ): ET[domain.CreateAndExerciseCommand[ApiRecord, ApiValue]]
+      ): ET[domain.CreateAndExerciseCommand[ApiRecord, ApiValue, TemplateId.RequiredPkg]]
 
       resp <- eitherT(
         handleFutureEitherFailure(commandService.createAndExercise(jwt, jwtPayload, cmd))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -126,7 +126,6 @@ object HttpService {
       _ = schedulePackageReload(packageService, packageReloadInterval)
 
       commandService = new CommandService(
-        packageService.resolveTemplateId,
         LedgerClientJwt.submitAndWaitForTransaction(client),
         LedgerClientJwt.submitAndWaitForTransactionTree(client),
       )

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/DomainJsonEncoder.scala
@@ -33,6 +33,37 @@ class DomainJsonEncoder(
 
     } yield y
 
+  def encodeCreateCommand(
+      cmd: domain.CreateCommand[lav1.value.Record, domain.TemplateId.OptionalPkg]
+  )(implicit
+      ev: JsonWriter[domain.CreateCommand[JsValue, domain.TemplateId.OptionalPkg]]
+  ): JsonError \/ JsValue =
+    for {
+      x <- cmd.traversePayload(
+        apiRecordToJsObject(_)
+      ): JsonError \/ domain.CreateCommand[JsValue, domain.TemplateId.OptionalPkg]
+      y <- SprayJson.encode(x).liftErr(JsonError)
+
+    } yield y
+
+  def encodeCreateAndExerciseCommand(
+      cmd: domain.CreateAndExerciseCommand[
+        lav1.value.Record,
+        lav1.value.Value,
+        domain.TemplateId.OptionalPkg,
+      ]
+  )(implicit
+      ev: JsonWriter[
+        domain.CreateAndExerciseCommand[JsValue, JsValue, domain.TemplateId.OptionalPkg]
+      ]
+  ): JsonError \/ JsValue =
+    for {
+      payload <- apiRecordToJsObject(cmd.payload): JsonError \/ JsValue
+      argument <- apiValueToJsValue(cmd.argument)
+      y <- SprayJson.encode(cmd.copy(payload = payload, argument = argument)).liftErr(JsonError)
+
+    } yield y
+
   object implicits {
     implicit val ApiValueJsonWriter: JsonWriter[lav1.value.Value] = (obj: lav1.value.Value) =>
       apiValueToJsValue(obj).valueOr(e => spray.json.serializationError(e.shows))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -271,8 +271,9 @@ object JsonProtocol extends DefaultJsonProtocol with ExtraFormats {
     domain.CommandMeta
   )
 
-  implicit val CreateCommandFormat: RootJsonFormat[domain.CreateCommand[JsValue]] = jsonFormat3(
-    domain.CreateCommand[JsValue]
+  implicit val CreateCommandFormat
+      : RootJsonFormat[domain.CreateCommand[JsValue, domain.TemplateId.OptionalPkg]] = jsonFormat3(
+    domain.CreateCommand[JsValue, domain.TemplateId.OptionalPkg]
   )
 
   implicit val ExerciseCommandFormat
@@ -310,9 +311,10 @@ object JsonProtocol extends DefaultJsonProtocol with ExtraFormats {
       }
     }
 
-  implicit val CreateAndExerciseCommandFormat
-      : RootJsonFormat[domain.CreateAndExerciseCommand[JsValue, JsValue]] =
-    jsonFormat5(domain.CreateAndExerciseCommand[JsValue, JsValue])
+  implicit val CreateAndExerciseCommandFormat: RootJsonFormat[
+    domain.CreateAndExerciseCommand[JsValue, JsValue, domain.TemplateId.OptionalPkg]
+  ] =
+    jsonFormat5(domain.CreateAndExerciseCommand[JsValue, JsValue, domain.TemplateId.OptionalPkg])
 
   implicit val ExerciseResponseFormat: RootJsonFormat[domain.ExerciseResponse[JsValue]] =
     jsonFormat2(domain.ExerciseResponse[JsValue])


### PR DESCRIPTION
While looking at errors produced during command submissions I got
confused by the fact that we resolve the template id in the command
service. Turns out there is no reason for doing that, our types are
just not precise enough. This PR fixes that by making sure that we
differentiate between commands where the template id has been resolved
and those where it hasn’t.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
