### PR TITLE
ledger-api-test-tool: Only wait for parties on participants under test.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -128,6 +128,8 @@ private[testtool] final class ParticipantTestContext private[participant] (
   private[this] val nextSubmissionId: () => String = nextId("submission")
   val nextKeyId: () => String = nextId("key")
 
+  override def toString: String = s"participant $endpointId"
+
   /** Gets the absolute offset of the ledger end at a point in time. Use [[end]] if you need
     * a reference to the moving end of the ledger.
     */

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -706,7 +706,7 @@ private[testtool] final class ParticipantTestContext private[participant] (
 
   private[infrastructure] def preallocateParties(
       n: Int,
-      participants: Iterable[ParticipantTestContext],
+      participantsUnderTest: Iterable[ParticipantTestContext],
   ): Future[Vector[Party]] =
     for {
       parties <-
@@ -715,7 +715,7 @@ private[testtool] final class ParticipantTestContext private[participant] (
         } else {
           reservePartyNames(n)
         }
-      _ <- waitForParties(participants, parties.toSet)
+      _ <- waitForParties(participantsUnderTest, parties.toSet)
     } yield parties
 
   private def reservePartyNames(n: Int): Future[Vector[Party]] =


### PR DESCRIPTION
Most tests only use one participant, so we can speed up waiting considerably if we don't wait on the other participants in those cases.

I also added a `toString` to improve error logging.

_Before:_
>   assertion failed: Parties from com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext@c71ccbf never appeared on com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext@1902cf05.

_After:_
>   assertion failed: Parties from participant alpha never appeared on participant beta.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
