### PR TITLE
Daml-lf suffixCid ignores V0 contract ids rather than erroring

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -33,7 +33,7 @@ object CidMapper {
   type NoCidChecker[-A1, +A2] = CidChecker[A1, A2, Nothing]
 
   type CidSuffixer[-A1, +A2] =
-    CidMapper[A1, A2, Value.ContractId, Value.ContractId.V1]
+    CidMapper[A1, A2, Value.ContractId, Value.ContractId]
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   private val _trivialMapper: CidMapper[Any, Any, Nothing, Any] =
@@ -74,10 +74,7 @@ trait CidContainer[+A] {
     suffixer.traverse[String] {
       case Value.ContractId.V1(discriminator, Bytes.Empty) =>
         Value.ContractId.V1.build(discriminator, f(discriminator))
-      case acoid @ Value.ContractId.V1(_, _) =>
-        Right(acoid)
-      case acoid @ Value.ContractId.V0(_) =>
-        Left(s"expect a Contract ID V1, found $acoid")
+      case acoid => Right(acoid)
     }(self)
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -74,7 +74,8 @@ trait CidContainer[+A] {
     suffixer.traverse[String] {
       case Value.ContractId.V1(discriminator, Bytes.Empty) =>
         Value.ContractId.V1.build(discriminator, f(discriminator))
-      case acoid => Right(acoid)
+      case acoid @ Value.ContractId.V1(_, _) => Right(acoid)
+      case acoid @ Value.ContractId.V0(_) => Right(acoid)
     }(self)
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -437,8 +437,8 @@ object Value extends CidContainer1[Value] {
 
     implicit val noCidMapper: CidMapper.NoCidChecker[ContractId, Nothing] =
       CidMapper.basicMapperInstance[ContractId, Nothing]
-    implicit val cidSuffixer: CidMapper.CidSuffixer[ContractId, ContractId.V1] =
-      CidMapper.basicMapperInstance[ContractId, ContractId.V1]
+    implicit val cidSuffixer: CidMapper.CidSuffixer[ContractId, ContractId] =
+      CidMapper.basicMapperInstance[ContractId, ContractId]
   }
 
   @deprecated("use com.daml.lf.transaction.NodeId", since = "1.4.0")

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -280,6 +280,13 @@ class TransactionSpec
       tx1 shouldBe Right(tx.map2(identity, mapping2))
 
     }
+    "suffixing v0 contract id should be a no op" in {
+
+      val v0Cid = V.ValueContractId(V.ContractId.V0.assertFromString("#deadbeef"))
+      val Right(v0CidSuffixed) = v0Cid.suffixCid(_ => Bytes.assertFromString("cafe"))
+      v0Cid shouldBe v0CidSuffixed
+
+    }
   }
 
   "contractKeys" - {


### PR DESCRIPTION
- canton currently ignores v0 contracts upon suffixing as those may still appear in value parameters. Ignoring rather erroring on such contract ids will make it possible for canton to adopt the lf-based suffixer
- corda appears to work with v1 contract ids, assuming that suffixing always results in a Right:
  https://github.com/DACH-NY/daml-on-corda/blob/main/engine/src/main/scala/com/digitalasset/platform/corda/engine/VaultBackedDamlState.scala#L101

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
