### PR TITLE
Fix flaky InstrumentedSourceSpec test

### DIFF
--- a/ledger/metrics/src/test/suite/scala/com/daml/metrics/InstrumentedSourceSpec.scala
+++ b/ledger/metrics/src/test/suite/scala/com/daml/metrics/InstrumentedSourceSpec.scala
@@ -171,8 +171,8 @@ final class InstrumentedSourceSpec extends AsyncFlatSpec with Matchers with Akka
       producerMaxSpeed = 10,
       consumerMaxSpeed = 5,
     ) map { samples =>
-      sampleAverage(samples) should be > 80.0
-      samplePercentage(samples)(_ == 100) should be > 80.0
+      sampleAverage(samples) should be > 75.0
+      samplePercentage(samples)(_ == 100) should be > 75.0
     }
   }
 


### PR DESCRIPTION
Flaky `InstrumentedSourceSpec` test
* Lower expectations in `signal mostly full buffer if slow consumer`

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
