### PR TITLE
A `ledger-api-test-tool` test case for divulging a contract with key twice on multiple participants [DPP-433]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractKeysIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractKeysIT.scala
@@ -13,12 +13,7 @@ import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.client.binding.Primitive.ContractId
 import com.daml.ledger.test.model.DA.Types.Tuple2
-import com.daml.ledger.test.model.Test.Delegated._
-import com.daml.ledger.test.model.Test.Delegation._
-import com.daml.ledger.test.model.Test.ShowDelegated._
-import com.daml.ledger.test.model.Test.TextKey._
-import com.daml.ledger.test.model.Test.TextKeyOperations._
-import com.daml.ledger.test.model.Test._
+import com.daml.ledger.test.model.Test
 import io.grpc.Status
 import scalaz.Tag
 
@@ -28,6 +23,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     "Divulged contracts cannot be fetched or looked up by key by non-stakeholders",
     allocate(SingleParty, SingleParty),
   )(implicit ec => { case Participants(Participant(alpha, owner), Participant(beta, delegate)) =>
+    import Test.{Delegated, Delegation, ShowDelegated}
     val key = alpha.nextKeyId()
     for {
       // create contracts to work with
@@ -70,6 +66,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     "Contract Keys should reject fetching an undisclosed contract",
     allocate(SingleParty, SingleParty),
   )(implicit ec => { case Participants(Participant(alpha, owner), Participant(beta, delegate)) =>
+    import Test.{Delegated, Delegation}
     val key = alpha.nextKeyId()
     for {
       // create contracts to work with
@@ -116,6 +113,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     "Contract keys should be scoped by maintainer",
     allocate(SingleParty, SingleParty),
   )(implicit ec => { case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
+    import Test.{TextKey, TextKeyOperations, MaintainerNotSignatory}
     val key1 = alpha.nextKeyId()
     val key2 = alpha.nextKeyId()
     val unknownKey = alpha.nextKeyId()
@@ -200,6 +198,7 @@ final class ContractKeysIT extends LedgerTestSuite {
 
   test("CKRecreate", "Contract keys can be recreated in single transaction", allocate(SingleParty))(
     implicit ec => { case Participants(Participant(ledger, owner)) =>
+      import Test.Delegated
       val key = ledger.nextKeyId()
       for {
         delegated1TxTree <- ledger
@@ -231,6 +230,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     "Contract keys created by transient contracts are properly archived",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, owner)) =>
+    import Test.{Delegated, Delegation}
     val key = ledger.nextKeyId()
     val key2 = ledger.nextKeyId()
 
@@ -258,6 +258,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     "The contract key should be exposed if the template specifies one",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    import Test.TextKey
     val expectedKey = ledger.nextKeyId()
     for {
       _ <- ledger.create(party, TextKey(party, expectedKey, List.empty))
@@ -280,6 +281,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     "Exercising by key should be possible only when the corresponding contract is available",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    import Test.TextKey
     val keyString = ledger.nextKeyId()
     val expectedKey = Value(
       Value.Sum.Record(
@@ -338,6 +340,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty, SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger1, party1), Participant(ledger2, party2)) =>
+      import Test.LocalKeyVisibilityOperations
       for {
         ops <- ledger1.create(party1, LocalKeyVisibilityOperations(party1, party2))
         _ <- synchronize(ledger1, ledger2)
@@ -369,6 +372,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty, SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger1, party1), Participant(ledger2, party2)) =>
+      import Test.{WithKey, WithKeyCreator, WithKeyFetcher}
       for {
         // Create a helper contract and exercise a choice creating and disclosing a WithKey contract
         creator1 <- ledger1.create(party1, WithKeyCreator(party1, party2))
@@ -385,7 +389,7 @@ final class ContractKeysIT extends LedgerTestSuite {
         _ <- ledger2.exercise(party2, fetcher.exerciseWithKeyFetcher_Fetch(_, withKey1))
 
         // Archive the disclosed contract
-        _ <- ledger1.exercise(party1, withKey1.exerciseWithKey_Archive(_))
+        _ <- ledger1.exercise(party1, withKey1.exerciseArchive(_))
 
         _ <- synchronize(ledger1, ledger2)
 
@@ -412,6 +416,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty, SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger1, party1), Participant(ledger2, party2)) =>
+      import Test.{WithKey, WithKeyCreatorAlternative}
       for {
         // Create a helper contract and exercise a choice creating and disclosing a WithKey contract
         creator1 <- ledger1.create(party1, WithKeyCreatorAlternative(party1, party2))
@@ -428,7 +433,7 @@ final class ContractKeysIT extends LedgerTestSuite {
         Seq(withKey1Event) <- ledger1.activeContractsByTemplateId(List(WithKey.id.unwrap), party1)
         withKey1 = ContractId.apply[WithKey](withKey1Event.contractId)
         // Archive the disclosed contract
-        _ <- ledger1.exercise(party1, withKey1.exerciseWithKey_Archive(_))
+        _ <- ledger1.exercise(party1, withKey1.exerciseArchive(_))
 
         _ <- synchronize(ledger1, ledger2)
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/DivulgenceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/DivulgenceIT.scala
@@ -6,16 +6,7 @@ package com.daml.ledger.api.testtool.suites
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.{synchronize, waitForContract}
-import com.daml.ledger.test.model.Test.Divulgence2._
-import com.daml.ledger.test.model.Test.Proposal._
-import com.daml.ledger.test.model.Test.{
-  Asset,
-  Divulgence1,
-  Divulgence2,
-  Proposal,
-  WithKey,
-  WithKeyDivulgenceHelper,
-}
+import com.daml.ledger.test.model.Test
 import scalaz.Tag
 
 final class DivulgenceIT extends LedgerTestSuite {
@@ -24,6 +15,7 @@ final class DivulgenceIT extends LedgerTestSuite {
     "Divulged contracts should not be exposed by the transaction service",
     allocate(TwoParties),
   )(implicit ec => { case Participants(Participant(ledger, alice, bob)) =>
+    import Test.{Divulgence1, Divulgence2}
     for {
       divulgence1 <- ledger.create(alice, Divulgence1(alice))
       divulgence2 <- ledger.create(bob, Divulgence2(bob, alice))
@@ -164,6 +156,7 @@ final class DivulgenceIT extends LedgerTestSuite {
     "Divulged contracts should not be exposed by the active contract service",
     allocate(TwoParties),
   )(implicit ec => { case Participants(Participant(ledger, alice, bob)) =>
+    import Test.{Divulgence1, Divulgence2}
     for {
       divulgence1 <- ledger.create(alice, Divulgence1(alice))
       divulgence2 <- ledger.create(bob, Divulgence2(bob, alice))
@@ -221,6 +214,7 @@ final class DivulgenceIT extends LedgerTestSuite {
     "Divulgence should behave as expected in a workflow involving keys",
     allocate(SingleParty, SingleParty),
   )(implicit ec => { case Participants(Participant(alpha, proposer), Participant(beta, owner)) =>
+    import Test.{Asset, Proposal}
     for {
       offer <- alpha.create(proposer, Proposal(from = proposer, to = owner))
       asset <- beta.create(owner, Asset(issuer = owner, owner = owner))
@@ -236,6 +230,7 @@ final class DivulgenceIT extends LedgerTestSuite {
     "Divulging, archiving and divulging again a contract with key should be possible",
     allocate(SingleParty, SingleParty),
   )(implicit ec => { case Participants(Participant(alpha, partyA), Participant(beta, partyB)) =>
+    import Test.{WithKey, WithKeyDivulgenceHelper}
     for {
       // Create a helper contract where partyB is a signatory
       helper <- beta.create(
@@ -254,7 +249,7 @@ final class DivulgenceIT extends LedgerTestSuite {
       _ <- synchronize(alpha, beta)
 
       // Archive the withKey1 contract
-      _ <- alpha.exercise(partyA, withKey1.exerciseWithKey_Archive(_))
+      _ <- alpha.exercise(partyA, withKey1.exerciseArchive(_))
 
       _ <- synchronize(alpha, beta)
 

--- a/ledger/test-common/src/main/daml/model/Test.daml
+++ b/ledger/test-common/src/main/daml/model/Test.daml
@@ -731,3 +731,19 @@ template WithKeyFetcher
         contractId : ContractId WithKey
       controller p2
       do fetch contractId
+
+
+template WithKeyDivulgenceHelper
+  with
+    divulgedTo : Party
+    withKeyOwner : Party
+  where
+    signatory divulgedTo
+
+    controller withKeyOwner can
+      nonconsuming WithKeyDivulgenceHelper_Fetch: ()
+        with
+          withKeyToFetch: ContractId WithKey
+        do
+          _ <- fetch withKeyToFetch
+          return ()

--- a/ledger/test-common/src/main/daml/model/Test.daml
+++ b/ledger/test-common/src/main/daml/model/Test.daml
@@ -690,10 +690,6 @@ template WithKey
     signatory p
     key p : Party
     maintainer key
-    controller p can
-      WithKey_Archive : ()
-        do
-          return ()
 
 template WithKeyCreator
   with


### PR DESCRIPTION
### Scenario
```
1. allocate partyA on participantA
2. allocate partyB on participantB
3. create a (helper : WithKeyDivulgenceHelper) contract with partyB being a signatory
4. create a (withKey1 : WithKey) contract with partyA being an owner
5. archive the withKey1 by exercising a choice on the helper - divulgence to partyB
6. create another contract (withKey2 : WithKey) with partyA being an owner
7. archive the withKey2 by exercising a choice on the helper - divulgence to partyB
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
