### PR TITLE
Fix windows skip again

### DIFF
--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -4,6 +4,7 @@
 parameters:
   release_tag: ''
   is_release: ''
+  skip_tests: ''
 
 steps:
   - bash: ci/configure-bazel.sh
@@ -29,8 +30,7 @@ steps:
       #   commit's own build (albeit with 0.0.0 as version number), and once as
       #   part of the release PR that triggered the build (with correct version
       #   number).
-      SKIP_TESTS: ${{and(eq(parameters.is_release, 'true'),
-                         eq(variables['Build.SourceBranchName'], 'main'))}}
+      SKIP_TESTS: ${{parameters.skip_tests}}
 
   - task: PublishBuildArtifacts@1
     condition: failed()

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -185,6 +185,8 @@ jobs:
     release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
     trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
     is_release: $[ dependencies.check_for_release.outputs['out.is_release'] ]
+    skip_tests: $[ and(eq(variables.is_release, 'true'),
+                       eq(variables['Build.SourceBranchName'], 'main')) ]
   timeoutInMinutes: 360
   pool:
     name: 'windows-pool'
@@ -200,6 +202,13 @@ jobs:
     - template: build-windows.yml
       parameters:
         release_tag: $(release_tag)
+        # Azure pipeline’s variable and parameter expansion is utter garbage.
+        # For whatever reason `env` values only seem to be able to use macro syntax
+        # and not runtime expression. is_release however is a runtime variable
+        # so template conditions won’t work. Therefore we define the variable here
+        # with a runtime expression, set the parameter to the (unexpanded) string "$(skip_tests)"
+        # and then splice that in via a template parameter.
+        skip_tests: $(skip_tests)
         is_release: variables.is_release
     - task: PublishBuildArtifacts@1
       condition: succeededOrFailed()


### PR DESCRIPTION
This took me embarassingly long to understand and debug (partially
because afaict Azure is broken):

The issue is that in the current state, parameters.is_release is not
expanded when setting the env var. That makes sense. The variable is
only set at runtime but the ${{}} template expressions are expanded
before that (it works below in the condition since that’s not in a
${{}} and is evaluated at runtime).

Now if we look at the other env var that does work (the release tag)
we can see something interesting. We set it to the macro
$(release_tag) in build.yml. However, that is not expanded since
template expansion happens way earlier. So the template parameter is
set to the literal string "$(release_tag)". We then splice that in via
template expansion ${{parameters.release_tag}} and then at runtime
azure will expand the macro.

Just changing is_release to a macro however would break the use in the
condition (I think you might be able to fix that if you put it in a
string but that just seems even more hacky).

So this PR instead defines a new variable skip_tests which we define
in the job and the splice it in via a macro.

Confusingly, `$[variables.is_release]` is not expanded in an env
definition. Afaict this is simply a bug. The only difference between
macros and runtime expressions according to the docs is that runtime
expressions need to replace the full RHs and that macros can only
reference a single variable. Wouldn’t help much here either anyway if
we want to stick to the parameter instead of referencing a variable
directly (which maybe we don’t, it doesn’t seem to help much but
that’s a separate question).


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
