### PR TITLE
Uniform configuration of the command service across all ledgers

### DIFF
--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
@@ -58,7 +58,6 @@ trait MultiParticipantFixture
     indexerConfig = ParticipantIndexerConfig(
       allowExistingSchema = false
     ),
-    maxCommandsInFlight = None,
   )
   private val participantId2 = v1.ParticipantId.assertFromString("participant2")
   private val participant2 = ParticipantConfig(
@@ -72,7 +71,6 @@ trait MultiParticipantFixture
     indexerConfig = ParticipantIndexerConfig(
       allowExistingSchema = false
     ),
-    maxCommandsInFlight = None,
   )
   override protected lazy val suiteResource = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)

--- a/ledger/participant-state/kvutils/app/BUILD.bazel
+++ b/ledger/participant-state/kvutils/app/BUILD.bazel
@@ -71,6 +71,7 @@ da_scala_test_suite(
         "//daml-lf/data",
         "//ledger/ledger-api-common",
         "//ledger/ledger-api-health",
+        "//ledger/participant-integration-api",
         "//ledger/participant-state",
         "//ledger/participant-state/kvutils",
         "//libs-scala/postgresql-testing",

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -26,6 +26,7 @@ final case class Config[Extra](
     mode: Mode,
     ledgerId: String,
     archiveFiles: Seq[Path],
+    commandConfig: CommandConfiguration,
     tlsConfig: Option[TlsConfiguration],
     participants: Seq[ParticipantConfig],
     maxInboundMessageSize: Int,
@@ -36,7 +37,6 @@ final case class Config[Extra](
     seeding: Seeding,
     metricsReporter: Option[MetricsReporter],
     metricsReportingInterval: Duration,
-    trackerRetentionPeriod: FiniteDuration,
     engineMode: EngineMode,
     enableAppendOnlySchema: Boolean, // TODO append-only: remove after removing support for the current (mutating) schema
     enableMutableContractStateCache: Boolean,
@@ -48,8 +48,6 @@ final case class Config[Extra](
 
 object Config {
   val DefaultPort: Port = Port(6865)
-  val DefaultTrackerRetentionPeriod: FiniteDuration =
-    CommandConfiguration.DefaultTrackerRetentionPeriod
 
   val DefaultMaxInboundMessageSize: Int = 64 * 1024 * 1024
 
@@ -58,6 +56,7 @@ object Config {
       mode = Mode.Run,
       ledgerId = UUID.randomUUID().toString,
       archiveFiles = Vector.empty,
+      commandConfig = CommandConfiguration.default,
       tlsConfig = None,
       participants = Vector.empty,
       maxInboundMessageSize = DefaultMaxInboundMessageSize,
@@ -68,7 +67,6 @@ object Config {
       seeding = Seeding.Strong,
       metricsReporter = None,
       metricsReportingInterval = Duration.ofSeconds(10),
-      trackerRetentionPeriod = DefaultTrackerRetentionPeriod,
       engineMode = EngineMode.Stable,
       enableAppendOnlySchema = false,
       enableMutableContractStateCache = false,
@@ -151,7 +149,6 @@ object Config {
               "server-jdbc-url, " +
               "api-server-connection-pool-size" +
               "api-server-connection-timeout" +
-              "max-commands-in-flight, " +
               "management-service-timeout, " +
               "run-mode, " +
               "shard-name, " +
@@ -242,8 +239,6 @@ object Config {
               .map(_.toBoolean)
               .getOrElse(ParticipantIndexerConfig.DefaultEnableCompression)
 
-            val maxCommandsInFlight =
-              kv.get("max-commands-in-flight").map(_.toInt)
             val managementServiceTimeout = kv
               .get("management-service-timeout")
               .map(Duration.parse)
@@ -281,7 +276,6 @@ object Config {
               ),
               apiServerDatabaseConnectionPoolSize = apiServerConnectionPoolSize,
               apiServerDatabaseConnectionTimeout = apiServerConnectionTimeout,
-              maxCommandsInFlight = maxCommandsInFlight,
               managementServiceTimeout = managementServiceTimeout,
               maxContractStateCacheSize = maxContractStateCacheSize,
               maxContractKeyStateCacheSize = maxContractKeyStateCacheSize,
@@ -333,13 +327,40 @@ object Config {
             config.withTlsConfig(c => c.copy(clientAuth = clientAuth))
           )
 
+        opt[Int]("max-commands-in-flight")
+          .optional()
+          .action((value, config) =>
+            config.copy(commandConfig = config.commandConfig.copy(maxCommandsInFlight = value))
+          )
+          .text(
+            "Maximum number of submitted commands waiting for completion for each party (only applied when using the CommandService). Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 256."
+          )
+
+        opt[Int]("max-parallel-submissions")
+          .optional()
+          .action((value, config) =>
+            config.copy(commandConfig = config.commandConfig.copy(maxParallelSubmissions = value))
+          )
+          .text(
+            "Maximum number of successfully interpreted commands waiting to be sequenced (applied only when running sandbox-classic). The threshold is shared across all parties. Overflowing it will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512."
+          )
+
+        opt[Int]("input-buffer-size")
+          .optional()
+          .action((value, config) =>
+            config.copy(commandConfig = config.commandConfig.copy(inputBufferSize = value))
+          )
+          .text(
+            "The maximum number of commands waiting to be submitted for each party. Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512."
+          )
+
         opt[Duration]("tracker-retention-period")
           .optional()
           .action((value, config) =>
-            config.copy(trackerRetentionPeriod = FiniteDuration(value.getSeconds, TimeUnit.SECONDS))
+            config.copy(commandConfig = config.commandConfig.copy(retentionPeriod = FiniteDuration(value.getSeconds, TimeUnit.SECONDS)))
           )
           .text(
-            s"How long will the command service keep an active command tracker for a given party. A longer period cuts down on the tracker instantiation cost for a party that seldom acts. A shorter period causes a quick removal of unused trackers. Default is $DefaultTrackerRetentionPeriod."
+            s"How long will the command service keep an active command tracker for a given party. A longer period cuts down on the tracker instantiation cost for a party that seldom acts. A shorter period causes a quick removal of unused trackers. Default is ${CommandConfiguration.DefaultTrackerRetentionPeriod}."
           )
 
         opt[Int]("max-inbound-message-size")

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -357,7 +357,10 @@ object Config {
         opt[Duration]("tracker-retention-period")
           .optional()
           .action((value, config) =>
-            config.copy(commandConfig = config.commandConfig.copy(retentionPeriod = FiniteDuration(value.getSeconds, TimeUnit.SECONDS)))
+            config.copy(commandConfig =
+              config.commandConfig
+                .copy(retentionPeriod = FiniteDuration(value.getSeconds, TimeUnit.SECONDS))
+            )
           )
           .text(
             s"How long will the command service keep an active command tracker for a given party. A longer period cuts down on the tracker instantiation cost for a party that seldom acts. A shorter period causes a quick removal of unused trackers. Default is ${CommandConfiguration.DefaultTrackerRetentionPeriod}."

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -14,7 +14,6 @@ import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.apiserver.{ApiServerConfig, TimeServiceBackend}
 import com.daml.platform.configuration.{
-  CommandConfiguration,
   LedgerConfiguration,
   PartyConfiguration,
 }
@@ -82,19 +81,6 @@ trait ConfigProvider[ExtraConfig] {
       maxContractKeyStateCacheSize = participantConfig.maxContractKeyStateCacheSize,
       enableMutableContractStateCache = config.enableMutableContractStateCache,
     )
-
-  def commandConfig(
-      participantConfig: ParticipantConfig,
-      config: Config[ExtraConfig],
-  ): CommandConfiguration = {
-    val defaultMaxCommandsInFlight = CommandConfiguration.default.maxCommandsInFlight
-
-    CommandConfiguration.default.copy(
-      maxCommandsInFlight =
-        participantConfig.maxCommandsInFlight.getOrElse(defaultMaxCommandsInFlight),
-      retentionPeriod = config.trackerRetentionPeriod,
-    )
-  }
 
   def partyConfig(config: Config[ExtraConfig]): PartyConfiguration =
     PartyConfiguration.default

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -13,10 +13,7 @@ import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.apiserver.{ApiServerConfig, TimeServiceBackend}
-import com.daml.platform.configuration.{
-  LedgerConfiguration,
-  PartyConfiguration,
-}
+import com.daml.platform.configuration.{LedgerConfiguration, PartyConfiguration}
 import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode}
 import io.grpc.ServerInterceptor
 import scopt.OptionParser

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
@@ -20,7 +20,6 @@ final case class ParticipantConfig(
     port: Port,
     portFile: Option[Path],
     serverJdbcUrl: String,
-    maxCommandsInFlight: Option[Int],
     managementServiceTimeout: Duration = ParticipantConfig.DefaultManagementServiceTimeout,
     indexerConfig: ParticipantIndexerConfig,
     apiServerDatabaseConnectionPoolSize: Int =

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -156,7 +156,7 @@ final class Runner[T <: ReadWriteService, Extra](
                 new StandaloneApiServer(
                   ledgerId = config.ledgerId,
                   config = factory.apiServerConfig(participantConfig, config),
-                  commandConfig = factory.commandConfig(participantConfig, config),
+                  commandConfig = config.commandConfig,
                   partyConfig = factory.partyConfig(config),
                   ledgerConfig = factory.ledgerConfig(config),
                   optWriteService = Some(writeService),

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
@@ -117,7 +117,7 @@ final class ConfigSpec
       )
         .getOrElse(parsingFailure())
 
-    config.trackerRetentionPeriod should be(expectedPeriod)
+    config.commandConfig.retentionPeriod should be(expectedPeriod)
   }
 
   it should "set the client-auth parameter when provided" in {


### PR DESCRIPTION
Modify command line options of the ledgers based on the kvutils/app library:
- Remove max-commands-in-flight sub-option from the participant group.
- Add command service configuration options in line with sandbox and daml-on-sql: max-commands-in-flight, max-parallel-submissions, input-buffer-size
