### PR TITLE
Define IncompleteTransaction for use by scenario-service

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -119,7 +119,7 @@ class ScenarioService(implicit
                       new Conversions(
                         context.homePackageId,
                         ledger,
-                        onLedger.ptx,
+                        onLedger.incompleteTransaction(),
                         machine.traceLog,
                         onLedger.commitLocation,
                         machine.stackTrace(),
@@ -131,7 +131,7 @@ class ScenarioService(implicit
                       new Conversions(
                         context.homePackageId,
                         ledger,
-                        onLedger.ptx,
+                        onLedger.incompleteTransaction(),
                         machine.traceLog,
                         onLedger.commitLocation,
                         machine.stackTrace(),
@@ -185,7 +185,7 @@ class ScenarioService(implicit
                       new Conversions(
                         context.homePackageId,
                         ledger,
-                        onLedger.ptx,
+                        onLedger.incompleteTransaction(),
                         clientMachine.traceLog,
                         onLedger.commitLocation,
                         ledgerMachine.stackTrace(),
@@ -197,7 +197,7 @@ class ScenarioService(implicit
                       new Conversions(
                         context.homePackageId,
                         ledger,
-                        onLedger.ptx,
+                        onLedger.incompleteTransaction(),
                         clientMachine.traceLog,
                         onLedger.commitLocation,
                         ledgerMachine.stackTrace(),

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -407,12 +407,12 @@ final class Conversions(
       .addAllNodes(tx.nodes.map(convertNode).asJava)
       .addAllRoots(tx.roots.toList.map(convertTxNodeId).asJava)
 
-    incomplete.exerciseContextMaybe.foreach { ctx =>
+    incomplete.exerciseContextMaybe.foreach { exe =>
       val ecBuilder = proto.ExerciseContext.newBuilder
-        .setTargetId(mkContractRef(ctx.targetCoid, ctx.templateId))
-        .setChoiceId(ctx.choiceId)
-        .setChosenValue(convertValue(ctx.chosenValue))
-      ctx.optLocation.map(loc => ecBuilder.setExerciseLocation(convertLocation(loc)))
+        .setTargetId(mkContractRef(exe.targetCoid, exe.templateId))
+        .setChoiceId(exe.choiceId)
+        .setChosenValue(convertValue(exe.chosenValue))
+      exe.optLocation.map(loc => ecBuilder.setExerciseLocation(convertLocation(loc)))
       builder.setExerciseContext(ecBuilder.build)
     }
     builder.build

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -301,8 +301,8 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
         case SResultError(err) =>
           return ResultError(
             Error(
-              s"Interpretation error: ${Pretty.prettyError(err, onLedger.ptx).render(80)}",
-              s"Last location: ${Pretty.prettyLoc(machine.lastLocation).render(80)}, partial transaction: ${onLedger.ptx.nodesToString}",
+              s"Interpretation error: ${Pretty.prettyError(err, onLedger.ptxInternal).render(80)}",
+              s"Last location: ${Pretty.prettyLoc(machine.lastLocation).render(80)}, partial transaction: ${onLedger.ptxInternal.nodesToString}",
             )
           )
 
@@ -363,14 +363,14 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
       }
     }
 
-    onLedger.ptx.finish match {
+    onLedger.ptxInternal.finish match {
       case PartialTransaction.CompleteTransaction(tx) =>
         val meta = Tx.Metadata(
           submissionSeed = None,
-          submissionTime = onLedger.ptx.submissionTime,
+          submissionTime = onLedger.ptxInternal.submissionTime,
           usedPackages = Set.empty,
           dependsOnTime = onLedger.dependsOnTime,
-          nodeSeeds = onLedger.ptx.actionNodeSeeds.toImmArray,
+          nodeSeeds = onLedger.ptxInternal.actionNodeSeeds.toImmArray,
         )
         config.profileDir.foreach { dir =>
           val desc = Engine.profileDesc(tx)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -16,7 +16,12 @@ import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SBuiltin.checkAborted
-import com.daml.lf.transaction.{ContractKeyUniquenessMode, Node, TransactionVersion}
+import com.daml.lf.transaction.{
+  ContractKeyUniquenessMode,
+  Node,
+  IncompleteTransaction,
+  TransactionVersion,
+}
 import com.daml.lf.value.{Value => V}
 import org.slf4j.LoggerFactory
 
@@ -109,7 +114,7 @@ private[lf] object Speedy {
       val validating: Boolean,
       val contractKeyUniqueness: ContractKeyUniquenessMode,
       /* The current partial transaction */
-      var ptx: PartialTransaction,
+      private[speedy] var ptx: PartialTransaction,
       /* Committers of the action. */
       var committers: Set[Party],
       /* Commit location, if a scenario commit is in progress. */
@@ -119,7 +124,12 @@ private[lf] object Speedy {
       // global contract discriminators, that are discriminators from contract created in previous transactions
       var globalDiscriminators: Set[crypto.Hash],
       var cachedContracts: Map[V.ContractId, CachedContract],
-  ) extends LedgerMode
+  ) extends LedgerMode {
+
+    private[lf] def ptxInternal: PartialTransaction = ptx //deprecated
+    private[lf] def incompleteTransaction(): IncompleteTransaction = ptx.finishIncomplete
+
+  }
 
   private[lf] final case object OffLedger extends LedgerMode
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -40,7 +40,7 @@ private[lf] object PartialTransaction {
   private type TX = GenTransaction[NodeId, Value.ContractId]
   private type ExerciseNode = Node.NodeExercises[NodeId, Value.ContractId]
 
-  private final case class ConcreteIncompleteTx(
+  private final case class IncompleteTxImpl(
       val transaction: TX,
       val exerciseContextMaybe: Option[ExerciseNode],
   ) extends TxIncompleteTransaction
@@ -356,7 +356,7 @@ private[lf] case class PartialTransaction(
       case _: PartialTransaction.RootContextInfo => None
     }
 
-    ConcreteIncompleteTx(
+    IncompleteTxImpl(
       GenTransaction(
         nodes,
         ImmArray(context.children.toImmArray.toSeq.sortBy(_.index)),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -17,11 +17,13 @@ import com.daml.lf.transaction.{
   SubmittedTransaction,
   Transaction => Tx,
   TransactionVersion => TxVersion,
+  IncompleteTransaction => TxIncompleteTransaction,
 }
 import com.daml.lf.value.Value
 
 import scala.collection.immutable.HashMap
 import scala.Ordering.Implicits.infixOrderingOps
+import scala.annotation.tailrec
 
 private[lf] object PartialTransaction {
 
@@ -34,6 +36,14 @@ private[lf] object PartialTransaction {
   type NodeIdx = Value.NodeIdx
   type Node = Node.GenNode[NodeId, Value.ContractId]
   type LeafNode = Node.LeafOnlyActionNode[Value.ContractId]
+
+  private type TX = GenTransaction[NodeId, Value.ContractId]
+  private type ExerciseNode = Node.NodeExercises[NodeId, Value.ContractId]
+
+  private final case class ConcreteIncompleteTx(
+      val transaction: TX,
+      val exerciseContextMaybe: Option[ExerciseNode],
+  ) extends TxIncompleteTransaction
 
   sealed abstract class ContextInfo {
     val actionChildSeed: Int => crypto.Hash
@@ -333,6 +343,28 @@ private[lf] case class PartialTransaction(
         IncompleteTransaction(this)
     }
 
+  // construct an IncompleteTransaction from the partial-transaction
+  def finishIncomplete: TxIncompleteTransaction = {
+
+    @tailrec
+    def unwindToExercise(
+        contextInfo: PartialTransaction.ContextInfo
+    ): Option[PartialTransaction.ExercisesContextInfo] = contextInfo match {
+      case ctx: PartialTransaction.ExercisesContextInfo => Some(ctx)
+      case ctx: PartialTransaction.TryContextInfo =>
+        unwindToExercise(ctx.parent.info)
+      case _: PartialTransaction.RootContextInfo => None
+    }
+
+    ConcreteIncompleteTx(
+      GenTransaction(
+        nodes,
+        ImmArray(context.children.toImmArray.toSeq.sortBy(_.index)),
+      ),
+      unwindToExercise(context.info).map(makeExNode(_)),
+    )
+  }
+
   /** Extend the 'PartialTransaction' with a node for creating a
     * contract instance.
     */
@@ -572,27 +604,12 @@ private[lf] case class PartialTransaction(
   def endExercises(value: Value[Value.ContractId]): PartialTransaction =
     context.info match {
       case ec: ExercisesContextInfo =>
-        val version = packageToTransactionVersion(ec.templateId.packageId)
-        val exerciseNode = Node.NodeExercises(
-          targetCoid = ec.targetId,
-          templateId = ec.templateId,
-          choiceId = ec.choiceId,
-          optLocation = ec.optLocation,
-          consuming = ec.consuming,
-          actingParties = ec.actingParties,
-          chosenValue = ec.chosenValue,
-          stakeholders = ec.stakeholders,
-          signatories = ec.signatories,
-          choiceObservers = ec.choiceObservers,
-          children = context.children.toImmArray,
-          exerciseResult = Some(value),
-          key = ec.contractKey,
-          byKey = ec.byKey,
-          version = version,
-        )
+        val exerciseNode =
+          makeExNode(ec).copy(children = context.children.toImmArray, exerciseResult = Some(value))
         val nodeId = ec.nodeId
         copy(
-          context = ec.parent.addActionChild(nodeId, version min context.minChildVersion),
+          context =
+            ec.parent.addActionChild(nodeId, exerciseNode.version min context.minChildVersion),
           nodes = nodes.updated(nodeId, exerciseNode),
           actionNodeSeeds = actionNodeSeeds :+ (nodeId -> ec.actionNodeSeed),
         )
@@ -605,33 +622,38 @@ private[lf] case class PartialTransaction(
   def abortExercises: PartialTransaction =
     context.info match {
       case ec: ExercisesContextInfo =>
-        val version = packageToTransactionVersion(ec.templateId.packageId)
-        val exerciseNode = Node.NodeExercises(
-          targetCoid = ec.targetId,
-          templateId = ec.templateId,
-          choiceId = ec.choiceId,
-          optLocation = ec.optLocation,
-          consuming = ec.consuming,
-          actingParties = ec.actingParties,
-          chosenValue = ec.chosenValue,
-          stakeholders = ec.stakeholders,
-          signatories = ec.signatories,
-          choiceObservers = ec.choiceObservers,
-          children = context.children.toImmArray,
-          exerciseResult = None,
-          key = ec.contractKey,
-          byKey = ec.byKey,
-          version = version,
-        )
+        val exerciseNode = makeExNode(ec).copy(children = context.children.toImmArray)
         val nodeId = ec.nodeId
         val actionNodeSeed = context.nextActionChildSeed
         copy(
-          context = ec.parent.addActionChild(nodeId, version min context.minChildVersion),
+          context =
+            ec.parent.addActionChild(nodeId, exerciseNode.version min context.minChildVersion),
           nodes = nodes.updated(nodeId, exerciseNode),
           actionNodeSeeds = actionNodeSeeds :+ (nodeId -> actionNodeSeed),
         )
       case _ => throw new RuntimeException("abortExercises called in non-exercise context")
     }
+
+  private[this] def makeExNode(ec: ExercisesContextInfo): ExerciseNode = {
+    val version = packageToTransactionVersion(ec.templateId.packageId)
+    Node.NodeExercises[NodeId, Value.ContractId](
+      targetCoid = ec.targetId,
+      templateId = ec.templateId,
+      choiceId = ec.choiceId,
+      optLocation = ec.optLocation,
+      consuming = ec.consuming,
+      actingParties = ec.actingParties,
+      chosenValue = ec.chosenValue,
+      stakeholders = ec.stakeholders,
+      signatories = ec.signatories,
+      choiceObservers = ec.choiceObservers,
+      children = ImmArray(Nil),
+      exerciseResult = None,
+      key = ec.contractKey,
+      byKey = ec.byKey,
+      version = version,
+    )
+  }
 
   /** Open a Try context.
     *  Must be closed by `endTry`, `abortTry`, or `rollbackTry`.

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/IncompleteTransaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/IncompleteTransaction.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package transaction
+
+import com.daml.lf.value.Value
+
+trait IncompleteTransaction {
+
+  type Nid = NodeId
+  type Cid = Value.ContractId
+  type TX = GenTransaction[Nid, Cid]
+  type ExerciseNode = Node.NodeExercises[Nid, Cid]
+
+  def transaction: TX
+  def exerciseContextMaybe: Option[ExerciseNode]
+}

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -174,7 +174,7 @@ class IdeLedgerClient(val compiledPackages: CompiledPackages) extends ScriptLedg
             val visible = SVisibleByKey.fromSubmitters(actAs.toSet, readAs)(stakeholders)
             cb(visible)
           case SResultFinalValue(SUnit) =>
-            onLedger.ptx.finish match {
+            onLedger.ptxInternal.finish match {
               case PartialTransaction.CompleteTransaction(tx) =>
                 ScenarioLedger.commitTransaction(
                   actAs = actAs.toSet,


### PR DESCRIPTION
Define `IncompleteTransaction`, as the external representation for an incomplete transaction.

- Use this in `scenario-service` instead of `PartialTransaction`, without changing the behaviour.
- Goal is for `PartialTransaction` to be an engine-internal detail.
- This opens up the chance to simplify the representation of transactions and there incremental construction (#9909)


changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
