### PR TITLE
Handle module-prefixes in Java codegen

### DIFF
--- a/language-support/codegen-common/BUILD.bazel
+++ b/language-support/codegen-common/BUILD.bazel
@@ -19,6 +19,7 @@ da_scala_library(
     visibility = ["//visibility:public"],
     deps = [
         "//daml-assistant/scala-daml-project-config",
+        "//daml-lf/data",
         "//libs-scala/build-info",
         "@maven//:ch_qos_logback_logback_classic",
     ],

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
@@ -7,8 +7,9 @@ import java.io.File
 import java.nio.file.{Path, Paths}
 
 import ch.qos.logback.classic.Level
+import com.daml.lf.data.Ref.{PackageName, PackageVersion}
 import com.daml.assistant.config._
-import io.circe.ACursor
+import io.circe.{ACursor, KeyDecoder}
 
 import scala.util.Try
 
@@ -30,6 +31,7 @@ object CodegenConfigReader {
     for {
       dar <- darPath(sdkConf)
       packagePrefix <- packagePrefix(sdkConf, dest)
+      modulePrefixes <- modulePrefixes(sdkConf)
       outputDirectory <- outputDirectory(sdkConf, dest)
       decoderPkgAndClass <- decoderPkgAndClass(sdkConf, dest)
       verbosity <- verbosity(sdkConf, dest): Result[Option[Int]]
@@ -37,6 +39,7 @@ object CodegenConfigReader {
       root <- root(sdkConf, dest): Result[Option[List[String]]]
     } yield Conf(
       darFiles = Map(dar -> packagePrefix),
+      modulePrefixes = modulePrefixes,
       outputDirectory = outputDirectory,
       decoderPkgAndClass = decoderPkgAndClass,
       verbosity = logLevel,
@@ -71,6 +74,14 @@ object CodegenConfigReader {
     codegen(sdkConf, mode)
       .downField("package-prefix")
       .as[Option[String]]
+      .left
+      .map(configParseError)
+
+  private def modulePrefixes(sdkConf: ProjectConfig): Result[Map[PackageReference, String]] =
+    sdkConf.content.hcursor
+      .downField("module-prefixes")
+      .as[Option[Map[PackageReference, String]]]
+      .map(_.getOrElse(Map.empty))
       .left
       .map(configParseError)
 
@@ -145,4 +156,20 @@ object CodegenConfigReader {
 
   private def resultR[A](a: A): Result[A] =
     Right(a): Result[A]
+
+  implicit val decodePackageReference: KeyDecoder[PackageReference] =
+    new KeyDecoder[PackageReference] {
+      // TODO (MK) For now we only allow name-vesion pairs to match the compiler. Once the compiler
+      // accepts package ids we can allow for those here as well.
+      final def apply(key: String): Option[PackageReference] = nameVersion(key)
+
+      private def nameVersion(key: String): Option[PackageReference] = key.split("-") match {
+        case Array(name, version) =>
+          for {
+            name <- PackageName.fromString(name).toOption
+            version <- PackageVersion.fromString(version).toOption
+          } yield PackageReference.NameVersion(name, version)
+        case _ => None
+      }
+    }
 }

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
@@ -159,7 +159,8 @@ object CodegenConfigReader {
 
   implicit val decodePackageReference: KeyDecoder[PackageReference] =
     new KeyDecoder[PackageReference] {
-      // TODO (MK) For now we only allow name-vesion pairs to match the compiler. Once the compiler
+      // TODO (MK) https://github.com/digital-asset/daml/issues/9934
+      // For now we only allow name-vesion pairs to match the compiler. Once the compiler
       // accepts package ids we can allow for those here as well.
       final def apply(key: String): Option[PackageReference] = nameVersion(key)
 

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/Conf.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/Conf.scala
@@ -13,7 +13,8 @@ import scopt.{OptionParser, Read}
 sealed trait PackageReference extends Product with Serializable
 
 object PackageReference {
-  // TODO (MK): We probably want to allow package id references here
+  // TODO (MK) https://github.com/digital-asset/daml/issues/9934
+  // We probably want to allow package id references here
   // but this needs to be supported in damlc first.
   final case class NameVersion(name: PackageName, version: PackageVersion)
       extends PackageReference {

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/Conf.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/Conf.scala
@@ -7,7 +7,20 @@ import java.nio.file.{Path, Paths}
 
 import ch.qos.logback.classic.Level
 import com.daml.buildinfo.BuildInfo
+import com.daml.lf.data.Ref.{PackageName, PackageVersion}
 import scopt.{OptionParser, Read}
+
+sealed trait PackageReference extends Product with Serializable
+
+object PackageReference {
+  // TODO (MK): We probably want to allow package id references here
+  // but this needs to be supported in damlc first.
+  final case class NameVersion(name: PackageName, version: PackageVersion)
+      extends PackageReference {
+    override final def toString(): String =
+      s"$name-$version"
+  }
+}
 
 /** @param darFiles The [[Set]] of Daml-LF [[Path]]s to convert into code. It MUST contain
   *                        all the Daml-LF packages dependencies.
@@ -17,6 +30,7 @@ import scopt.{OptionParser, Read}
 final case class Conf(
     darFiles: Map[Path, Option[String]] = Map(),
     outputDirectory: Path,
+    modulePrefixes: Map[PackageReference, String] = Map.empty,
     decoderPkgAndClass: Option[(String, String)] = None,
     verbosity: Level = Level.ERROR,
     roots: List[String] = Nil,

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -12,6 +12,7 @@ load(
 )
 load(
     "//rules_daml:daml.bzl",
+    "daml_build_test",
     "daml_compile",
 )
 load(
@@ -83,10 +84,10 @@ da_scala_test(
     scala_deps = [
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalatest_scalatest",
+        "@maven//:org_scalaz_scalaz_core",
     ],
     versioned_scala_deps = {
         "2.12": [
-            "@maven//:org_scalaz_scalaz_core",
             "@maven//:org_scala_lang_modules_scala_collection_compat",
         ],
     },
@@ -259,6 +260,87 @@ daml_compile(
     target = "1.dev",
 )
 
+daml_compile(
+    name = "pkg1",
+    srcs = glob(
+        [
+            "src/it/daml/Pkg1.0/*.daml",
+        ],
+    ),
+    project_name = "pkg",
+    version = "1.0.0",
+)
+
+daml_compile(
+    name = "pkg2",
+    srcs = glob(
+        [
+            "src/it/daml/Pkg2.0/*.daml",
+        ],
+    ),
+    project_name = "pkg",
+    version = "2.0.0",
+)
+
+daml_build_test(
+    name = "pkg-root",
+    dar_dict = {
+        ":pkg1.dar": "pkg1.dar",
+        ":pkg2.dar": "pkg2.dar",
+    },
+    project_dir = "src/it/daml/pkg-root",
+)
+
+# This sidesteps dar_to_java so it can read the config from daml.yaml
+# which is currently the only way to specify module-prefixes.
+genrule(
+    name = "pkg-root-srcjar",
+    srcs = [
+        "src/it/daml/pkg-root/daml.yaml",
+        ":pkg-root.dar",
+    ],
+    outs = ["pkg-root.srcjar"],
+    cmd = """
+      set -eou pipefail
+      work_dir=$$(mktemp -d)
+      trap "rm -rf $$work_dir" EXIT
+      export DAML_PROJECT=$$work_dir
+      cp $(location :src/it/daml/pkg-root/daml.yaml) $$work_dir/daml.yaml
+      mkdir -p $$work_dir/.daml/dist
+      cp $(location :pkg-root.dar) $$work_dir/.daml/dist/root-1.0.0.dar
+      PREV=$$PWD
+      cd $$work_dir
+      $$PREV/$(execpath //language-support/codegen-main:codegen-main) java
+      cd $$PREV
+      $(JAVABASE)/bin/jar -cf $@ -C $$work_dir/out .
+    """,
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    tools = ["//language-support/codegen-main"],
+)
+
+java_library(
+    name = "pkg-root.jar",
+    srcs = [":pkg-root.srcjar"],
+    deps = [
+        "//language-support/java/bindings:bindings-java",
+    ],
+)
+
+module_prefix_test = "src/it/java/com/daml/ModulePrefixes.java"
+
+java_test(
+    name = "integration-tests-module-prefixes",
+    srcs = [module_prefix_test],
+    test_class = "com.daml.ModulePrefixes",
+    deps = [
+        ":pkg-root.jar",
+        "@maven//:org_junit_jupiter_junit_jupiter_api",
+        "@maven//:org_junit_jupiter_junit_jupiter_engine",
+        "@maven//:org_junit_platform_junit_platform_commons",
+        "@maven//:org_junit_platform_junit_platform_runner",
+    ],
+)
+
 [
     [
         #
@@ -275,10 +357,13 @@ daml_compile(
         ),
         java_test(
             name = "integration-tests-%s" % target,
-            srcs = glob([
-                "src/it/java-%s/**/*.java" % target,
-                "src/it/java/**/*.java",
-            ]),
+            srcs = glob(
+                [
+                    "src/it/java-%s/**/*.java" % target,
+                    "src/it/java/**/*.java",
+                ],
+                exclude = [module_prefix_test],
+            ),
             test_class = "com.daml.AllTests",
             deps = [
                 ":integration-tests-model-%s.jar" % target,

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -84,10 +84,10 @@ da_scala_test(
     scala_deps = [
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalatest_scalatest",
+        "@maven//:org_scalaz_scalaz_core",
     ],
     versioned_scala_deps = {
         "2.12": [
-            "@maven//:org_scalaz_scalaz_core",
             "@maven//:org_scala_lang_modules_scala_collection_compat",
         ],
     },

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -84,10 +84,10 @@ da_scala_test(
     scala_deps = [
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalatest_scalatest",
-        "@maven//:org_scalaz_scalaz_core",
     ],
     versioned_scala_deps = {
         "2.12": [
+            "@maven//:org_scalaz_scalaz_core",
             "@maven//:org_scala_lang_modules_scala_collection_compat",
         ],
     },

--- a/language-support/java/codegen/src/it/daml/Pkg1.0/A.daml
+++ b/language-support/java/codegen/src/it/daml/Pkg1.0/A.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module A where
+
+template T1
+  with
+    p : Party
+  where
+    signatory p
+

--- a/language-support/java/codegen/src/it/daml/Pkg2.0/A.daml
+++ b/language-support/java/codegen/src/it/daml/Pkg2.0/A.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module A where
+
+template T2
+  with
+    p : Party
+  where
+    signatory p
+

--- a/language-support/java/codegen/src/it/daml/pkg-root/daml.yaml
+++ b/language-support/java/codegen/src/it/daml/pkg-root/daml.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: __VERSION__
+name: root
+source: language-support/java/codegen/src/it/daml/pkg-root/daml
+version: 1.0.0
+module-prefixes:
+  pkg-1.0.0: V1
+  pkg-2.0.0: V2
+dependencies:
+  - daml-prim
+  - daml-stdlib
+data-dependencies:
+  - pkg1.dar
+  - pkg2.dar
+codegen:
+  java:
+    output-directory: out
+    decoderClass: com.daml.ledger.javaapi.TestDecoder

--- a/language-support/java/codegen/src/it/daml/pkg-root/daml/Root.daml
+++ b/language-support/java/codegen/src/it/daml/pkg-root/daml/Root.daml
@@ -1,0 +1,13 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Root where
+
+import qualified V1.A
+import qualified V2.A
+
+scenario = do
+  p <- getParty "p"
+  submit p $ create (V1.A.T1 p)
+  submit p $ create (V2.A.T2 p)
+

--- a/language-support/java/codegen/src/it/java/com/daml/ModulePrefixes.java
+++ b/language-support/java/codegen/src/it/java/com/daml/ModulePrefixes.java
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import v1.a.T1;
+import v2.a.T2;
+
+// We’re only testing that modules get remapped correctly
+// while preserving the original module name.
+public class ModulePrefixes {
+  @Test
+  public void packageIds() {
+    assertEquals(T1.TEMPLATE_ID.getModuleName(), "A");
+    assertEquals(T2.TEMPLATE_ID.getModuleName(), "A");
+  }
+}

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -171,11 +171,9 @@ object CodeGenRunner extends StrictLogging {
     }.toList
     allModules.groupBy(_._1).foreach { case (m, grouped) =>
       if (grouped.length > 1) {
-        val pkgIds = grouped.map(_._2)
+        val pkgIds = grouped.view.map(_._2).mkString(", ")
         throw new IllegalArgumentException(
-          s"""Duplicate module $m found in multiple packages ${pkgIds.mkString(
-            ", "
-          )}. To resolve the conflict rename the modules in one of the packages via `module-prefixes`."""
+          s"""Duplicate module $m found in multiple packages $pkgIds. To resolve the conflict rename the modules in one of the packages via `module-prefixes`."""
         )
       }
     }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -161,14 +161,14 @@ object CodeGenRunner extends StrictLogging {
       pkgPrefixes: Map[PackageId, String],
       interfaces: Seq[Interface],
   ): Unit = {
-    val allModules: List[(String, PackageId)] = interfaces.view.flatMap { interface =>
-      val modules = interface.typeDecls.keys.view.map(name => name.module).toSet
-      modules.map(m =>
-        pkgPrefixes
-          .get(interface.packageId)
-          .fold(m.toString)(prefix => s"$prefix.$m") -> interface.packageId
-      )
-    }.toList
+    val allModules: Seq[(String, PackageId)] =
+      for {
+        interface <- interfaces
+        modules = interface.typeDecls.keySet.map(_.module)
+        module <- modules
+        maybePrefix = pkgPrefixes.get(interface.packageId)
+        prefixedName = maybePrefix.fold(module.toString)(prefix => s"$prefix.$module")
+      } yield prefixedName -> interface.packageId
     allModules.groupBy(_._1).foreach { case (m, grouped) =>
       if (grouped.length > 1) {
         val pkgIds = grouped.view.map(_._2).mkString(", ")

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -135,9 +135,9 @@ object CodeGenRunner extends StrictLogging {
           ),
         )
     }
-    val resolvedModulePrefixes: Map[PackageId, String] = modulePrefixes.view.map { case (k, v) =>
+    val resolvedModulePrefixes: Map[PackageId, String] = modulePrefixes.map { case (k, v) =>
       resolveRef(k) -> v.toLowerCase
-    }.toMap
+    }
     (pkgPrefixes.keySet union resolvedModulePrefixes.keySet).view.map { k =>
       val prefix = (pkgPrefixes.get(k), resolvedModulePrefixes.get(k)) match {
         case (None, None) =>

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -138,20 +138,18 @@ object CodeGenRunner extends StrictLogging {
     val resolvedModulePrefixes: Map[PackageId, String] = modulePrefixes.view.map { case (k, v) =>
       resolveRef(k) -> v.toLowerCase
     }.toMap
-    val resolvedPrefixes: Map[PackageId, String] =
-      (pkgPrefixes.keySet union resolvedModulePrefixes.keySet).view.map { k =>
-        val prefix = (pkgPrefixes.get(k), resolvedModulePrefixes.get(k)) match {
-          case (None, None) =>
-            throw new RuntimeException(
-              "Internal error: key in pkgPrefixes and resolvedModulePrefixes could not be found in either of them"
-            )
-          case (Some(a), None) => a.stripSuffix(".")
-          case (None, Some(b)) => b.stripSuffix(".")
-          case (Some(a), Some(b)) => s"""${a.stripSuffix(".")}.${b.stripSuffix(".")}"""
-        }
-        k -> prefix
-      }.toMap
-    resolvedPrefixes
+    (pkgPrefixes.keySet union resolvedModulePrefixes.keySet).view.map { k =>
+      val prefix = (pkgPrefixes.get(k), resolvedModulePrefixes.get(k)) match {
+        case (None, None) =>
+          throw new RuntimeException(
+            "Internal error: key in pkgPrefixes and resolvedModulePrefixes could not be found in either of them"
+          )
+        case (Some(a), None) => a.stripSuffix(".")
+        case (None, Some(b)) => b.stripSuffix(".")
+        case (Some(a), Some(b)) => s"""${a.stripSuffix(".")}.${b.stripSuffix(".")}"""
+      }
+      k -> prefix
+    }.toMap
   }
 
   /** Verify that no two module names collide when the given

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -112,7 +112,7 @@ object CodeGenRunner extends StrictLogging {
   /** Given the package prefixes specified per DAR and the module-prefixes specified in
     * daml.yaml, produce the combined prefixes per package id.
     */
-  def resolvePackagePrefixes(
+  private [codegen] def resolvePackagePrefixes(
       pkgPrefixes: Map[PackageId, String],
       modulePrefixes: Map[PackageReference, String],
       interfaces: Seq[Interface],
@@ -155,7 +155,7 @@ object CodeGenRunner extends StrictLogging {
   /** Verify that no two module names collide when the given
     * prefixes are applied.
     */
-  def detectModuleCollisions(
+  private [codegen] def detectModuleCollisions(
       pkgPrefixes: Map[PackageId, String],
       interfaces: Seq[Interface],
   ): Unit = {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -11,7 +11,7 @@ import com.daml.lf.archive.DarManifestReader
 import com.daml.lf.archive.DarReader
 import com.daml.lf.codegen.backend.Backend
 import com.daml.lf.codegen.backend.java.JavaBackend
-import com.daml.lf.codegen.conf.Conf
+import com.daml.lf.codegen.conf.{Conf, PackageReference}
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.iface.reader.{Errors, InterfaceReader}
@@ -109,6 +109,78 @@ object CodeGenRunner extends StrictLogging {
     logger.warn(s"Finish writing file '$outputFile'")
   }
 
+  /** Given the package prefixes specified per DAR and the module-prefixes specified in
+    * daml.yaml, produce the combined prefixes per package id.
+    */
+  def resolvePackagePrefixes(
+      pkgPrefixes: Map[PackageId, String],
+      modulePrefixes: Map[PackageReference, String],
+      interfaces: Seq[Interface],
+  ): Map[PackageId, String] = {
+    val metadata: Map[PackageReference.NameVersion, PackageId] = interfaces.view
+      .flatMap(iface =>
+        iface.metadata.iterator.map(metadata =>
+          PackageReference.NameVersion(metadata.name, metadata.version) -> iface.packageId
+        )
+      )
+      .toMap
+    def resolveRef(ref: PackageReference): PackageId = ref match {
+      case nameVersion: PackageReference.NameVersion =>
+        metadata.getOrElse(
+          nameVersion,
+          throw new IllegalArgumentException(
+            s"""No package $nameVersion found, available packages: ${metadata.keys.mkString(
+              ", "
+            )}"""
+          ),
+        )
+    }
+    val resolvedModulePrefixes: Map[PackageId, String] = modulePrefixes.view.map { case (k, v) =>
+      resolveRef(k) -> v.toLowerCase
+    }.toMap
+    val resolvedPrefixes: Map[PackageId, String] =
+      (pkgPrefixes.keySet union resolvedModulePrefixes.keySet).view.map { k =>
+        val prefix = (pkgPrefixes.get(k), resolvedModulePrefixes.get(k)) match {
+          case (None, None) =>
+            throw new RuntimeException(
+              "Internal error: key in pkgPrefixes and resolvedModulePrefixes could not be found in either of them"
+            )
+          case (Some(a), None) => a.stripSuffix(".")
+          case (None, Some(b)) => b.stripSuffix(".")
+          case (Some(a), Some(b)) => s"""${a.stripSuffix(".")}.${b.stripSuffix(".")}"""
+        }
+        k -> prefix
+      }.toMap
+    resolvedPrefixes
+  }
+
+  /** Verify that no two module names collide when the given
+    * prefixes are applied.
+    */
+  def detectModuleCollisions(
+      pkgPrefixes: Map[PackageId, String],
+      interfaces: Seq[Interface],
+  ): Unit = {
+    val allModules: List[(String, PackageId)] = interfaces.view.flatMap { interface =>
+      val modules = interface.typeDecls.keys.view.map(name => name.module).toSet
+      modules.map(m =>
+        pkgPrefixes
+          .get(interface.packageId)
+          .fold(m.toString)(prefix => s"$prefix.$m") -> interface.packageId
+      )
+    }.toList
+    allModules.groupBy(_._1).foreach { case (m, grouped) =>
+      if (grouped.length > 1) {
+        val pkgIds = grouped.map(_._2)
+        throw new IllegalArgumentException(
+          s"""Duplicate module $m found in multiple packages ${pkgIds.mkString(
+            ", "
+          )}. To resolve the conflict rename the modules in one of the packages via `module-prefixes`."""
+        )
+      }
+    }
+  }
+
   private[CodeGenRunner] def generateCode(
       interfaces: Seq[Interface],
       conf: Conf,
@@ -118,15 +190,18 @@ object CodeGenRunner extends StrictLogging {
       s"Start processing packageIds '${interfaces.map(_.packageId).mkString(", ")}' in directory '${conf.outputDirectory}'"
     )
 
+    val prefixes = resolvePackagePrefixes(pkgPrefixes, conf.modulePrefixes, interfaces)
+    detectModuleCollisions(prefixes, interfaces)
+
     // TODO (mp): pre-processing and escaping
     val preprocessingFuture: Future[InterfaceTrees] =
-      backend.preprocess(interfaces, conf, pkgPrefixes)
+      backend.preprocess(interfaces, conf, prefixes)
 
     val future: Future[Unit] = {
       for {
         preprocessedInterfaceTrees <- preprocessingFuture
         _ <- Future.traverse(preprocessedInterfaceTrees.interfaceTrees)(
-          processInterfaceTree(_, conf, pkgPrefixes)
+          processInterfaceTree(_, conf, prefixes)
         )
       } yield ()
     }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -112,7 +112,7 @@ object CodeGenRunner extends StrictLogging {
   /** Given the package prefixes specified per DAR and the module-prefixes specified in
     * daml.yaml, produce the combined prefixes per package id.
     */
-  private [codegen] def resolvePackagePrefixes(
+  private[codegen] def resolvePackagePrefixes(
       pkgPrefixes: Map[PackageId, String],
       modulePrefixes: Map[PackageReference, String],
       interfaces: Seq[Interface],
@@ -155,7 +155,7 @@ object CodeGenRunner extends StrictLogging {
   /** Verify that no two module names collide when the given
     * prefixes are applied.
     */
-  private [codegen] def detectModuleCollisions(
+  private[codegen] def detectModuleCollisions(
       pkgPrefixes: Map[PackageId, String],
       interfaces: Seq[Interface],
   ): Unit = {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/JavaBackend.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/JavaBackend.scala
@@ -13,7 +13,6 @@ import com.squareup.javapoet._
 import com.typesafe.scalalogging.StrictLogging
 import org.slf4j.MDC
 
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 
 private[codegen] object JavaBackend extends Backend with StrictLogging {
@@ -58,7 +57,6 @@ private[codegen] object JavaBackend extends Backend with StrictLogging {
       conf: Conf,
       packagePrefixes: Map[PackageId, String],
   )(implicit ec: ExecutionContext): Future[Unit] = {
-    val prefixes = packagePrefixes.view.mapValues(_.stripSuffix(".")).toMap
     nodeWithContext match {
       case moduleWithContext: ModuleWithContext if moduleWithContext.module.types.nonEmpty =>
         // this is a Daml module that contains type declarations => the codegen will create one file
@@ -66,7 +64,7 @@ private[codegen] object JavaBackend extends Backend with StrictLogging {
           logger.info(
             s"Generating code for module ${moduleWithContext.lineage.map(_._1).toSeq.mkString(".")}"
           )
-          for (javaFile <- createTypeDefinitionClasses(moduleWithContext, prefixes)) {
+          for (javaFile <- createTypeDefinitionClasses(moduleWithContext, packagePrefixes)) {
             logger.info(
               s"Writing ${javaFile.packageName}.${javaFile.typeSpec.name} to directory ${conf.outputDirectory}"
             )

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
@@ -91,7 +91,7 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
       CodeGenRunner.detectModuleCollisions(
         Map.empty,
         Seq(interface("pkg1", "A", "A.B"), interface("pkg2", "B", "A.B.C")),
-      ) === ()
+      ) === (())
     )
   }
 
@@ -118,7 +118,7 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
       CodeGenRunner.detectModuleCollisions(
         Map(PackageId.assertFromString("pkg2") -> "Pkg2"),
         Seq(interface("pkg1", "A"), interface("pkg2", "A")),
-      ) === ()
+      ) === (())
     )
   }
 

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
@@ -87,10 +87,12 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
   }
 
   it should "succeed if there are no collisions" in {
-    CodeGenRunner.detectModuleCollisions(
-      Map.empty,
-      Seq(interface("pkg1", "A", "A.B"), interface("pkg2", "B", "A.B.C")),
-    ) shouldBe (())
+    assert(
+      CodeGenRunner.detectModuleCollisions(
+        Map.empty,
+        Seq(interface("pkg1", "A", "A.B"), interface("pkg2", "B", "A.B.C")),
+      ) === ()
+    )
   }
 
   it should "fail if there is a collision" in {
@@ -112,10 +114,12 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
   }
 
   it should "succeed if collision is resolved by prefixing" in {
-    CodeGenRunner.detectModuleCollisions(
-      Map(PackageId.assertFromString("pkg2") -> "Pkg2"),
-      Seq(interface("pkg1", "A"), interface("pkg2", "A")),
-    ) shouldBe (())
+    assert(
+      CodeGenRunner.detectModuleCollisions(
+        Map(PackageId.assertFromString("pkg2") -> "Pkg2"),
+        Seq(interface("pkg1", "A"), interface("pkg2", "A")),
+      ) === ()
+    )
   }
 
   behavior of "resolvePackagePrefixes"
@@ -135,12 +139,14 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
     val interface1 = interface(pkg1, None)
     val interface2 = interface(pkg2, Some(PackageMetadata(name2, version)))
     val interface3 = interface(pkg3, Some(PackageMetadata(name3, version)))
-    CodeGenRunner.resolvePackagePrefixes(
-      pkgPrefixes,
-      modulePrefixes,
-      Seq(interface1, interface2, interface3),
-    ) shouldBe
-      Map(pkg1 -> "com.pkg1", pkg2 -> "com.pkg2.a.b", pkg3 -> "c.d")
+    assert(
+      CodeGenRunner.resolvePackagePrefixes(
+        pkgPrefixes,
+        modulePrefixes,
+        Seq(interface1, interface2, interface3),
+      ) ===
+        Map(pkg1 -> "com.pkg1", pkg2 -> "com.pkg2.a.b", pkg3 -> "c.d")
+    )
   }
   it should "fail if module-prefixes references non-existing package" in {
     val name2 = PackageName.assertFromString("name2")
@@ -148,7 +154,7 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
     val modulePrefixes =
       Map[PackageReference, String](PackageReference.NameVersion(name2, version) -> "A.B")
     assertThrows[IllegalArgumentException] {
-      CodeGenRunner.resolvePackagePrefixes(Map.empty, modulePrefixes, Seq.empty) shouldBe None
+      CodeGenRunner.resolvePackagePrefixes(Map.empty, modulePrefixes, Seq.empty)
     }
   }
 }

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
@@ -8,8 +8,18 @@ import java.nio.file.Files
 
 import com.daml.bazeltools.BazelRunfiles
 import com.daml.lf.archive.DarReader
+import com.daml.lf.data.ImmArray.ImmArraySeq
+import com.daml.lf.data.Ref.{
+  DottedName,
+  ModuleName,
+  PackageId,
+  PackageName,
+  PackageVersion,
+  QualifiedName,
+}
+import com.daml.lf.iface.{DefDataType, Interface, InterfaceType, PackageMetadata, Record}
 import com.daml.lf.codegen.backend.java.JavaBackend
-import com.daml.lf.codegen.conf.Conf
+import com.daml.lf.codegen.conf.{Conf, PackageReference}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -53,5 +63,92 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
     assert(interfaces.map(_.packageId).length == dar.all.length)
     assert(pkgPrefixes.size == dar.all.length)
     assert(pkgPrefixes.values.forall(_ == "PREFIX"))
+  }
+
+  behavior of "detectModuleCollisions"
+
+  def interface(pkgId: String, modNames: String*): Interface =
+    interface(pkgId, None, modNames: _*)
+
+  def interface(pkgId: String, metadata: Option[PackageMetadata], modNames: String*): Interface = {
+    val dummyType = InterfaceType.Normal(DefDataType(ImmArraySeq.empty, Record(ImmArraySeq.empty)))
+    Interface(
+      PackageId.assertFromString(pkgId),
+      metadata,
+      modNames.view
+        .map(n =>
+          QualifiedName(
+            ModuleName.assertFromString(n),
+            DottedName.assertFromString("Dummy"),
+          ) -> dummyType
+        )
+        .toMap,
+    )
+  }
+
+  it should "succeed if there are no collisions" in {
+    CodeGenRunner.detectModuleCollisions(
+      Map.empty,
+      Seq(interface("pkg1", "A", "A.B"), interface("pkg2", "B", "A.B.C")),
+    ) shouldBe (())
+  }
+
+  it should "fail if there is a collision" in {
+    assertThrows[IllegalArgumentException] {
+      CodeGenRunner.detectModuleCollisions(
+        Map.empty,
+        Seq(interface("pkg1", "A"), interface("pkg2", "A")),
+      )
+    }
+  }
+
+  it should "fail if there is a collision caused by prefixing" in {
+    assertThrows[IllegalArgumentException] {
+      CodeGenRunner.detectModuleCollisions(
+        Map(PackageId.assertFromString("pkg2") -> "A"),
+        Seq(interface("pkg1", "A.B"), interface("pkg2", "B")),
+      )
+    }
+  }
+
+  it should "succeed if collision is resolved by prefixing" in {
+    CodeGenRunner.detectModuleCollisions(
+      Map(PackageId.assertFromString("pkg2") -> "Pkg2"),
+      Seq(interface("pkg1", "A"), interface("pkg2", "A")),
+    ) shouldBe (())
+  }
+
+  behavior of "resolvePackagePrefixes"
+
+  it should "combine module-prefixes and pkgPrefixes" in {
+    val pkg1 = PackageId.assertFromString("pkg-1")
+    val pkg2 = PackageId.assertFromString("pkg-2")
+    val pkg3 = PackageId.assertFromString("pkg-3")
+    val pkgPrefixes = Seq(pkg1 -> "com.pkg1", pkg2 -> "com.pkg2").toMap
+    val name2 = PackageName.assertFromString("name2")
+    val name3 = PackageName.assertFromString("name3")
+    val version = PackageVersion.assertFromString("1.0.0")
+    val modulePrefixes = Seq[(PackageReference, String)](
+      PackageReference.NameVersion(name2, version) -> "A.B",
+      PackageReference.NameVersion(name3, version) -> "C.D",
+    ).toMap
+    val interface1 = interface(pkg1, None)
+    val interface2 = interface(pkg2, Some(PackageMetadata(name2, version)))
+    val interface3 = interface(pkg3, Some(PackageMetadata(name3, version)))
+    CodeGenRunner.resolvePackagePrefixes(
+      pkgPrefixes,
+      modulePrefixes,
+      Seq(interface1, interface2, interface3),
+    ) shouldBe
+      Seq(pkg1 -> "com.pkg1", pkg2 -> "com.pkg2.a.b", pkg3 -> "c.d").toMap
+  }
+  it should "fail if module-prefixes references non-existing package" in {
+    val name2 = PackageName.assertFromString("name2")
+    val version = PackageVersion.assertFromString("1.0.0")
+    val modulePrefixes =
+      Seq[(PackageReference, String)](PackageReference.NameVersion(name2, version) -> "A.B").toMap
+    assertThrows[IllegalArgumentException] {
+      CodeGenRunner.resolvePackagePrefixes(Map.empty, modulePrefixes, Seq.empty) shouldBe None
+    }
   }
 }

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
@@ -124,14 +124,14 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
     val pkg1 = PackageId.assertFromString("pkg-1")
     val pkg2 = PackageId.assertFromString("pkg-2")
     val pkg3 = PackageId.assertFromString("pkg-3")
-    val pkgPrefixes = Seq(pkg1 -> "com.pkg1", pkg2 -> "com.pkg2").toMap
+    val pkgPrefixes = Map(pkg1 -> "com.pkg1", pkg2 -> "com.pkg2")
     val name2 = PackageName.assertFromString("name2")
     val name3 = PackageName.assertFromString("name3")
     val version = PackageVersion.assertFromString("1.0.0")
-    val modulePrefixes = Seq[(PackageReference, String)](
+    val modulePrefixes = Map[PackageReference, String](
       PackageReference.NameVersion(name2, version) -> "A.B",
       PackageReference.NameVersion(name3, version) -> "C.D",
-    ).toMap
+    )
     val interface1 = interface(pkg1, None)
     val interface2 = interface(pkg2, Some(PackageMetadata(name2, version)))
     val interface3 = interface(pkg3, Some(PackageMetadata(name3, version)))
@@ -140,13 +140,13 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
       modulePrefixes,
       Seq(interface1, interface2, interface3),
     ) shouldBe
-      Seq(pkg1 -> "com.pkg1", pkg2 -> "com.pkg2.a.b", pkg3 -> "c.d").toMap
+      Map(pkg1 -> "com.pkg1", pkg2 -> "com.pkg2.a.b", pkg3 -> "c.d")
   }
   it should "fail if module-prefixes references non-existing package" in {
     val name2 = PackageName.assertFromString("name2")
     val version = PackageVersion.assertFromString("1.0.0")
     val modulePrefixes =
-      Seq[(PackageReference, String)](PackageReference.NameVersion(name2, version) -> "A.B").toMap
+      Map[PackageReference, String](PackageReference.NameVersion(name2, version) -> "A.B")
     assertThrows[IllegalArgumentException] {
       CodeGenRunner.resolvePackagePrefixes(Map.empty, modulePrefixes, Seq.empty) shouldBe None
     }

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/Main.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/Main.scala
@@ -28,7 +28,7 @@ object Main extends StrictLogging {
     }
 
   def generateCode(conf: Conf): Unit = conf match {
-    case Conf(darMap, outputDir, decoderPkgAndClass, verbosity, roots) =>
+    case Conf(darMap, outputDir, modulePrefixes @ _, decoderPkgAndClass, verbosity, roots) =>
       setGlobalLogLevel(verbosity)
       logUnsupportedEventDecoderOverride(decoderPkgAndClass)
       val (dars, packageName) = darsAndOnePackageName(darMap)


### PR DESCRIPTION
changelog_begin

- [Java Codegen] The Java codegen will now pick up the
  `module-prefixes` field from `daml.yaml` which can be used to handle
  module name collisions between different DALFs.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
