### PR TITLE
[JSON-API] Log templateId & choice name (if present) on command submissions in the json API

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -47,7 +47,7 @@ class CommandService(
   )(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): Future[Error \/ ActiveContract[lav1.value.Value]] = {
-    logger.trace("sending create command to ledger")
+    logger.trace(s"sending create command to ledger, templateId: ${input.templateId}")
     val command = createCommand(input)
     val request = submitAndWaitRequest(jwtPayload, input.meta, command, "create")
     val et: ET[ActiveContract[lav1.value.Value]] = for {
@@ -64,7 +64,8 @@ class CommandService(
   )(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): Future[Error \/ ExerciseResponse[lav1.value.Value]] = {
-    logger.trace("sending exercise command to ledger")
+    logger.trace(s"sending exercise command to ledger, templateId: ${input.reference
+      .fold(_._1, _._1)}, choice: ${input.choice}")
     val command = exerciseCommand(input)
     val request = submitAndWaitRequest(jwtPayload, input.meta, command, "exercise")
 
@@ -85,7 +86,9 @@ class CommandService(
   )(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): Future[Error \/ ExerciseResponse[lav1.value.Value]] = {
-    logger.trace("sending create and exercise command to ledger")
+    logger.trace(
+      s"sending create and exercise command to ledger, templateId: ${input.templateId}, choice: ${input.choice}"
+    )
     val command = createAndExerciseCommand(input)
     val request = submitAndWaitRequest(jwtPayload, input.meta, command, "createAndExercise")
     val et: ET[ExerciseResponse[lav1.value.Value]] = for {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -3,9 +3,11 @@
 
 package com.daml.http
 
+import com.daml.http.domain.TemplateId.RequiredPkg
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.http.domain.{
   ActiveContract,
+  Choice,
   Contract,
   CreateAndExerciseCommand,
   CreateCommand,
@@ -40,22 +42,42 @@ class CommandService(
 
   import CommandService._
 
+  def withTemplateLoggingContext[T](
+      templateId: TemplateId.RequiredPkg
+  )(implicit lc: LoggingContextOf[T]): withEnrichedLoggingContext[TemplateId.RequiredPkg, T] =
+    withEnrichedLoggingContext(
+      label[TemplateId.RequiredPkg],
+      ("template_id", templateId.toString),
+    )
+
+  def withTemplateChoiceLoggingContext[T](
+      templateId: TemplateId.RequiredPkg,
+      choice: domain.Choice,
+  )(implicit lc: LoggingContextOf[T]): withEnrichedLoggingContext[Choice, RequiredPkg with T] =
+    withTemplateLoggingContext(templateId).run(
+      withEnrichedLoggingContext(
+        label[domain.Choice],
+        ("choice", choice.toString),
+      )(_)
+    )
+
   def create(
       jwt: Jwt,
       jwtPayload: JwtWritePayload,
       input: CreateCommand[lav1.value.Record, TemplateId.RequiredPkg],
   )(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
-  ): Future[Error \/ ActiveContract[lav1.value.Value]] = {
-    logger.trace(s"sending create command to ledger, templateId: ${input.templateId}")
-    val command = createCommand(input)
-    val request = submitAndWaitRequest(jwtPayload, input.meta, command, "create")
-    val et: ET[ActiveContract[lav1.value.Value]] = for {
-      response <- logResult(Symbol("create"), submitAndWaitForTransaction(jwt, request))
-      contract <- either(exactlyOneActiveContract(response))
-    } yield contract
-    et.run
-  }
+  ): Future[Error \/ ActiveContract[lav1.value.Value]] =
+    withTemplateLoggingContext(input.templateId).run { implicit lc =>
+      logger.trace(s"sending create command to ledger")
+      val command = createCommand(input)
+      val request = submitAndWaitRequest(jwtPayload, input.meta, command, "create")
+      val et: ET[ActiveContract[lav1.value.Value]] = for {
+        response <- logResult(Symbol("create"), submitAndWaitForTransaction(jwt, request))
+        contract <- either(exactlyOneActiveContract(response))
+      } yield contract
+      et.run
+    }
 
   def exercise(
       jwt: Jwt,
@@ -63,21 +85,22 @@ class CommandService(
       input: ExerciseCommand[lav1.value.Value, ExerciseCommandRef],
   )(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
-  ): Future[Error \/ ExerciseResponse[lav1.value.Value]] = {
-    logger.trace(s"sending exercise command to ledger, templateId: ${input.reference
-      .fold(_._1, _._1)}, choice: ${input.choice}")
-    val command = exerciseCommand(input)
-    val request = submitAndWaitRequest(jwtPayload, input.meta, command, "exercise")
+  ): Future[Error \/ ExerciseResponse[lav1.value.Value]] =
+    withTemplateChoiceLoggingContext(input.reference.fold(_._1, _._1), input.choice).run {
+      implicit lc =>
+        logger.trace(s"sending exercise command to ledger")
+        val command = exerciseCommand(input)
+        val request = submitAndWaitRequest(jwtPayload, input.meta, command, "exercise")
 
-    val et: ET[ExerciseResponse[lav1.value.Value]] = for {
-      response <-
-        logResult(Symbol("exercise"), submitAndWaitForTransactionTree(jwt, request))
-      exerciseResult <- either(exerciseResult(response))
-      contracts <- either(contracts(response))
-    } yield ExerciseResponse(exerciseResult, contracts)
+        val et: ET[ExerciseResponse[lav1.value.Value]] = for {
+          response <-
+            logResult(Symbol("exercise"), submitAndWaitForTransactionTree(jwt, request))
+          exerciseResult <- either(exerciseResult(response))
+          contracts <- either(contracts(response))
+        } yield ExerciseResponse(exerciseResult, contracts)
 
-    et.run
-  }
+        et.run
+    }
 
   def createAndExercise(
       jwt: Jwt,
@@ -85,23 +108,22 @@ class CommandService(
       input: CreateAndExerciseCommand[lav1.value.Record, lav1.value.Value, TemplateId.RequiredPkg],
   )(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
-  ): Future[Error \/ ExerciseResponse[lav1.value.Value]] = {
-    logger.trace(
-      s"sending create and exercise command to ledger, templateId: ${input.templateId}, choice: ${input.choice}"
-    )
-    val command = createAndExerciseCommand(input)
-    val request = submitAndWaitRequest(jwtPayload, input.meta, command, "createAndExercise")
-    val et: ET[ExerciseResponse[lav1.value.Value]] = for {
-      response <- logResult(
-        Symbol("createAndExercise"),
-        submitAndWaitForTransactionTree(jwt, request),
-      )
-      exerciseResult <- either(exerciseResult(response))
-      contracts <- either(contracts(response))
-    } yield ExerciseResponse(exerciseResult, contracts)
+  ): Future[Error \/ ExerciseResponse[lav1.value.Value]] =
+    withTemplateChoiceLoggingContext(input.templateId, input.choice).run { implicit lc =>
+      logger.trace(s"sending create and exercise command to ledger")
+      val command = createAndExerciseCommand(input)
+      val request = submitAndWaitRequest(jwtPayload, input.meta, command, "createAndExercise")
+      val et: ET[ExerciseResponse[lav1.value.Value]] = for {
+        response <- logResult(
+          Symbol("createAndExercise"),
+          submitAndWaitForTransactionTree(jwt, request),
+        )
+        exerciseResult <- either(exerciseResult(response))
+        contracts <- either(contracts(response))
+      } yield ExerciseResponse(exerciseResult, contracts)
 
-    et.run
-  }
+      et.run
+    }
 
   private def logResult[A](op: Symbol, fa: Future[A])(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -110,7 +110,7 @@ class CommandService(
       lc: LoggingContextOf[InstanceUUID with RequestID]
   ): Future[Error \/ ExerciseResponse[lav1.value.Value]] =
     withTemplateChoiceLoggingContext(input.templateId, input.choice).run { implicit lc =>
-      logger.trace(s"sending create and exercise command to ledger")
+      logger.trace("sending create and exercise command to ledger")
       val command = createAndExerciseCommand(input)
       val request = submitAndWaitRequest(jwtPayload, input.meta, command, "createAndExercise")
       val et: ET[ExerciseResponse[lav1.value.Value]] = for {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -88,7 +88,7 @@ class CommandService(
   ): Future[Error \/ ExerciseResponse[lav1.value.Value]] =
     withTemplateChoiceLoggingContext(input.reference.fold(_._1, _._1), input.choice).run {
       implicit lc =>
-        logger.trace(s"sending exercise command to ledger")
+        logger.trace("sending exercise command to ledger")
         val command = exerciseCommand(input)
         val request = submitAndWaitRequest(jwtPayload, input.meta, command, "exercise")
 

--- a/libs-scala/contextualized-logging/BUILD.bazel
+++ b/libs-scala/contextualized-logging/BUILD.bazel
@@ -5,22 +5,22 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
     "da_scala_test_suite",
+    "silencer_plugin",
 )
 
 da_scala_library(
     name = "contextualized-logging",
     srcs = glob(["src/main/scala/**/*.scala"]),
+    plugins = [
+        silencer_plugin,
+    ],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = ["-Xsource:2.13"],
     tags = ["maven_coordinates=com.daml:contextualized-logging:__VERSION__"],
-    versioned_scala_deps = {
-        "2.12": [
-            "@maven//:org_scala_lang_modules_scala_collection_compat",
-        ],
-    },
     visibility = [
         "//visibility:public",
     ],

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContextOf.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContextOf.scala
@@ -48,6 +48,10 @@ object LoggingContextOf {
   ): withEnrichedLoggingContext[P, A] =
     new withEnrichedLoggingContext(kvs, loggingContext.extend[P])
 
+  def withEnrichedLoggingContext[P, A](label: label[P], kvs: (String, String)*)(implicit
+      loggingContext: LoggingContextOf[A]
+  ): withEnrichedLoggingContext[P, A] = withEnrichedLoggingContext(label, Map.from(kvs))
+
   final class withEnrichedLoggingContext[P, A] private[LoggingContextOf] (
       kvs: Map[String, String],
       loggingContext: LoggingContextOf[P with A],

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContextOf.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContextOf.scala
@@ -5,6 +5,7 @@ package com.daml.logging
 
 import scala.annotation.nowarn
 import scala.language.implicitConversions
+import scala.collection.compat._
 
 /** [[LoggingContext]] with a phantom type parameter representing what kind of
   * details are in it.  If a function that accepts a LoggingContext is supposed


### PR DESCRIPTION
fixes #9983

changelog_begin

- [JSON API] The template id & choice name (if present) are now logged on command submissions in the Json API (at trace level)

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
