### PR TITLE
Adds Indexer state to GRPC health checks [DPP-434]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
@@ -143,14 +143,15 @@ private[indexer] final class RecoveringIndexer(
         .release()
         .flatMap(_ => complete.future)
         .map(_ => {
+          updateHealthStatus(HealthStatus.unhealthy)
           logger.info("Stopped Indexer Server")
         })
     })
   }
 
-  private def reportErrorState(errMsg: String, exception: Throwable): Unit = {
+  private def reportErrorState(errorMessage: String, exception: Throwable): Unit = {
     updateHealthStatus(HealthStatus.unhealthy)
-    logger.error(errMsg, exception)
+    logger.error(errorMessage, exception)
   }
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -4,6 +4,7 @@
 package com.daml.platform.indexer
 
 import akka.stream.Materializer
+import com.daml.ledger.api.health.{HealthStatus, ReportsHealth}
 import com.daml.ledger.participant.state.v1.ReadService
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -20,11 +21,11 @@ final class StandaloneIndexerServer(
     metrics: Metrics,
     lfValueTranslationCache: LfValueTranslationCache.Cache,
 )(implicit materializer: Materializer, loggingContext: LoggingContext)
-    extends ResourceOwner[Unit] {
+    extends ResourceOwner[ReportsHealth] {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 
-  override def acquire()(implicit context: ResourceContext): Resource[Unit] = {
+  override def acquire()(implicit context: ResourceContext): Resource[ReportsHealth] = {
     val indexerFactory = new JdbcIndexer.Factory(
       ServerRole.Indexer,
       config,
@@ -33,14 +34,14 @@ final class StandaloneIndexerServer(
       metrics,
       lfValueTranslationCache,
     )
-    val indexer = new RecoveringIndexer(
+    val indexer = RecoveringIndexer(
       materializer.system.scheduler,
       materializer.executionContext,
       config.restartDelay,
     )
     config.startupMode match {
       case IndexerStartupMode.MigrateOnly =>
-        Resource.unit
+        Resource.successful(() => HealthStatus.healthy)
       case IndexerStartupMode.MigrateAndStart =>
         Resource
           .fromFuture(
@@ -48,22 +49,25 @@ final class StandaloneIndexerServer(
               .migrateSchema(config.allowExistingSchema)
           )
           .flatMap(startIndexer(indexer, _))
-          .map { _ =>
+          .map { healthReporter =>
             logger.debug("Waiting for the indexer to initialize the database.")
+            healthReporter
           }
       case IndexerStartupMode.ResetAndStart =>
         Resource
           .fromFuture(indexerFactory.resetSchema())
           .flatMap(startIndexer(indexer, _))
-          .map { _ =>
+          .map { healthReporter =>
             logger.debug("Waiting for the indexer to initialize the database.")
+            healthReporter
           }
       case IndexerStartupMode.ValidateAndStart =>
         Resource
           .fromFuture(indexerFactory.validateSchema())
           .flatMap(startIndexer(indexer, _))
-          .map { _ =>
+          .map { healthReporter =>
             logger.debug("Waiting for the indexer to initialize the database.")
+            healthReporter
           }
     }
   }
@@ -71,8 +75,8 @@ final class StandaloneIndexerServer(
   private def startIndexer(
       indexer: RecoveringIndexer,
       initializedIndexerFactory: ResourceOwner[Indexer],
-  )(implicit context: ResourceContext): Resource[Unit] =
+  )(implicit context: ResourceContext): Resource[ReportsHealth] =
     indexer
       .start(() => initializedIndexerFactory.flatMap(_.subscription(readService)).acquire())
-      .map(_ => ())
+      .map { case (indexerHealthReporter, _) => indexerHealthReporter }
 }

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -139,7 +139,7 @@ final class Runner[T <: ReadWriteService, Extra](
               )
               .map(ExecutionContext.fromExecutorService)
               .acquire()
-            _ <- participantConfig.mode match {
+            healthChecksWithIndexer <- participantConfig.mode match {
               case ParticipantRunMode.Combined | ParticipantRunMode.Indexer =>
                 new StandaloneIndexerServer(
                   readService = readService,
@@ -147,9 +147,9 @@ final class Runner[T <: ReadWriteService, Extra](
                   servicesExecutionContext = servicesExecutionContext,
                   metrics = metrics,
                   lfValueTranslationCache = lfValueTranslationCache,
-                ).acquire()
+                ).acquire().map(indexerHealth => healthChecks + ("indexer" -> indexerHealth))
               case ParticipantRunMode.LedgerApiServer =>
-                Resource.unit
+                Resource.successful(healthChecks)
             }
             _ <- participantConfig.mode match {
               case ParticipantRunMode.Combined | ParticipantRunMode.LedgerApiServer =>
@@ -161,7 +161,7 @@ final class Runner[T <: ReadWriteService, Extra](
                   ledgerConfig = factory.ledgerConfig(config),
                   optWriteService = Some(writeService),
                   authService = factory.authService(config),
-                  healthChecks = healthChecks,
+                  healthChecks = healthChecksWithIndexer,
                   metrics = metrics,
                   timeServiceBackend = factory.timeServiceBackend(config),
                   otherInterceptors = factory.interceptors(config),

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -185,7 +185,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
               servicesExecutionContext <- ResourceOwner
                 .forExecutorService(() => Executors.newWorkStealingPool())
                 .map(ExecutionContext.fromExecutorService)
-              _ <- new StandaloneIndexerServer(
+              indexerReportsHealth <- new StandaloneIndexerServer(
                 readService = readService,
                 config = IndexerConfig(
                   participantId = config.participantId,
@@ -254,7 +254,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                 ledgerConfig = config.ledgerConfig,
                 optWriteService = Some(writeService),
                 authService = authService,
-                healthChecks = healthChecks,
+                healthChecks = healthChecks + ("indexer" -> indexerReportsHealth),
                 metrics = metrics,
                 timeServiceBackend = timeServiceBackend,
                 otherServices = List(resetService),


### PR DESCRIPTION
Adds participant Indexer state to GRPC health checks.

CHANGELOG_BEGIN
[Integration Kit] The state of the participant indexer can now be checked via the GRPC health endpoint
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
