### PR TITLE
update Daml Hub auth in create-daml-app

### DIFF
--- a/templates/create-daml-app/ui/.gitignore
+++ b/templates/create-daml-app/ui/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/templates/create-daml-app/ui/src/components/LoginScreen.tsx.template
+++ b/templates/create-daml-app/ui/src/components/LoginScreen.tsx.template
@@ -45,16 +45,14 @@ const LoginScreen: React.FC<Props> = ({onLogin}) => {
 
   useEffect(() => {
     const url = new URL(window.location.toString());
-    const token = url.searchParams.get('token');
-    if (token === null) {
-      return;
-    }
     const party = url.searchParams.get('party');
     if (party === null) {
-      throw Error("When 'token' is passed via URL, 'party' must be passed too.");
+      return;
     }
     url.search = '';
     window.history.replaceState(window.history.state, '', url.toString());
+    const tokenCookiePair = document.cookie.split('; ').find(row => row.startsWith('DAMLHUB_LEDGER_ACCESS_TOKEN')) || '';
+    const token = tokenCookiePair.slice(tokenCookiePair.indexOf('=') + 1);
     login({token, party, ledgerId});
   }, [login]);
 

--- a/templates/create-daml-app/ui/src/components/LoginScreen.tsx.template
+++ b/templates/create-daml-app/ui/src/components/LoginScreen.tsx.template
@@ -43,6 +43,10 @@ const LoginScreen: React.FC<Props> = ({onLogin}) => {
     window.location.assign(`https://login.projectdabl.com/auth/login?ledgerId=${ledgerId}`);
   }
 
+  const getCookieValue = (name: string): string => (
+    document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)')?.pop() || ''
+  )
+
   useEffect(() => {
     const url = new URL(window.location.toString());
     const party = url.searchParams.get('party');
@@ -51,8 +55,7 @@ const LoginScreen: React.FC<Props> = ({onLogin}) => {
     }
     url.search = '';
     window.history.replaceState(window.history.state, '', url.toString());
-    const tokenCookiePair = document.cookie.split('; ').find(row => row.startsWith('DAMLHUB_LEDGER_ACCESS_TOKEN')) || '';
-    const token = tokenCookiePair.slice(tokenCookiePair.indexOf('=') + 1);
+    const token = getCookieValue('DAMLHUB_LEDGER_ACCESS_TOKEN');
     login({token, party, ledgerId});
   }, [login]);
 


### PR DESCRIPTION
Current documentation says the token is passed as a cookie. This is a little bit more secure than passing it as a URL param, as it used to be. Note that while it is no longer documented behaviour, the token is actually still passed as a param (in addition to the cookie), so existing users are not broken (yet). Still, better if the code we generate for them matches our current docs.

CHANGELOG_BEGIN
CHANGELOG_END