### PR TITLE
Backport Windows signing changes from #9786

### DIFF
--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -8,18 +8,25 @@ OUTPUT_DIR=$2
 
 mkdir -p $OUTPUT_DIR/github
 mkdir -p $OUTPUT_DIR/artifactory
-INSTALLER=daml-sdk-$RELEASE_TAG-windows.exe
-mv "bazel-bin/release/windows-installer/daml-sdk-installer.exe" "$OUTPUT_DIR/github/$INSTALLER"
-chmod +wx "$OUTPUT_DIR/github/$INSTALLER"
-cleanup () {
-    rm -f signing_key.pfx
-}
-trap cleanup EXIT
-echo "$SIGNING_KEY" | base64 -d > signing_key.pfx
-for path in "$OUTPUT_DIR/github/$INSTALLER"; do
-    MSYS_NO_PATHCONV=1 signtool.exe sign '/f' signing_key.pfx '/fd' sha256 '/tr' "http://timestamp.digicert.com" '/v' "$path"
-done
-rm signing_key.pfx
-trap - EXIT
+INSTALLER="$OUTPUT_DIR/github/daml-sdk-$RELEASE_TAG-windows.exe"
+mv "bazel-bin/release/windows-installer/daml-sdk-installer.exe" "$INSTALLER"
+chmod +wx "$INSTALLER"
+
+if ! [ -f /C/Users/u/.dotnet/tools/azuresigntool.exe ]; then
+    "/C/Program Files/dotnet/dotnet.exe" tool install --global AzureSignTool
+fi
+
+/C/Users/u/.dotnet/tools/azuresigntool.exe sign \
+  --azure-key-vault-url "$AZURE_KEY_VAULT_URL" \
+  --azure-key-vault-client-id "$AZURE_CLIENT_ID" \
+  --azure-key-vault-client-secret "$AZURE_CLIENT_SECRET" \
+  --azure-key-vault-certificate "$AZURE_KEY_VAULT_CERTIFICATE" \
+  --description "Daml SDK installer" \
+  --description-url "https://daml.com" \
+  --timestamp-rfc3161 "http://timestamp.digicert.com" \
+  --file-digest sha384 \
+  --verbose \
+  "$INSTALLER"
+
 TARBALL=daml-sdk-$RELEASE_TAG-windows.tar.gz
 cp bazel-bin/release/sdk-release-tarball.tar.gz "$OUTPUT_DIR/github/$TARBALL"


### PR DESCRIPTION
Our release failed to find the SIGNING_KEY variable which is very much
expected unfortunately.

The backport is not quite identical to #9786:
1. It only changes ci/copy-windows-release-artifacts.sh. The way our
   release process works we use CI config from main but source from the
   release branch so this is expected.
2. We don’t have EE support on this branch so I dropped that.

I did my best to not have any typoes but obviously this is hard to see
so please review carefully.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
