### PR TITLE
Do not terminate streams when no end-offset given in `ledger-api-bench-tool` [DPP-422]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/TransactionService.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/TransactionService.scala
@@ -69,11 +69,15 @@ final class TransactionService(
       beginOffset: Option[LedgerOffset],
       endOffset: Option[LedgerOffset],
   ): GetTransactionsRequest = {
-    GetTransactionsRequest.defaultInstance
+    val base = GetTransactionsRequest.defaultInstance
       .withLedgerId(ledgerId)
       .withBegin(beginOffset.getOrElse(ledgerBeginOffset))
-      .withEnd(endOffset.getOrElse(ledgerEndOffset))
       .withFilter(partyFilter(party, templateIds))
+
+    endOffset match {
+      case Some(end) => base.withEnd(end)
+      case None => base
+    }
   }
 
   private def partyFilter(
@@ -94,8 +98,5 @@ final class TransactionService(
 
   private def ledgerBeginOffset: LedgerOffset =
     LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)
-
-  private def ledgerEndOffset: LedgerOffset =
-    LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_END)
 
 }

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/TransactionService.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/TransactionService.scala
@@ -69,14 +69,14 @@ final class TransactionService(
       beginOffset: Option[LedgerOffset],
       endOffset: Option[LedgerOffset],
   ): GetTransactionsRequest = {
-    val base = GetTransactionsRequest.defaultInstance
+    val getTransactionsRequest = GetTransactionsRequest.defaultInstance
       .withLedgerId(ledgerId)
       .withBegin(beginOffset.getOrElse(ledgerBeginOffset))
       .withFilter(partyFilter(party, templateIds))
 
     endOffset match {
-      case Some(end) => base.withEnd(end)
-      case None => base
+      case Some(end) => getTransactionsRequest.withEnd(end)
+      case None => getTransactionsRequest
     }
   }
 


### PR DESCRIPTION
Do not terminate streams when no end-offset given in `ledger-api-bench-tool`. This change allows to subscribing to a slow-producing running ledger.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
