### PR TITLE
[In-memory fan-out] Performance optimizations [DPP-470]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/index/BuffersUpdater.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/BuffersUpdater.scala
@@ -113,12 +113,12 @@ private[index] object BuffersUpdater {
       updateMutableCache: ContractStateEvent => Unit,
       toContractStateEvents: TransactionLogUpdate => Iterator[ContractStateEvent] =
         convertToContractStateEvents,
+      executionContext: ExecutionContext,
       minBackoffStreamRestart: FiniteDuration = 100.millis,
       sysExitWithCode: Int => Unit = sys.exit(_),
   )(implicit
       mat: Materializer,
       loggingContext: LoggingContext,
-      executionContext: ExecutionContext,
   ): BuffersUpdater = new BuffersUpdater(
     subscribeToTransactionLogUpdates = subscribeToTransactionLogUpdates,
     updateCaches = (offset, transactionLogUpdate) => {
@@ -127,7 +127,7 @@ private[index] object BuffersUpdater {
     },
     minBackoffStreamRestart = minBackoffStreamRestart,
     sysExitWithCode = sysExitWithCode,
-  )
+  )(mat, loggingContext, executionContext)
 
   private[index] def convertToContractStateEvents(
       tx: TransactionLogUpdate

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -77,6 +77,7 @@ private[platform] object ReadOnlySqlLedger {
           maxContractKeyStateCacheSize,
           maxTransactionsInMemoryFanOutBufferSize,
           enableInMemoryFanOutForLedgerApi,
+          servicesExecutionContext = servicesExecutionContext,
         )
       else
         new ReadOnlySqlLedgerWithTranslationCache.Owner(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
@@ -29,7 +29,7 @@ import com.daml.scalautil.Statement.discard
 
 import scala.collection.mutable
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 private[index] object ReadOnlySqlLedgerWithMutableCache {
   final class Owner(
@@ -41,6 +41,7 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
       maxContractKeyStateCacheSize: Long,
       maxTransactionsInMemoryFanOutBufferSize: Long,
       enableInMemoryFanOutForLedgerApi: Boolean,
+      servicesExecutionContext: ExecutionContext,
   )(implicit mat: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[ReadOnlySqlLedgerWithMutableCache] {
     private val logger = ContextualizedLogger.get(getClass)
@@ -67,7 +68,7 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
           generalDispatcher,
           dispatcherLagMeter,
           ledgerEndOffset -> ledgerEndSequentialId,
-        )
+        ).acquire()
       } yield ledger
 
     private def dispatcherOffsetSeqIdOwner(ledgerEnd: Offset, evtSeqId: Long) = {
@@ -91,8 +92,6 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
         generalDispatcher: Dispatcher[Offset],
         dispatcherLagMeter: DispatcherLagMeter,
         startExclusive: (Offset, Long),
-    )(implicit
-        resourceContext: ResourceContext
     ) =
       if (enableInMemoryFanOutForLedgerApi)
         ledgerWithMutableCacheAndInMemoryFanOut(
@@ -114,39 +113,37 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
         generalDispatcher: Dispatcher[Offset],
         dispatcherLagMeter: DispatcherLagMeter,
         startExclusive: (Offset, Long),
-    )(implicit resourceContext: ResourceContext) =
+    ): ResourceOwner[ReadOnlySqlLedgerWithMutableCache] =
       for {
-        contractStore <- MutableCacheBackedContractStore
-          .ownerWithSubscription(
-            subscribeToContractStateEvents = maybeOffsetSeqId =>
-              cacheUpdatesDispatcher
-                .startingAt(
-                  maybeOffsetSeqId.getOrElse(startExclusive),
-                  RangeSource(
-                    ledgerDao.transactionsReader.getContractStateEvents(_, _)
-                  ),
-                )
-                .map(_._2),
-            contractsReader = ledgerDao.contractsReader,
-            signalNewLedgerHead = dispatcherLagMeter,
-            metrics = metrics,
-            maxContractsCacheSize = maxContractStateCacheSize,
-            maxKeyCacheSize = maxContractKeyStateCacheSize,
+        contractStore <- MutableCacheBackedContractStore.ownerWithSubscription(
+          subscribeToContractStateEvents = maybeOffsetSeqId =>
+            cacheUpdatesDispatcher
+              .startingAt(
+                maybeOffsetSeqId.getOrElse(startExclusive),
+                RangeSource(
+                  ledgerDao.transactionsReader.getContractStateEvents(_, _)
+                ),
+              )
+              .map(_._2),
+          contractsReader = ledgerDao.contractsReader,
+          signalNewLedgerHead = dispatcherLagMeter,
+          metrics = metrics,
+          maxContractsCacheSize = maxContractStateCacheSize,
+          maxKeyCacheSize = maxContractKeyStateCacheSize,
+          executionContext = servicesExecutionContext,
+        )
+        ledger <- ResourceOwner.forCloseable(() =>
+          new ReadOnlySqlLedgerWithMutableCache(
+            ledgerId,
+            ledgerDao,
+            ledgerDao.transactionsReader,
+            contractStore,
+            PruneBuffersNoOp,
+            cacheUpdatesDispatcher,
+            generalDispatcher,
+            dispatcherLagMeter,
           )
-        ledger <- ResourceOwner
-          .forCloseable(() =>
-            new ReadOnlySqlLedgerWithMutableCache(
-              ledgerId,
-              ledgerDao,
-              ledgerDao.transactionsReader,
-              contractStore,
-              PruneBuffersNoOp,
-              cacheUpdatesDispatcher,
-              generalDispatcher,
-              dispatcherLagMeter,
-            )
-          )
-          .acquire()
+        )
       } yield ledger
 
     private def ledgerWithMutableCacheAndInMemoryFanOut(
@@ -154,68 +151,70 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
         generalDispatcher: Dispatcher[Offset],
         dispatcherLagMeter: DispatcherLagMeter,
         startExclusive: (Offset, Long),
-    )(implicit resourceContext: ResourceContext) = {
+    ): ResourceOwner[ReadOnlySqlLedgerWithMutableCache] = {
+
       val transactionsBuffer = new EventsBuffer[Offset, TransactionLogUpdate](
         maxBufferSize = maxTransactionsInMemoryFanOutBufferSize,
         metrics = metrics,
         bufferQualifier = "transactions",
         isRangeEndMarker = _.isInstanceOf[TransactionLogUpdate.LedgerEndMarker],
       )
-      for {
-        contractStore <- MutableCacheBackedContractStore.owner(
-          contractsReader = ledgerDao.contractsReader,
-          signalNewLedgerHead = dispatcherLagMeter,
+
+      val contractStore = MutableCacheBackedContractStore(
+        ledgerDao.contractsReader,
+        dispatcherLagMeter,
+        metrics,
+        maxContractStateCacheSize,
+        maxContractKeyStateCacheSize,
+      )(servicesExecutionContext, loggingContext)
+
+      val bufferedTransactionsReader = BufferedTransactionsReader(
+        delegate = ledgerDao.transactionsReader,
+        transactionsBuffer = transactionsBuffer,
+        lfValueTranslation = new LfValueTranslation(
+          cache = LfValueTranslationCache.Cache.none,
           metrics = metrics,
-          maxContractsCacheSize = maxContractStateCacheSize,
-          maxKeyCacheSize = maxContractKeyStateCacheSize,
-        )
-        _ <- ResourceOwner
-          .forCloseable(() =>
-            BuffersUpdater(
-              subscribeToTransactionLogUpdates = maybeOffsetSeqId => {
-                val subscriptionStartExclusive @ (offsetStart, eventSeqIdStart) =
-                  maybeOffsetSeqId.getOrElse(startExclusive)
-                logger.info(
-                  s"Subscribing for transaction log updates after ${offsetStart.toHexString} -> $eventSeqIdStart"
+          enricherO = Some(enricher),
+          loadPackage =
+            (packageId, loggingContext) => ledgerDao.getLfArchive(packageId)(loggingContext),
+        ),
+        metrics = metrics,
+      )(loggingContext, servicesExecutionContext)
+
+      for {
+        _ <- ResourceOwner.forCloseable(() =>
+          BuffersUpdater(
+            subscribeToTransactionLogUpdates = maybeOffsetSeqId => {
+              val subscriptionStartExclusive @ (offsetStart, eventSeqIdStart) =
+                maybeOffsetSeqId.getOrElse(startExclusive)
+              logger.info(
+                s"Subscribing for transaction log updates after ${offsetStart.toHexString} -> $eventSeqIdStart"
+              )
+              cacheUpdatesDispatcher
+                .startingAt(
+                  subscriptionStartExclusive,
+                  RangeSource(
+                    ledgerDao.transactionsReader.getTransactionLogUpdates(_, _)
+                  ),
                 )
-                cacheUpdatesDispatcher
-                  .startingAt(
-                    subscriptionStartExclusive,
-                    RangeSource(
-                      ledgerDao.transactionsReader.getTransactionLogUpdates(_, _)
-                    ),
-                  )
-              },
-              updateTransactionsBuffer = transactionsBuffer.push,
-              updateMutableCache = contractStore.push,
-            )
+            },
+            updateTransactionsBuffer = transactionsBuffer.push,
+            updateMutableCache = contractStore.push,
+            executionContext = servicesExecutionContext,
           )
-          .acquire()
-        ledger <- ResourceOwner
-          .forCloseable(() =>
-            new ReadOnlySqlLedgerWithMutableCache(
-              ledgerId = ledgerId,
-              ledgerDao = ledgerDao,
-              ledgerDaoTransactionsReader = BufferedTransactionsReader(
-                delegate = ledgerDao.transactionsReader,
-                transactionsBuffer = transactionsBuffer,
-                lfValueTranslation = new LfValueTranslation(
-                  cache = LfValueTranslationCache.Cache.none,
-                  metrics = metrics,
-                  enricherO = Some(enricher),
-                  loadPackage =
-                    (packageId, loggingContext) => ledgerDao.getLfArchive(packageId)(loggingContext),
-                ),
-                metrics = metrics,
-              ),
-              pruneBuffers = transactionsBuffer.prune,
-              contractStore = contractStore,
-              contractStateEventsDispatcher = cacheUpdatesDispatcher,
-              dispatcher = generalDispatcher,
-              dispatcherLagger = dispatcherLagMeter,
-            )
+        )
+        ledger <- ResourceOwner.forCloseable(() =>
+          new ReadOnlySqlLedgerWithMutableCache(
+            ledgerId = ledgerId,
+            ledgerDao = ledgerDao,
+            ledgerDaoTransactionsReader = bufferedTransactionsReader,
+            pruneBuffers = transactionsBuffer.prune,
+            contractStore = contractStore,
+            contractStateEventsDispatcher = cacheUpdatesDispatcher,
+            dispatcher = generalDispatcher,
+            dispatcherLagger = dispatcherLagMeter,
           )
-          .acquire()
+        )
       } yield ledger
     }
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
@@ -115,7 +115,7 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
         startExclusive: (Offset, Long),
     ): ResourceOwner[ReadOnlySqlLedgerWithMutableCache] =
       for {
-        contractStore <- MutableCacheBackedContractStore.ownerWithSubscription(
+        contractStore <- new MutableCacheBackedContractStore.OwnerWithSubscription(
           subscribeToContractStateEvents = maybeOffsetSeqId =>
             cacheUpdatesDispatcher
               .startingAt(

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
@@ -70,9 +70,10 @@ final class BuffersUpdaterSpec
         updateTransactionsBuffer = updateTransactionsBufferMock,
         toContractStateEvents = Map(updateMock -> contractStateEventMocks.iterator),
         updateMutableCache = contractStateMock += _,
+        executionContext = scala.concurrent.ExecutionContext.global,
         minBackoffStreamRestart = 10.millis,
         sysExitWithCode = _ => fail("should not be triggered"),
-      )(materializer, loggingContext, scala.concurrent.ExecutionContext.global)
+      )(materializer, loggingContext)
 
       queue.offer((someOffset, someEventSeqId) -> updateMock) shouldBe QueueOfferResult.Enqueued
 
@@ -130,9 +131,10 @@ final class BuffersUpdaterSpec
         updateTransactionsBuffer = updateTransactionsBufferMock,
         toContractStateEvents = Map.empty.withDefaultValue(Iterator.empty),
         updateMutableCache = _ => (),
+        executionContext = scala.concurrent.ExecutionContext.global,
         minBackoffStreamRestart = 1.millis,
         sysExitWithCode = _ => fail("should not be triggered"),
-      )(materializer, loggingContext, scala.concurrent.ExecutionContext.global)
+      )(materializer, loggingContext)
 
       eventually {
         transactionsBufferMock should contain theSameElementsAs Seq(
@@ -162,9 +164,10 @@ final class BuffersUpdaterSpec
         updateTransactionsBuffer = updateTransactionsBufferMock,
         toContractStateEvents = Map.empty,
         updateMutableCache = _ => (),
+        executionContext = scala.concurrent.ExecutionContext.global,
         minBackoffStreamRestart = 1.millis,
         sysExitWithCode = shutdownCodeCapture.set,
-      )(materializer, loggingContext, scala.concurrent.ExecutionContext.global)
+      )(materializer, loggingContext)
 
       eventually {
         shutdownCodeCapture.get() shouldBe 1

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
@@ -390,17 +390,16 @@ object MutableCacheBackedContractStoreSpec {
       sourceSubscriber: Option[(Offset, EventSequentialId)] => Source[ContractStateEvent, NotUsed] =
         _ => Source.empty,
   )(implicit loggingContext: LoggingContext, materializer: Materializer) =
-    MutableCacheBackedContractStore
-      .ownerWithSubscription(
-        subscribeToContractStateEvents = sourceSubscriber,
-        minBackoffStreamRestart = 10.millis,
-        contractsReader = readerFixture,
-        signalNewLedgerHead = signalNewLedgerHead,
-        metrics = new Metrics(new MetricRegistry),
-        maxContractsCacheSize = cachesSize,
-        maxKeyCacheSize = cachesSize,
-        executionContext = scala.concurrent.ExecutionContext.global,
-      )
+    new MutableCacheBackedContractStore.OwnerWithSubscription(
+      subscribeToContractStateEvents = sourceSubscriber,
+      minBackoffStreamRestart = 10.millis,
+      contractsReader = readerFixture,
+      signalNewLedgerHead = signalNewLedgerHead,
+      metrics = new Metrics(new MetricRegistry),
+      maxContractsCacheSize = cachesSize,
+      maxKeyCacheSize = cachesSize,
+      executionContext = scala.concurrent.ExecutionContext.global,
+    )
       .acquire()(ResourceContext(scala.concurrent.ExecutionContext.global))
 
   case class ContractsReaderFixture() extends LedgerDaoContractsReader {


### PR DESCRIPTION
This PR brings optimizations to the in-memory fan-out flow. The PR can be reviewed by commit:

In the first commit, a scalability issue is addressed by the bounded execution context thread pool:
* `servicesExecutionContext` is used in all non-resource components
* Remove widespread use of `resourceContext` in building the in-memory fan-out and mutable contract state cache components

The second commit:
* Optimize stream construction in `TransactionLogUpdatesConversions.ToTransactionTree`

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
