### PR TITLE
Fix Tx.Metadata for normalized transactions

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -392,14 +392,14 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
       }
     }
 
-    onLedger.ptxInternal.finish match {
-      case PartialTransaction.CompleteTransaction(tx) =>
+    onLedger.finish match {
+      case PartialTransaction.CompleteTransaction(tx, nodeSeeds) =>
         val meta = Tx.Metadata(
           submissionSeed = None,
           submissionTime = onLedger.ptxInternal.submissionTime,
           usedPackages = Set.empty,
           dependsOnTime = onLedger.dependsOnTime,
-          nodeSeeds = onLedger.ptxInternal.actionNodeSeeds.toImmArray,
+          nodeSeeds = nodeSeeds,
         )
         config.profileDir.foreach { dir =>
           val desc = Engine.profileDesc(tx)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -496,7 +496,7 @@ class EngineTest
     "reinterpret to the same result" in {
       val Right((tx, txMeta)) = interpretResult
 
-      val Right((rtx, _)) =
+      val Right((rtx, newMeta)) =
         reinterpret(
           engine,
           Set(party),
@@ -507,6 +507,7 @@ class EngineTest
           lookupPackage,
         )
       isReplayedBy(tx, rtx) shouldBe Right(())
+      txMeta.nodeSeeds shouldBe newMeta.nodeSeeds
     }
 
     "be validated" in {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -121,6 +121,7 @@ private[lf] object Speedy {
       var cachedContracts: Map[V.ContractId, CachedContract],
   ) extends LedgerMode {
 
+    private[lf] def finish: PartialTransaction.Result = ptx.finish
     private[lf] def ptxInternal: PartialTransaction = ptx //deprecated
     private[lf] def incompleteTransaction(): IncompleteTransaction = ptx.finishIncomplete
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -196,8 +196,10 @@ private[lf] object PartialTransaction {
     localContracts = Set.empty,
   )
 
+  type NodeSeeds = ImmArray[(NodeId, crypto.Hash)]
+
   sealed abstract class Result extends Product with Serializable
-  final case class CompleteTransaction(tx: SubmittedTransaction) extends Result
+  final case class CompleteTransaction(tx: SubmittedTransaction, seeds: NodeSeeds) extends Result
   final case class IncompleteTransaction(ptx: PartialTransaction) extends Result
 
   sealed abstract class KeyMapping extends Product with Serializable
@@ -210,7 +212,7 @@ private[lf] object PartialTransaction {
 /** A transaction under construction
   *
   *  @param nodes The nodes of the transaction graph being built up.
-  *  @param actionNodeSeeds The seeds of Create and Exercise nodes
+  *  @param actionNodeSeeds The seeds of Action nodes in pre-order. NodeIds are determined by finish.
   *  @param consumedBy 'ContractId's of all contracts that have
   *                    been consumed by nodes up to now.
   *  @param context The context of what sub-transaction is being
@@ -258,7 +260,7 @@ private[lf] case class PartialTransaction(
     submissionTime: Time.Timestamp,
     nextNodeIdx: Int,
     nodes: HashMap[NodeId, PartialTransaction.Node],
-    actionNodeSeeds: BackStack[(NodeId, crypto.Hash)],
+    actionNodeSeeds: BackStack[crypto.Hash],
     consumedBy: Map[Value.ContractId, NodeId],
     context: PartialTransaction.Context,
     aborted: Option[Tx.TransactionError],
@@ -320,6 +322,10 @@ private[lf] case class PartialTransaction(
       sb.toString
     }
 
+  private def normalizedNodeSeeds(): NodeSeeds = {
+    ImmArray(actionNodeSeeds.toImmArray.toList.zipWithIndex.map { case (v, i) => (NodeId(i), v) })
+  }
+
   /** Finish building a transaction; i.e., try to extract a complete
     *  transaction from the given 'PartialTransaction'. This returns:
     * - a SubmittedTransaction in case of success ;
@@ -337,7 +343,8 @@ private[lf] case class PartialTransaction(
         CompleteTransaction(
           SubmittedTransaction(
             TxVersion.asVersionedTransaction(tx)
-          )
+          ),
+          normalizedNodeSeeds(),
         )
       case _ =>
         IncompleteTransaction(this)
@@ -406,7 +413,7 @@ private[lf] case class PartialTransaction(
         nextNodeIdx = nextNodeIdx + 1,
         context = context.addActionChild(nid, version),
         nodes = nodes.updated(nid, createNode),
-        actionNodeSeeds = actionNodeSeeds :+ (nid -> actionNodeSeed),
+        actionNodeSeeds = actionNodeSeeds :+ actionNodeSeed,
         localContracts = localContracts + cid,
       ).noteAuthFails(nid, CheckAuthorization.authorizeCreate(createNode), auth)
 
@@ -575,6 +582,7 @@ private[lf] case class PartialTransaction(
           copy(
             nextNodeIdx = nextNodeIdx + 1,
             context = Context(ec),
+            actionNodeSeeds = actionNodeSeeds :+ ec.actionNodeSeed, // must push before children
             // important: the semantics of Daml dictate that contracts are immediately
             // inactive as soon as you exercise it. therefore, mark it as consumed now.
             consumedBy = if (consuming) consumedBy.updated(targetId, nid) else consumedBy,
@@ -611,7 +619,6 @@ private[lf] case class PartialTransaction(
           context =
             ec.parent.addActionChild(nodeId, exerciseNode.version min context.minChildVersion),
           nodes = nodes.updated(nodeId, exerciseNode),
-          actionNodeSeeds = actionNodeSeeds :+ (nodeId -> ec.actionNodeSeed),
         )
       case _ => throw new RuntimeException("endExercises called in non-exercise context")
     }
@@ -629,7 +636,7 @@ private[lf] case class PartialTransaction(
           context =
             ec.parent.addActionChild(nodeId, exerciseNode.version min context.minChildVersion),
           nodes = nodes.updated(nodeId, exerciseNode),
-          actionNodeSeeds = actionNodeSeeds :+ (nodeId -> actionNodeSeed),
+          actionNodeSeeds = actionNodeSeeds :+ actionNodeSeed,
         )
       case _ => throw new RuntimeException("abortExercises called in non-exercise context")
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
@@ -30,7 +30,7 @@ class NormalizeRollbacksSpec extends AnyWordSpec with Matchers with Inside {
   def test(name: String)(orig: Shape.Top, expected: Shape.Top): Unit = {
     s"normalize: ($orig) -- $name" should {
       val tx = Shape.toTransaction(orig)
-      val txN = NormalizeRollbacks.normalizeTx(tx) // code under test
+      val (txN, _) = NormalizeRollbacks.normalizeTx(tx) // code under test
       val shapeN = Shape.ofTransaction(txN)
       "be as expected" in {
         assert(shapeN == expected)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -30,7 +30,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   )
 
   private[this] def contractIdsInOrder(ptx: PartialTransaction): Seq[Value.ContractId] = {
-    inside(ptx.finish) { case CompleteTransaction(tx) =>
+    inside(ptx.finish) { case CompleteTransaction(tx, _) =>
       tx.fold(Vector.empty[Value.ContractId]) {
         case (acc, (_, create: Node.NodeCreate[Value.ContractId])) => acc :+ create.coid
         case (acc, _) => acc

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
@@ -79,7 +79,7 @@ class ProfilerTest extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
           onLedger.ptx.finish match {
             case IncompleteTransaction(_) =>
               sys.error("unexpected IncompleteTransaction")
-            case CompleteTransaction(_) =>
+            case CompleteTransaction(_, _) =>
               machine.profile.events.asScala.toList.map(ev => (ev.open, ev.rawLabel))
           }
         }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -55,7 +55,7 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
           onLedger.ptx.finish match {
             case IncompleteTransaction(_) =>
               sys.error("unexpected IncompleteTransaction")
-            case CompleteTransaction(tx) =>
+            case CompleteTransaction(tx, _) =>
               tx
           }
         }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -404,7 +404,7 @@ object ScenarioRunner {
       ledgerMachine.run() match {
         case SResultFinalValue(resultValue) =>
           onLedger.ptxInternal.finish match {
-            case PartialTransaction.CompleteTransaction(tx) =>
+            case PartialTransaction.CompleteTransaction(tx, _) =>
               ledger.commit(committers, readAs, location, tx) match {
                 case Left(err) => SubmissionError(err, onLedger.ptxInternal)
                 case Right(r) =>

--- a/daml-lf/tests/Exceptions.daml
+++ b/daml-lf/tests/Exceptions.daml
@@ -185,3 +185,26 @@ template GlobalLookups
          -- this one needs to check activeness for an entry in globalKeyInputs
          None <- lookupByKey @K k
          pure ()
+
+template NodeSeeds
+  with
+    p : Party
+  where
+    signatory p
+    -- Produces a transaction with all node types so we can
+    -- check which produce node seed and which do not.
+    choice CreateAllTypes : ()
+      with
+        cid : ContractId K
+      controller p
+      do _ <- fetch cid
+         Some _ <- lookupByKey @K (p, 0)
+         create (K p 1 "")
+         try do
+           _ <- fetch cid
+           Some _ <- lookupByKey @K (p, 0)
+           create (K p 2 "")
+           throw E
+         catch
+           E -> pure ()
+         pure ()


### PR DESCRIPTION
Fix Tx.Metadata for normalized transactions

The primary cause of the bug was the `Tx.Metadata` was referencing node-ids calculated prior to the normalization of the transaction. The bug did *not* manifest if normalization made no change to the node-ids, which was until recently was always the case if the transaction contained no rollback nodes.

With the recent change to `reinterpret` (adding a try-catch handler around the command being reinterpreted), the pre-normalized tx was constructed with transitory node-ids which did not end up matching the final node-ids after normalization... even in the case that the tx contains no rollback nodes!

The fix is to never use the transitory node-ids generated before normalization, specifically those which were in `actionNodeSeeds`, and instead calculate the correct NodeIds in `PartialTransaction.finish`. This is easy, so long as we always collect the actionNodeSeeds in pre-order. Which this PR also ensures.


changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
