### PR TITLE
[Mutable state cache] contractStateEvents bounded DB fetch size [DPP-464]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -681,6 +681,11 @@ final class Metrics(val registry: MetricRegistry) {
           registry.counter(Prefix :+ "transaction_trees_buffer_size")
         val flatTransactionsBufferSize: Counter =
           registry.counter(Prefix :+ "flat_transactions_buffer_size")
+
+        val getContractStateEventsChunkSize: Histogram =
+          registry.histogram(Prefix :+ "get_contract_state_events_chunk_fetch_size")
+        val getTransactionLogUpdatesChunkSize: Histogram =
+          registry.histogram(Prefix :+ "get_transaction_log_updates_chunk_fetch_size")
       }
 
       object read {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionsReader.scala
@@ -562,11 +562,16 @@ private[appendonlydao] object TransactionsReader {
       s"You can only split a range in a strictly positive number of chunks ($numberOfChunks)",
     )
 
+    val rangeSize = endInclusive - startExclusive
+    require(
+      rangeSize >= 0,
+      s"Range size should be positive but got bounds ($startExclusive, $endInclusive]",
+    )
+
     val minChunkSize = math.max(1, maxChunkSize / 10)
 
-    val rangeSize = endInclusive - startExclusive
-
-    if (rangeSize == 0L) Vector.empty
+    if (rangeSize == 0L)
+      Vector.empty
     else {
       val targetChunkSize = rangeSize / numberOfChunks.toLong
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/TransactionsReader.scala
@@ -288,6 +288,12 @@ private[appendonlydao] final class TransactionsReader(
           )
           .iterator
       )
+      .map { range =>
+        metrics.daml.services.index.getTransactionLogUpdatesChunkSize.update(
+          range.endInclusive - range.startExclusive
+        )
+        range
+      }
       // Dispatch database fetches in parallel
       .mapAsync(eventProcessingParallelism) { range =>
         dispatcher.executeSql(dbMetrics.getTransactionLogUpdates) { implicit conn =>
@@ -411,6 +417,12 @@ private[appendonlydao] final class TransactionsReader(
           )
           .iterator
       )
+      .map { range =>
+        metrics.daml.services.index.getContractStateEventsChunkSize.update(
+          range.endInclusive - range.startExclusive
+        )
+        range
+      }
       // Dispatch database fetches in parallel
       .mapAsync(eventProcessingParallelism) { range =>
         dispatcher.executeSql(dbMetrics.getContractStateEvents) { implicit conn =>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
@@ -117,7 +117,7 @@ private[appendonlydao] class TransactionsReaderSpec
         ) shouldBe Vector.empty[EventsRange[Long]]
     }
 
-    "throw if numberOfChunks below 1" in {
+    "throw if numberOfChunks is below 1" in {
       intercept[IllegalArgumentException] {
         TransactionsReader.splitRange(
           startExclusive = 100L,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
@@ -128,7 +128,7 @@ private[appendonlydao] class TransactionsReaderSpec
       }.getMessage shouldBe "requirement failed: You can only split a range in a strictly positive number of chunks (0)"
     }
 
-    "throw if maxChunkSize below 1" in {
+    "throw if maxChunkSize is below 1" in {
       intercept[IllegalArgumentException] {
         TransactionsReader.splitRange(
           startExclusive = 100L,
@@ -147,7 +147,7 @@ private[appendonlydao] class TransactionsReaderSpec
           numberOfChunks = 100,
           maxChunkSize = 10,
         )
-      }.getMessage shouldBe s"requirement failed: Range size should be positive but got bounds (300, 200]"
+      }.getMessage shouldBe "requirement failed: Range size should be positive but got bounds (300, 200]"
     }
 
     "satisfy the required properties" in {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
@@ -139,6 +139,17 @@ private[appendonlydao] class TransactionsReaderSpec
       }.getMessage shouldBe "requirement failed: Maximum chunk size must be strictly positive, but was 0"
     }
 
+    "startExclusive is after endInclusive" in {
+      intercept[IllegalArgumentException] {
+        TransactionsReader.splitRange(
+          startExclusive = 300L,
+          endInclusive = 200L,
+          numberOfChunks = 100,
+          maxChunkSize = 10,
+        )
+      }.getMessage shouldBe s"requirement failed: Range size should be positive but got bounds (300, 200]"
+    }
+
     "satisfy the required properties" in {
       // Disable shrinking in forAll in order to ensure that the generator bounds are respected
       // in case of assertion failures

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.store.appendonlydao.events
 
-import org.scalacheck.Gen
+import org.scalacheck.{Gen, Shrink}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -13,8 +13,13 @@ private[appendonlydao] class TransactionsReaderSpec
     with Matchers
     with ScalaCheckPropertyChecks {
   "splitRange" should {
-    "correctly split in equal ranges" in {
-      TransactionsReader.splitRange(100L, 200L, 4, 10, 100) shouldBe Vector(
+    "correctly split in equal ranges by number of chunks" in {
+      TransactionsReader.splitRange(
+        startExclusive = 100L,
+        endInclusive = 200L,
+        numberOfChunks = 4,
+        maxChunkSize = 100,
+      ) shouldBe Vector(
         EventsRange(100L, 125L),
         EventsRange(125L, 150L),
         EventsRange(150L, 175L),
@@ -22,91 +27,166 @@ private[appendonlydao] class TransactionsReaderSpec
       )
     }
 
-    "correctly split in non-equal ranges" in {
-      TransactionsReader.splitRange(100L, 200L, 3, 10, 100) shouldBe Vector(
-        EventsRange(100L, 134L),
-        EventsRange(134L, 168L),
-        EventsRange(168L, 200L),
-      )
-    }
-
-    "output ranges of sizes at least minChunkSize" in {
-      TransactionsReader.splitRange(100L, 200L, 3, 50, 100) shouldBe Vector(
-        EventsRange(100L, 150L),
-        EventsRange(150L, 200L),
-      )
-    }
-
-    "output one range if minChunkSize higher than range size" in {
-      TransactionsReader.splitRange(100L, 200L, 3, 200, 100) shouldBe Vector(
-        EventsRange(100L, 200L)
-      )
-    }
-
-    "use the effectiveChunkSize if maxChunkSize is higher than double of the minChunkSize" in {
-      TransactionsReader.splitRange(100L, 200L, 3, 75, 90) shouldBe Vector(
-        EventsRange(100L, 200L)
-      )
-    }
-
-    "output only one range if minChunkSize greater than half the range" in {
-      TransactionsReader.splitRange(100L, 200L, 3, 51, 100) shouldBe Vector(
-        EventsRange(100L, 200L)
-      )
-    }
-
-    "output only one range if minChunkSize is gteq to range size" in {
-      TransactionsReader.splitRange(100L, 200L, 3, 100, 100) shouldBe Vector(
-        EventsRange(100L, 200L)
+    "fairly split in non-equal ranges by number of chunks" in {
+      TransactionsReader.splitRange(
+        startExclusive = 100L,
+        endInclusive = 200L,
+        numberOfChunks = 6,
+        maxChunkSize = 100,
+      ) shouldBe Vector(
+        EventsRange(100L, 117L),
+        EventsRange(117L, 134L),
+        EventsRange(134L, 151L),
+        EventsRange(151L, 168L),
+        EventsRange(168L, 184L),
+        EventsRange(184L, 200L),
       )
     }
 
     "output ranges of at most max chunk size" in {
-      TransactionsReader.splitRange(100L, 200L, 1, 20, 50) shouldBe Vector(
+      TransactionsReader.splitRange(
+        startExclusive = 100L,
+        endInclusive = 200L,
+        numberOfChunks = 1,
+        maxChunkSize = 50,
+      ) shouldBe Vector(
         EventsRange(100L, 150L),
         EventsRange(150L, 200L),
       )
     }
 
+    "output one range if use maxChunkSize/10 higher than range size" in {
+      TransactionsReader.splitRange(
+        startExclusive = 100L,
+        endInclusive = 110L,
+        numberOfChunks = 3,
+        maxChunkSize = 100,
+      ) shouldBe Vector(
+        EventsRange(100L, 110L)
+      )
+    }
+
+    "prioritize satisfying the maxChunkSize over numberOfChunks" in {
+      TransactionsReader
+        .splitRange(
+          startExclusive = 0L,
+          endInclusive = 3L,
+          numberOfChunks = 2,
+          maxChunkSize = 1,
+        ) shouldBe Vector(
+        EventsRange(0L, 1L),
+        EventsRange(1L, 2L),
+        EventsRange(2L, 3L),
+      )
+    }
+
+    "prioritize satisfying a minimum chunk size of maxChunkSize/10 over numberOfChunks" in {
+      TransactionsReader
+        .splitRange(
+          startExclusive = 0L,
+          endInclusive = 6L,
+          numberOfChunks = 6,
+          maxChunkSize = 20,
+        ) shouldBe Vector(
+        EventsRange(0L, 2L),
+        EventsRange(2L, 4L),
+        EventsRange(4L, 6L),
+      )
+    }
+
+    "work for max chunk size of 1" in {
+      TransactionsReader
+        .splitRange(
+          startExclusive = 5L,
+          endInclusive = 7L,
+          numberOfChunks = 10,
+          maxChunkSize = 1,
+        ) shouldBe Vector(
+        EventsRange(5L, 6L),
+        EventsRange(6L, 7L),
+      )
+    }
+
+    "return empty vector if startExclusive and endInclusive are equal" in {
+      TransactionsReader
+        .splitRange(
+          startExclusive = 11L,
+          endInclusive = 11L,
+          numberOfChunks = 100,
+          maxChunkSize = 100,
+        ) shouldBe Vector.empty[EventsRange[Long]]
+    }
+
     "throw if numberOfChunks below 1" in {
       intercept[IllegalArgumentException] {
-        TransactionsReader.splitRange(100L, 200L, 0, 100, 100)
-      }.getMessage shouldBe "You can only split a range in a strictly positive number of chunks (0)"
+        TransactionsReader.splitRange(
+          startExclusive = 100L,
+          endInclusive = 200L,
+          numberOfChunks = 0,
+          maxChunkSize = 100,
+        )
+      }.getMessage shouldBe "requirement failed: You can only split a range in a strictly positive number of chunks (0)"
+    }
+
+    "throw if maxChunkSize below 1" in {
+      intercept[IllegalArgumentException] {
+        TransactionsReader.splitRange(
+          startExclusive = 100L,
+          endInclusive = 200L,
+          numberOfChunks = 100,
+          maxChunkSize = 0,
+        )
+      }.getMessage shouldBe "requirement failed: Maximum chunk size must be strictly positive, but was 0"
     }
 
     "satisfy the required properties" in {
-      forAll(Gen.choose(1, 10), Gen.choose(1, 20), Gen.choose(1, 100)) {
-        (minChunkSize, maxChunkSize, rangeSize) =>
-          (minChunkSize >= 1 && minChunkSize <= 10) shouldBe true
-          (maxChunkSize >= 1 && maxChunkSize <= 20) shouldBe true
-          (rangeSize >= 1 && rangeSize <= 100) shouldBe true
+      // Disable shrinking in forAll in order to ensure that the generator bounds are respected
+      // in case of assertion failures
+      implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
-          val ranges =
-            TransactionsReader.splitRange(100L, rangeSize + 100L, 8, minChunkSize, maxChunkSize)
+      val maxChunkSize_Gen = Gen.choose(1, 20)
+      val pageSize_Gen = Gen.choose(1L, 100L)
+      val numberOfChunks_Gen = Gen.choose(1, 10)
 
-          val subRangeSizes = ranges.map { case EventsRange(startExclusive, endInclusive) =>
-            endInclusive - startExclusive
-          }
-          subRangeSizes.sum shouldBe rangeSize
+      forAll(
+        maxChunkSize_Gen,
+        pageSize_Gen,
+        numberOfChunks_Gen,
+        minSuccessful(1000),
+      ) { (maxChunkSize, rangeSize, numberOfChunks) =>
+        val ranges =
+          TransactionsReader.splitRange(
+            startExclusive = 0L,
+            endInclusive = rangeSize,
+            numberOfChunks = numberOfChunks,
+            maxChunkSize = maxChunkSize,
+          )
 
-          val minEffectiveMaxChunkSize = minChunkSize * 2
-          val minEffectiveMinChunkSize = math.ceil(maxChunkSize.toDouble / 2.toDouble).toInt
+        /* Assert non-empty ranges */
+        ranges.size should be > 0
 
-          subRangeSizes.forall(size =>
-            size <= minEffectiveMaxChunkSize && size >= minEffectiveMinChunkSize
-          ) shouldBe true
-      }
-    }
+        /* Assert ranges are gap-less and non-overlapping */
+        ranges.foldLeft(0L) {
+          case (lastStartExclusive, EventsRange(startExclusive, endInclusive)) =>
+            startExclusive shouldBe lastStartExclusive
+            endInclusive
+        }
 
-    "Gen.choose" in {
-      val firstGen = Gen.choose(1, 10)
-      val secondGen = Gen.choose(1, 20)
-      val thirdGen = Gen.choose(1, 100)
-      forAll(firstGen, secondGen, thirdGen) { (firstBound, secondBound, thirdBound) =>
-        (firstBound >= 1 && firstBound <= 10) shouldBe true
-        (secondBound >= 1 && secondBound <= 20) shouldBe true
-        (thirdBound >= 1 && thirdBound <= 100) shouldBe true
-        println("Checked")
+        ranges.last.endInclusive shouldBe rangeSize
+
+        val subRangeSizes = ranges.map { case EventsRange(startExclusive, endInclusive) =>
+          endInclusive - startExclusive
+        }
+
+        /* Assert page sizes satisfy bounds and are similar in length */
+        val maxSubrangeSize = subRangeSizes.max
+
+        subRangeSizes.foreach { size =>
+          size should be <= maxChunkSize.toLong
+          size should be >= maxSubrangeSize - 1L
+          size should be >= Math.min(maxChunkSize.toLong / 10, rangeSize)
+          size should be > 0L
+        }
       }
     }
   }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
@@ -55,7 +55,7 @@ private[appendonlydao] class TransactionsReaderSpec
       )
     }
 
-    "output one range if use maxChunkSize/10 higher than range size" in {
+    "output one range if maxChunkSize/10 (as minimum chunk size) is higher than range size" in {
       TransactionsReader.splitRange(
         startExclusive = 100L,
         endInclusive = 110L,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/TransactionsReaderSpec.scala
@@ -3,10 +3,15 @@
 
 package com.daml.platform.store.appendonlydao.events
 
+import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-private[appendonlydao] class TransactionsReaderSpec extends AnyWordSpec with Matchers {
+private[appendonlydao] class TransactionsReaderSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
   "splitRange" should {
     "correctly split in equal ranges" in {
       TransactionsReader.splitRange(100L, 200L, 4, 10, 100) shouldBe Vector(
@@ -38,6 +43,12 @@ private[appendonlydao] class TransactionsReaderSpec extends AnyWordSpec with Mat
       )
     }
 
+    "use the effectiveChunkSize if maxChunkSize is higher than double of the minChunkSize" in {
+      TransactionsReader.splitRange(100L, 200L, 3, 75, 90) shouldBe Vector(
+        EventsRange(100L, 200L)
+      )
+    }
+
     "output only one range if minChunkSize greater than half the range" in {
       TransactionsReader.splitRange(100L, 200L, 3, 51, 100) shouldBe Vector(
         EventsRange(100L, 200L)
@@ -61,6 +72,42 @@ private[appendonlydao] class TransactionsReaderSpec extends AnyWordSpec with Mat
       intercept[IllegalArgumentException] {
         TransactionsReader.splitRange(100L, 200L, 0, 100, 100)
       }.getMessage shouldBe "You can only split a range in a strictly positive number of chunks (0)"
+    }
+
+    "satisfy the required properties" in {
+      forAll(Gen.choose(1, 10), Gen.choose(1, 20), Gen.choose(1, 100)) {
+        (minChunkSize, maxChunkSize, rangeSize) =>
+          (minChunkSize >= 1 && minChunkSize <= 10) shouldBe true
+          (maxChunkSize >= 1 && maxChunkSize <= 20) shouldBe true
+          (rangeSize >= 1 && rangeSize <= 100) shouldBe true
+
+          val ranges =
+            TransactionsReader.splitRange(100L, rangeSize + 100L, 8, minChunkSize, maxChunkSize)
+
+          val subRangeSizes = ranges.map { case EventsRange(startExclusive, endInclusive) =>
+            endInclusive - startExclusive
+          }
+          subRangeSizes.sum shouldBe rangeSize
+
+          val minEffectiveMaxChunkSize = minChunkSize * 2
+          val minEffectiveMinChunkSize = math.ceil(maxChunkSize.toDouble / 2.toDouble).toInt
+
+          subRangeSizes.forall(size =>
+            size <= minEffectiveMaxChunkSize && size >= minEffectiveMinChunkSize
+          ) shouldBe true
+      }
+    }
+
+    "Gen.choose" in {
+      val firstGen = Gen.choose(1, 10)
+      val secondGen = Gen.choose(1, 20)
+      val thirdGen = Gen.choose(1, 100)
+      forAll(firstGen, secondGen, thirdGen) { (firstBound, secondBound, thirdBound) =>
+        (firstBound >= 1 && firstBound <= 10) shouldBe true
+        (secondBound >= 1 && secondBound <= 20) shouldBe true
+        (thirdBound >= 1 && thirdBound <= 100) shouldBe true
+        println("Checked")
+      }
     }
   }
 }

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -390,12 +390,22 @@ object Config {
           .text(
             s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${IndexConfiguration.DefaultEventsPageSize}."
           )
+          .validate(pageSize =>
+            Either.cond(pageSize > 0, pageSize, "events-page-size should be strictly positive")
+          )
           .action((eventsPageSize, config) => config.copy(eventsPageSize = eventsPageSize))
 
         opt[Int]("buffers-prefetching-parallelism")
           .optional()
           .text(
             s"Number of events fetched/decoded in parallel for populating the Ledger API internal buffers. Default is ${IndexConfiguration.DefaultEventsProcessingParallelism}."
+          )
+          .validate(buffersPrefetchingParallelism =>
+            Either.cond(
+              buffersPrefetchingParallelism > 0,
+              buffersPrefetchingParallelism,
+              "buffers-prefetching-parallelism should be strictly positive",
+            )
           )
           .action((eventsProcessingParallelism, config) =>
             config.copy(eventsProcessingParallelism = eventsProcessingParallelism)

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -391,7 +391,8 @@ object Config {
             s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${IndexConfiguration.DefaultEventsPageSize}."
           )
           .validate(pageSize =>
-            Either.cond(pageSize > 0, pageSize, "events-page-size should be strictly positive")
+            if (pageSize > 0) Right(pageSize)
+            else Left("events-page-size should be strictly positive")
           )
           .action((eventsPageSize, config) => config.copy(eventsPageSize = eventsPageSize))
 
@@ -401,11 +402,8 @@ object Config {
             s"Number of events fetched/decoded in parallel for populating the Ledger API internal buffers. Default is ${IndexConfiguration.DefaultEventsProcessingParallelism}."
           )
           .validate(buffersPrefetchingParallelism =>
-            Either.cond(
-              buffersPrefetchingParallelism > 0,
-              buffersPrefetchingParallelism,
-              "buffers-prefetching-parallelism should be strictly positive",
-            )
+            if (buffersPrefetchingParallelism > 0) Right(buffersPrefetchingParallelism)
+            else Left("buffers-prefetching-parallelism should be strictly positive")
           )
           .action((eventsProcessingParallelism, config) =>
             config.copy(eventsProcessingParallelism = eventsProcessingParallelism)

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -390,10 +390,10 @@ object Config {
           .text(
             s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${IndexConfiguration.DefaultEventsPageSize}."
           )
-          .validate(pageSize =>
-            if (pageSize > 0) Right(pageSize)
+          .validate { pageSize =>
+            if (pageSize > 0) Right(())
             else Left("events-page-size should be strictly positive")
-          )
+          }
           .action((eventsPageSize, config) => config.copy(eventsPageSize = eventsPageSize))
 
         opt[Int]("buffers-prefetching-parallelism")
@@ -401,10 +401,10 @@ object Config {
           .text(
             s"Number of events fetched/decoded in parallel for populating the Ledger API internal buffers. Default is ${IndexConfiguration.DefaultEventsProcessingParallelism}."
           )
-          .validate(buffersPrefetchingParallelism =>
-            if (buffersPrefetchingParallelism > 0) Right(buffersPrefetchingParallelism)
+          .validate { buffersPrefetchingParallelism =>
+            if (buffersPrefetchingParallelism > 0) Right(())
             else Left("buffers-prefetching-parallelism should be strictly positive")
-          )
+          }
           .action((eventsProcessingParallelism, config) =>
             config.copy(eventsProcessingParallelism = eventsProcessingParallelism)
           )


### PR DESCRIPTION
Currently, `contractStateEvents` stream used for populating the mutable contract state cache does not use paging/limit in the DB queries. This gap in implementation can lead to Ledger API crashes when running in memory-constrained scenarios. 

This PR mitigates the issue by limiting the result sets in `contractStateEvents` to the CLI-configured `pageSize`.

The ranges for paged parallel fetches with the `pageSize` limit are generated using `TransactionsReader.splitRange`, which was additionally simplified and more comprehensively tested:
* `minChunkSize` is not passed anymore since it could not be respected anyhow. Instead, it is derived internally as being `maxChunkSize / 10`
* A property check test is added.

As observed empirically, this additional optimization reduces the two-level dispatcher lag by at least 2x.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
