### PR TITLE
Release ledger API test tool per LF version

### DIFF
--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -163,6 +163,13 @@ da_scala_binary(
                 "@maven//:org_scala_lang_modules_scala_collection_compat",
                 "@maven//:com_github_scopt_scopt",
             ],
+            tags = [
+                "maven_coordinates=com.daml:ledger-api-test-tool-{}:__VERSION__".format(lf_version),
+                # We release this as a fat jar so this tag ensures that the dependencies in the generated
+                # POM file are set correctly.
+                "fat_jar",
+                "no_scala_version_suffix",
+            ],
             visibility = ["//visibility:public"],
             runtime_deps = [
                 "@maven//:ch_qos_logback_logback_classic",

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -121,6 +121,12 @@
   type: jar-scala
 - target: //ledger/ledger-api-test-tool:ledger-api-test-tool
   type: jar-deploy
+- target: //ledger/ledger-api-test-tool:ledger-api-test-tool-1.13
+  type: jar-deploy
+- target: //ledger/ledger-api-test-tool:ledger-api-test-tool-1.14
+  type: jar-deploy
+- target: //ledger/ledger-api-test-tool:ledger-api-test-tool-1.dev
+  type: jar-deploy
 - target: //ledger/ledger-on-memory:ledger-on-memory
   type: jar-scala
 - target: //ledger/ledger-on-memory:ledger-on-memory-app


### PR DESCRIPTION
Currently it is impossible to test new features until they land in the
default LF version. This is clearly not great. This PR releases one
Ledger API test tool per LF version (with the LF version being in the
name) to make it easier for Canton and others to test new features.

Note that at least the way things are setup now we won’t go back in
time. We will only publish stable, preview & dev but not older
versions. If needed, we could expand that in the future.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
