### PR TITLE
Drop logging on CompletionSource

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandCompletionSource.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandCompletionSource.scala
@@ -35,12 +35,5 @@ object CommandCompletionSource {
     ClientAdapter
       .serverStreaming(request, stub)
       .mapConcat(toStreamElements)
-      .log(
-        "completion at client",
-        {
-          case CompletionStreamElement.CheckpointElement(c) => s"Checkpoint ${c.offset}"
-          case CompletionStreamElement.CompletionElement(c) => s"Completion $c"
-        },
-      )
   }
 }


### PR DESCRIPTION
The debug logs don’t seem all that useful and we don’t have them for
other sources, e.g., TransactionSource. They also come with error logs
for failed sources which again is inconsistent with other sources,
noisy and confusing.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
