### PR TITLE
`ledger-api-bench-tool` - Completions stream  [DPP-399]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/Cli.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/Cli.scala
@@ -3,10 +3,11 @@
 
 package com.daml.ledger.api.benchtool
 
+import com.daml.ledger.api.benchtool.Config.StreamConfig
 import com.daml.ledger.api.tls.TlsConfigurationCli
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.value.Identifier
-import scopt.{OptionParser, Read}
+import scopt.{OptionDef, OptionParser, Read}
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success, Try}
@@ -35,7 +36,7 @@ object Cli {
         s"Stream configuration."
       )
       .valueName(
-        "stream-type=<transactions|transaction-trees|active-contracts>,name=<streamName>,party=<party>[,begin-offset=<offset>][,end-offset=<offset>][,template-ids=<id1>|<id2>][,max-delay=<seconds>]"
+        "<param1>=<value1>,<param2>=<value2>,..."
       )
       .action { case (streamConfig, config) =>
         config.copy(streams = config.streams :+ streamConfig)
@@ -66,6 +67,34 @@ object Cli {
 
     help("help").text("Prints this information")
 
+    private def note(level: Int, param: String, desc: String = ""): OptionDef[Unit, Config] = {
+      val paddedParam = s"${" " * level * 2}$param"
+      val internalPadding = math.max(1, 40 - paddedParam.length)
+      note(s"$paddedParam${" " * internalPadding}$desc")
+    }
+
+    note(0, "")
+    note(0, "Stream configuration parameters:")
+    note(1, "Transactions/transaction trees:")
+    note(2, "stream-type=<transactions|transaction-trees>", "(required)")
+    note(2, "name=<stream-name>", "Stream name used to identify results (required)")
+    note(2, "party=<party>", "(required)")
+    note(2, "begin-offset=<offset>")
+    note(2, "end-offset=<offset>")
+    note(2, "template-ids=<id1>|<id2>")
+    note(2, "max-delay=<seconds>", "Max record time delay objective")
+    note(2, "min-consumption-speed=<speed>", "Min consumption speed objective")
+    note(1, "Active contract sets:")
+    note(2, "stream-type=active-contracts", "(required)")
+    note(2, "name=<stream-name>", "Stream name used to identify results (required)")
+    note(2, "party=<party>", "(required)")
+    note(2, "template-ids=<id1>|<id2>")
+    note(1, "Command completions:")
+    note(2, "stream-type=completions", "(required)")
+    note(2, "name=<stream-name>", "Stream name used to identify results (required)")
+    note(2, "party=<party>", "(required)")
+    note(2, "begin-offset=<offset>")
+    note(2, "template-ids=<id1>|<id2>")
   }
 
   def config(args: Array[String]): Option[Config] =
@@ -99,15 +128,9 @@ object Cli {
         def offset(stringValue: String): LedgerOffset =
           LedgerOffset.defaultInstance.withAbsolute(stringValue)
 
-        val config = for {
+        def transactionsConfig: Either[String, StreamConfig.TransactionsStreamConfig] = for {
           name <- stringField("name")
           party <- stringField("party")
-          streamType <- stringField("stream-type").flatMap[String, Config.StreamConfig.StreamType] {
-            case "transactions" => Right(Config.StreamConfig.StreamType.Transactions)
-            case "transaction-trees" => Right(Config.StreamConfig.StreamType.TransactionTrees)
-            case "active-contracts" => Right(Config.StreamConfig.StreamType.ActiveContracts)
-            case invalid => Left(s"Invalid stream type: $invalid")
-          }
           templateIds <- optionalStringField("template-ids").flatMap {
             case Some(ids) => listOfTemplateIds(ids).map(Some(_))
             case None => Right(None)
@@ -116,9 +139,8 @@ object Cli {
           endOffset <- optionalStringField("end-offset").map(_.map(offset))
           maxDelaySeconds <- optionalLongField("max-delay")
           minConsumptionSpeed <- optionalDoubleField("min-consumption-speed")
-        } yield Config.StreamConfig(
+        } yield Config.StreamConfig.TransactionsStreamConfig(
           name = name,
-          streamType = streamType,
           party = party,
           templateIds = templateIds,
           beginOffset = beginOffset,
@@ -128,6 +150,63 @@ object Cli {
             minConsumptionSpeed = minConsumptionSpeed,
           ),
         )
+
+        def transactionTreesConfig: Either[String, StreamConfig.TransactionTreesStreamConfig] =
+          for {
+            name <- stringField("name")
+            party <- stringField("party")
+            templateIds <- optionalStringField("template-ids").flatMap {
+              case Some(ids) => listOfTemplateIds(ids).map(Some(_))
+              case None => Right(None)
+            }
+            beginOffset <- optionalStringField("begin-offset").map(_.map(offset))
+            endOffset <- optionalStringField("end-offset").map(_.map(offset))
+            maxDelaySeconds <- optionalLongField("max-delay")
+            minConsumptionSpeed <- optionalDoubleField("min-consumption-speed")
+          } yield Config.StreamConfig.TransactionTreesStreamConfig(
+            name = name,
+            party = party,
+            templateIds = templateIds,
+            beginOffset = beginOffset,
+            endOffset = endOffset,
+            objectives = Config.StreamConfig.Objectives(
+              maxDelaySeconds = maxDelaySeconds,
+              minConsumptionSpeed = minConsumptionSpeed,
+            ),
+          )
+
+        def activeContractsConfig: Either[String, StreamConfig.ActiveContractsStreamConfig] = for {
+          name <- stringField("name")
+          party <- stringField("party")
+          templateIds <- optionalStringField("template-ids").flatMap {
+            case Some(ids) => listOfTemplateIds(ids).map(Some(_))
+            case None => Right(None)
+          }
+        } yield Config.StreamConfig.ActiveContractsStreamConfig(
+          name = name,
+          party = party,
+          templateIds = templateIds,
+        )
+
+        def completionsConfig: Either[String, StreamConfig.CompletionsStreamConfig] = for {
+          name <- stringField("name")
+          party <- stringField("party")
+          applicationId <- stringField("application-id")
+          beginOffset <- optionalStringField("begin-offset").map(_.map(offset))
+        } yield Config.StreamConfig.CompletionsStreamConfig(
+          name = name,
+          party = party,
+          applicationId = applicationId,
+          beginOffset = beginOffset,
+        )
+
+        val config = stringField("stream-type").flatMap[String, Config.StreamConfig] {
+          case "transactions" => transactionsConfig
+          case "transaction-trees" => transactionTreesConfig
+          case "active-contracts" => activeContractsConfig
+          case "completions" => completionsConfig
+          case invalid => Left(s"Invalid stream type: $invalid")
+        }
 
         config.fold(error => throw new IllegalArgumentException(error), identity)
       }

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/Config.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/Config.scala
@@ -18,23 +18,42 @@ case class Config(
 )
 
 object Config {
-  case class StreamConfig(
-      name: String,
-      streamType: Config.StreamConfig.StreamType,
-      party: String,
-      templateIds: Option[List[Identifier]],
-      beginOffset: Option[LedgerOffset],
-      endOffset: Option[LedgerOffset],
-      objectives: StreamConfig.Objectives,
-  )
+  trait StreamConfig {
+    def name: String
+    def party: String
+  }
 
   object StreamConfig {
-    sealed trait StreamType
-    object StreamType {
-      case object Transactions extends StreamType
-      case object TransactionTrees extends StreamType
-      case object ActiveContracts extends StreamType
-    }
+    case class TransactionsStreamConfig(
+        name: String,
+        party: String,
+        templateIds: Option[List[Identifier]],
+        beginOffset: Option[LedgerOffset],
+        endOffset: Option[LedgerOffset],
+        objectives: StreamConfig.Objectives,
+    ) extends StreamConfig
+
+    case class TransactionTreesStreamConfig(
+        name: String,
+        party: String,
+        templateIds: Option[List[Identifier]],
+        beginOffset: Option[LedgerOffset],
+        endOffset: Option[LedgerOffset],
+        objectives: StreamConfig.Objectives,
+    ) extends StreamConfig
+
+    case class ActiveContractsStreamConfig(
+        name: String,
+        party: String,
+        templateIds: Option[List[Identifier]],
+    ) extends StreamConfig
+
+    case class CompletionsStreamConfig(
+        name: String,
+        party: String,
+        applicationId: String,
+        beginOffset: Option[LedgerOffset],
+    ) extends StreamConfig
 
     case class Objectives(
         maxDelaySeconds: Option[Long],

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/MetricsSet.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/MetricsSet.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.api.benchtool.metrics
 import com.daml.ledger.api.benchtool.Config.StreamConfig.Objectives
 import com.daml.ledger.api.benchtool.metrics.objectives.{MaxDelay, MinConsumptionSpeed}
 import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
+import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse,
@@ -46,6 +47,19 @@ object MetricsSet {
         countingFunction = _.activeContracts.length
       ),
       SizeMetric.empty[GetActiveContractsResponse](
+        sizingFunction = _.serializedSize.toLong
+      ),
+    )
+
+  def completionsMetrics: List[Metric[CompletionStreamResponse]] =
+    List[Metric[CompletionStreamResponse]](
+      CountRateMetric.empty(
+        countingFunction = _.completions.length
+      ),
+      TotalCountMetric.empty(
+        countingFunction = _.completions.length
+      ),
+      SizeMetric.empty(
         sizingFunction = _.serializedSize.toLong
       ),
     )

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/ActiveContractsService.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/ActiveContractsService.scala
@@ -22,7 +22,7 @@ final class ActiveContractsService(
     ActiveContractsServiceGrpc.stub(channel)
 
   def getActiveContracts[Result](
-      config: Config.StreamConfig,
+      config: Config.StreamConfig.ActiveContractsStreamConfig,
       observer: ObserverWithResult[GetActiveContractsResponse, Result],
   ): Future[Result] = {
     service.getActiveContracts(getActiveContractsRequest(ledgerId, config), observer)
@@ -30,7 +30,10 @@ final class ActiveContractsService(
     observer.result
   }
 
-  private def getActiveContractsRequest(ledgerId: String, config: Config.StreamConfig) = {
+  private def getActiveContractsRequest(
+      ledgerId: String,
+      config: Config.StreamConfig.ActiveContractsStreamConfig,
+  ) = {
     val templatesFilter = config.templateIds match {
       case Some(ids) =>
         Filters.defaultInstance.withInclusive(

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/CommandCompletionService.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/CommandCompletionService.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.services
+
+import com.daml.ledger.api.benchtool.Config
+import com.daml.ledger.api.benchtool.util.ObserverWithResult
+import com.daml.ledger.api.v1.command_completion_service.{
+  CommandCompletionServiceGrpc,
+  CompletionStreamRequest,
+  CompletionStreamResponse,
+}
+import io.grpc.Channel
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Future
+
+class CommandCompletionService(
+    channel: Channel,
+    ledgerId: String,
+) {
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val service: CommandCompletionServiceGrpc.CommandCompletionServiceStub =
+    CommandCompletionServiceGrpc.stub(channel)
+
+  def completions[Result](
+      config: Config.StreamConfig.CompletionsStreamConfig,
+      observer: ObserverWithResult[CompletionStreamResponse, Result],
+  ): Future[Result] = {
+    val request = completionsRequest(ledgerId, config)
+    service.completionStream(request, observer)
+    logger.info(s"Started fetching completions")
+    observer.result
+  }
+
+  private def completionsRequest(
+      ledgerId: String,
+      config: Config.StreamConfig.CompletionsStreamConfig,
+  ): CompletionStreamRequest = {
+    val request = CompletionStreamRequest.defaultInstance
+      .withLedgerId(ledgerId)
+      .withParties(List(config.party))
+      .withApplicationId(config.applicationId)
+
+    config.beginOffset match {
+      case Some(offset) => request.withOffset(offset)
+      case None => request
+    }
+  }
+
+}

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/TransactionService.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/TransactionService.scala
@@ -28,23 +28,35 @@ final class TransactionService(
     TransactionServiceGrpc.stub(channel)
 
   def transactions[Result](
-      config: Config.StreamConfig,
+      config: Config.StreamConfig.TransactionsStreamConfig,
       observer: ObserverWithResult[GetTransactionsResponse, Result],
   ): Future[Result] = {
-    val request = getTransactionsRequest(ledgerId, config)
+    val request = getTransactionsRequest(
+      ledgerId = ledgerId,
+      party = config.party,
+      templateIds = config.templateIds,
+      beginOffset = config.beginOffset,
+      endOffset = config.endOffset,
+    )
     service.getTransactions(request, observer)
     logger.info("Started fetching transactions")
     observer.result
   }
 
   def transactionTrees[Result](
-      config: Config.StreamConfig,
+      config: Config.StreamConfig.TransactionTreesStreamConfig,
       observer: ObserverWithResult[
         GetTransactionTreesResponse,
         Result,
       ],
   ): Future[Result] = {
-    val request = getTransactionsRequest(ledgerId, config)
+    val request = getTransactionsRequest(
+      ledgerId = ledgerId,
+      party = config.party,
+      templateIds = config.templateIds,
+      beginOffset = config.beginOffset,
+      endOffset = config.endOffset,
+    )
     service.getTransactionTrees(request, observer)
     logger.info("Started fetching transaction trees")
     observer.result
@@ -52,13 +64,16 @@ final class TransactionService(
 
   private def getTransactionsRequest(
       ledgerId: String,
-      config: Config.StreamConfig,
+      party: String,
+      templateIds: Option[List[Identifier]],
+      beginOffset: Option[LedgerOffset],
+      endOffset: Option[LedgerOffset],
   ): GetTransactionsRequest = {
     GetTransactionsRequest.defaultInstance
       .withLedgerId(ledgerId)
-      .withBegin(config.beginOffset.getOrElse(ledgerBeginOffset))
-      .withEnd(config.endOffset.getOrElse(ledgerEndOffset))
-      .withFilter(partyFilter(config.party, config.templateIds))
+      .withBegin(beginOffset.getOrElse(ledgerBeginOffset))
+      .withEnd(endOffset.getOrElse(ledgerEndOffset))
+      .withFilter(partyFilter(party, templateIds))
   }
 
   private def partyFilter(


### PR DESCRIPTION
### Changes
- reading completions streams
- specific configuration classes for each stream type
- improved `help`, example below:

```
❯ java -jar bazel-bin/ledger/ledger-api-bench-tool/ledger-api-bench-tool_deploy.jar --help
A tool for measuring transaction streaming performance of a ledger.
Usage: ledger-api-bench-tool [options]

  -e, --endpoint <hostname>:<port>
                           Ledger API endpoint
  -s, --consume-stream <param1>=<value1>,<param2>=<value2>,...
                           Stream configuration.
  -r, --log-interval <value>
                           Stream metrics log interval.
  --core-pool-size <value>
                           Initial size of the worker thread pool.
  --max-pool-size <value>  Maximum size of the worker thread pool.
  --pem <value>            TLS: The pem file to be used as the private key.
  --crt <value>            TLS: The crt file to be used as the cert chain.
                                   Required for client authentication.
  --cacrt <value>          TLS: The crt file to be used as the trusted root CA.
  --tls                    TLS: Enable tls. This is redundant if --pem, --crt or --cacrt are set
  --help                   Prints this information

Stream configuration parameters:
  Transactions/transaction trees:
    stream-type=<transactions|transaction-trees> (required)
    name=<stream-name>                  Stream name used to identify results (required)
    party=<party>                       (required)
    begin-offset=<offset>
    end-offset=<offset>
    template-ids=<id1>|<id2>
    max-delay=<seconds>                 Max record time delay objective
    min-consumption-speed=<speed>       Min consumption speed objective
  Active contract sets:
    stream-type=active-contracts        (required)
    name=<stream-name>                  Stream name used to identify results (required)
    party=<party>                       (required)
    template-ids=<id1>|<id2>
  Command completions:
    stream-type=completions             (required)
    name=<stream-name>                  Stream name used to identify results (required)
    party=<party>                       (required)
    begin-offset=<offset>
    template-ids=<id1>|<id2>

```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
