### PR TITLE
Skip Scala_2_12 job on releases

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -104,6 +104,13 @@ jobs:
     - template: report-end.yml
 
 - job: Linux_scala_2_12
+  # We disable this for release builds. The actual release happens via the regular Linux builds
+  # and running tests on two scala versions doesn’t add any value if the tests already
+  # passed on the respective PRs that added the changes. The only difference here
+  # is the release version which should not affect things differently depending on the
+  # Scala version.
+  condition: and(succeeded(),
+                 eq(dependencies.check_for_release.outputs['out.is_release'], 'false'))
   dependsOn:
     - da_ghc_lib
     - check_for_release
@@ -111,9 +118,6 @@ jobs:
     release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
     release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
     trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
-    # For old release builds, this job is redundant since the default is already 2.12.
-    # However, since bugfix releases are not very frequent we opt for the simple solution
-    # of simply running this build either way.
     is_release: $[ eq(dependencies.check_for_release.outputs['out.is_release'], 'true') ]
   timeoutInMinutes: 360
   pool:


### PR DESCRIPTION
This currently breaks older releases because they require a different
Scala 2.12 version. It also adds zero value for a release that
defaults to Scala 2.12 and it adds basically no value for a release
that defaults to Scala 2.13 (see comment for details).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
