### PR TITLE
Adapt `ledger-api-bench-tool` to work with LR [DPP-424]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/MetricsManager.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/metrics/MetricsManager.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.benchtool.metrics
 
+import akka.actor.CoordinatedShutdown
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.{ActorRef, ActorSystem, Props, SpawnProtocol}
 import akka.util.Timeout
@@ -14,6 +15,14 @@ import scala.concurrent.{ExecutionContext, Future}
 case class MetricsManager[T](collector: ActorRef[MetricsCollector.Message])(implicit
     system: ActorSystem[SpawnProtocol.Command]
 ) {
+  CoordinatedShutdown(system).addTask(
+    phase = CoordinatedShutdown.PhaseBeforeServiceUnbind,
+    taskName = "report-results",
+  ) { () =>
+    println(s"Coordinated shutdown in progress...")
+    result().map(_ => akka.Done)(system.executionContext)
+  }
+
   def sendNewValue(value: T): Unit =
     collector ! MetricsCollector.Message.NewValue(value)
 

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/util/MetricReporter.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/util/MetricReporter.scala
@@ -34,7 +34,11 @@ object MetricReporter {
 
         val violatedObjective: Option[String] = metric.violatedObjective
           .map { case (objective, value) =>
-            s"!!! OBJECTIVE NOT MET: ${formattedObjective(objective)} (actual: ${formattedValue(value)})"
+            s"""!!! FAILURE
+               |!!! OBJECTIVE NOT MET: ${formattedObjective(objective)} (actual: ${formattedValue(
+              value
+            )})
+               |""".stripMargin
           }
 
         val all: String = (List(finalValue) ::: violatedObjective.toList)


### PR DESCRIPTION
### Changes
- added Akka's `CoordinatedShutdown` task to the metric collecting actor so that the final report is logged on graceful shutdown even if streams are not terminated
- handling `UNAVAILABLE` exception with specific error message in case a Ledger API server shuts down without gracefully closing streams. Instead of failing a tool run, print the final metrics report basing on data collected up to the point of failure.
- slightly changed the format of the final report to make it compatible with other DA tools 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
