### PR TITLE
contextualized-logging: Introduce different logging types for more structure. [KVL-996]

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -29,8 +29,14 @@ load("@scala_version//:index.bzl", "scala_major_version", "scala_major_version_s
 # Use the macros `da_scala_*` defined in this file, instead of the stock rules
 # `scala_*` from `rules_scala` in order for these default flags to take effect.
 
-def resolve_scala_deps(deps, scala_deps = [], versioned_scala_deps = {}):
-    return deps + ["{}_{}".format(d, scala_major_version_suffix) for d in scala_deps + versioned_scala_deps.get(scala_major_version, [])]
+def resolve_scala_deps(deps, scala_deps = [], versioned_deps = {}, versioned_scala_deps = {}):
+    return deps + \
+           versioned_deps.get(scala_major_version, []) + \
+           [
+               "{}_{}".format(d, scala_major_version_suffix)
+               for d in scala_deps +
+                        versioned_scala_deps.get(scala_major_version, [])
+           ]
 
 def extra_scalacopts(scala_deps, plugins):
     return (["-P:silencer:lineContentFilters=import scala.collection.compat._"] if (scala_major_version != "2.12" and
@@ -209,13 +215,14 @@ def _wrap_rule(
         generated_srcs = [],  # hiding from the underlying rule
         deps = [],
         scala_deps = [],
+        versioned_deps = {},
         versioned_scala_deps = {},
         runtime_deps = [],
         scala_runtime_deps = [],
         exports = [],
         scala_exports = [],
         **kwargs):
-    deps = resolve_scala_deps(deps, scala_deps, versioned_scala_deps)
+    deps = resolve_scala_deps(deps, scala_deps, versioned_deps, versioned_scala_deps)
     runtime_deps = resolve_scala_deps(runtime_deps, scala_runtime_deps)
     exports = resolve_scala_deps(exports, scala_exports)
     if (len(exports) > 0):
@@ -234,12 +241,13 @@ def _wrap_rule_no_plugins(
         rule,
         deps = [],
         scala_deps = [],
+        versioned_deps = {},
         versioned_scala_deps = {},
         runtime_deps = [],
         scala_runtime_deps = [],
         scalacopts = [],
         **kwargs):
-    deps = resolve_scala_deps(deps, scala_deps, versioned_scala_deps)
+    deps = resolve_scala_deps(deps, scala_deps, versioned_deps, versioned_scala_deps)
     runtime_deps = resolve_scala_deps(runtime_deps, scala_runtime_deps)
     rule(
         scalacopts = common_scalacopts + scalacopts,
@@ -514,10 +522,20 @@ Arguments:
   doctitle: title for Scalaadoc's index.html. Typically the name of the library
 """
 
-def _create_scaladoc_jar(name, srcs, plugins = [], deps = [], scala_deps = [], versioned_scala_deps = {}, scalacopts = [], generated_srcs = [], **kwargs):
+def _create_scaladoc_jar(
+        name,
+        srcs,
+        plugins = [],
+        deps = [],
+        scala_deps = [],
+        versioned_deps = {},
+        versioned_scala_deps = {},
+        scalacopts = [],
+        generated_srcs = [],
+        **kwargs):
     # Limit execution to Linux and MacOS
     if is_windows == False:
-        deps = resolve_scala_deps(deps, scala_deps, versioned_scala_deps)
+        deps = resolve_scala_deps(deps, scala_deps, versioned_deps, versioned_scala_deps)
         compat_scalacopts = extra_scalacopts(scala_deps = scala_deps, plugins = plugins)
         scaladoc_jar(
             name = name + "_scaladoc",
@@ -533,6 +551,7 @@ def _create_scala_repl(
         name,
         deps = [],
         scala_deps = [],
+        versioned_deps = {},
         versioned_scala_deps = {},
         runtime_deps = [],
         scala_runtime_deps = [],
@@ -545,7 +564,7 @@ def _create_scala_repl(
         generated_srcs = None,
         **kwargs):
     name = name + "_repl"
-    deps = resolve_scala_deps(deps, scala_deps, versioned_scala_deps)
+    deps = resolve_scala_deps(deps, scala_deps, versioned_deps, versioned_scala_deps)
     runtime_deps = resolve_scala_deps(runtime_deps, scala_runtime_deps)
     tags = tags + ["manual"]
     scala_repl(name = name, deps = deps, runtime_deps = runtime_deps, tags = tags, **kwargs)
@@ -703,10 +722,11 @@ def da_scala_test_suite(initial_heap_size = default_initial_heap_size, max_heap_
 def da_scala_benchmark_jmh(
         deps = [],
         scala_deps = [],
+        versioned_deps = {},
         versioned_scala_deps = {},
         runtime_deps = [],
         scala_runtime_deps = [],
         **kwargs):
-    deps = resolve_scala_deps(deps, scala_deps, versioned_scala_deps)
+    deps = resolve_scala_deps(deps, scala_deps, versioned_deps, versioned_scala_deps)
     runtime_deps = resolve_scala_deps(runtime_deps, scala_runtime_deps)
     _wrap_rule_no_plugins(scala_benchmark_jmh, deps, runtime_deps, **kwargs)

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -56,6 +56,7 @@ da_scala_library(
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
         "//libs-scala/auth-utils",
+        "//libs-scala/contextualized-logging",
     ],
 )
 

--- a/ledger/ledger-api-client/BUILD.bazel
+++ b/ledger/ledger-api-client/BUILD.bazel
@@ -21,6 +21,9 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_stream",
     ],
     tags = ["maven_coordinates=com.daml:ledger-api-client:__VERSION__"],
+    versioned_deps = {
+        "2.12": ["//libs-scala/contextualized-logging"],  # transient dependency, but 2.12 is confused
+    },
     visibility = [
         "//visibility:public",
     ],

--- a/ledger/ledger-api-client/BUILD.bazel
+++ b/ledger/ledger-api-client/BUILD.bazel
@@ -123,6 +123,7 @@ da_scala_test_suite(
         "//ledger/sandbox-common:sandbox-common-scala-tests-lib",
         "//ledger/test-common",
         "//libs-scala/concurrent",
+        "//libs-scala/contextualized-logging",
         "//libs-scala/grpc-utils",
         "//libs-scala/ports",
         "//libs-scala/resources",

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -70,6 +70,7 @@ da_scala_library(
         "//language-support/scala/bindings",
         "//ledger/ledger-api-domain",
         "//libs-scala/concurrent",
+        "//libs-scala/contextualized-logging",
         "@maven//:io_zipkin_brave_brave",
     ],
 )
@@ -115,6 +116,7 @@ da_scala_test_suite(
         "//ledger/metrics",
         "//ledger/metrics:metrics-test-lib",
         "//libs-scala/concurrent",
+        "//libs-scala/contextualized-logging",
         "//libs-scala/grpc-utils",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:ch_qos_logback_logback_core",

--- a/ledger/ledger-api-domain/BUILD.bazel
+++ b/ledger/ledger-api-domain/BUILD.bazel
@@ -20,6 +20,7 @@ da_scala_library(
         "//daml-lf/data",
         "//daml-lf/transaction",
         "//ledger/participant-state",
+        "//libs-scala/contextualized-logging",
         "@maven//:io_zipkin_brave_brave",
     ],
 )

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -60,7 +60,7 @@ object domain {
 
   implicit object `LedgerOffset to LoggingValue` extends ToLoggingValue[LedgerOffset] {
     override def apply(value: LedgerOffset): LoggingValue =
-      new LoggingValue.FromString(value match {
+      new LoggingValue.OfString(value match {
         case LedgerOffset.Absolute(absolute) => absolute
         case LedgerOffset.LedgerBegin => "%begin%"
         case LedgerOffset.LedgerEnd => "%end%"

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -12,6 +12,8 @@ import com.daml.lf.command.{Commands => LfCommands}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.LedgerString.ordering
 import com.daml.lf.value.{Value => Lf}
+import com.daml.logging.LoggingValue
+import com.daml.logging.LoggingValue.ToLoggingValue
 import scalaz.syntax.tag._
 import scalaz.{@@, Tag}
 
@@ -54,6 +56,15 @@ object domain {
 
     case object LedgerEnd extends LedgerOffset
 
+  }
+
+  implicit object `LedgerOffset to LoggingValue` extends ToLoggingValue[LedgerOffset] {
+    override def apply(value: LedgerOffset): LoggingValue =
+      new LoggingValue.FromString(value match {
+        case LedgerOffset.Absolute(absolute) => absolute
+        case LedgerOffset.LedgerBegin => "%begin%"
+        case LedgerOffset.LedgerEnd => "%end%"
+      })
   }
 
   sealed trait Event extends Product with Serializable {

--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -55,7 +55,6 @@ compile_deps = [
     "@maven//:io_grpc_grpc_netty",
     "@maven//:io_grpc_grpc_services",
     "@maven//:io_netty_netty_handler",
-    "@maven//:net_logstash_logback_logstash_logback_encoder",
     "@maven//:org_flywaydb_flyway_core",
     "@maven//:io_opentelemetry_opentelemetry_api",
     "@maven//:io_opentelemetry_opentelemetry_context",

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -16,7 +16,7 @@ import com.daml.ledger.api.v1.command_completion_service._
 import com.daml.ledger.api.validation.PartyNameChecker
 import com.daml.ledger.participant.state.index.v2.IndexCompletionsService
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
-import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries}
 import com.daml.metrics.Metrics
 import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.services.domain.CommandCompletionService
@@ -63,10 +63,10 @@ private[apiserver] final class ApiCommandCompletionService private (
   private def singleCompletionLoggable(
       commandId: String,
       statusCode: Option[Int],
-  ): Map[String, String] =
-    Map(
+  ): LoggingEntries =
+    LoggingEntries(
       logging.commandId(commandId),
-      "statusCode" -> statusCode.map(_.toString).getOrElse(""),
+      "statusCode" -> statusCode.fold("")(_.toString),
     )
 
   override def getLedgerEnd(ledgerId: domain.LedgerId): Future[LedgerOffset.Absolute] =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -16,41 +16,30 @@ import com.daml.ledger.api.domain.{
 }
 import com.daml.ledger.api.v1.transaction_filter.Filters
 import com.daml.logging.{LoggingEntries, LoggingEntry, LoggingValue}
-import net.logstash.logback.argument.StructuredArguments
 import scalaz.syntax.tag.ToTagOps
 
 package object logging {
 
   private[services] def parties(parties: Iterable[String]): LoggingEntry =
-    "parties" -> StructuredArguments.toString(parties.toArray)
+    "parties" -> parties
 
   private[services] def party(party: String): LoggingEntry =
-    "parties" -> StructuredArguments.toString(Array(party))
+    "parties" -> Seq(party)
 
   private[services] def actAs(parties: Iterable[String]): LoggingEntry =
-    "actAs" -> StructuredArguments.toString(parties.toArray)
+    "actAs" -> parties
 
   private[services] def readAs(parties: Iterable[String]): LoggingEntry =
-    "readAs" -> StructuredArguments.toString(parties.toArray)
+    "readAs" -> parties
 
-  private[services] def startExclusive(o: LedgerOffset): LoggingEntry =
-    "startExclusive" -> offsetValue(o)
+  private[services] def startExclusive(offset: LedgerOffset): LoggingEntry =
+    "startExclusive" -> offset
 
-  private[services] def endInclusive(o: Option[LedgerOffset]): LoggingEntry =
-    "endInclusive" -> nullableOffsetValue(o)
+  private[services] def endInclusive(offset: Option[LedgerOffset]): LoggingEntry =
+    "endInclusive" -> offset
 
-  private[services] def offset(o: Option[LedgerOffset]): LoggingEntry =
-    "offset" -> nullableOffsetValue(o)
-
-  private[this] def nullableOffsetValue(o: Option[LedgerOffset]): String =
-    o.fold("")(offsetValue)
-
-  private[this] def offsetValue(o: LedgerOffset): String =
-    o match {
-      case LedgerOffset.Absolute(absolute) => absolute
-      case LedgerOffset.LedgerBegin => "%begin%"
-      case LedgerOffset.LedgerEnd => "%end%"
-    }
+  private[services] def offset(offset: Option[LedgerOffset]): LoggingEntry =
+    "offset" -> offset
 
   private[services] def applicationId(id: ApplicationId): LoggingEntry =
     "applicationId" -> id.unwrap
@@ -61,8 +50,8 @@ package object logging {
   private[services] def commandId(id: CommandId): LoggingEntry =
     "commandId" -> id.unwrap
 
-  private[services] def deduplicateUntil(t: Instant): LoggingEntry =
-    "deduplicateUntil" -> t.toString
+  private[services] def deduplicateUntil(instant: Instant): LoggingEntry =
+    "deduplicateUntil" -> instant
 
   private[services] def eventId(id: EventId): LoggingEntry =
     "eventId" -> id.unwrap
@@ -82,7 +71,7 @@ package object logging {
     "submissionId" -> id
 
   private[services] def submittedAt(t: Instant): LoggingEntry =
-    "submittedAt" -> t.toString
+    "submittedAt" -> t
 
   private[services] def transactionId(id: String): LoggingEntry =
     "transactionId" -> id

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.api.domain.{
   WorkflowId,
 }
 import com.daml.ledger.api.v1.transaction_filter.Filters
-import com.daml.logging.{LoggingEntries, LoggingEntry}
+import com.daml.logging.{LoggingEntries, LoggingEntry, LoggingValue}
 import net.logstash.logback.argument.StructuredArguments
 import scalaz.syntax.tag.ToTagOps
 
@@ -72,9 +72,9 @@ package object logging {
       Iterator
         .continually(s"party-$party")
         .zip(
-          filters.inclusive.fold(Iterator.single("all-templates"))(
-            _.templateIds.iterator.map(_.toString)
-          )
+          filters.inclusive
+            .fold(Iterator.single("all-templates"))(_.templateIds.iterator.map(_.toString))
+            .map(LoggingValue.from(_))
         )
     })
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -21,7 +21,7 @@ import com.daml.ledger.api.v1.transaction_service.{
 }
 import com.daml.ledger.api.validation.PartyNameChecker
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
-import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries}
 import com.daml.metrics.Metrics
 import com.daml.platform.apiserver.services.{StreamMetrics, logging}
 import com.daml.ledger
@@ -93,8 +93,8 @@ private[apiserver] final class ApiTransactionService private (
       transactionId: String,
       workflowId: String,
       offset: String,
-  ): Map[String, String] =
-    Map(
+  ): LoggingEntries =
+    LoggingEntries(
       logging.commandId(commandId),
       logging.transactionId(transactionId),
       logging.workflowId(workflowId),

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
@@ -27,7 +27,7 @@ import com.daml.ledger.participant.state.v1.{
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext.withEnrichedLoggingContextFrom
-import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries}
+import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries, LoggingEntry}
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.indexer.ExecuteUpdate.ExecuteUpdateFlow
 import com.daml.platform.indexer.OffsetUpdate.PreparedTransactionInsert
@@ -311,40 +311,56 @@ trait ExecuteUpdate {
     }
 
   private object Logging {
-    def submissionId(id: SubmissionId): (String, String) =
+    def submissionId(id: SubmissionId): LoggingEntry =
       "submissionId" -> id
-    def submissionIdOpt(id: Option[SubmissionId]): (String, String) =
-      "submissionId" -> id.getOrElse("")
-    def participantId(id: ParticipantId): (String, String) =
+
+    def submissionIdOpt(id: Option[SubmissionId]): LoggingEntry =
+      "submissionId" -> id
+
+    def participantId(id: ParticipantId): LoggingEntry =
       "participantId" -> id
-    def commandId(id: CommandId): (String, String) =
+
+    def commandId(id: CommandId): LoggingEntry =
       "commandId" -> id
-    def party(party: Party): (String, String) =
+
+    def party(party: Party): LoggingEntry =
       "party" -> party
-    def transactionId(id: TransactionId): (String, String) =
+
+    def transactionId(id: TransactionId): LoggingEntry =
       "transactionId" -> id
-    def applicationId(id: ApplicationId): (String, String) =
+
+    def applicationId(id: ApplicationId): LoggingEntry =
       "applicationId" -> id
-    def workflowIdOpt(id: Option[WorkflowId]): (String, String) =
-      "workflowId" -> id.getOrElse("")
-    def ledgerTime(time: Timestamp): (String, String) =
-      "ledgerTime" -> time.toInstant.toString
-    def submissionTime(time: Timestamp): (String, String) =
-      "submissionTime" -> time.toInstant.toString
-    def configGeneration(generation: Long): (String, String) =
-      "configGeneration" -> generation.toString
-    def maxDeduplicationTime(time: Duration): (String, String) =
-      "maxDeduplicationTime" -> time.toString
-    def deduplicateUntil(time: Instant): (String, String) =
+
+    def workflowIdOpt(id: Option[WorkflowId]): LoggingEntry =
+      "workflowId" -> id
+
+    def ledgerTime(time: Timestamp): LoggingEntry =
+      "ledgerTime" -> time.toInstant
+
+    def submissionTime(time: Timestamp): LoggingEntry =
+      "submissionTime" -> time.toInstant
+
+    def configGeneration(generation: Long): LoggingEntry =
+      "configGeneration" -> generation
+
+    def maxDeduplicationTime(time: Duration): LoggingEntry =
+      "maxDeduplicationTime" -> time
+
+    def deduplicateUntil(time: Instant): LoggingEntry =
       "deduplicateUntil" -> time.toString
-    def rejectionReason(reason: String): (String, String) =
+
+    def rejectionReason(reason: String): LoggingEntry =
       "rejectionReason" -> reason
-    def displayName(name: String): (String, String) =
+
+    def displayName(name: String): LoggingEntry =
       "displayName" -> name
-    def sourceDescriptionOpt(description: Option[String]): (String, String) =
-      "sourceDescription" -> description.getOrElse("")
-    def submitter(parties: List[Party]): (String, String) =
-      "submitter" -> parties.mkString("[", ", ", "]")
+
+    def sourceDescriptionOpt(description: Option[String]): LoggingEntry =
+      "sourceDescription" -> description
+
+    def submitter(parties: List[Party]): LoggingEntry =
+      "submitter" -> parties
 
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
@@ -235,8 +235,8 @@ trait ExecuteUpdate {
       update: Update,
   ): LoggingEntries =
     loggingEntriesFor(update) :+
-      "updateRecordTime" -> update.recordTime.toInstant.toString :+
-      "updateOffset" -> offset.toHexString
+      "updateRecordTime" -> update.recordTime.toInstant :+
+      "updateOffset" -> offset
 
   private def loggingEntriesFor(update: Update): LoggingEntries =
     update match {
@@ -348,7 +348,7 @@ trait ExecuteUpdate {
       "maxDeduplicationTime" -> time
 
     def deduplicateUntil(time: Instant): LoggingEntry =
-      "deduplicateUntil" -> time.toString
+      "deduplicateUntil" -> time
 
     def rejectionReason(reason: String): LoggingEntry =
       "rejectionReason" -> reason

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/IndexerLoggingContext.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/IndexerLoggingContext.scala
@@ -35,8 +35,8 @@ object IndexerLoggingContext {
       update: Update,
   ): LoggingEntries =
     loggingEntriesFor(update) :+
-      "updateRecordTime" -> update.recordTime.toInstant.toString :+
-      "updateOffset" -> offset.toHexString
+      "updateRecordTime" -> update.recordTime.toInstant :+
+      "updateOffset" -> offset
 
   private def loggingEntriesFor(update: Update): LoggingEntries =
     update match {

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/IndexerLoggingContext.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/IndexerLoggingContext.scala
@@ -27,7 +27,7 @@ import com.daml.ledger.participant.state.v1.{
   WorkflowId,
 }
 import com.daml.lf.data.Time.Timestamp
-import com.daml.logging.LoggingEntries
+import com.daml.logging.{LoggingEntries, LoggingEntry}
 
 object IndexerLoggingContext {
   def loggingEntriesFor(
@@ -111,40 +111,56 @@ object IndexerLoggingContext {
     }
 
   private object Logging {
-    def submissionId(id: SubmissionId): (String, String) =
+    def submissionId(id: SubmissionId): LoggingEntry =
       "submissionId" -> id
-    def submissionIdOpt(id: Option[SubmissionId]): (String, String) =
-      "submissionId" -> id.getOrElse("")
-    def participantId(id: ParticipantId): (String, String) =
+
+    def submissionIdOpt(id: Option[SubmissionId]): LoggingEntry =
+      "submissionId" -> id
+
+    def participantId(id: ParticipantId): LoggingEntry =
       "participantId" -> id
-    def commandId(id: CommandId): (String, String) =
+
+    def commandId(id: CommandId): LoggingEntry =
       "commandId" -> id
-    def party(party: Party): (String, String) =
+
+    def party(party: Party): LoggingEntry =
       "party" -> party
-    def transactionId(id: TransactionId): (String, String) =
+
+    def transactionId(id: TransactionId): LoggingEntry =
       "transactionId" -> id
-    def applicationId(id: ApplicationId): (String, String) =
+
+    def applicationId(id: ApplicationId): LoggingEntry =
       "applicationId" -> id
-    def workflowIdOpt(id: Option[WorkflowId]): (String, String) =
-      "workflowId" -> id.getOrElse("")
-    def ledgerTime(time: Timestamp): (String, String) =
-      "ledgerTime" -> time.toInstant.toString
-    def submissionTime(time: Timestamp): (String, String) =
-      "submissionTime" -> time.toInstant.toString
-    def configGeneration(generation: Long): (String, String) =
-      "configGeneration" -> generation.toString
-    def maxDeduplicationTime(time: Duration): (String, String) =
-      "maxDeduplicationTime" -> time.toString
-    def deduplicateUntil(time: Instant): (String, String) =
-      "deduplicateUntil" -> time.toString
-    def rejectionReason(reason: String): (String, String) =
+
+    def workflowIdOpt(id: Option[WorkflowId]): LoggingEntry =
+      "workflowId" -> id
+
+    def ledgerTime(time: Timestamp): LoggingEntry =
+      "ledgerTime" -> time.toInstant
+
+    def submissionTime(time: Timestamp): LoggingEntry =
+      "submissionTime" -> time.toInstant
+
+    def configGeneration(generation: Long): LoggingEntry =
+      "configGeneration" -> generation
+
+    def maxDeduplicationTime(time: Duration): LoggingEntry =
+      "maxDeduplicationTime" -> time
+
+    def deduplicateUntil(time: Instant): LoggingEntry =
+      "deduplicateUntil" -> time
+
+    def rejectionReason(reason: String): LoggingEntry =
       "rejectionReason" -> reason
-    def displayName(name: String): (String, String) =
+
+    def displayName(name: String): LoggingEntry =
       "displayName" -> name
-    def sourceDescriptionOpt(description: Option[String]): (String, String) =
-      "sourceDescription" -> description.getOrElse("")
-    def submitter(parties: List[Party]): (String, String) =
-      "submitter" -> parties.mkString("[", ", ", "]")
+
+    def sourceDescriptionOpt(description: Option[String]): LoggingEntry =
+      "sourceDescription" -> description
+
+    def submitter(parties: List[Party]): LoggingEntry =
+      "submitter" -> parties
   }
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -22,8 +22,8 @@ import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.lf.archive.Decode
-import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.data.Ref.{PackageId, Party}
+import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.engine.ValueEnricher
 import com.daml.lf.transaction.BlindingInfo
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
@@ -142,7 +142,7 @@ private class JdbcLedgerDao(
       endInclusive: Offset,
   )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed] =
     PaginatingAsyncStream(PageSize) { queryOffset =>
-      withEnrichedLoggingContext("queryOffset" -> queryOffset.toString) { implicit loggingContext =>
+      withEnrichedLoggingContext("queryOffset" -> queryOffset) { implicit loggingContext =>
         dbDispatcher.executeSql(metrics.daml.index.db.loadConfigurationEntries) {
           storageBackend.configurationEntries(
             startExclusive = startExclusive,
@@ -285,7 +285,7 @@ private class JdbcLedgerDao(
       endInclusive: Offset,
   )(implicit loggingContext: LoggingContext): Source[(Offset, PartyLedgerEntry), NotUsed] = {
     PaginatingAsyncStream(PageSize) { queryOffset =>
-      withEnrichedLoggingContext("queryOffset" -> queryOffset.toString) { implicit loggingContext =>
+      withEnrichedLoggingContext("queryOffset" -> queryOffset) { implicit loggingContext =>
         dbDispatcher.executeSql(metrics.daml.index.db.loadPartyEntries)(
           storageBackend.partyEntries(
             startExclusive = startExclusive,
@@ -547,7 +547,7 @@ private class JdbcLedgerDao(
       endInclusive: Offset,
   )(implicit loggingContext: LoggingContext): Source[(Offset, PackageLedgerEntry), NotUsed] =
     PaginatingAsyncStream(PageSize) { queryOffset =>
-      withEnrichedLoggingContext("queryOffset" -> queryOffset.toString) { implicit loggingContext =>
+      withEnrichedLoggingContext("queryOffset" -> queryOffset) { implicit loggingContext =>
         dbDispatcher.executeSql(metrics.daml.index.db.loadPackageEntries)(
           storageBackend.packageEntries(
             startExclusive = startExclusive,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -27,7 +27,7 @@ import com.daml.lf.data.Ref.{PackageId, Party}
 import com.daml.lf.engine.ValueEnricher
 import com.daml.lf.transaction.BlindingInfo
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
-import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntry}
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.indexer.{CurrentOffset, IncrementalOffsetStep, OffsetStep}
@@ -731,12 +731,11 @@ private class JdbcLedgerDao(
 private[platform] object JdbcLedgerDao {
 
   object Logging {
+    def submissionId(id: String): LoggingEntry =
+      "submissionId" -> id
 
-    def submissionId(id: String): (String, String) = "submissionId" -> id
-
-    def transactionId(id: TransactionId): (String, String) =
+    def transactionId(id: TransactionId): LoggingEntry =
       "transactionId" -> id
-
   }
 
   def readOwner(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -4,7 +4,6 @@ package com.daml.platform.store.dao
 
 import java.sql.Connection
 import java.time.Instant
-
 import java.util.{Date, UUID}
 
 import akka.NotUsed
@@ -41,7 +40,7 @@ import com.daml.lf.data.Ref.{PackageId, Party}
 import com.daml.lf.engine.ValueEnricher
 import com.daml.lf.transaction.BlindingInfo
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
-import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntry}
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.indexer.{CurrentOffset, OffsetStep}
@@ -1003,12 +1002,11 @@ private class JdbcLedgerDao(
 private[platform] object JdbcLedgerDao {
 
   object Logging {
+    def submissionId(id: String): LoggingEntry =
+      "submissionId" -> id
 
-    def submissionId(id: String): (String, String) = "submissionId" -> id
-
-    def transactionId(id: TransactionId): (String, String) =
+    def transactionId(id: TransactionId): LoggingEntry =
       "transactionId" -> id
-
   }
 
   def readOwner(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -203,7 +203,7 @@ private class JdbcLedgerDao(
       endInclusive: Offset,
   )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed] =
     PaginatingAsyncStream(PageSize) { queryOffset =>
-      withEnrichedLoggingContext("queryOffset" -> queryOffset.toString) { implicit loggingContext =>
+      withEnrichedLoggingContext("queryOffset" -> queryOffset) { implicit loggingContext =>
         dbDispatcher.executeSql(metrics.daml.index.db.loadConfigurationEntries) {
           implicit connection =>
             SQL(queries.SQL_GET_CONFIGURATION_ENTRIES)
@@ -412,7 +412,7 @@ private class JdbcLedgerDao(
       endInclusive: Offset,
   )(implicit loggingContext: LoggingContext): Source[(Offset, PartyLedgerEntry), NotUsed] = {
     PaginatingAsyncStream(PageSize) { queryOffset =>
-      withEnrichedLoggingContext("queryOffset" -> queryOffset.toString) { implicit loggingContext =>
+      withEnrichedLoggingContext("queryOffset" -> queryOffset) { implicit loggingContext =>
         dbDispatcher.executeSql(metrics.daml.index.db.loadPartyEntries) { implicit connection =>
           SQL(queries.SQL_GET_PARTY_ENTRIES)
             .on(
@@ -787,7 +787,7 @@ private class JdbcLedgerDao(
       endInclusive: Offset,
   )(implicit loggingContext: LoggingContext): Source[(Offset, PackageLedgerEntry), NotUsed] =
     PaginatingAsyncStream(PageSize) { queryOffset =>
-      withEnrichedLoggingContext("queryOffset" -> queryOffset.toString) { implicit loggingContext =>
+      withEnrichedLoggingContext("queryOffset" -> queryOffset) { implicit loggingContext =>
         dbDispatcher.executeSql(metrics.daml.index.db.loadPackageEntries) { implicit connection =>
           SQL(queries.SQL_GET_PACKAGE_ENTRIES)
             .on(

--- a/ledger/participant-state/BUILD.bazel
+++ b/ledger/participant-state/BUILD.bazel
@@ -31,6 +31,7 @@ da_scala_library(
         "//ledger/ledger-api-health",
         "//ledger/metrics",
         "//ledger/participant-state/protobuf:ledger_configuration_proto_java",
+        "//libs-scala/contextualized-logging",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_slf4j_slf4j_api",
     ],

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -63,6 +63,7 @@ da_scala_library(
         "//libs-scala/resources-akka",
         "//libs-scala/resources-grpc",
         "//libs-scala/timer-utils",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_dropwizard_metrics_metrics_core",

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -63,7 +63,6 @@ da_scala_library(
         "//libs-scala/resources-akka",
         "//libs-scala/resources-grpc",
         "//libs-scala/timer-utils",
-        "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_dropwizard_metrics_metrics_core",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch
 import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.logging.LoggingContext.newLoggingContext
+import com.daml.logging.LoggingContext.newLoggingContextWith
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.telemetry.{NoOpTelemetryContext, TelemetryContext}
 
@@ -70,7 +70,7 @@ class BatchingLedgerWriter(val queue: BatchingQueue, val writer: LedgerWriter)(
     // Pick a correlation id for the batch.
     val correlationId = UUID.randomUUID().toString
 
-    newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
+    newLoggingContextWith("correlationId" -> correlationId) { implicit loggingContext =>
       // Log the correlation ids of the submissions so we can correlate the batch to the submissions.
       val childCorrelationIds = submissions.map(_.getCorrelationId).mkString(", ")
       logger.trace(s"Committing batch $correlationId with submissions: $childCorrelationIds")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -38,7 +38,7 @@ private[kvutils] class ConfigCommitter(
   override protected val committerName = "config"
 
   override protected def extraLoggingContext(result: Result): LoggingEntries =
-    LoggingEntries("generation" -> result.submission.getConfiguration.getGeneration.toString)
+    LoggingEntries("generation" -> result.submission.getConfiguration.getGeneration)
 
   override protected def init(
       ctx: CommitContext,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -16,7 +16,7 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Engine, VisibleByKey}
 import com.daml.lf.language.Ast
-import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries, LoggingValue}
+import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries}
 import com.daml.metrics.Metrics
 import com.google.protobuf.ByteString
 
@@ -30,12 +30,6 @@ private[committer] object PackageCommitter {
   )
 
   type Step = CommitStep[Result]
-
-  // Orphan, but we can't do much about that.
-  // Adding this to Daml-LF would probably be overkill.
-  private implicit val `DamlLf.Archive to LoggingValue`
-      : LoggingValue.ToLoggingValue[DamlLf.Archive] =
-    value => LoggingValue.OfString(value.getHash)
 }
 
 final private[kvutils] class PackageCommitter(
@@ -53,7 +47,7 @@ final private[kvutils] class PackageCommitter(
 
   override protected def extraLoggingContext(result: Result): LoggingEntries =
     LoggingEntries(
-      "packages" -> result.uploadEntry.getArchivesList.asScala
+      "packages" -> result.uploadEntry.getArchivesList.asScala.view.map(_.getHash)
     )
 
   /** The initial internal state passed to first step. */

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -16,8 +16,7 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Engine, VisibleByKey}
 import com.daml.lf.language.Ast
-import com.daml.logging.LoggingValue.ToLoggingValue
-import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries}
+import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries, LoggingValue}
 import com.daml.metrics.Metrics
 import com.google.protobuf.ByteString
 
@@ -34,8 +33,9 @@ private[committer] object PackageCommitter {
 
   // Orphan, but we can't do much about that.
   // Adding this to Daml-LF would probably be overkill.
-  private implicit val `DamlLf.Archive to LoggingValue`: ToLoggingValue[DamlLf.Archive] =
-    value => generator => generator.writeString(value.getHash)
+  private implicit val `DamlLf.Archive to LoggingValue`
+      : LoggingValue.ToLoggingValue[DamlLf.Archive] =
+    value => LoggingValue.OfString(value.getHash)
 }
 
 final private[kvutils] class PackageCommitter(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -16,6 +16,7 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Engine, VisibleByKey}
 import com.daml.lf.language.Ast
+import com.daml.logging.LoggingValue.ToLoggingValue
 import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries}
 import com.daml.metrics.Metrics
 import com.google.protobuf.ByteString
@@ -30,6 +31,11 @@ private[committer] object PackageCommitter {
   )
 
   type Step = CommitStep[Result]
+
+  // Orphan, but we can't do much about that.
+  // Adding this to Daml-LF would probably be overkill.
+  private implicit val `DamlLf.Archive to LoggingValue`: ToLoggingValue[DamlLf.Archive] =
+    value => generator => generator.writeString(value.getHash)
 }
 
 final private[kvutils] class PackageCommitter(
@@ -48,8 +54,6 @@ final private[kvutils] class PackageCommitter(
   override protected def extraLoggingContext(result: Result): LoggingEntries =
     LoggingEntries(
       "packages" -> result.uploadEntry.getArchivesList.asScala
-        .map(_.getHash)
-        .mkString("[", ", ", "]")
     )
 
   /** The initial internal state passed to first step. */

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -67,7 +67,7 @@ private[kvutils] class TransactionCommitter(
       transactionEntry: DamlTransactionEntrySummary
   ): LoggingEntries =
     LoggingEntries(
-      "submitters" -> transactionEntry.submitters.mkString("[", ", ", "]")
+      "submitters" -> transactionEntry.submitters
     )
 
   override protected def init(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}
 import com.daml.lf.data.Time.Timestamp
-import com.daml.logging.LoggingContext.newLoggingContext
+import com.daml.logging.LoggingContext.newLoggingContextWith
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
@@ -49,7 +49,7 @@ class ValidatingCommitter[LogResult](
       envelope: Raw.Envelope,
       submittingParticipantId: ParticipantId,
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
-    newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
+    newLoggingContextWith("correlationId" -> correlationId) { implicit loggingContext =>
       validator
         .validateAndCommitWithContext(
           envelope,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -23,7 +23,7 @@ import com.daml.ledger.validator._
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
 import com.daml.lf.data.Time
 import com.daml.lf.data.Time.Timestamp
-import com.daml.logging.LoggingContext.newLoggingContext
+import com.daml.logging.LoggingContext.newLoggingContextWith
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
 
@@ -63,7 +63,7 @@ object BatchedSubmissionValidator {
   private def withCorrelationIdLogged[T](
       correlationId: CorrelationId
   )(f: LoggingContext => T): T = {
-    newLoggingContext("correlationId" -> correlationId) { loggingContext =>
+    newLoggingContextWith("correlationId" -> correlationId) { loggingContext =>
       f(loggingContext)
     }
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -19,7 +19,8 @@ import com.daml.ledger.validator.{
   LedgerStateAccess,
   LedgerStateOperationsReaderAdapter,
 }
-import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.logging.ContextualizedLogger
+import com.daml.logging.LoggingContext.newLoggingContextWith
 import com.daml.timer.RetryStrategy
 
 import scala.concurrent.duration._
@@ -62,7 +63,7 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
       exportRecordTime: Instant,
       ledgerStateAccess: LedgerStateAccess[Any],
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
-    LoggingContext.newLoggingContext(
+    newLoggingContextWith(
       "participantId" -> submittingParticipantId,
       "correlationId" -> correlationId,
     ) { implicit loggingContext =>

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
@@ -44,6 +44,6 @@ object Offset {
 
   implicit object `Offset to LoggingValue` extends ToLoggingValue[Offset] {
     override def apply(value: Offset): LoggingValue =
-      new LoggingValue.FromString(value.toHexString)
+      new LoggingValue.OfString(value.toHexString)
   }
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
@@ -6,6 +6,8 @@ package com.daml.ledger.participant.state.v1
 import java.io.InputStream
 
 import com.daml.lf.data.{Bytes, Ref}
+import com.daml.logging.LoggingValue
+import com.daml.logging.LoggingValue.ToLoggingValue
 
 /** Offsets into streams with hierarchical addressing.
   *
@@ -32,7 +34,6 @@ final case class Offset(bytes: Bytes) extends Ordered[Offset] {
 }
 
 object Offset {
-
   val beforeBegin: Offset = Offset.fromByteArray(Array.empty[Byte])
 
   def fromByteArray(bytes: Array[Byte]) = new Offset(Bytes.fromByteArray(bytes))
@@ -40,4 +41,9 @@ object Offset {
   def fromInputStream(is: InputStream) = new Offset(Bytes.fromInputStream(is))
 
   def fromHexString(s: Ref.HexString) = new Offset(Bytes.fromHexString(s))
+
+  implicit object `Offset to LoggingValue` extends ToLoggingValue[Offset] {
+    override def apply(value: Offset): LoggingValue =
+      new LoggingValue.FromString(value.toHexString)
+  }
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -30,7 +30,7 @@ import com.daml.lf.transaction.{
   StandardTransactionCommitter,
   TransactionCommitter,
 }
-import com.daml.logging.LoggingContext.newLoggingContext
+import com.daml.logging.LoggingContext.newLoggingContextWith
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, MetricsReporting}
 import com.daml.platform.apiserver._
@@ -50,9 +50,9 @@ import com.daml.platform.store.{FlywayMigrations, LfValueTranslationCache}
 import com.daml.ports.Port
 import scalaz.syntax.tag._
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 object SandboxServer {
@@ -106,7 +106,7 @@ object SandboxServer {
       config: SandboxConfig
   )(implicit resourceContext: ResourceContext): Future[Unit] = {
 
-    newLoggingContext(logging.participantId(config.participantId)) { implicit loggingContext =>
+    newLoggingContextWith(logging.participantId(config.participantId)) { implicit loggingContext =>
       logger.info("Running only schema migration scripts")
       new FlywayMigrations(config.jdbcUrl.get)
         .migrate(enableAppendOnlySchema = config.enableAppendOnlySchema)
@@ -449,7 +449,7 @@ final class SandboxServer(
   }
 
   private def start(): Future[SandboxState] = {
-    newLoggingContext(logging.participantId(config.participantId)) { implicit loggingContext =>
+    newLoggingContextWith(logging.participantId(config.participantId)) { implicit loggingContext =>
       val packageStore = loadDamlPackages()
       val apiServerResource = buildAndStartApiServer(
         materializer,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -6,7 +6,7 @@ package com.daml.platform.sandbox.stores
 import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 import com.daml.api.util.TimeProvider
-import com.daml.daml_lf_dev.DamlLf.Archive
+import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.participant.state.v1.{
   Configuration,
@@ -72,7 +72,7 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
   // WritePackagesService
   override def uploadPackages(
       submissionId: SubmissionId,
-      payload: List[Archive],
+      payload: List[DamlLf.Archive],
       sourceDescription: Option[String],
   )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     withEnrichedLoggingContext(
@@ -81,8 +81,7 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
       "packageHashes" -> payload.view.map(_.getHash),
     ) { implicit loggingContext =>
       FutureConverters.toJava(
-        ledger
-          .uploadPackages(submissionId, timeProvider.getCurrentTime, sourceDescription, payload)
+        ledger.uploadPackages(submissionId, timeProvider.getCurrentTime, sourceDescription, payload)
       )
     }
 

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -42,13 +42,13 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
       estimatedInterpretationCost: Long,
   )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     withEnrichedLoggingContext(
-      "actAs" -> submitterInfo.actAs.mkString(","),
+      "actAs" -> submitterInfo.actAs,
       "applicationId" -> submitterInfo.applicationId,
       "commandId" -> submitterInfo.commandId,
-      "deduplicateUntil" -> submitterInfo.deduplicateUntil.toString,
-      "submissionTime" -> transactionMeta.submissionTime.toInstant.toString,
-      "workflowId" -> transactionMeta.workflowId.getOrElse(""),
-      "ledgerTime" -> transactionMeta.ledgerEffectiveTime.toInstant.toString,
+      "deduplicateUntil" -> submitterInfo.deduplicateUntil,
+      "submissionTime" -> transactionMeta.submissionTime.toInstant,
+      "workflowId" -> transactionMeta.workflowId,
+      "ledgerTime" -> transactionMeta.ledgerEffectiveTime.toInstant,
     ) { implicit loggingContext =>
       FutureConverters.toJava(
         ledger.publishTransaction(submitterInfo, transactionMeta, transaction)
@@ -77,8 +77,8 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
   )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     withEnrichedLoggingContext(
       "submissionId" -> submissionId,
-      "description" -> sourceDescription.getOrElse(""),
-      "packageHashes" -> payload.iterator.map(_.getHash).mkString(","),
+      "description" -> sourceDescription,
+      "packageHashes" -> payload.view.map(_.getHash),
     ) { implicit loggingContext =>
       FutureConverters.toJava(
         ledger
@@ -93,10 +93,10 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
       config: Configuration,
   )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
     withEnrichedLoggingContext(
-      "maxRecordTime" -> maxRecordTime.toInstant.toString,
+      "maxRecordTime" -> maxRecordTime.toInstant,
       "submissionId" -> submissionId,
-      "configGeneration" -> config.generation.toString,
-      "configMaxDeduplicationTime" -> config.maxDeduplicationTime.toString,
+      "configGeneration" -> config.generation,
+      "configMaxDeduplicationTime" -> config.maxDeduplicationTime,
     ) { implicit loggingContext =>
       FutureConverters.toJava(ledger.publishConfiguration(maxRecordTime, submissionId, config))
     }

--- a/ledger/sandbox-common/BUILD.bazel
+++ b/ledger/sandbox-common/BUILD.bazel
@@ -136,6 +136,7 @@ da_scala_library(
         "//ledger/participant-state",
         "//ledger/test-common",
         "//ledger/test-common:dar-files-stable-lib",
+        "//libs-scala/contextualized-logging",
         "//libs-scala/ports",
         "//libs-scala/postgresql-testing",
         "//libs-scala/resources",

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/logging/package.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/logging/package.scala
@@ -4,9 +4,10 @@
 package com.daml.platform.sandbox
 
 import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.logging.LoggingEntry
 
 package object logging {
 
-  def participantId(id: ParticipantId): (String, String) = "participantId" -> id
+  def participantId(id: ParticipantId): LoggingEntry = "participantId" -> id
 
 }

--- a/libs-scala/contextualized-logging/BUILD.bazel
+++ b/libs-scala/contextualized-logging/BUILD.bazel
@@ -36,9 +36,9 @@ da_scala_test_suite(
     srcs = glob(["src/test/suite/**/*.scala"]),
     resources = glob(["src/test/suite/resources/**/*"]),
     scala_deps = [
+        "@maven//:com_chuusai_shapeless",
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
-        "@maven//:com_chuusai_shapeless",
         "@maven//:io_circe_circe_core",
         "@maven//:io_circe_circe_generic",
         "@maven//:io_circe_circe_parser",
@@ -50,6 +50,7 @@ da_scala_test_suite(
         ":contextualized-logging",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:ch_qos_logback_logback_core",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:net_logstash_logback_logstash_logback_encoder",
         "@maven//:org_mockito_mockito_core",
         "@maven//:org_slf4j_slf4j_api",

--- a/libs-scala/contextualized-logging/BUILD.bazel
+++ b/libs-scala/contextualized-logging/BUILD.bazel
@@ -24,6 +24,7 @@ da_scala_library(
     ],
     deps = [
         "//libs-scala/grpc-utils",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:io_grpc_grpc_api",
         "@maven//:net_logstash_logback_logstash_logback_encoder",
         "@maven//:org_slf4j_slf4j_api",

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/JsonStringSerializer.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/JsonStringSerializer.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.logging
+
+import java.io.StringWriter
+
+import com.fasterxml.jackson.core.json.JsonWriteFeature
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter
+import com.fasterxml.jackson.core.{JsonFactoryBuilder, JsonGenerator}
+import net.logstash.logback.argument.StructuredArgument
+
+object JsonStringSerializer {
+  private val toStringJsonFactory =
+    new JsonFactoryBuilder().disable(JsonWriteFeature.QUOTE_FIELD_NAMES).build()
+
+  def serialize(value: StructuredArgument): String = {
+    val writer = new StringWriter
+    val generator =
+      toStringJsonFactory.createGenerator(writer).setPrettyPrinter(SpaceSeparatedPrettyPrinter)
+    value.writeTo(generator)
+    generator.flush()
+    writer.toString
+  }
+
+  private object SpaceSeparatedPrettyPrinter extends MinimalPrettyPrinter {
+    override def writeObjectFieldValueSeparator(g: JsonGenerator): Unit = {
+      super.writeObjectFieldValueSeparator(g)
+      g.writeRaw(' ')
+    }
+
+    override def writeObjectEntrySeparator(g: JsonGenerator): Unit = {
+      super.writeObjectEntrySeparator(g)
+      g.writeRaw(' ')
+    }
+
+    override def writeArrayValueSeparator(g: JsonGenerator): Unit = {
+      super.writeArrayValueSeparator(g)
+      g.writeRaw(' ')
+    }
+  }
+}

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
@@ -14,7 +14,7 @@ object LoggingContext {
   def newLoggingContext[A](f: LoggingContext => A): A =
     newLoggingContext(LoggingEntries.empty)(f)
 
-  def newLoggingContext[A](entry: LoggingEntry, entries: LoggingEntry*)(
+  def newLoggingContextWith[A](entry: LoggingEntry, entries: LoggingEntry*)(
       f: LoggingContext => A
   ): A =
     newLoggingContext(withEnrichedLoggingContext(entry, entries: _*)(f)(_))

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
@@ -3,10 +3,15 @@
 
 package com.daml.logging
 
+import java.io.StringWriter
+
+import com.daml.logging.LoggingEntries._
+import com.fasterxml.jackson.core.json.JsonWriteFeature
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter
+import com.fasterxml.jackson.core.{JsonFactoryBuilder, JsonGenerator}
 import net.logstash.logback.argument.StructuredArgument
-import net.logstash.logback.marker.MapEntriesAppendingMarker
+import net.logstash.logback.marker.LogstashMarker
 import org.slf4j.Marker
-import scala.jdk.CollectionConverters._
 
 final class LoggingEntries private (
     private[logging] val contents: Map[LoggingKey, LoggingValue]
@@ -21,15 +26,52 @@ final class LoggingEntries private (
     new LoggingEntries(contents ++ other.contents)
 
   private[logging] def loggingMarker: Marker with StructuredArgument =
-    new MapEntriesAppendingMarker(contents.asJava)
+    new LoggingMarker(contents)
 }
 
 object LoggingEntries {
   val empty: LoggingEntries = new LoggingEntries(Map.empty)
+
+  private val toStringJsonFactory =
+    new JsonFactoryBuilder().disable(JsonWriteFeature.QUOTE_FIELD_NAMES).build()
 
   def apply(entries: LoggingEntry*): LoggingEntries =
     new LoggingEntries(entries.toMap)
 
   def fromIterator(entries: Iterator[LoggingEntry]): LoggingEntries =
     new LoggingEntries(entries.toMap)
+
+  private final class LoggingMarker(contents: Map[LoggingKey, LoggingValue])
+      extends LogstashMarker(LogstashMarker.MARKER_NAME_PREFIX + "LOGGING_ENTRIES")
+      with StructuredArgument {
+    override def writeTo(generator: JsonGenerator): Unit = {
+      contents.foreach { case (key, LoggingValue(value)) =>
+        generator.writeFieldName(key)
+        generator.writeObject(value)
+      }
+    }
+
+    override def toStringSelf: String = {
+      val writer = new StringWriter
+      val generator =
+        toStringJsonFactory.createGenerator(writer).setPrettyPrinter(SpaceSeparatedPrettyPrinter)
+      generator.writeStartObject()
+      writeTo(generator)
+      generator.writeEndObject()
+      generator.flush()
+      writer.toString
+    }
+  }
+
+  private object SpaceSeparatedPrettyPrinter extends MinimalPrettyPrinter {
+    override def writeObjectFieldValueSeparator(g: JsonGenerator): Unit = {
+      super.writeObjectFieldValueSeparator(g)
+      g.writeRaw(' ')
+    }
+
+    override def writeObjectEntrySeparator(g: JsonGenerator): Unit = {
+      super.writeObjectEntrySeparator(g)
+      g.writeRaw(' ')
+    }
+  }
 }

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
@@ -3,10 +3,7 @@
 
 package com.daml.logging
 
-import com.daml.logging.LoggingEntries._
-import com.fasterxml.jackson.core.JsonGenerator
 import net.logstash.logback.argument.StructuredArgument
-import net.logstash.logback.marker.LogstashMarker
 import org.slf4j.Marker
 
 final class LoggingEntries private (
@@ -33,22 +30,4 @@ object LoggingEntries {
 
   def fromIterator(entries: Iterator[LoggingEntry]): LoggingEntries =
     new LoggingEntries(entries.toMap)
-
-  private final class LoggingMarker(contents: Map[LoggingKey, LoggingValue])
-      extends LogstashMarker(LogstashMarker.MARKER_NAME_PREFIX + "LOGGING_ENTRIES")
-      with StructuredArgument {
-    override def writeTo(generator: JsonGenerator): Unit = {
-      contents.foreach { case (key, value) =>
-        generator.writeFieldName(key)
-        value.writeTo(generator)
-      }
-    }
-
-    override def toStringSelf: String =
-      JsonStringSerializer.serialize { generator =>
-        generator.writeStartObject()
-        writeTo(generator)
-        generator.writeEndObject()
-      }
-  }
 }

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
@@ -73,5 +73,10 @@ object LoggingEntries {
       super.writeObjectEntrySeparator(g)
       g.writeRaw(' ')
     }
+
+    override def writeArrayValueSeparator(g: JsonGenerator): Unit = {
+      super.writeArrayValueSeparator(g)
+      g.writeRaw(' ')
+    }
   }
 }

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
@@ -45,9 +45,9 @@ object LoggingEntries {
       extends LogstashMarker(LogstashMarker.MARKER_NAME_PREFIX + "LOGGING_ENTRIES")
       with StructuredArgument {
     override def writeTo(generator: JsonGenerator): Unit = {
-      contents.foreach { case (key, LoggingValue(value)) =>
+      contents.foreach { case (key, value) =>
         generator.writeFieldName(key)
-        generator.writeObject(value)
+        value.writeTo(generator)
       }
     }
 

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingMarker.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingMarker.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.logging
+
+import com.fasterxml.jackson.core.JsonGenerator
+import net.logstash.logback.argument.StructuredArgument
+import net.logstash.logback.marker.LogstashMarker
+
+private[logging] final class LoggingMarker(contents: Map[LoggingKey, LoggingValue])
+    extends LogstashMarker(LogstashMarker.MARKER_NAME_PREFIX + "LOGGING_ENTRIES")
+    with StructuredArgument {
+  override def writeTo(generator: JsonGenerator): Unit = {
+    contents.foreach { case (key, value) =>
+      generator.writeFieldName(key)
+      LoggingValueSerializer.writeValue(value, generator)
+    }
+  }
+
+  override def toStringSelf: String =
+    JsonStringSerializer.serialize { generator =>
+      generator.writeStartObject()
+      writeTo(generator)
+      generator.writeEndObject()
+    }
+}

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
@@ -5,7 +5,6 @@ package com.daml.logging
 
 import java.time.{Duration, Instant}
 
-import scala.collection.SeqView
 import scala.language.implicitConversions
 
 sealed trait LoggingValue
@@ -50,11 +49,6 @@ object LoggingValue {
     case None => Empty
     case Some(value) => elementToLoggingValue(value)
   }
-
-  implicit def `SeqView[T] to LoggingValue`[T](implicit
-      elementToLoggingValue: ToLoggingValue[T]
-  ): ToLoggingValue[SeqView[T]] =
-    sequence => OfIterable(sequence.map(elementToLoggingValue.apply))
 
   implicit def `Iterable[T] to LoggingValue`[T](implicit
       elementToLoggingValue: ToLoggingValue[T]

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
@@ -10,10 +10,8 @@ import com.fasterxml.jackson.core.JsonGenerator
 import scala.collection.SeqView
 import scala.language.implicitConversions
 
-final case class LoggingValue(value: String) {
-  def writeTo(generator: JsonGenerator): Unit = {
-    generator.writeString(value)
-  }
+sealed trait LoggingValue {
+  def writeTo(generator: JsonGenerator): Unit
 }
 
 object LoggingValue {
@@ -25,25 +23,41 @@ object LoggingValue {
   implicit def from[T](value: T)(implicit toLoggingValue: ToLoggingValue[T]): LoggingValue =
     toLoggingValue(value)
 
-  implicit object `String to LoggingValue` extends ToLoggingValue[String] {
-    override def apply(value: String): LoggingValue =
-      new LoggingValue(value)
-  }
-
-  class ToStringToLoggingValue[T] extends ToLoggingValue[T] {
+  private final class ToStringToLoggingValue[T] extends ToLoggingValue[T] {
     override def apply(value: T): LoggingValue =
-      new LoggingValue(value.toString)
+      `String to LoggingValue`(value.toString)
   }
 
-  implicit val `Int to LoggingValue`: ToLoggingValue[Int] = new ToStringToLoggingValue
-  implicit val `Long to LoggingValue`: ToLoggingValue[Long] = new ToStringToLoggingValue
+  implicit val `String to LoggingValue`: ToLoggingValue[String] = value =>
+    new LoggingValue {
+      override def writeTo(generator: JsonGenerator): Unit =
+        generator.writeString(value)
+    }
+
+  implicit val `Int to LoggingValue`: ToLoggingValue[Int] = value =>
+    new LoggingValue {
+      override def writeTo(generator: JsonGenerator): Unit =
+        generator.writeNumber(value)
+    }
+
+  implicit val `Long to LoggingValue`: ToLoggingValue[Long] = value =>
+    new LoggingValue {
+      override def writeTo(generator: JsonGenerator): Unit =
+        generator.writeNumber(value)
+    }
+
   implicit val `Instant to LoggingValue`: ToLoggingValue[Instant] = new ToStringToLoggingValue
+
   implicit val `Duration to LoggingValue`: ToLoggingValue[Duration] = new ToStringToLoggingValue
 
   implicit def `Option[T] to LoggingValue`[T](implicit
       elementToLoggingValue: ToLoggingValue[T]
   ): ToLoggingValue[Option[T]] = {
-    case None => ""
+    case None =>
+      new LoggingValue {
+        override def writeTo(generator: JsonGenerator): Unit =
+          generator.writeNull()
+      }
     case Some(value) => elementToLoggingValue(value)
   }
 
@@ -51,9 +65,15 @@ object LoggingValue {
       elementToLoggingValue: ToLoggingValue[T]
   ): ToLoggingValue[SeqView[T]] =
     (sequence: SeqView[T]) =>
-      new LoggingValue(
-        sequence.map(element => elementToLoggingValue.apply(element).value).mkString("[", ", ", "]")
-      )
+      new LoggingValue {
+        override def writeTo(generator: JsonGenerator): Unit = {
+          generator.writeStartArray()
+          sequence.foreach { element =>
+            elementToLoggingValue.apply(element).writeTo(generator)
+          }
+          generator.writeEndArray()
+        }
+      }
 
   implicit def `Seq[T] to LoggingValue`[T](implicit
       elementToLoggingValue: ToLoggingValue[T]

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
@@ -28,10 +28,8 @@ object LoggingValue {
   implicit def from[T](value: T)(implicit toLoggingValue: ToLoggingValue[T]): LoggingValue =
     toLoggingValue(value)
 
-  private final class ToStringToLoggingValue[T] extends ToLoggingValue[T] {
-    override def apply(value: T): LoggingValue =
-      OfString(value.toString)
-  }
+  // This is not implicit because we only want to expose it for specific types.
+  val ToStringToLoggingValue: ToLoggingValue[Any] = value => OfString(value.toString)
 
   implicit val `String to LoggingValue`: ToLoggingValue[String] = OfString(_)
 
@@ -39,9 +37,9 @@ object LoggingValue {
 
   implicit val `Long to LoggingValue`: ToLoggingValue[Long] = OfLong(_)
 
-  implicit val `Instant to LoggingValue`: ToLoggingValue[Instant] = new ToStringToLoggingValue
+  implicit val `Instant to LoggingValue`: ToLoggingValue[Instant] = ToStringToLoggingValue
 
-  implicit val `Duration to LoggingValue`: ToLoggingValue[Duration] = new ToStringToLoggingValue
+  implicit val `Duration to LoggingValue`: ToLoggingValue[Duration] = ToStringToLoggingValue
 
   implicit def `Option[T] to LoggingValue`[T](implicit
       elementToLoggingValue: ToLoggingValue[T]

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
@@ -5,10 +5,16 @@ package com.daml.logging
 
 import java.time.{Duration, Instant}
 
+import com.fasterxml.jackson.core.JsonGenerator
+
 import scala.collection.SeqView
 import scala.language.implicitConversions
 
-final case class LoggingValue(value: String) extends AnyVal
+final case class LoggingValue(value: String) {
+  def writeTo(generator: JsonGenerator): Unit = {
+    generator.writeString(value)
+  }
+}
 
 object LoggingValue {
   trait ToLoggingValue[-T] {

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.logging
+
+import java.time.{Duration, Instant}
+
+import scala.collection.SeqView
+import scala.language.implicitConversions
+
+final case class LoggingValue(value: String) extends AnyVal
+
+object LoggingValue {
+  trait ToLoggingValue[-T] {
+    def apply(value: T): LoggingValue
+  }
+
+  @inline
+  implicit def from[T](value: T)(implicit toLoggingValue: ToLoggingValue[T]): LoggingValue =
+    toLoggingValue(value)
+
+  implicit object `String to LoggingValue` extends ToLoggingValue[String] {
+    override def apply(value: String): LoggingValue =
+      new LoggingValue(value)
+  }
+
+  class ToStringToLoggingValue[T] extends ToLoggingValue[T] {
+    override def apply(value: T): LoggingValue =
+      new LoggingValue(value.toString)
+  }
+
+  implicit val `Int to LoggingValue`: ToLoggingValue[Int] = new ToStringToLoggingValue
+  implicit val `Long to LoggingValue`: ToLoggingValue[Long] = new ToStringToLoggingValue
+  implicit val `Instant to LoggingValue`: ToLoggingValue[Instant] = new ToStringToLoggingValue
+  implicit val `Duration to LoggingValue`: ToLoggingValue[Duration] = new ToStringToLoggingValue
+
+  implicit def `Option[T] to LoggingValue`[T](implicit
+      elementToLoggingValue: ToLoggingValue[T]
+  ): ToLoggingValue[Option[T]] = {
+    case None => ""
+    case Some(value) => elementToLoggingValue(value)
+  }
+
+  implicit def `SeqView[T] to LoggingValue`[T](implicit
+      elementToLoggingValue: ToLoggingValue[T]
+  ): ToLoggingValue[SeqView[T]] =
+    (sequence: SeqView[T]) =>
+      new LoggingValue(
+        sequence.map(element => elementToLoggingValue.apply(element).value).mkString("[", ", ", "]")
+      )
+
+  implicit def `Seq[T] to LoggingValue`[T](implicit
+      elementToLoggingValue: ToLoggingValue[T]
+  ): ToLoggingValue[Seq[T]] =
+    (sequence: Seq[T]) => `SeqView[T] to LoggingValue`(elementToLoggingValue)(sequence.view)
+}

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValueSerializer.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValueSerializer.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.logging
+
+import com.fasterxml.jackson.core.JsonGenerator
+
+private[logging] object LoggingValueSerializer {
+  def writeValue(value: LoggingValue, generator: JsonGenerator): Unit = {
+    value match {
+      case LoggingValue.Empty =>
+        generator.writeNull()
+      case LoggingValue.OfString(value) =>
+        generator.writeString(value)
+      case LoggingValue.OfInt(value) =>
+        generator.writeNumber(value)
+      case LoggingValue.OfLong(value) =>
+        generator.writeNumber(value)
+      case LoggingValue.OfIterable(sequence) =>
+        generator.writeStartArray()
+        sequence.foreach(writeValue(_, generator))
+        generator.writeEndArray()
+    }
+  }
+}

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/package.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/package.scala
@@ -7,6 +7,5 @@ package object logging {
   type LoggingContextOf[+P] = LoggingContextOf.Module.Instance.T[P]
 
   type LoggingKey = String
-  type LoggingValue = String
   type LoggingEntry = (LoggingKey, LoggingValue)
 }

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/ContextualizedLoggerSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/ContextualizedLoggerSpec.scala
@@ -34,14 +34,14 @@ final class ContextualizedLoggerSpec
     withContext("id" -> "foobar")() { logger => implicit loggingContext =>
       logger.info("a")
       val m = logger.withoutContext
-      verify(m).info(toStringEqTo[Marker]("{id=foobar}"), eqTo("a"))
+      verify(m).info(toStringEqTo[Marker]("""{id: "foobar"}"""), eqTo("a"))
     }
 
   it should "pass the context via the markers if a throwable is provided" in
     withContext("id" -> "foo")() { logger => implicit loggingContext =>
       logger.error("a", new IllegalArgumentException("quux"))
       verify(logger.withoutContext).error(
-        toStringEqTo[Marker]("{id=foo}"),
+        toStringEqTo[Marker]("""{id: "foo"}"""),
         eqTo("a"),
         withMessage[IllegalArgumentException]("quux"),
       )
@@ -63,9 +63,9 @@ final class ContextualizedLoggerSpec
       }
       logger.info("c")
       val m = logger.withoutContext
-      verify(m).info(toStringEqTo[Marker]("{i1=x}"), eqTo("a"))
-      verify(m).info(toStringEqTo[Marker]("{i1=x, i2=y}"), eqTo("b"))
-      verify(m).info(toStringEqTo[Marker]("{i1=x}"), eqTo("c"))
+      verify(m).info(toStringEqTo[Marker]("""{i1: "x"}"""), eqTo("a"))
+      verify(m).info(toStringEqTo[Marker]("""{i1: "x", i2: "y"}"""), eqTo("b"))
+      verify(m).info(toStringEqTo[Marker]("""{i1: "x"}"""), eqTo("c"))
     }
 
   it should "override with values provided in a more specific scope" in
@@ -76,9 +76,9 @@ final class ContextualizedLoggerSpec
       }
       logger.info("c")
       val m = logger.withoutContext
-      verify(m).info(toStringEqTo[Marker]("{id=foobar}"), eqTo("a"))
-      verify(m).info(toStringEqTo[Marker]("{id=quux}"), eqTo("b"))
-      verify(m).info(toStringEqTo[Marker]("{id=foobar}"), eqTo("c"))
+      verify(m).info(toStringEqTo[Marker]("""{id: "foobar"}"""), eqTo("a"))
+      verify(m).info(toStringEqTo[Marker]("""{id: "quux"}"""), eqTo("b"))
+      verify(m).info(toStringEqTo[Marker]("""{id: "foobar"}"""), eqTo("c"))
     }
 
   it should "pick the expected context also when executing in a future" in
@@ -87,14 +87,18 @@ final class ContextualizedLoggerSpec
       import scala.concurrent.duration.DurationInt
       import scala.concurrent.{Await, Future}
 
-      val f1 = Future { logger.info("a") }
+      val f1 = Future {
+        logger.info("a")
+      }
       LoggingContext.withEnrichedLoggingContext("id" -> "next") { implicit loggingContext =>
-        val f2 = Future { logger.info("b") }
+        val f2 = Future {
+          logger.info("b")
+        }
         Await.result(Future.sequence(Seq(f1, f2)), 10.seconds)
       }
       val m = logger.withoutContext
-      verify(m).info(toStringEqTo[Marker]("{id=future}"), eqTo("a"))
-      verify(m).info(toStringEqTo[Marker]("{id=next}"), eqTo("b"))
+      verify(m).info(toStringEqTo[Marker]("""{id: "future"}"""), eqTo("a"))
+      verify(m).info(toStringEqTo[Marker]("""{id: "next"}"""), eqTo("b"))
     }
 
   it should "drop the context if new context is provided at a more specific scope" in
@@ -105,9 +109,9 @@ final class ContextualizedLoggerSpec
       }
       logger.info("d")
       val m = logger.withoutContext
-      verify(m).info(toStringEqTo[Marker]("{id=foobar}"), eqTo("a"))
+      verify(m).info(toStringEqTo[Marker]("""{id: "foobar"}"""), eqTo("a"))
       verify(m).info("b")
-      verify(m).info(toStringEqTo[Marker]("{id=foobar}"), eqTo("d"))
+      verify(m).info(toStringEqTo[Marker]("""{id: "foobar"}"""), eqTo("d"))
     }
 
   it should "allow the user to use the underlying logger, foregoing context" in
@@ -122,7 +126,7 @@ final class ContextualizedLoggerSpec
       logger.info("b")
       val m = logger.withoutContext
       verify(m).info("a")
-      verify(m).info(toStringEqTo[Marker]("{id=foobar}"), eqTo("b"))
+      verify(m).info(toStringEqTo[Marker]("""{id: "foobar"}"""), eqTo("b"))
     }
 
   it should "debug foreach stream item" in
@@ -139,19 +143,21 @@ final class ContextualizedLoggerSpec
 
       items.foreach { item =>
         verify(logger.withoutContext)
-          .debug(toStringEqTo[Marker]("{id=foobar}"), eqTo(s"$item"))
+          .debug(toStringEqTo[Marker]("""{id: "foobar"}"""), eqTo(item.toString))
       }
     }
 
-  def withEmptyContext(f: ContextualizedLogger => LoggingContext => Unit): Unit =
+  private def withEmptyContext(f: ContextualizedLogger => LoggingContext => Unit): Unit =
     LoggingContext.newLoggingContext(f(ContextualizedLogger.createFor(mockLogger(Level.INFO))))
 
-  def withContext(kv: (String, String))(level: Level = Level.INFO)(
+  private def withContext(entry: LoggingEntry)(level: Level = Level.INFO)(
       f: ContextualizedLogger => LoggingContext => Unit
   ): Unit =
-    LoggingContext.newLoggingContext(kv)(f(ContextualizedLogger.createFor(mockLogger(level))))
+    LoggingContext.newLoggingContextWith(entry)(
+      f(ContextualizedLogger.createFor(mockLogger(level)))
+    )
 
-  def mockLogger(level: Level): Logger = {
+  private def mockLogger(level: Level): Logger = {
     val mocked = mock[Logger]
     when(mocked.isTraceEnabled()).thenReturn(level.toInt <= EventConstants.TRACE_INT)
     when(mocked.isDebugEnabled()).thenReturn(level.toInt <= EventConstants.DEBUG_INT)
@@ -161,10 +167,9 @@ final class ContextualizedLoggerSpec
     mocked
   }
 
-  def toStringEqTo[T](s: String): T =
-    argThat[T]((_: T).toString == s)
+  private def toStringEqTo[T](expected: String): T =
+    argThat[T]((_: T).toString == expected, s"toString value of: $expected")
 
-  def withMessage[T <: Throwable](s: String): Throwable =
-    argThat[T]((_: T).getMessage == s)
-
+  private def withMessage[T <: Throwable](expected: String): Throwable =
+    argThat[T]((_: T).getMessage == expected, s"throwable with message: $expected")
 }

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/JsonStringSerializerSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/JsonStringSerializerSpec.scala
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.logging
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class JsonStringSerializerSpec extends AnyWordSpec with Matchers {
+  "serializing a value to a string" can {
+    "serialize strings" in {
+      val result = JsonStringSerializer.serialize { generator => generator.writeString("hello") }
+      result should be("\"hello\"")
+    }
+
+    "serialize numbers" in {
+      val result = JsonStringSerializer.serialize { generator => generator.writeNumber(99) }
+      result should be("99")
+    }
+
+    "serialize null" in {
+      val result = JsonStringSerializer.serialize { generator => generator.writeNull() }
+      result should be("null")
+    }
+
+    "serialize objects minimally, with spaces, and no quotes around field names" in {
+      val result = JsonStringSerializer.serialize { generator =>
+        generator.writeStartObject()
+        generator.writeFieldName("foo")
+        generator.writeNumber(7)
+        generator.writeFieldName("bar")
+        generator.writeString("eleven")
+        generator.writeEndObject()
+      }
+      result should be("{foo: 7, bar: \"eleven\"}")
+    }
+
+    "serialize empty objects minimally" in {
+      val result = JsonStringSerializer.serialize { generator =>
+        generator.writeStartObject()
+        generator.writeEndObject()
+      }
+      result should be("{}")
+    }
+
+    "serialize arrays minimally, but with spaces" in {
+      val result = JsonStringSerializer.serialize { generator =>
+        generator.writeStartArray()
+        generator.writeNumber(1)
+        generator.writeNumber(2)
+        generator.writeString("fizz")
+        generator.writeNull()
+        generator.writeString("buzz")
+        generator.writeEndArray()
+      }
+      result should be("[1, 2, \"fizz\", null, \"buzz\"]")
+    }
+
+    "serialize empty arrays minimally" in {
+      val result = JsonStringSerializer.serialize { generator =>
+        generator.writeStartArray()
+        generator.writeEndArray()
+      }
+      result should be("[]")
+    }
+  }
+}

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
@@ -3,41 +3,65 @@
 
 package com.daml.logging
 
+import java.io.StringWriter
+
+import com.daml.logging.LoggingValueSpec._
+import com.fasterxml.jackson.core.JsonFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class LoggingValueSpec extends AnyWordSpec with Matchers {
   "a logging value" can {
     "be constructed from a string" in {
-      LoggingValue.from("foo bar").value should be("foo bar")
+      val value = LoggingValue.from("foo bar")
+      writingToGenerator(value) should be("\"foo bar\"")
     }
 
     "be constructed from an int" in {
-      LoggingValue.from(1981).value should be("1981")
+      val value = LoggingValue.from(1981)
+      writingToGenerator(value) should be("\"1981\"")
     }
 
     "be constructed from a long" in {
-      LoggingValue.from(Long.MaxValue).value should be("9223372036854775807")
+      val value = LoggingValue.from(Long.MaxValue)
+      writingToGenerator(value) should be("\"9223372036854775807\"")
     }
 
     "be constructed from a defined optional value" in {
-      LoggingValue.from(Some(99)).value should be("99")
+      val value = LoggingValue.from(Some(99))
+      writingToGenerator(value) should be("\"99\"")
     }
 
     "be constructed from an empty optional value" in {
-      LoggingValue.from(None: Option[String]).value should be("")
+      val value = LoggingValue.from(None: Option[String])
+      writingToGenerator(value) should be("\"\"")
     }
 
     "be constructed from a sequence" in {
-      LoggingValue.from(Seq("a", "b", "c")).value should be("[a, b, c]")
+      val value = LoggingValue.from(Seq("a", "b", "c"))
+      writingToGenerator(value) should be("\"[a, b, c]\"")
     }
 
     "be constructed from an empty sequence" in {
-      LoggingValue.from(Seq.empty[Long]).value should be("[]")
+      val value = LoggingValue.from(Seq.empty[Long])
+      writingToGenerator(value) should be("\"[]\"")
     }
 
     "be constructed from a sequence view" in {
-      LoggingValue.from(Seq(1, 4, 7).view.map(_ * 2)).value should be("[2, 8, 14]")
+      val value = LoggingValue.from(Seq(1, 4, 7).view.map(_ * 2))
+      writingToGenerator(value) should be("\"[2, 8, 14]\"")
     }
+  }
+}
+
+object LoggingValueSpec {
+  private val testJsonFactory = new JsonFactory
+
+  private def writingToGenerator(value: LoggingValue): String = {
+    val writer = new StringWriter
+    val generator = testJsonFactory.createGenerator(writer)
+    value.writeTo(generator)
+    generator.flush()
+    writer.toString
   }
 }

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.logging
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class LoggingValueSpec extends AnyWordSpec with Matchers {
+  "a logging value" can {
+    "be constructed from a string" in {
+      LoggingValue.from("foo bar").value should be("foo bar")
+    }
+
+    "be constructed from an int" in {
+      LoggingValue.from(1981).value should be("1981")
+    }
+
+    "be constructed from a long" in {
+      LoggingValue.from(Long.MaxValue).value should be("9223372036854775807")
+    }
+
+    "be constructed from a defined optional value" in {
+      LoggingValue.from(Some(99)).value should be("99")
+    }
+
+    "be constructed from an empty optional value" in {
+      LoggingValue.from(None: Option[String]).value should be("")
+    }
+
+    "be constructed from a sequence" in {
+      LoggingValue.from(Seq("a", "b", "c")).value should be("[a, b, c]")
+    }
+
+    "be constructed from an empty sequence" in {
+      LoggingValue.from(Seq.empty[Long]).value should be("[]")
+    }
+
+    "be constructed from a sequence view" in {
+      LoggingValue.from(Seq(1, 4, 7).view.map(_ * 2)).value should be("[2, 8, 14]")
+    }
+  }
+}

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
@@ -19,37 +19,37 @@ class LoggingValueSpec extends AnyWordSpec with Matchers {
 
     "be constructed from an int" in {
       val value = LoggingValue.from(1981)
-      writingToGenerator(value) should be("\"1981\"")
+      writingToGenerator(value) should be("1981")
     }
 
     "be constructed from a long" in {
       val value = LoggingValue.from(Long.MaxValue)
-      writingToGenerator(value) should be("\"9223372036854775807\"")
+      writingToGenerator(value) should be("9223372036854775807")
     }
 
     "be constructed from a defined optional value" in {
       val value = LoggingValue.from(Some(99))
-      writingToGenerator(value) should be("\"99\"")
+      writingToGenerator(value) should be("99")
     }
 
     "be constructed from an empty optional value" in {
       val value = LoggingValue.from(None: Option[String])
-      writingToGenerator(value) should be("\"\"")
+      writingToGenerator(value) should be("null")
     }
 
     "be constructed from a sequence" in {
       val value = LoggingValue.from(Seq("a", "b", "c"))
-      writingToGenerator(value) should be("\"[a, b, c]\"")
+      writingToGenerator(value) should be("[\"a\",\"b\",\"c\"]")
     }
 
     "be constructed from an empty sequence" in {
       val value = LoggingValue.from(Seq.empty[Long])
-      writingToGenerator(value) should be("\"[]\"")
+      writingToGenerator(value) should be("[]")
     }
 
     "be constructed from a sequence view" in {
       val value = LoggingValue.from(Seq(1, 4, 7).view.map(_ * 2))
-      writingToGenerator(value) should be("\"[2, 8, 14]\"")
+      writingToGenerator(value) should be("[2,8,14]")
     }
   }
 }

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
@@ -60,7 +60,7 @@ object LoggingValueSpec {
   private def writingToGenerator(value: LoggingValue): String = {
     val writer = new StringWriter
     val generator = testJsonFactory.createGenerator(writer)
-    value.writeTo(generator)
+    LoggingValueSerializer.writeValue(value, generator)
     generator.flush()
     writer.toString
   }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -42,7 +42,7 @@ object TriggerRunnerImpl {
       restartConfig: TriggerRestartConfig,
   ) {
     private[trigger] def withLoggingContext[T](f: LoggingContextOf[Config with Trigger] => T): T =
-      trigger.withLoggingContext[Config]("triggerId" -> triggerInstance.toString)(f)
+      trigger.withLoggingContext.labelled[Config]("triggerId" -> triggerInstance.toString)(f)
   }
 
   sealed trait Message


### PR DESCRIPTION
This introduces a `LoggingValue` enumeration that can serialize different data types in a more JSON-friendly way.

For example, a submission log line now looks like this:

```
15:16:38.856 [in-memory-ledger-akka.actor.default-dispatcher-8] INFO  c.d.p.a.s.ApiSubmissionService - Submitting transaction , context: {readAs: [], submittedAt: "2021-06-28T13:16:38.852Z", actAs: ["SemanticDoubleSpendShared-alpha-11e2a521f23e-party-0"], commandId: "SemanticDoubleSpendShared-alpha-11e2a521f23e-command-0", applicationId: "SemanticDoubleSpendShared", deduplicateUntil: "2021-06-29T13:16:38.852Z"}
```

Note that strings are correctly quoted, including inside JSON arrays. Numbers will remain unquoted. In addition, `None` will now serialize to `null`, not an empty string.

I have turned off quoting for the field names for now, to keep the output closer to the previous format, but it can easily be turned back on.

I think the implicit conversions make the code that uses the `withEnrichedLoggingContext` function much more pleasant, though of course you might disagree.

### Changelog

- The log output of Daml components has changed so that the structured part is closer to JSON. This allows us to distinguish and parse numbers and lists. If you are parsing this log output, you may need to change your parser.

  The log output has changed from:

      context: {a=b, x=1, foo=bar, parties=[alice, bob]}

  to:

      context: {a: "b", x: 1, foo: "bar", parties: ["alice", "bob"]}

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
