### PR TITLE
[JSON-API] Add db metrics & response construction metrics

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -725,6 +725,12 @@ final class Metrics(val registry: MetricRegistry) {
       // Meters how long parsing and decoding of an incoming json payload takes
       val incomingJsonParsingAndValidationTimer: Timer =
         registry.timer(Prefix :+ "incoming_json_parsing_and_validation_timing")
+      // Meters how long the construction of the response json payload takes
+      val responseCreationTimer: Timer = registry.timer(Prefix :+ "response_creation_timing")
+      // Meters how long a find by contract key database operation takes
+      val dbFindByContractKey: Timer = registry.timer(Prefix :+ "db_find_by_contract_key_timing")
+      // Meters how long a find by contract id database operation takes
+      val dbFindByContractId: Timer = registry.timer(Prefix :+ "db_find_by_contract_id_timing")
       // Meters http requests throughput
       val httpRequestThroughput: Meter = registry.meter(Prefix :+ "http_request_throughput")
       // Meters how many websocket connections are currently active


### PR DESCRIPTION
Solves the last bits of #10020 except the `For command submissions the duration of the request to the ledger.` point.

changelog_begin

- [JSON-API] The database operations (regardless of in-memory or postgres) contain now metrics for fetching contracts by id or key (seperate metrics foreach)
- [JSON-API] The time for a repsonse payload construction of a request is now also tracked in a metric

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
