### PR TITLE
Resolve contract keys conflicts in disclosed contracts (#9948) (#10034)

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -453,6 +453,8 @@ final class Metrics(val registry: MetricRegistry) {
           val deleteContractWitnessesBatch: Timer =
             registry.timer(dbPrefix :+ "delete_contract_witnesses_batch")
           val deleteContractsBatch: Timer = registry.timer(dbPrefix :+ "delete_contracts_batch")
+          val nullifyPastKeysBatch: Timer =
+            registry.timer(dbPrefix :+ "nullify_contract_keys_batch")
           val insertContractsBatch: Timer = registry.timer(dbPrefix :+ "insert_contracts_batch")
           val insertContractWitnessesBatch: Timer =
             registry.timer(dbPrefix :+ "insert_contract_witnesses_batch")

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTable.scala
@@ -23,6 +23,20 @@ private[events] abstract class ContractsTable extends PostCommitValidationData {
   private def deleteContract(contractId: ContractId): Vector[NamedParameter] =
     Vector[NamedParameter]("contract_id" -> contractId)
 
+  // This query blanks out contract keys for all previous contracts irrespective of how they were created
+  // a) for disclosed contracts
+  // b) for contracts where parties hosted by this participant are stakeholders
+  // The contracts covered by case b) are an empty set, considering the guarantees of the committer that
+  // all transactions communicated via the update stream adhere to the ledger model i.e. all conflict on
+  // contract keys have been resolved at this point. Such contracts must have been archived already
+  // either in a previous or current transaction. What we are left with effectively are contracts covered
+  // by case a).
+  private val nullifyPastKeysQuery =
+    s"update participant_contracts set create_key_hash = null where create_key_hash = {create_key_hash}"
+
+  private def nullifyPastKeys(contractKeyHash: String): Vector[NamedParameter] =
+    Vector[NamedParameter]("create_key_hash" -> contractKeyHash)
+
   def toExecutables(
       info: TransactionIndexing.ContractsInfo,
       tx: TransactionIndexing.TransactionInfo,
@@ -32,6 +46,20 @@ private[events] abstract class ContractsTable extends PostCommitValidationData {
   protected def buildDeletes(info: TransactionIndexing.ContractsInfo): Option[BatchSql] = {
     val deletes = info.netArchives.iterator.map(deleteContract).toSeq
     batch(deleteContractQuery, deletes)
+  }
+
+  protected def buildNullifyPastKeys(info: TransactionIndexing.ContractsInfo): Option[BatchSql] = {
+    val nullifyPastKey = info.netCreates
+      .flatMap(create =>
+        create.key
+          .map(convertLfValueKey(create.templateId, _))
+          .map(_.hash.bytes.toHexString)
+          .toList
+      )
+      .iterator
+      .map(nullifyPastKeys)
+      .toSeq
+    batch(nullifyPastKeysQuery, nullifyPastKey)
   }
 
   override def lookupContractKeyGlobally(
@@ -68,7 +96,11 @@ private[events] object ContractsTable {
     def execute()(implicit connection: Connection): Unit
   }
 
-  final case class Executables(deleteContracts: Option[BatchSql], insertContracts: Executable)
+  final case class Executables(
+      deleteContracts: Option[BatchSql],
+      insertContracts: Executable,
+      nullifyPastKeys: Option[BatchSql],
+  )
 
   def apply(dbType: DbType): ContractsTable =
     dbType match {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTableH2.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTableH2.scala
@@ -27,6 +27,7 @@ object ContractsTableH2 extends ContractsTable {
   ): ContractsTable.Executables = ContractsTable.Executables(
     deleteContracts = buildDeletes(info),
     insertContracts = buildInserts(tx, info, serialized),
+    nullifyPastKeys = buildNullifyPastKeys(info),
   )
 
   private def insertContract(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTableOracle.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTableOracle.scala
@@ -27,6 +27,7 @@ object ContractsTableOracle extends ContractsTable {
   ): ContractsTable.Executables = ContractsTable.Executables(
     deleteContracts = buildDeletes(info),
     insertContracts = buildInserts(tx, info, serialized),
+    nullifyPastKeys = buildNullifyPastKeys(info),
   )
 
   private def insertContract(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTablePostgres.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTablePostgres.scala
@@ -42,6 +42,7 @@ object ContractsTablePostgres extends ContractsTable {
     ContractsTable.Executables(
       deleteContracts = buildDeletes(info),
       insertContracts = buildInserts(tx, info, serialized),
+      nullifyPastKeys = buildNullifyPastKeys(info),
     )
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsWriter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsWriter.scala
@@ -49,6 +49,10 @@ private[platform] object TransactionsWriter {
         Timed.value(deleteContractsBatch, deleteContracts.execute())
       }
 
+      for (nullifyPastKeys <- contractsTableExecutables.nullifyPastKeys) {
+        Timed.value(nullifyPastKeysBatch, nullifyPastKeys.execute())
+      }
+
       Timed.value(insertContractsBatch, contractsTableExecutables.insertContracts.execute())
 
       // Insert the witnesses last to respect the foreign key constraint of the underlying storage.


### PR DESCRIPTION
* Resolve contract keys conflicts in disclosed contracts (#9948)

* build queries for nullifications of past key

* format code

CHANGELOG_BEGIN
In case a contract key is already present in a past contract in the contract table nullify it. This gets rid of contract keys of previously disclosed contracts. We never discover that disclosed contracts get archived, so we get conflicts on such past keys
CHANGELOG_END

Co-authored-by: Moritz Kiefer <moritz.kiefer@purelyfunctional.org>

* correct oracle implemantation (new)

Co-authored-by: Moritz Kiefer <moritz.kiefer@purelyfunctional.org>

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
