### PR TITLE
Upgrade canton to 0.25.0-snapshot supporting lf-1.13 and enable/fix tests

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -398,7 +398,7 @@ java_import(
     jars = glob(["lib/**/*.jar"]),
 )
         """,
-            sha256 = "2ab610e13cadef0756aa1eebf8be9c40192b7cca1774ebd0df06c662628a6c4d",
-            strip_prefix = "canton-community-0.24.0",
-            urls = ["https://www.canton.io/releases/canton-community-0.24.0.tar.gz"],
+            sha256 = "e97468ddb6b4bd03b05c714fecbf8a2127ba697001a7980a31dd781e7fffa53f",
+            strip_prefix = "canton-community-0.25.0-SNAPSHOT",
+            urls = ["https://www.canton.io/releases/canton-community-20210606.tar.gz"],
         )

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -63,8 +63,7 @@ conformance_test(
     ],
     lf_versions = [
         "stable",
-        # FIXME: add latest once canton-test-runner supports LF 1.13
-        #  "latest",
+        "latest",
     ],
     ports = [
         5011,
@@ -82,7 +81,6 @@ conformance_test(
         ",ParticipantPruningIT" +  # see "conformance-test-participant-pruning" below
         ",ConfigManagementServiceIT,LedgerConfigurationServiceIT" +  # dynamic config management not supported by Canton
         ",ClosedWorldIT" +  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
-        ",CommandServiceIT:CSCreateAndBadExerciseChoice,CommandSubmissionCompletionIT:CSCRefuseBadChoice" +  # FIXME: canton should be updated with last SDK to produce proper output message for those tests to pass
         # Excluding tests that require contract key uniqueness and RWArchiveVsFailedLookupByKey (finding a lookup failure after contract creation)
         ",RaceConditionIT:WWDoubleNonTransientCreate,RaceConditionIT:WWArchiveVsNonTransientCreate,RaceConditionIT:RWTransientCreateVsNonTransientCreate,RaceConditionIT:RWArchiveVsFailedLookupByKey",
     ],
@@ -105,8 +103,7 @@ conformance_test(
     ],
     lf_versions = [
         "stable",
-        # FIXME: add latest once canton-test-runner supports LF 1.13
-        #  "latest",
+        "latest",
     ],
     ports = [
         5011,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -300,7 +300,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         Status.Code.INVALID_ARGUMENT,
         Some(
           Pattern.compile(
-            "Interpretation error: Error: (User abort: Assertion failed\\.|Unhandled exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"Assertion failed\" \\}\\.) Details: Last location: \\[[^\\]]*\\], partial transaction: root node"
+            "Interpretation error: Error: (User abort: Assertion failed.|Unhandled exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"Assertion failed\" \\}\\.) [Dd]etails(: |=)Last location: \\[[^\\]]*\\], partial transaction: root node"
           )
         ),
       )
@@ -543,7 +543,11 @@ final class CommandServiceIT extends LedgerTestSuite {
       assertGrpcError(
         failure,
         Status.Code.INVALID_ARGUMENT,
-        s"unknown choice $missingChoice",
+        Some(
+          Pattern.compile(
+            "(unknown|Couldn't find requested) choice " + missingChoice
+          )
+        ),
       )
     }
   })

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandSubmissionCompletionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandSubmissionCompletionIT.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import java.util.regex.Pattern
+
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -103,7 +105,11 @@ final class CommandSubmissionCompletionIT extends LedgerTestSuite {
       assertGrpcError(
         failure,
         Status.Code.INVALID_ARGUMENT,
-        s"unknown choice $badChoice",
+        Some(
+          Pattern.compile(
+            "(unknown|Couldn't find requested) choice " + badChoice
+          )
+        ),
       )
     }
   })


### PR DESCRIPTION
Made three tests more flexible in terms of expected error message:
1. CommandServiceIT:CSReturnStackTrace extended parsing to support details= and ;-based format of error properties - found by @daravep 

I will make the following two expected results less flexible again after the next canton upgrade:

2. CommandServiceIT:CSCreateAndBadExerciseChoice reenable previously expected prior to 7bc925e4d203d0dd1c3fb71545f791cacf75d0db as a viable error output
3. CommandSubmissionCompletionIT:CSCRefuseBadChoice - same as 2.

changelog_begin
changelog_end

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
