### PR TITLE
DPP-393 Enable sandbox tests for the append-only schema

### DIFF
--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SandboxEnableAppendOnlySchema.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SandboxEnableAppendOnlySchema.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.services
+
+// TODO append-only: remove once the append-only schema is enabled by default
+trait SandboxEnableAppendOnlySchema {
+  this: SandboxFixture =>
+
+  override def enableAppendOnlySchema: Boolean = true
+}

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SandboxFixture.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SandboxFixture.scala
@@ -18,9 +18,13 @@ import scala.concurrent.duration.DurationInt
 trait SandboxFixture extends AbstractSandboxFixture with SuiteResource[(SandboxServer, Channel)] {
   self: Suite =>
 
+  // TODO append-only: remove after the mutating schema is removed
+  protected def enableAppendOnlySchema: Boolean = false
+
   override protected def config: SandboxConfig =
     super.config.copy(
-      ledgerConfig = LedgerConfiguration.defaultLedgerBackedIndex
+      ledgerConfig = LedgerConfiguration.defaultLedgerBackedIndex,
+      enableAppendOnlySchema = enableAppendOnlySchema,
     )
 
   protected def server: SandboxServer = suiteResource.value._1

--- a/ledger/sandbox-classic/src/test/resources/logback-test.xml
+++ b/ledger/sandbox-classic/src/test/resources/logback-test.xml
@@ -16,4 +16,17 @@
     <logger name="com.daml.platform.store.dao.HikariConnection" level="INFO">
         <appender-ref ref="SqlLedgerSpecAppender" />
     </logger>
+
+    <!-- TODO append-only: remove duplicated definitions from this file -->
+    <appender name="SqlLedgerSpecAppenderAppendOnly" class="com.daml.platform.testing.LogCollector">
+        <test>com.daml.platform.sandbox.stores.ledger.sql.SqlLedgerSpecAppendOnly</test>
+    </appender>
+
+    <logger name="com.daml.platform.sandbox.stores.ledger.sql.SqlLedger" level="INFO">
+        <appender-ref ref="SqlLedgerSpecAppenderAppendOnly" />
+    </logger>
+
+    <logger name="com.daml.platform.store.appendonlydao.HikariConnection" level="INFO">
+        <appender-ref ref="SqlLedgerSpecAppenderAppendOnly" />
+    </logger>
 </configuration>

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/ScenarioLoadingITPostgres.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/ScenarioLoadingITPostgres.scala
@@ -3,4 +3,12 @@
 
 package com.daml.platform.sandbox
 
+import com.daml.platform.sandbox.services.SandboxEnableAppendOnlySchema
+
 final class ScenarioLoadingITPostgres extends ScenarioLoadingITBase with SandboxBackend.Postgresql
+
+// TODO append-only: remove this class once the append-only schema is the default one
+final class ScenarioLoadingITPostgresAppendOnly
+    extends ScenarioLoadingITBase
+    with SandboxBackend.Postgresql
+    with SandboxEnableAppendOnlySchema

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandServiceBackPressureIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandServiceBackPressureIT.scala
@@ -18,7 +18,11 @@ import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.platform.participant.util.ValueConversions._
 import com.daml.platform.sandbox.SandboxBackend
 import com.daml.platform.sandbox.config.SandboxConfig
-import com.daml.platform.sandbox.services.{SandboxFixture, TestCommands}
+import com.daml.platform.sandbox.services.{
+  SandboxFixture,
+  SandboxEnableAppendOnlySchema,
+  TestCommands,
+}
 import io.grpc.Status
 import org.scalatest.{Assertion, Inspectors}
 import org.scalatest.matchers.should.Matchers
@@ -28,7 +32,7 @@ import scalaz.syntax.tag._
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-class CommandServiceBackPressureIT
+sealed trait CommandServiceBackPressureITBase
     extends AsyncWordSpec
     with Matchers
     with Inspectors
@@ -113,3 +117,15 @@ class CommandServiceBackPressureIT
     )
 
 }
+
+// CommandServiceBackPressureIT on a Postgresql ledger
+final class CommandServiceBackPressurePostgresIT
+    extends CommandServiceBackPressureITBase
+    with SandboxBackend.Postgresql
+
+// CommandServiceBackPressureIT on a Postgresql ledger with the append-only schema
+// TODO append-only: remove this class once the append-only schema is the default one
+final class CommandServiceBackPressureAppendOnlyIT
+    extends CommandServiceBackPressureITBase
+    with SandboxBackend.Postgresql
+    with SandboxEnableAppendOnlySchema

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandServiceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandServiceIT.scala
@@ -20,7 +20,11 @@ import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.platform.participant.util.ValueConversions._
 import com.daml.platform.sandbox.SandboxBackend
 import com.daml.platform.sandbox.config.SandboxConfig
-import com.daml.platform.sandbox.services.{SandboxFixture, TestCommands}
+import com.daml.platform.sandbox.services.{
+  SandboxEnableAppendOnlySchema,
+  SandboxFixture,
+  TestCommands,
+}
 import com.daml.platform.services.time.TimeProviderType
 import com.google.protobuf.duration.{Duration => ProtoDuration}
 import org.scalatest.Inspectors
@@ -28,12 +32,11 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import scalaz.syntax.tag._
 
-class CommandServiceIT
+sealed trait CommandServiceITBase
     extends AsyncWordSpec
     with Matchers
     with Inspectors
     with SandboxFixture
-    with SandboxBackend.Postgresql
     with TestCommands
     with SuiteResourceManagementAroundAll {
 
@@ -128,3 +131,13 @@ class CommandServiceIT
     )
 
 }
+
+// CommandServiceIT on a Postgresql ledger
+final class CommandServicePostgresIT extends CommandServiceITBase with SandboxBackend.Postgresql
+
+// CommandServiceIT on a Postgresql ledger with the append-only schema
+// TODO append-only: remove this class once the append-only schema is the default one
+final class CommandServiceAppendOnlyIT
+    extends CommandServiceITBase
+    with SandboxBackend.Postgresql
+    with SandboxEnableAppendOnlySchema

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/completion/CompletionServiceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/completion/CompletionServiceIT.scala
@@ -19,7 +19,11 @@ import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.platform.participant.util.ValueConversions._
 import com.daml.platform.sandbox.SandboxBackend
 import com.daml.platform.sandbox.config.SandboxConfig
-import com.daml.platform.sandbox.services.{SandboxFixture, TestCommands}
+import com.daml.platform.sandbox.services.{
+  SandboxEnableAppendOnlySchema,
+  SandboxFixture,
+  TestCommands,
+}
 import com.daml.platform.testing.StreamConsumer
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
@@ -29,12 +33,11 @@ import scalaz.syntax.tag._
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
-class CompletionServiceIT
+sealed trait CompletionServiceITBase
     extends AsyncWordSpec
     with Matchers
     with Inspectors
     with SandboxFixture
-    with SandboxBackend.Postgresql
     with TestCommands
     with SuiteResourceManagementAroundAll {
 
@@ -155,3 +158,15 @@ class CompletionServiceIT
     )
 
 }
+
+// CompletionServiceIT on a Postgresql ledger
+final class CompletionServicePostgresIT
+    extends CompletionServiceITBase
+    with SandboxBackend.Postgresql
+
+// CompletionServiceIT on a Postgresql ledger with the append-only schema
+// TODO append-only: remove this class once the append-only schema is the default one
+final class CompletionServiceAppendOnlyIT
+    extends CompletionServiceITBase
+    with SandboxBackend.Postgresql
+    with SandboxEnableAppendOnlySchema

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/configuration/LedgerConfigurationServiceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/configuration/LedgerConfigurationServiceIT.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.api.v1.ledger_configuration_service.{
   LedgerConfigurationServiceGrpc,
 }
 import com.daml.platform.sandbox.SandboxBackend
-import com.daml.platform.sandbox.services.SandboxFixture
+import com.daml.platform.sandbox.services.{SandboxEnableAppendOnlySchema, SandboxFixture}
 import com.google.protobuf.duration.Duration
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -49,4 +49,12 @@ final class LedgerConfigurationServicePostgresIT
     extends LedgerConfigurationServiceITBase
     with SandboxFixture
     with SandboxBackend.Postgresql
+    with SuiteResourceManagementAroundAll
+
+// TODO append-only: remove this class once the append-only schema is the default one
+final class LedgerConfigurationServicePostgresAppendOnlyIT
+    extends LedgerConfigurationServiceITBase
+    with SandboxFixture
+    with SandboxBackend.Postgresql
+    with SandboxEnableAppendOnlySchema
     with SuiteResourceManagementAroundAll

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/identity/LedgerIdentityServiceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/identity/LedgerIdentityServiceIT.scala
@@ -11,7 +11,7 @@ import com.daml.lf.data.Ref
 import com.daml.platform.common.LedgerIdMode
 import com.daml.platform.sandbox.SandboxBackend
 import com.daml.platform.sandbox.config.SandboxConfig
-import com.daml.platform.sandbox.services.SandboxFixture
+import com.daml.platform.sandbox.services.{SandboxEnableAppendOnlySchema, SandboxFixture}
 import com.daml.testing.postgresql.PostgresAroundAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -50,6 +50,12 @@ final class LedgerIdentityServiceInMemoryGivenIT extends LedgerIdentityServiceIT
 final class LedgerIdentityServicePostgresGivenIT
     extends LedgerIdentityServiceITBaseGiven
     with SandboxBackend.Postgresql
+
+// TODO append-only: remove this class once the append-only schema is the default one
+final class LedgerIdentityServicePostgresAppendOnlyGivenIT
+    extends LedgerIdentityServiceITBaseGiven
+    with SandboxBackend.Postgresql
+    with SandboxEnableAppendOnlySchema
 
 sealed trait LedgerIdentityServiceITBaseDynamic
     extends AnyWordSpec
@@ -124,3 +130,9 @@ final class LedgerIdentityServicePostgresDynamicSharedPostgresIT
     }
   }
 }
+
+// TODO append-only: remove this class once the append-only schema is the default one
+final class LedgerIdentityServicePostgresAppendOnlyDynamicIT
+    extends LedgerIdentityServiceITBaseDynamic
+    with SandboxBackend.Postgresql
+    with SandboxEnableAppendOnlySchema

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/reset/ResetServiceH2DatabaseIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/reset/ResetServiceH2DatabaseIT.scala
@@ -10,3 +10,5 @@ final class ResetServiceH2DatabaseIT
     extends ResetServiceDatabaseIT
     with SandboxFixture
     with SandboxBackend.H2Database
+
+// TODO append-only: add a test for H2 on the append-only schema

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/reset/ResetServicePostgresqlIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/reset/ResetServicePostgresqlIT.scala
@@ -4,9 +4,16 @@
 package com.daml.platform.sandbox.services.reset
 
 import com.daml.platform.sandbox.SandboxBackend
-import com.daml.platform.sandbox.services.SandboxFixture
+import com.daml.platform.sandbox.services.{SandboxEnableAppendOnlySchema, SandboxFixture}
 
 final class ResetServicePostgresqlIT
     extends ResetServiceDatabaseIT
     with SandboxFixture
     with SandboxBackend.Postgresql
+
+// TODO append-only: remove this class once the append-only schema is the default one
+final class ResetServicePostgresqlAppendOnlyIT
+    extends ResetServiceDatabaseIT
+    with SandboxFixture
+    with SandboxBackend.Postgresql
+    with SandboxEnableAppendOnlySchema

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpecAppendOnly.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpecAppendOnly.scala
@@ -41,6 +41,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.util.{Success, Try}
 
+// TODO append-only: Remove this class once the mutating schema is removed
 final class SqlLedgerSpecAppendOnly
     extends AsyncWordSpec
     with Matchers

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpecAppendOnly.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpecAppendOnly.scala
@@ -1,0 +1,328 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.stores.ledger.sql
+
+import java.io.File
+import java.time.Instant
+
+import ch.qos.logback.classic.Level
+import com.daml.api.util.TimeProvider
+import com.daml.bazeltools.BazelRunfiles.rlocation
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.api.domain.{LedgerId, ParticipantId}
+import com.daml.ledger.api.health.Healthy
+import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
+import com.daml.ledger.resources.{Resource, ResourceContext, TestResourceContext}
+import com.daml.ledger.test.ModelTestDar
+import com.daml.lf.archive.DarReader
+import com.daml.lf.data.{ImmArray, Ref}
+import com.daml.lf.engine.Engine
+import com.daml.lf.transaction.LegacyTransactionCommitter
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.common.{LedgerIdMode, MismatchException}
+import com.daml.platform.configuration.ServerRole
+import com.daml.platform.packages.InMemoryPackageStore
+import com.daml.platform.sandbox.MetricsAround
+import com.daml.platform.sandbox.config.LedgerName
+import com.daml.platform.sandbox.stores.ledger.Ledger
+import com.daml.platform.sandbox.stores.ledger.sql.SqlLedgerSpecAppendOnly._
+import com.daml.platform.store.{IndexMetadata, LfValueTranslationCache}
+import com.daml.platform.testing.LogCollector
+import com.daml.testing.postgresql.PostgresAroundEach
+import org.scalatest.concurrent.{AsyncTimeLimitedTests, Eventually, ScaledTimeSpans}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Minute, Seconds, Span}
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.collection.mutable
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+import scala.util.{Success, Try}
+
+final class SqlLedgerSpecAppendOnly
+    extends AsyncWordSpec
+    with Matchers
+    with AsyncTimeLimitedTests
+    with ScaledTimeSpans
+    with Eventually
+    with TestResourceContext
+    with AkkaBeforeAndAfterAll
+    with PostgresAroundEach
+    with MetricsAround {
+
+  protected implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
+
+  override val timeLimit: Span = scaled(Span(1, Minute))
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(10, Seconds)))
+
+  private val createdLedgers = mutable.Buffer[Resource[Ledger]]()
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    createdLedgers.clear()
+  }
+
+  override protected def afterEach(): Unit = {
+    LogCollector.clear[SqlLedgerSpecAppendOnly]
+    for (ledger <- createdLedgers)
+      Await.result(ledger.release(), 2.seconds)
+    super.afterEach()
+  }
+
+  "SQL Ledger" should {
+    "be able to be created from scratch with a random ledger ID" in {
+      for {
+        ledger <- createSqlLedger(validatePartyAllocation = false)
+      } yield {
+        ledger.ledgerId should not be ""
+      }
+    }
+
+    "be able to be created from scratch with a given ledger ID" in {
+      for {
+        ledger <- createSqlLedger(ledgerId, validatePartyAllocation = false)
+      } yield {
+        ledger.ledgerId should be(ledgerId)
+      }
+    }
+
+    "be able to be reused keeping the old ledger ID" in {
+      for {
+        ledger1 <- createSqlLedger(ledgerId, validatePartyAllocation = false)
+        ledger2 <- createSqlLedger(ledgerId, validatePartyAllocation = false)
+        ledger3 <- createSqlLedger(validatePartyAllocation = false)
+      } yield {
+        ledger1.ledgerId should not be LedgerId
+        ledger1.ledgerId should be(ledger2.ledgerId)
+        ledger2.ledgerId should be(ledger3.ledgerId)
+      }
+    }
+
+    "refuse to create a new ledger when there is already one with a different ledger ID" in {
+      for {
+        _ <- createSqlLedger(ledgerId = "TheLedger", validatePartyAllocation = false)
+        throwable <- createSqlLedger(
+          ledgerId = "AnotherLedger",
+          validatePartyAllocation = false,
+        ).failed
+      } yield {
+        throwable.getMessage should be(
+          "The provided ledger id does not match the existing one. Existing: \"TheLedger\", Provided: \"AnotherLedger\"."
+        )
+      }
+    }
+
+    "correctly initialized the participant ID" in {
+      val participantId = makeParticipantId("TheOnlyParticipant")
+      for {
+        _ <- createSqlLedgerWithParticipantId(participantId, validatePartyAllocation = false)
+        metadata <- IndexMetadata.read(postgresDatabase.url)
+      } yield {
+        metadata.participantId shouldEqual participantId
+      }
+    }
+
+    "allow to resume on an existing participant ID" in {
+      val participantId = makeParticipantId("TheParticipant")
+      for {
+        _ <- createSqlLedgerWithParticipantId(participantId, validatePartyAllocation = false)
+        _ <- createSqlLedgerWithParticipantId(participantId, validatePartyAllocation = false)
+        metadata <- IndexMetadata.read(postgresDatabase.url)
+      } yield {
+        metadata.participantId shouldEqual participantId
+      }
+    }
+
+    "refuse to create a new ledger when there is already one with a different participant ID" in {
+      val expectedExisting = makeParticipantId("TheParticipant")
+      val expectedProvided = makeParticipantId("AnotherParticipant")
+      for {
+        _ <- createSqlLedgerWithParticipantId(expectedExisting, validatePartyAllocation = false)
+        throwable <- createSqlLedgerWithParticipantId(
+          expectedProvided,
+          validatePartyAllocation = false,
+        ).failed
+      } yield {
+        throwable match {
+          case mismatch: MismatchException.ParticipantId =>
+            mismatch.existing shouldEqual expectedExisting
+            mismatch.provided shouldEqual expectedProvided
+          case _ =>
+            fail("Did not get the expected exception type", throwable)
+        }
+      }
+    }
+
+    "load no packages by default" in {
+      for {
+        ledger <- createSqlLedger(validatePartyAllocation = false)
+        packages <- ledger.listLfPackages()
+      } yield {
+        packages should have size 0
+      }
+    }
+
+    "load packages if provided with a dynamic ledger ID" in {
+      for {
+        ledger <- createSqlLedger(
+          packages = testDar.all,
+          validatePartyAllocation = false,
+        )
+        packages <- ledger.listLfPackages()
+      } yield {
+        packages should have size testDar.all.length.toLong
+      }
+    }
+
+    "load packages if provided with a static ledger ID" in {
+      for {
+        ledger <- createSqlLedger(
+          ledgerId = "TheLedger",
+          packages = testDar.all,
+          validatePartyAllocation = false,
+        )
+        packages <- ledger.listLfPackages()
+      } yield {
+        packages should have size testDar.all.length.toLong
+      }
+    }
+
+    "load no packages if the ledger already exists" in {
+      for {
+        _ <- createSqlLedger(ledgerId = "TheLedger", validatePartyAllocation = false)
+        ledger <- createSqlLedger(
+          ledgerId = "TheLedger",
+          packages = testDar.all,
+          validatePartyAllocation = false,
+        )
+        packages <- ledger.listLfPackages()
+      } yield {
+        packages should have size 0
+      }
+    }
+
+    "be healthy" in {
+      for {
+        ledger <- createSqlLedger(validatePartyAllocation = false)
+      } yield {
+        ledger.currentHealth() should be(Healthy)
+      }
+    }
+
+    /** Workaround test for asserting that PostgreSQL asynchronous commits are disabled in
+      * [[com.daml.platform.store.dao.JdbcLedgerDao]] transactions when used from [[SqlLedger]].
+      *
+      * NOTE: This is needed for ensuring durability guarantees of Daml-on-SQL.
+      */
+    "does not use async commit when building JdbcLedgerDao" in {
+      for {
+        _ <- createSqlLedger(validatePartyAllocation = false)
+      } yield {
+        val hikariDataSourceLogs =
+          LogCollector.read[this.type]("com.daml.platform.store.appendonlydao.HikariConnection")
+        hikariDataSourceLogs should contain(
+          Level.INFO -> "Creating Hikari connections with synchronous commit ON"
+        )
+      }
+    }
+  }
+
+  private def createSqlLedger(validatePartyAllocation: Boolean): Future[Ledger] =
+    createSqlLedger(None, None, List.empty, validatePartyAllocation)
+
+  private def createSqlLedger(
+      ledgerId: String,
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(ledgerId, List.empty, validatePartyAllocation)
+
+  private def createSqlLedger(
+      ledgerId: LedgerId,
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(ledgerId, List.empty, validatePartyAllocation)
+
+  private def createSqlLedger(
+      packages: List[DamlLf.Archive],
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(None, None, packages, validatePartyAllocation)
+
+  private def createSqlLedger(
+      ledgerId: String,
+      packages: List[DamlLf.Archive],
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] = {
+    val assertedLedgerId: LedgerId = LedgerId(Ref.LedgerString.assertFromString(ledgerId))
+    createSqlLedger(assertedLedgerId, packages, validatePartyAllocation)
+  }
+
+  private def createSqlLedger(
+      ledgerId: LedgerId,
+      packages: List[DamlLf.Archive],
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(Some(ledgerId), None, packages, validatePartyAllocation)
+
+  private def createSqlLedgerWithParticipantId(
+      participantId: ParticipantId,
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] =
+    createSqlLedger(None, Some(participantId), List.empty, validatePartyAllocation)
+
+  private def makeParticipantId(id: String): ParticipantId =
+    ParticipantId(Ref.ParticipantId.assertFromString(id))
+
+  private val DefaultParticipantId = makeParticipantId("test-participant-id")
+
+  private def createSqlLedger(
+      ledgerId: Option[LedgerId],
+      participantId: Option[ParticipantId],
+      packages: List[DamlLf.Archive],
+      validatePartyAllocation: Boolean,
+  ): Future[Ledger] = {
+    metrics.getNames.forEach(name => { val _ = metrics.remove(name) })
+    val ledger =
+      new SqlLedger.Owner(
+        name = LedgerName(getClass.getSimpleName),
+        serverRole = ServerRole.Testing(getClass),
+        jdbcUrl = postgresDatabase.url,
+        databaseConnectionPoolSize = 16,
+        databaseConnectionTimeout = 250.millis,
+        providedLedgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
+        participantId = participantId.getOrElse(DefaultParticipantId),
+        timeProvider = TimeProvider.UTC,
+        packages = InMemoryPackageStore.empty
+          .withPackages(Instant.EPOCH, None, packages)
+          .fold(sys.error, identity),
+        initialLedgerEntries = ImmArray.empty,
+        queueDepth = queueDepth,
+        transactionCommitter = LegacyTransactionCommitter,
+        startMode = SqlStartMode.MigrateAndStart,
+        eventsPageSize = 100,
+        servicesExecutionContext = executionContext,
+        metrics = new Metrics(metrics),
+        lfValueTranslationCache = LfValueTranslationCache.Cache.none,
+        engine = new Engine(),
+        validatePartyAllocation = validatePartyAllocation,
+        enableAppendOnlySchema = true,
+      ).acquire()(ResourceContext(system.dispatcher))
+    createdLedgers += ledger
+    ledger.asFuture
+  }
+}
+
+object SqlLedgerSpecAppendOnly {
+  private val queueDepth = 128
+
+  private val ledgerId: LedgerId = LedgerId(Ref.LedgerString.assertFromString("TheLedger"))
+
+  private val Success(testDar) = {
+    val reader = DarReader { (_, stream) => Try(DamlLf.Archive.parseFrom(stream)) }
+    val fileName = new File(rlocation(ModelTestDar.path))
+    reader.readArchiveFromFile(fileName)
+  }
+}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/TransactionStreamTerminationIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/TransactionStreamTerminationIT.scala
@@ -42,6 +42,7 @@ class TransactionStreamTerminationIT
     PatienceConfig(scaled(Span(15000, Millis)), scaled(Span(150, Millis)))
 
   override protected def config: SandboxConfig = super.config.copy(
+    // TODO: this class does not use SandboxBackend.H2Database, the jdbc url provided here will have no effect
     jdbcUrl = Some("jdbc:h2:mem:static_time;db_close_delay=-1"),
     timeProviderType = Some(TimeProviderType.Static),
   )


### PR DESCRIPTION
This PR enables sandbox classic tests on the Postgresql append-only schema.

Most test files are extended, the `SqlLedgerSpec` file is duplicated.