### PR TITLE
[In-memory fan-out] Object liveness tracker 

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -675,6 +675,9 @@ final class Metrics(val registry: MetricRegistry) {
             registry.timer(Prefix :+ "get_transaction_trees")
           val getFlatTransactions: Timer =
             registry.timer(Prefix :+ "get_flat_transactions")
+
+          val transactionLogUpdatesRefs: Counter =
+            registry.counter(Prefix :+ "transaction_log_updates_refs")
         }
 
         val transactionTreesBufferSize: Counter =

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
@@ -152,11 +152,12 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
         generalDispatcher: Dispatcher[Offset],
         dispatcherLagMeter: DispatcherLagMeter,
     )(implicit resourceContext: ResourceContext) = {
-      val transactionsBuffer = new EventsBuffer[Offset, TransactionLogUpdate](
+      val transactionsBuffer = EventsBuffer[Offset, TransactionLogUpdate](
         maxBufferSize = maxTransactionsInMemoryFanOutBufferSize,
         metrics = metrics,
         bufferQualifier = "transactions",
         isRangeEndMarker = _.isInstanceOf[TransactionLogUpdate.LedgerEndMarker],
+        enableReferenceTracking = true,
       )
       for {
         contractStore <- MutableCacheBackedContractStore.owner(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/ObjectsLivenessTracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/ObjectsLivenessTracker.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.cache
+
+import java.util.{Timer, TimerTask}
+
+import scala.annotation.tailrec
+import scala.ref.{PhantomReference, ReferenceQueue}
+
+private[cache] class ObjectsLivenessTracker[T <: AnyRef](
+    incrementCounter: () => Unit,
+    decrementCounter: () => Unit,
+    referenceQueue: ReferenceQueue[T],
+) {
+  private[cache] val refs = java.util.Collections.newSetFromMap(
+    new java.util.concurrent.ConcurrentHashMap[PhantomReference[T], java.lang.Boolean]
+  )
+
+  private val timer = new Timer("buffer-liveness-tracker", true)
+  timer.scheduleAtFixedRate(
+    new TimerTask {
+      override def run(): Unit = {
+
+        @tailrec
+        def pollAndClear(): Unit = {
+          val maybeHead = referenceQueue.poll
+          maybeHead.foreach { case ref: PhantomReference[_] =>
+            ref.clear()
+            refs.remove(ref)
+            decrementCounter()
+          }
+          if (maybeHead.nonEmpty) pollAndClear()
+        }
+
+        pollAndClear()
+      }
+    },
+    100L,
+    100L,
+  )
+
+  def track(obj: T): Unit = {
+    incrementCounter()
+    val _ = refs.add(new PhantomReference(obj, referenceQueue))
+  }
+}
+
+private[cache] object ObjectsLivenessTracker {
+  def apply[T <: AnyRef](
+      incrementCounter: () => Unit,
+      decrementCounter: () => Unit,
+  ): ObjectsLivenessTracker[T] =
+    new ObjectsLivenessTracker(incrementCounter, decrementCounter, new ReferenceQueue[T])
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/EventsBufferSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/EventsBufferSpec.scala
@@ -192,6 +192,7 @@ class EventsBufferSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPr
       new Metrics(new MetricRegistry),
       "integers",
       _ == Int.MaxValue, // Signifies ledger end
+      _ => _ => (),
     )
     elems.foreach { case (offset, event) => buffer.push(offset, event) }
     test(buffer)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/ObjectsLivenessTrackerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/ObjectsLivenessTrackerSpec.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.cache
+
+import java.util.concurrent.atomic.AtomicLong
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ObjectsLivenessTrackerSpec extends AnyFlatSpec with Matchers {
+  behavior of classOf[ObjectsLivenessTracker[_]].getSimpleName
+
+  it should "track" in {
+    val counter = new AtomicLong(0L)
+    val tracker = ObjectsLivenessTracker[Object](
+      { () => counter.incrementAndGet(); () },
+      { () => counter.decrementAndGet(); () },
+    )
+
+    var daRefs = (1 to 1000).map(_ => new Object)
+    daRefs.foreach(tracker.track)
+
+    counter.get() shouldBe 1000L
+    daRefs = null
+
+    System.gc()
+
+    Thread.sleep(1000L)
+    tracker.refs.isEmpty shouldBe true
+    counter.get() shouldBe 0L
+  }
+}


### PR DESCRIPTION
This PR introduces`ObjectLivenessTracker` which updates a counter based on the JVM reachability status of the objects it tracks. The feature can:
* Help discover memory leaks
* Track slow consumers and the buffer slices they are keeping alive (of the in-memory fan-out buffers for transactions).

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
