### PR TITLE
Use simpler tree representation for transactions when possible

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+wi=5
+i=25
+
+whatBranch() {
+    git rev-parse --abbrev-ref HEAD
+}
+
+bench() {
+    git checkout $1
+    bazel run //daml-lf/scenario-interpreter:scenario-perf -- -f 1 -i $i -wi $wi
+}
+
+run() {
+    bench $1 2>&1 | grep 'Average]' | xargs echo $1
+}
+
+here=$(whatBranch)
+base=main
+
+run $here
+run $here
+
+run $base
+run $base
+
+run $here
+run $here
+
+run $base
+run $base

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -13,6 +13,7 @@ import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{SubmittedTransaction, Transaction => Tx}
 import com.daml.lf.transaction.Node._
+import com.daml.lf.transaction.NodeId
 import com.daml.lf.value.Value
 import java.nio.file.Files
 
@@ -301,8 +302,8 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
         case SResultError(err) =>
           return ResultError(
             Error(
-              s"Interpretation error: ${Pretty.prettyError(err, onLedger.ptx).render(80)}",
-              s"Last location: ${Pretty.prettyLoc(machine.lastLocation).render(80)}, partial transaction: ${onLedger.ptx.nodesToString}",
+              s"Interpretation error: ${Pretty.prettyError(err).render(80)}",
+              s"Last location: ${Pretty.prettyLoc(machine.lastLocation).render(80)}", //, partial transaction: ${onLedger.ptx.nodesToString}", //NICK
             )
           )
 
@@ -370,7 +371,12 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
           submissionTime = onLedger.ptx.submissionTime,
           usedPackages = Set.empty,
           dependsOnTime = onLedger.dependsOnTime,
-          nodeSeeds = onLedger.ptx.actionNodeSeeds.toImmArray,
+          //nodeSeeds = onLedger.ptx.xactionNodeSeeds.toImmArray //NICK
+          nodeSeeds = ImmArray(
+            onLedger.ptx.actionNodeSeeds.toImmArray.toList.zipWithIndex.map { case (v, i) =>
+              (NodeId(i), v)
+            }
+          ),
         )
         config.profileDir.foreach { dir =>
           val desc = Engine.profileDesc(tx)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1667,8 +1667,8 @@ private[lf] object SBuiltin {
     */
   private[speedy] def checkAborted(ptx: PartialTransaction): Unit =
     ptx.aborted match {
-      case Some(Tx.AuthFailureDuringExecution(nid, fa)) =>
-        throw DamlEFailedAuthorization(nid, fa)
+      case Some(Tx.AuthFailureDuringExecution(fa)) =>
+        throw DamlEFailedAuthorization(fa)
       case Some(Tx.ContractNotActive(coid, tid, consumedBy)) =>
         throw DamlELocalContractNotActive(coid, tid, consumedBy)
       case Some(Tx.DuplicateContractKey(key)) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -7,7 +7,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
 import com.daml.lf.ledger.EventId
 import com.daml.lf.ledger.FailedAuthorization
-import com.daml.lf.transaction.{GlobalKey, NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{GlobalKey, Transaction => Tx}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.lf.scenario.ScenarioLedger
@@ -67,7 +67,7 @@ object SError {
   final case class DamlELocalContractNotActive(
       coid: ContractId,
       templateId: TypeConName,
-      consumedBy: NodeId,
+      consumedBy: Option[PartialTransaction.Tree],
   ) extends SErrorDamlException
 
   final case class DamlELocalContractKeyNotVisible(
@@ -130,8 +130,8 @@ object SError {
 
   /** There was an authorization failure during execution. */
   final case class DamlEFailedAuthorization(
-      nid: NodeId,
-      fa: FailedAuthorization,
+      //nid: NodeId, //NICK: can't have a node-id anymore; but we could have a Tree.
+      fa: FailedAuthorization
   ) extends SErrorDamlException
 
   /** A fetch or exercise was being made against a contract that has not

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -527,10 +527,10 @@ object Repl {
       .map { expr =>
         val (machine, errOrLedger) =
           state.scenarioRunner.run(expr)
-        machine.withOnLedger("invokeTest") { onLedger =>
+        machine.withOnLedger("invokeTest") { _ =>
           errOrLedger match {
             case Left((err, ledger @ _)) =>
-              println(prettyError(err, onLedger.ptx).render(128))
+              println(prettyError(err).render(128))
               (false, state)
             case Right((diff @ _, steps @ _, ledger, value @ _)) =>
               // NOTE(JM): cannot print this, output used in tests.
@@ -561,13 +561,13 @@ object Repl {
     allTests.foreach { case (name, body) =>
       print(name + ": ")
       val (machine, errOrLedger) = state.scenarioRunner.run(body)
-      machine.withOnLedger("cmdTestAll") { onLedger =>
+      machine.withOnLedger("cmdTestAll") { _ =>
         errOrLedger match {
           case Left((err, ledger @ _)) =>
             println(
               "failed at " +
                 prettyLoc(machine.lastLocation).render(128) +
-                ": " + prettyError(err, onLedger.ptx).render(128)
+                ": " + prettyError(err).render(128)
             )
             failures += 1
           case Right((diff, steps, ledger @ _, value @ _)) =>
@@ -595,10 +595,10 @@ object Repl {
         println("Collecting profile...")
         val (machine, errOrLedger) =
           state.scenarioRunner.run(expr)
-        machine.withOnLedger("cmdProfile") { onLedger =>
+        machine.withOnLedger("cmdProfile") { _ =>
           errOrLedger match {
             case Left((err, ledger @ _)) =>
-              println(prettyError(err, onLedger.ptx).render(128))
+              println(prettyError(err).render(128))
               (false, state)
             case Right((diff @ _, steps @ _, ledger @ _, value @ _)) =>
               println("Writing profile...")

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -897,10 +897,13 @@ object Transaction {
   /** Signals that the contract-id `coid` was expected to be active, but
     * is not.
     */
+
+  private type Tree = TxTree[Value.ContractId]
+
   final case class ContractNotActive(
       coid: Value.ContractId,
       templateId: TypeConName,
-      consumedBy: NodeId,
+      consumedBy: Option[Tree],
   ) extends TransactionError
 
   /** Signals that within the transaction we got to a point where
@@ -924,8 +927,8 @@ object Transaction {
   ) extends TransactionError
 
   final case class AuthFailureDuringExecution(
-      nid: NodeId,
-      fa: FailedAuthorization,
+      //nid: NodeId, //NICK
+      fa: FailedAuthorization
   ) extends TransactionError
 
   @deprecated("use Validation.isRepledBy", since = "1.10.0")

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TxTree.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TxTree.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package transaction
+
+import com.daml.lf.data.Trampoline.{Bounce, Land, Trampoline}
+import com.daml.lf.data.ImmArray
+import com.daml.lf.transaction.Node.{GenNode, LeafOnlyActionNode, NodeExercises, NodeRollback}
+
+// Simple tree representation for transactions. No node-ids and mapping here!
+
+// A sub transaction-tree (TxTree); a node and it's children.
+// Ties the recursive knot via the Nid type parameter of GenNode.
+final case class TxTree[Cid](node: GenNode[TxTree[Cid], Cid])
+
+// A full transaction (TxTreeTop) is a forest of trees
+final case class TxTreeTop[Cid](roots: ImmArray[TxTree[Cid]]) {
+
+  // The final tx has increasing node-ids when nodes are listed in pre-order.
+  // The root node-id is 0 (we have tests that rely on this)
+  def toStandardTransaction: GenTransaction[NodeId, Cid] = {
+    pushTrees(initialState, roots.toList) { (finalState, roots) =>
+      Land(GenTransaction(finalState.nodeMap, ImmArray(roots)))
+    }.bounce
+  }
+
+  private[this] type Tree = TxTree[Cid]
+  private[this] type Nid = NodeId
+  private[this] type Node = GenNode[Nid, Cid]
+
+  // State manages a counter for node-id generation, and accumulates the nodes-map
+  private[this] case class State(index: Int, nodeMap: Map[Nid, Node]) {
+
+    def next[R](k: (State, Nid) => Trampoline[R]): Trampoline[R] = {
+      k(State(index + 1, nodeMap), NodeId(index))
+    }
+
+    def push[R](nid: Nid, node: Node)(k: (State, Nid) => Trampoline[R]): Trampoline[R] = {
+      k(State(index, nodeMap = nodeMap + (nid -> node)), nid)
+    }
+
+  }
+
+  private val initialState = State(0, Map.empty)
+
+  private[this] def pushTree[R](s: State, x: Tree)(
+      k: (State, Nid) => Trampoline[R]
+  ): Trampoline[R] = {
+    x match {
+      case TxTree(node) =>
+        s.next { (s, me) =>
+          node match {
+
+            case leaf: LeafOnlyActionNode[_] =>
+              s.push(me, leaf)(k)
+
+            case exe: NodeExercises[_, _] =>
+              pushTrees(s, exe.children.toList) { (s, children) =>
+                val node = exe.copy(children = ImmArray(children))
+                s.push(me, node)(k)
+              }
+
+            case rb: NodeRollback[_] =>
+              pushTrees(s, rb.children.toList) { (s, children) =>
+                val node = rb.copy(children = ImmArray(children))
+                s.push(me, node)(k)
+              }
+          }
+        }
+    }
+  }
+
+  private[this] def pushTrees[R](s: State, xs: List[Tree])(
+      k: (State, List[Nid]) => Trampoline[R]
+  ): Trampoline[R] = {
+    Bounce { () =>
+      xs match {
+        case Nil => k(s, Nil)
+        case x :: xs =>
+          pushTree(s, x) { (s, y) =>
+            pushTrees(s, xs) { (s, ys) =>
+              Bounce { () =>
+                k(s, y :: ys)
+              }
+            }
+          }
+      }
+    }
+  }
+}


### PR DESCRIPTION
WIP/Prototype

This work was initially driven for perf reasons. And there is about a 1% improvement. But it turns out that some tricky and fragile code in `PartialTransaction` which managed and used `NodeId` has been removed.

Use simpler tree representation for transactions when possible:
- add simpler tree representation for transactions (`TxTree`, `TxTreeTop`)
- have the rollback normalizer take/consume this rep
- support conversion from this simpler rep to the standard tx rep ( `toStandardTransaction`)

Change speedy `PartialTransaction` to construct this simpler rep:
- remove all node-id tracking
- ensure collection of `actionNodeSeeds` still works
- remove use of `NodeId` in some daml exceptions
- All tests `bazel test daml-lf/...` are working

TODO:
- some work still required to adapt `scenario-service`


changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
