### PR TITLE
compress bazel build logs

### DIFF
--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -47,13 +47,16 @@ steps:
         git_current_tree: "'"$(git rev-parse HEAD:./)"'",
       }'
       target_dir="$(Build.StagingDirectory)/$(pipeline_id)"
+      mkdir -p "$target_dir"
       cp "job-md.json" "$target_dir/job-md.json"
       for log_file in 'build-profile.json' 'build-events.json' 'test-profile.json' 'test-events.json'; do
         [[ -f "$log_file" ]] && cp "$log_file" "$target_dir/$log_file" || echo "$log_file not found"
       done
       cd "$(Build.StagingDirectory)"
       GZIP=-9 tar czf "$(pipeline_id).tar.gz" "$(pipeline_id)"
-      gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$(pipeline_id).tar.gz"
+      date="$(echo $(pipeline_id) | cut -c1-7)/$(echo $(pipeline_id) | cut -c9-10)/"
+      #TODO: FIXME
+      echo gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$date/$(pipeline_id).tar.gz"
     condition: succeededOrFailed()
     displayName: 'Upload Bazel metrics'
     env:

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -46,7 +46,7 @@ steps:
         git_current_commit: "'"$(git rev-parse HEAD)"'",
         git_current_tree: "'"$(git rev-parse HEAD:./)"'",
       }'
-      target_dir="$(Build.StaginDirectory)/$(pipeline_id)"
+      target_dir="$(Build.StagingDirectory)/$(pipeline_id)"
       cp "job-md.json" "$target_dir/job-md.json"
       for log_file in 'build-profile.json' 'build-events.json' 'test-profile.json' 'test-events.json'; do
         [[ -f "$log_file" ]] && cp "$log_file" "$target_dir/$log_file" || echo "$log_file not found"

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -53,7 +53,7 @@ steps:
         [[ -f "$log_file" ]] && cp "$log_file" "$target_dir/$log_file" || echo "$log_file not found"
       done
       cd "$(Build.StagingDirectory)"
-      GZIP=-9 tar czf "$(pipeline_id).tar.gz" "$(pipeline_id)"
+      GZIP=-9 tar --force-local czf "$(pipeline_id).tar.gz" "$(pipeline_id)"
       date="$(echo $(pipeline_id) | cut -c1-7)/$(echo $(pipeline_id) | cut -c9-10)/"
       #TODO: FIXME
       echo gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$date/$(pipeline_id).tar.gz"

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -54,9 +54,8 @@ steps:
       done
       cd "$(Build.StagingDirectory)"
       GZIP=-9 tar --force-local -c -z -f "$(pipeline_id).tar.gz" "$(pipeline_id)"
-      date="$(echo $(pipeline_id) | cut -c1-7)/$(echo $(pipeline_id) | cut -c9-10)/"
-      #TODO: FIXME
-      echo gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$date/$(pipeline_id).tar.gz"
+      date="$(echo $(pipeline_id) | cut -c1-7)/$(echo $(pipeline_id) | cut -c9-10)"
+      gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$date/$(pipeline_id).tar.gz"
     condition: succeededOrFailed()
     displayName: 'Upload Bazel metrics'
     env:

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -53,10 +53,9 @@ steps:
         [[ -f "$log_file" ]] && cp "$log_file" "$target_dir/$log_file" || echo "$log_file not found"
       done
       cd "$(Build.StagingDirectory)"
-      GZIP=-9 tar --force-local -c -z -f "$(pipeline_id).tar.gz" "$(pipeline_id)"
+      GZIP=-9 tar --force-local -c -z -f "build-event-logs.tar.gz" "$(pipeline_id)"
       date="$(echo $(pipeline_id) | cut -c1-7)/$(echo $(pipeline_id) | cut -c9-10)"
-      ls
-      gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$date/$(pipeline_id).tar.gz"
+      gcs "$GCRED" cp "build-event-logs.tar.gz" "gs://daml-data/bazel-metrics/$date/$(pipeline_id).tar.gz"
     condition: succeededOrFailed()
     displayName: 'Upload Bazel metrics'
     env:

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -46,12 +46,15 @@ steps:
         git_current_commit: "'"$(git rev-parse HEAD)"'",
         git_current_tree: "'"$(git rev-parse HEAD:./)"'",
       }'
-      jq <job-md.json .
-      gcs "$GCRED" cp "job-md.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/job-md.json"
-      [[ -f "build-profile.json" ]] && gcs "$GCRED" cp "build-profile.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/build-profile.json" || echo "build-profile.json not found"
-      [[ -f "build-events.json" ]] && gcs "$GCRED" cp "build-events.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/build-events.json" || echo "build-events.json not found"
-      [[ -f "test-profile.json" ]] && gcs "$GCRED" cp "test-profile.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/test-profile.json" || echo "test-profile.json not found"
-      [[ -f "test-events.json" ]] && gcs "$GCRED" cp "test-events.json" "gs://daml-data/bazel-metrics/$(pipeline_id)/test-events.json" || echo "test-events.json not found"
+      target_dir="$(Build.StaginDirectory)/$(pipeline_id)"
+      cp "job-md.json" "$target_dir/job-md.json"
+      [[ -f "build-profile.json" ]] && cp "build-profile.json" "$target_dir/build-profile.json" || echo "build-profile.json not found"
+      [[ -f "build-events.json" ]] && cp "build-events.json" "$target_dir/build-events.json" || echo "build-events.json not found"
+      [[ -f "test-profile.json" ]] && cp "test-profile.json" "$target_dir/test-profile.json" || echo "test-profile.json not found"
+      [[ -f "test-events.json" ]] && cp "test-events.json" "$target_dir/test-events.json" || echo "test-events.json not found"
+      cd "$(Build.StagingDirectory)"
+      GZIP=-9 tar czf "$(pipeline_id).tar.gz" "$(pipeline_id)"
+      gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$(pipeline_id).tar.gz"
     condition: succeededOrFailed()
     displayName: 'Upload Bazel metrics'
     env:

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -55,6 +55,7 @@ steps:
       cd "$(Build.StagingDirectory)"
       GZIP=-9 tar --force-local -c -z -f "$(pipeline_id).tar.gz" "$(pipeline_id)"
       date="$(echo $(pipeline_id) | cut -c1-7)/$(echo $(pipeline_id) | cut -c9-10)"
+      ls
       gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$date/$(pipeline_id).tar.gz"
     condition: succeededOrFailed()
     displayName: 'Upload Bazel metrics'

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -53,7 +53,7 @@ steps:
         [[ -f "$log_file" ]] && cp "$log_file" "$target_dir/$log_file" || echo "$log_file not found"
       done
       cd "$(Build.StagingDirectory)"
-      GZIP=-9 tar --force-local czf "$(pipeline_id).tar.gz" "$(pipeline_id)"
+      GZIP=-9 tar --force-local -c -z -f "$(pipeline_id).tar.gz" "$(pipeline_id)"
       date="$(echo $(pipeline_id) | cut -c1-7)/$(echo $(pipeline_id) | cut -c9-10)/"
       #TODO: FIXME
       echo gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$date/$(pipeline_id).tar.gz"

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -48,10 +48,9 @@ steps:
       }'
       target_dir="$(Build.StaginDirectory)/$(pipeline_id)"
       cp "job-md.json" "$target_dir/job-md.json"
-      [[ -f "build-profile.json" ]] && cp "build-profile.json" "$target_dir/build-profile.json" || echo "build-profile.json not found"
-      [[ -f "build-events.json" ]] && cp "build-events.json" "$target_dir/build-events.json" || echo "build-events.json not found"
-      [[ -f "test-profile.json" ]] && cp "test-profile.json" "$target_dir/test-profile.json" || echo "test-profile.json not found"
-      [[ -f "test-events.json" ]] && cp "test-events.json" "$target_dir/test-events.json" || echo "test-events.json not found"
+      for log_file in 'build-profile.json' 'build-events.json' 'test-profile.json' 'test-events.json'; do
+        [[ -f "$log_file" ]] && cp "$log_file" "$target_dir/$log_file" || echo "$log_file not found"
+      done
       cd "$(Build.StagingDirectory)"
       GZIP=-9 tar czf "$(pipeline_id).tar.gz" "$(pipeline_id)"
       gcs "$GCRED" cp "$(pipeline_id).tar.gz" "gs://daml-data/bazel-metrics/$(pipeline_id).tar.gz"


### PR DESCRIPTION
Anecdotally, I see a 25x reduction in size when compressing. Time to compress and decompress is negligible, whereas storage costs and transfer times may not be.

Since, as far as I'm aware, we don't currently have anything depending on the current format, I could run a script locally to transform all of the existing logs to match the new format.

CHANGELOG_BEGIN
CHANGELOG_END