### PR TITLE
[DROPPED] [In-memory fan-out] Use Offset.predecessor to establish the end inclusive of fetched ranges

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/EventsBuffer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/EventsBuffer.scala
@@ -107,7 +107,8 @@ private[platform] final class EventsBuffer[O: Ordering, E](
           val vectorSlice =
             bufferSnapshot.vector.slice(bufferStartInclusiveIdx, bufferEndExclusiveIdx)
 
-          if (bufferStartInclusiveIdx == 0) Prefix(vectorSlice)
+          if (vectorSlice.isEmpty) Empty
+          else if (bufferStartInclusiveIdx == 0) Prefix(vectorSlice)
           else Inclusive(vectorSlice)
         }
       },

--- a/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v1/OffsetSpec.scala
+++ b/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v1/OffsetSpec.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import org.scalatest.RecoverMethods
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class OffsetSpec extends AnyWordSpec with Matchers with RecoverMethods {
+  "Offset.predecessor" should {
+    "fail if beforeBegin" in {
+      a[UnsupportedOperationException] should be thrownBy {
+        Offset.beforeBegin.predecessor
+      }
+    }
+
+    "fail if all zeros" in {
+      a[UnsupportedOperationException] should be thrownBy {
+        Offset.fromByteArray(Array(0.toByte, 0.toByte)).predecessor
+      }
+    }
+
+    "return predecessor" in {
+      Offset.fromByteArray(Array(255.toByte)).predecessor shouldBe
+        Offset.fromByteArray(Array(254.toByte))
+
+      Offset.fromByteArray(Array(128.toByte)).predecessor shouldBe
+        Offset.fromByteArray(Array(127.toByte))
+
+      Offset.fromByteArray(Array(128.toByte, 0.toByte)).predecessor shouldBe
+        Offset.fromByteArray(Array(127.toByte, 255.toByte))
+
+      val _0_1_1_0_0 =
+        Offset.fromByteArray(Array(0.toByte, 1.toByte, 1.toByte, 0.toByte, 0.toByte))
+
+      val _0_1_0_255_255 =
+        Offset.fromByteArray(Array(0.toByte, 1.toByte, 0.toByte, 255.toByte, 255.toByte))
+
+      _0_1_1_0_0.predecessor shouldBe _0_1_0_255_255
+    }
+  }
+}


### PR DESCRIPTION
Implement and use `Offset.predecessor` to establish the end inclusive of fetched ranges.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
