### PR TITLE
reduce noise in Scala bindings

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -74,9 +74,9 @@ object CommandTrackerFlow {
                 1,
                 { case e =>
                   logger.warn(
-                    s"Completion Stream failed with an error. Trying to recover in ${backOffDuration} ..",
-                    e,
+                    s"Completion Stream failed with an error. Trying to recover in ${backOffDuration} .."
                   )
+                  logger.debug(e)
                   delayedEmptySource(backOffDuration)
                 },
               )

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -76,7 +76,10 @@ object CommandTrackerFlow {
                   logger.warn(
                     s"Completion Stream failed with an error. Trying to recover in ${backOffDuration} .."
                   )
-                  logger.debug(e)
+                  logger.debug(
+                    s"Completion Stream failed with an error. Trying to recover in ${backOffDuration} ..",
+                    e,
+                  )
                   delayedEmptySource(backOffDuration)
                 },
               )


### PR DESCRIPTION
It's unlikely most clients will want all the details of the stack trace.

CHANGELOG_BEGIN
CHANGELOG_END