### PR TITLE
Allow two different time formats as input for the metrics reporting interval

### DIFF
--- a/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
+++ b/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
@@ -6,9 +6,28 @@ package com.daml.cliopts
 import com.daml.metrics.MetricsReporter
 import scopt.OptionDef
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{Duration, FiniteDuration, NANOSECONDS}
+import scala.util.Try
 
 object Metrics {
+  private case class DurationFormat(unwrap: FiniteDuration)
+
+  private implicit val scoptDurationFormat: scopt.Read[DurationFormat] = scopt.Read.reads {
+    duration =>
+      Try {
+        Duration(duration)
+      }.orElse(Try {
+        Duration.fromNanos(
+          java.time.Duration.parse(duration).toNanos
+        )
+      }).flatMap(duration =>
+        Try {
+          if (!duration.isFinite)
+            throw new RuntimeException(s"Input duration $duration is not finite")
+          else DurationFormat(FiniteDuration(duration.toNanos, NANOSECONDS))
+        }
+      ).get
+  }
 
   def metricsReporterParse[C](parser: scopt.OptionParser[C])(
       metricsReporter: Setter[C, Option[MetricsReporter]],
@@ -31,8 +50,8 @@ object Metrics {
     hideIfRequested(optionMetricsReporter)
 
     val optionMetricsReportingInterval =
-      opt[FiniteDuration]("metrics-reporting-interval")
-        .action((interval, config) => metricsReportingInterval(_ => interval, config))
+      opt[DurationFormat]("metrics-reporting-interval")
+        .action((interval, config) => metricsReportingInterval(_ => interval.unwrap, config))
         .optional()
         .text("Set metric reporting interval.")
     hideIfRequested(optionMetricsReportingInterval)

--- a/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
+++ b/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
@@ -23,7 +23,7 @@ object Metrics {
       }).flatMap(duration =>
         Try {
           if (!duration.isFinite)
-            throw new RuntimeException(s"Input duration $duration is not finite")
+            throw new IllegalArgumentException(s"Input duration $duration is not finite")
           else DurationFormat(FiniteDuration(duration.toNanos, NANOSECONDS))
         }
       ).get

--- a/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
+++ b/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
@@ -12,6 +12,8 @@ import scala.util.Try
 object Metrics {
   private case class DurationFormat(unwrap: FiniteDuration)
 
+  // We're trying to parse the java duration first for backwards compatibility as
+  // removing it and only supporting the scala duration variant would be a breaking change.
   private implicit val scoptDurationFormat: scopt.Read[DurationFormat] = scopt.Read.reads {
     duration =>
       Try {

--- a/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
+++ b/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
@@ -15,11 +15,11 @@ object Metrics {
   private implicit val scoptDurationFormat: scopt.Read[DurationFormat] = scopt.Read.reads {
     duration =>
       Try {
-        Duration(duration)
-      }.orElse(Try {
         Duration.fromNanos(
           java.time.Duration.parse(duration).toNanos
         )
+      }.orElse(Try {
+        Duration(duration)
       }).flatMap(duration =>
         Try {
           if (!duration.isFinite)

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
@@ -266,9 +266,16 @@ abstract class CommonCliSpecBase(
       config shouldEqual None
     }
 
-    "parse the metrics reporting interval when given" in {
+    "parse the metrics reporting interval (java duration format) when given" in {
       checkOption(
         Array("--metrics-reporting-interval", "PT1M30S"),
+        _.copy(metricsReportingInterval = 90.seconds),
+      )
+    }
+
+    "parse the metrics reporting interval (scala duration format) when given" in {
+      checkOption(
+        Array("--metrics-reporting-interval", "1.5min"),
         _.copy(metricsReportingInterval = 90.seconds),
       )
     }

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
@@ -268,7 +268,7 @@ abstract class CommonCliSpecBase(
 
     "parse the metrics reporting interval when given" in {
       checkOption(
-        Array("--metrics-reporting-interval", "1.5m"),
+        Array("--metrics-reporting-interval", "PT1M30S"),
         _.copy(metricsReportingInterval = 90.seconds),
       )
     }


### PR DESCRIPTION
and accordingly revert to using the old test for the CommonCliSpecBase in sandbox-common.

changelog_begin

- for applications which support the --metrics-reporter-interval cli option, these now support both the java and scala duration string format (e.g. PT1M30S and 1.5min)

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
