### PR TITLE
LF: Move Speedy Interpretation Error to transaction package

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf.engine
+package com.daml.lf
+package engine
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{BackStack, ImmArray, ImmArrayCons}
@@ -75,8 +76,11 @@ object ResultError {
     ResultError(Error.Package(packageError))
   def apply(preprocessingError: Error.Preprocessing.Error): ResultError =
     ResultError(Error.Preprocessing(preprocessingError))
-  def apply(interpretationError: Error.Interpretation.Error): ResultError =
-    ResultError(Error.Interpretation(interpretationError))
+  def apply(
+      interpretationError: Error.Interpretation.Error,
+      details: Option[String] = None,
+  ): ResultError =
+    ResultError(Error.Interpretation(interpretationError, details))
   def apply(validationError: Error.Validation.Error): ResultError =
     ResultError(Error.Validation(validationError))
 }
@@ -165,7 +169,10 @@ object Result {
     ResultNeedContract(
       acoid,
       {
-        case None => ResultError(Error.Interpretation.ContractNotFound(acoid))
+        case None =>
+          ResultError(
+            Error.Interpretation.DamlException(interpretation.Error.ContractNotFound(acoid))
+          )
         case Some(contract) => resume(contract)
       },
     )

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -31,6 +31,7 @@ import Value._
 import com.daml.lf.speedy.{InitialSeeding, SValue, svalue}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.command._
+import com.daml.lf.engine.Error.Interpretation
 import com.daml.lf.transaction.Node.{GenActionNode, GenNode}
 import com.daml.lf.transaction.test.TransactionBuilder.assertAsVersionedValue
 import org.scalactic.Equality
@@ -755,9 +756,9 @@ class EngineTest
       val submitResult = engine
         .submit(submitters, Commands(ImmArray(command), let, "test"), participant, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
-      inside(submitResult) { case Left(err) =>
-        err shouldBe Error.Interpretation(
-          Error.Interpretation.ContractKeyNotFound(
+      inside(submitResult) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe Interpretation.DamlException(
+          interpretation.Error.ContractKeyNotFound(
             GlobalKey.assertBuild(
               BasicTests_WithKey,
               ValueRecord(
@@ -969,21 +970,22 @@ class EngineTest
         )
         .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
-      inside(result) { case Left(err) =>
-        err shouldBe Error.Interpretation(
-          Error.Interpretation.ContractKeyNotFound(
-            GlobalKey.assertBuild(
-              BasicTests_WithKey,
-              ValueRecord(
-                Some(BasicTests_WithKey),
-                ImmArray(
-                  (Some[Ref.Name]("p"), ValueParty(alice)),
-                  (Some[Ref.Name]("k"), ValueInt64(43)),
+      inside(result) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe
+          Interpretation.DamlException(
+            interpretation.Error.ContractKeyNotFound(
+              GlobalKey.assertBuild(
+                BasicTests_WithKey,
+                ValueRecord(
+                  Some(BasicTests_WithKey),
+                  ImmArray(
+                    (Some[Ref.Name]("p"), ValueParty(alice)),
+                    (Some[Ref.Name]("k"), ValueInt64(43)),
+                  ),
                 ),
-              ),
+              )
             )
           )
-        )
       }
     }
     "error if Speedy fails to find the key" in {
@@ -1014,21 +1016,22 @@ class EngineTest
         )
         .consume(_ => None, lookupPackage, lookupKey, VisibleByKey.fromSubmitters(submitters))
 
-      inside(result) { case Left(err) =>
-        err shouldBe Error.Interpretation(
-          Error.Interpretation.ContractKeyNotFound(
-            GlobalKey.assertBuild(
-              BasicTests_WithKey,
-              ValueRecord(
-                Some(BasicTests_WithKey),
-                ImmArray(
-                  (Some[Ref.Name]("p"), ValueParty(alice)),
-                  (Some[Ref.Name]("k"), ValueInt64(43)),
+      inside(result) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe
+          Interpretation.DamlException(
+            interpretation.Error.ContractKeyNotFound(
+              GlobalKey.assertBuild(
+                BasicTests_WithKey,
+                ValueRecord(
+                  Some(BasicTests_WithKey),
+                  ImmArray(
+                    (Some[Ref.Name]("p"), ValueParty(alice)),
+                    (Some[Ref.Name]("k"), ValueInt64(43)),
+                  ),
                 ),
-              ),
+              )
             )
           )
-        )
       }
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf.speedy
+package com.daml.lf
+package speedy
 
 /** The simplified AST for the speedy interpreter.
   *
@@ -377,9 +378,9 @@ object SExpr {
   /** We cannot crash in the engine call back.
     * Rather, we set the control to this expression and then crash when executing.
     */
-  final case class SEDamlException(error: SErrorDamlException) extends SExpr {
+  final case class SEDamlException(error: interpretation.Error) extends SExpr {
     def execute(machine: Machine): Unit = {
-      throw error
+      throw SErrorDamlException(error)
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -10,6 +10,7 @@ import com.daml.lf.data._
 import com.daml.lf.data.Ref._
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SError.SErrorCrash
+import com.daml.lf.value.Value.ValueArithmeticError
 import com.daml.lf.value.{Value => V}
 
 import scala.jdk.CollectionConverters._
@@ -214,24 +215,18 @@ object SValue {
   }
 
   object SArithmeticError {
-    // The package ID should match the ID of the stable package daml-prim-DA-Exception-ArithmeticError
-    // See test compiler/damlc/tests/src/stable-packages.sh
-    val tyCon: Ref.TypeConName = Ref.Identifier.assertFromString(
-      "cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a:DA.Exception.ArithmeticError:ArithmeticError"
-    )
-    val typ: Type = TTyCon(tyCon)
-    val fields: ImmArray[Ref.Name] = ImmArray(Ref.Name.assertFromString("message"))
+    val fields: ImmArray[Ref.Name] = ImmArray(ValueArithmeticError.fieldName)
     def apply(builtinName: String, args: ImmArray[String]): SAny = {
       val array = new util.ArrayList[SValue](1)
       array.add(
         SText(s"ArithmeticError while evaluating ($builtinName ${args.iterator.mkString(" ")}).")
       )
-      SAny(typ, SRecord(tyCon, fields, array))
+      SAny(ValueArithmeticError.typ, SRecord(ValueArithmeticError.tyCon, fields, array))
     }
     // Assumes excep is properly typed
     def unapply(excep: SAny): Option[SValue] =
       excep match {
-        case SAnyException(SRecord(`tyCon`, _, args)) => Some(args.get(0))
+        case SAnyException(SRecord(ValueArithmeticError.tyCon, _, args)) => Some(args.get(0))
         case _ => None
       }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -18,8 +18,8 @@ import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SBuiltin.checkAborted
 import com.daml.lf.transaction.{
   ContractKeyUniquenessMode,
-  Node,
   IncompleteTransaction,
+  Node,
   TransactionVersion,
 }
 import com.daml.lf.value.{Value => V}
@@ -1067,7 +1067,7 @@ private[lf] object Speedy {
     }
 
     machine.ctrl = altOpt
-      .getOrElse(throw DamlEMatchError(s"No match for $v in ${alts.toList}"))
+      .getOrElse(crash(s"No match for $v in ${alts.toList}"))
       .body
   }
 
@@ -1330,7 +1330,9 @@ private[lf] object Speedy {
         machine.kontStack.clear()
         machine.env.clear()
         machine.envBase = 0
-        throw DamlEUnhandledException(excep)
+        throw SErrorDamlException(
+          interpretation.Error.UnhandledException(excep.ty, excep.value.toValue)
+        )
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -7,7 +7,6 @@ package speedy
 import com.daml.lf.data.Ref.{ChoiceName, Location, Party, TypeConName}
 import com.daml.lf.data.{BackStack, ImmArray, Ref, Time}
 import com.daml.lf.ledger.{Authorize, FailedAuthorization}
-import com.daml.lf.speedy.SError.DamlEUnhandledException
 import com.daml.lf.transaction.{
   ContractKeyUniquenessMode,
   GenTransaction,
@@ -700,7 +699,9 @@ private[lf] case class PartialTransaction(
   def rollbackTry(ex: SValue.SAny): PartialTransaction = {
     // we must never create a rollback containing a node with a version pre-dating exceptions
     if (context.minChildVersion < TxVersion.minExceptions) {
-      throw DamlEUnhandledException(ex)
+      throw SError.SErrorDamlException(
+        interpretation.Error.UnhandledException(ex.ty, ex.value.toValue)
+      )
     }
     context.info match {
       case info: TryContextInfo =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -4,19 +4,19 @@
 package com.daml.lf
 package speedy
 
-import java.util
-
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{PackageId, Party}
+import com.daml.lf.interpretation.{Error => IE}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{LanguageVersion, Interface}
 import com.daml.lf.speedy.Compiler.FullStackTrace
 import com.daml.lf.speedy.SResult.{SResultError, SResultFinalValue}
-import com.daml.lf.speedy.SError.DamlEUnhandledException
+import com.daml.lf.speedy.SError.SErrorDamlException
 import com.daml.lf.speedy.SValue.SUnit
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.testing.parser.ParserParameters
 import com.daml.lf.validation.Validation
+import com.daml.lf.value.Value.{ValueRecord, ValueText}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -53,39 +53,34 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
        }
       """)
 
-    val List(e1, e2) =
+    val List((t1, e1), (t2, e2)) =
       List("M:E1", "M:E2")
         .map(id =>
           data.Ref.Identifier.assertFromString(s"${defaultParserParameters.defaultPackageId}:$id")
         )
-        .map(tyCon =>
-          SValue.SAny(
-            TTyCon(tyCon),
-            SValue.SRecord(tyCon, data.ImmArray.empty, new util.ArrayList()),
-          )
-        )
+        .map(tyCon => TTyCon(tyCon) -> ValueRecord(Some(tyCon), data.ImmArray.empty))
     val arithmeticCon = data.Ref.Identifier.assertFromString(
       "cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a:DA.Exception.ArithmeticError:ArithmeticError"
     )
-    val fields = new util.ArrayList[SValue]()
-    fields.add(SValue.SText("ArithmeticError while evaluating (DIV_INT64 1 0)."))
     val divZeroE =
-      SValue.SAny(
-        TTyCon(arithmeticCon),
-        SValue.SRecord(
-          arithmeticCon,
-          data.ImmArray(data.Ref.Name.assertFromString("message")),
-          fields,
+      ValueRecord(
+        Some(arithmeticCon),
+        data.ImmArray(
+          Some(data.Ref.Name.assertFromString("message")) ->
+            ValueText("ArithmeticError while evaluating (DIV_INT64 1 0).")
         ),
       )
 
     val testCases = Table[String, SResult](
       ("expression", "expected"),
-      ("M:unhandled1", SResultError(DamlEUnhandledException(e1))),
-      ("M:unhandled2", SResultError(DamlEUnhandledException(e1))),
-      ("M:unhandled3", SResultError(DamlEUnhandledException(e1))),
-      ("M:unhandled4", SResultError(DamlEUnhandledException(e2))),
-      ("M:divZero", SResultError(DamlEUnhandledException(divZeroE))),
+      ("M:unhandled1", SResultError(SErrorDamlException(IE.UnhandledException(t1, e1)))),
+      ("M:unhandled2", SResultError(SErrorDamlException(IE.UnhandledException(t1, e1)))),
+      ("M:unhandled3", SResultError(SErrorDamlException(IE.UnhandledException(t1, e1)))),
+      ("M:unhandled4", SResultError(SErrorDamlException(IE.UnhandledException(t2, e2)))),
+      (
+        "M:divZero",
+        SResultError(SErrorDamlException(IE.UnhandledException(TTyCon(arithmeticCon), divZeroE))),
+      ),
     )
 
     forEvery(testCases) { (exp: String, expected: SResult) =>
@@ -471,16 +466,6 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
     val example: Expr = EApp(e"M:causeRollback", EPrimLit(PLParty(party)))
     def transactionSeed: crypto.Hash = crypto.Hash.hashPrivateKey("transactionSeed")
 
-    val anException = {
-      val id = "M:AnException"
-      val tyCon =
-        data.Ref.Identifier.assertFromString(s"${defaultParserParameters.defaultPackageId}:$id")
-      SValue.SAny(
-        TTyCon(tyCon),
-        SValue.SRecord(tyCon, data.ImmArray.empty, new util.ArrayList()),
-      )
-    }
-
     "works as expected for a contract version POST-dating exceptions" in {
       val pkgs = mkPackagesAtVersion(LanguageVersion.v1_dev)
       val res = Speedy.Machine.fromUpdateExpr(pkgs, transactionSeed, example, party).run()
@@ -488,9 +473,16 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
     }
 
     "causes an uncatchable exception to be thrown for a contract version PRE-dating exceptions" in {
+
+      val id = "M:AnException"
+      val tyCon =
+        data.Ref.Identifier.assertFromString(s"${defaultParserParameters.defaultPackageId}:$id")
+      val anException =
+        IE.UnhandledException(TTyCon(tyCon), ValueRecord(Some(tyCon), data.ImmArray.empty))
+
       val pkgs = mkPackagesAtVersion(LanguageVersion.v1_11)
       val res = Speedy.Machine.fromUpdateExpr(pkgs, transactionSeed, example, party).run()
-      res shouldBe SResultError(DamlEUnhandledException(anException))
+      res shouldBe SResultError(SErrorDamlException(anException))
     }
 
     def mkPackagesAtVersion(languageVersion: LanguageVersion): PureCompiledPackages = {
@@ -692,12 +684,8 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
     val anException = {
       val id = "NewM:AnException"
-      val tyCon =
-        data.Ref.Identifier.assertFromString(s"$newPid:$id")
-      SValue.SAny(
-        TTyCon(tyCon),
-        SValue.SRecord(tyCon, data.ImmArray.empty, new util.ArrayList()),
-      )
+      val tyCon = data.Ref.Identifier.assertFromString(s"$newPid:$id")
+      IE.UnhandledException(TTyCon(tyCon), ValueRecord(Some(tyCon), data.ImmArray.empty))
     }
 
     def transactionSeed: crypto.Hash = crypto.Hash.hashPrivateKey("transactionSeed")
@@ -713,12 +701,12 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
     "causes uncatchable exception when an old contract is within a new-exercise within a try-catch" in {
       val res = Speedy.Machine.fromUpdateExpr(pkgs, transactionSeed, causeUncatchable, party).run()
-      res shouldBe SResultError(DamlEUnhandledException(anException))
+      res shouldBe SResultError(SErrorDamlException(anException))
     }
 
     "causes uncatchable exception when an old contract is within a new-exercise which aborts" in {
       val res = Speedy.Machine.fromUpdateExpr(pkgs, transactionSeed, causeUncatchable2, party).run()
-      res shouldBe SResultError(DamlEUnhandledException(anException))
+      res shouldBe SResultError(SErrorDamlException(anException))
     }
 
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -7,13 +7,15 @@ package speedy
 import java.util
 
 import com.daml.lf.data._
+import com.daml.lf.interpretation.{Error => IE}
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.SError.{DamlEUnhandledException, SError, SErrorCrash}
+import com.daml.lf.speedy.SError.{SError, SErrorCrash}
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult.{SResultError, SResultFinalValue, SResultNeedPackage}
 import com.daml.lf.speedy.SValue.{SValue => _, _}
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.value.Value
+import com.daml.lf.value.Value.ValueArithmeticError
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.freespec.AnyFreeSpec
@@ -1485,7 +1487,11 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
         inside(
           evalSExpr(SEAppAtomicSaturatedBuiltin(builtin, args.map(SEValue(_)).toArray), false)
         ) {
-          case Left(DamlEUnhandledException(SArithmeticError(SText(msg))))
+          case Left(
+                SError.SErrorDamlException(
+                  IE.UnhandledException(ValueArithmeticError.typ, ValueArithmeticError(msg))
+                )
+              )
               if msg == s"ArithmeticError while evaluating ($name ${args.iterator.map(lit2string).mkString(" ")})." =>
         }
       }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf.speedy
+package com.daml.lf
+package speedy
 
 import com.daml.lf.CompiledPackages
 import com.daml.lf.crypto
@@ -317,7 +318,7 @@ object ScenarioRunner {
 
       ledger.ledgerData.activeKeys.get(gk) match {
         case None =>
-          missingWith(DamlEContractKeyNotFound(gk))
+          missingWith(SErrorDamlException(interpretation.Error.ContractKeyNotFound(gk)))
         case Some(acoid) =>
           ledger.lookupGlobalContract(
             view = ScenarioLedger.ParticipantView(actAs, readAs),

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -1,0 +1,99 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package interpretation
+
+import com.daml.lf.data.Ref.{Location, Party, TypeConName}
+import com.daml.lf.transaction.{GlobalKey, NodeId}
+import com.daml.lf.language.Ast
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value.ContractId
+
+/** Daml exceptions that should be reported to the user
+  */
+sealed abstract class Error extends Serializable with Product {
+  override def toString: String = s"$productPrefix(${productIterator.mkString(",")}"
+}
+
+object Error {
+
+  /** Unhandled exceptions */
+  final case class UnhandledException(exceptionType: Ast.Type, value: Value[ContractId])
+      extends Error
+
+  /** User initiated error, via e.g. 'abort' or 'assert' */
+  final case class UserError(message: String) extends Error
+
+  final case class ContractNotFound(cid: Value.ContractId) extends Error
+
+  /** Template pre-condition (ensure) evaluated to false and the transaction
+    * was aborted. Note that the compiler will throw instead of returning False
+    * for code in LF >= 1.14 so this will never be thrown for newer versions.
+    */
+  final case class TemplatePreconditionViolated(
+      templateId: TypeConName,
+      optLocation: Option[Location],
+      arg: Value[ContractId],
+  ) extends Error
+
+  /** A fetch or an exercise on a transaction-local contract that has already
+    * been consumed.
+    */
+  final case class ContractNotActive(
+      coid: ContractId,
+      templateId: TypeConName,
+      consumedBy: NodeId,
+  ) extends Error
+
+  final case class LocalContractKeyNotVisible(
+      coid: ContractId,
+      key: GlobalKey,
+      actAs: Set[Party],
+      readAs: Set[Party],
+      stakeholders: Set[Party],
+  ) extends Error
+
+  /** Fetch-by-key failed
+    */
+  final case class ContractKeyNotFound(
+      key: GlobalKey
+  ) extends Error
+
+  /** Two contracts with the same key were active at the same time.
+    * See com.daml.lf.transaction.Transaction.DuplicateContractKey
+    * for more details.
+    */
+  final case class DuplicateContractKey(
+      key: GlobalKey
+  ) extends Error
+
+  /** A create with a contract key failed because the list of maintainers was empty */
+  final case class CreateEmptyContractKeyMaintainers(
+      templateId: TypeConName,
+      arg: Value[ContractId],
+      key: Value[Nothing],
+  ) extends Error
+
+  /** A fetch or lookup of a contract key without maintainers */
+  final case class FetchEmptyContractKeyMaintainers(
+      templateId: TypeConName,
+      key: Value[Nothing],
+  ) extends Error
+
+  /** We tried to fetch / exercise a contract of the wrong type --
+    * see <https://github.com/digital-asset/daml/issues/1005>.
+    */
+  final case class WronglyTypedContract(
+      coid: ContractId,
+      expected: TypeConName,
+      actual: TypeConName,
+  ) extends Error
+
+  /** There was an authorization failure during execution. */
+  final case class FailedAuthorization(
+      nid: NodeId,
+      fa: ledger.FailedAuthorization,
+  ) extends Error
+
+}

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf.engine.script
+package com.daml.lf
+package engine.script
 
 import java.time.Clock
 
@@ -14,9 +15,8 @@ import com.daml.lf.data.Ref.{Identifier, Name, PackageId, Party}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.script.ledgerinteraction.{ScriptLedgerClient, ScriptTimeMode}
 import com.daml.lf.language.Ast
-import com.daml.lf.speedy.SError.DamlEUserError
 import com.daml.lf.speedy.SExpr.{SEApp, SEValue}
-import com.daml.lf.speedy.{SExpr, SValue}
+import com.daml.lf.speedy.{SError, SExpr, SValue}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.value.Value
@@ -161,7 +161,9 @@ object ScriptF {
             Future.successful(SEApp(SEValue(data.continue), Array(SEValue(SUnit))))
           case Left(()) =>
             Future.failed(
-              new DamlEUserError("Expected submit to fail but it succeeded")
+              SError.SErrorDamlException(
+                interpretation.Error.UserError("Expected submit to fail but it succeeded")
+              )
             )
         }
       } yield v

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -374,10 +374,10 @@ final class JsonApiIt
           run(clients, QualifiedName.assertFromString("ScriptTest:jsonFailingCreateAndExercise"))
         )
       } yield {
-        exception.cause.getMessage should include("Error: User abort: Assertion failed.")
+        exception.cause.getMessage should include("User abort: Assertion failed.")
       }
     }
-    "submitMustFail succeeds on assertion falure" in {
+    "submitMustFail succeeds on assertion failure" in {
       for {
         clients <- getClients()
         result <- run(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -27,6 +27,7 @@ import com.daml.ledger.participant.state.v1.{
 import com.daml.lf.crypto
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.engine.{Error => LfError}
+import com.daml.lf.interpretation.{Error => InterpretationError}
 import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.logging.LoggingContext.{withEnrichedLoggingContext, withEnrichedLoggingContextFrom}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -289,8 +290,11 @@ private[apiserver] final class ApiSubmissionService private[services] (
           // TODO https://github.com/digital-asset/daml/issues/9974
           //  Review once LF errors are properly structured
           case LfError.Interpretation(
-                LfError.Interpretation.ContractNotFound(_) |
-                LfError.Interpretation.DuplicateContractKey(_)
+                LfError.Interpretation.DamlException(
+                  InterpretationError.ContractNotFound(_) |
+                  InterpretationError.DuplicateContractKey(_)
+                ),
+                _,
               ) | LfError.Validation(LfError.Validation.ReplayMismatch(_)) =>
             Status.ABORTED.withDescription(cause.explain)
           case _ => Status.INVALID_ARGUMENT.withDescription(cause.explain)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ErrorCause.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ErrorCause.scala
@@ -18,10 +18,8 @@ private[platform] object ErrorCause {
     override def explain: String = {
       val details = {
         error match {
-          case LfError.Interpretation(LfError.Interpretation.Generic(_, detailMsg)) =>
-            detailMsg
-          case _ =>
-            "N/A"
+          case LfError.Interpretation(_, Some(detailMsg)) => detailMsg
+          case _ => "N/A"
         }
       }
       s"Command interpretation error in LF-DAMLe: ${error.msg}. Details: $details."


### PR DESCRIPTION
We move the Speedy Interpretation Error (so called `SErrorDamlException`) to the transaction package, where com.daml.lf.ledger.FailedAuthorization is already living already. 

Like that we can use them in Speedy *and* in Engine without having to convert them back and force.

In this PR we take care of note changing the error message (some of them are quite dummy) to keep stability of the ledger API integration test. 

part of #9974

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
