### PR TITLE
Add warning about using divulged contracts in pruning doc

### DIFF
--- a/docs/source/ops/index.rst
+++ b/docs/source/ops/index.rst
@@ -31,7 +31,9 @@ Still, Daml applications may be affected in the following ways:
 - Pruning may affect the behavior of Ledger API calls that allow to read data from the ledger: see the next sub-section for more information about API impacts.
 
 .. warning::
-   Participant pruning and the use of *divulged contracts* during interpretation are in conflict with each other. A participant may never learn about the archival of a divulged contract and has no reliable way to detect when a divulged contract can safely be removed from the participant node, resulting in an ever growing participant node database and failed command submissions due to a potentially outdated view of the contract on the participant. Users are advised to not use divulged contracts in their Daml workflows.
+  Participants may know of contracts for which they don't know the current activeness status. This happens through :ref:`divulgence <da-model-divulgence>` where a party learns of the existence of a contract without being guaranteed to ever see its archival. Such contracts are pruned by the feature described on this page as not doing so could easily lead to an ever growing participant state.
+  
+During command submission, parties can currently resolve the contract ids of divulged contracts. This is mutually incompatible with the pruning behaviour described above. Daml code that may end up running on pruned participants should therefore never rely on that behaviour.```
 
 How the Daml Ledger API is affected
 -----------------------------------

--- a/docs/source/ops/index.rst
+++ b/docs/source/ops/index.rst
@@ -30,6 +30,9 @@ Still, Daml applications may be affected in the following ways:
 - Command deduplication and command tracker retention should always configured in such a way, that the associated windows don't overlap with the pruning window, so that their operation is unaffected by pruning.
 - Pruning may affect the behavior of Ledger API calls that allow to read data from the ledger: see the next sub-section for more information about API impacts.
 
+.. warning::
+   Participant pruning and the use of *divulged contracts* during interpretation are in conflict with each other. A participant may never learn about the archival of a divulged contract and has no reliable way to detect when a divulged contract can safely be removed from the participant node, resulting in an ever growing participant node database and failed command submissions due to a potentially outdated view of the contract on the participant. Users are advised to not use divulged contracts in their Daml workflows.
+
 How the Daml Ledger API is affected
 -----------------------------------
 

--- a/docs/source/ops/index.rst
+++ b/docs/source/ops/index.rst
@@ -33,7 +33,7 @@ Still, Daml applications may be affected in the following ways:
 .. warning::
   Participants may know of contracts for which they don't know the current activeness status. This happens through :ref:`divulgence <da-model-divulgence>` where a party learns of the existence of a contract without being guaranteed to ever see its archival. Such contracts are pruned by the feature described on this page as not doing so could easily lead to an ever growing participant state.
   
-During command submission, parties can currently resolve the contract ids of divulged contracts. This is mutually incompatible with the pruning behaviour described above. Daml code that may end up running on pruned participants should therefore never rely on that behaviour.```
+During command submission, parties can currently resolve the contract ids of divulged contracts. This is mutually incompatible with the pruning behaviour described above. Daml code that may end up running on pruned participants should therefore never rely on that behaviour.
 
 How the Daml Ledger API is affected
 -----------------------------------


### PR DESCRIPTION
Contributes to #9283.

CHANGELOG_BEGIN
[ledger api] Add warning about incompatibility between pruning and
divulged contracts to pruning docs.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
