### PR TITLE
[JSON-API] Concurrent query etc. metrics

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -112,7 +112,7 @@ class Endpoints(
         extendWithRequestIdLogCtx(implicit lc => {
           val t0 = System.nanoTime
           logger.info(s"Incoming request on ${req.uri} from ${connection.remoteAddress}")
-          metrics.daml.HttpJsonApi.httpRequestRunning.mark()
+          metrics.daml.HttpJsonApi.httpRequestThroughput.mark()
           Timed
             .future(metrics.daml.HttpJsonApi.httpRequest, lcFhr(lc))
             .map(res => {
@@ -152,7 +152,7 @@ class Endpoints(
       metrics: Metrics,
   ): ET[domain.SyncResponse[JsValue]] =
     for {
-      _ <- EitherT.pure(metrics.daml.HttpJsonApi.commandSubmission.mark())
+      _ <- EitherT.pure(metrics.daml.HttpJsonApi.commandSubmissionThroughput.mark())
       t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
       (jwt, jwtPayload, reqBody) = t3
       resp <- withJwtPayloadLoggingContext(jwtPayload)(fn(jwt, jwtPayload, reqBody))
@@ -309,7 +309,7 @@ class Endpoints(
       metrics: Metrics,
   ): ET[domain.SyncResponse[domain.PartyDetails]] =
     EitherT
-      .pure(metrics.daml.HttpJsonApi.partyAllocation.mark())
+      .pure(metrics.daml.HttpJsonApi.allocatePartyThroughput.mark())
       .flatMap(_ => proxyWithCommand(partiesService.allocate)(req).map(domain.OkResponse(_)))
 
   def listPackages(req: HttpRequest)(implicit
@@ -341,7 +341,7 @@ class Endpoints(
       metrics: Metrics,
   ): ET[domain.SyncResponse[Unit]] =
     for {
-      _ <- EitherT.pure(metrics.daml.HttpJsonApi.packageAllocation.mark())
+      _ <- EitherT.pure(metrics.daml.HttpJsonApi.uploadPackagesThroughput.mark())
       t2 <- either(inputSource(req)): ET[(Jwt, Source[ByteString, Any])]
 
       (jwt, source) = t2

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -112,6 +112,7 @@ class Endpoints(
         extendWithRequestIdLogCtx(implicit lc => {
           val t0 = System.nanoTime
           logger.info(s"Incoming request on ${req.uri} from ${connection.remoteAddress}")
+          metrics.daml.HttpJsonApi.httpRequestRunning.mark()
           Timed
             .future(metrics.daml.HttpJsonApi.httpRequest, lcFhr(lc))
             .map(res => {
@@ -148,15 +149,19 @@ class Endpoints(
       lc: LoggingContextOf[InstanceUUID with RequestID],
       ev1: JsonWriter[T[JsValue]],
       ev2: Traverse[T],
-  ): ET[domain.SyncResponse[JsValue]] = for {
-    t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
-    (jwt, jwtPayload, reqBody) = t3
-    resp <- withJwtPayloadLoggingContext(jwtPayload)(fn(jwt, jwtPayload, reqBody))
-    jsVal <- either(SprayJson.encode1(resp).liftErr(ServerError)): ET[JsValue]
-  } yield domain.OkResponse(jsVal)
+      metrics: Metrics,
+  ): ET[domain.SyncResponse[JsValue]] =
+    for {
+      _ <- EitherT.pure(metrics.daml.HttpJsonApi.commandSubmission.mark())
+      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
+      (jwt, jwtPayload, reqBody) = t3
+      resp <- withJwtPayloadLoggingContext(jwtPayload)(fn(jwt, jwtPayload, reqBody))
+      jsVal <- either(SprayJson.encode1(resp).liftErr(ServerError)): ET[JsValue]
+    } yield domain.OkResponse(jsVal)
 
   def create(req: HttpRequest)(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID]
+      lc: LoggingContextOf[InstanceUUID with RequestID],
+      metrics: Metrics,
   ): ET[domain.SyncResponse[JsValue]] =
     handleCommand(req) { (jwt, jwtPayload, reqBody) => implicit lc =>
       for {
@@ -171,7 +176,8 @@ class Endpoints(
     }
 
   def exercise(req: HttpRequest)(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID]
+      lc: LoggingContextOf[InstanceUUID with RequestID],
+      metrics: Metrics,
   ): ET[domain.SyncResponse[JsValue]] =
     handleCommand(req) { (jwt, jwtPayload, reqBody) => implicit lc =>
       for {
@@ -197,7 +203,8 @@ class Endpoints(
     }
 
   def createAndExercise(req: HttpRequest)(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID]
+      lc: LoggingContextOf[InstanceUUID with RequestID],
+      metrics: Metrics,
   ): ET[domain.SyncResponse[JsValue]] =
     handleCommand(req) { (jwt, jwtPayload, reqBody) => implicit lc =>
       for {
@@ -298,9 +305,12 @@ class Endpoints(
       .map(ps => partiesResponse(parties = ps._1.toList, unknownParties = ps._2.toList))
 
   def allocateParty(req: HttpRequest)(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID]
+      lc: LoggingContextOf[InstanceUUID with RequestID],
+      metrics: Metrics,
   ): ET[domain.SyncResponse[domain.PartyDetails]] =
-    proxyWithCommand(partiesService.allocate)(req).map(domain.OkResponse(_))
+    EitherT
+      .pure(metrics.daml.HttpJsonApi.partyAllocation.mark())
+      .flatMap(_ => proxyWithCommand(partiesService.allocate)(req).map(domain.OkResponse(_)))
 
   def listPackages(req: HttpRequest)(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
@@ -327,9 +337,11 @@ class Endpoints(
   }
 
   def uploadDarFile(req: HttpRequest)(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID]
+      lc: LoggingContextOf[InstanceUUID with RequestID],
+      metrics: Metrics,
   ): ET[domain.SyncResponse[Unit]] =
     for {
+      _ <- EitherT.pure(metrics.daml.HttpJsonApi.packageAllocation.mark())
       t2 <- either(inputSource(req)): ET[(Jwt, Source[ByteString, Any])]
 
       (jwt, source) = t2

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -114,7 +114,7 @@ class Endpoints(
           logger.info(s"Incoming request on ${req.uri} from ${connection.remoteAddress}")
           metrics.daml.HttpJsonApi.httpRequestThroughput.mark()
           Timed
-            .future(metrics.daml.HttpJsonApi.httpRequest, lcFhr(lc))
+            .future(metrics.daml.HttpJsonApi.httpRequestTimer, lcFhr(lc))
             .map(res => {
               logger.trace(s"Processed request after ${System.nanoTime() - t0}ns")
               logger.info(s"Responding to client with HTTP ${res.status}")

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -411,20 +411,20 @@ class WebSocketService(
     Flow[A]
       .watchTermination() { (_, future) =>
         discard { numConns.incrementAndGet }
-        metrics.daml.HttpJsonApi.websocketRequest.inc()
+        metrics.daml.HttpJsonApi.websocketRequestCounter.inc()
         logger.info(
           s"New websocket client has connected, current number of clients:${numConns.get()}"
         )
         future onComplete {
           case Success(_) =>
             discard { numConns.decrementAndGet }
-            metrics.daml.HttpJsonApi.websocketRequest.dec()
+            metrics.daml.HttpJsonApi.websocketRequestCounter.dec()
             logger.info(
               s"Websocket client has disconnected. Current number of clients: ${numConns.get()}"
             )
           case Failure(ex) =>
             discard { numConns.decrementAndGet }
-            metrics.daml.HttpJsonApi.websocketRequest.dec()
+            metrics.daml.HttpJsonApi.websocketRequestCounter.dec()
             logger.info(
               s"Websocket client interrupted on Failure: ${ex.getMessage}. remaining number of clients: ${numConns.get()}"
             )

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -707,7 +707,11 @@ final class Metrics(val registry: MetricRegistry) {
       private val Prefix: MetricName = daml.Prefix :+ "http_json_api"
 
       val httpRequest: Timer = registry.timer(Prefix :+ "http_request")
+      val httpRequestRunning: Meter = registry.meter(Prefix :+ "http_request_running")
       val websocketRequest: Counter = registry.counter(Prefix :+ "websocket_request")
+      val commandSubmission: Meter = registry.meter(Prefix :+ "command_submission")
+      val packageAllocation: Meter = registry.meter(Prefix :+ "package_allocation")
+      val partyAllocation: Meter = registry.meter(Prefix :+ "party_allocation")
     }
   }
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -706,12 +706,19 @@ final class Metrics(val registry: MetricRegistry) {
     object HttpJsonApi {
       private val Prefix: MetricName = daml.Prefix :+ "http_json_api"
 
+      // Meters how long processing of a request takes
       val httpRequest: Timer = registry.timer(Prefix :+ "http_request")
-      val httpRequestRunning: Meter = registry.meter(Prefix :+ "http_request_running")
-      val websocketRequest: Counter = registry.counter(Prefix :+ "websocket_request")
-      val commandSubmission: Meter = registry.meter(Prefix :+ "command_submission")
-      val packageAllocation: Meter = registry.meter(Prefix :+ "package_allocation")
-      val partyAllocation: Meter = registry.meter(Prefix :+ "party_allocation")
+      // Meters http requests throughput
+      val httpRequestThroughput: Meter = registry.meter(Prefix :+ "http_request_throughput")
+      // Meters how many websocket connections are currently active
+      val websocketRequest: Counter = registry.counter(Prefix :+ "websocket_request_count")
+      // Meters command submissions throughput
+      val commandSubmissionThroughput: Meter =
+        registry.meter(Prefix :+ "command_submission_throughput")
+      // Meters package uploads throughput
+      val uploadPackagesThroughput: Meter = registry.meter(Prefix :+ "upload_packages_throughput")
+      // Meters party allocation throughput
+      val allocatePartyThroughput: Meter = registry.meter(Prefix :+ "allocation_party_throughput")
     }
   }
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -707,11 +707,11 @@ final class Metrics(val registry: MetricRegistry) {
       private val Prefix: MetricName = daml.Prefix :+ "http_json_api"
 
       // Meters how long processing of a request takes
-      val httpRequest: Timer = registry.timer(Prefix :+ "http_request")
+      val httpRequestTimer: Timer = registry.timer(Prefix :+ "http_request_timing")
       // Meters http requests throughput
       val httpRequestThroughput: Meter = registry.meter(Prefix :+ "http_request_throughput")
       // Meters how many websocket connections are currently active
-      val websocketRequest: Counter = registry.counter(Prefix :+ "websocket_request_count")
+      val websocketRequestCounter: Counter = registry.counter(Prefix :+ "websocket_request_count")
       // Meters command submissions throughput
       val commandSubmissionThroughput: Meter =
         registry.meter(Prefix :+ "command_submission_throughput")


### PR DESCRIPTION
Should fix #10021

It was fun to play around with the metrics and trying to do some fun stress testing to ensure that the metrics work correctly :smile:

changelog_begin

- [JSON-API] The metrics which describe the amount of these concurrent events is now available:
	- running http request
	- command submissions
	- package allocations
	- party allocations

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [x] If necessary also did manual testing

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
