### PR TITLE
DPP-390 remove appendonly todos

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableFlatEvents.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableFlatEvents.scala
@@ -122,7 +122,6 @@ private[events] object EventsTableFlatEvents {
       requestingParty: Party,
   ): SimpleSql[Row] = {
     val witnessesWhereClause =
-      // TODO varchars are not texts according to postgreSQL - we need to do lot of casting. since these are primarlily the same I suggest for the final approach to pick either and align
       sqlFunctions.arrayIntersectionWhereClause("flat_event_witnesses", requestingParty)
     SQL"""select #$selectColumns, array[$requestingParty] as event_witnesses,
                  case when submitters = array[$requestingParty]::text[] then command_id else '' end as command_id

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableFlatEventsRangeQueries.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsTableFlatEventsRangeQueries.scala
@@ -308,9 +308,8 @@ private[events] object EventsTableFlatEventsRangeQueries {
         party: Party,
         pageSize: Int,
     ): QueryParts = {
-      // TODO inline the def, only used once
-      def witnessesWhereClause(prefix: String) =
-        sqlFunctions.arrayIntersectionWhereClause(s"$prefix.flat_event_witnesses", party)
+      val witnessesWhereClause =
+        sqlFunctions.arrayIntersectionWhereClause(s"active_cs.flat_event_witnesses", party)
       SQL"""select #$selectColumns, array[$party] as event_witnesses,
                    case when active_cs.submitters = array[$party]::text[] then active_cs.command_id else '' end as command_id
             from participant_events as active_cs
@@ -325,7 +324,7 @@ private[events] object EventsTableFlatEventsRangeQueries {
                       archived_cs.event_kind = 20 and -- consuming
                       archived_cs.event_offset <= ${range.endInclusive._1: Offset}
                   )
-                  and #${witnessesWhereClause("active_cs")}
+                  and #$witnessesWhereClause
             order by active_cs.event_sequential_id limit $pageSize"""
     }
 


### PR DESCRIPTION
This PR removes TODOs from the appendonly package.

Notes regarding the TODO about string data types:
- we do not want to restrict the maximum length of any column, so we should not use `varchar(n)`
- `varchar` and `text` are the exact same thing internally
- most resources recommend using the concise `text` over the old `varchar`

We already use `text` for all columns. The reason why we have to use type casts is because the postgres type of `array['foo']` is `text[]` if `'foo'` is part of the prepared statement and `varchar[]` if `'foo'` is a parameter value, so we end up comparing with both data types. And while `text` and `varchar` are comparable, `text[]` and `varchar[]` are not.