### PR TITLE
Try to unflake JSON API failure tests

### DIFF
--- a/ledger-service/http-json/src/failure/resources/application.conf
+++ b/ledger-service/http-json/src/failure/resources/application.conf
@@ -1,0 +1,6 @@
+akka {
+  # Reducing this should hopefully ensure that the tests
+  # that test for timeouts always hit the server side request timeout
+  # and not another timeout somewhere in akka-http.
+  http.server.request-timeout = 5 s
+}


### PR DESCRIPTION
On CI we occasionally see the timeout tests fail with
`UnexpectedConnectionClosureException` instead of the expected
server-side timout error. I haven’t managed to reliably reproduce this
or figure out what is going wrong (the closest seems to be
https://github.com/akka/akka-http/issues/3806 but I struggle to see
how that applies here).

This change seems at least promising and at worst, it just speeds up
the tests (by waiting less) and doesn’t change flakiness which still
seems like an improvement.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
