### PR TITLE
Add per-query offsets to HTTP-JSON API

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1301,7 +1301,7 @@ Moreover, an ``offset`` may be specified alongside the query itself::
         {"templateIds": ["Iou:Iou"], "offset": "5609"}
     ]
 
-Per-query ``offset``s take precedence over the ``offset`` message. The
+Per-query ``offset`` s take precedence over the ``offset`` message. The
 ``offset`` message is still applied to queries that don't specify one.
 
 The output is a series of JSON documents, each ``payload`` formatted
@@ -1345,8 +1345,24 @@ off an initial "loading" indicator::
         "offset": "2"
     }
 
-Events in the following "live" data may include ``events`` that precede
-this ``offset`` if an earlier per-query ``offset`` was specified.
+.. note::
+
+    Events in the following "live" data may include ``events`` that precede
+    this ``offset`` if an earlier per-query ``offset`` was specified.
+
+    This has been done with the intent of allowing to use per-query ``offset`` s to
+    efficiently use a single connection to multiplex various requests. To give an
+    example of how this would work, let's say that there are two contract templates,
+    ``A`` and ``B`` . Your application first queries for ``A`` s without specifying
+    an offset. Then some client-side interaction requires the application to do the
+    same for ``B`` s. The application can save the latest observed offset for the
+    previous query, which let's say is ``42``, and issue a new request that queries
+    for all ``B`` s without specifying an offset and all ``A`` s from ``42``. While
+    this happens on the client, a few more ``A`` s and ``B`` s are created and the
+    new request is issued once the latest offset is ``47``. The response to this
+    will contain a message with all active ``B`` s, followed by the message reporting
+    the offset ``47``, followed by a stream of live updates that contains new ``A`` s
+    starting from ``42`` and new ``B`` s starting from ``47`` .
 
 To keep the stream alive, you'll occasionally see messages like this,
 which can be safely ignored if you do not need to capture the last seen ledger offset::

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1284,12 +1284,25 @@ different sets of template IDs::
         {"templateIds": ["Iou:Iou"]}
     ]
 
+Queries have two ways to specify an offset.
+
 An optional ``offset`` returned by a prior query (see output examples
 below) may be specified *before* the above, as a separate body.  It must
 be a string, and if specified, the stream will begin immediately *after*
 the response body that included that offset::
 
     {"offset": "5609"}
+
+Moreover, a ``queryOffset`` may be specified alongside the query itself::
+
+    [
+        {"templateIds": ["Iou:Iou"], "query": {"amount": {"%lte": 50}}},
+        {"templateIds": ["Iou:Iou"], "query": {"amount": {"%gt": 50}}},
+        {"templateIds": ["Iou:Iou"], "queryOffset": "5609"}
+    ]
+
+If both an ``offset`` and a ``queryOffset`` are specified, ``queryOffset``
+takes precedence.
 
 The output is a series of JSON documents, each ``payload`` formatted
 according to :doc:`lf-value-specification`::
@@ -1331,6 +1344,9 @@ off an initial "loading" indicator::
         "events": [],
         "offset": "2"
     }
+
+Events in the following "live" data may include ``events`` that precede
+this ``offset`` if an earlier ``queryOffset`` was specified.
 
 To keep the stream alive, you'll occasionally see messages like this,
 which can be safely ignored if you do not need to capture the last seen ledger offset::

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1293,16 +1293,16 @@ the response body that included that offset::
 
     {"offset": "5609"}
 
-Moreover, a ``queryOffset`` may be specified alongside the query itself::
+Moreover, an ``offset`` may be specified alongside the query itself::
 
     [
         {"templateIds": ["Iou:Iou"], "query": {"amount": {"%lte": 50}}},
         {"templateIds": ["Iou:Iou"], "query": {"amount": {"%gt": 50}}},
-        {"templateIds": ["Iou:Iou"], "queryOffset": "5609"}
+        {"templateIds": ["Iou:Iou"], "offset": "5609"}
     ]
 
-If both an ``offset`` and a ``queryOffset`` are specified, ``queryOffset``
-takes precedence.
+Per-query ``offset``s take precedence over the ``offset`` message. The
+``offset`` message is still applied to queries that don't specify one.
 
 The output is a series of JSON documents, each ``payload`` formatted
 according to :doc:`lf-value-specification`::
@@ -1346,7 +1346,7 @@ off an initial "loading" indicator::
     }
 
 Events in the following "live" data may include ``events`` that precede
-this ``offset`` if an earlier ``queryOffset`` was specified.
+this ``offset`` if an earlier per-query ``offset`` was specified.
 
 To keep the stream alive, you'll occasionally see messages like this,
 which can be safely ignored if you do not need to capture the last seen ledger offset::

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -234,12 +234,14 @@ alias(
     da_scala_library(
         name = "integration-tests-lib-{}".format(edition),
         srcs = glob(["src/itlib/scala/**/*.scala"]),
+        plugins = [silencer_plugin],
         resources = glob(["src/itlib/resources/**/*"]),
         scala_deps = [
             "@maven//:com_chuusai_shapeless",
             "@maven//:com_typesafe_akka_akka_http_core",
             "@maven//:com_typesafe_scala_logging_scala_logging",
             "@maven//:io_spray_spray_json",
+            "@maven//:org_scala_lang_modules_scala_collection_compat",
             "@maven//:org_scalacheck_scalacheck",
             "@maven//:org_scalactic_scalactic",
             "@maven//:org_scalatest_scalatest",
@@ -303,6 +305,7 @@ alias(
         ],
         plugins = [
             "@maven//:org_typelevel_kind_projector_{}".format(scala_version_suffix),
+            silencer_plugin,
         ],
         resources = glob(["src/it/resources/**/*"]),
         scala_deps = [
@@ -311,6 +314,7 @@ alias(
             "@maven//:com_typesafe_akka_akka_http_core",
             "@maven//:com_typesafe_scala_logging_scala_logging",
             "@maven//:io_spray_spray_json",
+            "@maven//:org_scala_lang_modules_scala_collection_compat",
             "@maven//:org_scalacheck_scalacheck",
             "@maven//:org_scalatest_scalatest",
             "@maven//:org_scalaz_scalaz_core",
@@ -373,12 +377,14 @@ alias(
         flaky = True,
         plugins = [
             "@maven//:org_typelevel_kind_projector_{}".format(scala_version_suffix),
+            silencer_plugin,
         ],
         resources = glob(["src/failure/resources/**/*"]),
         scala_deps = [
             "@maven//:com_typesafe_akka_akka_http_core",
             "@maven//:com_typesafe_scala_logging_scala_logging",
             "@maven//:io_spray_spray_json",
+            "@maven//:org_scala_lang_modules_scala_collection_compat",
             "@maven//:org_scalatest_scalatest",
             "@maven//:org_scalaz_scalaz_core",
         ],

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -377,14 +377,12 @@ alias(
         flaky = True,
         plugins = [
             "@maven//:org_typelevel_kind_projector_{}".format(scala_version_suffix),
-            silencer_plugin,
         ],
         resources = glob(["src/failure/resources/**/*"]),
         scala_deps = [
             "@maven//:com_typesafe_akka_akka_http_core",
             "@maven//:com_typesafe_scala_logging_scala_logging",
             "@maven//:io_spray_spray_json",
-            "@maven//:org_scala_lang_modules_scala_collection_compat",
             "@maven//:org_scalatest_scalatest",
             "@maven//:org_scalaz_scalaz_core",
         ],

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -747,6 +747,28 @@ abstract class AbstractWebsocketServiceIntegrationTest
     go(createCount)
   }
 
+  private[this] def readAcsAt(until: domain.Offset): Consume.FCC[JsValue, Map[String, JsValue]] = {
+    val dslSyntax = Consume.syntax[JsValue]
+    import dslSyntax._
+    def go(
+        acs: Map[String, JsValue],
+        latest: Option[domain.Offset],
+    ): Consume.FCC[JsValue, Map[String, JsValue]] =
+      if (latest.fold(false)(domain.Offset.ordering.greaterThanOrEqual(_, until))) {
+        point(acs)
+      } else {
+        for {
+          ContractDelta(creates, deletes, offset) <- readOne
+          _ = println("#" * 80)
+          _ = println(offset)
+          _ = println(creates)
+          _ = println(deletes)
+          next <- go(acs ++ creates -- deletes.map(_.contractId.unwrap), offset)
+        } yield next
+      }
+    go(acs = Map.empty, latest = None)
+  }
+
   "fetch should should return an error if empty list of (templateId, key) pairs is passed" in withHttpService {
     (uri, _, _) =>
       singleClientFetchStream(jwt, uri, "[]")
@@ -914,6 +936,111 @@ abstract class AbstractWebsocketServiceIntegrationTest
       } yield inside(result) { case ShouldHaveEnded(_, 2, _) =>
         succeed
       }
+  }
+
+  "Per-query offsets should override offsets issued on a per-query basis" in withHttpService {
+    (uri, _, _) =>
+      val dslSyntax = Consume.syntax[JsValue]
+      import dslSyntax._
+      import spray.json._
+      def createIouCommand(currency: String): String =
+        s"""{
+           |  "templateId": "Iou:Iou",
+           |  "payload": {
+           |    "observers": [],
+           |    "issuer": "Alice",
+           |    "amount": "999.99",
+           |    "currency": "$currency",
+           |    "owner": "Alice"
+           |  }
+           |}""".stripMargin
+      def createIou(currency: String): Future[Assertion] =
+        HttpServiceTestFixture
+          .postJsonStringRequest(
+            uri.withPath(Uri.Path("/v1/create")),
+            createIouCommand(currency),
+            headersWithAuth,
+          )
+          .map(_._1 shouldBe a[StatusCodes.Success])
+      def contractsQuery(currency: String): String =
+        s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}}"""
+      def contractsQueryWithOffset(offset: domain.Offset, currency: String): String =
+        s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}, "query_offset":"${offset.unwrap}"}"""
+      def contracts(currency: String, offset: Option[domain.Offset]): String =
+        offset.fold(contractsQuery(currency))(contractsQueryWithOffset(_, currency))
+      def ledgerEnd(expectedContracts: Int): Future[domain.Offset] = {
+        def go(killSwitch: UniqueKillSwitch): Sink[JsValue, Future[domain.Offset]] =
+          Consume.interpret(
+            for {
+              _ <- readAcsN(expectedContracts)
+              ContractDelta(Vector(), _, Some(offset)) <- readOne
+              _ = killSwitch.shutdown()
+              _ <- drain
+            } yield offset
+          )
+        val (killSwitch, source) =
+          singleClientQueryStream(jwt, uri, """{"templateIds":["Iou:Iou"]}""")
+            .viaMat(KillSwitches.single)(Keep.right)
+            .preMaterialize()
+        source.via(parseResp).runWith(go(killSwitch))
+      }
+      def test(
+          end: domain.Offset,
+          eurFrom: Option[domain.Offset],
+          usdFrom: Option[domain.Offset],
+          expected: Map[String, Int],
+      ): Future[Assertion] = {
+        def go(killSwitch: UniqueKillSwitch): Sink[JsValue, Future[Assertion]] = {
+          Consume.interpret(
+            for {
+              contracts <- readAcsAt(end)
+              result = contracts
+                .map(_._2.asJsObject.fields("currency").asInstanceOf[JsString].value)
+                .groupBy(identity)
+                .view
+                .mapValues(_.size)
+                .toMap
+              ContractDelta(Vector(), _, _) <- readOne
+              _ = println("*" * 80)
+              _ = println(contracts)
+              _ = println(result)
+              _ = println("*" * 80)
+              _ = killSwitch.shutdown()
+              _ <- drain
+            } yield result shouldEqual expected
+          )
+        }
+        val (killSwitch, source) =
+          singleClientQueryStream(
+            jwt,
+            uri,
+            Seq(contracts("EUR", eurFrom), contracts("USD", usdFrom)).mkString("[", ",", "]"),
+          )
+            .viaMat(KillSwitches.single)(Keep.right)
+            .preMaterialize()
+        source.via(parseResp).runWith(go(killSwitch))
+      }
+
+      for {
+        _ <- createIou("EUR")
+        _ <- createIou("USD")
+        offset1 <- ledgerEnd(2)
+        _ <- createIou("EUR")
+        _ <- createIou("USD")
+        offset2 <- ledgerEnd(4)
+        _ <- createIou("EUR")
+        _ <- createIou("USD")
+        offset3 <- ledgerEnd(6)
+        result <- test(
+          end = offset3,
+          eurFrom = Some(offset1),
+          usdFrom = Some(offset2),
+          expected = Map(
+            "EUR" -> 2,
+            "USD" -> 1,
+          ),
+        )
+      } yield result
   }
 
   "ContractKeyStreamRequest" - {

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -1088,7 +1088,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
         usdFrom = Some(offset2),
         expected = Map(
           "EUR" -> 3,
-          "USD" -> 1,
+          "USD" -> 3, // FIXME This should be 1
         ),
       )
     } yield succeed

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -1032,6 +1032,28 @@ abstract class AbstractWebsocketServiceIntegrationTest
       _ <- createIou("USD")
       offset3 <- ledgerEnd(6)
       _ <- test(
+        clue = "No offsets",
+        end = offset3,
+        queryFrom = None,
+        eurFrom = None,
+        usdFrom = None,
+        expected = Map(
+          "EUR" -> 3,
+          "USD" -> 3,
+        ),
+      )
+      _ <- test(
+        clue = "Offset message only",
+        end = offset3,
+        queryFrom = Some(offset2),
+        eurFrom = None,
+        usdFrom = None,
+        expected = Map(
+          "EUR" -> 1,
+          "USD" -> 1,
+        ),
+      )
+      _ <- test(
         clue = "Per-query offsets only",
         end = offset3,
         queryFrom = None,

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -752,11 +752,13 @@ abstract class AbstractWebsocketServiceIntegrationTest
   ): Consume.FCC[JsValue, Map[String, JsValue]] = {
     val dslSyntax = Consume.syntax[JsValue]
     import dslSyntax._
+    import domain.Offset.ordering
+    import scalaz.syntax.order._
     def go(
         acs: Map[String, JsValue],
         latest: Option[domain.Offset],
     ): Consume.FCC[JsValue, Map[String, JsValue]] =
-      if (latest.fold(false)(domain.Offset.ordering.greaterThanOrEqual(_, until))) {
+      if (latest.fold(false)(_ >= until)) {
         point(acs)
       } else {
         for {

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -1088,7 +1088,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
         usdFrom = Some(offset2),
         expected = Map(
           "EUR" -> 3,
-          "USD" -> 3, // FIXME This should be 1
+          "USD" -> 1,
         ),
       )
     } yield succeed

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -997,9 +997,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
               result = contracts
                 .map(_._2.asJsObject.fields("currency").asInstanceOf[JsString].value)
                 .groupBy(identity)
-                .view
-                .mapValues(_.size)
-                .toMap
+                .map { case (k, vs) => k -> vs.size }
               ContractDelta(Vector(), _, _) <- readOne
               _ = println("*" * 80)
               _ = println(contracts)

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -1041,17 +1041,16 @@ abstract class AbstractWebsocketServiceIntegrationTest
             "USD" -> 1,
           ),
         )
-        // FIXME Fails, for some reason the ACS is fetched but it shouldn't, investigating
-//        _ <- test(
-//          end = offset3,
-//          queryFrom = Some(offset2),
-//          eurFrom = None,
-//          usdFrom = Some(offset1),
-//          expected = Map(
-//            "EUR" -> 1,
-//            "USD" -> 2,
-//          ),
-//        )
+        _ <- test(
+          end = offset3,
+          queryFrom = Some(offset2),
+          eurFrom = None,
+          usdFrom = Some(offset1),
+          expected = Map(
+            "EUR" -> 1,
+            "USD" -> 2,
+          ),
+        )
         // FIXME Fails, the ACS blocks must be filtered
 //        _ <- test(
 //          end = offset3,

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -977,7 +977,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
         Consume.interpret(
           for {
             _ <- readAcsN(expectedContracts)
-            ContractDelta(Vector(), _, Some(offset)) <- readOne
+            ContractDelta(Vector(), Vector(), Some(offset)) <- readOne
             _ = killSwitch.shutdown()
             _ <- drain
           } yield offset

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -969,7 +969,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
     def contractsQuery(currency: String): String =
       s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}}"""
     def contractsQueryWithOffset(offset: domain.Offset, currency: String): String =
-      s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}, "queryOffset":"${offset.unwrap}"}"""
+      s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}, "offset":"${offset.unwrap}"}"""
     def contracts(currency: String, offset: Option[domain.Offset]): String =
       offset.fold(contractsQuery(currency))(contractsQueryWithOffset(_, currency))
     def acsEnd(expectedContracts: Int): Future[domain.Offset] = {

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -997,12 +997,11 @@ abstract class AbstractWebsocketServiceIntegrationTest
         usdFrom: Option[domain.Offset],
         expected: Map[String, Int],
     ): Future[Assertion] = {
-      val fakeLiveMarker: JsValue = JsObject("events" -> JsArray.empty, "offset" -> JsNumber(0))
       def go(killSwitch: UniqueKillSwitch): Sink[JsValue, Future[Assertion]] = {
         Consume.interpret(
           for {
             acs <- readAcsN(expectedAcsSize)
-            _ <- if (acs.nonEmpty) readOne else point(fakeLiveMarker)
+            _ <- if (acs.nonEmpty) readOne else point(())
             contracts <- updateAcs(Map.from(acs), expectedEvents)
             result = contracts
               .map(_._2.asJsObject.fields("currency").asInstanceOf[JsString].value)

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -1017,8 +1017,6 @@ abstract class AbstractWebsocketServiceIntegrationTest
               .map(_._2.asJsObject.fields("currency").asInstanceOf[JsString].value)
               .groupBy(identity)
               .map { case (k, vs) => k -> vs.size }
-            // If this fails with a match error, there is something else lingering in the stream
-            ContractDelta(Vector(), _, _) <- readOne
             _ = killSwitch.shutdown()
           } yield withClue(clue) { result shouldEqual expected }
         )

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -765,9 +765,9 @@ abstract class AbstractWebsocketServiceIntegrationTest
         point(acs)
       } else {
         for {
-          ContractDelta(creates, deletes, _) <- readOne
-          newAcs = acs ++ creates -- deletes.map(_.contractId.unwrap)
-          events = creates.size - deletes.size
+          ContractDelta(creates, archives, _) <- readOne
+          newAcs = acs ++ creates -- archives.map(_.contractId.unwrap)
+          events = creates.size + archives.size
           next <- go(newAcs, missingEvents - events)
         } yield next
       }

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -752,7 +752,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
     * The caller is in charge of reading the live marker if that is expected
     */
   private[this] def updateAcs(
-      acs: Vector[(String, JsValue)],
+      acs: Map[String, JsValue],
       events: Int,
   ): Consume.FCC[JsValue, Map[String, JsValue]] = {
     val dslSyntax = Consume.syntax[JsValue]
@@ -771,7 +771,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
           next <- go(newAcs, missingEvents - events)
         } yield next
       }
-    go(Map.from(acs), events)
+    go(acs, events)
   }
 
   "fetch should should return an error if empty list of (templateId, key) pairs is passed" in withHttpService {
@@ -1003,7 +1003,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
           for {
             acs <- readAcsN(expectedAcsSize)
             _ <- if (acs.nonEmpty) readOne else point(fakeLiveMarker)
-            contracts <- updateAcs(acs, expectedEvents)
+            contracts <- updateAcs(Map.from(acs), expectedEvents)
             result = contracts
               .map(_._2.asJsObject.fields("currency").asInstanceOf[JsString].value)
               .groupBy(identity)

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -23,6 +23,7 @@ import scalaz.{-\/, \/-}
 import spray.json.{JsArray, JsNull, JsNumber, JsObject, JsString, JsValue}
 
 import scala.annotation.nowarn
+import scala.collection.compat._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -969,7 +969,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
     def contractsQuery(currency: String): String =
       s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}}"""
     def contractsQueryWithOffset(offset: domain.Offset, currency: String): String =
-      s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}, "query_offset":"${offset.unwrap}"}"""
+      s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}, "queryOffset":"${offset.unwrap}"}"""
     def contracts(currency: String, offset: Option[domain.Offset]): String =
       offset.fold(contractsQuery(currency))(contractsQueryWithOffset(_, currency))
     def acsEnd(expectedContracts: Int): Future[domain.Offset] = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -427,7 +427,7 @@ private[http] object ContractsFetch {
   /** Split a series of ACS responses into two channels: one with contracts, the
     * other with a single result, the last offset.
     */
-  private[this] def acsAndBoundary
+  private[http] def acsAndBoundary
       : Graph[FanOutShape2[lav1.active_contracts_service.GetActiveContractsResponse, Seq[
         lav1.event.CreatedEvent,
       ], BeginBookmark[String]], NotUsed] =

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -427,7 +427,7 @@ private[http] object ContractsFetch {
   /** Split a series of ACS responses into two channels: one with contracts, the
     * other with a single result, the last offset.
     */
-  private[http] def acsAndBoundary
+  private[this] def acsAndBoundary
       : Graph[FanOutShape2[lav1.active_contracts_service.GetActiveContractsResponse, Seq[
         lav1.event.CreatedEvent,
       ], BeginBookmark[String]], NotUsed] =

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -450,7 +450,6 @@ class ContractsService(
         fob.foreach(a => logger.debug(s"contracts fetch completed at: ${a.toString}"))
         NotUsed
       }
-      .wireTap(step => println(s"^^^ TXS $step"))
   }
 
   private def apiAcToLfAc(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -414,7 +414,6 @@ class ContractsService(
         if (activeContracts.nonEmpty) Acs(activeContracts.toVector)
         else LiveBegin(AbsoluteBookmark(domain.Offset(offset)))
       }
-      .wireTap(step => println(s",,, ACS $step"))
   }
 
   /** An ACS ++ transaction stream of `templateIds`, starting at `startOffset`

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -445,11 +445,10 @@ class ContractsService(
           .viaMat(transactionsFollowingBoundary(transactionsSince).divertToHead)(Keep.right),
       source.viaMat(acsFollowingAndBoundary(transactionsSince).divertToHead)(Keep.right),
     )
-    contractsAndBoundary
-      .mapMaterializedValue { fob =>
-        fob.foreach(a => logger.debug(s"contracts fetch completed at: ${a.toString}"))
-        NotUsed
-      }
+    contractsAndBoundary mapMaterializedValue { fob =>
+      fob.foreach(a => logger.debug(s"contracts fetch completed at: ${a.toString}"))
+      NotUsed
+    }
   }
 
   private def apiAcToLfAc(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -16,12 +16,13 @@ import com.daml.http.json.JsonProtocol.LfValueDatabaseCodec.{
   apiValueToJsValue => toDbCompatibleJson
 }
 import com.daml.http.query.ValuePredicate
-import com.daml.http.util.ApiValueToLfValueConverter
+import util.{AbsoluteBookmark, ApiValueToLfValueConverter, ContractStreamStep, InsertDeleteStep}
+import com.daml.http.util.ContractStreamStep.{Acs, LiveBegin}
 import com.daml.http.util.FutureUtil.toFuture
-import com.daml.http.util.Logging.{InstanceUUID}
-import util.{ContractStreamStep, InsertDeleteStep}
+import com.daml.http.util.Logging.InstanceUUID
 import com.daml.jwt.domain.Jwt
 import com.daml.ledger.api.refinements.{ApiTypes => lar}
+import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.daml.ledger.api.{v1 => api}
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import com.daml.util.ExceptionOps._
@@ -400,6 +401,19 @@ class ContractsService(
     type P = domain.ActiveContract[LfValue] => Boolean
     sealed case class Params(params: Map[String, JsValue]) extends InMemoryQuery
     sealed case class Filter(p: P) extends InMemoryQuery
+  }
+
+  private[http] def liveAcsAsInsertDeleteStepSource(
+      jwt: Jwt,
+      parties: OneAnd[Set, lar.Party],
+      templateIds: List[domain.TemplateId.RequiredPkg],
+  ): Source[ContractStreamStep.LAV1, NotUsed] = {
+    val txnFilter = util.Transactions.transactionFilterFor(parties, templateIds)
+    getActiveContracts(jwt, txnFilter, true).map {
+      case GetActiveContractsResponse(offset, _, activeContracts, _) =>
+        if (activeContracts.nonEmpty) Acs(activeContracts.toVector)
+        else LiveBegin(AbsoluteBookmark(domain.Offset(offset)))
+    }
   }
 
   /** An ACS ++ transaction stream of `templateIds`, starting at `startOffset`

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -679,7 +679,6 @@ class WebSocketService(
         .map(_.mapPos(Q.renderCreatedMetadata).render)
         .prepend(reportUnresolvedTemplateIds(unresolved))
         .map(jsv => \/-(wsMessage(jsv)))
-        .wireTap(msg => println(s"%%%%%% $msg"))
     } else {
       reportUnresolvedTemplateIds(unresolved)
         .map(jsv => \/-(wsMessage(jsv)))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -286,6 +286,7 @@ object WebSocketService {
         )
 
       import scalaz.syntax.tag._
+      import scalaz.syntax.foldable1._
       private implicit val stringOrder = scalaz.Order.fromScalaOrdering[String]
 
       override def startingOffset(
@@ -294,8 +295,7 @@ object WebSocketService {
       ): Option[domain.StartingOffset] =
         request.queries
           .map(_.offset)
-          .minimumBy(_.fold("")(_.unwrap))
-          .get // Safe on NonEmptyList
+          .minimumBy1(_.fold("")(_.unwrap))
           .map(domain.StartingOffset(_))
 
     }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -268,12 +268,7 @@ object WebSocketService {
       override def requestOffset(request: SearchForeverRequest): Option[StartingOffset] =
         request.queries.toList.view
           .map(_.offset)
-          .fold(none[domain.Offset]) {
-            case (Some(o1), Some(o2)) => Some(domain.Offset.ordering.min(o1, o2))
-            case (o1, None) if o1.isDefined => o1
-            case (None, o2) if o2.isDefined => o2
-            case _ => None
-          }
+          .fold(none[domain.Offset])(domain.Offset.min)
           .map(StartingOffset.apply)
 
     }
@@ -521,13 +516,7 @@ class WebSocketService(
 
     val requestOffset = Q.requestOffset(request)
 
-    val startingOffset =
-      (offPrefix, requestOffset) match {
-        case (Some(a), Some(b)) => Some(domain.StartingOffset.ordering.min(a, b))
-        case (a, None) if a.isDefined => a
-        case (None, b) if b.isDefined => b
-        case _ => None
-      }
+    val startingOffset = domain.StartingOffset.min(offPrefix, requestOffset)
 
     if (resolved.nonEmpty) {
       def prefilter: Future[

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -663,6 +663,7 @@ class WebSocketService(
                     throw new IllegalStateException("Transaction in ACS")
                 }
               }, {
+                // This is the case where we made no ACS request because everything had an offset
                 // Get the earliest available offset from where to start from
                 val liveStartingOffset = Q.liveStartingOffset(offPrefix, request)
                 val StreamPredicate(_, _, fn, _) =

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -535,13 +535,13 @@ class WebSocketService(
       jwt: Jwt,
       parties: OneAnd[Set, domain.Party],
       offPrefix: Option[domain.StartingOffset],
-      r: A,
+      rawRequest: A,
   )(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): Source[Error \/ Message, NotUsed] = {
     val Q = implicitly[StreamQuery[A]]
 
-    val request = Q.adjustRequest(offPrefix, r)
+    val request = Q.adjustRequest(offPrefix, rawRequest)
 
     val StreamPredicate(resolved, unresolved, fn, dbQuery) =
       Q.predicate(request, resolveTemplateId, lookupType)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -315,7 +315,7 @@ object WebSocketService {
       import domain.Offset.ordering
       import scalaz.std.option.optionOrder
 
-      // This is called `adjustRequest` already filled in the blank offsets
+      // This is called after `adjustRequest` already filled in the blank offsets
       override def liveStartingOffset(
           prefix: Option[domain.StartingOffset],
           request: SearchForeverRequest,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -179,7 +179,8 @@ object WebSocketService {
     ): A
 
     def startingOffset(
-        request: A
+        prefix: Option[domain.StartingOffset],
+        request: A,
     ): Option[domain.StartingOffset]
 
   }
@@ -288,7 +289,8 @@ object WebSocketService {
       private implicit val stringOrder = scalaz.Order.fromScalaOrdering[String]
 
       override def startingOffset(
-          request: SearchForeverRequest
+          prefix: Option[domain.StartingOffset],
+          request: SearchForeverRequest,
       ): Option[domain.StartingOffset] =
         request.queries
           .map(_.offset)
@@ -392,8 +394,9 @@ object WebSocketService {
     ): NonEmptyList[domain.ContractKeyStreamRequest[Cid, LfV]] = request
 
     override def startingOffset(
-        request: NonEmptyList[domain.ContractKeyStreamRequest[Cid, LfV]]
-    ): Option[domain.StartingOffset] = None
+        prefix: Option[domain.StartingOffset],
+        request: NonEmptyList[domain.ContractKeyStreamRequest[Cid, LfV]],
+    ): Option[domain.StartingOffset] = prefix
 
   }
 
@@ -546,7 +549,7 @@ class WebSocketService(
     val StreamPredicate(resolved, unresolved, fn, dbQuery) =
       Q.predicate(request, resolveTemplateId, lookupType)
 
-    val startingOffset = Q.startingOffset(request)
+    val startingOffset = Q.startingOffset(offPrefix, request)
 
     if (resolved.nonEmpty) {
       def prefilter: Future[

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model.ws.{BinaryMessage, Message, TextMessage}
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.Materializer
 import com.daml.http.EndpointsCompanion._
-import com.daml.http.domain.{JwtPayload, SearchForeverRequest}
+import com.daml.http.domain.{JwtPayload, SearchForeverRequest, StartingOffset}
 import com.daml.http.json.{DomainJsonDecoder, JsonProtocol, SprayJson}
 import JsonProtocol.LfValueDatabaseCodec
 import com.daml.http.LedgerClientJwt.Terminates
@@ -52,7 +52,7 @@ object WebSocketService {
   private final case class StreamPredicate[+Positive](
       resolved: Set[domain.TemplateId.RequiredPkg],
       unresolved: Set[domain.TemplateId.OptionalPkg],
-      fn: domain.ActiveContract[LfV] => Option[Positive],
+      fn: (domain.ActiveContract[LfV], Option[domain.Offset]) => Option[Positive],
       dbQuery: (OneAnd[Set, domain.Party], dbbackend.ContractDao) => ConnectionIO[
         _ <: Vector[(domain.ActiveContract[JsValue], Positive)]
       ],
@@ -172,6 +172,9 @@ object WebSocketService {
     ): StreamPredicate[Positive]
 
     def renderCreatedMetadata(p: Positive): Map[String, JsValue]
+
+    def requestOffset(request: A): Option[domain.StartingOffset]
+
   }
 
   implicit val SearchForeverRequestWithStreamQuery: StreamQueryReader[domain.SearchForeverRequest] =
@@ -199,6 +202,8 @@ object WebSocketService {
         import scalaz.syntax.foldable._
         import util.Collections._
 
+        val indexedOffsets = request.queries.map(_.offset).toVector
+
         val (resolved, unresolved, q) = request.queries.zipWithIndex
           .foldMap { case (gacr, ix) =>
             val (resolved, unresolved) =
@@ -206,10 +211,18 @@ object WebSocketService {
             val q: CompiledQueries = prepareFilters(resolved, gacr.query, lookupType)
             (resolved, unresolved, q transform ((_, p) => NonEmptyList((p, ix))))
           }
-        def fn(a: domain.ActiveContract[LfV]): Option[Positive] =
+        def fn(a: domain.ActiveContract[LfV], o: Option[domain.Offset]): Option[Positive] = {
           q.get(a.templateId).flatMap { preds =>
-            preds.collect(Function unlift { case ((_, p), ix) => p(a.payload) option ix })
+            preds.collect(Function unlift { case ((_, p), ix) =>
+              val matchesPredicate = p(a.payload)
+              val matchesOffset = indexedOffsets(ix).flatMap(q => o.map((_, q))).fold(true) {
+                case (o, q) => domain.Offset.ordering.greaterThan(o, q)
+              }
+              (matchesPredicate && matchesOffset).option(ix)
+            })
           }
+        }
+
         def dbQueriesPlan(implicit
             sjd: dbbackend.SupportedJdbcDriver
         ): (Seq[(domain.TemplateId.RequiredPkg, doobie.Fragment)], Map[Int, Int]) = {
@@ -251,6 +264,18 @@ object WebSocketService {
           import spray.json._, JsonProtocol._
           "matchedQueries" -> p.toJson
         }
+
+      override def requestOffset(request: SearchForeverRequest): Option[StartingOffset] =
+        request.queries.toList.view
+          .map(_.offset)
+          .fold(none[domain.Offset]) {
+            case (Some(o1), Some(o2)) => Some(domain.Offset.ordering.min(o1, o2))
+            case (o1, None) if o1.isDefined => o1
+            case (None, o2) if o2.isDefined => o2
+            case _ => None
+          }
+          .map(StartingOffset.apply)
+
     }
 
   implicit val EnrichedContractKeyWithStreamQuery
@@ -313,7 +338,7 @@ object WebSocketService {
               case None => acc.updated(el._1, HashSet(el._2))
             }
         )
-      val fn: domain.ActiveContract[LfV] => Option[Positive] = { a =>
+      val fn: (domain.ActiveContract[LfV], Option[domain.Offset]) => Option[Positive] = { (a, _) =>
         a.key match {
           case None => None
           case Some(k) => if (q.getOrElse(a.templateId, HashSet()).contains(k)) Some(()) else None
@@ -340,6 +365,11 @@ object WebSocketService {
     }
 
     override def renderCreatedMetadata(p: Unit) = Map.empty
+
+    override def requestOffset(
+        request: NonEmptyList[domain.ContractKeyStreamRequest[Cid, LfV]]
+    ): Option[StartingOffset] = None
+
   }
 
   private[this] def keyEquality(k: LfV)(implicit
@@ -489,6 +519,16 @@ class WebSocketService(
     val StreamPredicate(resolved, unresolved, fn, dbQuery) =
       Q.predicate(request, resolveTemplateId, lookupType)
 
+    val requestOffset = Q.requestOffset(request)
+
+    val startingOffset =
+      (offPrefix, requestOffset) match {
+        case (Some(a), Some(b)) => Some(domain.StartingOffset.ordering.min(a, b))
+        case (a, None) if a.isDefined => a
+        case (None, b) if b.isDefined => b
+        case _ => None
+      }
+
     if (resolved.nonEmpty) {
       def prefilter: Future[
         (
@@ -500,7 +540,7 @@ class WebSocketService(
         )
       ] =
         contractsService.daoAndFetch
-          .filter(_ => offPrefix.isEmpty)
+          .filter(_ => startingOffset.isEmpty)
           .cata(
             { case (dao, fetch) =>
               val tx = for {
@@ -513,7 +553,7 @@ class WebSocketService(
               )
               dao.transact(tx).unsafeToFuture()
             },
-            Future.successful((Source.empty, offPrefix)),
+            Future.successful((Source.empty, startingOffset)),
           )
 
       Source
@@ -613,7 +653,7 @@ class WebSocketService(
     TextMessage(jsVal.compactPrint)
 
   private def convertFilterContracts[Pos](
-      fn: domain.ActiveContract[LfV] => Option[Pos]
+      fn: (domain.ActiveContract[LfV], Option[domain.Offset]) => Option[Pos]
   ): Flow[ContractStreamStep.LAV1, StepAndErrors[Pos, JsValue], NotUsed] =
     Flow
       .fromFunction { step: ContractStreamStep.LAV1 =>
@@ -632,7 +672,7 @@ class WebSocketService(
           errors ++ aerrors,
           dstep mapInserts { inserts: Vector[domain.ActiveContract[LfV]] =>
             inserts.flatMap { ac =>
-              fn(ac).map((ac, _)).toList
+              fn(ac, dstep.bookmark.flatMap(_.toOption)).map((ac, _)).toList
             }
           },
         )

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -220,11 +220,13 @@ object WebSocketService {
             (resolved, unresolved, q transform ((_, p) => NonEmptyList((p, ix))))
           }
         def fn(a: domain.ActiveContract[LfV], o: Option[domain.Offset]): Option[Positive] = {
+          import domain.Offset.ordering
+          import scalaz.syntax.order._
           q.get(a.templateId).flatMap { preds =>
             preds.collect(Function unlift { case ((_, p), ix) =>
               val matchesPredicate = p(a.payload)
               val matchesOffset = indexedOffsets(ix).flatMap(q => o.map((_, q))).fold(true) {
-                case (o, q) => domain.Offset.ordering.greaterThan(o, q)
+                case (o, q) => o > q
               }
               (matchesPredicate && matchesOffset).option(ix)
             })

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -622,7 +622,10 @@ class WebSocketService(
             .cata(
               _.map { acsAndLiveMarker =>
                 acsAndLiveMarker.flatMapConcat {
-                  case acs @ StepAndErrors(_, Acs(_)) => Source.single(acs)
+                  case acs @ StepAndErrors(_, Acs(_)) if acs.nonEmpty =>
+                    Source.single(acs)
+                  case StepAndErrors(_, Acs(_)) =>
+                    Source.empty
                   case liveBegin @ StepAndErrors(_, LiveBegin(offset)) =>
                     // Produce the predicate that is going to be applied to the incoming transaction stream
                     // We need to apply this to the request with all the offsets shifted so that each stream

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -215,7 +215,8 @@ object WebSocketService {
         import scalaz.syntax.foldable._
         import util.Collections._
 
-        val indexedOffsets = request.queries.map(_.offset).toVector
+        val indexedOffsets: Vector[Option[domain.Offset]] =
+          request.queries.map(_.offset).toVector
 
         val (resolved, unresolved, q) = request.queries.zipWithIndex
           .foldMap { case (gacr, ix) =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -575,7 +575,7 @@ class WebSocketService(
               Source.empty
             }
           val liveMarker = liveBegin(bookmark.map(_.toDomain))
-          (acs ++ liveMarker).wireTap(step => println(s"--- DBS $step"))
+          acs ++ liveMarker
         }
         dao.transact(tx).unsafeToFuture()
       },

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -178,11 +178,15 @@ object WebSocketService {
         request: A,
     ): Option[A]
 
+    /** Perform any necessary adjustment to the request based on the prefix
+      */
     def adjustRequest(
         prefix: Option[domain.StartingOffset],
         request: A,
     ): A
 
+    /** Specify the offset from which the live part of the query should start
+      */
     def liveStartingOffset(
         prefix: Option[domain.StartingOffset],
         request: A,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -315,6 +315,7 @@ object WebSocketService {
       import domain.Offset.ordering
       import scalaz.std.option.optionOrder
 
+      // This is called `adjustRequest` already filled in the blank offsets
       override def liveStartingOffset(
           prefix: Option[domain.StartingOffset],
           request: SearchForeverRequest,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -302,7 +302,8 @@ object WebSocketService {
         )
 
       import scalaz.syntax.foldable1._
-      import domain.Offset.orderingOptional
+      import domain.Offset.ordering
+      import scalaz.std.option.optionOrder
 
       override def liveStartingOffset(
           prefix: Option[domain.StartingOffset],

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -128,13 +128,19 @@ object domain {
       ekey: EnrichedContractKey[LfV],
   )
 
-  case class GetActiveContractsRequest(
+  final case class GetActiveContractsRequest(
       templateIds: OneAnd[Set, TemplateId.OptionalPkg],
       query: Map[String, JsValue],
   )
 
+  final case class SearchForeverQuery(
+      templateIds: OneAnd[Set, TemplateId.OptionalPkg],
+      query: Map[String, JsValue],
+      offset: Option[domain.Offset],
+  )
+
   final case class SearchForeverRequest(
-      queries: NonEmptyList[GetActiveContractsRequest]
+      queries: NonEmptyList[SearchForeverQuery]
   )
 
   final case class PartyDetails(identifier: Party, displayName: Option[String], isLocal: Boolean)
@@ -143,7 +149,6 @@ object domain {
 
   final case class CommandMeta(
       commandId: Option[CommandId]
-      // TODO(Leo): add Option[WorkflowId] back
   )
 
   final case class CreateCommand[+LfV, TmplId](
@@ -213,6 +218,11 @@ object domain {
   }
 
   final case class StartingOffset(offset: Offset)
+
+  object StartingOffset {
+    implicit val ordering: Order[StartingOffset] =
+      Order.orderBy[StartingOffset, Offset](_.offset)(Offset.ordering)
+  }
 
   type LedgerIdTag = lar.LedgerIdTag
   type LedgerId = lar.LedgerId

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -187,15 +187,6 @@ object domain {
       PartyDetails(Party(p.party), p.displayName, p.isLocal)
   }
 
-  private[this] def minOption[A](implicit
-      ordering: Order[A]
-  ): (Option[A], Option[A]) => Option[A] = {
-    case (Some(a1), Some(a2)) => Some(ordering.min(a1, a2))
-    case (a1, None) if a1.isDefined => a1
-    case (None, a2) if a2.isDefined => a2
-    case _ => None
-  }
-
   sealed trait OffsetTag
 
   type Offset = String @@ OffsetTag
@@ -224,18 +215,9 @@ object domain {
 
     implicit val semigroup: Semigroup[Offset] = Tag.unsubst(Semigroup[Offset @@ Tags.LastVal])
     implicit val ordering: Order[Offset] = Order.orderBy[Offset, String](Offset.unwrap(_))
-
-    val min: (Option[Offset], Option[Offset]) => Option[Offset] = minOption(ordering)
   }
 
   final case class StartingOffset(offset: Offset)
-
-  object StartingOffset {
-    implicit val ordering: Order[StartingOffset] =
-      Order.orderBy[StartingOffset, Offset](_.offset)(Offset.ordering)
-    val min: (Option[StartingOffset], Option[StartingOffset]) => Option[StartingOffset] =
-      minOption(ordering)
-  }
 
   type LedgerIdTag = lar.LedgerIdTag
   type LedgerId = lar.LedgerId

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -187,6 +187,15 @@ object domain {
       PartyDetails(Party(p.party), p.displayName, p.isLocal)
   }
 
+  private[this] def minOption[A](implicit
+      ordering: Order[A]
+  ): (Option[A], Option[A]) => Option[A] = {
+    case (Some(a1), Some(a2)) => Some(ordering.min(a1, a2))
+    case (a1, None) if a1.isDefined => a1
+    case (None, a2) if a2.isDefined => a2
+    case _ => None
+  }
+
   sealed trait OffsetTag
 
   type Offset = String @@ OffsetTag
@@ -215,6 +224,8 @@ object domain {
 
     implicit val semigroup: Semigroup[Offset] = Tag.unsubst(Semigroup[Offset @@ Tags.LastVal])
     implicit val ordering: Order[Offset] = Order.orderBy[Offset, String](Offset.unwrap(_))
+
+    val min: (Option[Offset], Option[Offset]) => Option[Offset] = minOption(ordering)
   }
 
   final case class StartingOffset(offset: Offset)
@@ -222,6 +233,8 @@ object domain {
   object StartingOffset {
     implicit val ordering: Order[StartingOffset] =
       Order.orderBy[StartingOffset, Offset](_.offset)(Offset.ordering)
+    val min: (Option[StartingOffset], Option[StartingOffset]) => Option[StartingOffset] =
+      minOption(ordering)
   }
 
   type LedgerIdTag = lar.LedgerIdTag

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -215,8 +215,7 @@ object domain {
 
     implicit val semigroup: Semigroup[Offset] = Tag.unsubst(Semigroup[Offset @@ Tags.LastVal])
     implicit val ordering: Order[Offset] = Order.orderBy[Offset, String](Offset.unwrap(_))
-    implicit val orderingOptional: Order[Option[Offset]] =
-      Order.orderBy[Option[Offset], String](_.fold("")(Offset.unwrap))
+
   }
 
   final case class StartingOffset(offset: Offset)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -215,6 +215,8 @@ object domain {
 
     implicit val semigroup: Semigroup[Offset] = Tag.unsubst(Semigroup[Offset @@ Tags.LastVal])
     implicit val ordering: Order[Offset] = Order.orderBy[Offset, String](Offset.unwrap(_))
+    implicit val orderingOptional: Order[Option[Offset]] =
+      Order.orderBy[Option[Offset], String](_.fold("")(Offset.unwrap))
   }
 
   final case class StartingOffset(offset: Offset)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -263,7 +263,9 @@ object JsonProtocol extends DefaultJsonProtocol with ExtraFormats {
         deserializationError(
           s"unsupported query fields $extras; likely should be within 'query' subobject"
         )
-      val extraFields = jsv.asJsObject.fields.view.filterKeys(validExtraFields).toMap
+      val extraFields = jsv.asJsObject.fields.filter { case (fieldName, _) =>
+        validExtraFields(fieldName)
+      }
       val nonEmptyTids = tids.headOption.cata(
         h => OneAnd(h, tids - h),
         deserializationError("search requires at least one item in 'templateIds'"),

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -258,10 +258,10 @@ object JsonProtocol extends DefaultJsonProtocol with ExtraFormats {
     implicit val primitive: JsonReader[BaseRequest] = jsonFormat2(BaseRequest.apply)
     jsv => {
       val BaseRequest(tids, query) = jsv.convertTo[BaseRequest]
-      val extras = jsv.asJsObject.fields.keySet diff validKeys
-      if (extras.nonEmpty)
+      val unsupported = jsv.asJsObject.fields.keySet diff validKeys
+      if (unsupported.nonEmpty)
         deserializationError(
-          s"unsupported query fields $extras; likely should be within 'query' subobject"
+          s"unsupported query fields $unsupported; likely should be within 'query' subobject"
         )
       val extraFields = jsv.asJsObject.fields.filter { case (fieldName, _) =>
         validExtraFields(fieldName)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -280,7 +280,7 @@ object JsonProtocol extends DefaultJsonProtocol with ExtraFormats {
     )
 
   implicit val SearchForeverQueryFormat: RootJsonReader[domain.SearchForeverQuery] = {
-    val OffsetKey = "queryOffset"
+    val OffsetKey = "offset"
     requestJsonReader(validExtraFields = Set(OffsetKey))((tids, query, extra) =>
       domain.SearchForeverQuery(tids, query, extra.get(OffsetKey).map(_.convertTo[domain.Offset]))
     )

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -280,7 +280,7 @@ object JsonProtocol extends DefaultJsonProtocol with ExtraFormats {
     )
 
   implicit val SearchForeverQueryFormat: RootJsonReader[domain.SearchForeverQuery] = {
-    val OffsetKey = "query_offset"
+    val OffsetKey = "queryOffset"
     requestJsonReader(validExtraFields = Set(OffsetKey))((tids, query, extra) =>
       domain.SearchForeverQuery(tids, query, extra.get(OffsetKey).map(_.convertTo[domain.Offset]))
     )


### PR DESCRIPTION
changelog_begin
[HTTP/JSON API] The streaming query endpoint now accepts to override the
offset for each query using the `query_offset` field. You can read more
about it on the documentation.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
