### PR TITLE
[JSON-API] Log source and path of incoming http requests & the response with info level

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -5,7 +5,9 @@ package com.daml.http
 
 import akka.actor.{ActorSystem, Cancellable}
 import akka.http.scaladsl.Http
+import akka.stream.scaladsl.Sink
 import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.Materializer
 import com.daml.auth.TokenHolder
@@ -193,16 +195,31 @@ object HttpService {
         websocketService,
       )
 
+      ignoreConParam = (res: Future[HttpResponse]) => (_: Http.IncomingConnection) => res
+
       defaultEndpoints =
-        jsonEndpoints.all orElse websocketEndpoints.transactionWebSocket orElse EndpointsCompanion.notFound
+        jsonEndpoints.all orElse
+          (websocketEndpoints.transactionWebSocket andThen ignoreConParam) orElse
+          (EndpointsCompanion.notFound andThen ignoreConParam)
 
       allEndpoints = staticContentConfig.cata(
-        c => StaticContentEndpoints.all(c) orElse defaultEndpoints,
+        c =>
+          (StaticContentEndpoints.all(c) andThen ignoreConParam) orElse
+            defaultEndpoints,
         defaultEndpoints,
       )
 
       binding <- liftET[Error](
-        Http().newServerAt(address, httpPort).withSettings(settings).bind(allEndpoints)
+        Http()
+          .newServerAt(address, httpPort)
+          .withSettings(settings)
+          .connectionSource()
+          .to {
+            Sink.foreach { connection =>
+              connection.handleWithAsyncHandler(allEndpoints(_)(connection))
+            }
+          }
+          .run()
       )
 
       _ <- either(portFile.cata(f => createPortFile(f, binding), \/-(()))): ET[Unit]


### PR DESCRIPTION
This should fix #9981. However logging the request origin (ip address) is something which goes beyond the issue.

Example output can be:
```
15-06-2021 11:57:22.053 [http-json-ledger-api-akka.actor.default-dispatcher-5] INFO  com.daml.http.Endpoints - Incoming request on http://localhost:5634/v1/create from /127.0.0.1:53992 , context: {instance_uuid=be3cea67-a148-4475-a200-3baaeacba240, request_id=997e32e9-1fc9-4460-b97c-80774af604a4} 
[...]
15-06-2021 11:57:22.312 [http-json-ledger-api-akka.actor.default-dispatcher-8] INFO  com.daml.http.Endpoints - Responding to client with HTTP 500 Internal Server Error , context: {instance_uuid=be3cea67-a148-4475-a200-3baaeacba240, request_id=997e32e9-1fc9-4460-b97c-80774af604a4}
```

I can imagine that it is somehow possible to simplify the code, however I did not find a better way yet.
Also, the extraction of the origin ip looks weird but so far is the only possiblity I found. However I'm definitely not completely satisfied with it.

changelog_begin

- [JSON-API] The source and the path for incoming http requests are now logged
- [JSON-API] The http response for a request is now logged

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [x] test my changes manually, because testing automatically doesn't work/is not feasible

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
