### PR TITLE
Introduce metrics in the http-json service.

### DIFF
--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -193,6 +193,7 @@ da_scala_test_suite(
         "//ledger/ledger-api-auth",
         "//ledger/ledger-api-common",
         "//ledger/ledger-resources",
+        "//ledger/metrics",
         "//ledger/participant-integration-api",
         "//ledger/participant-integration-api:participant-integration-api-tests-lib",
         "//ledger/participant-state",
@@ -209,6 +210,7 @@ da_scala_test_suite(
         "//libs-scala/resources-akka",
         "//libs-scala/resources-grpc",
         "@maven//:com_auth0_java_jwt",
+        "@maven//:io_dropwizard_metrics_metrics_core",
     ],
 )
 

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -58,9 +58,13 @@ import scalaz.syntax.traverse._
 import scalaz.{-\/, \/-}
 import spray.json._
 
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, Future}
 import scala.util.control.NonFatal
+
+import com.daml.metrics.Metrics
+import com.codahale.metrics.MetricRegistry
+import com.daml.platform.configuration.MetricsReporter
 
 trait JsonApiFixture
     extends AbstractSandboxFixture
@@ -159,6 +163,8 @@ trait JsonApiFixture
                 override val nonRepudiation = nonrepudiation.Configuration.Cli.Empty
                 override val logLevel = None
                 override val logEncoder = LogEncoder.Plain
+                override val metricsReporter: Option[MetricsReporter] = None
+                override val metricsReportingInterval: FiniteDuration = 10.seconds
               }
               HttpService
                 .start(config)(
@@ -167,6 +173,7 @@ trait JsonApiFixture
                   jsonApiExecutionSequencerFactory,
                   jsonApiActorSystem.dispatcher,
                   lc,
+                  metrics = new Metrics(new MetricRegistry()),
                 )
                 .flatMap({
                   case -\/(e) => Future.failed(new IllegalStateException(e.toString))

--- a/ledger-service/cli-opts/BUILD.bazel
+++ b/ledger-service/cli-opts/BUILD.bazel
@@ -27,6 +27,7 @@ da_scala_library(
     ],
     deps = [
         "//ledger/ledger-api-common",
+        "//ledger/participant-integration-api",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:ch_qos_logback_logback_core",
         "@maven//:io_netty_netty_handler",

--- a/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
+++ b/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.cliopts
+
+import com.daml.platform.configuration.MetricsReporter
+
+import scala.concurrent.duration.FiniteDuration
+
+object Metrics {
+
+  def metricsReporterParse[C](parser: scopt.OptionParser[C])(
+      metricsReporter: Setter[C, Option[MetricsReporter]],
+      metricsReportingInterval: Setter[C, FiniteDuration],
+  ): Unit = {
+    import parser.opt
+
+    opt[MetricsReporter]("metrics-reporter")
+      .action((reporter, config) => metricsReporter(_ => Some(reporter), config))
+      .optional()
+      .text(s"Start a metrics reporter. ${MetricsReporter.cliHint}")
+
+    opt[FiniteDuration]("metrics-reporting-interval")
+      .action((interval, config) => metricsReportingInterval(_ => interval, config))
+      .optional()
+      .text("Set metric reporting interval.")
+    ()
+  }
+}

--- a/ledger-service/http-json-cli/BUILD.bazel
+++ b/ledger-service/http-json-cli/BUILD.bazel
@@ -20,6 +20,7 @@ da_scala_library(
         "//ledger-service/cli-opts",
         "//ledger-service/utils",
         "//ledger/ledger-api-common",
+        "//ledger/participant-integration-api",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:io_netty_netty_handler",
         "@maven//:org_slf4j_slf4j_api",

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
@@ -19,6 +19,7 @@ import scala.util.Try
 
 import ch.qos.logback.classic.{Level => LogLevel}
 import com.daml.cliopts.Logging.LogEncoder
+import com.daml.platform.configuration.MetricsReporter
 
 // The internal transient scopt structure *and* StartSettings; external `start`
 // users should extend StartSettings or DefaultStartSettings themselves
@@ -41,6 +42,8 @@ private[http] final case class Config(
     nonRepudiation: nonrepudiation.Configuration.Cli = nonrepudiation.Configuration.Cli.Empty,
     logLevel: Option[LogLevel] = None, // the default is in logback.xml
     logEncoder: LogEncoder = LogEncoder.Plain,
+    metricsReporter: Option[MetricsReporter] = None,
+    metricsReportingInterval: FiniteDuration = 10 seconds,
 ) extends StartSettings
 
 private[http] object Config {

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/OptionParser.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/OptionParser.scala
@@ -168,5 +168,9 @@ class OptionParser(getEnvVar: String => Option[String], supportedJdbcDriverNames
 
   cliopts.Logging.logLevelParse(this)((f, c) => c.copy(logLevel = f(c.logLevel)))
   cliopts.Logging.logEncoderParse(this)((f, c) => c.copy(logEncoder = f(c.logEncoder)))
+  cliopts.Metrics.metricsReporterParse(this)(
+    (f, c) => c.copy(metricsReporter = f(c.metricsReporter)),
+    (f, c) => c.copy(metricsReportingInterval = f(c.metricsReportingInterval)),
+  )
 
 }

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/StartSettings.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/StartSettings.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import ch.qos.logback.classic.{Level => LogLevel}
 import com.daml.cliopts.Logging.LogEncoder
+import com.daml.platform.configuration.MetricsReporter
 
 // defined separately from Config so
 //  1. it is absolutely lexically apparent what `import startSettings._` means
@@ -33,6 +34,8 @@ trait StartSettings {
   val nonRepudiation: nonrepudiation.Configuration.Cli
   val logLevel: Option[LogLevel]
   val logEncoder: LogEncoder
+  val metricsReporter: Option[MetricsReporter]
+  val metricsReportingInterval: FiniteDuration
 }
 
 object StartSettings {

--- a/ledger-service/http-json-testing/BUILD.bazel
+++ b/ledger-service/http-json-testing/BUILD.bazel
@@ -55,6 +55,7 @@ hj_scalacopts = lf_scalacopts + [
             "//ledger/caching",
             "//ledger/ledger-api-auth",
             "//ledger/ledger-api-common",
+            "//ledger/metrics",
             "//ledger/participant-integration-api",
             "//ledger/participant-state",
             "//ledger/sandbox-classic",
@@ -62,6 +63,7 @@ hj_scalacopts = lf_scalacopts + [
             "//libs-scala/auth-utils",
             "//libs-scala/contextualized-logging",
             "//libs-scala/ports",
+            "@maven//:io_dropwizard_metrics_metrics_core",
         ],
     )
     for edition in [

--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -11,6 +11,7 @@ import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
 import akka.stream.Materializer
+import com.codahale.metrics.MetricRegistry
 import com.daml.api.util.TimestampConversion
 import com.daml.bazeltools.BazelRunfiles.rlocation
 import com.daml.grpc.adapter.ExecutionSequencerFactory
@@ -36,6 +37,7 @@ import com.daml.ledger.client.configuration.{
 }
 import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.daml.logging.LoggingContextOf
+import com.daml.metrics.Metrics
 import com.daml.platform.common.LedgerIdMode
 import com.daml.platform.sandbox
 import com.daml.platform.sandbox.SandboxServer
@@ -77,6 +79,8 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
       ec: ExecutionContext,
   ): Future[A] = {
     implicit val lc: LoggingContextOf[InstanceUUID] = instanceUUIDLogCtx()
+    implicit val metrics: Metrics = new Metrics(new MetricRegistry())
+
     val applicationId = ApplicationId(testName)
 
     val contractDaoF: Future[Option[ContractDao]] = jdbcConfig.map(c => initializeDb(c)).sequence

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -65,11 +65,18 @@ hj_scalacopts = lf_scalacopts + [
             "//ledger-service/utils",
             "//ledger/ledger-api-auth",
             "//ledger/ledger-api-common",
+            "//ledger/metrics",
             "//libs-scala/auth-utils",
+            "//libs-scala/concurrent",
             "//libs-scala/contextualized-logging",
             "//libs-scala/doobie-slf4j",
             "//libs-scala/ports",
             "//libs-scala/scala-utils",
+            "@maven//:io_dropwizard_metrics_metrics_core",
+            "//ledger/sandbox-common:sandbox-common-{}".format(edition),
+            "//ledger/ledger-resources",
+            "//ledger/participant-integration-api",
+            "//libs-scala/resources",
         ],
     )
     for edition in [
@@ -140,7 +147,10 @@ json_deps = {
 da_scala_binary(
     name = "http-json-binary",
     main_class = "com.daml.http.Main",
-    resources = [":src/main/resources/logback.xml"],
+    resources = [
+        ":src/main/resources/application.conf",
+        ":src/main/resources/logback.xml",
+    ],
     scala_deps = json_scala_deps,
     scalacopts = hj_scalacopts,
     tags = [

--- a/ledger-service/http-json/src/main/resources/application.conf
+++ b/ledger-service/http-json/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+akka {
+    jvm-shutdown-hooks = off
+}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -40,6 +40,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import scala.util.control.NonFatal
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
+import com.daml.metrics.{Metrics, Timed}
 
 class Endpoints(
     allowNonHttps: Boolean,
@@ -63,7 +64,8 @@ class Endpoints(
   import Uri.Path._
 
   def all(implicit
-      lc: LoggingContextOf[InstanceUUID]
+      lc: LoggingContextOf[InstanceUUID],
+      metrics: Metrics,
   ): PartialFunction[HttpRequest, Future[HttpResponse]] = {
     val dispatch: PartialFunction[HttpRequest, LoggingContextOf[
       InstanceUUID with RequestID
@@ -103,16 +105,16 @@ class Endpoints(
     }
     import scalaz.std.partialFunction._, scalaz.syntax.arrow._
     (dispatch &&& { case r => r }) andThen { case (lcFhr, req) =>
-      extendWithRequestIdLogCtx(implicit lc =>
-        // TODO: Refactor this somehow into an own function
-        for {
-          _ <- Future.unit
-          _ = logger.trace(s"Incoming request on ${req.uri}")
-          t0 = System.nanoTime()
-          res <- lcFhr(lc)
-          _ = logger.trace(s"Processed request after ${System.nanoTime() - t0}ns")
-        } yield res
-      )
+      extendWithRequestIdLogCtx(implicit lc => {
+        val t0 = System.nanoTime
+        logger.trace(s"Incoming request on ${req.uri}")
+        Timed
+          .future(metrics.registry.timer("daml.ledger_service.http_json.requests_timer"), lcFhr(lc))
+          .map(res => {
+            logger.trace(s"Processed request after ${System.nanoTime() - t0}ns")
+            res
+          })
+      })
     }
   }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -34,6 +34,7 @@ import com.daml.ledger.client.{LedgerClient => DamlLedgerClient}
 import com.daml.ledger.service.LedgerReader
 import com.daml.ledger.service.LedgerReader.PackageStore
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
+import com.daml.metrics.Metrics
 import com.daml.ports.{Port, PortFiles}
 import com.daml.scalautil.Statement.discard
 import scalaz.Scalaz._
@@ -71,6 +72,7 @@ object HttpService {
       aesf: ExecutionSequencerFactory,
       ec: ExecutionContext,
       lc: LoggingContextOf[InstanceUUID],
+      metrics: Metrics,
   ): Future[Error \/ ServerBinding] = {
 
     logger.info("HTTP Server pre-startup")

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
@@ -17,6 +17,7 @@ import EndpointsCompanion._
 import com.daml.http.domain.JwtPayload
 import com.daml.http.util.Logging.{InstanceUUID, RequestID, extendWithRequestIdLogCtx}
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
+import com.daml.metrics.{Metrics, Timed}
 
 object WebsocketEndpoints {
   private[http] val tokenPrefix: String = "jwt.token."
@@ -58,6 +59,7 @@ class WebsocketEndpoints(
   def transactionWebSocket(implicit
       ec: ExecutionContext,
       lc: LoggingContextOf[InstanceUUID],
+      metrics: Metrics,
   ) = {
     val dispatch: PartialFunction[HttpRequest, LoggingContextOf[
       InstanceUUID with RequestID
@@ -106,16 +108,16 @@ class WebsocketEndpoints(
     }
     import scalaz.std.partialFunction._, scalaz.syntax.arrow._
     (dispatch &&& { case r => r }) andThen { case (lcFhr, req) =>
-      extendWithRequestIdLogCtx(implicit lc =>
-        // TODO: Refactor this somehow into an own function
-        for {
-          _ <- Future.unit
-          _ = logger.trace(s"Incoming request on ${req.uri}")
-          t0 = System.nanoTime()
-          res <- lcFhr(lc)
-          _ = logger.trace(s"Processed request after ${System.nanoTime() - t0}ns")
-        } yield res
-      )
+      extendWithRequestIdLogCtx(implicit lc => {
+        val t0 = System.nanoTime
+        logger.trace(s"Incoming request on ${req.uri}")
+        Timed
+          .future(metrics.registry.timer("daml.ledger_service.http_json.requests_timer"), lcFhr(lc))
+          .map(res => {
+            logger.trace(s"Processed request after ${System.nanoTime() - t0}ns")
+            res
+          })
+      })
     }
   }
 

--- a/ledger/sandbox-common/BUILD.bazel
+++ b/ledger/sandbox-common/BUILD.bazel
@@ -16,6 +16,9 @@ da_scala_library(
     scala_deps = [
         "@maven//:com_github_scopt_scopt",
         "@maven//:org_scalaz_scalaz_core",
+        "@maven//:org_typelevel_cats_core",
+        "@maven//:org_typelevel_cats_effect",
+        "@maven//:org_typelevel_cats_kernel",
     ],
     tags = ["maven_coordinates=com.daml:sandbox-common:__VERSION__"],
     visibility = [


### PR DESCRIPTION
This implements simple request-time metrics (for the http-json service).

Looking into existing code of the code base I think my implementation is a bit controversial, however I decided to mostly not use existing code within the code base, because the abstractions I used are not tied to Future (thus more flexible) and from an external library (cats.effect) which means less code to maintain. Especially the flexibility for the implementation was important to me, because I would like to reduce the usage of Future if possible and use an abstraction which is referential transparent and cancelable (my implementation is in this regard not perfect either but better less Future than more).

Besides these points, the implementation tries to make sure all resources are released properly as the introduction of an additional resource forced me to take care of scaleable resource management with good working shutdown management. This is the reason for the great refactoring of the main method.

Lastly, I'm aware that we did not decide on how much Cats we like to use here, however to me it was more important to produce well working and maintainable code first.

changelog_begin
[HTTP/JSON API]
- metrics reporting can now be chosen via the command line option --metrics-reporter, valid options are console, csv://, graphite:// and prometheus://
- metrics reporting interval can also now be chosen via a command line option --metrics-reporting-interval
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
