### PR TITLE
Don't duplicate log failed futures in the http json api (commandservice specific ones)

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -314,17 +314,15 @@ class Endpoints(
 
     } yield domain.OkResponse(())
 
-  private def handleFutureEitherFailure[A: Show, B](fa: Future[A \/ B])(implicit
+  private def handleFutureEitherFailure[B](fa: Future[Error \/ B])(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
-  ): Future[ServerError \/ B] =
+  ): Future[Error \/ B] =
     fa.recover { case NonFatal(e) =>
       logger.error("Future failed", e)
       -\/(ServerError(e.description))
     }
 
-  private def handleFutureEitherFailure[A: Show, B](
-      fa: Future[A \/ B]
-  )(implicit
+  private def handleFutureEitherFailure[A: Show, B](fa: Future[A \/ B])(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): Future[ServerError \/ B] =
     fa.map(_.liftErr(ServerError)).recover { case NonFatal(e) =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -130,7 +130,6 @@ class Endpoints(
         decoder.decodeCreateCommand(reqBody).liftErr(InvalidUserInput)
       ): ET[domain.CreateCommand[ApiRecord, TemplateId.RequiredPkg]]
 
-      // If the future fails the error is already logged in the CommandService
       ac <- eitherT(
         handleFutureEitherFailure(commandService.create(jwt, jwtPayload, cmd))
       ): ET[domain.ActiveContract[ApiValue]]
@@ -159,7 +158,6 @@ class Endpoints(
 
       resolvedCmd = cmd.copy(argument = apiArg, reference = resolvedRef)
 
-      // If the future fails the error is already logged in the CommandService
       resp <- eitherT(
         handleFutureEitherFailure(
           commandService.exercise(jwt, jwtPayload, resolvedCmd)
@@ -182,7 +180,6 @@ class Endpoints(
         decoder.decodeCreateAndExerciseCommand(reqBody).liftErr(InvalidUserInput)
       ): ET[domain.CreateAndExerciseCommand[ApiRecord, ApiValue, TemplateId.RequiredPkg]]
 
-      // If the future fails the error is already logged in the CommandService
       resp <- eitherT(
         handleFutureEitherFailure(
           commandService.createAndExercise(jwt, jwtPayload, cmd)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -314,9 +314,9 @@ class Endpoints(
 
     } yield domain.OkResponse(())
 
-  private def handleFutureEitherFailure[B](fa: Future[Error \/ B])(implicit
+  private def handleFutureEitherFailure[A: Show, B](fa: Future[A \/ B])(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
-  ): Future[Error \/ B] =
+  ): Future[ServerError \/ B] =
     fa.recover { case NonFatal(e) =>
       logger.error("Future failed", e)
       -\/(ServerError(e.description))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -130,7 +130,7 @@ class Endpoints(
         decoder.decodeCreateCommand(reqBody).liftErr(InvalidUserInput)
       ): ET[domain.CreateCommand[ApiRecord, TemplateId.RequiredPkg]]
 
-      // If this fails the error is already logged in the CommandService
+      // If the future fails the error is already logged in the CommandService
       ac <- eitherT(
         handleFutureEitherFailure(commandService.create(jwt, jwtPayload, cmd))
       ): ET[domain.ActiveContract[ApiValue]]
@@ -159,7 +159,7 @@ class Endpoints(
 
       resolvedCmd = cmd.copy(argument = apiArg, reference = resolvedRef)
 
-      // If this fails the error is already logged in the CommandService
+      // If the future fails the error is already logged in the CommandService
       resp <- eitherT(
         handleFutureEitherFailure(
           commandService.exercise(jwt, jwtPayload, resolvedCmd)
@@ -182,7 +182,7 @@ class Endpoints(
         decoder.decodeCreateAndExerciseCommand(reqBody).liftErr(InvalidUserInput)
       ): ET[domain.CreateAndExerciseCommand[ApiRecord, ApiValue, TemplateId.RequiredPkg]]
 
-      // If this fails the error is already logged in the CommandService
+      // If the future fails the error is already logged in the CommandService
       resp <- eitherT(
         handleFutureEitherFailure(
           commandService.createAndExercise(jwt, jwtPayload, cmd)


### PR DESCRIPTION
fixes #9985

This removes duplicate logging for me. Tested this manually with main and with my branch and the duplicate did not appear anymore with my branch (just send a command req with a wrong party).

changelog_begin

- [JSON API] Errors which arise from the CommandService are not logged twice anymore (thus reducing noise)

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
