### PR TITLE
Make PartialTransaction be an engine-internal detail

### DIFF
--- a/compiler/damlc/tests/daml-test-files/TransientFailure.daml
+++ b/compiler/damlc/tests/daml-test-files/TransientFailure.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR exercises C on #1:1
+-- @ERROR Assertion failed
 module TransientFailure where
 
 template T'

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -243,25 +243,11 @@ main =
                     [ "Scenario execution failed on commit at Test:57:3:"
                     , ".*"
                     , ".*failed due to a missing authorization.*"
-                    , ".*"
-                    , ".*"
-                    , ".*"
-                    , "Partial transaction:"
-                    , "  Sub-transactions:"
-                    , "     0"
-                    , ".*create Test:Helper.*"
                     ]
                 expectScriptFailure rs (vr "testPartialSubmitMustFail") $ \r ->
                   matchRegex r $ T.unlines
                     [ "Scenario execution failed on commit at Test:62:3:"
                     , "  Aborted:  Expected submit to fail but it succeeded"
-                    , ".*"
-                    , ".*"
-                    , ".*"
-                    , "Partial transaction:"
-                    , "  Sub-transactions:"
-                    , "     0"
-                    , ".*create Test:Helper.*"
                     ]
                 pure (),
               testCase "query" $

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -104,21 +104,22 @@ final class Conversions(
             .setArg(convertValue(arg))
             .build
         )
-      case SError.DamlELocalContractNotActive(coid, tid, consumedBy) =>
+      //TODO: remove consumedBy from DamlELocalContractNotActive
+      case SError.DamlELocalContractNotActive(coid, tid, consumedBy @ _) =>
         builder.setUpdateLocalContractNotActive(
           proto.ScenarioError.ContractNotActive.newBuilder
             .setContractRef(mkContractRef(coid, tid))
-            .setConsumedBy(proto.NodeId.newBuilder.setId(consumedBy.toString).build)
             .build
         )
       case SError.DamlEDuplicateContractKey(key) =>
         builder.setScenarioCommitError(
           proto.CommitError.newBuilder.setUniqueKeyViolation(convertGlobalKey(key)).build
         )
-      case SError.DamlEFailedAuthorization(nid, fa) =>
+      //TODO: remove nid from DamlEFailedAuthorization
+      case SError.DamlEFailedAuthorization(nid @ _, fa) =>
         builder.setScenarioCommitError(
           proto.CommitError.newBuilder
-            .setFailedAuthorizations(convertFailedAuthorization(nid, fa))
+            .setFailedAuthorizations(convertFailedAuthorization(fa))
             .build
         )
 
@@ -246,13 +247,11 @@ final class Conversions(
   }
 
   def convertFailedAuthorization(
-      nodeId: NodeId,
-      fa: FailedAuthorization,
+      fa: FailedAuthorization
   ): proto.FailedAuthorizations = {
     val builder = proto.FailedAuthorizations.newBuilder
     builder.addFailedAuthorizations {
       val faBuilder = proto.FailedAuthorization.newBuilder
-      faBuilder.setNodeId(convertTxNodeId(nodeId))
       fa match {
         case FailedAuthorization.CreateMissingAuthorization(
               templateId,
@@ -401,12 +400,10 @@ final class Conversions(
       .build
   }
 
-  def convertPartialTransaction(ptx: SPartialTransaction): proto.PartialTransaction = {
+  def convertPartialTransaction(ptx: SPartialTransaction): proto.PartialTransaction = { //TODO: remove PartialTransaction from proto
     val builder = proto.PartialTransaction.newBuilder
-      .addAllNodes(ptx.nodes.map(convertNode).asJava)
-      .addAllRoots(
-        ptx.context.children.toImmArray.toSeq.sortBy(_.index).map(convertTxNodeId).asJava
-      )
+      .addAllNodes(Nil.map(convertNode).asJava)
+      .addAllRoots(Nil.map(convertTxNodeId).asJava)
 
     @tailrec
     def unwindToExercise(

--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -221,8 +221,6 @@ Stack trace
    location is the first entry in the list.
 Ledger time
    The ledger time at which the error occurred.
-Partial transaction
-   The transaction that is being constructed, but not yet committed to the ledger.
 Committed transaction
    Transactions that were successfully committed to the ledger prior to the error.
 Trace
@@ -243,8 +241,6 @@ The ``abort``, ``assert`` and ``debug`` inbuilt functions can be used in updates
       Aborted:  stop
 
     Ledger time: 1970-01-01T00:00:00Z
-
-    Partial transaction:
 
     Trace:
       "hello, world!"
@@ -270,13 +266,6 @@ in the contract, but not authorizing the create:
           failed due to a missing authorization from 'Bob'
 
     Ledger time: 1970-01-01T00:00:00Z
-
-    Partial transaction:
-      Sub-transactions:
-         #0
-         └─> create CreateAuthFailure:Example
-             with
-               party1 = 'Alice'; party2 = 'Bob'
 
 To create the "Example" contract one would need to bring both parties to
 authorize the creation via a choice, for example 'Alice' could create a contract
@@ -304,15 +293,6 @@ choice 'Consume' of which he is not a controller
           failed due to a missing authorization from 'Alice'
 
     Ledger time: 1970-01-01T00:00:00Z
-
-    Partial transaction:
-      Sub-transactions:
-         #0
-         └─> fetch #0:0 (ExerciseAuthFailure:Example)
-
-         #1
-         └─> 'Alice' exercises Consume on #0:0 (ExerciseAuthFailure:Example)
-                     with
 
     Committed transactions:
       TX #0 1970-01-01T00:00:00Z (unknown source)
@@ -349,8 +329,6 @@ to exercise the contract the following error would occur:
       Disclosed to: 'Alice'
 
     Ledger time: 1970-01-01T00:00:00Z
-
-    Partial transaction:
 
     Committed transactions:
       TX #0 1970-01-01T00:00:00Z (unknown source)


### PR DESCRIPTION
Goal: Make `PartialTransaction` be an engine-internal detail, and not a user facing concept.
- This opens up the chance to simplify the representation of transactions (https://github.com/digital-asset/daml/pull/9909)

Changes here:
- Stop `scenario-service` reporting _partial transaction_ info.
- Adapt a couple of tests.
- Update doc

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
