### PR TITLE
truncate party name for 64 chars for multi-valued submitters to avoid…

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -38,16 +38,16 @@ final class Metrics(val registry: MetricRegistry) {
       val validSubmissions: Meter =
         registry.meter(Prefix :+ "valid_submissions")
 
-      def inputBufferLength(party: String): Counter =
-        registry.counter(Prefix :+ party.substring(0, 64) :+ "input_buffer_length")
-      def inputBufferCapacity(party: String): Counter =
-        registry.counter(Prefix :+ party.substring(0, 64) :+ "input_buffer_capacity")
-      def inputBufferDelay(party: String): Timer =
-        registry.timer(Prefix :+ party.substring(0, 64) :+ "input_buffer_delay")
-      def maxInFlightLength(party: String): Counter =
-        registry.counter(Prefix :+ party.substring(0, 64) :+ "max_in_flight_length")
-      def maxInFlightCapacity(party: String): Counter =
-        registry.counter(Prefix :+ party.substring(0, 64) :+ "max_in_flight_capacity")
+      def inputBufferLength(firstParty: String): Counter =
+        registry.counter(Prefix :+ firstParty :+ "input_buffer_length")
+      def inputBufferCapacity(firstParty: String): Counter =
+        registry.counter(Prefix :+ firstParty :+ "input_buffer_capacity")
+      def inputBufferDelay(firstParty: String): Timer =
+        registry.timer(Prefix :+ firstParty :+ "input_buffer_delay")
+      def maxInFlightLength(firstParty: String): Counter =
+        registry.counter(Prefix :+ firstParty :+ "max_in_flight_length")
+      def maxInFlightCapacity(firstParty: String): Counter =
+        registry.counter(Prefix :+ firstParty :+ "max_in_flight_capacity")
     }
 
     object execution {

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -39,15 +39,15 @@ final class Metrics(val registry: MetricRegistry) {
         registry.meter(Prefix :+ "valid_submissions")
 
       def inputBufferLength(party: String): Counter =
-        registry.counter(Prefix :+ party :+ "input_buffer_length")
+        registry.counter(Prefix :+ party.substring(0, 64) :+ "input_buffer_length")
       def inputBufferCapacity(party: String): Counter =
-        registry.counter(Prefix :+ party :+ "input_buffer_capacity")
+        registry.counter(Prefix :+ party.substring(0, 64) :+ "input_buffer_capacity")
       def inputBufferDelay(party: String): Timer =
-        registry.timer(Prefix :+ party :+ "input_buffer_delay")
+        registry.timer(Prefix :+ party.substring(0, 64) :+ "input_buffer_delay")
       def maxInFlightLength(party: String): Counter =
-        registry.counter(Prefix :+ party :+ "max_in_flight_length")
+        registry.counter(Prefix :+ party.substring(0, 64) :+ "max_in_flight_length")
       def maxInFlightCapacity(party: String): Counter =
-        registry.counter(Prefix :+ party :+ "max_in_flight_capacity")
+        registry.counter(Prefix :+ party.substring(0, 64) :+ "max_in_flight_capacity")
     }
 
     object execution {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -104,7 +104,8 @@ private[apiserver] final class ApiCommandService private (
     // is specified in the command completion request.
     val parties = CommandsValidator.effectiveSubmitters(request.getCommands).actAs
     val submitter = TrackerMap.Key(application = appId, parties = parties)
-    val metricsPrefix = parties.toList.sorted.mkString("_")
+    // Use just name of first party for open-ended metrics to avoid unbounded metrics name for multiple parties
+    val metricsPrefixFirstParty = parties.toList.sorted.head
     submissionTracker.track(submitter, request) {
       for {
         ledgerEnd <- services.getCompletionEnd().map(_.getOffset)
@@ -129,17 +130,17 @@ private[apiserver] final class ApiCommandService private (
           if (configuration.limitMaxCommandsInFlight)
             MaxInFlight(
               configuration.maxCommandsInFlight,
-              capacityCounter = metrics.daml.commands.maxInFlightCapacity(metricsPrefix),
-              lengthCounter = metrics.daml.commands.maxInFlightLength(metricsPrefix),
+              capacityCounter = metrics.daml.commands.maxInFlightCapacity(metricsPrefixFirstParty),
+              lengthCounter = metrics.daml.commands.maxInFlightLength(metricsPrefixFirstParty),
             ).joinMat(tracker)(Keep.right)
           else
             tracker
         TrackerImpl(
           trackingFlow,
           configuration.inputBufferSize,
-          capacityCounter = metrics.daml.commands.inputBufferCapacity(metricsPrefix),
-          lengthCounter = metrics.daml.commands.inputBufferLength(metricsPrefix),
-          delayTimer = metrics.daml.commands.inputBufferDelay(metricsPrefix),
+          capacityCounter = metrics.daml.commands.inputBufferCapacity(metricsPrefixFirstParty),
+          lengthCounter = metrics.daml.commands.inputBufferLength(metricsPrefixFirstParty),
+          delayTimer = metrics.daml.commands.inputBufferDelay(metricsPrefixFirstParty),
         )
       }
     }


### PR DESCRIPTION
Avoid excessively long metrics names by using just the first party in dynamic metrics that may contained many valued submitters

When selecting CSV metrics reporter these blow out due to file name being too long

```17:47:10.995 [metrics-csv-reporter-1-thread-1] WARN  com.codahale.metrics.CsvReporter - Error writing to daml.commands.deduplicationRandomParty_10_jNLwlihol993wLaFX29RIymtuFBxQ2v8RRAIKUFMcZFlAgClXukeqBXI0eihsQIO798OAqrv3DLui7zJJe6eqHPXJNj94jzlns9i_deduplicationRandomParty_11_frfwzaJ21OvR4Aj7S6UH8kqC2hOE1IdKti7Q4Due3reiBc6fy9VEl4fUX9PjvPkiXwO1L3zMuTFfsWfMl3fT10CLMBMjyTBuv9.max_in_flight_capacity
java.io.IOException: File name too long
	at java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.io.File.createNewFile(File.java:1012)
	at com.codahale.metrics.CsvReporter.report(CsvReporter.java:319)
	at com.codahale.metrics.CsvReporter.reportCounter(CsvReporter.java:308)
	at com.codahale.metrics.CsvReporter.report(CsvReporter.java:232)
	at com.codahale.metrics.ScheduledReporter.report(ScheduledReporter.java:242)
```