### PR TITLE
Proxy ledger API health endpoint in JSON API health endpoint

### DIFF
--- a/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
+++ b/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
@@ -63,7 +63,7 @@ final class FailureTests
         (status, out) <- getRequestEncoded(uri.withPath(Uri.Path("/readyz")))
         _ = status shouldBe StatusCodes.ServiceUnavailable
         _ = out shouldBe
-          """[-] ledger failed
+          """[-] ledger failed (io.grpc.StatusRuntimeException: UNAVAILABLE: io exception)
             |[+] database ok
             |readyz check failed
             |""".stripMargin.replace("\r\n", "\n")
@@ -263,7 +263,7 @@ final class FailureTests
       (status, out) <- getRequestEncoded(uri.withPath(Uri.Path("/readyz")))
       _ = status shouldBe StatusCodes.ServiceUnavailable
       _ = out shouldBe
-        """[+] ledger ok
+        """[+] ledger ok (SERVING)
           |[-] database failed
           |readyz check failed
           |""".stripMargin.replace("\r\n", "\n")

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HealthService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HealthService.scala
@@ -4,37 +4,49 @@
 package com.daml.http
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, StatusCodes}
+import io.grpc.health.v1.health.HealthCheckResponse
 import scalaz.Scalaz._
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
 final class HealthService(
-    getLedgerEnd: HealthService.GetLedgerEnd,
+    getLedgerEnd: HealthService.GetHealthCheckResponse,
     contractDao: Option[dbbackend.ContractDao],
     timeoutSeconds: Int,
 ) {
+
   import HealthService._
   def ready()(implicit ec: ExecutionContext): Future[ReadyResponse] =
     for {
-      ledger <- getLedgerEnd().transform(r => Try(r.isSuccess))
+      ledger <- getLedgerEnd().transform {
+        case Failure(err) => Success(false, Some(err.toString))
+        case Success(resp) =>
+          Success(
+            resp.status == HealthCheckResponse.ServingStatus.SERVING,
+            Some(resp.status.toString),
+          )
+      }
       optDb <- contractDao.traverse(opt =>
         opt.isValid(timeoutSeconds).unsafeToFuture().recover { case NonFatal(_) =>
           false
         }
       )
-    } yield ReadyResponse(Seq(Check("ledger", ledger)) ++ optDb.toList.map(Check("database", _)))
+    } yield ReadyResponse(
+      Seq(Check("ledger", ledger._1, ledger._2)) ++ optDb.toList.map(Check("database", _, None))
+    )
 }
 
 object HealthService {
-  case class Check(name: String, result: Boolean)
+  case class Check(name: String, result: Boolean, details: Option[String])
   case class ReadyResponse(checks: Seq[Check]) {
     val ok = checks.forall(_.result)
     private def check(c: Check) = {
       val (checkBox, result) = if (c.result) { ("+", "ok") }
       else { ("-", "failed") }
-      s"[$checkBox] ${c.name} $result"
+      val output = s"[$checkBox] ${c.name} $result"
+      c.details.fold(output)(d => s"$output ($d)")
     }
 
     // Format modeled after k8s’ own healthchecks
@@ -48,6 +60,5 @@ object HealthService {
         entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, render()),
       )
   }
-  // We only check health so we don’t care about the offset
-  type GetLedgerEnd = () => Future[Unit]
+  type GetHealthCheckResponse = () => Future[HealthCheckResponse]
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HealthService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HealthService.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
 final class HealthService(
-    getLedgerEnd: HealthService.GetHealthCheckResponse,
+    getLedgerHealth: HealthService.GetHealthCheckResponse,
     contractDao: Option[dbbackend.ContractDao],
     timeoutSeconds: Int,
 ) {
@@ -20,7 +20,7 @@ final class HealthService(
   import HealthService._
   def ready()(implicit ec: ExecutionContext): Future[ReadyResponse] =
     for {
-      ledger <- getLedgerEnd().transform {
+      ledger <- getLedgerHealth().transform {
         case Failure(err) => Success(false, Some(err.toString))
         case Success(resp) =>
           Success(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HealthService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HealthService.scala
@@ -21,11 +21,10 @@ final class HealthService(
   def ready()(implicit ec: ExecutionContext): Future[ReadyResponse] =
     for {
       ledger <- getLedgerHealth().transform {
-        case Failure(err) => Success(false, Some(err.toString))
+        case Failure(err) => Success((false, Some(err.toString)))
         case Success(resp) =>
           Success(
-            resp.status == HealthCheckResponse.ServingStatus.SERVING,
-            Some(resp.status.toString),
+            (resp.status == HealthCheckResponse.ServingStatus.SERVING, Some(resp.status.toString))
           )
       }
       optDb <- contractDao.traverse(opt =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -37,6 +37,7 @@ import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import com.daml.metrics.Metrics
 import com.daml.ports.{Port, PortFiles}
 import com.daml.scalautil.Statement.discard
+import io.grpc.health.v1.health.{HealthCheckRequest, HealthGrpc}
 import scalaz.Scalaz._
 import scalaz._
 
@@ -157,8 +158,10 @@ object HttpService {
         ),
       )
 
+      ledgerHealthService = HealthGrpc.stub(client.channel)
+
       healthService = new HealthService(
-        getLedgerEnd(pkgManagementClient, tokenHolder),
+        () => ledgerHealthService.check(HealthCheckRequest()),
         contractDao,
         healthTimeoutSeconds,
       )


### PR DESCRIPTION
This is a bit more useful than just querying ledger end.

changelog_begin

- [JSON API] The healthcheck endpoint on the JSON API now proxies the
  health check endpoint on the underlying ledger. Previously it only
  queried for ledger end to determine ledger health.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
