### PR TITLE
Remove flyway warning when using the append-only schema

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
@@ -91,7 +91,6 @@ private[platform] object FlywayMigrations {
         .configure()
         .locations(
           "classpath:com/daml/platform/db/migration/" + dbType.name,
-          "classpath:com/daml/platform/db/migration/" + dbType.name + "-appendonly",
           "classpath:db/migration/" + dbType.name,
           "classpath:db/migration/" + dbType.name + "-appendonly",
         )


### PR DESCRIPTION
The removed line was only useful for java migrations, which we don't have in the append-only schema. Flyway then complained about having a location for migration scripts with nothing at that location.

changelog_begin
changelog_end
