### PR TITLE
Load the correct logback file for the http json service respecting the deployment situation

### DIFF
--- a/ledger-service/cli-opts/src/main/scala/cliopts/Logging.scala
+++ b/ledger-service/cli-opts/src/main/scala/cliopts/Logging.scala
@@ -5,8 +5,6 @@ package com.daml.cliopts
 
 import ch.qos.logback.classic.{Level => LogLevel}
 
-import java.io.FileInputStream
-
 object Logging {
 
   sealed trait PathKind
@@ -23,7 +21,8 @@ object Logging {
     import org.slf4j.LoggerFactory
     import scala.util.Using
     import java.io.InputStream
-    def reloadConfig(stream: => InputStream) = {
+    import java.io.FileInputStream
+    def reloadConfig(stream: => InputStream): Unit =
       Using.resource(stream) { stream =>
         try {
           val context = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
@@ -38,11 +37,8 @@ object Logging {
               s"reconfigured failed using url $path: $je"
             )
             je.printStackTrace(System.err)
-        } finally {
-          stream.close()
-        }
+        } finally stream.close()
       }
-    }
     path match {
       case PathKind.OutsideOfJar(path) => reloadConfig(new FileInputStream(path))
       case PathKind.InsideOfJar(pathToLogbackFileInJarFile) =>

--- a/ledger-service/cli-opts/src/main/scala/cliopts/Logging.scala
+++ b/ledger-service/cli-opts/src/main/scala/cliopts/Logging.scala
@@ -13,7 +13,7 @@ object Logging {
     final case class InsideOfJar(path: String) extends PathKind
   }
 
-  def reconfigure(clazz: Class[_], path: PathKind): Unit = {
+  def reconfigure(clazz: Class[_]): Unit = {
     // Try reconfiguring the library
     import ch.qos.logback.core.joran.spi.JoranException
     import ch.qos.logback.classic.LoggerContext
@@ -22,6 +22,11 @@ object Logging {
     import scala.util.Using
     import java.io.InputStream
     import java.io.FileInputStream
+    val path: PathKind =
+      System.getProperty("logback.configurationFile") match {
+        case null => PathKind.InsideOfJar("logback.xml")
+        case path => PathKind.OutsideOfJar(path)
+      }
     def reloadConfig(stream: => InputStream): Unit =
       Using.resource(stream) { stream =>
         try {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
 import akka.stream.Materializer
-import com.daml.cliopts.Logging.{LogEncoder, PathKind}
+import com.daml.cliopts.Logging.LogEncoder
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.runtime.JdbcDrivers
 import com.daml.scalautil.Statement.discard
@@ -46,12 +46,7 @@ object Main {
       case LogEncoder.Plain => () // This is the default
       case LogEncoder.Json =>
         Logging.setUseJsonLogEncoderSystemProp()
-        val path: PathKind =
-          System.getProperty("logback.configurationFile") match {
-            case null => PathKind.InsideOfJar("logback.xml")
-            case path => PathKind.OutsideOfJar(path)
-          }
-        Logging.reconfigure(getClass, path)
+        Logging.reconfigure(getClass)
     }
     // Here we set all things which are related to logging but not to
     // any env vars in the logback.xml file.

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
 import akka.stream.Materializer
-import com.daml.cliopts.Logging.LogEncoder
+import com.daml.cliopts.Logging.{LogEncoder, PathKind}
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.runtime.JdbcDrivers
 import com.daml.scalautil.Statement.discard
@@ -46,7 +46,12 @@ object Main {
       case LogEncoder.Plain => () // This is the default
       case LogEncoder.Json =>
         Logging.setUseJsonLogEncoderSystemProp()
-        Logging.reconfigure(getClass, "logback.xml")
+        val path: PathKind =
+          System.getProperty("logback.configurationFile") match {
+            case null => PathKind.InsideOfJar("logback.xml")
+            case path => PathKind.OutsideOfJar(path)
+          }
+        Logging.reconfigure(getClass, path)
     }
     // Here we set all things which are related to logging but not to
     // any env vars in the logback.xml file.


### PR DESCRIPTION
Prior it was not possible to enable json logging for the packaged daml sdk, because of a bug in how we reload the logback.xml for configuration changes. These changes now make use of an env var which exists for the case of being packaged with the daml sdk to retrieve the absolute path to the logback file and handing it over for the reload.

changelog_begin

[HTTP-JSON]
- fixed that json log output could not be enabled via cli options except via usage of env vars

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
