### PR TITLE
[JSON-API] Add information from the jwtpayload to the logging context

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -199,7 +199,7 @@ class CommandService(
           jwtPayload.ledgerId,
           jwtPayload.applicationId,
           commandId,
-          jwtPayload.actAs,
+          jwtPayload.submitter,
           jwtPayload.readAs,
           command,
         )

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -123,7 +123,7 @@ class Endpoints(
     }
   }
 
-  def withJwtPayloadLoggingContext[T[_], A](jwtPayload: JwtPayloadG[T])(
+  def withJwtPayloadLoggingContext[A](jwtPayload: JwtPayloadG)(
       fn: LoggingContextOf[JwtPayloadTag with InstanceUUID with RequestID] => A
   )(implicit lc: LoggingContextOf[InstanceUUID with RequestID]): A =
     withEnrichedLoggingContext(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -29,12 +29,13 @@ import com.daml.http.util.Logging.{InstanceUUID, RequestID, extendWithRequestIdL
 import com.daml.http.util.ProtobufByteStrings
 import com.daml.jwt.domain.Jwt
 import com.daml.ledger.api.{v1 => lav1}
+import com.daml.logging.LoggingContextOf.withEnrichedLoggingContext
 import com.daml.util.ExceptionOps._
 import scalaz.std.scalaFuture._
 import scalaz.syntax.std.option._
 import scalaz.syntax.show._
 import scalaz.syntax.traverse._
-import scalaz.{-\/, EitherT, NonEmptyList, Show, \/, \/-}
+import scalaz.{-\/, EitherT, NonEmptyList, Show, Traverse, \/, \/-}
 import spray.json._
 
 import scala.concurrent.duration.FiniteDuration
@@ -122,77 +123,106 @@ class Endpoints(
     }
   }
 
+  def withJwtPayloadLoggingContext[A, B](jwtPayload: JwtPayload)(
+      fn: LoggingContextOf[JwtPayload with InstanceUUID with RequestID] => A
+  )(implicit lc: LoggingContextOf[InstanceUUID with RequestID]): A =
+    withEnrichedLoggingContext(
+      LoggingContextOf.label[JwtPayload],
+      Map(
+        "ledger_id" -> jwtPayload.ledgerId.toString,
+        "act_as" -> jwtPayload.actAs.toString,
+        "application_id" -> jwtPayload.applicationId.toString,
+        "read_as" -> jwtPayload.readAs.toString,
+      ),
+    ).run(lc => fn(lc))
+
+  // I think this is not the best name.
+  // Naming things is hard :/
+  def handleCommand[T[_]](req: HttpRequest)(
+      fn: (
+          Jwt,
+          JwtWritePayload,
+          JsValue,
+      ) => LoggingContextOf[JwtWritePayload with InstanceUUID with RequestID] => ET[T[ApiValue]]
+  )(implicit
+      lc: LoggingContextOf[InstanceUUID with RequestID],
+      ev1: JsonWriter[T[JsValue]],
+      ev2: Traverse[T],
+  ): ET[domain.SyncResponse[JsValue]] = for {
+    t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
+    (jwt, jwtPayload, reqBody) = t3
+    resp <-
+      withEnrichedLoggingContext(
+        LoggingContextOf.label[JwtWritePayload],
+        Map(
+          "ledger_id" -> jwtPayload.ledgerId.toString,
+          "act_as" -> jwtPayload.actAs.toString,
+          "application_id" -> jwtPayload.applicationId.toString,
+          "read_as" -> jwtPayload.readAs.toString,
+        ),
+      )
+        .run(fn(jwt, jwtPayload, reqBody))
+
+    jsVal <- either(SprayJson.encode1(resp).liftErr(ServerError)): ET[JsValue]
+  } yield domain.OkResponse(jsVal)
+
   def create(req: HttpRequest)(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): ET[domain.SyncResponse[JsValue]] =
-    for {
-      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
+    handleCommand(req) { (jwt, jwtPayload, reqBody) => implicit lc =>
+      for {
+        cmd <- either(
+          decoder.decodeCreateCommand(reqBody).liftErr(InvalidUserInput)
+        ): ET[domain.CreateCommand[ApiRecord, TemplateId.RequiredPkg]]
 
-      (jwt, jwtPayload, reqBody) = t3
-
-      cmd <- either(
-        decoder.decodeCreateCommand(reqBody).liftErr(InvalidUserInput)
-      ): ET[domain.CreateCommand[ApiRecord, TemplateId.RequiredPkg]]
-
-      ac <- eitherT(
-        handleFutureEitherFailure(commandService.create(jwt, jwtPayload, cmd))
-      ): ET[domain.ActiveContract[ApiValue]]
-
-      jsVal <- either(SprayJson.encode1(ac).liftErr(ServerError)): ET[JsValue]
-
-    } yield domain.OkResponse(jsVal)
+        ac <- eitherT(
+          handleFutureEitherFailure(commandService.create(jwt, jwtPayload, cmd))
+        ): ET[domain.ActiveContract[ApiValue]]
+      } yield ac
+    }
 
   def exercise(req: HttpRequest)(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): ET[domain.SyncResponse[JsValue]] =
-    for {
-      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
+    handleCommand(req) { (jwt, jwtPayload, reqBody) => implicit lc =>
+      for {
+        cmd <- either(
+          decoder.decodeExerciseCommand(reqBody).liftErr(InvalidUserInput)
+        ): ET[domain.ExerciseCommand[LfValue, domain.ContractLocator[LfValue]]]
 
-      (jwt, jwtPayload, reqBody) = t3
+        resolvedRef <- eitherT(
+          resolveReference(jwt, jwtPayload, cmd.reference)
+        ): ET[domain.ResolvedContractRef[ApiValue]]
 
-      cmd <- either(
-        decoder.decodeExerciseCommand(reqBody).liftErr(InvalidUserInput)
-      ): ET[domain.ExerciseCommand[LfValue, domain.ContractLocator[LfValue]]]
+        apiArg <- either(lfValueToApiValue(cmd.argument)): ET[ApiValue]
 
-      resolvedRef <- eitherT(
-        resolveReference(jwt, jwtPayload, cmd.reference)
-      ): ET[domain.ResolvedContractRef[ApiValue]]
+        resolvedCmd = cmd.copy(argument = apiArg, reference = resolvedRef)
 
-      apiArg <- either(lfValueToApiValue(cmd.argument)): ET[ApiValue]
+        resp <- eitherT(
+          handleFutureEitherFailure(
+            commandService.exercise(jwt, jwtPayload, resolvedCmd)
+          )
+        ): ET[domain.ExerciseResponse[ApiValue]]
 
-      resolvedCmd = cmd.copy(argument = apiArg, reference = resolvedRef)
-
-      resp <- eitherT(
-        handleFutureEitherFailure(
-          commandService.exercise(jwt, jwtPayload, resolvedCmd)
-        )
-      ): ET[domain.ExerciseResponse[ApiValue]]
-
-      jsVal <- either(SprayJson.encode1(resp).liftErr(ServerError)): ET[JsValue]
-
-    } yield domain.OkResponse(jsVal)
+      } yield resp
+    }
 
   def createAndExercise(req: HttpRequest)(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): ET[domain.SyncResponse[JsValue]] =
-    for {
-      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
+    handleCommand(req) { (jwt, jwtPayload, reqBody) => implicit lc =>
+      for {
+        cmd <- either(
+          decoder.decodeCreateAndExerciseCommand(reqBody).liftErr(InvalidUserInput)
+        ): ET[domain.CreateAndExerciseCommand[ApiRecord, ApiValue, TemplateId.RequiredPkg]]
 
-      (jwt, jwtPayload, reqBody) = t3
-
-      cmd <- either(
-        decoder.decodeCreateAndExerciseCommand(reqBody).liftErr(InvalidUserInput)
-      ): ET[domain.CreateAndExerciseCommand[ApiRecord, ApiValue, TemplateId.RequiredPkg]]
-
-      resp <- eitherT(
-        handleFutureEitherFailure(
-          commandService.createAndExercise(jwt, jwtPayload, cmd)
-        )
-      ): ET[domain.ExerciseResponse[ApiValue]]
-
-      jsVal <- either(SprayJson.encode1(resp).liftErr(ServerError)): ET[JsValue]
-
-    } yield domain.OkResponse(jsVal)
+        resp <- eitherT(
+          handleFutureEitherFailure(
+            commandService.createAndExercise(jwt, jwtPayload, cmd)
+          )
+        ): ET[domain.ExerciseResponse[ApiValue]]
+      } yield resp
+    }
 
   def fetch(req: HttpRequest)(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
@@ -202,21 +232,25 @@ class Endpoints(
 
       (jwt, jwtPayload, reqBody) = input
 
-      _ = logger.debug(s"/v1/fetch reqBody: $reqBody")
+      jsVal <- withJwtPayloadLoggingContext(jwtPayload) { implicit lc =>
+        logger.debug(s"/v1/fetch reqBody: $reqBody")
+        for {
 
-      cl <- either(
-        decoder.decodeContractLocator(reqBody).liftErr(InvalidUserInput)
-      ): ET[domain.ContractLocator[LfValue]]
+          cl <- either(
+            decoder.decodeContractLocator(reqBody).liftErr(InvalidUserInput)
+          ): ET[domain.ContractLocator[LfValue]]
 
-      _ = logger.debug(s"/v1/fetch cl: $cl")
+          _ = logger.debug(s"/v1/fetch cl: $cl")
 
-      ac <- eitherT(
-        handleFutureFailure(contractsService.lookup(jwt, jwtPayload, cl))
-      ): ET[Option[domain.ActiveContract[JsValue]]]
+          ac <- eitherT(
+            handleFutureFailure(contractsService.lookup(jwt, jwtPayload, cl))
+          ): ET[Option[domain.ActiveContract[JsValue]]]
 
-      jsVal <- either(
-        ac.cata(x => toJsValue(x), \/-(JsNull))
-      ): ET[JsValue]
+          jsVal <- either(
+            ac.cata(x => toJsValue(x), \/-(JsNull))
+          ): ET[JsValue]
+        } yield jsVal
+      }
 
     } yield domain.OkResponse(jsVal)
 
@@ -225,13 +259,15 @@ class Endpoints(
   ): Future[Error \/ SearchResult[Error \/ JsValue]] =
     inputAndJwtPayload[JwtPayload](req).map {
       _.map { case (jwt, jwtPayload, _) =>
-        val result: SearchResult[ContractsService.Error \/ domain.ActiveContract[LfValue]] =
-          contractsService.retrieveAll(jwt, jwtPayload)
+        withJwtPayloadLoggingContext(jwtPayload) { implicit lc =>
+          val result: SearchResult[ContractsService.Error \/ domain.ActiveContract[LfValue]] =
+            contractsService.retrieveAll(jwt, jwtPayload)
 
-        domain.SyncResponse.covariant.map(result) { source =>
-          source
-            .via(handleSourceFailure)
-            .map(_.flatMap(lfAcToJsValue)): Source[Error \/ JsValue, NotUsed]
+          domain.SyncResponse.covariant.map(result) { source =>
+            source
+              .via(handleSourceFailure)
+              .map(_.flatMap(lfAcToJsValue)): Source[Error \/ JsValue, NotUsed]
+          }
         }
       }
     }
@@ -241,19 +277,21 @@ class Endpoints(
   ): Future[Error \/ SearchResult[Error \/ JsValue]] =
     inputAndJwtPayload[JwtPayload](req).map {
       _.flatMap { case (jwt, jwtPayload, reqBody) =>
-        SprayJson
-          .decode[domain.GetActiveContractsRequest](reqBody)
-          .liftErr[Error](InvalidUserInput)
-          .map { cmd =>
-            val result: SearchResult[ContractsService.Error \/ domain.ActiveContract[JsValue]] =
-              contractsService.search(jwt, jwtPayload, cmd)
+        withJwtPayloadLoggingContext(jwtPayload) { implicit lc =>
+          SprayJson
+            .decode[domain.GetActiveContractsRequest](reqBody)
+            .liftErr[Error](InvalidUserInput)
+            .map { cmd =>
+              val result: SearchResult[ContractsService.Error \/ domain.ActiveContract[JsValue]] =
+                contractsService.search(jwt, jwtPayload, cmd)
 
-            domain.SyncResponse.covariant.map(result) { source =>
-              source
-                .via(handleSourceFailure)
-                .map(_.flatMap(toJsValue[domain.ActiveContract[JsValue]](_)))
+              domain.SyncResponse.covariant.map(result) { source =>
+                source
+                  .via(handleSourceFailure)
+                  .map(_.flatMap(toJsValue[domain.ActiveContract[JsValue]](_)))
+              }
             }
-          }
+        }
       }
     }
 
@@ -485,7 +523,7 @@ class Endpoints(
       jwtPayload: JwtWritePayload,
       reference: domain.ContractLocator[LfValue],
   )(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID]
+      lc: LoggingContextOf[JwtWritePayload with InstanceUUID with RequestID]
   ): Future[Error \/ domain.ResolvedContractRef[ApiValue]] =
     contractsService
       .resolveContractReference(jwt, jwtPayload.parties, reference)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -123,9 +123,9 @@ class Endpoints(
     }
   }
 
-  def withJwtPayloadLoggingContext[A, B](jwtPayload: JwtPayload)(
-      fn: LoggingContextOf[JwtPayload with B] => A
-  )(implicit lc: LoggingContextOf[B]): A =
+  def withJwtPayloadLoggingContext[A](jwtPayload: JwtPayload)(
+      fn: LoggingContextOf[JwtPayload with InstanceUUID with RequestID] => A
+  )(implicit lc: LoggingContextOf[InstanceUUID with RequestID]): A =
     withEnrichedLoggingContext(
       LoggingContextOf.label[JwtPayload],
       Map(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -134,7 +134,7 @@ class Endpoints(
         "application_id" -> jwtPayload.applicationId.toString,
         "read_as" -> jwtPayload.readAs.toString,
       ),
-    ).run(lc => fn(lc))
+    ).run(fn)
 
   // I think this is not the best name.
   // Naming things is hard :/

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -136,8 +136,6 @@ class Endpoints(
       ),
     ).run(fn)
 
-  // I think this is not the best name.
-  // Naming things is hard :/
   def handleCommand[T[_]](req: HttpRequest)(
       fn: (
           Jwt,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -124,8 +124,8 @@ class Endpoints(
   }
 
   def withJwtPayloadLoggingContext[A, B](jwtPayload: JwtPayload)(
-      fn: LoggingContextOf[JwtPayload with InstanceUUID with RequestID] => A
-  )(implicit lc: LoggingContextOf[InstanceUUID with RequestID]): A =
+      fn: LoggingContextOf[JwtPayload with B] => A
+  )(implicit lc: LoggingContextOf[B]): A =
     withEnrichedLoggingContext(
       LoggingContextOf.label[JwtPayload],
       Map(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -55,11 +55,11 @@ object domain {
 
   trait JwtPayloadTag
 
-  trait JwtPayloadG[T[_]] {
+  trait JwtPayloadG {
     val ledgerId: LedgerId
     val applicationId: ApplicationId
     val readAs: List[Party]
-    val actAs: T[Party]
+    val actAs: List[Party]
     val parties: OneAnd[Set, Party]
   }
 
@@ -68,9 +68,10 @@ object domain {
   final case class JwtWritePayload(
       ledgerId: LedgerId,
       applicationId: ApplicationId,
-      actAs: NonEmptyList[Party],
+      submitter: NonEmptyList[Party],
       readAs: List[Party],
-  ) extends JwtPayloadG[NonEmptyList] {
+  ) extends JwtPayloadG {
+    override val actAs: List[Party] = submitter.toList
     override val parties: OneAnd[Set, Party] =
       oneAndSet(actAs.head, actAs.tail.toSet union readAs.toSet)
   }
@@ -83,7 +84,7 @@ object domain {
       readAs: List[Party],
       actAs: List[Party],
       parties: OneAnd[Set, Party],
-  ) extends JwtPayloadG[List] {}
+  ) extends JwtPayloadG {}
 
   object JwtPayload {
     def apply(

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/DomainSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/DomainSpec.scala
@@ -16,7 +16,7 @@ final class DomainSpec extends AnyFreeSpec with Matchers {
   "JwtWritePayload" - {
     "parties deduplicates between actAs and readAs" in {
       val payload =
-        JwtWritePayload(ledgerId, appId, actAs = NonEmptyList(alice), readAs = List(alice, bob))
+        JwtWritePayload(ledgerId, appId, submitter = NonEmptyList(alice), readAs = List(alice, bob))
       payload.parties shouldBe OneAnd(alice, Set(bob))
     }
   }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/DomainSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/DomainSpec.scala
@@ -14,7 +14,7 @@ final class DomainSpec extends AnyFreeSpec with Matchers {
   private val alice = Party("Alice")
   private val bob = Party("Bob")
   "JwtWritePayload" - {
-    "parties deduplicates between actAs and readAs" in {
+    "parties deduplicates between actAs/submitter and readAs" in {
       val payload =
         JwtWritePayload(ledgerId, appId, submitter = NonEmptyList(alice), readAs = List(alice, bob))
       payload.parties shouldBe OneAnd(alice, Set(bob))


### PR DESCRIPTION
This fixes #9982.

Only problematic thing with my changes is that IntelliJ now complains a bit more although it compiles fine:
![image](https://user-images.githubusercontent.com/25414896/121925753-86036280-cd3d-11eb-9e42-f82105d36964.png)

However, I think this is the right direction but I'm not sure if that is already enough, what do you think @cocreature?

changelog_begin

- [JSON API] For applicable requests actAs, readAs, applicationId & ledgerId are included in the log context

changelog_end


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
