### PR TITLE
Fix the notion of transaction equivalence in the ledger model for exceptions.

### DIFF
--- a/docs/source/concepts/ledger-model/ledger-exceptions.rst
+++ b/docs/source/concepts/ledger-model/ledger-exceptions.rst
@@ -144,13 +144,13 @@ More generally, two transactions are equivalent if:
 
 - The transactions have the same "before-after" relation between their actions.
 
-- The transactions have the same set of "rollback roots".
-  A rollback root is an action whose parent is a rollback node.
+- The transactions have the same set of "rollback children".
+  A "rollback child" is an action whose direct parent is a rollback node.
 
 For all three transactions above, the "transaction tree ignoring rollbacks"
 consists only of top-level actions (`act1`, `act2`, and `act3`), the
 "before-after" relation only says that `act2` comes before `act3`,
-and all three actions are rollback roots. Thus all three transactions
+and all three actions are rollback children. Thus all three transactions
 are equivalent.
 
 **Transaction normalization** is the process by which equivalent transactions

--- a/docs/source/concepts/ledger-model/ledger-exceptions.rst
+++ b/docs/source/concepts/ledger-model/ledger-exceptions.rst
@@ -144,13 +144,14 @@ More generally, two transactions are equivalent if:
 
 - The transactions have the same "before-after" relation between their actions.
 
-- The transactions have the same set of rolled back actions. That is, they have
-  the same set of actions directly or indirectly under a rollback node.
+- The transactions have the same set of "rollback roots".
+  A rollback root is an action whose parent is a rollback node.
 
 For all three transactions above, the "transaction tree ignoring rollbacks"
 consists only of top-level actions (`act1`, `act2`, and `act3`), the
 "before-after" relation only says that `act2` comes before `act3`,
-and all actions are rolled back. Thus all three transactions are equivalent.
+and all three actions are rollback roots. Thus all three transactions
+are equivalent.
 
 **Transaction normalization** is the process by which equivalent transactions
 are converted into the same transaction. In the case above, all three


### PR DESCRIPTION
@andreaslochbihler-da found that our normalization rules don't normalize rollbacks across exercises, which our notion of transaction equivalence expects them to. For example, the transactions

```
rollback [ exercise [ rollback [ create ]]]
```

and

```
rollback [ exercise [ create ] ]
```

are considered equivalent under the old definition, but do not normalize to each other.

This PR is one possible solution, where we keep our current normalization rules but change the definition of transaction equivalence. In particular, instead of just requiring that the set of rolled back actions to be the same, we require that the set of "rollback children" be the same, where a "rollback child" is an action that has a rollback node as its direct parent. This prevents normalization across exercises because that would eliminate some rollback children.

The idea here is that the set of "rollback childern" encodes the set of "rolled back actions" relative to each action's subtree, unlike before where we only looked at the set of "rolled back actions" relative to the whole transaction. The set of "rollback children" encodes all that information, but with a simple definition.

A completely different solution is to introduce new normalization rules that work across exercise nodes. Unfortunately these rules would be non-local, and that seems very difficult to do correctly & efficiently.

Follow up to #9816, part of #8020.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
