### PR TITLE
participant-integration-api: Move transaction requests to structured logging. [KVL-996]

### DIFF
--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByIdRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByIdRequest.scala
@@ -4,14 +4,12 @@
 package com.daml.ledger.api.messages.transaction
 
 import brave.propagation.TraceContext
-import com.daml.lf.data.Ref.Party
 import com.daml.ledger.api.domain.{LedgerId, TransactionId}
-
-import scala.collection.immutable
+import com.daml.lf.data.Ref.Party
 
 final case class GetTransactionByIdRequest(
     ledgerId: LedgerId,
     transactionId: TransactionId,
-    requestingParties: immutable.Set[Party],
+    requestingParties: Set[Party],
     traceContext: Option[TraceContext],
 )

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionTreesRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionTreesRequest.scala
@@ -4,16 +4,14 @@
 package com.daml.ledger.api.messages.transaction
 
 import brave.propagation.TraceContext
-import com.daml.lf.data.Ref.Party
 import com.daml.ledger.api.domain.{LedgerId, LedgerOffset}
-
-import scala.collection.immutable
+import com.daml.lf.data.Ref.Party
 
 final case class GetTransactionTreesRequest(
     ledgerId: LedgerId,
     startExclusive: LedgerOffset,
     endInclusive: Option[LedgerOffset],
-    parties: immutable.Set[Party],
+    parties: Set[Party],
     verbose: Boolean,
     traceContext: Option[TraceContext],
 )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrp
 import com.daml.ledger.api.v1.active_contracts_service._
 import com.daml.ledger.api.validation.TransactionFilterValidator
 import com.daml.ledger.participant.state.index.v2.{IndexActiveContractsService => ACSBackend}
-import com.daml.logging.LoggingContext.withEnrichedLoggingContextFrom
+import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.platform.api.grpc.GrpcApiService
@@ -43,7 +43,7 @@ private[apiserver] final class ApiActiveContractsService private (
       .fold(
         t => Source.failed(ValidationLogger.logFailureWithContext(request, t)),
         filters =>
-          withEnrichedLoggingContextFrom(logging.filters(filters)) { implicit loggingContext =>
+          withEnrichedLoggingContext(logging.filters(filters)) { implicit loggingContext =>
             logger.info(s"Received request for active contracts: $request")
             backend.getActiveContracts(filters, request.verbose)
           },

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -67,13 +67,15 @@ package object logging {
       filters: TransactionFilter
   ): LoggingEntry =
     "filters" -> LoggingValue.Nested(
-      LoggingEntries.fromIterable(
-        filters.filtersByParty.view.mapValues(partyFilters =>
-          partyFilters.inclusive match {
-            case None => "all-templates"
-            case Some(inclusiveFilters) => inclusiveFilters.templateIds.view.map(_.toString)
-          }
-        )
+      LoggingEntries.fromMap(
+        filters.filtersByParty.view
+          .mapValues[LoggingValue](partyFilters =>
+            partyFilters.inclusive match {
+              case None => "all-templates"
+              case Some(inclusiveFilters) => inclusiveFilters.templateIds.view.map(_.toString)
+            }
+          )
+          .toMap
       )
     )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -10,6 +10,7 @@ import com.daml.ledger.api.domain.{
   CommandId,
   Commands,
   EventId,
+  LedgerId,
   LedgerOffset,
   TransactionFilter,
   TransactionId,
@@ -43,6 +44,9 @@ package object logging {
 
   private[services] def offset(offset: String): LoggingEntry =
     "offset" -> offset
+
+  private[services] def ledgerId(id: LedgerId): LoggingEntry =
+    "ledgerId" -> id.unwrap
 
   private[services] def applicationId(id: ApplicationId): LoggingEntry =
     "applicationId" -> id.unwrap
@@ -102,5 +106,8 @@ package object logging {
     )
     cmds.workflowId.fold(context)(context :+ workflowId(_))
   }
+
+  private[services] def verbose(v: Boolean): LoggingEntry =
+    "verbose" -> v
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -41,6 +41,9 @@ package object logging {
   private[services] def offset(offset: Option[LedgerOffset]): LoggingEntry =
     "offset" -> offset
 
+  private[services] def offset(offset: String): LoggingEntry =
+    "offset" -> offset
+
   private[services] def applicationId(id: ApplicationId): LoggingEntry =
     "applicationId" -> id.unwrap
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -61,17 +61,17 @@ package object logging {
 
   private[services] def filters(
       filters: TransactionFilter
-  ): LoggingEntries =
-    LoggingEntries.fromIterator(filters.filtersByParty.iterator.flatMap {
-      case (party, partyFilters) =>
-        Iterator
-          .continually(s"party-$party")
-          .zip(
-            partyFilters.inclusive
-              .fold(Iterator.single("all-templates"))(_.templateIds.iterator.map(_.toString))
-              .map(LoggingValue.from(_))
-          )
-    })
+  ): LoggingEntry =
+    "filters" -> LoggingValue.Nested(
+      LoggingEntries.fromView(
+        filters.filtersByParty.view.mapValues(partyFilters =>
+          partyFilters.inclusive match {
+            case None => "all-templates"
+            case Some(inclusiveFilters) => inclusiveFilters.templateIds.view.map(_.toString)
+          }
+        )
+      )
+    )
 
   private[services] def submissionId(id: String): LoggingEntry =
     "submissionId" -> id

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -67,7 +67,7 @@ package object logging {
       filters: TransactionFilter
   ): LoggingEntry =
     "filters" -> LoggingValue.Nested(
-      LoggingEntries.fromView(
+      LoggingEntries.fromIterable(
         filters.filtersByParty.view.mapValues(partyFilters =>
           partyFilters.inclusive match {
             case None => "all-templates"

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -11,10 +11,10 @@ import com.daml.ledger.api.domain.{
   Commands,
   EventId,
   LedgerOffset,
+  TransactionFilter,
   TransactionId,
   WorkflowId,
 }
-import com.daml.ledger.api.v1.transaction_filter.Filters
 import com.daml.logging.{LoggingEntries, LoggingEntry, LoggingValue}
 import scalaz.syntax.tag.ToTagOps
 
@@ -59,15 +59,18 @@ package object logging {
   private[services] def eventId(id: EventId): LoggingEntry =
     "eventId" -> id.unwrap
 
-  private[services] def filters(filtersByParty: Map[String, Filters]): LoggingEntries =
-    LoggingEntries.fromIterator(filtersByParty.iterator.flatMap { case (party, filters) =>
-      Iterator
-        .continually(s"party-$party")
-        .zip(
-          filters.inclusive
-            .fold(Iterator.single("all-templates"))(_.templateIds.iterator.map(_.toString))
-            .map(LoggingValue.from(_))
-        )
+  private[services] def filters(
+      filters: TransactionFilter
+  ): LoggingEntries =
+    LoggingEntries.fromIterator(filters.filtersByParty.iterator.flatMap {
+      case (party, partyFilters) =>
+        Iterator
+          .continually(s"party-$party")
+          .zip(
+            partyFilters.inclusive
+              .fold(Iterator.single("all-templates"))(_.templateIds.iterator.map(_.toString))
+              .map(LoggingValue.from(_))
+          )
     })
 
   private[services] def submissionId(id: String): LoggingEntry =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -68,14 +68,13 @@ package object logging {
   ): LoggingEntry =
     "filters" -> LoggingValue.Nested(
       LoggingEntries.fromMap(
-        filters.filtersByParty.view
-          .mapValues[LoggingValue](partyFilters =>
-            partyFilters.inclusive match {
-              case None => "all-templates"
-              case Some(inclusiveFilters) => inclusiveFilters.templateIds.view.map(_.toString)
-            }
-          )
-          .toMap
+        filters.filtersByParty.view.map { case (party, partyFilters) =>
+          (party: String) -> (partyFilters.inclusive match {
+            case None => LoggingValue.from("all-templates")
+            case Some(inclusiveFilters) =>
+              LoggingValue.from(inclusiveFilters.templateIds.view.map(_.toString))
+          })
+        }.toMap
       )
     )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -221,6 +221,6 @@ private[apiserver] final class ApiTransactionService private (
       logging.commandId(commandId),
       logging.transactionId(transactionId),
       logging.workflowId(workflowId),
-      "offset" -> offset,
+      logging.offset(offset),
     )
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -19,7 +19,7 @@ import com.daml.ledger.api.v1.transaction_service.{
 import com.daml.ledger.api.validation.PartyNameChecker
 import com.daml.ledger.participant.state.index.v2.IndexTransactionsService
 import com.daml.lf.data.Ref.Party
-import com.daml.logging.LoggingContext.withEnrichedLoggingContext
+import com.daml.logging.LoggingContext.{withEnrichedLoggingContext, withEnrichedLoggingContextFrom}
 import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries}
 import com.daml.metrics.Metrics
 import com.daml.platform.apiserver.services.transaction.ApiTransactionService._
@@ -75,9 +75,10 @@ private[apiserver] final class ApiTransactionService private (
     withEnrichedLoggingContext(
       logging.startExclusive(request.startExclusive),
       logging.endInclusive(request.endInclusive),
-      logging.parties(request.filter.filtersByParty.keys),
     ) { implicit loggingContext =>
-      logger.info("Received request for transactions.")
+      withEnrichedLoggingContextFrom(logging.filters(request.filter)) { implicit loggingContext =>
+        logger.info("Received request for transactions.")
+      }
       logger.trace(s"Transaction request: $request")
       transactionsService
         .transactions(request.startExclusive, request.endInclusive, request.filter, request.verbose)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -67,7 +67,8 @@ private[apiserver] final class ApiTransactionService private (
       logging.endInclusive(request.endInclusive),
       logging.parties(request.filter.filtersByParty.keys),
     ) { implicit loggingContext =>
-      logger.info(s"Received request for transaction: $request")
+      logger.info("Received request for transactions.")
+      logger.trace(s"Transaction request: $request")
       transactionsService
         .transactions(request.startExclusive, request.endInclusive, request.filter, request.verbose)
         .via(logger.debugStream(transactionsLoggable))
@@ -98,13 +99,14 @@ private[apiserver] final class ApiTransactionService private (
 
   override def getTransactionTrees(
       request: GetTransactionTreesRequest
-  ): Source[GetTransactionTreesResponse, NotUsed] =
+  ): Source[GetTransactionTreesResponse, NotUsed] = {
     withEnrichedLoggingContext(
       logging.startExclusive(request.startExclusive),
       logging.endInclusive(request.endInclusive),
       logging.parties(request.parties),
     ) { implicit loggingContext =>
-      logger.info(s"Received request for transaction tree subscription: $request")
+      logger.info("Received request for transaction trees.")
+      logger.trace(s"Transaction tree request: $request")
       transactionsService
         .transactionTrees(
           request.startExclusive,
@@ -116,6 +118,7 @@ private[apiserver] final class ApiTransactionService private (
         .via(logger.logErrorsOnStream)
         .via(StreamMetrics.countElements(metrics.daml.lapi.streams.transactionTrees))
     }
+  }
 
   override def getTransactionByEventId(
       request: GetTransactionByEventIdRequest
@@ -124,7 +127,8 @@ private[apiserver] final class ApiTransactionService private (
       logging.eventId(request.eventId),
       logging.parties(request.requestingParties),
     ) { implicit loggingContext =>
-      logger.info(s"Received request for transaction by event id: $request")
+      logger.info("Received request for transaction by event ID.")
+      logger.trace(s"Transaction by event ID: $request")
       ledger.EventId
         .fromString(request.eventId.unwrap)
         .map { case ledger.EventId(transactionId, _) =>
@@ -147,7 +151,8 @@ private[apiserver] final class ApiTransactionService private (
       logging.transactionId(request.transactionId),
       logging.parties(request.requestingParties),
     ) { implicit loggingContext =>
-      logger.info(s"Received request for transaction by id $request")
+      logger.info("Received request for transaction by ID.")
+      logger.trace(s"Transaction by ID: $request")
       lookUpTreeByTransactionId(request.transactionId, request.requestingParties)
         .andThen(logger.logErrorsOnCall[GetTransactionResponse])
     }
@@ -159,7 +164,8 @@ private[apiserver] final class ApiTransactionService private (
       logging.eventId(request.eventId),
       logging.parties(request.requestingParties),
     ) { implicit loggingContext =>
-      logger.info(s"Received request for flat transaction by event id: $request")
+      logger.info("Received request for flat transaction by event ID.")
+      logger.trace(s"Flat transaction by event ID: $request")
       ledger.EventId
         .fromString(request.eventId.unwrap)
         .fold(
@@ -183,7 +189,8 @@ private[apiserver] final class ApiTransactionService private (
       logging.transactionId(request.transactionId),
       logging.parties(request.requestingParties),
     ) { implicit loggingContext =>
-      logger.info(s"Received request for flat transaction by id: $request")
+      logger.info("Received request for flat transaction by ID.")
+      logger.trace(s"Flat transaction by ID: $request")
       lookUpFlatByTransactionId(request.transactionId, request.requestingParties)
         .andThen(logger.logErrorsOnCall[GetFlatTransactionResponse])
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -117,7 +117,7 @@ private[apiserver] final class ApiTransactionService private (
       logging.parties(request.requestingParties),
     ) { implicit loggingContext =>
       logger.info("Received request for transaction by event ID.")
-      logger.trace(s"Transaction by event ID: $request")
+      logger.trace(s"Transaction by event ID request: $request")
       ledger.EventId
         .fromString(request.eventId.unwrap)
         .map { case ledger.EventId(transactionId, _) =>
@@ -141,7 +141,7 @@ private[apiserver] final class ApiTransactionService private (
       logging.parties(request.requestingParties),
     ) { implicit loggingContext =>
       logger.info("Received request for transaction by ID.")
-      logger.trace(s"Transaction by ID: $request")
+      logger.trace(s"Transaction by ID request: $request")
       lookUpTreeByTransactionId(request.transactionId, request.requestingParties)
         .andThen(logger.logErrorsOnCall[GetTransactionResponse])
     }
@@ -154,7 +154,7 @@ private[apiserver] final class ApiTransactionService private (
       logging.parties(request.requestingParties),
     ) { implicit loggingContext =>
       logger.info("Received request for flat transaction by event ID.")
-      logger.trace(s"Flat transaction by event ID: $request")
+      logger.trace(s"Flat transaction by event ID request: $request")
       ledger.EventId
         .fromString(request.eventId.unwrap)
         .fold(
@@ -179,7 +179,7 @@ private[apiserver] final class ApiTransactionService private (
       logging.parties(request.requestingParties),
     ) { implicit loggingContext =>
       logger.info("Received request for flat transaction by ID.")
-      logger.trace(s"Flat transaction by ID: $request")
+      logger.trace(s"Flat transaction by ID request: $request")
       lookUpFlatByTransactionId(request.transactionId, request.requestingParties)
         .andThen(logger.logErrorsOnCall[GetFlatTransactionResponse])
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -19,7 +19,7 @@ import com.daml.ledger.api.v1.transaction_service.{
 import com.daml.ledger.api.validation.PartyNameChecker
 import com.daml.ledger.participant.state.index.v2.IndexTransactionsService
 import com.daml.lf.data.Ref.Party
-import com.daml.logging.LoggingContext.{withEnrichedLoggingContext, withEnrichedLoggingContextFrom}
+import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext, LoggingEntries}
 import com.daml.metrics.Metrics
 import com.daml.platform.apiserver.services.transaction.ApiTransactionService._
@@ -76,7 +76,7 @@ private[apiserver] final class ApiTransactionService private (
       logging.startExclusive(request.startExclusive),
       logging.endInclusive(request.endInclusive),
     ) { implicit loggingContext =>
-      withEnrichedLoggingContextFrom(logging.filters(request.filter)) { implicit loggingContext =>
+      withEnrichedLoggingContext(logging.filters(request.filter)) { implicit loggingContext =>
         logger.info("Received request for transactions.")
       }
       logger.trace(s"Transaction request: $request")

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
@@ -12,6 +12,9 @@ final class LoggingEntries private (
   def isEmpty: Boolean =
     contents.isEmpty
 
+  def +:(entry: LoggingEntry): LoggingEntries =
+    new LoggingEntries(contents + entry)
+
   def :+(entry: LoggingEntry): LoggingEntries =
     new LoggingEntries(contents + entry)
 

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
@@ -6,8 +6,6 @@ package com.daml.logging
 import net.logstash.logback.argument.StructuredArgument
 import org.slf4j.Marker
 
-import scala.collection.View
-
 final class LoggingEntries private (
     private[logging] val contents: Map[LoggingKey, LoggingValue]
 ) extends AnyVal {
@@ -33,6 +31,6 @@ object LoggingEntries {
   def apply(entries: LoggingEntry*): LoggingEntries =
     new LoggingEntries(entries.toMap)
 
-  def fromView(entries: View[LoggingEntry]): LoggingEntries =
+  def fromIterable(entries: Iterable[LoggingEntry]): LoggingEntries =
     new LoggingEntries(entries.toMap)
 }

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
@@ -6,6 +6,8 @@ package com.daml.logging
 import net.logstash.logback.argument.StructuredArgument
 import org.slf4j.Marker
 
+import scala.collection.View
+
 final class LoggingEntries private (
     private[logging] val contents: Map[LoggingKey, LoggingValue]
 ) extends AnyVal {
@@ -31,6 +33,6 @@ object LoggingEntries {
   def apply(entries: LoggingEntry*): LoggingEntries =
     new LoggingEntries(entries.toMap)
 
-  def fromIterator(entries: Iterator[LoggingEntry]): LoggingEntries =
+  def fromView(entries: View[LoggingEntry]): LoggingEntries =
     new LoggingEntries(entries.toMap)
 }

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingEntries.scala
@@ -31,6 +31,6 @@ object LoggingEntries {
   def apply(entries: LoggingEntry*): LoggingEntries =
     new LoggingEntries(entries.toMap)
 
-  def fromIterable(entries: Iterable[LoggingEntry]): LoggingEntries =
-    new LoggingEntries(entries.toMap)
+  def fromMap(entries: Map[LoggingKey, LoggingValue]): LoggingEntries =
+    new LoggingEntries(entries)
 }

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
@@ -12,6 +12,10 @@ sealed trait LoggingValue
 object LoggingValue {
   final object Empty extends LoggingValue
 
+  final object False extends LoggingValue
+
+  final object True extends LoggingValue
+
   final case class OfString(value: String) extends LoggingValue
 
   final case class OfInt(value: Int) extends LoggingValue
@@ -34,6 +38,11 @@ object LoggingValue {
   val ToStringToLoggingValue: ToLoggingValue[Any] = value => OfString(value.toString)
 
   implicit val `String to LoggingValue`: ToLoggingValue[String] = OfString(_)
+
+  implicit val `Boolean to LoggingValue`: ToLoggingValue[Boolean] = {
+    case false => False
+    case true => True
+  }
 
   implicit val `Int to LoggingValue`: ToLoggingValue[Int] = OfInt(_)
 

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValue.scala
@@ -20,6 +20,8 @@ object LoggingValue {
 
   final case class OfIterable(sequence: Iterable[LoggingValue]) extends LoggingValue
 
+  final case class Nested(entries: LoggingEntries) extends LoggingValue
+
   trait ToLoggingValue[-T] {
     def apply(value: T): LoggingValue
   }

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValueSerializer.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValueSerializer.scala
@@ -10,6 +10,10 @@ private[logging] object LoggingValueSerializer {
     value match {
       case LoggingValue.Empty =>
         generator.writeNull()
+      case LoggingValue.False =>
+        generator.writeBoolean(false)
+      case LoggingValue.True =>
+        generator.writeBoolean(true)
       case LoggingValue.OfString(value) =>
         generator.writeString(value)
       case LoggingValue.OfInt(value) =>

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValueSerializer.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValueSerializer.scala
@@ -20,6 +20,10 @@ private[logging] object LoggingValueSerializer {
         generator.writeStartArray()
         sequence.foreach(writeValue(_, generator))
         generator.writeEndArray()
+      case LoggingValue.Nested(entries) =>
+        generator.writeStartObject()
+        entries.loggingMarker.writeTo(generator)
+        generator.writeEndObject()
     }
   }
 }

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/JsonStringSerializerSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/JsonStringSerializerSpec.scala
@@ -8,6 +8,16 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class JsonStringSerializerSpec extends AnyWordSpec with Matchers {
   "serializing a value to a string" can {
+    "serialize null" in {
+      val result = JsonStringSerializer.serialize { generator => generator.writeNull() }
+      result should be("null")
+    }
+
+    "serialize booleans" in {
+      val result = JsonStringSerializer.serialize { generator => generator.writeBoolean(true) }
+      result should be("true")
+    }
+
     "serialize strings" in {
       val result = JsonStringSerializer.serialize { generator => generator.writeString("hello") }
       result should be("\"hello\"")
@@ -16,11 +26,6 @@ class JsonStringSerializerSpec extends AnyWordSpec with Matchers {
     "serialize numbers" in {
       val result = JsonStringSerializer.serialize { generator => generator.writeNumber(99) }
       result should be("99")
-    }
-
-    "serialize null" in {
-      val result = JsonStringSerializer.serialize { generator => generator.writeNull() }
-      result should be("null")
     }
 
     "serialize objects minimally, with spaces, and no quotes around field names" in {

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/LoggingValueSpec.scala
@@ -12,6 +12,16 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class LoggingValueSpec extends AnyWordSpec with Matchers {
   "a logging value" can {
+    "be constructed from the boolean `false`" in {
+      val value = LoggingValue.from(false)
+      writingToGenerator(value) should be("false")
+    }
+
+    "be constructed from the boolean `true`" in {
+      val value = LoggingValue.from(true)
+      writingToGenerator(value) should be("true")
+    }
+
     "be constructed from a string" in {
       val value = LoggingValue.from("foo bar")
       writingToGenerator(value) should be("\"foo bar\"")


### PR DESCRIPTION
This also removes the "subscription ID". I am pretty sure it's not used except for a single log line, which makes it useless as a correlation ID.

If we want to correlate logs, let's add a correlation ID.

### Changelog

- **[Ledger API Server]** The amount of data logged in the API transaction service has been reduced at INFO level. Please enable TRACE logging to log the request data structures.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
