### PR TITLE
[JSON-API] Add moar timing metrics

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -89,9 +89,11 @@ class Endpoints(
         case req @ HttpRequest(POST, Uri.Path("/v1/create-and-exercise"), _, _, _) =>
           (implicit lc => httpResponse(createAndExercise(req)))
       }
-    val queryDispatch = mkDispatchFunWithTimer(apiMetrics.queryTimer) {
+    val queryAllDispatch = mkDispatchFunWithTimer(apiMetrics.queryAllTimer) {
       case req @ HttpRequest(GET, Uri.Path("/v1/query"), _, _, _) =>
         (implicit lc => httpResponse(retrieveAll(req)))
+    }
+    val queryMatchingDispatch = mkDispatchFunWithTimer(apiMetrics.queryMatchingTimer) {
       case req @ HttpRequest(POST, Uri.Path("/v1/query"), _, _, _) =>
         (implicit lc => httpResponse(query(req)))
     }
@@ -138,7 +140,8 @@ class Endpoints(
     }
     import scalaz.std.partialFunction._, scalaz.syntax.arrow._
     ((commandDispatch orElse
-      queryDispatch orElse
+      queryAllDispatch orElse
+      queryMatchingDispatch orElse
       fetchDispatch orElse
       getPartyDispatch orElse
       allocatePartyDispatch orElse

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -708,10 +708,15 @@ final class Metrics(val registry: MetricRegistry) {
 
       // Meters how long processing of a request takes
       val httpRequestTimer: Timer = registry.timer(Prefix :+ "http_request_timing")
+      // Meters how long processing of a command submission request takes
       val commandSubmissionTimer: Timer = registry.timer(Prefix :+ "command_submission_timing")
+      // Meters how long processing of a query request takes
       val queryTimer: Timer = registry.timer(Prefix :+ "query_timing")
+      // Meters how long processing of a party management request takes
       val partyManagementTimer: Timer = registry.timer(Prefix :+ "party_management_timing")
+      // Meters how long processing of a package management request takes
       val packageManagementTimer: Timer = registry.timer(Prefix :+ "package_management_timing")
+      // Meters how long parsing and decoding of incoming json payload takes
       val incomingJsonParsingAndValidationTimer: Timer =
         registry.timer(Prefix :+ "incoming_json_parsing_and_validation_timing")
       // Meters http requests throughput

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -708,8 +708,10 @@ final class Metrics(val registry: MetricRegistry) {
 
       // Meters how long processing of a command submission request takes
       val commandSubmissionTimer: Timer = registry.timer(Prefix :+ "command_submission_timing")
-      // Meters how long processing of a query request takes
-      val queryTimer: Timer = registry.timer(Prefix :+ "query_timing")
+      // Meters how long processing of a query GET request takes
+      val queryAllTimer: Timer = registry.timer(Prefix :+ "query_all_timing")
+      // Meters how long processing of a query POST request takes
+      val queryMatchingTimer: Timer = registry.timer(Prefix :+ "query_matching_timing")
       // Meters how long processing of a fetch request takes
       val fetchTimer: Timer = registry.timer(Prefix :+ "fetch_timing")
       // Meters how long processing of a get party/parties request takes

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -706,17 +706,21 @@ final class Metrics(val registry: MetricRegistry) {
     object HttpJsonApi {
       private val Prefix: MetricName = daml.Prefix :+ "http_json_api"
 
-      // Meters how long processing of a request takes
-      val httpRequestTimer: Timer = registry.timer(Prefix :+ "http_request_timing")
       // Meters how long processing of a command submission request takes
       val commandSubmissionTimer: Timer = registry.timer(Prefix :+ "command_submission_timing")
       // Meters how long processing of a query request takes
       val queryTimer: Timer = registry.timer(Prefix :+ "query_timing")
+      // Meters how long processing of a fetch request takes
+      val fetchTimer: Timer = registry.timer(Prefix :+ "fetch_timing")
+      // Meters how long processing of a get party/parties request takes
+      val getPartyTimer: Timer = registry.timer(Prefix :+ "get_party_timing")
       // Meters how long processing of a party management request takes
-      val partyManagementTimer: Timer = registry.timer(Prefix :+ "party_management_timing")
+      val allocatePartyTimer: Timer = registry.timer(Prefix :+ "allocate_party_timing")
       // Meters how long processing of a package management request takes
-      val packageManagementTimer: Timer = registry.timer(Prefix :+ "package_management_timing")
-      // Meters how long parsing and decoding of incoming json payload takes
+      val downloadPackageTimer: Timer = registry.timer(Prefix :+ "download_package_timing")
+      // Meters how long processing of a package upload request takes
+      val uploadPackageTimer: Timer = registry.timer(Prefix :+ "upload_package_timing")
+      // Meters how long parsing and decoding of an incoming json payload takes
       val incomingJsonParsingAndValidationTimer: Timer =
         registry.timer(Prefix :+ "incoming_json_parsing_and_validation_timing")
       // Meters http requests throughput

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -708,6 +708,12 @@ final class Metrics(val registry: MetricRegistry) {
 
       // Meters how long processing of a request takes
       val httpRequestTimer: Timer = registry.timer(Prefix :+ "http_request_timing")
+      val commandSubmissionTimer: Timer = registry.timer(Prefix :+ "command_submission_timing")
+      val queryTimer: Timer = registry.timer(Prefix :+ "query_timing")
+      val partyManagementTimer: Timer = registry.timer(Prefix :+ "party_management_timing")
+      val packageManagementTimer: Timer = registry.timer(Prefix :+ "package_management_timing")
+      val incomingJsonParsingAndValidationTimer: Timer =
+        registry.timer(Prefix :+ "incoming_json_parsing_and_validation_timing")
       // Meters http requests throughput
       val httpRequestThroughput: Meter = registry.meter(Prefix :+ "http_request_throughput")
       // Meters how many websocket connections are currently active


### PR DESCRIPTION
Solves part of #10020

I want to add the db metrics with a seperate PR as this seems to be a bit more complex (also because I have not worked in that part of the code yet).

changelog_begin

- [JSON-API] Timing metrics are now available for party management, package management, command submission and query endpoints.
- [JSON-API] Also added a timing metric for parsing and decoding of incoming json payloads

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
