### PR TITLE
make json-api's scopt better-typed by passing JDBC drivers implicitly

### DIFF
--- a/ledger-service/http-json-cli/BUILD.bazel
+++ b/ledger-service/http-json-cli/BUILD.bazel
@@ -34,6 +34,7 @@ da_scala_library(
         scala_deps = [
             "@maven//:com_github_scopt_scopt",
             "@maven//:com_typesafe_scala_logging_scala_logging",
+            "@maven//:org_scalaz_scalaz_core",
         ],
         visibility = ["//visibility:public"],
         exports = [":base"],

--- a/ledger-service/http-json-cli/ce/src/main/scala/com/daml/http/Cli.scala
+++ b/ledger-service/http-json-cli/ce/src/main/scala/com/daml/http/Cli.scala
@@ -4,9 +4,8 @@
 package com.daml.http
 
 object Cli extends CliBase {
-  override protected def configParser(
-      getEnvVar: String => Option[String],
-      supportedJdbcDriverNames: Set[String],
+  override protected def configParser(getEnvVar: String => Option[String])(implicit
+      supportedJdbcDriverNames: Config.SupportedJdbcDriverNames
   ): OptionParser =
-    new OptionParser(getEnvVar, supportedJdbcDriverNames)
+    new OptionParser(getEnvVar)
 }

--- a/ledger-service/http-json-cli/ee/src/main/scala/com/daml/http/Cli.scala
+++ b/ledger-service/http-json-cli/ee/src/main/scala/com/daml/http/Cli.scala
@@ -4,9 +4,8 @@
 package com.daml.http
 
 object Cli extends CliBase {
-  override protected def configParser(
-      getEnvVar: String => Option[String],
-      supportedJdbcDriverNames: Set[String],
+  override protected def configParser(getEnvVar: String => Option[String])(implicit
+      supportedJdbcDriverNames: Config.SupportedJdbcDriverNames
   ): OptionParser =
-    new OptionParser(getEnvVar, supportedJdbcDriverNames) with NonRepudiationOptions
+    new OptionParser(getEnvVar) with NonRepudiationOptions
 }

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/CliBase.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/CliBase.scala
@@ -9,12 +9,14 @@ trait CliBase {
       args: collection.Seq[String],
       supportedJdbcDriverNames: Set[String],
       getEnvVar: String => Option[String] = sys.env.get,
-  ): Option[Config] =
-    configParser(getEnvVar, supportedJdbcDriverNames).parse(args, Config.Empty)
+  ): Option[Config] = {
+    implicit val jdn: Config.SupportedJdbcDriverNames =
+      Config.SupportedJdbcDrivers(supportedJdbcDriverNames)
+    configParser(getEnvVar).parse(args, Config.Empty)
+  }
 
-  protected def configParser(
-      getEnvVar: String => Option[String],
-      supportedJdbcDriverNames: Set[String],
+  protected[this] def configParser(getEnvVar: String => Option[String])(implicit
+      supportedJdbcDriverNames: Config.SupportedJdbcDriverNames
   ): OptionParser
 
 }

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
@@ -11,8 +11,9 @@ import akka.stream.ThrottleMode
 import com.daml.util.ExceptionOps._
 import com.daml.ledger.api.tls.TlsConfiguration
 import scalaz.std.option._
+import scalaz.syntax.tag._
 import scalaz.syntax.traverse._
-import scalaz.{Show, \/}
+import scalaz.{@@, Show, Tag, \/}
 
 import scala.concurrent.duration._
 import scala.util.Try
@@ -58,25 +59,23 @@ private[http] object Config {
       ThrottleMode.Shaping,
       heartBeatPer = 5 second,
     )
+
+  type SupportedJdbcDriverNames = Set[String] @@ SupportedJdbcDrivers
+  sealed trait SupportedJdbcDrivers
+  val SupportedJdbcDrivers = Tag.of[SupportedJdbcDrivers]
 }
 
-private[http] abstract class ConfigCompanion[A](name: String) {
+private[http] abstract class ConfigCompanion[A, ReadCtx](name: String) {
 
   protected val indent: String = List.fill(8)(" ").mkString
 
-  def create(x: Map[String, String], supportedJdbcDriverNames: Set[String]): Either[String, A]
+  protected[this] def create(x: Map[String, String])(implicit readCtx: ReadCtx): Either[String, A]
 
-  def createUnsafe(x: Map[String, String], supportedJdbcDriverNames: Set[String]): A =
-    create(x, supportedJdbcDriverNames).fold(
-      e => sys.error(e),
-      identity,
-    )
-
-  def validate(
-      x: Map[String, String],
-      supportedJdbcDriverNames: Set[String],
-  ): Either[String, Unit] =
-    create(x, supportedJdbcDriverNames).map(_ => ())
+  private[http] implicit final def `read instance`(implicit ctx: ReadCtx): scopt.Read[A] =
+    scopt.Read.reads { s =>
+      val x = implicitly[scopt.Read[Map[String, String]]].reads(s)
+      create(x).fold(e => throw new IllegalArgumentException(e), identity)
+    }
 
   protected def requiredField(m: Map[String, String])(k: String): Either[String, String] =
     m.get(k).filter(_.nonEmpty).toRight(s"Invalid $name, must contain '$k' field")
@@ -117,15 +116,16 @@ private[http] final case class JdbcConfig(
     createSchema: Boolean = false,
 )
 
-private[http] object JdbcConfig extends ConfigCompanion[JdbcConfig]("JdbcConfig") {
+private[http] object JdbcConfig
+    extends ConfigCompanion[JdbcConfig, Config.SupportedJdbcDriverNames]("JdbcConfig") {
 
   implicit val showInstance: Show[JdbcConfig] = Show.shows(a =>
     s"JdbcConfig(driver=${a.driver}, url=${a.url}, user=${a.user}, createSchema=${a.createSchema})"
   )
 
-  def help(supportedJdbcDriverNames: Set[String]): String =
+  def help(implicit supportedJdbcDriverNames: Config.SupportedJdbcDriverNames): String =
     "Contains comma-separated key-value pairs. Where:\n" +
-      s"${indent}driver -- JDBC driver class name, ${supportedJdbcDriverNames.mkString(", ")} supported right now,\n" +
+      s"${indent}driver -- JDBC driver class name, ${supportedJdbcDriverNames.unwrap.mkString(", ")} supported right now,\n" +
       s"${indent}url -- JDBC connection URL,\n" +
       s"${indent}user -- database user name,\n" +
       s"${indent}password -- database user password,\n" +
@@ -146,12 +146,12 @@ private[http] object JdbcConfig extends ConfigCompanion[JdbcConfig]("JdbcConfig"
     "<true|false>",
   )
 
-  override def create(
-      x: Map[String, String],
-      supportedJdbcDriverNames: Set[String],
+  override def create(x: Map[String, String])(implicit
+      readCtx: Config.SupportedJdbcDriverNames
   ): Either[String, JdbcConfig] =
     for {
       driver <- requiredField(x)("driver")
+      Config.SupportedJdbcDrivers(supportedJdbcDriverNames) = readCtx
       _ <- Either.cond(
         supportedJdbcDriverNames(driver),
         (),
@@ -189,7 +189,8 @@ final case class WebsocketConfig(
     heartBeatPer: FiniteDuration,
 )
 
-private[http] object WebsocketConfig extends ConfigCompanion[WebsocketConfig]("WebsocketConfig") {
+private[http] object WebsocketConfig
+    extends ConfigCompanion[WebsocketConfig, DummyImplicit]("WebsocketConfig") {
 
   implicit val showInstance: Show[WebsocketConfig] = Show.shows(c =>
     s"WebsocketConfig(maxDuration=${c.maxDuration}, heartBeatPer=${c.heartBeatPer}.seconds)"
@@ -207,9 +208,8 @@ private[http] object WebsocketConfig extends ConfigCompanion[WebsocketConfig]("W
   )
 
   override def create(
-      x: Map[String, String],
-      supportedJdbcDriverNames: Set[String],
-  ): Either[String, WebsocketConfig] =
+      x: Map[String, String]
+  )(implicit readCtx: DummyImplicit): Either[String, WebsocketConfig] =
     for {
       md <- optionalLongField(x)("maxDuration")
       hbp <- optionalLongField(x)("heartBeatPer")
@@ -233,7 +233,7 @@ private[http] final case class StaticContentConfig(
 )
 
 private[http] object StaticContentConfig
-    extends ConfigCompanion[StaticContentConfig]("StaticContentConfig") {
+    extends ConfigCompanion[StaticContentConfig, DummyImplicit]("StaticContentConfig") {
 
   implicit val showInstance: Show[StaticContentConfig] =
     Show.shows(a => s"StaticContentConfig(prefix=${a.prefix}, directory=${a.directory})")
@@ -247,9 +247,8 @@ private[http] object StaticContentConfig
   lazy val usage: String = helpString("<URL prefix>", "<directory>")
 
   override def create(
-      x: Map[String, String],
-      supportedJdbcDriverNames: Set[String],
-  ): Either[String, StaticContentConfig] =
+      x: Map[String, String]
+  )(implicit readCtx: DummyImplicit): Either[String, StaticContentConfig] =
     for {
       prefix <- requiredField(x)("prefix").flatMap(prefixCantStartWithSlash)
       directory <- requiredDirectoryField(x)("directory")

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -27,6 +27,7 @@ hj_scalacopts = lf_scalacopts + [
         ],
         scala_deps = [
             "@maven//:com_chuusai_shapeless",
+            "@maven//:com_github_scopt_scopt",
             "@maven//:com_lihaoyi_sourcecode",
             "@maven//:com_typesafe_akka_akka_http",
             "@maven//:com_typesafe_akka_akka_http_core",


### PR DESCRIPTION
This solves two warts in the code:

- the `validate`/`createUnsafe` double-parse, because scopt doesn't let you flatMap;
- the non-`JdbcConfig` sub-configs appeared to need to know the JDBC drivers when they really don't, because of a quirk in the inherited implementation (a "foolish consistency", literally)

That coherence of `scopt.Read` instances calls for all its dependencies to be coherent leads us to treat `supportedJdbcDriverNames` as a nullary typeclass instance.  This is a nullary typeclass by the same justification as `SupportedJdbcDriver`; see scaladoc there for more.

And we solve the latter problem by...adding a type parameter, how else.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
