### PR TITLE
DEL-8657 update version info for Haskell LF libraries

### DIFF
--- a/build-scripts/build_hs_lf_tooling.sh
+++ b/build-scripts/build_hs_lf_tooling.sh
@@ -17,7 +17,7 @@ mkdir -p $TARGET_DIR
 
 # This version needs to be adapted in all cabal files, too
 # The script below will fail on the `cp` command otherwise.
-LIB_VERSION="0.1.13.0"
+LIB_VERSION="0.1.15.0"
 
 package_from_dir() {
     local dir=$1

--- a/compiler/daml-lf-ast/daml-lf-ast.cabal
+++ b/compiler/daml-lf-ast/daml-lf-ast.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: daml-lf-ast
 build-type: Simple
-version: 0.1.13.0
+version: 0.1.15.0
 synopsis: DAML-LF AST
 license: Apache-2.0
 author: Digital Asset

--- a/compiler/daml-lf-proto/daml-lf-proto.cabal
+++ b/compiler/daml-lf-proto/daml-lf-proto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: daml-lf-proto
 build-type: Simple
-version: 0.1.13.0
+version: 0.1.15.0
 synopsis: DAML-LF Protobuf Encoding
 license: Apache-2.0
 author: Digital Asset

--- a/compiler/daml-lf-reader/daml-lf-reader.cabal
+++ b/compiler/daml-lf-reader/daml-lf-reader.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: daml-lf-reader
 build-type: Simple
-version: 0.1.13.0
+version: 0.1.15.0
 synopsis: DAML-LF Archive reader
 license: Apache-2.0
 author: Digital Asset

--- a/libs-haskell/da-hs-base/da-hs-base.cabal
+++ b/libs-haskell/da-hs-base/da-hs-base.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: da-hs-base
 build-type: Simple
-version: 0.1.13.0
+version: 0.1.15.0
 synopsis: Kitchen sink package for common functionality shared between packages
 license: Apache-2.0
 author: Digital Asset

--- a/libs-haskell/da-hs-base/da-hs-base.cabal
+++ b/libs-haskell/da-hs-base/da-hs-base.cabal
@@ -65,6 +65,7 @@ library
       DA.Service.Logger.Impl.Pure
       DA.Signals
       Data.Conduit.Tar.Extra
+      Data.List.Extended
       Data.NameMap
       Data.Semigroup.FixedPoint
       Data.Text.Extended


### PR DESCRIPTION
We are past the 1.14 feature set so it is 1.15, even though more changes may come in before 1.15.0 is released.