### PR TITLE
Improvements to the documentation with regards to offsets

### DIFF
--- a/docs/source/app-dev/app-arch.rst
+++ b/docs/source/app-dev/app-arch.rst
@@ -151,10 +151,28 @@ To use command deduplication, you should:
 For more details on command deduplication, see the :ref:`Ledger API Services <command-submission-service-deduplication>` documentation.
 
 
+.. _dealing-with-failures:
+
+Dealing with failures
+*********************
+
+.. _crash-recovery:
+
+Crash recovery
+==============
+
+In order to restart your application from a previously known ledger state,
+your application must keep track of the last ledger offset received
+from the :ref:`transaction service <transaction-service>` or the
+:ref:`command completion service <command-completion-service>`.
+
+By persisting this offset alongside the relevant state as part of a single,
+atomic operation, your application can resume from where it left off.
+
 .. _failing-over-between-ledger-api-endpoints:
 
 Failing over between Ledger API endpoints
-*****************************************
+=========================================
 
 Some Daml Ledgers support exposing multiple eventually consistent Ledger API
 endpoints where command deduplication works across these Ledger API endpoints.
@@ -166,9 +184,8 @@ Below we describe how you can build your application such that it can switch
 between such eventually consistent Ledger API endpoints to tolerate server
 failures. You can do this using the following two steps.
 
-First, your application must keep track of the last ledger offset received
-from the :ref:`transaction service <transaction-service>` or the
-:ref:`command completion service <command-completion-service>`.  When switching to a new
+First, your application must keep track of the ledger offset as described in the
+:ref:`paragraph about crash recovery <crash-recovery>`. When switching to a new
 Ledger API endpoint, it must resume consumption of the transaction (tree)
 and/or the command completion streams starting from this last received
 offset.

--- a/docs/source/app-dev/bindings-java/quickstart.rst
+++ b/docs/source/app-dev/bindings-java/quickstart.rst
@@ -547,7 +547,7 @@ It consists of the application in file ``IouMain.java``. It uses the class ``Iou
       :lines: 61-77
       :dedent: 4
 
-   Note the use of ``blockingForEach`` to ensure that the contract store is fully built and the ledger-offset up to which the ACS provides data is known before moving on.
+   ``blockingForEach`` is used to ensure that the contract store is consistent with the ledger state at the latest offset observed by the client.
 
 #. The Transaction Service is wired up to update the contract store on occurrences of ``ArchiveEvent`` and ``CreateEvent`` for Ious. Since ``getTransactions`` is called without end offset, it will stream transactions indefinitely, until the application is terminated.
 

--- a/docs/source/app-dev/services.rst
+++ b/docs/source/app-dev/services.rst
@@ -164,11 +164,11 @@ See :ref:`verbosity` above.
   The RPCs exposed as part of the transaction and active contracts services make use of offsets.
 
   An offset is an ever-growing number assigned by the participant to each transaction as they are received from the ledger.
-  This number is opaque to the client and must be used as-is (i.e. cliend-side transformations like incrementing it are not guaranteed to produce a valid offset).
+  This number is opaque to the client and must be used as-is (i.e. client-side transformations like incrementing it are not guaranteed to produce a valid offset).
   The state of a ledger (i.e. the set of active contracts) as exposed by the Ledger API is valid at a specific offset, which is why the last message your application receives when calling the ``ActiveContractsService`` is precisely that offset.
   In this way, the client can keep track of the relevant state without needing to invoke the ``ActiveContractsService`` again, by starting to read transactions from the given offset.
 
-  Offsets are also useful to perform crash recovery and fail over as documented more in depth in the :ref:`application architecture <dealing-with-failures>` page.
+  Offsets are also useful to perform crash recovery and failover as documented more in depth in the :ref:`application architecture <dealing-with-failures>` page.
 
   You can read more about offsets in the `protobuf documentation of the API <../app-dev/grpc/proto-docs.html#ledgeroffset>`__.
 

--- a/docs/source/app-dev/services.rst
+++ b/docs/source/app-dev/services.rst
@@ -163,8 +163,8 @@ See :ref:`verbosity` above.
 
   The RPCs exposed as part of the transaction and active contracts services make use of offsets.
 
-  An offset is an ever-growing number assigned by the participant to each transaction as they are received from the ledger.
-  This number is opaque to the client and must be used as-is (i.e. client-side transformations like incrementing it are not guaranteed to produce a valid offset).
+  An offset is an opaque string of bytes assigned by the participant to each transaction as they are received from the ledger.
+  Two offsets returned by the same participant are guaranteed to be lexicographically ordered: while interacting with a single participant, the offset of two transactions can be compared to tell which was committed earlier.
   The state of a ledger (i.e. the set of active contracts) as exposed by the Ledger API is valid at a specific offset, which is why the last message your application receives when calling the ``ActiveContractsService`` is precisely that offset.
   In this way, the client can keep track of the relevant state without needing to invoke the ``ActiveContractsService`` again, by starting to read transactions from the given offset.
 

--- a/docs/source/app-dev/services.rst
+++ b/docs/source/app-dev/services.rst
@@ -159,6 +159,19 @@ Verbosity
 
 See :ref:`verbosity` above.
 
+.. note::
+
+  The RPCs exposed as part of the transaction and active contracts services make use of offsets.
+
+  An offset is an ever-growing number assigned by the participant to each transaction as they are received from the ledger.
+  This number is opaque to the client and must be used as-is (i.e. cliend-side transformations like incrementing it are not guaranteed to produce a valid offset).
+  The state of a ledger (i.e. the set of active contracts) as exposed by the Ledger API is valid at a specific offset, which is why the last message your application receives when calling the ``ActiveContractsService`` is precisely that offset.
+  In this way, the client can keep track of the relevant state without needing to invoke the ``ActiveContractsService`` again, by starting to read transactions from the given offset.
+
+  Offsets are also useful to perform crash recovery and fail over as documented more in depth in the :ref:`application architecture <dealing-with-failures>` page.
+
+  You can read more about offsets in the `protobuf documentation of the API <../app-dev/grpc/proto-docs.html#ledgeroffset>`__.
+
 .. _ledger-api-utility-services:
 
 Utility services


### PR DESCRIPTION
changelog_begin
[Docs] Improvements to the documentation with regards to offsets
changelog_end

- Simplify wording to explain the usage of `blockingForEach` in the Java
bindings quickstart page
- Describe offsets in prose in the page about the Ledger API services
- Suggest how to perform crash recovery with offsets on the application
architecture page
- Link to the relevant Protobuf reference docs where approriate

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
