### PR TITLE
Add dependency proto3-suite for Setup.hs

### DIFF
--- a/build-scripts/build_hs_lf_tooling.sh
+++ b/build-scripts/build_hs_lf_tooling.sh
@@ -129,7 +129,8 @@ custom-setup
     Cabal,
     directory,
     filepath,
-    process
+    process,
+    proto3-suite
 
 library
   default-language: Haskell2010


### PR DESCRIPTION
The Setup.hs attempts to call out to programs installed by `proto3-suite` to generate code based off the proto files.
There should be a `setup-depends:` on `proto3-suite`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
