### PR TITLE
Scenario: move Scenario Error Throwable to scenario package

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -18,7 +18,6 @@ import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.ModuleName
 import com.daml.lf.language.LanguageVersion
 import com.daml.lf.scenario.api.v1.{Map => _, _}
-import com.daml.lf.speedy.ScenarioRunner
 import io.grpc.stub.StreamObserver
 import io.grpc.{Status, StatusRuntimeException}
 import io.grpc.netty.NettyServerBuilder

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -336,7 +336,7 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
         case SResultError(err) =>
           return ResultError(
             Error.Interpretation.Generic(
-              s"Interpretation error: ${Pretty.prettyError(err, onLedger.ptxInternal).render(80)}"
+              s"Interpretation error: ${Pretty.prettyError(err, Some(onLedger.ptxInternal)).render(80)}"
             ),
             detailMsg,
           )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -12,15 +12,9 @@ import Value.{NodeId => _, _}
 import com.daml.lf.transaction.Node._
 import com.daml.lf.ledger._
 import com.daml.lf.data.Ref._
-import com.daml.lf.data.Time
 import com.daml.lf.scenario.ScenarioLedger.TransactionId
 import com.daml.lf.scenario._
-import com.daml.lf.transaction.{
-  ContractKeyUniquenessMode,
-  NodeId,
-  TransactionVersion,
-  Transaction => Tx,
-}
+import com.daml.lf.transaction.{NodeId, TransactionVersion => TxVersion, Transaction => Tx}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SBuiltin._
@@ -31,14 +25,7 @@ import com.daml.lf.speedy.SBuiltin._
 
 private[lf] object Pretty {
 
-  private[this] val dummyTx = PartialTransaction.initial(
-    (_ => TransactionVersion.minVersion),
-    ContractKeyUniquenessMode.On,
-    submissionTime = Time.Timestamp.MinValue,
-    initialSeeds = InitialSeeding.NoSeed,
-  )
-
-  def prettyError(err: SError, ptx: PartialTransaction = dummyTx): Doc =
+  def prettyError(err: SError, optPtx: Option[PartialTransaction] = None): Doc =
     // TODO https://github.com/digital-asset/daml/issues/9974
     //  (MK) I’m not convinced the partial transaction here provides any real value.
     //  Afaict the only thing we use it for is to produce slightly different error
@@ -47,20 +34,20 @@ private[lf] object Pretty {
     //  have a hard time believing that it is really useful here.
     text("Error:") & (err match {
       case ex: SErrorDamlException =>
-        prettyDamlException(ex.error, ptx)
+        prettyDamlException(ex.error, optPtx)
       case SErrorCrash(reason) =>
         text(s"CRASH: $reason")
       case SRequiresOnLedger(operation) =>
         text(s"Operation is not supported off-ledger: $operation")
-
-      case serr: SErrorScenario =>
-        prettyScenarioError(serr)
     })
 
   def prettyParty(p: Party): Doc =
     char('\'') + text(p) + char('\'')
 
-  def prettyDamlException(error: interpretation.Error, ptx: PartialTransaction = dummyTx): Doc = {
+  def prettyDamlException(
+      error: interpretation.Error,
+      optPtx: Option[PartialTransaction] = None,
+  ): Doc = {
     import interpretation.Error._
     error match {
       case FailedAuthorization(nid, fa) =>
@@ -77,10 +64,7 @@ private[lf] object Pretty {
         text("Update failed due to fetch of an inactive contract") & prettyContractId(coid) &
           char('(') + (prettyTypeConName(tid)) + text(").") /
           text(s"The contract had been consumed in sub-transaction #$consumedBy:") +
-          (ptx.nodes.get(consumedBy) match {
-            // FIXME(JM): How should we show this? If the node pointed to by consumedBy
-            // is not in nodes, it must not be done yet, hence the contract is recursively
-            // exercised.
+          (optPtx.flatMap(_.nodes.get(consumedBy)) match {
             case None =>
               (line + text("Recursive exercise of ") + prettyTypeConName(tid)).nested(4)
             case Some(node) =>
@@ -153,57 +137,6 @@ private[lf] object Pretty {
             case Some(coid) => text("found") & prettyContractId(coid)
           })
     }
-
-  def prettyScenarioError(serr: SErrorScenario): Doc =
-    text("Scenario failed") & (serr match {
-      case ScenarioErrorContractNotEffective(coid, tid, effectiveAt) =>
-        text(s"due to a fetch of an inactive contract") & prettyContractId(coid) &
-          char('(') + (prettyIdentifier(tid)) + text(").") &
-          text(s"that becomes effective at $effectiveAt")
-      case ScenarioErrorContractNotActive(coid, tid, consumedBy) =>
-        text("due to a fetch of a consumed contract") & prettyContractId(coid) &
-          char('(') + (prettyIdentifier(tid)) + text(").") /
-          text("The contract had been consumed in transaction") & prettyEventId(consumedBy)
-      case ScenarioErrorContractNotVisible(coid, tid, actAs, readAs, observers) =>
-        text("due to the failure to fetch the contract") & prettyContractId(coid) &
-          char('(') + (prettyIdentifier(tid)) + text(").") /
-          text("The contract had not been disclosed to the reading parties:") &
-          text("actAs:") & intercalate(comma + space, actAs.map(prettyParty))
-            .tightBracketBy(char('{'), char('}')) &
-          text("readAs:") & intercalate(comma + space, readAs.map(prettyParty))
-            .tightBracketBy(char('{'), char('}')) +
-          char('.') / text("The contract had been disclosed to:") & intercalate(
-            comma + space,
-            observers.map(prettyParty),
-          ) + char('.')
-      case ScenarioErrorContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
-        text("due to the failure to fetch the contract") & prettyContractId(coid) &
-          char('(') + (prettyIdentifier(gk.templateId)) + text(") associated with key ") +
-          prettyValue(false)(gk.key) &
-          text("The contract had not been disclosed to the reading parties:") &
-          text("actAs:") & intercalate(comma + space, actAs.map(prettyParty))
-            .tightBracketBy(char('{'), char('}')) &
-          text("readAs:") & intercalate(comma + space, readAs.map(prettyParty))
-            .tightBracketBy(char('{'), char('}')) +
-          char('.') / text("Stakeholders:") & intercalate(
-            comma + space,
-            stakeholders.map(prettyParty),
-          ) + char('.')
-
-      case ScenarioErrorCommitError(ScenarioLedger.CommitError.UniqueKeyViolation(gk)) =>
-        (text("due to unique key violation for key:") & prettyValue(false)(gk.gk.key) & text(
-          "for template"
-        ) & prettyIdentifier(gk.gk.templateId))
-
-      case ScenarioErrorMustFailSucceeded(tx @ _) =>
-        // TODO(JM): Further info needed. Location annotations?
-        text("due to a mustfailAt that succeeded.")
-
-      case ScenarioErrorInvalidPartyName(_, msg) => text(s"Invalid party: $msg")
-
-      case ScenarioErrorPartyAlreadyExists(party) =>
-        text(s"Tried to allocate a party that already exists: $party")
-    })
 
   private def prettyFailedAuthorization(id: NodeId, failure: FailedAuthorization): String = {
     failure match {
@@ -347,7 +280,7 @@ private[lf] object Pretty {
     )
   }
 
-  def prettyOptVersion(opt: Option[TransactionVersion]) = {
+  def prettyOptVersion(opt: Option[TxVersion]) = {
     opt match {
       case Some(v) =>
         text("version:") & str(v.protoValue)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -4,17 +4,16 @@
 package com.daml.lf
 package speedy
 
-import com.daml.lf.data.Ref._
-import com.daml.lf.data.Time
-import com.daml.lf.ledger.EventId
-import com.daml.lf.transaction.{GlobalKey, Transaction => Tx}
-import com.daml.lf.value.Value.ContractId
-import com.daml.lf.scenario.ScenarioLedger
+import scala.util.control.NoStackTrace
 
 object SError {
 
   /** Errors that can arise during interpretation */
-  sealed abstract class SError extends RuntimeException with Product with Serializable
+  sealed abstract class SError
+      extends RuntimeException
+      with NoStackTrace
+      with Product
+      with Serializable
 
   /** A malformed expression was encountered. The assumption is that the
     * expressions are type-checked and the loaded packages have been validated,
@@ -36,56 +35,5 @@ object SError {
 
   /** Daml exceptions that should be reported to the user. */
   final case class SErrorDamlException(error: interpretation.Error) extends SError
-
-  /** Errors from scenario interpretation. */
-  sealed trait SErrorScenario extends SError
-
-  final case class ScenarioErrorContractNotEffective(
-      coid: ContractId,
-      templateId: Identifier,
-      effectiveAt: Time.Timestamp,
-  ) extends SErrorScenario
-
-  final case class ScenarioErrorContractNotActive(
-      coid: ContractId,
-      templateId: Identifier,
-      consumedBy: EventId,
-  ) extends SErrorScenario
-
-  /** A fetch or exercise was being made against a contract that has not
-    * been disclosed to 'committer'.
-    */
-  final case class ScenarioErrorContractNotVisible(
-      coid: ContractId,
-      templateId: Identifier,
-      actAs: Set[Party],
-      readAs: Set[Party],
-      observers: Set[Party],
-  ) extends SErrorScenario
-
-  /** A fetchByKey or lookupByKey was being made against a key
-    * for which the contract exists but has not
-    * been disclosed to 'committer'.
-    */
-  final case class ScenarioErrorContractKeyNotVisible(
-      coid: ContractId,
-      key: GlobalKey,
-      actAs: Set[Party],
-      readAs: Set[Party],
-      stakeholders: Set[Party],
-  ) extends SErrorScenario
-
-  /** The transaction failed due to a commit error */
-  final case class ScenarioErrorCommitError(commitError: ScenarioLedger.CommitError)
-      extends SErrorScenario
-
-  /** The transaction produced by the update expression in a 'mustFailAt' succeeded. */
-  final case class ScenarioErrorMustFailSucceeded(tx: Tx.Transaction) extends SErrorScenario
-
-  /** Invalid party name supplied to 'getParty'. */
-  final case class ScenarioErrorInvalidPartyName(name: String, msg: String) extends SErrorScenario
-
-  /** Tried to allocate a party that already exists. */
-  final case class ScenarioErrorPartyAlreadyExists(name: String) extends SErrorScenario
 
 }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -11,6 +11,7 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.daml.lf.language.Util._
 import com.daml.lf.speedy.Pretty._
+import com.daml.lf.scenario.{ScenarioRunner, Pretty => PrettyScenario}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SExpr.LfDefRef
 import com.daml.lf.validation.Validation
@@ -526,10 +527,7 @@ object Repl {
           state.scenarioRunner.run(expr)
         errOrLedger match {
           case error: ScenarioRunner.ScenarioError =>
-            println(
-              prettyError(error.error)
-                .render(128)
-            )
+            println(PrettyScenario.prettyError(error.error).render(128))
             (false, state)
           case success: ScenarioRunner.ScenarioSuccess =>
             // NOTE(JM): cannot print this, output used in tests.
@@ -564,8 +562,7 @@ object Repl {
           println(
             "failed at " +
               prettyLoc(machine.lastLocation).render(128) +
-              ": " + prettyError(error.error)
-                .render(128)
+              ": " + PrettyScenario.prettyError(error.error).render(128)
           )
           failures += 1
         case success: ScenarioRunner.ScenarioSuccess =>
@@ -595,7 +592,7 @@ object Repl {
         machine.withOnLedger("cmdProfile") { onLedger =>
           errOrLedger match {
             case error: ScenarioRunner.ScenarioError =>
-              println(prettyError(error.error, onLedger.ptx).render(128))
+              println(PrettyScenario.prettyError(error.error, Some(onLedger.ptx)).render(128))
               (false, state)
             case _: ScenarioRunner.ScenarioSuccess =>
               println("Writing profile...")

--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -13,12 +13,15 @@ load(
     "//rules_daml:daml.bzl",
     "daml_compile",
 )
+load("@scala_version//:index.bzl", "scala_major_version")
 
 da_scala_library(
     name = "scenario-interpreter",
     srcs = glob(["src/main/**/*.scala"]),
     main_class = "com.daml.lf.speedy.Main",
+    scala_deps = ["@maven//:org_typelevel_paiges_core"],
     tags = ["maven_coordinates=com.daml:daml-lf-scenario-interpreter:__VERSION__"],
+    versioned_scala_deps = {"2.12": ["@maven//:org_scalaz_scalaz_core"]},
     visibility = [
         "//visibility:public",
     ],

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package scenario
+
+import com.daml.lf.data.Ref.{Identifier, Party}
+import com.daml.lf.data.Time
+import com.daml.lf.ledger.EventId
+import com.daml.lf.speedy.SError.SError
+import com.daml.lf.transaction.{GlobalKey, Transaction}
+import com.daml.lf.value.Value.ContractId
+
+import scala.util.control.NoStackTrace
+
+/** Errors from scenario interpretation. */
+sealed abstract class Error
+    extends RuntimeException
+    with NoStackTrace
+    with Product
+    with Serializable
+
+object Error {
+
+  final case class RunnerException(err: SError) extends Error
+
+  final case class Internal(reason: String) extends Error {
+    override def toString = "CRASH: " + reason
+  }
+
+  final case class ContractNotEffective(
+      coid: ContractId,
+      templateId: Identifier,
+      effectiveAt: Time.Timestamp,
+  ) extends Error
+
+  final case class ContractNotActive(
+      coid: ContractId,
+      templateId: Identifier,
+      consumedBy: EventId,
+  ) extends Error
+
+  /** A fetch or exercise was being made against a contract that has not
+    * been disclosed to 'committer'.
+    */
+  final case class ContractNotVisible(
+      coid: ContractId,
+      templateId: Identifier,
+      actAs: Set[Party],
+      readAs: Set[Party],
+      observers: Set[Party],
+  ) extends Error
+
+  /** A fetchByKey or lookupByKey was being made against a key
+    * for which the contract exists but has not
+    * been disclosed to 'committer'.
+    */
+  final case class ContractKeyNotVisible(
+      coid: ContractId,
+      key: GlobalKey,
+      actAs: Set[Party],
+      readAs: Set[Party],
+      stakeholders: Set[Party],
+  ) extends Error
+
+  /** The transaction failed due to a commit error */
+  final case class CommitError(commitError: ScenarioLedger.CommitError) extends Error
+
+  /** The transaction produced by the update expression in a 'mustFailAt' succeeded. */
+  final case class MustFailSucceeded(tx: Transaction.Transaction) extends Error
+
+  /** Invalid party name supplied to 'getParty'. */
+  final case class InvalidPartyName(name: String, msg: String) extends Error
+
+  /** Tried to allocate a party that already exists. */
+  final case class PartyAlreadyExists(name: String) extends Error
+
+}

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package scenario
+
+import com.daml.lf.speedy.PartialTransaction
+
+import org.typelevel.paiges.Doc
+import org.typelevel.paiges.Doc._
+
+private[lf] object Pretty {
+
+  import speedy.Pretty._
+
+  def prettyError(err: Error, optPtx: Option[PartialTransaction] = None): Doc =
+    err match {
+      case Error.RunnerException(serror) =>
+        speedy.Pretty.prettyError(serror, optPtx)
+      case Error.Internal(msg) =>
+        text(s"CRASH: $msg ")
+      case Error.ContractNotEffective(coid, tid, effectiveAt) =>
+        text(s"Scenario failed due to a fetch of an inactive contract") & prettyContractId(coid) &
+          char('(') + (prettyIdentifier(tid)) + text(").") &
+          text(s"that becomes effective at $effectiveAt")
+      case Error.ContractNotActive(coid, tid, consumedBy) =>
+        text("Scenario failed due to a fetch of a consumed contract") & prettyContractId(coid) &
+          char('(') + (prettyIdentifier(tid)) + text(").") /
+          text("The contract had been consumed in transaction") & prettyEventId(consumedBy)
+      case Error.ContractNotVisible(coid, tid, actAs, readAs, observers) =>
+        text("Scenario failed due to the failure to fetch the contract") & prettyContractId(coid) &
+          char('(') + (prettyIdentifier(tid)) + text(").") /
+          text("The contract had not been disclosed to the reading parties:") &
+          text("actAs:") & intercalate(comma + space, actAs.map(prettyParty))
+            .tightBracketBy(char('{'), char('}')) &
+          text("readAs:") & intercalate(comma + space, readAs.map(prettyParty))
+            .tightBracketBy(char('{'), char('}')) +
+          char('.') / text("The contract had been disclosed to:") & intercalate(
+            comma + space,
+            observers.map(prettyParty),
+          ) + char('.')
+      case Error.ContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
+        text("Scenario failed due to the failure to fetch the contract") & prettyContractId(coid) &
+          char('(') + (prettyIdentifier(gk.templateId)) + text(") associated with key ") +
+          prettyValue(false)(gk.key) &
+          text("The contract had not been disclosed to the reading parties:") &
+          text("actAs:") & intercalate(comma + space, actAs.map(prettyParty))
+            .tightBracketBy(char('{'), char('}')) &
+          text("readAs:") & intercalate(comma + space, readAs.map(prettyParty))
+            .tightBracketBy(char('{'), char('}')) +
+          char('.') / text("Stakeholders:") & intercalate(
+            comma + space,
+            stakeholders.map(prettyParty),
+          ) + char('.')
+
+      case Error.CommitError(ScenarioLedger.CommitError.UniqueKeyViolation(gk)) =>
+        (text("Scenario failed due to unique key violation for key:") & prettyValue(false)(
+          gk.gk.key
+        ) & text(
+          "for template"
+        ) & prettyIdentifier(gk.gk.templateId))
+
+      case Error.MustFailSucceeded(tx @ _) =>
+        // TODO(JM): Further info needed. Location annotations?
+        text("Scenario failed due to a mustfailAt that succeeded.")
+
+      case Error.InvalidPartyName(_, msg) => text(s"Error: Invalid party: $msg")
+
+      case Error.PartyAlreadyExists(party) =>
+        text(s"Error: Tried to allocate a party that already exists: $party")
+    }
+
+}

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -14,7 +14,7 @@ import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
-import com.daml.lf.scenario.ScenarioLedger
+import com.daml.lf.scenario.{ScenarioLedger, ScenarioRunner}
 import com.daml.lf.speedy.Speedy.Machine
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -166,7 +166,7 @@ class CachedLedgerApi(initStep: Int, ledger: ScenarioLedger)
       actAs: Set[Party],
       readAs: Set[Party],
       callback: ContractInst[Value.VersionedValue[ContractId]] => Unit,
-  ): Either[SError.SError, Unit] = {
+  ): Either[scenario.Error, Unit] = {
     step += 1
     super.lookupContract(
       coid,
@@ -187,7 +187,7 @@ class CannedLedgerApi(
       actAs: Set[Party],
       readAs: Set[Party],
       callback: ContractInst[Value.VersionedValue[ContractId]] => Unit,
-  ): Either[SError.SError, Unit] = {
+  ): Either[scenario.Error, Unit] = {
     step += 1
     val coinst = cachedContract(step)
     Right(callback(coinst))

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/ScenarioRunnerTest.scala
@@ -3,10 +3,11 @@
 
 package com.daml
 package lf
-package speedy
+package scenario
 
 import com.daml.lf.data.Ref
 import com.daml.lf.language.Ast
+import com.daml.lf.speedy.SValue
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatest.concurrent.ScalaFutures
@@ -17,7 +18,7 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
     "mangle party names correctly" in {
       val e = Ast.EScenario(Ast.ScenarioGetParty(Ast.EPrimLit(Ast.PLText("foo-bar"))))
       val txSeed = crypto.Hash.hashPrivateKey("ScenarioRunnerTest")
-      val m = Speedy.Machine.fromScenarioExpr(PureCompiledPackages.Empty, e)
+      val m = speedy.Speedy.Machine.fromScenarioExpr(PureCompiledPackages.Empty, e)
       val sr = ScenarioRunner(m, txSeed, _ + "-XXX")
       sr.run() match {
         case success: ScenarioRunner.ScenarioSuccess =>

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -11,8 +11,7 @@ import com.daml.lf.data.Ref.DefinitionRef
 import com.daml.lf.data.{Relation => _, _}
 import com.daml.lf.engine.Engine
 import com.daml.lf.language.Ast
-import com.daml.lf.scenario.ScenarioLedger
-import com.daml.lf.speedy.ScenarioRunner
+import com.daml.lf.scenario.{ScenarioLedger, ScenarioRunner}
 import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.sandbox.stores.InMemoryActiveLedgerState
 import com.daml.platform.store.entries.LedgerEntry
@@ -122,7 +121,7 @@ private[sandbox] object ScenarioLoader {
     (scenarioLedger, scenarioRef)
   }
 
-  @nowarn("cat=deprecation&origin=com\\.daml\\.lf\\.speedy\\.ScenarioRunner\\.getScenarioLedger")
+  @nowarn("cat=deprecation&origin=com\\.daml\\.lf\\.scenario\\.ScenarioRunner\\.getScenarioLedger")
   private def getScenarioLedger(
       engine: Engine,
       transactionSeed: Hash,


### PR DESCRIPTION
com.daml.lf.speedy.SErrorScenario => com.daml.lf.scenario.Error

We move scenario errors out of speedy as the latter has no need to know about. 

part of #9974

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
