### PR TITLE
[JSON-API] Add metrics for ledger command submission timing

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -217,7 +217,10 @@ class Endpoints(
         _ <- EitherT.pure(parseAndDecodeTimerCtx.close())
 
         ac <- eitherT(
-          handleFutureEitherFailure(commandService.create(jwt, jwtPayload, cmd))
+          Timed.future(
+            metrics.daml.HttpJsonApi.commandSubmissionLedgerTimer,
+            handleFutureEitherFailure(commandService.create(jwt, jwtPayload, cmd)),
+          )
         ): ET[domain.ActiveContract[ApiValue]]
       } yield ac
     }
@@ -241,8 +244,11 @@ class Endpoints(
         resolvedCmd = cmd.copy(argument = apiArg, reference = resolvedRef)
 
         resp <- eitherT(
-          handleFutureEitherFailure(
-            commandService.exercise(jwt, jwtPayload, resolvedCmd)
+          Timed.future(
+            metrics.daml.HttpJsonApi.commandSubmissionLedgerTimer,
+            handleFutureEitherFailure(
+              commandService.exercise(jwt, jwtPayload, resolvedCmd)
+            ),
           )
         ): ET[domain.ExerciseResponse[ApiValue]]
 
@@ -261,8 +267,11 @@ class Endpoints(
         _ <- EitherT.pure(parseAndDecodeTimerCtx.close())
 
         resp <- eitherT(
-          handleFutureEitherFailure(
-            commandService.createAndExercise(jwt, jwtPayload, cmd)
+          Timed.future(
+            metrics.daml.HttpJsonApi.commandSubmissionLedgerTimer,
+            handleFutureEitherFailure(
+              commandService.createAndExercise(jwt, jwtPayload, cmd)
+            ),
           )
         ): ET[domain.ExerciseResponse[ApiValue]]
       } yield resp

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -731,6 +731,9 @@ final class Metrics(val registry: MetricRegistry) {
       val dbFindByContractKey: Timer = registry.timer(Prefix :+ "db_find_by_contract_key_timing")
       // Meters how long a find by contract id database operation takes
       val dbFindByContractId: Timer = registry.timer(Prefix :+ "db_find_by_contract_id_timing")
+      // Meters how long processing of the command submission request takes on the ledger
+      val commandSubmissionLedgerTimer: Timer =
+        registry.timer(Prefix :+ "command_submission_ledger_timing")
       // Meters http requests throughput
       val httpRequestThroughput: Meter = registry.meter(Prefix :+ "http_request_throughput")
       // Meters how many websocket connections are currently active


### PR DESCRIPTION
This will fix #10020 (finally).

changelog_begin

- [JSON-API] Timing metrics which measure how long the processing of a command submission request takes on the ledger are now available

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
