### PR TITLE
allow CI pools to use any zone

### DIFF
--- a/infra/modules/gcp_cdn_bucket/outputs.tf
+++ b/infra/modules/gcp_cdn_bucket/outputs.tf
@@ -3,10 +3,10 @@
 
 output external_ip {
   description = "The external IP assigned to the global fowarding rule."
-  value       = "${google_compute_global_address.default.address}"
+  value       = google_compute_global_address.default.address
 }
 
 output bucket_name {
   description = "Name of the GCS bucket that will receive the objects."
-  value       = "${google_storage_bucket.default.name}"
+  value       = google_storage_bucket.default.name
 }

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -23,11 +23,16 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-ubuntu_20_04
     instance_template = google_compute_instance_template.vsts-agent-ubuntu_20_04.self_link
   }
 
+  # uncomment when we get a provider >3.55
+  #distribution_policy_target_shape = "ANY"
+
   update_policy {
     type            = "PROACTIVE"
     minimal_action  = "REPLACE"
     max_surge_fixed = 3
     min_ready_sec   = 60
+
+    instance_redistribution_type = "NONE"
   }
 }
 

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -34,6 +34,9 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
     instance_template = google_compute_instance_template.vsts-agent-windows[count.index].self_link
   }
 
+  # uncomment when we get a provider >3.55
+  #distribution_policy_target_shape = "ANY"
+
   update_policy {
     type           = "PROACTIVE"
     minimal_action = "REPLACE"
@@ -44,6 +47,8 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
     # calculated with: serial console last timestamp after boot - VM start
     # 09:54:28 - 09:45:55 = 513 seconds
     min_ready_sec = 520
+
+    instance_redistribution_type = "NONE"
   }
 }
 


### PR DESCRIPTION
This morning we started with very restricted CI pools (2/6 for Windows and 7/20 for Linux), apparently because the region we run in (us-east1) has three zones, two of them were unable to allocate new nodes, and the default policy is to distribute nodes evenly between zones.

I've manually changed the distribution policy. Unfortunately this option is not yet available in our version of the GCP Terraform plugin.

CHANGELOG_BEGIN
CHANGELOG_END