### PR TITLE
test different template-ID frequencies in the "mega" perf scenario

### DIFF
--- a/ledger-service/http-json-perf/daml/LargeAcs.daml
+++ b/ledger-service/http-json-perf/daml/LargeAcs.daml
@@ -4,6 +4,8 @@
 {-# LANGUAGE RecordWildCards #-}
 module LargeAcs where
 
+import DA.Functor (void)
+
 template Genesis with
     issuer : Party
     owner : Party
@@ -18,21 +20,26 @@ template Genesis with
           totalSteps : Int
           amountCycle : [Decimal]
           observersCycle : [[Party]]
+          whichTemplateCycle : [WhichTemplate]
         controller owner
         do
           assert (totalSteps >= 0)
           amounts <- infCycle amountCycle
           observerses <- infCycle observersCycle
-          makeIouRange totalSteps amounts observerses this
+          whichTemplates <- infCycle whichTemplateCycle
+          makeIouRange totalSteps amounts observerses whichTemplates this
 
-makeIouRange : Int -> InfCycle Decimal -> InfCycle [Party] -> Genesis -> Update ()
-makeIouRange count amountCycle observersCycle g =
+makeIouRange : Int -> InfCycle Decimal -> InfCycle [Party] -> InfCycle WhichTemplate -> Genesis -> Update ()
+makeIouRange count amountCycle observersCycle whichTemplateCycle g =
   if count <= 0 then pure () else do
     let Genesis {..} = g
         (amount, amounts) = popCycle amountCycle
         (observers, observerses) = popCycle observersCycle
-    create Iou with ..
-    makeIouRange (count - 1) amounts observerses g
+        (whichTemplate, whichTemplates) = popCycle whichTemplateCycle
+    case whichTemplate of
+      UseIou -> void $ create Iou with ..
+      UseNotIou -> void $ create NotIou with ..
+    makeIouRange (count - 1) amounts observerses whichTemplates g
 
 data InfCycle a = InfCycle { list : [a], orig : [a] }
   deriving (Eq, Ord, Show)
@@ -42,7 +49,7 @@ infCycle xs = do
   assert $ case xs of
       [] -> False
       _::_ -> True
-  pure (InfCycle xs xs)
+  pure (InfCycle [] xs)
 
 popCycle : InfCycle a -> (a, InfCycle a)
 popCycle (InfCycle (x :: xs) orig) = (x, InfCycle xs orig)
@@ -58,8 +65,21 @@ template Iou
     amount : Decimal
     observers : [Party]
   where
-    ensure amount > 0.0
-
     signatory issuer, owner
 
     observer observers
+
+template NotIou
+  with
+    issuer : Party
+    owner : Party
+    currency : Text
+    amount : Decimal
+    observers : [Party]
+  where
+    signatory issuer, owner
+
+    observer observers
+
+data WhichTemplate = UseIou | UseNotIou
+  deriving (Eq, Show)

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryMegaAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryMegaAcs.scala
@@ -3,6 +3,7 @@
 package com.daml.http.perf.scenario
 
 import io.gatling.core.Predef._
+import io.gatling.core.feeder.Record
 import io.gatling.http.Predef._
 import spray.json._, DefaultJsonProtocol._
 
@@ -14,7 +15,7 @@ class SyncQueryMegaAcs extends Simulation with SimulationConfig with HasRandomAm
   private[this] val notAliceJwt =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJOb3RBbGljZSJdfX0.Rk1dm5ndpgTrQFTZ_eLRWPxmYqpuV5GOWSTU4U3dAGk"
 
-  private type Discriminator = (String, String, Seq[Seq[String]])
+  private type Discriminator = (String, String, Seq[Seq[String]], Seq[WhichTemplate])
 
   private[this] val discriminators: Seq[Discriminator] = Seq(
     // label, readAs, observers
@@ -26,13 +27,25 @@ class SyncQueryMegaAcs extends Simulation with SimulationConfig with HasRandomAm
         Seq((Seq(notAliceParty), 1), (Seq.empty, 19)),
         Seq((Seq(notAliceParty), 1), (Seq.empty, 9)),
       ),
+      Seq(Seq(UseIou -> 1)),
     ),
-    ("", Seq(), Seq()),
-  ).flatMap { case (label, readAses, observerses) =>
+    (
+      "all matches by template ID distribution",
+      Seq(aliceJwt),
+      Seq(Seq(Seq.empty -> 1)),
+      Seq(Seq(UseIou -> 1, UseNotIou -> 99)),
+    ),
+  ).flatMap { case (label, readAses, observerses, whichTemplates) =>
     for {
       readAs <- readAses
       observers <- observerses
-    } yield (s"$label, ${reportCycle(observers) * 100}% positive", readAs, makeCycle(observers))
+      whichTemplate <- whichTemplates
+    } yield (
+      s"$label, party ${reportCycle(observers) * 100}% positive + tpid ${reportCycle(whichTemplate) * 100}% positive",
+      readAs,
+      makeCycle(observers),
+      makeCycle(whichTemplate),
+    )
   }
 
   private val createRequest =
@@ -58,7 +71,8 @@ class SyncQueryMegaAcs extends Simulation with SimulationConfig with HasRandomAm
   "argument": {
     "totalSteps": 1000,
     "amountCycle": [${amount}],
-    "observersCycle": ${observersCycle}
+    "observersCycle": ${observersCycle},
+    "whichTemplateCycle": ${whichTemplateCycle}
   }
 }"""))
 
@@ -67,28 +81,35 @@ class SyncQueryMegaAcs extends Simulation with SimulationConfig with HasRandomAm
       .post("/v1/query")
       .header(HttpHeaderNames.Authorization, "Bearer ${reqJwt}")
       .body(StringBody("""{
-    "templateIds": ["LargeAcs:Iou"],
+    "templateIds": ["LargeAcs:${templateId}"],
     "query": {"amount": ${amount}}
 }"""))
 
-  private val scns = discriminators map { case (scnName, reqJwt, observersCycle) =>
-    val env = Map("observersCycle" -> observersCycle.toJson)
-    scenario(s"SyncQueryMegaScenario $scnName")
-      .exec(createRequest.silent)
-      // populate the ACS
-      .repeat(100, "amount") {
-        feed(Iterator continually env)
-          .exec(createManyRequest.silent)
-      }
-      // run queries
-      .repeat(500) {
-        // unless we request under Alice, we don't get negatives in the DB
-        feed(
-          Iterator(Map("amount" -> randomAmount(), "reqJwt" -> jwt)) ++
-            Iterator.continually(Map("amount" -> randomAmount(), "reqJwt" -> reqJwt))
-        )
-          .exec(queryRequest)
-      }
+  private val scns = discriminators map {
+    case (scnName, reqJwt, observersCycle, whichTemplateCycle) =>
+      val env = Map(
+        "observersCycle" -> observersCycle.toJson,
+        "whichTemplateCycle" -> whichTemplateCycle.map(_.productPrefix).toJson,
+      )
+      scenario(s"SyncQueryMegaScenario $scnName")
+        .exec(createRequest.silent)
+        // populate the ACS
+        .repeat(100, "amount") {
+          feed(Iterator continually env)
+            .exec(createManyRequest.silent)
+        }
+        // run queries
+        .repeat(500) {
+          // unless we request under Alice, we don't get negatives in the DB
+          def m(amount: Int, reqJwt: String, templateId: String): Record[Any] =
+            Map("amount" -> amount, "reqJwt" -> reqJwt, "templateId" -> templateId)
+          feed(
+            (for (templateId <- Seq("Iou", "NotIou"))
+              yield m(randomAmount(), jwt, templateId)).iterator
+              ++ Iterator.continually(m(randomAmount(), reqJwt, "Iou"))
+          )
+            .exec(queryRequest)
+        }
   }
 
   // TODO SC run other scns
@@ -100,6 +121,10 @@ class SyncQueryMegaAcs extends Simulation with SimulationConfig with HasRandomAm
 }
 
 object SyncQueryMegaAcs {
+  private sealed abstract class WhichTemplate extends Product with Serializable
+  private case object UseIou extends WhichTemplate
+  private case object UseNotIou extends WhichTemplate
+
   private def reportCycle(s: Seq[(_, Int)]): Double = {
     val (_, h) +: _ = s
     h.toDouble / s.view.map(_._2).sum

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryMegaAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryMegaAcs.scala
@@ -31,8 +31,8 @@ class SyncQueryMegaAcs extends Simulation with SimulationConfig with HasRandomAm
     ),
     (
       "all matches by template ID distribution",
-      Seq(aliceJwt),
-      Seq(Seq(Seq.empty -> 1)),
+      Seq(notAliceJwt),
+      Seq(Seq(Seq.empty -> 1), Seq(Seq(notAliceParty) -> 1, Seq.empty -> 99)),
       Seq(Seq(UseIou -> 1, UseNotIou -> 99)),
     ),
   ).flatMap { case (label, readAses, observerses, whichTemplates) =>


### PR DESCRIPTION
Extends the "mega" scenario with a `NotIou` template that can be created too, letting us check how much `contract_tpid_idx` helps.

Furthers #9460, to help provide better guidance for #9895.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
