### PR TITLE
Unhide JSON API metrics

### DIFF
--- a/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
+++ b/ledger-service/cli-opts/src/main/scala/cliopts/Metrics.scala
@@ -4,7 +4,6 @@
 package com.daml.cliopts
 
 import com.daml.metrics.MetricsReporter
-import scopt.OptionDef
 
 import scala.concurrent.duration.{Duration, FiniteDuration, NANOSECONDS}
 import scala.util.Try
@@ -34,28 +33,19 @@ object Metrics {
   def metricsReporterParse[C](parser: scopt.OptionParser[C])(
       metricsReporter: Setter[C, Option[MetricsReporter]],
       metricsReportingInterval: Setter[C, FiniteDuration],
-      hide: Boolean = false,
   ): Unit = {
     import parser.opt
 
-    def hideIfRequested[A](opt: OptionDef[A, C]): Unit =
-      if (hide) {
-        opt.hidden()
-        ()
-      }
+    opt[MetricsReporter]("metrics-reporter")
+      .action((reporter, config) => metricsReporter(_ => Some(reporter), config))
+      .optional()
+      .text(s"Start a metrics reporter. ${MetricsReporter.cliHint}")
 
-    val optionMetricsReporter =
-      opt[MetricsReporter]("metrics-reporter")
-        .action((reporter, config) => metricsReporter(_ => Some(reporter), config))
-        .optional()
-        .text(s"Start a metrics reporter. ${MetricsReporter.cliHint}")
-    hideIfRequested(optionMetricsReporter)
+    opt[DurationFormat]("metrics-reporting-interval")
+      .action((interval, config) => metricsReportingInterval(_ => interval.unwrap, config))
+      .optional()
+      .text("Set metric reporting interval.")
 
-    val optionMetricsReportingInterval =
-      opt[DurationFormat]("metrics-reporting-interval")
-        .action((interval, config) => metricsReportingInterval(_ => interval.unwrap, config))
-        .optional()
-        .text("Set metric reporting interval.")
-    hideIfRequested(optionMetricsReportingInterval)
+    ()
   }
 }

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/OptionParser.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/OptionParser.scala
@@ -163,7 +163,6 @@ class OptionParser(getEnvVar: String => Option[String])(implicit
   cliopts.Metrics.metricsReporterParse(this)(
     (f, c) => c.copy(metricsReporter = f(c.metricsReporter)),
     (f, c) => c.copy(metricsReportingInterval = f(c.metricsReportingInterval)),
-    hide = true,
   )
 
 }


### PR DESCRIPTION
These were originally hidden in the first PR because the metrics were
very shaky. Now they are actually useful and mentioned in release
notes so hiding this option makes no sense.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
