### PR TITLE
Daml assistant capitalization

### DIFF
--- a/compatibility/bazel_tools/daml_sdk.bzl
+++ b/compatibility/bazel_tools/daml_sdk.bzl
@@ -18,7 +18,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 """
 
 def _daml_sdk_impl(ctx):
-    # The DAML assistant will mark the installed SDK read-only.
+    # The Daml assistant will mark the installed SDK read-only.
     # This breaks Bazel horribly on Windows to the point where
     # even `bazel clean --expunge` fails because it cannot remove
     # the installed SDK. Therefore, we do not use the assistant to

--- a/compiler/damlc/tests/src/daml-ghc-deterministic.sh
+++ b/compiler/damlc/tests/src/daml-ghc-deterministic.sh
@@ -29,7 +29,7 @@ damlc=$(rlocation "$TEST_WORKSPACE/$1")
 protoc=$(rlocation "$TEST_WORKSPACE/$2")
 diff="$3"
 
-# Check that DAML compilation is deterministic.
+# Check that Daml compilation is deterministic.
 TMP_SRC1=$(mktemp -d)
 TMP_SRC2=$(mktemp -d)
 TMP_OUT=$(mktemp -d)

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -117,10 +117,10 @@ versionChecks Env{..} =
                 , ""
                 ]
 
-        -- DAML assistant is outdated.
+        -- Daml assistant is outdated.
         when (not isHead && not projectSdkVersionIsOld && assistantVersionIsOld) $ do
             hPutStr stderr . unlines $
-                [ "WARNING: Using an outdated version of the DAML assistant."
+                [ "WARNING: Using an outdated version of the Daml assistant."
                 , "Please upgrade to the latest stable version by running:"
                 , ""
                 , "    daml install latest"

--- a/daml-assistant/src/DA/Daml/Assistant/Install/Completion.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/Completion.hs
@@ -71,7 +71,7 @@ doInstallBashCompletions damlPath output = do
         Left e -> do
             output ("Bash completions not installed: " <> displayException e)
             catchIO (removePathForcibly scriptPath) (const $ pure ())
-        Right () -> output "Bash completions installed for DAML assistant."
+        Right () -> output "Bash completions installed for Daml assistant."
 
 -- | Generate the Zsh completion script.
 doInstallZshCompletions :: DamlPath -> (String -> IO ()) -> IO ()
@@ -81,7 +81,7 @@ doInstallZshCompletions damlPath output = do
     createDirectoryIfMissing True (takeDirectory scriptPath)
     BSL.writeFile scriptPath script
     output $ unlines
-        [ "Zsh completions installed for DAML assistant."
+        [ "Zsh completions installed for Daml assistant."
         , "To use them, add '~/.daml/zsh' to your $fpath, e.g. by adding the following"
         , "to the beginning of '~/.zshrc' before you call 'compinit':"
         , "fpath=(~/.daml/zsh $fpath)"

--- a/daml-assistant/src/DA/Daml/Assistant/Install/Path.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/Path.hs
@@ -110,7 +110,7 @@ updatePath installOpts output targetPath
                     ci <- isCI
                     if stdinIsTerminal && stdoutIsTerminal && not ci
                       then do
-                        answer <- prompt output ("Add DAML Assistant executable to your PATH (in " ++ configFile ++ ")?") "Yes" ["No"]
+                        answer <- prompt output ("Add Daml assistant executable to your PATH (in " ++ configFile ++ ")?") "Yes" ["No"]
                         when (answer `elem` ["Yes", "yes", "y", "Y"]) $ doUpdatePath cfgFile cmd
                       else output setPathManualMsg
                   Yes -> doUpdatePath cfgFile cmd


### PR DESCRIPTION
changelog_begin
changelog_end

- DAML -> daml
- Assistant -> assistant

The capitalization of the latter fixed one occurrence of a capitalized 'A'
which was inconsistent with the vast majority of uncapitalized 'a's.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
