### PR TITLE
add tar to dev-env

### DIFF
--- a/dev-env/bin/tar
+++ b/dev-env/bin/tar
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool


### PR DESCRIPTION
It's already in default.nix, but there was no symlink in `dev-env/bin`.

I need it for #10162 but it felt worth a separate PR.

CHANGELOG_BEGIN
CHANGELOG_END