### PR TITLE
Make data-deps exception tests version-aware.

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -1211,7 +1211,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             [ "build"
             , "--project-root", tmpDir </> "lib"
             , "-o", tmpDir </> "lib" </> "lib.dar"
-            , "--target", LF.renderVersion (LF.featureMinVersion LF.featureDamlExceptions) ]
+            , "--target", LF.renderVersion (LF.featureMinVersion LF.featureExceptions) ]
 
         step "building project that imports it via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "main")
@@ -1289,7 +1289,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             [ "build"
             , "--project-root", tmpDir </> "lib"
             , "-o", tmpDir </> "lib" </> "lib.dar"
-            , "--target", LF.renderVersion (LF.featureMinVersion LF.featureDamlExceptions) ]
+            , "--target", LF.renderVersion (LF.featureMinVersion LF.featureExceptions) ]
 
         step "building project that imports it via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "main")

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -1211,7 +1211,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             [ "build"
             , "--project-root", tmpDir </> "lib"
             , "-o", tmpDir </> "lib" </> "lib.dar"
-            , "--target", renderVersion (featureMinVersion featureDamlExceptions) ]
+            , "--target", LF.renderVersion (LF.featureMinVersion LF.featureDamlExceptions) ]
 
         step "building project that imports it via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "main")
@@ -1244,7 +1244,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
         callProcessSilent damlc
             [ "build"
             , "--project-root", tmpDir </> "main"
-            , "--target", renderVersion versionDev ]
+            , "--target", LF.renderVersion LF.versionDev ]
 
     , testCaseSteps "Standard library exceptions" $ \step -> withTempDir $ \tmpDir -> do
         step "building project to be imported via data-dependencies"
@@ -1289,7 +1289,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             [ "build"
             , "--project-root", tmpDir </> "lib"
             , "-o", tmpDir </> "lib" </> "lib.dar"
-            , "--target", renderVersion (featureMinVersion featureDamlExceptions) ]
+            , "--target", LF.renderVersion (LF.featureMinVersion LF.featureDamlExceptions) ]
 
         step "building project that imports it via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "main")
@@ -1350,12 +1350,12 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
         callProcessSilent damlc
             [ "build"
             , "--project-root", tmpDir </> "main"
-            , "--target", renderVersion versionDev ]
+            , "--target", LF.renderVersion LF.versionDev ]
         step "running damlc test"
         callProcessSilent damlc
             [ "test"
             , "--project-root", tmpDir </> "main"
-            , "--target", renderVersion versionDev ]
+            , "--target", LF.renderVersion LF.versionDev ]
     ]
   where
     simpleImportTest :: String -> [String] -> [String] -> TestTree

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -1183,8 +1183,6 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             ]
         callProcessSilent damlc [ "build", "--project-root", tmpDir </> "proj" ]
 
-    -- TODO https://github.com/digital-asset/daml/issues/8020
-    --   Replace with a simpleImportTest once exceptions are stable.
     , testCaseSteps "User-defined exceptions" $ \step -> withTempDir $ \tmpDir -> do
         step "building project to be imported via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "lib")
@@ -1213,7 +1211,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             [ "build"
             , "--project-root", tmpDir </> "lib"
             , "-o", tmpDir </> "lib" </> "lib.dar"
-            , "--target=1.dev"]
+            , "--target", renderVersion (featureMinVersion featureDamlExceptions) ]
 
         step "building project that imports it via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "main")
@@ -1246,7 +1244,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
         callProcessSilent damlc
             [ "build"
             , "--project-root", tmpDir </> "main"
-            , "--target=1.dev"]
+            , "--target", renderVersion versionDev ]
 
     , testCaseSteps "Standard library exceptions" $ \step -> withTempDir $ \tmpDir -> do
         step "building project to be imported via data-dependencies"
@@ -1291,7 +1289,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             [ "build"
             , "--project-root", tmpDir </> "lib"
             , "-o", tmpDir </> "lib" </> "lib.dar"
-            , "--target=1.dev"]
+            , "--target", renderVersion (featureMinVersion featureDamlExceptions) ]
 
         step "building project that imports it via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "main")
@@ -1352,12 +1350,12 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
         callProcessSilent damlc
             [ "build"
             , "--project-root", tmpDir </> "main"
-            , "--target=1.dev"]
+            , "--target", renderVersion versionDev ]
         step "running damlc test"
         callProcessSilent damlc
             [ "test"
             , "--project-root", tmpDir </> "main"
-            , "--target=1.dev"]
+            , "--target", renderVersion versionDev ]
     ]
   where
     simpleImportTest :: String -> [String] -> [String] -> TestTree


### PR DESCRIPTION
This PR changes the exception data-dependencies tests to do a cross-version import of exceptions (once we release exceptions in preview).

It also removes the last exceptions TODO from the Haskell side, other than changing `featureMinVersion` once we start releasing excepions.

Part of #8020

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
