### PR TITLE
Fix Windows test skipping

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -59,6 +59,6 @@ bazel build `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/build_exec
 
 bazel shutdown
 
-if ($env:SKIP_TESTS = "False") {
+if ($env:SKIP_TESTS -ceq "False") {
     bazel test `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/test_execution_windows.log //...
 }


### PR DESCRIPTION
= doesn’t seem to work. -ceq is case insensitive comparison. I think
-eq would also work here but I see no point in worrying about case.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
