### PR TITLE
Add proper error handling for missing contract keys

### DIFF
--- a/compiler/damlc/tests/daml-test-files/FetchByKey.daml
+++ b/compiler/damlc/tests/daml-test-files/FetchByKey.daml
@@ -1,0 +1,41 @@
+-- @ERROR range=30:1-30:11; Attempt to fetch or exercise by key
+-- @ERROR range=34:1-34:11; Attempt to fetch or exercise by key
+module FetchByKey where
+
+template WithKey
+  with
+    p : Party
+  where
+    signatory p
+    key p : Party
+    maintainer key
+
+template Helper
+  with
+    p : Party
+  where
+    signatory p
+    choice Fail1 : ()
+      controller p
+      -- fail when fetching from the ledger
+      do fetchByKey @WithKey p
+         pure ()
+    choice Fail2 : ()
+      controller p
+      -- fail internally in speedy
+      do None <- lookupByKey @WithKey p
+         fetchByKey @WithKey p
+         pure ()
+
+failLedger = do
+  p <- getParty "p"
+  submit p $ createAndExercise (Helper p) Fail1
+
+failSpeedy = do
+  p <- getParty "p"
+  submit p $ createAndExercise (Helper p) Fail2
+
+mustFail = do
+  p <- getParty "p"
+  submitMustFail p $ createAndExercise (Helper p) Fail1
+  submitMustFail p $ createAndExercise (Helper p) Fail2

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -328,6 +328,18 @@ prettyScenarioErrorError (Just err) =  do
         , label_ "Stakeholders:"
             $ prettyParties scenarioError_ContractKeyNotVisibleStakeholders
         ]
+    ScenarioErrorErrorScenarioContractKeyNotFound ScenarioError_ContractKeyNotFound{..} ->
+      pure $ vcat
+        [ "Attempt to fetch or exercise by key but no contract with that key was found."
+        , label_ "Template:"
+            $ prettyMay "<missing template id>"
+                (prettyDefName world)
+                scenarioError_ContractKeyNotFoundTemplateId
+        , label_ "Key: "
+          $ prettyMay "<missing key>"
+              (prettyValue' False 0 world)
+              scenarioError_ContractKeyNotFoundKey
+        ]
 
 partyDifference :: V.Vector Party -> V.Vector Party -> Doc SyntaxClass
 partyDifference with without =

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -196,6 +196,11 @@ message ScenarioError {
     repeated Party stakeholders = 5;
   }
 
+  message ContractKeyNotFound {
+    Identifier template_id = 1;
+    Value key = 2;
+  }
+
   message ContractNotEffective {
     ContractRef contract_ref = 1;
     sfixed64 effective_at = 2;
@@ -257,6 +262,7 @@ message ScenarioError {
     Empty scenario_mustfail_succeeded = 22;
     string scenario_invalid_party_name = 23;
     ContractKeyNotVisible scenario_contract_key_not_visible = 24;
+    ContractKeyNotFound scenario_contract_key_not_found = 27;
     string scenario_party_already_exists = 25;
   }
 }

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -183,6 +183,14 @@ final class Conversions(
             .build
         )
 
+      case SError.DamlEContractKeyNotFound(gk) =>
+        builder.setScenarioContractKeyNotFound(
+          proto.ScenarioError.ContractKeyNotFound.newBuilder
+            .setTemplateId(convertIdentifier(gk.templateId))
+            .setKey(convertValue(gk.key))
+            .build
+        )
+
       case SError.ScenarioErrorCommitError(commitError) =>
         builder.setScenarioCommitError(
           convertCommitError(commitError)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -301,6 +301,9 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
           // produce a different gRPC error code.
           return ResultError(Error.Interpretation(Error.Interpretation.DuplicateContractKey(key)))
 
+        case SResultError(SError.DamlEContractKeyNotFound(key)) =>
+          return ResultError(Error.Interpretation.ContractKeyNotFound(key))
+
         case SResultError(err) =>
           return ResultError(
             Error.Interpretation.Generic(
@@ -340,11 +343,7 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
               if (cb(SKeyLookupResult(result)))
                 interpretLoop(machine, time)
               else
-                ResultError(
-                  Error.Interpretation.Generic(
-                    s"dependency error: couldn't find key ${gk.globalKey}"
-                  )
-                ),
+                ResultError(Error.Interpretation.ContractKeyNotFound(gk.globalKey)),
           )
 
         case SResultNeedLocalKeyVisible(stakeholders, _, cb) =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -88,7 +88,7 @@ object Error {
     }
 
     final case class ContractKeyNotFound(key: GlobalKey) extends Error {
-      override def msg = s"Contract with key $key could not be found"
+      override def msg = s"dependency error: couldn't find key: $key"
     }
 
     /** See com.daml.lf.transaction.Transaction.DuplicateContractKey

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -5,7 +5,7 @@ package com.daml.lf
 package engine
 
 import com.daml.lf.data.Ref
-import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers}
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 
 sealed abstract class Error {
@@ -87,8 +87,8 @@ object Error {
       override def msg = s"Contract could not be found with id $ci"
     }
 
-    final case class GlobalKeyNotFound(globalKey: GlobalKeyWithMaintainers) extends Error {
-      override def msg = s"dependency error: couldn't find key ${globalKey.globalKey}"
+    final case class ContractKeyNotFound(key: GlobalKey) extends Error {
+      override def msg = s"Contract with key $key could not be found"
     }
 
     /** See com.daml.lf.transaction.Transaction.DuplicateContractKey

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -741,16 +741,18 @@ class EngineTest
         .submit(submitters, Commands(ImmArray(command), let, "test"), participant, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
       inside(submitResult) { case Left(err) =>
-        err shouldBe Error.Interpretation.ContractKeyNotFound(
-          GlobalKey.assertBuild(
-            BasicTests_WithKey,
-            ValueRecord(
-              Some(BasicTests_WithKey),
-              ImmArray(
-                (Some[Ref.Name]("p"), ValueParty(alice)),
-                (Some[Ref.Name]("k"), ValueInt64(43)),
+        err shouldBe Error.Interpretation(
+          Error.Interpretation.ContractKeyNotFound(
+            GlobalKey.assertBuild(
+              BasicTests_WithKey,
+              ValueRecord(
+                Some(BasicTests_WithKey),
+                ImmArray(
+                  (Some[Ref.Name]("p"), ValueParty(alice)),
+                  (Some[Ref.Name]("k"), ValueInt64(43)),
+                ),
               ),
-            ),
+            )
           )
         )
       }
@@ -953,16 +955,18 @@ class EngineTest
         .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       inside(result) { case Left(err) =>
-        err shouldBe Error.Interpretation.ContractKeyNotFound(
-          GlobalKey.assertBuild(
-            BasicTests_WithKey,
-            ValueRecord(
-              Some(BasicTests_WithKey),
-              ImmArray(
-                (Some[Ref.Name]("p"), ValueParty(alice)),
-                (Some[Ref.Name]("k"), ValueInt64(43)),
+        err shouldBe Error.Interpretation(
+          Error.Interpretation.ContractKeyNotFound(
+            GlobalKey.assertBuild(
+              BasicTests_WithKey,
+              ValueRecord(
+                Some(BasicTests_WithKey),
+                ImmArray(
+                  (Some[Ref.Name]("p"), ValueParty(alice)),
+                  (Some[Ref.Name]("k"), ValueInt64(43)),
+                ),
               ),
-            ),
+            )
           )
         )
       }
@@ -996,16 +1000,18 @@ class EngineTest
         .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
       inside(result) { case Left(err) =>
-        err shouldBe Error.Interpretation.ContractKeyNotFound(
-          GlobalKey.assertBuild(
-            BasicTests_WithKey,
-            ValueRecord(
-              Some(BasicTests_WithKey),
-              ImmArray(
-                (Some[Ref.Name]("p"), ValueParty(alice)),
-                (Some[Ref.Name]("k"), ValueInt64(43)),
+        err shouldBe Error.Interpretation(
+          Error.Interpretation.ContractKeyNotFound(
+            GlobalKey.assertBuild(
+              BasicTests_WithKey,
+              ValueRecord(
+                Some(BasicTests_WithKey),
+                ImmArray(
+                  (Some[Ref.Name]("p"), ValueParty(alice)),
+                  (Some[Ref.Name]("k"), ValueInt64(43)),
+                ),
               ),
-            ),
+            )
           )
         )
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -88,6 +88,12 @@ private[lf] object Pretty {
               (line + prettyPartialTransactionNode(node)).nested(4)
           })
 
+      case DamlEContractKeyNotFound(gk) =>
+        text(
+          "Update failed due to fetch-by-key or exercise-by-key which did not find a contract with key"
+        ) &
+          prettyValue(false)(gk.key) & char('(') + prettyIdentifier(gk.templateId) + char(')')
+
       case DamlELocalContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
         text(
           "Update failed due to a fetch, lookup or exercise by key of contract not visible to the reading parties"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1167,8 +1167,7 @@ private[lf] object SBuiltin {
       override def handleInputKeyFound(machine: Machine, cid: V.ContractId): Unit =
         machine.ctrl = importCid(cid)
       override def handleInactiveKey(machine: Machine, gkey: GlobalKey): Unit =
-        // TODO (MK) Produce a proper error here.
-        crash(s"Could not find key $gkey")
+        machine.ctrl = SEDamlException(DamlEContractKeyNotFound(gkey))
       override def handleActiveKey(machine: Machine, cid: V.ContractId): Unit =
         machine.returnValue = SContractId(cid)
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -78,6 +78,12 @@ object SError {
       stakeholders: Set[Party],
   ) extends SErrorDamlException
 
+  /** Fetch-by-key failed
+    */
+  final case class DamlEContractKeyNotFound(
+      key: GlobalKey
+  ) extends SErrorDamlException
+
   /** Two contracts with the same key were active at the same time.
     * See com.daml.lf.transaction.Transaction.DuplicateContractKey
     * for more details.

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -247,7 +247,7 @@ final case class ScenarioRunner(
 
     ledger.ledgerData.activeKeys.get(gk) match {
       case None =>
-        missingWith(SErrorCrash(s"Key $gk not found"))
+        missingWith(DamlEContractKeyNotFound(gk))
       case Some(acoid) =>
         ledger.lookupGlobalContract(
           view = ScenarioLedger.ParticipantView(actAs, readAs),

--- a/daml-lf/tests/BasicTests.daml
+++ b/daml-lf/tests/BasicTests.daml
@@ -366,6 +366,19 @@ template LookerUpByKey
         do
           lookupByKey @WithKey (p, n)
 
+template FailedFetchByKey
+  with
+    p : Party
+  where
+    signatory p
+    choice FetchAfterLookup : (ContractId WithKey, WithKey)
+      with
+        n : Int
+      controller p
+      do let key = (p, n)
+         None <- lookupByKey @WithKey key
+         fetchByKey @WithKey key
+
 
 test_failedAuths = scenario do
   alice <- getParty "alice"


### PR DESCRIPTION
These are clearly not internal errors so we should not be calling
`crash` here. Canton in fact already started string matching on the
crash message which is definitely not what we want.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
