### PR TITLE
LF: avoid usage of GlobalKey.key in engine error

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -152,7 +152,7 @@ object Error {
           // TODO https://github.com/digital-asset/daml/issues/9974
           //   we should probably use ${cid.coid} instead of $cid
           s"Contract could not be found with id $cid"
-        case interpretation.Error.ContractKeyNotFound(key) =>
+        case interpretation.Error.ContractKeyNotFound(key, _) =>
           s"dependency error: couldn't find key: $key"
         case _ =>
           s"Interpretation error: Error: ${speedy.Pretty.prettyDamlException(error).render(80)}"

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -67,7 +67,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
         effectiveAt,
         id,
       ) match {
-        case LookupOk(_, coinst, _) => Some(coinst)
+        case LookupOk(_, coinst, _, _) => Some(coinst)
         case _: LookupContractNotEffective | _: LookupContractNotActive |
             _: LookupContractNotVisible | _: LookupContractNotFound =>
           None

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -68,17 +68,17 @@ private[lf] object Pretty {
             case Some(node) =>
               (line + prettyPartialTransactionNode(node)).nested(4)
           })
-      case ContractKeyNotFound(gk) =>
+      case ContractKeyNotFound(tid, key) =>
         text(
           "Update failed due to fetch-by-key or exercise-by-key which did not find a contract with key"
         ) &
-          prettyValue(false)(gk.key) & char('(') + prettyIdentifier(gk.templateId) + char(')')
-      case LocalContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
+          prettyValue(false)(key) & char('(') + prettyIdentifier(tid) + char(')')
+      case LocalContractKeyNotVisible(coid, tid, key, actAs, readAs, stakeholders) =>
         text(
           "Update failed due to a fetch, lookup or exercise by key of contract not visible to the reading parties"
         ) & prettyContractId(coid) &
-          char('(') + (prettyIdentifier(gk.templateId)) + text(") associated with key ") +
-          prettyValue(false)(gk.key) &
+          char('(') + (prettyIdentifier(tid)) + text(") associated with key ") +
+          prettyValue(false)(key) &
           text("No reading party is a stakeholder:") &
           text("actAs:") & intercalate(comma + space, actAs.map(prettyParty))
             .tightBracketBy(char('{'), char('}')) &
@@ -88,8 +88,8 @@ private[lf] object Pretty {
             comma + space,
             stakeholders.map(prettyParty),
           ) + char('.')
-      case DuplicateContractKey(key) =>
-        text("Update failed due to a duplicate contract key") & prettyValue(false)(key.key)
+      case DuplicateContractKey(_, key) =>
+        text("Update failed due to a duplicate contract key") & prettyValue(false)(key)
       case WronglyTypedContract(coid, expected, actual) =>
         text("Update failed due to wrongly typed contract id") & prettyContractId(coid) /
           text("Expected contract of type") & prettyTypeConName(expected) & text(

--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -32,6 +32,7 @@ da_scala_library(
         "//daml-lf/language",
         "//daml-lf/transaction",
         "//libs-scala/nameof",
+        "//libs-scala/scala-utils",
     ],
 )
 

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
@@ -8,7 +8,8 @@ import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.data.Time
 import com.daml.lf.ledger.EventId
 import com.daml.lf.speedy.SError.SError
-import com.daml.lf.transaction.{GlobalKey, Transaction}
+import com.daml.lf.transaction.Transaction
+import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 
 import scala.util.control.NoStackTrace
@@ -57,7 +58,8 @@ object Error {
     */
   final case class ContractKeyNotVisible(
       coid: ContractId,
-      key: GlobalKey,
+      templateId: Identifier,
+      key: Value[Nothing],
       actAs: Set[Party],
       readAs: Set[Party],
       stakeholders: Set[Party],

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
@@ -39,10 +39,10 @@ private[lf] object Pretty {
             comma + space,
             observers.map(prettyParty),
           ) + char('.')
-      case Error.ContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
+      case Error.ContractKeyNotVisible(coid, tid, key, actAs, readAs, stakeholders) =>
         text("Scenario failed due to the failure to fetch the contract") & prettyContractId(coid) &
-          char('(') + (prettyIdentifier(gk.templateId)) + text(") associated with key ") +
-          prettyValue(false)(gk.key) &
+          char('(') + (prettyIdentifier(tid)) + text(") associated with key ") +
+          prettyValue(false)(key) &
           text("The contract had not been disclosed to the reading parties:") &
           text("actAs:") & intercalate(comma + space, actAs.map(prettyParty))
             .tightBracketBy(char('{'), char('}')) &
@@ -53,12 +53,9 @@ private[lf] object Pretty {
             stakeholders.map(prettyParty),
           ) + char('.')
 
-      case Error.CommitError(ScenarioLedger.CommitError.UniqueKeyViolation(gk)) =>
-        (text("Scenario failed due to unique key violation for key:") & prettyValue(false)(
-          gk.gk.key
-        ) & text(
-          "for template"
-        ) & prettyIdentifier(gk.gk.templateId))
+      case Error.CommitError(ScenarioLedger.CommitError.UniqueKeyViolation(err)) =>
+        (text("Scenario failed due to unique key violation for key:") &
+          prettyValue(false)(err.key) & text("for template") & prettyIdentifier(err.templateId))
 
       case Error.MustFailSucceeded(tx @ _) =>
         // TODO(JM): Further info needed. Location annotations?

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -6,7 +6,6 @@ package transaction
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
-import com.daml.lf.ledger.FailedAuthorization
 import com.daml.lf.transaction.Node.GenNode
 import com.daml.lf.value.Value
 import scalaz.Equal
@@ -890,43 +889,6 @@ object Transaction {
       f: crypto.Hash => Bytes,
   ): Either[String, CommittedTransaction] =
     submittedTransaction.suffixCid(f).map(CommittedTransaction(_))
-
-  /** Errors that can happen during building transactions. */
-  sealed abstract class TransactionError extends Product with Serializable
-
-  /** Signals that the contract-id `coid` was expected to be active, but
-    * is not.
-    */
-  final case class ContractNotActive(
-      coid: Value.ContractId,
-      templateId: TypeConName,
-      consumedBy: NodeId,
-  ) extends TransactionError
-
-  /** Signals that within the transaction we got to a point where
-    * two contracts with the same key were active.
-    *
-    * Note that speedy only detects duplicate key collisions
-    * if both contracts are used in the transaction in by-key operations
-    * meaning lookup, fetch or exercise-by-key or local creates.
-    *
-    * Two notable cases that will never produce duplicate key errors
-    * is a standalone create or a create and a fetch (but not fetch-by-key)
-    * with the same key.
-    *
-    * For ledger implementors this means that (for contract key uniqueness)
-    * it is sufficient to only look at the inputs and the outputs of the
-    * transaction whlie leaving all internal checks within the transaction
-    *  to the engine.
-    */
-  final case class DuplicateContractKey(
-      key: GlobalKey
-  ) extends TransactionError
-
-  final case class AuthFailureDuringExecution(
-      nid: NodeId,
-      fa: FailedAuthorization,
-  ) extends TransactionError
 
   @deprecated("use Validation.isRepledBy", since = "1.10.0")
   def isReplayedBy[Nid, Cid](

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -59,7 +59,7 @@ class IdeLedgerClient(val compiledPackages: CompiledPackages, traceLog: TraceLog
       effectiveAt = ledger.currentTime,
     )
     val filtered = acs.collect {
-      case ScenarioLedger.LookupOk(cid, Value.ContractInst(tpl, arg, _), stakeholders)
+      case ScenarioLedger.LookupOk(cid, Value.ContractInst(tpl, arg, _), _, stakeholders)
           if tpl == templateId && parties.any(stakeholders.contains(_)) =>
         (cid, arg)
     }
@@ -81,7 +81,7 @@ class IdeLedgerClient(val compiledPackages: CompiledPackages, traceLog: TraceLog
       effectiveAt = ledger.currentTime,
       cid,
     ) match {
-      case ScenarioLedger.LookupOk(_, Value.ContractInst(_, arg, _), stakeholders)
+      case ScenarioLedger.LookupOk(_, Value.ContractInst(_, arg, _), _, stakeholders)
           if parties.any(stakeholders.contains(_)) =>
         Future.successful(Some(ScriptLedgerClient.ActiveContract(templateId, cid, arg.value)))
       case _ =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -292,7 +292,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
           case LfError.Interpretation(
                 LfError.Interpretation.DamlException(
                   InterpretationError.ContractNotFound(_) |
-                  InterpretationError.DuplicateContractKey(_)
+                  InterpretationError.DuplicateContractKey(_, _)
                 ),
                 _,
               ) | LfError.Validation(LfError.Validation.ReplayMismatch(_)) =>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
@@ -31,7 +31,7 @@ import com.daml.lf.engine.{Error => LfError}
 import com.daml.lf.interpretation.{Error => LfInterpretationError}
 import com.daml.lf.language.LookupError
 import com.daml.lf
-import com.daml.lf.transaction.{GlobalKey, NodeId, ReplayNodeMismatch}
+import com.daml.lf.transaction.{NodeId, ReplayNodeMismatch}
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.value.Value
 import com.daml.logging.LoggingContext
@@ -208,9 +208,7 @@ class ApiSubmissionServiceSpec
       ErrorCause.DamlLf(
         LfError.Interpretation(
           LfError.Interpretation.DamlException(
-            LfInterpretationError.DuplicateContractKey(
-              GlobalKey.assertBuild(tmplId, Value.ValueUnit)
-            )
+            LfInterpretationError.DuplicateContractKey(tmplId, Value.ValueUnit)
           ),
           None,
         )


### PR DESCRIPTION
This will allow to drop the `key: Value[ContractId]` field from
GlobalKey in an upcomming PR.

addition, this is a nice addition for #9974 (no more transaction.Error)

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
