### PR TITLE
[In-memory fan-out] BufferedTransactionsReader implementation [DPP-413] [DPP-414]

### DIFF
--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -346,7 +346,7 @@ conformance_test(
     server = ":conformance-test-postgresql-bin",
     server_args = [
         "--contract-id-seeding=testing-weak",
-        "--participant participant-id=conformance-test,port=6865,contract-state-cache-max-size=1,contract-key-state-cache-max-size=1,ledger-api-transactions-buffer-max-size=1",
+        "--participant participant-id=conformance-test,port=6865,contract-state-cache-max-size=1,contract-key-state-cache-max-size=1,ledger-api-transactions-buffer-max-size=10",
         "--index-append-only-schema-unsafe",
         "--mutable-contract-state-cache-unsafe",
         "--buffered-ledger-api-streams-unsafe",
@@ -354,7 +354,6 @@ conformance_test(
     tags = [],
     test_tool_args = [
         "--verbose",
-        "--include=ContractKeysIT,DivulgenceIT,TransactionServiceIT,RaceConditionIT",
     ],
 )
 

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -660,7 +660,27 @@ final class Metrics(val registry: MetricRegistry) {
           def push(qualifier: String): Timer = registry.timer(Prefix :+ qualifier :+ "push")
           def slice(qualifier: String): Timer = registry.timer(Prefix :+ qualifier :+ "slice")
           def prune(qualifier: String): Timer = registry.timer(Prefix :+ qualifier :+ "prune")
+
+          val totalTransactionTreesRetrieved: Counter =
+            registry.counter(Prefix :+ "total_transactions_trees_retrieved")
+          val transactionTreeEventsResolvedFromBuffer: Counter =
+            registry.counter(Prefix :+ "transaction_tree_events_from_buffer")
+
+          val totalFlatTransactionsRetrieved: Counter =
+            registry.counter(Prefix :+ "total_flat_transactions_retrieved")
+          val flatTransactionEventsResolvedFromBuffer: Counter =
+            registry.counter(Prefix :+ "flat_transaction_events_from_buffer")
         }
+
+        val getTransactionTreesSource: Timer =
+          registry.timer(Prefix :+ "get_transaction_trees_source")
+        val getFlatTransactionsSource: Timer =
+          registry.timer(Prefix :+ "get_flat_transactions_source")
+
+        val transactionTreesBufferSize: Counter =
+          registry.counter(Prefix :+ "transaction_trees_output_buffer_size")
+        val flatTransactionsBufferSize: Counter =
+          registry.counter(Prefix :+ "flat_transactions_output_buffer_size")
       }
 
       object read {

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -661,26 +661,26 @@ final class Metrics(val registry: MetricRegistry) {
           def slice(qualifier: String): Timer = registry.timer(Prefix :+ qualifier :+ "slice")
           def prune(qualifier: String): Timer = registry.timer(Prefix :+ qualifier :+ "prune")
 
-          val totalTransactionTreesRetrieved: Counter =
-            registry.counter(Prefix :+ "total_transactions_trees_retrieved")
-          val transactionTreeEventsResolvedFromBuffer: Counter =
-            registry.counter(Prefix :+ "transaction_tree_events_from_buffer")
+          val transactionTreesTotal: Counter =
+            registry.counter(Prefix :+ "transaction_trees_total")
+          val transactionTreesBuffered: Counter =
+            registry.counter(Prefix :+ "transaction_trees_buffered")
 
-          val totalFlatTransactionsRetrieved: Counter =
-            registry.counter(Prefix :+ "total_flat_transactions_retrieved")
-          val flatTransactionEventsResolvedFromBuffer: Counter =
-            registry.counter(Prefix :+ "flat_transaction_events_from_buffer")
+          val flatTransactionsTotal: Counter =
+            registry.counter(Prefix :+ "flat_transactions_total")
+          val flatTransactionsBuffered: Counter =
+            registry.counter(Prefix :+ "flat_transactions_buffered")
+
+          val getTransactionTrees: Timer =
+            registry.timer(Prefix :+ "get_transaction_trees")
+          val getFlatTransactions: Timer =
+            registry.timer(Prefix :+ "get_flat_transactions")
         }
 
-        val getTransactionTreesSource: Timer =
-          registry.timer(Prefix :+ "get_transaction_trees_source")
-        val getFlatTransactionsSource: Timer =
-          registry.timer(Prefix :+ "get_flat_transactions_source")
-
         val transactionTreesBufferSize: Counter =
-          registry.counter(Prefix :+ "transaction_trees_output_buffer_size")
+          registry.counter(Prefix :+ "transaction_trees_buffer_size")
         val flatTransactionsBufferSize: Counter =
-          registry.counter(Prefix :+ "flat_transactions_output_buffer_size")
+          registry.counter(Prefix :+ "flat_transactions_buffer_size")
       }
 
       object read {

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
@@ -12,14 +12,17 @@ import com.codahale.metrics.Timer
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.participant.state.v1.Offset
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
+import com.daml.lf.engine.ValueEnricher
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.akkastreams.dispatcher.SubSource.RangeSource
 import com.daml.platform.index.ReadOnlySqlLedgerWithMutableCache.DispatcherLagMeter
+import com.daml.platform.store.LfValueTranslationCache
+import com.daml.platform.store.appendonlydao.events.{BufferedTransactionsReader, LfValueTranslation}
 import com.daml.platform.store.cache.MutableCacheBackedContractStore.SignalNewLedgerHead
 import com.daml.platform.store.cache.{EventsBuffer, MutableCacheBackedContractStore}
-import com.daml.platform.store.dao.LedgerReadDao
+import com.daml.platform.store.dao.{LedgerDaoTransactionsReader, LedgerReadDao}
 import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.scalautil.Statement.discard
 
@@ -30,6 +33,7 @@ import scala.concurrent.{Await, Future}
 private[index] object ReadOnlySqlLedgerWithMutableCache {
   final class Owner(
       ledgerDao: LedgerReadDao,
+      enricher: ValueEnricher,
       ledgerId: LedgerId,
       metrics: Metrics,
       maxContractStateCacheSize: Long,
@@ -123,6 +127,7 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
             new ReadOnlySqlLedgerWithMutableCache(
               ledgerId,
               ledgerDao,
+              ledgerDao.transactionsReader,
               contractStore,
               cacheUpdatesDispatcher,
               generalDispatcher,
@@ -173,6 +178,18 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
             new ReadOnlySqlLedgerWithMutableCache(
               ledgerId,
               ledgerDao,
+              BufferedTransactionsReader(
+                delegate = ledgerDao.transactionsReader,
+                transactionsBuffer = transactionsBuffer,
+                lfValueTranslation = new LfValueTranslation(
+                  cache = LfValueTranslationCache.Cache.none,
+                  metrics = metrics,
+                  enricherO = Some(enricher),
+                  loadPackage =
+                    (packageId, loggingContext) => ledgerDao.getLfArchive(packageId)(loggingContext),
+                ),
+                metrics = metrics,
+              ),
               contractStore,
               cacheUpdatesDispatcher,
               generalDispatcher,
@@ -223,12 +240,19 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
 private final class ReadOnlySqlLedgerWithMutableCache(
     ledgerId: LedgerId,
     ledgerDao: LedgerReadDao,
+    ledgerDaoTransactionsReader: LedgerDaoTransactionsReader,
     contractStore: MutableCacheBackedContractStore,
     contractStateEventsDispatcher: Dispatcher[(Offset, Long)],
     dispatcher: Dispatcher[Offset],
     dispatcherLagger: DispatcherLagMeter,
 )(implicit mat: Materializer, loggingContext: LoggingContext)
-    extends ReadOnlySqlLedger(ledgerId, ledgerDao, contractStore, dispatcher) {
+    extends ReadOnlySqlLedger(
+      ledgerId,
+      ledgerDao,
+      ledgerDaoTransactionsReader,
+      contractStore,
+      dispatcher,
+    ) {
 
   protected val (ledgerEndUpdateKillSwitch, ledgerEndUpdateDone) =
     RestartSource

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithTranslationCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithTranslationCache.scala
@@ -71,6 +71,7 @@ private final class ReadOnlySqlLedgerWithTranslationCache(
     extends ReadOnlySqlLedger(
       ledgerId,
       ledgerDao,
+      ledgerDao.transactionsReader,
       contractStore,
       dispatcher,
     ) {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -34,7 +34,7 @@ import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.LoggingContext
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.akkastreams.dispatcher.SubSource.RangeSource
-import com.daml.platform.store.dao.LedgerReadDao
+import com.daml.platform.store.dao.{LedgerDaoTransactionsReader, LedgerReadDao}
 import com.daml.platform.store.entries.{ConfigurationEntry, PackageLedgerEntry, PartyLedgerEntry}
 import scalaz.syntax.tag.ToTagOps
 
@@ -44,6 +44,7 @@ import scala.util.Try
 private[platform] abstract class BaseLedger(
     val ledgerId: LedgerId,
     ledgerDao: LedgerReadDao,
+    transactionsReader: LedgerDaoTransactionsReader,
     contractStore: ContractStore,
     dispatcher: Dispatcher[Offset],
 ) extends ReadOnlyLedger {
@@ -65,7 +66,7 @@ private[platform] abstract class BaseLedger(
   )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] =
     dispatcher.startingAt(
       startExclusive.getOrElse(Offset.beforeBegin),
-      RangeSource(ledgerDao.transactionsReader.getFlatTransactions(_, _, filter, verbose)),
+      RangeSource(transactionsReader.getFlatTransactions(_, _, filter, verbose)),
       endInclusive,
     )
 
@@ -80,7 +81,7 @@ private[platform] abstract class BaseLedger(
     dispatcher.startingAt(
       startExclusive.getOrElse(Offset.beforeBegin),
       RangeSource(
-        ledgerDao.transactionsReader.getTransactionTrees(_, _, requestingParties, verbose)
+        transactionsReader.getTransactionTrees(_, _, requestingParties, verbose)
       ),
       endInclusive,
     )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/BufferedTransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/BufferedTransactionsReader.scala
@@ -48,11 +48,10 @@ private[events] class BufferedTransactionsReader(
       toApiTx = toFlatTransaction,
       apiResponseCtor = GetTransactionsResponse(_),
       fetchTransactions = delegate.getFlatTransactions(_, _, _, _)(loggingContext),
-      sourceTimer = metrics.daml.services.index.getFlatTransactionsSource,
+      sourceTimer = metrics.daml.services.index.streamsBuffer.getFlatTransactions,
       resolvedFromBufferCounter =
-        metrics.daml.services.index.streamsBuffer.flatTransactionEventsResolvedFromBuffer,
-      totalRetrievedCounter =
-        metrics.daml.services.index.streamsBuffer.totalFlatTransactionsRetrieved,
+        metrics.daml.services.index.streamsBuffer.flatTransactionsBuffered,
+      totalRetrievedCounter = metrics.daml.services.index.streamsBuffer.flatTransactionsTotal,
       bufferSizeCounter =
         // TODO in-memory fan-out: Specialize the metric per consumer
         metrics.daml.services.index.flatTransactionsBufferSize,
@@ -71,11 +70,10 @@ private[events] class BufferedTransactionsReader(
       toApiTx = toTransactionTree,
       apiResponseCtor = GetTransactionTreesResponse(_),
       fetchTransactions = delegate.getTransactionTrees(_, _, _, _)(loggingContext),
-      sourceTimer = metrics.daml.services.index.getTransactionTreesSource,
+      sourceTimer = metrics.daml.services.index.streamsBuffer.getTransactionTrees,
       resolvedFromBufferCounter =
-        metrics.daml.services.index.streamsBuffer.transactionTreeEventsResolvedFromBuffer,
-      totalRetrievedCounter =
-        metrics.daml.services.index.streamsBuffer.totalTransactionTreesRetrieved,
+        metrics.daml.services.index.streamsBuffer.transactionTreesBuffered,
+      totalRetrievedCounter = metrics.daml.services.index.streamsBuffer.transactionTreesTotal,
       bufferSizeCounter =
         // TODO in-memory fan-out: Specialize the metric per consumer
         metrics.daml.services.index.transactionTreesBufferSize,
@@ -113,7 +111,7 @@ private[events] class BufferedTransactionsReader(
       loggingContext: LoggingContext
   ): Source[((Offset, EventSequentialId), TransactionLogUpdate), NotUsed] =
     throw new UnsupportedOperationException(
-      s"getTransactionUpdates is not supported on ${getClass.getSimpleName}"
+      s"getTransactionLogUpdates is not supported on ${getClass.getSimpleName}"
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/BufferedTransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/BufferedTransactionsReader.scala
@@ -1,0 +1,211 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import com.codahale.metrics.{Counter, Timer}
+import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
+import com.daml.ledger.api.v1.transaction.{TransactionTree, Transaction => FlatTransaction}
+import com.daml.ledger.api.v1.transaction_service.{
+  GetFlatTransactionResponse,
+  GetTransactionResponse,
+  GetTransactionTreesResponse,
+  GetTransactionsResponse,
+}
+import com.daml.ledger.participant.state.v1.{Offset, TransactionId}
+import com.daml.logging.LoggingContext
+import com.daml.metrics.{InstrumentedSource, Metrics, Timed}
+import com.daml.platform.store.appendonlydao.events.BufferedTransactionsReader.getTransactions
+import com.daml.platform.store.cache.MutableCacheBackedContractStore.EventSequentialId
+import com.daml.platform.store.cache.{BufferSlice, EventsBuffer}
+import com.daml.platform.store.dao.LedgerDaoTransactionsReader
+import com.daml.platform.store.dao.events.ContractStateEvent
+import com.daml.platform.store.interfaces.TransactionLogUpdate
+import com.daml.platform.store.interfaces.TransactionLogUpdate.{Transaction => TxUpdate}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+private[events] class BufferedTransactionsReader(
+    protected val delegate: LedgerDaoTransactionsReader,
+    val transactionsBuffer: EventsBuffer[Offset, TransactionLogUpdate],
+    toFlatTransaction: (TxUpdate, FilterRelation, Boolean) => Future[Option[FlatTransaction]],
+    toTransactionTree: (TxUpdate, Set[Party], Boolean) => Future[Option[TransactionTree]],
+    metrics: Metrics,
+)(implicit executionContext: ExecutionContext)
+    extends LedgerDaoTransactionsReader {
+
+  private val outputStreamBufferSize = 128
+
+  override def getFlatTransactions(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      filter: FilterRelation,
+      verbose: Boolean,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] =
+    getTransactions(transactionsBuffer)(startExclusive, endInclusive, filter, verbose)(
+      toApiTx = toFlatTransaction,
+      apiResponseCtor = GetTransactionsResponse(_),
+      fetchTransactions = delegate.getFlatTransactions(_, _, _, _)(loggingContext),
+      sourceTimer = metrics.daml.services.index.getFlatTransactionsSource,
+      resolvedFromBufferCounter =
+        metrics.daml.services.index.streamsBuffer.flatTransactionEventsResolvedFromBuffer,
+      totalRetrievedCounter =
+        metrics.daml.services.index.streamsBuffer.totalFlatTransactionsRetrieved,
+      bufferSizeCounter =
+        // TODO in-memory fan-out: Specialize the metric per consumer
+        metrics.daml.services.index.flatTransactionsBufferSize,
+      outputStreamBufferSize = outputStreamBufferSize,
+    )
+
+  override def getTransactionTrees(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      requestingParties: Set[Party],
+      verbose: Boolean,
+  )(implicit
+      loggingContext: LoggingContext
+  ): Source[(Offset, GetTransactionTreesResponse), NotUsed] =
+    getTransactions(transactionsBuffer)(startExclusive, endInclusive, requestingParties, verbose)(
+      toApiTx = toTransactionTree,
+      apiResponseCtor = GetTransactionTreesResponse(_),
+      fetchTransactions = delegate.getTransactionTrees(_, _, _, _)(loggingContext),
+      sourceTimer = metrics.daml.services.index.getTransactionTreesSource,
+      resolvedFromBufferCounter =
+        metrics.daml.services.index.streamsBuffer.transactionTreeEventsResolvedFromBuffer,
+      totalRetrievedCounter =
+        metrics.daml.services.index.streamsBuffer.totalTransactionTreesRetrieved,
+      bufferSizeCounter =
+        // TODO in-memory fan-out: Specialize the metric per consumer
+        metrics.daml.services.index.transactionTreesBufferSize,
+      outputStreamBufferSize = outputStreamBufferSize,
+    )
+
+  override def lookupFlatTransactionById(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]] =
+    delegate.lookupFlatTransactionById(transactionId, requestingParties)
+
+  override def lookupTransactionTreeById(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]] =
+    delegate.lookupTransactionTreeById(transactionId, requestingParties)
+
+  override def getActiveContracts(activeAt: Offset, filter: FilterRelation, verbose: Boolean)(
+      implicit loggingContext: LoggingContext
+  ): Source[GetActiveContractsResponse, NotUsed] =
+    delegate.getActiveContracts(activeAt, filter, verbose)
+
+  override def getContractStateEvents(startExclusive: (Offset, Long), endInclusive: (Offset, Long))(
+      implicit loggingContext: LoggingContext
+  ): Source[((Offset, Long), ContractStateEvent), NotUsed] =
+    throw new UnsupportedOperationException(
+      s"getContractStateEvents is not supported on ${getClass.getSimpleName}"
+    )
+
+  override def getTransactionLogUpdates(
+      startExclusive: (Offset, EventSequentialId),
+      endInclusive: (Offset, EventSequentialId),
+  )(implicit
+      loggingContext: LoggingContext
+  ): Source[((Offset, EventSequentialId), TransactionLogUpdate), NotUsed] =
+    throw new UnsupportedOperationException(
+      s"getTransactionUpdates is not supported on ${getClass.getSimpleName}"
+    )
+}
+
+private[platform] object BufferedTransactionsReader {
+  type FetchTransactions[FILTER, API_RESPONSE] =
+    (Offset, Offset, FILTER, Boolean) => Source[(Offset, API_RESPONSE), NotUsed]
+
+  def apply(
+      delegate: LedgerDaoTransactionsReader,
+      transactionsBuffer: EventsBuffer[Offset, TransactionLogUpdate],
+      lfValueTranslation: LfValueTranslation,
+      metrics: Metrics,
+  )(implicit
+      loggingContext: LoggingContext,
+      executionContext: ExecutionContext,
+  ): BufferedTransactionsReader =
+    new BufferedTransactionsReader(
+      delegate = delegate,
+      transactionsBuffer = transactionsBuffer,
+      toFlatTransaction =
+        TransactionLogUpdatesConversions.ToFlatTransaction(_, _, _, lfValueTranslation),
+      toTransactionTree =
+        TransactionLogUpdatesConversions.ToTransactionTree(_, _, _, lfValueTranslation),
+      metrics = metrics,
+    )
+
+  private[events] def getTransactions[FILTER, API_TX, API_RESPONSE](
+      transactionsBuffer: EventsBuffer[Offset, TransactionLogUpdate]
+  )(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      filter: FILTER,
+      verbose: Boolean,
+  )(
+      toApiTx: (TxUpdate, FILTER, Boolean) => Future[Option[API_TX]],
+      apiResponseCtor: Seq[API_TX] => API_RESPONSE,
+      fetchTransactions: FetchTransactions[FILTER, API_RESPONSE],
+      sourceTimer: Timer,
+      resolvedFromBufferCounter: Counter,
+      totalRetrievedCounter: Counter,
+      outputStreamBufferSize: Int,
+      bufferSizeCounter: Counter,
+  )(implicit executionContext: ExecutionContext): Source[(Offset, API_RESPONSE), NotUsed] = {
+    def filterBuffered(
+        slice: Vector[(Offset, TransactionLogUpdate)]
+    ): Future[Iterator[(Offset, API_RESPONSE)]] =
+      Future
+        .traverse(
+          slice.iterator
+            .collect { case (offset, tx: TxUpdate) =>
+              toApiTx(tx, filter, verbose).map(offset -> _)
+            }
+        )(identity)
+        .map(_.collect { case (offset, Some(tx)) =>
+          resolvedFromBufferCounter.inc()
+          offset -> apiResponseCtor(Seq(tx))
+        })
+
+    val transactionsSource = Timed.source(
+      sourceTimer, {
+        // TODO Scala 2.13.5: Remove the @unchecked once migrated to Scala 2.13.5 where this false positive exhaustivity check for Vectors is fixed
+        (transactionsBuffer.slice(startExclusive, endInclusive): @unchecked) match {
+          case BufferSlice.Empty =>
+            fetchTransactions(startExclusive, endInclusive, filter, verbose)
+
+          // TODO in-memory fan-out: Implement and use Offset.predecessor
+          case BufferSlice.Prefix(slice) if slice.size <= 1 =>
+            fetchTransactions(startExclusive, endInclusive, filter, verbose)
+
+          // TODO in-memory fan-out: Implement and use Offset.predecessor
+          case BufferSlice.Prefix((firstOffset: Offset, _) +: tl) =>
+            fetchTransactions(startExclusive, firstOffset, filter, verbose)
+              .concat(
+                Source.futureSource(filterBuffered(tl).map(it => Source.fromIterator(() => it)))
+              )
+              .mapMaterializedValue(_ => NotUsed)
+
+          case BufferSlice.Inclusive(slice) =>
+            Source
+              .futureSource(filterBuffered(slice).map(it => Source.fromIterator(() => it)))
+              .mapMaterializedValue(_ => NotUsed)
+        }
+      }.map(tx => {
+        totalRetrievedCounter.inc()
+        tx
+      }),
+    )
+
+    InstrumentedSource.bufferedSource(
+      original = transactionsSource,
+      counter = bufferSizeCounter,
+      size = outputStreamBufferSize,
+    )
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTable.scala
@@ -47,6 +47,9 @@ object EventsTable {
       events.headOption.flatMap { first =>
         val flatEvents =
           TransactionConversion.removeTransient(events.iterator.map(_.event).toVector)
+        // Allows emitting flat transactions with no events, a use-case needed
+        // for the functioning of DAML triggers.
+        // (more details in https://github.com/digital-asset/daml/issues/6975)
         if (flatEvents.nonEmpty || first.commandId.nonEmpty)
           Some(
             ApiTransaction(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
@@ -153,7 +153,7 @@ final class LfValueTranslation(
     }
   }
 
-  private[this] def toApiValue(
+  def toApiValue(
       value: LfValue,
       verbose: Boolean,
       attribute: => String,
@@ -178,7 +178,7 @@ final class LfValueTranslation(
     )
   }
 
-  private[this] def toApiRecord(
+  def toApiRecord(
       value: LfValue,
       verbose: Boolean,
       attribute: => String,
@@ -218,7 +218,7 @@ final class LfValueTranslation(
   private def decompressAndDeserialize(algorithm: Compression.Algorithm, value: InputStream) =
     ValueSerializer.deserializeValue(algorithm.decompress(value))
 
-  private[this] def enricher: ValueEnricher = {
+  def enricher: ValueEnricher = {
     // Note: LfValueTranslation is used by JdbcLedgerDao for both serialization and deserialization.
     // Sometimes the JdbcLedgerDao is used in a way that it never needs to deserialize data in verbose mode
     // (e.g., the indexer, or some tests). In this case, the enricher is not required.

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionLogUpdatesConversions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionLogUpdatesConversions.scala
@@ -1,0 +1,423 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.time.Instant
+
+import com.daml.ledger.api.v1
+import com.daml.ledger.api.v1.transaction.{
+  TransactionTree,
+  TreeEvent,
+  Transaction => FlatTransaction,
+}
+import com.daml.lf.data.Ref
+import com.daml.logging.LoggingContext
+import com.daml.platform.ApiOffset
+import com.daml.platform.api.v1.event.EventOps.TreeEventOps
+import com.daml.platform.participant.util.LfEngineToApi
+import com.daml.platform.store.interfaces.TransactionLogUpdate
+import com.daml.platform.store.interfaces.TransactionLogUpdate.{CreatedEvent, ExercisedEvent}
+import com.google.protobuf.timestamp.Timestamp
+
+import scala.concurrent.{ExecutionContext, Future}
+
+private[events] object TransactionLogUpdatesConversions {
+  object ToFlatTransaction {
+    def apply(
+        tx: TransactionLogUpdate.Transaction,
+        filter: FilterRelation,
+        verbose: Boolean,
+        lfValueTranslation: LfValueTranslation,
+    )(implicit
+        loggingContext: LoggingContext,
+        executionContext: ExecutionContext,
+    ): Future[Option[FlatTransaction]] = {
+      val aux = tx.events.filter(FlatTransactionPredicate(_, filter))
+      val nonTransientIds = permanent(aux)
+      val events = aux.filter(ev => nonTransientIds(ev.contractId))
+
+      events.headOption
+        .collect {
+          case first if first.commandId.nonEmpty || events.nonEmpty =>
+            Future
+              .traverse(events)(toFlatEvent(_, filter.keySet, verbose, lfValueTranslation))
+              .map(_.collect { case Some(v) => v })
+              .map {
+                case Vector() => None
+                case flatEvents =>
+                  Some(
+                    FlatTransaction(
+                      transactionId = first.transactionId,
+                      commandId = getCommandId(
+                        events,
+                        tx.commandId,
+                        filter.keySet,
+                      ), // TODO // TDT Check condition for command id
+                      workflowId = first.workflowId,
+                      effectiveAt = Some(instantToTimestamp(first.ledgerEffectiveTime)),
+                      events = flatEvents,
+                      offset = ApiOffset.toApiString(tx.offset),
+                      traceContext = None,
+                    )
+                  )
+              }
+        }
+        .getOrElse(Future.successful(None))
+    }
+
+    private val FlatTransactionPredicate =
+      (event: TransactionLogUpdate.Event, filter: FilterRelation) =>
+        if (filter.size == 1) {
+          val (party, templateIds) = filter.iterator.next()
+          if (templateIds.isEmpty)
+            event.flatEventWitnesses.contains(party)
+          else
+            // Single-party request, restricted to a set of template identifiers
+            event.flatEventWitnesses.contains(party) && templateIds.contains(event.templateId)
+        } else {
+          // Multi-party requests
+          // If no party requests specific template identifiers
+          val parties = filter.keySet
+          if (filter.forall(_._2.isEmpty))
+            event.flatEventWitnesses.intersect(parties.map(_.toString)).nonEmpty
+          else {
+            // If all parties request the same template identifier
+            val templateIds = filter.valuesIterator.flatten.toSet
+            if (filter.valuesIterator.forall(_ == templateIds)) {
+              event.flatEventWitnesses.intersect(parties.map(_.toString)).nonEmpty &&
+              templateIds.contains(event.templateId)
+            } else {
+              // If there are different template identifier but there are no wildcard parties
+              val partiesAndTemplateIds = Relation.flatten(filter).toSet
+              val wildcardParties = filter.filter(_._2.isEmpty).keySet
+              if (wildcardParties.isEmpty) {
+                partiesAndTemplateIds.exists { case (party, identifier) =>
+                  event.flatEventWitnesses.contains(party) && identifier == event.templateId
+                }
+              } else {
+                // If there are wildcard parties and different template identifiers
+                partiesAndTemplateIds.exists { case (party, identifier) =>
+                  event.flatEventWitnesses.contains(party) && identifier == event.templateId
+                } || event.flatEventWitnesses.intersect(wildcardParties.map(_.toString)).nonEmpty
+              }
+            }
+          }
+        }
+
+    private def permanent(events: Seq[TransactionLogUpdate.Event]): Set[ContractId] =
+      events.foldLeft(Set.empty[ContractId]) {
+        case (contractIds, event: TransactionLogUpdate.CreatedEvent) =>
+          contractIds + event.contractId
+        case (contractIds, event) if !contractIds.contains(event.contractId) =>
+          contractIds + event.contractId
+        case (contractIds, event) => contractIds - event.contractId
+      }
+
+    private def toFlatEvent(
+        event: TransactionLogUpdate.Event,
+        requestingParties: Set[Party],
+        verbose: Boolean,
+        lfValueTranslation: LfValueTranslation,
+    )(implicit
+        loggingContext: LoggingContext,
+        executionContext: ExecutionContext,
+    ): Future[Option[com.daml.ledger.api.v1.event.Event]] =
+      event match {
+        case createdEvent: TransactionLogUpdate.CreatedEvent =>
+          createdToFlatEvent(requestingParties, verbose, lfValueTranslation, createdEvent)
+
+        case exercisedEvent: TransactionLogUpdate.ExercisedEvent if exercisedEvent.consuming =>
+          Future.successful(Some(exercisedToFlatEvent(requestingParties, exercisedEvent)))
+
+        case _ => Future.successful(None)
+      }
+
+    private def createdToFlatEvent(
+        requestingParties: Set[Party],
+        verbose: Boolean,
+        lfValueTranslation: LfValueTranslation,
+        createdEvent: CreatedEvent,
+    )(implicit
+        loggingContext: LoggingContext,
+        executionContext: ExecutionContext,
+    ) = {
+      val eventualContractKey = createdEvent.contractKey
+        .map(
+          lfValueTranslation
+            .toApiValue(
+              _,
+              verbose,
+              "create key",
+              value =>
+                lfValueTranslation.enricher
+                  .enrichContractKey(createdEvent.templateId, value.value),
+            )
+            .map(Some(_))
+        )
+        .getOrElse(Future.successful(None))
+
+      val eventualCreateArguments = lfValueTranslation.toApiRecord(
+        createdEvent.createArgument,
+        verbose,
+        "create argument",
+        value =>
+          lfValueTranslation.enricher
+            .enrichContract(createdEvent.templateId, value.value),
+      )
+
+      for {
+        maybeContractKey <- eventualContractKey
+        createArguments <- eventualCreateArguments
+      } yield Some(
+        com.daml.ledger.api.v1.event.Event(
+          com.daml.ledger.api.v1.event.Event.Event.Created(
+            com.daml.ledger.api.v1.event.CreatedEvent(
+              eventId = createdEvent.eventId.toLedgerString,
+              contractId = createdEvent.contractId.coid,
+              templateId = Some(LfEngineToApi.toApiIdentifier(createdEvent.templateId)),
+              contractKey = maybeContractKey,
+              createArguments = Some(createArguments),
+              witnessParties = createdEvent.flatEventWitnesses
+                .intersect(requestingParties.map(_.toString))
+                .toSeq,
+              signatories = createdEvent.createSignatories.toSeq,
+              observers = createdEvent.createObservers.toSeq,
+              agreementText = createdEvent.createAgreementText.orElse(Some("")),
+            )
+          )
+        )
+      )
+    }
+
+    private def exercisedToFlatEvent(
+        requestingParties: Set[Party],
+        exercisedEvent: ExercisedEvent,
+    ) =
+      v1.event.Event(
+        v1.event.Event.Event.Archived(
+          v1.event.ArchivedEvent(
+            eventId = exercisedEvent.eventId.toLedgerString,
+            contractId = exercisedEvent.contractId.coid,
+            templateId = Some(LfEngineToApi.toApiIdentifier(exercisedEvent.templateId)),
+            witnessParties = exercisedEvent.flatEventWitnesses
+              .intersect(requestingParties.map(_.toString))
+              .toSeq,
+          )
+        )
+      )
+  }
+
+  object ToTransactionTree {
+    def apply(
+        tx: TransactionLogUpdate.Transaction,
+        requestingParties: Set[Party],
+        verbose: Boolean,
+        lfValueTranslation: LfValueTranslation,
+    )(implicit
+        loggingContext: LoggingContext,
+        executionContext: ExecutionContext,
+    ): Future[Option[TransactionTree]] = {
+      val filteredForVisibility = tx.events
+        .filter(TransactionTreePredicate(requestingParties))
+
+      val treeEvents = filteredForVisibility
+        .collect {
+          case createdEvent: TransactionLogUpdate.CreatedEvent =>
+            createdToTransactionTreeEvent(
+              requestingParties,
+              verbose,
+              lfValueTranslation,
+              createdEvent,
+            )
+          case exercisedEvent: TransactionLogUpdate.ExercisedEvent =>
+            exercisedToTransactionTreeEvent(
+              requestingParties,
+              verbose,
+              lfValueTranslation,
+              exercisedEvent,
+            )
+        }
+
+      if (treeEvents.isEmpty)
+        Future.successful(Option.empty)
+      else
+        Future.traverse(treeEvents)(identity).map { treeEvents =>
+          val visible = treeEvents.map(_.eventId)
+          val visibleSet = visible.toSet
+          val eventsById = treeEvents.iterator
+            .map(e => e.eventId -> e.filterChildEventIds(visibleSet))
+            .toMap
+
+          // All event identifiers that appear as a child of another item in this response
+          val children = eventsById.valuesIterator.flatMap(_.childEventIds).toSet
+
+          // The roots for this request are all visible items
+          // that are not a child of some other visible item
+          val rootEventIds = visible.filterNot(children)
+
+          Some(
+            TransactionTree(
+              transactionId = tx.transactionId,
+              commandId = getCommandId(
+                filteredForVisibility,
+                tx.commandId,
+                requestingParties,
+              ), // TDT use submitters predicate to set commandId
+              workflowId = tx.workflowId,
+              effectiveAt = Some(instantToTimestamp(tx.effectiveAt)),
+              offset = ApiOffset.toApiString(tx.offset),
+              eventsById = eventsById,
+              rootEventIds = rootEventIds,
+              traceContext = None,
+            )
+          )
+        }
+    }
+
+    private def exercisedToTransactionTreeEvent(
+        requestingParties: Set[Party],
+        verbose: Boolean,
+        lfValueTranslation: LfValueTranslation,
+        exercisedEvent: ExercisedEvent,
+    )(implicit
+        loggingContext: LoggingContext,
+        executionContext: ExecutionContext,
+    ) = {
+      val eventualChoiceArgument = lfValueTranslation.toApiValue(
+        exercisedEvent.exerciseArgument,
+        verbose,
+        "exercise argument",
+        value =>
+          lfValueTranslation.enricher
+            .enrichChoiceArgument(
+              exercisedEvent.templateId,
+              Ref.Name.assertFromString(exercisedEvent.choice),
+              value.value,
+            ),
+      )
+
+      val eventualExerciseResult = exercisedEvent.exerciseResult
+        .map(
+          lfValueTranslation
+            .toApiValue(
+              _,
+              verbose,
+              "exercise result",
+              value =>
+                lfValueTranslation.enricher.enrichChoiceResult(
+                  exercisedEvent.templateId,
+                  Ref.Name.assertFromString(exercisedEvent.choice),
+                  value.value,
+                ),
+            )
+            .map(Some(_))
+        )
+        .getOrElse(Future.successful(None))
+
+      for {
+        choiceArgument <- eventualChoiceArgument
+        maybeExerciseResult <- eventualExerciseResult
+      } yield TreeEvent(
+        TreeEvent.Kind.Exercised(
+          v1.event.ExercisedEvent(
+            eventId = exercisedEvent.eventId.toLedgerString,
+            contractId = exercisedEvent.contractId.coid,
+            templateId = Some(LfEngineToApi.toApiIdentifier(exercisedEvent.templateId)),
+            choice = exercisedEvent.choice,
+            choiceArgument = Some(choiceArgument),
+            actingParties = exercisedEvent.actingParties.toSeq,
+            consuming = exercisedEvent.consuming,
+            witnessParties = exercisedEvent.treeEventWitnesses
+              .intersect(requestingParties.map(_.toString))
+              .toSeq,
+            childEventIds = exercisedEvent.children,
+            exerciseResult = maybeExerciseResult,
+          )
+        )
+      )
+    }
+
+    private def createdToTransactionTreeEvent(
+        requestingParties: Set[Party],
+        verbose: Boolean,
+        lfValueTranslation: LfValueTranslation,
+        createdEvent: CreatedEvent,
+    )(implicit
+        loggingContext: LoggingContext,
+        executionContext: ExecutionContext,
+    ) = {
+      val eventualContractKey = createdEvent.contractKey
+        .map(
+          lfValueTranslation
+            .toApiValue(
+              _,
+              verbose,
+              "create key",
+              value =>
+                lfValueTranslation.enricher
+                  .enrichContractKey(createdEvent.templateId, value.value),
+            )
+            .map(Some(_))
+        )
+        .getOrElse(Future.successful(None))
+
+      val eventualCreateArguments = lfValueTranslation.toApiRecord(
+        createdEvent.createArgument,
+        verbose,
+        "create argument",
+        value =>
+          lfValueTranslation.enricher
+            .enrichContract(createdEvent.templateId, value.value),
+      )
+
+      for {
+        maybeContractKey <- eventualContractKey
+        createArguments <- eventualCreateArguments
+      } yield TreeEvent(
+        TreeEvent.Kind.Created(
+          com.daml.ledger.api.v1.event.CreatedEvent(
+            eventId = createdEvent.eventId.toLedgerString,
+            contractId = createdEvent.contractId.coid,
+            templateId = Some(LfEngineToApi.toApiIdentifier(createdEvent.templateId)),
+            contractKey = maybeContractKey,
+            createArguments = Some(createArguments),
+            witnessParties = createdEvent.treeEventWitnesses
+              .intersect(requestingParties.map(_.toString))
+              .toSeq,
+            signatories = createdEvent.createSignatories.toSeq,
+            observers = createdEvent.createObservers.toSeq,
+            agreementText = createdEvent.createAgreementText.orElse(Some("")),
+          )
+        )
+      )
+    }
+
+    private val TransactionTreePredicate: Set[Party] => TransactionLogUpdate.Event => Boolean =
+      requestingParties => {
+        case createdEvent: CreatedEvent =>
+          createdEvent.treeEventWitnesses
+            .intersect(requestingParties.map(_.toString))
+            .nonEmpty
+        case exercised: ExercisedEvent =>
+          exercised.treeEventWitnesses
+            .intersect(requestingParties.map(_.toString))
+            .nonEmpty
+      }
+  }
+
+  private def instantToTimestamp(t: Instant): Timestamp =
+    Timestamp(seconds = t.getEpochSecond, nanos = t.getNano)
+
+  private def getCommandId(
+      events: Vector[TransactionLogUpdate.Event],
+      commandId: String,
+      requestingParties: Set[Party],
+  ) =
+    events
+      .find(_.commandId != "")
+      // TODO // TDT Double check condition for command id setting
+      .filter(_.submitters.diff(requestingParties.map(_.toString)).isEmpty)
+      .map(_ => commandId)
+      .getOrElse("")
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionLogUpdatesReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionLogUpdatesReader.scala
@@ -11,7 +11,6 @@ import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.serialization.{Compression, ValueSerializer}
 
 object TransactionLogUpdatesReader {
-
   def toTransactionEvent(
       raw: RawTransactionEvent
   ): TransactionLogUpdate.Event =
@@ -37,6 +36,7 @@ object TransactionLogUpdatesReader {
           ),
           treeEventWitnesses = raw.treeEventWitnesses,
           flatEventWitnesses = raw.flatEventWitnesses,
+          submitters = raw.submitters,
           choice = raw.exerciseChoice.mandatory("exercise_choice"),
           actingParties = raw.exerciseActors
             .mandatory("exercise_actors")
@@ -92,6 +92,7 @@ object TransactionLogUpdatesReader {
           contractKey = maybeGlobalKey,
           treeEventWitnesses = raw.treeEventWitnesses,
           flatEventWitnesses = raw.flatEventWitnesses,
+          submitters = raw.submitters,
           createArgument = createArgumentDecompressed,
           createSignatories = raw.createSignatories.mandatory("create_signatories").toSet,
           createObservers = raw.createObservers.mandatory("create_observers").toSet,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionsReader.scala
@@ -333,7 +333,6 @@ private[appendonlydao] final class TransactionsReader(
     val first = events.head
     TransactionLogUpdate.Transaction(
       transactionId = first.transactionId,
-      commandId = first.commandId,
       workflowId = first.workflowId,
       effectiveAt = first.ledgerEffectiveTime,
       offset = first.eventOffset,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
@@ -376,6 +376,7 @@ object StorageBackend {
       createArgumentCompression: Option[Int],
       treeEventWitnesses: Set[String],
       flatEventWitnesses: Set[String],
+      submitters: Set[String],
       exerciseChoice: Option[String],
       exerciseArgument: Option[InputStream],
       exerciseArgumentCompression: Option[Int],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
@@ -819,6 +819,7 @@ trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_BATCH] {
       int("create_argument_compression").? ~
       array[String]("tree_event_witnesses") ~
       array[String]("flat_event_witnesses") ~
+      array[String]("submitters") ~
       str("exercise_choice").? ~
       binaryStream("exercise_argument").? ~
       int("exercise_argument_compression").? ~
@@ -830,7 +831,7 @@ trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_BATCH] {
       offset("event_offset")).map {
       case eventKind ~ transactionId ~ nodeIndex ~ commandId ~ workflowId ~ eventId ~ contractId ~ templateId ~ ledgerEffectiveTime ~ createSignatories ~
           createObservers ~ createAgreementText ~ createKeyValue ~ createKeyCompression ~
-          createArgument ~ createArgumentCompression ~ treeEventWitnesses ~ flatEventWitnesses ~ exerciseChoice ~
+          createArgument ~ createArgumentCompression ~ treeEventWitnesses ~ flatEventWitnesses ~ submitters ~ exerciseChoice ~
           exerciseArgument ~ exerciseArgumentCompression ~ exerciseResult ~ exerciseResultCompression ~ exerciseActors ~
           exerciseChildEventIds ~ eventSequentialId ~ offset =>
         RawTransactionEvent(
@@ -852,6 +853,7 @@ trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_BATCH] {
           createArgumentCompression,
           treeEventWitnesses.toSet,
           flatEventWitnesses.toSet,
+          submitters.toSet,
           exerciseChoice,
           exerciseArgument,
           exerciseArgumentCompression,
@@ -887,6 +889,7 @@ trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_BATCH] {
            create_argument_compression,
            tree_event_witnesses,
            flat_event_witnesses,
+           submitters,
            exercise_choice,
            exercise_argument,
            exercise_argument_compression,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/EventsBuffer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/EventsBuffer.scala
@@ -10,6 +10,7 @@ import com.daml.platform.store.cache.EventsBuffer.{
   SearchableByVector,
   UnorderedException,
 }
+import com.daml.platform.store.cache.BufferSlice.{Inclusive, Prefix, BufferSlice, Empty}
 
 import scala.annotation.tailrec
 import scala.collection.Searching.{Found, InsertionPoint, SearchResult}
@@ -86,26 +87,28 @@ private[platform] final class EventsBuffer[O: Ordering, E](
     * @param endInclusive The end inclusive bound of the requested range.
     * @return The series of events as an ordered vector satisfying the input bounds.
     */
-  def slice(startExclusive: O, endInclusive: O): Vector[(O, E)] =
+  def slice(startExclusive: O, endInclusive: O): BufferSlice[(O, E)] =
     Timed.value(
       sliceTimer, {
         val bufferSnapshot = _bufferStateRef
         if (bufferSnapshot.rangeEnd.exists(_ < endInclusive)) {
           throw RequestOffBufferBounds(bufferSnapshot.vector.last._1, endInclusive)
-        } else if (bufferSnapshot.vector.isEmpty) {
-          Vector.empty
-        } else {
-          val bufferEndExclusiveIdx = bufferSnapshot.vector.searchBy(endInclusive, _._1) match {
-            case Found(foundIndex) => foundIndex + 1
-            case InsertionPoint(insertionPoint) => insertionPoint
-          }
+        } else if (bufferSnapshot.vector.isEmpty)
+          Empty
+        else {
+          val Seq(bufferStartInclusiveIdx, bufferEndExclusiveIdx) =
+            Seq(startExclusive, endInclusive)
+              .map(bufferSnapshot.vector.searchBy(_, _._1))
+              .map {
+                case InsertionPoint(insertionPoint) => insertionPoint
+                case Found(foundIndex) => foundIndex + 1
+              }
 
-          val bufferStartInclusiveIdx = bufferSnapshot.vector.searchBy(startExclusive, _._1) match {
-            case InsertionPoint(insertionPoint) => insertionPoint
-            case Found(foundIndex) => foundIndex + 1
-          }
+          val vectorSlice =
+            bufferSnapshot.vector.slice(bufferStartInclusiveIdx, bufferEndExclusiveIdx)
 
-          bufferSnapshot.vector.slice(bufferStartInclusiveIdx, bufferEndExclusiveIdx)
+          if (bufferStartInclusiveIdx == 0) Prefix(vectorSlice)
+          else Inclusive(vectorSlice)
         }
       },
     )
@@ -130,7 +133,26 @@ private[platform] final class EventsBuffer[O: Ordering, E](
     )
 }
 
-private[cache] object EventsBuffer {
+private[platform] object BufferSlice {
+
+  /** Specialized slice representation of a Vector */
+  private[platform] sealed trait BufferSlice[+ELEM] extends Product with Serializable {
+    def slice: Vector[ELEM]
+  }
+
+  /** The source was empty */
+  private[platform] final case object Empty extends BufferSlice[Nothing] {
+    override val slice: Vector[Nothing] = Vector.empty
+  }
+
+  /** A slice of a vector that is inclusive (start index of the slice in the source vector is gteq to 1) */
+  private[platform] final case class Inclusive[ELEM](slice: Vector[ELEM]) extends BufferSlice[ELEM]
+
+  /** A slice of a vector that is also the vector's prefix (i.e. start index of the slice in the source vector is 0) */
+  private[platform] final case class Prefix[ELEM](slice: Vector[ELEM]) extends BufferSlice[ELEM]
+}
+
+private[platform] object EventsBuffer {
   private final case class BufferStateRef[O, E](
       vector: Vector[(O, E)] = Vector.empty,
       rangeEnd: Option[O] = Option.empty,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTable.scala
@@ -125,6 +125,9 @@ private[events] object EventsTable {
       events.headOption.flatMap { first =>
         val flatEvents =
           TransactionConversion.removeTransient(events.iterator.map(_.event).toVector)
+        // Allows emitting flat transactions with no events, a use-case needed
+        // for the functioning of DAML triggers.
+        // (more details in https://github.com/digital-asset/daml/issues/6975)
         if (flatEvents.nonEmpty || first.commandId.nonEmpty)
           Some(
             ApiTransaction(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/TransactionLogUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/TransactionLogUpdate.scala
@@ -61,7 +61,9 @@ object TransactionLogUpdate {
     def commandId: String
     def workflowId: String
     def ledgerEffectiveTime: Instant
+    def treeEventWitnesses: Set[String]
     def flatEventWitnesses: Set[String]
+    def submitters: Set[String]
     def templateId: Identifier
     def contractId: ContractId
   }
@@ -80,6 +82,7 @@ object TransactionLogUpdate {
       contractKey: Option[LfValue.VersionedValue[events.ContractId]],
       treeEventWitnesses: Set[String],
       flatEventWitnesses: Set[String],
+      submitters: Set[String],
       createArgument: LfValue.VersionedValue[events.ContractId],
       createSignatories: Set[String],
       createObservers: Set[String],
@@ -100,6 +103,7 @@ object TransactionLogUpdate {
       contractKey: Option[LfValue.VersionedValue[events.ContractId]],
       treeEventWitnesses: Set[String],
       flatEventWitnesses: Set[String],
+      submitters: Set[String],
       choice: String,
       actingParties: Set[IdString.Party],
       children: Seq[String],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/TransactionLogUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/TransactionLogUpdate.scala
@@ -33,7 +33,6 @@ object TransactionLogUpdate {
     */
   final case class Transaction(
       transactionId: String,
-      commandId: String,
       workflowId: String,
       effectiveAt: Instant,
       offset: Offset,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionLogUpdatesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionLogUpdatesSpec.scala
@@ -109,7 +109,6 @@ private[dao] trait JdbcLedgerDaoTransactionLogUpdatesSpec
   ): Unit = {
     actual.transactionId shouldBe expected.transactionId
     actual.workflowId shouldBe expected.workflowId.value
-    actual.commandId shouldBe expected.commandId.value
     actual.effectiveAt shouldBe expected.ledgerEffectiveTime
     actual.offset shouldBe expectedOffset
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
@@ -227,6 +227,7 @@ final class BuffersUpdaterSpec
         commandId = null,
         workflowId = null,
         treeEventWitnesses = null,
+        submitters = null,
         choice = null,
         actingParties = null,
         children = null,
@@ -247,6 +248,7 @@ final class BuffersUpdaterSpec
         contractKey = Some(createdContractKey),
         treeEventWitnesses = Set("bob"), // Unused in ContractStateEvent
         flatEventWitnesses = createdFlatEventWitnesses,
+        submitters = null,
         createArgument = createArgument,
         createSignatories = null,
         createObservers = null,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
@@ -256,7 +256,6 @@ final class BuffersUpdaterSpec
       )
       val transaction = TransactionLogUpdate.Transaction(
         transactionId = "some-tx-id",
-        commandId = "some-cmd-id",
         workflowId = "some-workflow-id",
         effectiveAt = Instant.EPOCH,
         offset = Offset.beforeBegin,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/BufferedTransactionsReaderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/BufferedTransactionsReaderSpec.scala
@@ -1,0 +1,207 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.appendonlydao.events
+
+import java.time.Instant
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.metrics.Metrics
+import com.daml.platform.store.appendonlydao.events.BufferedTransactionsReader.FetchTransactions
+import com.daml.platform.store.appendonlydao.events.BufferedTransactionsReaderSpec.{
+  predecessor,
+  transactionLogUpdate,
+}
+import com.daml.platform.store.cache.EventsBuffer
+import com.daml.platform.store.interfaces.TransactionLogUpdate
+import org.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.Future
+
+class BufferedTransactionsReaderSpec
+    extends AsyncWordSpec
+    with MockitoSugar
+    with Matchers
+    with BeforeAndAfterAll {
+  private val actorSystem = ActorSystem()
+  private implicit val materializer: Materializer = Materializer(actorSystem)
+
+  "getTransactions" when {
+    val metrics = new Metrics(new MetricRegistry())
+    val offsetUpdates @ Seq(
+      (offset1, update1),
+      (offset2, update2),
+      (offset3, update3),
+      (offset4, update4),
+    ) =
+      (1 to 4).map { idx =>
+        Offset.fromByteArray(BigInt(idx * 2 + 1234).toByteArray) -> transactionLogUpdate(s"tx-$idx")
+      }
+
+    // Dummy filters. We're not interested in concrete details
+    // since we are asserting only the generic getTransactions method
+    val filter, otherFilter = new Object
+
+    val txApiMap @ Seq(
+      (apiTx1, apiResponse1),
+      (apiTx2, apiResponse2),
+      (apiTx3, apiResponse3),
+      (apiTx4, apiResponse4),
+    ) = (1 to 4).map(idx => s"Some API TX $idx" -> s"Some API response $idx")
+
+    val toApiTx: (TransactionLogUpdate, Object, Boolean) => Future[Option[String]] = {
+      case (`update1`, `otherFilter`, false) => Future.successful(None)
+      case (`update1`, `filter`, false) => Future.successful(Some(apiTx1))
+      case (`update2`, `filter`, false) => Future.successful(Some(apiTx2))
+      case (`update3`, `filter`, false) => Future.successful(Some(apiTx3))
+      case (`update4`, `filter`, false) => Future.successful(Some(apiTx4))
+      case unexpected => fail(s"Unexpected $unexpected")
+    }
+
+    val apiResponseCtor = txApiMap.map { case (apiTx, apiResponse) =>
+      Seq(apiTx) -> apiResponse
+    }.toMap
+
+    val transactionsBuffer = new EventsBuffer[Offset, TransactionLogUpdate](
+      maxBufferSize = 3L,
+      metrics = metrics,
+      bufferQualifier = "test",
+      isRangeEndMarker = _.isInstanceOf[TransactionLogUpdate.LedgerEndMarker],
+    )
+
+    offsetUpdates.foreach { case (offset, update) =>
+      transactionsBuffer.push(offset, update)
+    }
+
+    def readerGetTransactionsGeneric(
+        eventsBuffer: EventsBuffer[Offset, TransactionLogUpdate],
+        startExclusive: Offset,
+        endInclusive: Offset,
+        fetchTransactions: FetchTransactions[Object, String],
+    ) =
+      BufferedTransactionsReader
+        .getTransactions(eventsBuffer)(
+          startExclusive = startExclusive,
+          endInclusive = endInclusive,
+          filter = filter,
+          verbose = false,
+        )(
+          toApiTx = toApiTx,
+          apiResponseCtor = apiResponseCtor,
+          fetchTransactions = fetchTransactions,
+          sourceTimer = metrics.daml.services.index.getTransactionTreesSource,
+          resolvedFromBufferCounter =
+            metrics.daml.services.index.streamsBuffer.transactionTreeEventsResolvedFromBuffer,
+          totalRetrievedCounter =
+            metrics.daml.services.index.streamsBuffer.totalTransactionTreesRetrieved,
+          bufferSizeCounter = metrics.daml.services.index.transactionTreesBufferSize,
+          outputStreamBufferSize = 128,
+        )
+        .runWith(Sink.seq)
+
+    "request within buffer range inclusive on offset gap as start exclusive" should {
+      "fetch from buffer" in {
+        readerGetTransactionsGeneric(
+          eventsBuffer = transactionsBuffer,
+          startExclusive = predecessor(offset3),
+          endInclusive = offset4,
+          fetchTransactions = (_, _, _, _) => fail("Should not fetch"),
+        ).map(
+          _ should contain theSameElementsInOrderAs Seq(
+            offset3 -> apiResponse3,
+            offset4 -> apiResponse4,
+          )
+        )
+      }
+    }
+
+    "request within buffer range inclusive on existing offset as start inclusive" should {
+      "fetch from buffer" in {
+        readerGetTransactionsGeneric(
+          eventsBuffer = transactionsBuffer,
+          startExclusive = offset2,
+          endInclusive = offset4,
+          fetchTransactions = (_, _, _, _) => fail("Should not fetch"),
+        ).map(
+          _ should contain theSameElementsInOrderAs Seq(
+            offset3 -> apiResponse3,
+            offset4 -> apiResponse4,
+          )
+        )
+      }
+    }
+
+    "request before buffer start" should {
+      "fetch from buffer and storage" in {
+        readerGetTransactionsGeneric(
+          eventsBuffer = transactionsBuffer,
+          startExclusive = offset1,
+          endInclusive = offset3,
+          fetchTransactions = {
+            case (`offset1`, `offset2`, `filter`, false) =>
+              Source.single(offset2 -> apiResponse4)
+            case unexpected => fail(s"Unexpected $unexpected")
+          },
+        ).map(
+          _ should contain theSameElementsInOrderAs Seq(
+            offset2 -> apiResponse4, // apiResponse4 on purpose in order to distinguish from fetched from buffer
+            offset3 -> apiResponse3,
+          )
+        )
+      }
+    }
+
+    "request before buffer bounds" should {
+      "fetch only from storage" in {
+        val transactionsBuffer = new EventsBuffer[Offset, TransactionLogUpdate](
+          maxBufferSize = 1L,
+          metrics = metrics,
+          bufferQualifier = "test",
+          isRangeEndMarker = _.isInstanceOf[TransactionLogUpdate.LedgerEndMarker],
+        )
+
+        offsetUpdates.foreach { case (offset, update) =>
+          transactionsBuffer.push(offset, update)
+        }
+        val fetchedElements = Vector(offset2 -> apiResponse1, offset3 -> apiResponse2)
+
+        readerGetTransactionsGeneric(
+          eventsBuffer = transactionsBuffer,
+          startExclusive = offset1,
+          endInclusive = offset3,
+          fetchTransactions = {
+            case (`offset1`, `offset3`, `filter`, false) =>
+              Source.fromIterator(() => fetchedElements.iterator)
+            case unexpected => fail(s"Unexpected $unexpected")
+          },
+        ).map(_ should contain theSameElementsInOrderAs fetchedElements)
+      }
+    }
+  }
+
+  override def afterAll(): Unit = {
+    val _ = actorSystem.terminate()
+  }
+}
+
+object BufferedTransactionsReaderSpec {
+  private def transactionLogUpdate(discriminator: String) =
+    TransactionLogUpdate.Transaction(
+      transactionId = discriminator,
+      commandId = "",
+      workflowId = "",
+      effectiveAt = Instant.EPOCH,
+      offset = Offset.beforeBegin,
+      events = Vector(null),
+    )
+
+  private def predecessor(offset: Offset): Offset =
+    Offset.fromByteArray((BigInt(offset.toByteArray) - 1).toByteArray)
+}

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -5,6 +5,7 @@ package com.daml.platform.sandbox.stores.ledger.sql
 
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
+
 import akka.Done
 import akka.stream.QueueOfferResult.{Dropped, Enqueued, QueueClosed}
 import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete}
@@ -361,7 +362,7 @@ private final class SqlLedger(
     timeProvider: TimeProvider,
     persistenceQueue: PersistenceQueue,
     transactionCommitter: TransactionCommitter,
-) extends BaseLedger(ledgerId, ledgerDao, contractStore, dispatcher)
+) extends BaseLedger(ledgerId, ledgerDao, ledgerDao.transactionsReader, contractStore, dispatcher)
     with Ledger {
 
   private val logger = ContextualizedLogger.get(this.getClass)


### PR DESCRIPTION
This PR targets the implementation of the `BufferedTransactionsReader` as the layer using the in-memory `TransactionsBuffer` for serving the transaction streaming queries:
* `getTransactions`
* `getTransactionTrees`

Additionally, the `EventsBuffer` return type is enriched to `BufferSlice` which provides further information about the slice returned wrt the positioning in the underlying vector.

**NOTE** In the current PR, only the generic `BufferedTransactionsReader` logic is asserted in a unit test. DTO conversions and privacy logic for the re-implemented `getTransactions` and `getTransactionTrees` are considered asserted by conformance tests. 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
