### PR TITLE
dev-env: Use `nix-shell` for scripts instead of sourcing `dade-common`.

### DIFF
--- a/dev-env/bin/ghcide
+++ b/dev-env/bin/ghcide
@@ -1,4 +1,9 @@
-#!/usr/bin/env bash
-DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
-bazel build @ghcide-exe//ghcide && bazel-bin/external/ghcide/ghcide-0.7.2.0/_install/bin/ghcide "$@"
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../../shell.nix
+
+set -e
+set -u
+set -x
+
+bazel build @ghcide-exe//ghcide
+exec ./bazel-bin/external/ghcide/ghcide-0.7.2.0/_install/bin/ghcide "$@"

--- a/dev-env/bin/ghcide
+++ b/dev-env/bin/ghcide
@@ -1,9 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash ../../shell.nix
 
-set -e
-set -u
-set -x
+set -euo pipefail
 
 bazel build @ghcide-exe//ghcide
 exec ./bazel-bin/external/ghcide/ghcide-0.7.2.0/_install/bin/ghcide "$@"

--- a/language-support/hs/bindings/README.md
+++ b/language-support/hs/bindings/README.md
@@ -48,12 +48,17 @@ Also, in the instructions below we export the `daml-ledger` package to `/tmp` wh
     make
     make prefix=/usr/local/grpc install
 
+## Install Nix
+
+Follow the instructions from the [Nix manual][].
+
+[Nix manual]: https://nixos.org/manual/nix/
+
 ## Clone daml repo, and export the daml-ledger package
 
     cd /tmp
     git clone https://github.com/digital-asset/daml.git
     cd daml
-    eval $(dev-env/bin/dade-assist)
     language-support/hs/bindings/export-package.sh /tmp
 
 ## Write a Daml Ledger App in Haskell (or copy one!), and build it

--- a/language-support/hs/bindings/export-package.sh
+++ b/language-support/hs/bindings/export-package.sh
@@ -1,13 +1,15 @@
-#!/usr/bin/env bash
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../../../shell.nix
+
 # Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -eou pipefail
 
 if [ "$#" -ne 1 ]; then
-    echo "Expected exactly one argument."
-    echo "Usage: ${BASH_SOURCE[0]} TARGET_DIR"
-    exit 1
+  echo "Expected exactly one argument."
+  echo "Usage: ${BASH_SOURCE[0]} TARGET_DIR"
+  exit 1
 fi
 
 TARGET_DIR=$(realpath $1)

--- a/language-support/hs/bindings/package.yaml
+++ b/language-support/hs/bindings/package.yaml
@@ -7,7 +7,7 @@ description:         Haskell bindings for a DAML Ledger
 license:             Apache-2.0
 author:              The DAML Authors
 maintainer:          nick.chapman@digitalasset.com
-github:              https://github.com/digital-asset/daml
+github:              digital-asset/daml
 
 dependencies:
 - async

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -150,6 +150,7 @@ in rec {
     # Build tools
 
     bazel = pkgs.writeScriptBin "bazel" (''
+      #!${pkgs.bash}/bin/bash
       # Set the JAVA_HOME to our JDK
       export JAVA_HOME=${jdk.home}
       export GIT_SSL_CAINFO="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,8 +1,8 @@
-{ system ? builtins.currentSystem }:
+{ system ? builtins.currentSystem
+, pkgs ? import ./nixpkgs.nix { inherit system; }
+}:
 
 let
-  pkgs = import ./nixpkgs.nix { inherit system; };
-
   # Selects "bin" output from multi-output derivations which are has it. For
   # other multi-output derivations, select only the first output. For
   # single-output generation, do nothing.
@@ -27,10 +27,20 @@ in rec {
 
   ghc = bazel_dependencies.ghc;
 
-  # Tools used in the dev-env. These are invoked through wrappers
-  # in dev-env/bin. See the development guide for more information:
-  # https://digitalasset.atlassian.net/wiki/spaces/DEL/pages/104431683/Maintaining+the+Nix+Development+Environment
-  tools = pkgs.lib.mapAttrs (_: pkg: selectBin pkg) (rec {
+  # wrap the .bazelrc to automate the configuration of
+  # `build --config <kernel>`
+  bazelrc =
+    let
+      kernel =
+        if pkgs.stdenv.targetPlatform.isLinux then "linux"
+        else if pkgs.stdenv.targetPlatform.isDarwin then "darwin"
+        else throw "unsupported system";
+    in
+      pkgs.writeText "daml-bazelrc" ''
+        build --config ${kernel}
+      '';
+
+  toolAttrs = rec {
     # Code generators
 
     make            = pkgs.gnumake;
@@ -139,24 +149,7 @@ in rec {
 
     # Build tools
 
-    # wrap the .bazelrc to automate the configuration of
-    # `build --config <kernel>`
-    bazelrc =
-      let
-        kernel =
-          if pkgs.stdenv.targetPlatform.isLinux then "linux"
-          else if pkgs.stdenv.targetPlatform.isDarwin then "darwin"
-          else throw "unsupported system";
-      in
-        pkgs.writeText "daml-bazelrc" ''
-          build --config ${kernel}
-        '';
-
     bazel = pkgs.writeScriptBin "bazel" (''
-      if [ -z "''${DADE_REPO_ROOT:-}" ]; then
-          >&2 echo "Please run bazel inside of the dev-env"
-          exit 1
-      fi
       # Set the JAVA_HOME to our JDK
       export JAVA_HOME=${jdk.home}
       export GIT_SSL_CAINFO="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
@@ -218,7 +211,10 @@ in rec {
       template
     ]);
     nix-store-gcs-proxy = pkgs.callPackage ./tools/nix-store-gcs-proxy {};
-  });
+  };
+
+  # Tools used in the dev-env. These are invoked through wrappers in dev-env/bin.
+  tools = pkgs.lib.mapAttrs (_: pkg: selectBin pkg) toolAttrs;
 
   # Set of packages that we want Hydra to build for us
   cached = bazel_dependencies // {

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,6 @@
+{ pkgs ? import ./nix/nixpkgs.nix { }
+, default ? import ./nix/default.nix { inherit pkgs; }
+}:
+pkgs.mkShell {
+  buildInputs = pkgs.lib.attrsets.mapAttrsToList (name: value: value) default.toolAttrs;
+}


### PR DESCRIPTION
This introduces a _shell.nix_ file which exposes the various tooling, so that shell scripts can use it, as a more "standard" workflow than _dade-common_.

We then use this in _dev-env/bin/ghcide_ and _language-support/hs/bindings/export-package.sh_.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
