### PR TITLE
Switch Scala version Bazel config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,10 +16,10 @@ build:darwin --repository_cache=.bazel-cache/repo
 fetch:darwin --repository_cache=.bazel-cache/repo
 sync:darwin --repository_cache=.bazel-cache/repo
 
-build:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.5
-fetch:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.5
-query:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.5
-sync:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.5
+build:scala_2_12 --repo_env=DAML_SCALA_VERSION=2.12.13
+fetch:scala_2_12 --repo_env=DAML_SCALA_VERSION=2.12.13
+query:scala_2_12 --repo_env=DAML_SCALA_VERSION=2.12.13
+sync:scala_2_12 --repo_env=DAML_SCALA_VERSION=2.12.13
 
 test:oracle --repo_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -374,9 +374,9 @@ jobs:
         CMP="$(semver compare "$RELEASE_TAG" '1.11.0-snapshot.20210212.6300.0.ad161d7f')"
 
         if [[ $CMP == '1' || "$RELEASE_TAG" == '0.0.0' ]]; then
-            setvar scala_2_13 true
+            setvar scala_2_12 false
         else
-            setvar scala_2_13 false
+            setvar scala_2_12 true
         fi
       name: out
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -374,9 +374,9 @@ jobs:
         CMP="$(semver compare "$RELEASE_TAG" '1.11.0-snapshot.20210212.6300.0.ad161d7f')"
 
         if [[ $CMP == '1' || "$RELEASE_TAG" == '0.0.0' ]]; then
-            setvar scala_2_12 false
+            setvar scala_2_13 true
         else
-            setvar scala_2_12 true
+            setvar scala_2_13 false
         fi
       name: out
 

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -16,10 +16,10 @@ build:darwin --repository_cache=.bazel-cache/repo
 fetch:darwin --repository_cache=.bazel-cache/repo
 sync:darwin --repository_cache=.bazel-cache/repo
 
-build:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.5
-fetch:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.5
-query:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.5
-sync:scala_2_13 --repo_env=DAML_SCALA_VERSION=2.13.5
+build:scala_2_12 --repo_env=DAML_SCALA_VERSION=2.12.13
+fetch:scala_2_12 --repo_env=DAML_SCALA_VERSION=2.12.13
+query:scala_2_12 --repo_env=DAML_SCALA_VERSION=2.12.13
+sync:scala_2_12 --repo_env=DAML_SCALA_VERSION=2.12.13
 
 test:oracle --repo_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
 


### PR DESCRIPTION
changelog_begin
changelog_end

This allows to easily test with Scala 2.12.x locally. The `scala_2_13` Bazel
configuration is no longer needed becase now Scala 2.13.x is the default.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
