### PR TITLE
skip fix_bazel_cache on forks

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -5,6 +5,7 @@ jobs:
 
 - job: fix_bazel_cache
   timeoutInMinutes: 120
+  condition: eq(variables['System.PullRequest.IsFork'], 'False')
   pool:
     name: 'ubuntu_20_04'
     demands: assignment -equals default


### PR DESCRIPTION
Secrets are not available to forks, so they can't delete things from the
cache.

CHANGELOG_BEGIN
CHANGELOG_END