### PR TITLE
Revert "Try to unflake JSON API failure tests (#9855)"

### DIFF
--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -364,6 +364,8 @@ alias(
             "//ledger/test-common/test-certificates",
             "@toxiproxy_dev_env//:bin/toxiproxy-cmd" if not is_windows else "@toxiproxy_dev_env//:toxiproxy-server-windows-amd64.exe",
         ],
+        # See https://github.com/digital-asset/daml/issues/9886
+        flaky = True,
         plugins = [
             "@maven//:org_typelevel_kind_projector_{}".format(scala_version_suffix),
         ],

--- a/ledger-service/http-json/src/failure/resources/application.conf
+++ b/ledger-service/http-json/src/failure/resources/application.conf
@@ -1,6 +1,0 @@
-akka {
-  # Reducing this should hopefully ensure that the tests
-  # that test for timeouts always hit the server side request timeout
-  # and not another timeout somewhere in akka-http.
-  http.server.request-timeout = 5 s
-}


### PR DESCRIPTION
This has made things worse not better. Now tests that should be
successful hit the timeout.

Still not sure what is actually going wrong so marking it as flaky
Tracked in #9886

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
