### PR TITLE
Switch to our own nodes for releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,8 @@ jobs:
                  eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
                  eq(variables['Build.SourceBranchName'], 'main'))
   pool:
-    vmImage: "Ubuntu-16.04"
+    name: 'ubuntu_20_04'
+    demands: assignment -equals default
   variables:
     release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
     release_tag: $[ dependencies.check_for_release.outputs['out.release_tag'] ]


### PR DESCRIPTION
Ubuntu 16.04 nodes are about to go away and there dosen’t seem to be a
compelling reason to use the hosted nodes here anyway.

This is obviously hard/impossible to test without a release but I did
do some basic sanity checks: The release build seems to rely on the
following tools (+ things like rm which are clearly there)
1. git
2. gpg
3. sha256sum
4. gcloud
5. curl

All of those are installed on our own nodes. If this doesn’t work we
could also run (parts of) this in dev-env but for now this should do
the job.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
