### PR TITLE
DPP-432 Add exception tests to the JdbcLedgerDao suite

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoExceptionSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoExceptionSpec.scala
@@ -1,0 +1,115 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao
+
+import com.daml.lf.transaction.TransactionVersion
+import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.value.Value.{ContractId, ContractInst}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{Inside, LoneElement, OptionValues}
+
+/** There are two important parts to cover with Daml exceptions:
+  * - Create and exercise nodes under rollback nodes should not be indexed
+  * - Lookup and fetch nodes under rollback nodes may lead to divulgence
+  */
+private[dao] trait JdbcLedgerDaoExceptionSpec extends LoneElement with Inside with OptionValues {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  private def contractsReader = ledgerDao.contractsReader
+
+  behavior of "JdbcLedgerDao (exceptions)"
+
+  it should "not find contracts created under rollback nodes" in {
+    val builder = TransactionBuilder(TransactionVersion.VDev)
+    val rollback = builder.add(builder.rollback())
+    val cid1 = builder.newCid
+    val cid2 = builder.newCid
+    builder.add(
+      createNode(absCid = cid1, signatories = Set(alice), stakeholders = Set(alice)),
+      rollback,
+    )
+    builder.add(createNode(absCid = cid2, signatories = Set(alice), stakeholders = Set(alice)))
+    val offsetAndEntry = fromTransaction(builder.buildCommitted())
+
+    for {
+      _ <- store(offsetAndEntry)
+      result1 <- contractsReader.lookupActiveContractAndLoadArgument(Set(alice), cid1)
+      result2 <- contractsReader.lookupActiveContractAndLoadArgument(Set(alice), cid2)
+    } yield {
+      result1 shouldBe None
+      result2.value shouldBe a[ContractInst[_]]
+    }
+  }
+
+  it should "divulge contracts fetched under rollback nodes" in {
+    val stakeholders = Set(alice)
+    val divulgees = Set(bob)
+
+    // A transaction that fetches a contract under a rollback node
+    def rolledBackFetch(createCid: ContractId, fetcherCid: ContractId) = {
+      val builder = TransactionBuilder(TransactionVersion.VDev)
+      val exercise1 = exerciseNode(fetcherCid).copy(
+        consuming = false,
+        actingParties = stakeholders,
+        signatories = divulgees,
+        stakeholders = stakeholders.union(divulgees),
+      )
+      val rollback = builder.rollback()
+      val exercise2 = fetchNode(createCid).copy(
+        actingParties = stakeholders,
+        signatories = stakeholders,
+        stakeholders = stakeholders,
+      )
+
+      val exercise1Nid = builder.add(exercise1)
+      val rollbackNid = builder.add(rollback, exercise1Nid)
+      builder.add(exercise2, rollbackNid)
+      fromTransaction(builder.buildCommitted()).copy()
+    }
+
+    for {
+      // Create contract to be divulged
+      (_, tx1) <- createAndStoreContract(
+        submittingParties = stakeholders,
+        signatories = stakeholders,
+        stakeholders = stakeholders,
+        key = None,
+      )
+      create = nonTransient(tx1).loneElement
+      createCid = ContractId.assertFromString(create.coid)
+
+      // Create "Fetcher" contract
+      (_, tx2) <- createAndStoreContract(
+        submittingParties = divulgees,
+        signatories = divulgees,
+        stakeholders = stakeholders.union(divulgees),
+        key = None,
+      )
+      fetcher = nonTransient(tx1).loneElement
+      fetcherCid = ContractId.assertFromString(fetcher.coid)
+
+      // Exercise a choice on the "Fetcher" contract that divulges the first contract
+      _ <- store(
+        divulgedContracts = Map((create, someVersionedContractInstance) -> divulgees),
+        blindingInfo = None,
+        offsetAndTx = rolledBackFetch(createCid, fetcherCid),
+      )
+      resultAlice <- contractsReader.lookupActiveContractAndLoadArgument(Set(alice), createCid)
+      resultBob <- contractsReader.lookupActiveContractAndLoadArgument(Set(bob), createCid)
+      resultCharlie <- contractsReader.lookupActiveContractAndLoadArgument(Set(charlie), createCid)
+    } yield {
+      withClue("Alice is stakeholder") {
+        resultAlice.value shouldBe a[ContractInst[_]]
+      }
+      withClue("Contract was divulged to Bob under a rollback node") {
+        resultBob.value shouldBe a[ContractInst[_]]
+      }
+      withClue("Charlie is unrelated and must not see the contract") {
+        resultCharlie shouldBe None
+      }
+    }
+  }
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoExceptionSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoExceptionSpec.scala
@@ -57,7 +57,7 @@ private[dao] trait JdbcLedgerDaoExceptionSpec extends LoneElement with Inside wi
         stakeholders = stakeholders.union(divulgees),
       )
       val rollback = builder.rollback()
-      val exercise2 = fetchNode(createCid).copy(
+      val fetch1 = fetchNode(createCid).copy(
         actingParties = stakeholders,
         signatories = stakeholders,
         stakeholders = stakeholders,
@@ -65,7 +65,7 @@ private[dao] trait JdbcLedgerDaoExceptionSpec extends LoneElement with Inside wi
 
       val exercise1Nid = builder.add(exercise1)
       val rollbackNid = builder.add(rollback, exercise1Nid)
-      builder.add(exercise2, rollbackNid)
+      builder.add(fetch1, rollbackNid)
       fromTransaction(builder.buildCommitted()).copy()
     }
 
@@ -87,7 +87,7 @@ private[dao] trait JdbcLedgerDaoExceptionSpec extends LoneElement with Inside wi
         stakeholders = stakeholders.union(divulgees),
         key = None,
       )
-      fetcher = nonTransient(tx1).loneElement
+      fetcher = nonTransient(tx2).loneElement
       fetcherCid = ContractId.assertFromString(fetcher.coid)
 
       // Exercise a choice on the "Fetcher" contract that divulges the first contract
@@ -128,7 +128,7 @@ private[dao] trait JdbcLedgerDaoExceptionSpec extends LoneElement with Inside wi
       stakeholders = stakeholders.union(divulgees),
     )
     val rollback = builder.rollback()
-    val exercise2 = fetchNode(createCid).copy(
+    val fetch1 = fetchNode(createCid).copy(
       actingParties = stakeholders,
       signatories = stakeholders,
       stakeholders = stakeholders,
@@ -138,7 +138,7 @@ private[dao] trait JdbcLedgerDaoExceptionSpec extends LoneElement with Inside wi
     builder.add(create2)
     val exercise1Nid = builder.add(exercise1)
     val rollbackNid = builder.add(rollback, exercise1Nid)
-    builder.add(exercise2, rollbackNid)
+    builder.add(fetch1, rollbackNid)
     val offsetAndEntry = fromTransaction(builder.buildCommitted()).copy()
 
     for {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoH2DatabaseSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoH2DatabaseSpec.scala
@@ -18,6 +18,7 @@ final class JdbcLedgerDaoH2DatabaseSpec
     with JdbcLedgerDaoConfigurationSpec
     with JdbcLedgerDaoContractsSpec
     with JdbcLedgerDaoDivulgenceSpec
+    with JdbcLedgerDaoExceptionSpec
     with JdbcLedgerDaoPartiesSpec
     with JdbcLedgerDaoTransactionsSpec
     with JdbcLedgerDaoTransactionTreesSpec

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoOracleDatabaseSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoOracleDatabaseSpec.scala
@@ -18,6 +18,7 @@ class JdbcLedgerDaoOracleDatabaseSpec
     with JdbcLedgerDaoCompletionsSpec
     with JdbcLedgerDaoContractsSpec
     with JdbcLedgerDaoDivulgenceSpec
+    with JdbcLedgerDaoExceptionSpec
     with JdbcLedgerDaoTransactionsSpec
     with JdbcLedgerDaoTransactionTreesSpec
     with JdbcLedgerDaoTransactionsWriterSpec

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPipelinedOracleSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPipelinedOracleSpec.scala
@@ -16,6 +16,7 @@ class JdbcLedgerDaoPipelinedOracleSpec
     with JdbcLedgerDaoCompletionsSpec
     with JdbcLedgerDaoContractsSpec
     with JdbcLedgerDaoDivulgenceSpec
+    with JdbcLedgerDaoExceptionSpec
     with JdbcLedgerDaoTransactionsSpec
     with JdbcLedgerDaoTransactionTreesSpec
     with JdbcLedgerDaoTransactionsWriterSpec

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPipelinedPostgresqlSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPipelinedPostgresqlSpec.scala
@@ -16,6 +16,7 @@ final class JdbcLedgerDaoPipelinedPostgresqlSpec
     with JdbcLedgerDaoCompletionsSpec
     with JdbcLedgerDaoContractsSpec
     with JdbcLedgerDaoDivulgenceSpec
+    with JdbcLedgerDaoExceptionSpec
     with JdbcLedgerDaoTransactionsSpec
     with JdbcLedgerDaoTransactionTreesSpec
     with JdbcLedgerDaoTransactionsWriterSpec

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPostgresqlAppendOnlySpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPostgresqlAppendOnlySpec.scala
@@ -19,6 +19,7 @@ final class JdbcLedgerDaoPostgresqlAppendOnlySpec
     with JdbcLedgerDaoContractsSpec
     with JdbcLedgerDaoContractsAppendOnlySpec
     with JdbcLedgerDaoDivulgenceSpec
+    with JdbcLedgerDaoExceptionSpec
     with JdbcLedgerDaoPartiesSpec
     with JdbcLedgerDaoTransactionsSpec
     with JdbcLedgerDaoTransactionTreesSpec

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPostgresqlSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPostgresqlSpec.scala
@@ -18,6 +18,7 @@ final class JdbcLedgerDaoPostgresqlSpec
     with JdbcLedgerDaoConfigurationSpec
     with JdbcLedgerDaoContractsSpec
     with JdbcLedgerDaoDivulgenceSpec
+    with JdbcLedgerDaoExceptionSpec
     with JdbcLedgerDaoPartiesSpec
     with JdbcLedgerDaoTransactionsSpec
     with JdbcLedgerDaoTransactionTreesSpec


### PR DESCRIPTION
This PR adds coverage for Daml exceptions for the JdbcLedgerDao suite.

These tests overlap with the ledger API test tool, but only for ledgers that don't prune (or otherwise preprocess) Rollback nodes before the `ReadService` interface. By adding the test to the JdbcLedgerDao suite, we make sure exceptions are covered independent of the ledger implementations in this repository.

Additionally, one test uses a transaction that can only be produced by a privacy-aware ledger, which is something the ledger API test tool can not cover in this repository.