### PR TITLE
[Scala client bindings] Fix a "deadlock" in CommandRetryFlow

### DIFF
--- a/language-support/scala/bindings-akka/BUILD.bazel
+++ b/language-support/scala/bindings-akka/BUILD.bazel
@@ -83,6 +83,7 @@ da_scala_test_suite(
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:com_typesafe_akka_akka_stream_testkit",
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalatest_scalatest",
         "@maven//:org_scalaz_scalaz_core",
@@ -102,5 +103,7 @@ da_scala_test_suite(
         "//ledger/metrics",
         "@maven//:com_google_api_grpc_proto_google_common_protos",
         "@maven//:com_typesafe_config",
+        "@maven//:io_dropwizard_metrics_metrics_core",
+        "@maven//:org_reactivestreams_reactive_streams",
     ],
 )

--- a/language-support/scala/bindings-akka/BUILD.bazel
+++ b/language-support/scala/bindings-akka/BUILD.bazel
@@ -66,6 +66,7 @@ da_scala_library(
         "@maven//:ch_qos_logback_logback_core",
         "@maven//:com_google_api_grpc_proto_google_common_protos",
         "@maven//:com_typesafe_config",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_netty_netty_handler",
         "@maven//:io_netty_netty_tcnative_boringssl_static",

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
@@ -100,6 +100,7 @@ class LedgerClientBinding(
         ledgerClient.commandClient,
         timeProvider,
         retryTimeout,
+        ledgerClient.config.commandClient.maxCommandsInFlight,
         createRetry,
       )
     } yield Flow[Ctx[C, CompositeCommand]]

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
@@ -100,7 +100,6 @@ class LedgerClientBinding(
         ledgerClient.commandClient,
         timeProvider,
         retryTimeout,
-        ledgerClient.config.commandClient.maxCommandsInFlight,
         createRetry,
       )
     } yield Flow[Ctx[C, CompositeCommand]]

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
@@ -35,7 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 final class LedgerClient private (
     val channel: Channel,
-    config: LedgerClientConfiguration,
+    val config: LedgerClientConfiguration,
     val ledgerId: LedgerId,
 )(implicit ec: ExecutionContext, esf: ExecutionSequencerFactory)
     extends Closeable {

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
@@ -46,7 +46,7 @@ final class CommandClient(
     commandCompletionService: CommandCompletionServiceStub,
     ledgerId: LedgerId,
     applicationId: String,
-    config: CommandClientConfiguration,
+    val config: CommandClientConfiguration,
     logger: Logger = LoggerFactory.getLogger(getClass),
 )(implicit esf: ExecutionSequencerFactory) {
 


### PR DESCRIPTION
The "deadlock" occurs when a command is sent to the RETRY_PORT, but at
the same time new commands are coming in as well. If the
commandSubmissionFlow is limited (e.g. via the MaxInFlight flow), then
backpressure is exerted on the merge flow and ultimately back to the
retryDecider. This in turn prevents new command results from being
propagated to the PROPAGATE_PORT, and therefore the limited
commandSubmissionFlow ends up backpressuring itself into a "deadlock".

To circumvent this, two new measures are in place:
1. The Merge flow is now a MergePreferred flow, giving precedence to
submission retries.
2. An additional buffer is added to the retry feedback loop, so that the
limited commandSubmissionFlow can keep making progress.

Ideally this buffer would have an additional feature of rerouting new
elements to a completely different port if the buffer is full, but that
would likely require a custom graph stage.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
