### PR TITLE
Drop pkgIds argument from Engine.validatePackages

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -420,8 +420,7 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
     * preloaded.
     */
   def validatePackages(
-      pkgIds: Set[PackageId],
-      pkgs: Map[PackageId, Package],
+      pkgs: Map[PackageId, Package]
   ): Either[Error.Package.Error, Unit] = {
     for {
       _ <- pkgs
@@ -434,14 +433,7 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
         }
         .toLeft(())
       _ <- {
-        val unknownPackages = pkgIds.filterNot(pkgs.isDefinedAt)
-        Either.cond(
-          unknownPackages.isEmpty,
-          (),
-          Error.Package.Generic(s"Unknown packages ${unknownPackages.mkString(", ")}"),
-        )
-      }
-      _ <- {
+        val pkgIds = pkgs.keySet
         val missingDeps = pkgs.valuesIterator.flatMap(_.directDeps).toSet.filterNot(pkgIds)
         Either.cond(
           missingDeps.isEmpty,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -89,7 +89,7 @@ private[apiserver] final class ApiPackageManagementService private (
       dar <- darReader.readArchive("package-upload", stream)
       packages <- Try(dar.all.iterator.map(Decode.decodeArchive).toMap)
       _ <- engine
-        .validatePackages(packages.keySet, packages)
+        .validatePackages(packages)
         .left
         .map(e => new IllegalArgumentException(e.msg))
         .toTry

--- a/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPackageManagementServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPackageManagementServiceSpec.scala
@@ -74,7 +74,7 @@ class ApiPackageManagementServiceSpec
 
     val mockEngine = mock[Engine]
     when(
-      mockEngine.validatePackages(any[Set[PackageId]], any[Map[PackageId, Ast.Package]])
+      mockEngine.validatePackages(any[Map[PackageId, Ast.Package]])
     ).thenReturn(Right(()))
 
     val mockIndexTransactionsService = mock[IndexTransactionsService]

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -188,18 +188,10 @@ final private[kvutils] class PackageCommitter(
   ): Either[String, Map[Ref.PackageId, Ast.Package]] =
     metrics.daml.kvutils.committer.packageUpload.decodeTimer.time { () =>
       type Result = Either[List[String], Map[Ref.PackageId, Ast.Package]]
-      val knownPackages = engine.compiledPackages().packageIds.toSet[String]
-
       archives
         .foldLeft[Result](Right(Map.empty)) { (acc, arch) =>
           try {
-            if (knownPackages(arch.getHash)) {
-              // If the package is already known by the engine, we don't decode it but still verify its hash.
-              lf.archive.Reader.HashChecker.decodeArchive(arch)
-              acc
-            } else {
-              acc.map(_ + lf.archive.Decode.decodeArchive(arch))
-            }
+            acc.map(_ + lf.archive.Decode.decodeArchive(arch))
           } catch {
             case NonFatal(e) =>
               Left(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -222,16 +222,10 @@ final private[kvutils] class PackageCommitter(
       Right(pkgsCache)
 
   private def validatePackages(
-      uploadEntry: DamlPackageUploadEntry.Builder,
-      pkgs: Map[Ref.PackageId, Ast.Package],
+      pkgs: Map[Ref.PackageId, Ast.Package]
   ): Either[String, Unit] =
     metrics.daml.kvutils.committer.packageUpload.validateTimer.time { () =>
-      val allPkgIds = uploadEntry.getArchivesList
-        .iterator()
-        .asScala
-        .map(pkg => Ref.PackageId.assertFromString(pkg.getHash))
-        .toSet
-      engine.validatePackages(allPkgIds, pkgs).left.map(_.msg)
+      engine.validatePackages(pkgs).left.map(_.msg)
     }
 
   // Strict validation
@@ -243,7 +237,7 @@ final private[kvutils] class PackageCommitter(
       val Result(uploadEntry, packagesCache) = partialResult
       val result = for {
         packages <- decodePackagesIfNeeded(packagesCache, uploadEntry.getArchivesList.asScala)
-        _ <- validatePackages(uploadEntry, packages)
+        _ <- validatePackages(packages)
       } yield StepContinue(Result(uploadEntry, packages))
 
       result match {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
@@ -217,6 +217,12 @@ class PackageCommitterSpec extends AnyWordSpec with Matchers with ParallelTestEx
       )
     }
 
+    "accept submissions when dependencies are known by the engine" in {
+      val committer = newCommitter
+      committer.engine.preloadPackage(libraryPackageId, libraryPackage)
+      shouldSucceed(committer.submit(buildSubmission(dependentArchive, libraryArchive)))
+    }
+
     "reject not authorized submissions" in {
       val committer = newCommitter
 


### PR DESCRIPTION
Doesn’t do anything useful, we just use it to validate that it matches
the keys of pkgs.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
