### PR TITLE
Run scenarios in off-ledger machine

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -29,8 +29,7 @@ final class Conversions(
 
   // The ledger data will not contain information from the partial transaction at this point.
   // We need the mapping for converting error message so we manually add it here.
-  private val ptxCoidToNodeId = incomplete
-    .fold[Map[NodeId, N.GenNode[NodeId, V.ContractId]]](Map.empty)(_.transaction.nodes)
+  private val ptxCoidToNodeId = incomplete.map(_.transaction.nodes).getOrElse(Map.empty)
     .collect { case (nodeId, node: N.NodeCreate[V.ContractId]) =>
       node.coid -> ledger.ptxEventId(nodeId)
     }

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -29,7 +29,9 @@ final class Conversions(
 
   // The ledger data will not contain information from the partial transaction at this point.
   // We need the mapping for converting error message so we manually add it here.
-  private val ptxCoidToNodeId = incomplete.map(_.transaction.nodes).getOrElse(Map.empty)
+  private val ptxCoidToNodeId = incomplete
+    .map(_.transaction.nodes)
+    .getOrElse(Map.empty)
     .collect { case (nodeId, node: N.NodeCreate[V.ContractId]) =>
       node.coid -> ledger.ptxEventId(nodeId)
     }

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -16,7 +16,7 @@ import scala.jdk.CollectionConverters._
 final class Conversions(
     homePackageId: Ref.PackageId,
     ledger: ScenarioLedger,
-    incomplete: IncompleteTransaction,
+    incomplete: Option[IncompleteTransaction],
     traceLog: TraceLog,
     commitLocation: Option[Ref.Location],
     stackTrace: ImmArray[Ref.Location],
@@ -29,7 +29,8 @@ final class Conversions(
 
   // The ledger data will not contain information from the partial transaction at this point.
   // We need the mapping for converting error message so we manually add it here.
-  private val ptxCoidToNodeId = incomplete.transaction.nodes
+  private val ptxCoidToNodeId = incomplete
+    .fold[Map[NodeId, N.GenNode[NodeId, V.ContractId]]](Map.empty)(_.transaction.nodes)
     .collect { case (nodeId, node: N.NodeCreate[V.ContractId]) =>
       node.coid -> ledger.ptxEventId(nodeId)
     }
@@ -75,8 +76,10 @@ final class Conversions(
 
     builder.addAllStackTrace(stackTrace.map(convertLocation).toSeq.asJava)
 
-    builder.setPartialTransaction(
-      convertPartialTransaction(incomplete)
+    incomplete.foreach(ptx =>
+      builder.setPartialTransaction(
+        convertPartialTransaction(ptx)
+      )
     )
 
     err match {

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -84,7 +84,6 @@ da_scala_test(
         "//daml-lf/data",
         "//daml-lf/language",
         "//daml-lf/parser",
-        "//daml-lf/transaction",
     ],
 )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -57,7 +57,7 @@ private[lf] object Pretty {
   def prettyParty(p: Party): Doc =
     char('\'') + text(p) + char('\'')
 
-  def prettyDamlException(ex: SErrorDamlException, ptx: PartialTransaction): Doc =
+  private def prettyDamlException(ex: SErrorDamlException, ptx: PartialTransaction): Doc =
     ex match {
       case DamlEFailedAuthorization(nid, fa) =>
         text(prettyFailedAuthorization(nid, fa))

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -552,14 +552,14 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
     PureCompiledPackages.assertBuild(rawPkgs, compilerConfig)
   }
 
+  private val party = Party.assertFromString("Alice")
+
   private def runUpdateExpr(pkgs1: PureCompiledPackages)(e: Expr): SResult = {
     def transactionSeed: crypto.Hash = crypto.Hash.hashPrivateKey("ExceptionTest.scala")
-    Speedy.Machine.fromScenarioExpr(pkgs1, transactionSeed, e).run()
+    Speedy.Machine.fromUpdateExpr(pkgs1, transactionSeed, e, party).run()
   }
 
   "rollback of creates (mixed versions)" should {
-
-    val party = Party.assertFromString("Alice")
 
     val oldPid: PackageId = Ref.PackageId.assertFromString("OldPackage")
     val newPid: PackageId = Ref.PackageId.assertFromString("Newpackage")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinBigNumericTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinBigNumericTest.scala
@@ -384,10 +384,8 @@ object SBuiltinBigNumericTest {
 
   private def evalSExpr(e: SExpr, onLedger: Boolean): Either[SError, SValue] = {
     val machine = if (onLedger) {
-      val seed = crypto.Hash.hashPrivateKey("SBuiltinTest")
       Speedy.Machine.fromScenarioSExpr(
         compiledPackages,
-        transactionSeed = seed,
         scenario = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(e)),
       )
     } else {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1601,10 +1601,11 @@ object SBuiltinTest {
   private def evalSExpr(e: SExpr, onLedger: Boolean): Either[SError, SValue] = {
     val machine = if (onLedger) {
       val seed = crypto.Hash.hashPrivateKey("SBuiltinTest")
-      Speedy.Machine.fromScenarioSExpr(
+      Speedy.Machine.fromUpdateSExpr(
         compiledPackages,
         transactionSeed = seed,
-        scenario = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(e)),
+        updateSE = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(e)),
+        committer = Ref.Party.assertFromString("Alice"),
       )
     } else {
       Speedy.Machine.fromPureSExpr(compiledPackages, e)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -136,10 +136,11 @@ class OrderingSpec
 
   private def translatePrimValue(typ: iface.Type, v: Value[Value.ContractId]) = {
     val seed = crypto.Hash.hashPrivateKey("OrderingSpec")
-    val machine = Speedy.Machine.fromScenarioSExpr(
+    val machine = Speedy.Machine.fromUpdateSExpr(
       PureCompiledPackages.Empty,
       transactionSeed = seed,
-      scenario = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(SEImportValue(toAstType(typ), v))),
+      updateSE = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(SEImportValue(toAstType(typ), v))),
+      committer = Ref.Party.assertFromString("Alice"),
     )
 
     machine.run() match {

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -7,7 +7,7 @@ import com.daml.lf.CompiledPackages
 import com.daml.lf.crypto
 import com.daml.lf.scenario.ScenarioLedger
 import com.daml.lf.data.Ref._
-import com.daml.lf.data.{Ref, Time}
+import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.engine.Engine
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction}
@@ -15,6 +15,7 @@ import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.lf.speedy.Speedy.{OffLedger, OnLedger}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
+import com.daml.lf.transaction.IncompleteTransaction
 import com.daml.lf.value.Value
 
 import scala.annotation.tailrec
@@ -41,18 +42,16 @@ final case class ScenarioRunner(
   var seed = initialSeed
 
   var ledger: ScenarioLedger = ScenarioLedger.initialLedger(Time.Timestamp.Epoch)
-  val onLedger = machine.ledgerMode match {
-    case OffLedger => throw SRequiresOnLedger("ScenarioRunner")
-    case onLedger: OnLedger => onLedger
-  }
+  var currentSubmission: Option[CurrentSubmission] = None
 
-  def run(): Either[(SError, ScenarioLedger), (Double, Int, ScenarioLedger, SValue)] =
+  def run(): ScenarioResult =
     handleUnsafe(runUnsafe()) match {
-      case Left(err) => Left((err, ledger))
-      case Right(t) => Right(t)
+      case Left(err) =>
+        ScenarioError(ledger, machine.traceLog, currentSubmission, machine.stackTrace(), err)
+      case Right(t) => t
     }
 
-  private def runUnsafe(): (Double, Int, ScenarioLedger, SValue) = {
+  private def runUnsafe(): ScenarioSuccess = {
     // NOTE(JM): Written with an imperative loop and exceptions for speed
     // and so that we don't need to worry about stack usage.
     val startTime = System.nanoTime()
@@ -87,25 +86,17 @@ final case class ScenarioRunner(
             SExpr.SEValue(commands),
             location,
             seed,
+            machine.traceLog,
           )
-          // TODO (MK) We copy the ptx & commit location and the trace
-          // log to the off-ledger machine as a temporary hack until
-          // the callsites have changed sufficiently to allow us to
-          // avoid this gross mess.
-          machine.withOnLedger("runUnsafe") { onLedger =>
-            onLedger.ptx = submitResult.ptx
-            onLedger.commitLocation = location
-          }
-          submitResult.traceLog.iterator.foreach { case (msg, loc) =>
-            machine.traceLog.add(msg, loc)
-          }
           if (mustFail) {
             submitResult match {
-              case Commit(result, _, _, _) =>
+              case Commit(result, _, ptx) =>
+                currentSubmission = Some(CurrentSubmission(location, ptx.finishIncomplete))
                 throw new SRunnerException(
                   ScenarioErrorMustFailSucceeded(result.richTransaction.transaction)
                 )
               case err: SubmissionError =>
+                currentSubmission = None
                 // TODO (MK) This is gross, we need to unwind the transaction to
                 // get the right root context to derived the seed for the next transaction.
                 val rootCtx = err.ptx.unwind.context
@@ -117,13 +108,15 @@ final case class ScenarioRunner(
             }
           } else {
             submitResult match {
-              case Commit(result, value, _, _) =>
+              case Commit(result, value, _) =>
+                currentSubmission = None
                 seed = nextSeed(
                   crypto.Hash.deriveNodeSeed(seed, result.richTransaction.transaction.roots.length)
                 )
                 ledger = result.newLedger
                 callback(value)
-              case SubmissionError(err, _, _) =>
+              case SubmissionError(err, ptx) =>
+                currentSubmission = Some(CurrentSubmission(location, ptx.finishIncomplete))
                 throw new SRunnerException(err)
             }
           }
@@ -143,7 +136,7 @@ final case class ScenarioRunner(
     }
     val endTime = System.nanoTime()
     val diff = (endTime - startTime) / 1000.0 / 1000.0
-    (diff, steps, ledger, finalValue)
+    ScenarioSuccess(ledger, machine.traceLog, diff, steps, finalValue)
   }
 
   private def crash(reason: String) =
@@ -175,13 +168,12 @@ object ScenarioRunner {
     val scenarioExpr = getScenarioExpr(scenarioRef, scenarioDef)
     val speedyMachine = Speedy.Machine.fromScenarioExpr(
       engine.compiledPackages(),
-      transactionSeed,
       scenarioExpr,
     )
     ScenarioRunner(speedyMachine, transactionSeed).run() match {
-      case Left(e) =>
-        throw new RuntimeException(s"error running scenario $scenarioRef in scenario $e")
-      case Right((_, _, l, _)) => l
+      case err: ScenarioError =>
+        throw new RuntimeException(s"error running scenario $scenarioRef in scenario ${err.error}")
+      case success: ScenarioSuccess => success.ledger
     }
   }
 
@@ -214,17 +206,15 @@ object ScenarioRunner {
     // TODO (MK) Temporary to leak the ptx from the submission machine
     // to the parent machine.
     def ptx: PartialTransaction
-    def traceLog: TraceLog
   }
 
   final case class Commit[R](
       result: R,
       value: SValue,
       ptx: PartialTransaction,
-      traceLog: TraceLog,
   ) extends SubmissionResult[R]
 
-  final case class SubmissionError(error: SError, ptx: PartialTransaction, traceLog: TraceLog)
+  final case class SubmissionError(error: SError, ptx: PartialTransaction)
       extends SubmissionResult[Nothing]
 
   // The interface we need from a ledger during submission. We allow abstracting over this so we can play
@@ -384,6 +374,7 @@ object ScenarioRunner {
       commands: SExpr,
       location: Option[Location],
       seed: crypto.Hash,
+      traceLog: TraceLog = Speedy.Machine.newTraceLog,
   ): SubmissionResult[R] = {
     val ledgerMachine = Speedy.Machine(
       compiledPackages = compiledPackages,
@@ -392,6 +383,7 @@ object ScenarioRunner {
       expr = SExpr.SEApp(commands, Array(SExpr.SEValue(SValue.SToken))),
       globalCids = Set.empty,
       committers = committers,
+      traceLog = traceLog,
     )
     val onLedger = ledgerMachine.ledgerMode match {
       case OffLedger => throw SRequiresOnLedger("ScenarioRunner")
@@ -404,23 +396,23 @@ object ScenarioRunner {
           onLedger.ptxInternal.finish match {
             case PartialTransaction.CompleteTransaction(tx) =>
               ledger.commit(committers, readAs, location, tx) match {
-                case Left(err) => SubmissionError(err, onLedger.ptxInternal, ledgerMachine.traceLog)
+                case Left(err) => SubmissionError(err, onLedger.ptxInternal)
                 case Right(r) =>
-                  Commit(r, resultValue, onLedger.ptxInternal, ledgerMachine.traceLog)
+                  Commit(r, resultValue, onLedger.ptxInternal)
               }
             case PartialTransaction.IncompleteTransaction(ptx) =>
               throw new RuntimeException(s"Unexpected abort: $ptx")
           }
         case SResultError(err) =>
-          SubmissionError(err, onLedger.ptxInternal, ledgerMachine.traceLog)
+          SubmissionError(err, onLedger.ptxInternal)
         case SResultNeedContract(coid, tid @ _, committers, _, cbPresent) =>
           ledger.lookupContract(coid, committers, readAs, cbPresent) match {
-            case Left(err) => SubmissionError(err, onLedger.ptxInternal, ledgerMachine.traceLog)
+            case Left(err) => SubmissionError(err, onLedger.ptxInternal)
             case Right(_) => go()
           }
         case SResultNeedKey(keyWithMaintainers, committers, cb) =>
           ledger.lookupKey(keyWithMaintainers.globalKey, committers, readAs, cb) match {
-            case Left(err) => SubmissionError(err, onLedger.ptxInternal, ledgerMachine.traceLog)
+            case Left(err) => SubmissionError(err, onLedger.ptxInternal)
             case Right(_) => go()
           }
         case SResultNeedLocalKeyVisible(stakeholders, committers, cb) =>
@@ -451,4 +443,29 @@ object ScenarioRunner {
       // to avoid breaking all tests we keep it for now at least.
       Time.Timestamp.MinValue,
     )
+
+  sealed abstract class ScenarioResult {
+    def ledger: ScenarioLedger
+    def traceLog: TraceLog
+  }
+
+  final case class CurrentSubmission(
+      commitLocation: Option[Location],
+      ptx: IncompleteTransaction,
+  )
+
+  final case class ScenarioSuccess(
+      ledger: ScenarioLedger,
+      traceLog: TraceLog,
+      duration: Double,
+      steps: Int,
+      resultValue: SValue,
+  ) extends ScenarioResult
+  final case class ScenarioError(
+      ledger: ScenarioLedger,
+      traceLog: TraceLog,
+      currentSubmission: Option[CurrentSubmission],
+      stackTrace: ImmArray[Location],
+      error: SError,
+  ) extends ScenarioResult
 }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -444,7 +444,7 @@ object ScenarioRunner {
       Time.Timestamp.MinValue,
     )
 
-  sealed abstract class ScenarioResult {
+  sealed abstract class ScenarioResult extends Product with Serializable {
     def ledger: ScenarioLedger
     def traceLog: TraceLog
   }

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -52,14 +52,11 @@ class CollectAuthorityState {
         stacktracing = Compiler.NoStackTrace
       )
 
-    // NOTE(MH): We use a static seed to get reproducible runs.
-    val seeding = crypto.Hash.secureRandom(crypto.Hash.hashPrivateKey("scenario-perf"))
     val compiledPackages = PureCompiledPackages.assertBuild(packagesMap, compilerConfig)
     val expr = EVal(Identifier(packages.main._1, QualifiedName.assertFromString(scenario)))
 
     machine = Machine.fromScenarioExpr(
       compiledPackages,
-      seeding(),
       expr,
     )
     the_sexpr = machine.ctrl
@@ -95,9 +92,9 @@ class CollectAuthorityState {
             location,
             crypto.Hash.hashPrivateKey(step.toString),
           ) match {
-            case ScenarioRunner.Commit(_, value, _, _) =>
+            case ScenarioRunner.Commit(_, value, _) =>
               callback(value)
-            case ScenarioRunner.SubmissionError(err, _, _) => crash(s"Submission failed $err")
+            case ScenarioRunner.SubmissionError(err, _) => crash(s"Submission failed $err")
           }
         case SResultNeedContract(_, _, _, _, _) =>
           crash("Off-ledger need contract callback")
@@ -137,8 +134,8 @@ class CollectAuthorityState {
             location,
             crypto.Hash.hashPrivateKey(step.toString),
           ) match {
-            case ScenarioRunner.SubmissionError(err, _, _) => crash(s"Submission failed $err")
-            case ScenarioRunner.Commit(result, value, _, _) =>
+            case ScenarioRunner.SubmissionError(err, _) => crash(s"Submission failed $err")
+            case ScenarioRunner.Commit(result, value, _) =>
               ledger = result.newLedger
               cachedCommit = cachedCommit + (step -> value)
               callback(value)

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -17,13 +17,13 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
     "mangle party names correctly" in {
       val e = Ast.EScenario(Ast.ScenarioGetParty(Ast.EPrimLit(Ast.PLText("foo-bar"))))
       val txSeed = crypto.Hash.hashPrivateKey("ScenarioRunnerTest")
-      val m = Speedy.Machine.fromScenarioExpr(PureCompiledPackages.Empty, txSeed, e)
+      val m = Speedy.Machine.fromScenarioExpr(PureCompiledPackages.Empty, e)
       val sr = ScenarioRunner(m, txSeed, _ + "-XXX")
       sr.run() match {
-        case Right((_, _, _, value)) =>
-          value shouldBe SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX"))
-        case res =>
-          sys.error(s"unexpected result $res")
+        case success: ScenarioRunner.ScenarioSuccess =>
+          success.resultValue shouldBe SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX"))
+        case error: ScenarioRunner.ScenarioError =>
+          sys.error(s"unexpected result ${error.error}")
       }
     }
   }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -66,12 +66,6 @@ object ScriptF {
     def compiledPackages = machine.compiledPackages
     val valueTranslator = new ValueTranslator(compiledPackages.interface)
     val utcClock = Clock.systemUTC()
-    // Copy the tracelog from the client to the off-ledger machine.
-    def copyTracelog(client: ScriptLedgerClient) = {
-      for ((msg, optLoc) <- client.tracelogIterator) {
-        machine.traceLog.add(msg, optLoc)
-      }
-    }
     def addPartyParticipantMapping(party: Party, participant: Participant) = {
       _clients =
         _clients.copy(party_participants = _clients.party_participants + (party -> participant))
@@ -108,7 +102,6 @@ object ScriptF {
           data.cmds,
           data.stackTrace.topFrame,
         )
-        _ = env.copyTracelog(client)
         v <- submitRes match {
           case Right(results) =>
             Converter.toFuture(
@@ -163,7 +156,6 @@ object ScriptF {
           data.cmds,
           data.stackTrace.topFrame,
         )
-        _ = env.copyTracelog(client)
         v <- submitRes match {
           case Right(()) =>
             Future.successful(SEApp(SEValue(data.continue), Array(SEValue(SUnit))))
@@ -200,7 +192,6 @@ object ScriptF {
             submitRes,
           )
         )
-        _ = env.copyTracelog(client)
       } yield SEApp(SEValue(data.continue), Array(SEValue(res)))
   }
   final case class Query(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
@@ -322,6 +322,4 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
       case TreeEvent(TreeEvent.Kind.Empty) =>
         throw new ConverterException("Invalid tree event Empty")
     }
-
-  override def tracelogIterator = Iterator.empty
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -451,8 +451,6 @@ class JsonLedgerClient(
       case SuccessResponse(result, _) => Future.successful(Right(result))
     }
   }
-
-  override def tracelogIterator = Iterator.empty
 }
 
 object JsonLedgerClient {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
@@ -126,6 +126,4 @@ trait ScriptLedgerClient {
   def setStaticTime(
       time: Time.Timestamp
   )(implicit ec: ExecutionContext, esf: ExecutionSequencerFactory, mat: Materializer): Future[Unit]
-
-  def tracelogIterator: Iterator[(String, Option[Location])]
 }


### PR DESCRIPTION
This PR builds on the previous PR that split scenario execution in two
different speedy machines and now actually makes the machine that runs
scenarios run in off-ledger mode just like we handle Daml Script.

This required a bunch of refactoring to make it nice so apologies for
the slightly large PR. Hopefully it’s still relatively easy to follow
and luckily it deletes more code than it adds.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
