### PR TITLE
Include rollback nodes in danglingRefGenNode

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -844,6 +844,7 @@ object Transaction {
 
   /** Transaction nodes */
   type Node = Node.GenNode[NodeId, Value.ContractId]
+  type ActionNode = Node.GenActionNode[NodeId, Value.ContractId]
   type LeafNode = Node.LeafOnlyActionNode[Value.ContractId]
 
   /** (Complete) transactions, which are the result of interpreting a


### PR DESCRIPTION
This PR fixes the todo in danglingRefGenNode to include rollback
nodes.

Some tests simply don’t work on rollback nodes so I added
danglingRefGenActionNode. For other tests, we just need to switch how
we generate nodes and versions to be a bit more sensible.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
