### PR TITLE
Log call to submitAndWaitRequest with the command id provided in the log ctx

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -162,7 +162,7 @@ class CommandService(
     )
       .run { implicit lc =>
         logger.info(
-          s"Submitting $commandKind command and synchronously waiting for completion"
+          s"Submitting $commandKind command"
         )
         Commands.submitAndWaitRequest(
           jwtPayload.ledgerId,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -151,7 +151,9 @@ class CommandService(
       jwtPayload: JwtWritePayload,
       meta: Option[domain.CommandMeta],
       command: lav1.commands.Command.Command,
-  )(implicit lc: LoggingContextOf[InstanceUUID]): lav1.command_service.SubmitAndWaitRequest = {
+  )(implicit
+      lc: LoggingContextOf[InstanceUUID with RequestID]
+  ): lav1.command_service.SubmitAndWaitRequest = {
     val commandId: lar.CommandId = meta.flatMap(_.commandId).getOrElse(uniqueCommandId())
     withEnrichedLoggingContext(
       label[lar.CommandId],


### PR DESCRIPTION
this fixes #9918

The trace ctx is being done in a seperate pr.

changelog_begin

- [HTTP-JSON] Calls which trigger a submitAndWaitRequest are logged with the command id provided in the log ctx

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
