### PR TITLE
Move exercise context computation to the client side

### DIFF
--- a/compiler/scenario-service/client/BUILD.bazel
+++ b/compiler/scenario-service/client/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel_tools:haskell.bzl", "da_haskell_library")
+load("//bazel_tools:haskell.bzl", "da_haskell_library", "da_haskell_test")
 
 da_haskell_library(
     name = "client",
@@ -40,6 +40,56 @@ da_haskell_library(
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-proto",
+        "//compiler/damlc/daml-opts:daml-opts-types",
+        "//compiler/scenario-service/protos:scenario_service_haskell_proto",
+        "//daml-assistant:daml-project-config",
+        "//libs-haskell/bazel-runfiles",
+        "//libs-haskell/da-hs-base",
+    ],
+)
+
+da_haskell_test(
+    name = "tests",
+    srcs = glob(["test/**/*.hs"]),
+    hackage_deps = [
+        "async",
+        "base",
+        "binary",
+        "blaze-html",
+        "bytestring",
+        "conduit-extra",
+        "conduit",
+        "containers",
+        "cryptonite",
+        "deepseq",
+        "directory",
+        "extra",
+        "filepath",
+        "grpc-haskell",
+        "grpc-haskell-core",
+        "hashable",
+        "lens",
+        "mtl",
+        "process",
+        "proto3-suite",
+        "proto3-wire",
+        "split",
+        "stm",
+        "system-filepath",
+        "text",
+        "tasty",
+        "tasty-hunit",
+        "time",
+        "transformers",
+        "uri-encode",
+        "vector",
+    ],
+    main_function = "DA.Daml.LF.PrettyScenarioSpec.main",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":client",
         "//compiler/daml-lf-ast",
         "//compiler/daml-lf-proto",
         "//compiler/damlc/daml-opts:daml-opts-types",

--- a/compiler/scenario-service/client/test/DA/Daml/LF/PrettyScenarioSpec.hs
+++ b/compiler/scenario-service/client/test/DA/Daml/LF/PrettyScenarioSpec.hs
@@ -1,0 +1,117 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Daml.LF.PrettyScenarioSpec (main) where
+
+import DA.Daml.LF.PrettyScenario
+import qualified ScenarioService as S
+
+import Control.Monad.State.Strict
+import Data.Bifunctor
+import qualified Data.Text.Lazy as TL
+import qualified Data.Vector as V
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = defaultMain $ testGroup "PrettyScenario"
+  [ ptxExerciseContextTests
+  ]
+
+ctx :: String -> ExerciseContext
+ctx choice = ExerciseContext
+  { targetId = Just (S.ContractRef "#0" Nothing)
+  , choiceId = TL.pack choice
+  , exerciseLocation = Nothing
+  , chosenValue = Nothing
+  }
+
+ptxExerciseContextTests :: TestTree
+ptxExerciseContextTests = testGroup "ptxExerciseContext"
+  [ testCase "returns the last root exercise node" $ do
+      ptxExerciseContext (toPtx [Exercise "1" False [], Exercise "2" False []]) @?= Just (ctx "2")
+  , testCase "ignores complete exercise nodes" $ do
+      ptxExerciseContext (toPtx [Exercise "1" False [], Exercise "2" True []]) @?= Nothing
+  , testCase "ignores create, fetch and lookup nodes" $ do
+      ptxExerciseContext (toPtx [Create, Fetch, Lookup]) @?= Nothing
+  , testCase "does not decend in rollback node" $ do
+      ptxExerciseContext (toPtx [Rollback [Exercise "1" False []]]) @?= Nothing
+  , testCase "decends in exercise" $ do
+      ptxExerciseContext (toPtx [Exercise "0" False [Exercise "1" False []]]) @?= Just (ctx "1")
+  ]
+
+type Transaction = [Node]
+
+data Node
+    = Create
+    | Lookup
+    | Fetch
+    | Exercise String Bool [Node]
+    | Rollback [Node]
+
+toPtx :: Transaction -> S.PartialTransaction
+toPtx nodes = case runState (mapM go nodes) (0, []) of
+    (roots, (_, nodes)) -> S.PartialTransaction
+      { partialTransactionRoots = V.fromList roots
+      , partialTransactionNodes = V.fromList (reverse nodes)
+      }
+  where
+      go :: Node -> State (Int, [S.Node]) S.NodeId
+      go n = do
+          nid <- nextNodeId
+          nodeNode <- case n of
+              Create -> pure $ S.NodeNodeCreate S.Node_Create
+                { node_CreateContractInstance = Nothing
+                , node_CreateSignatories = V.empty
+                , node_CreateStakeholders = V.empty
+                , node_CreateKeyWithMaintainers = Nothing
+                }
+              Fetch -> pure $ S.NodeNodeFetch S.Node_Fetch
+                { node_FetchContractId = "#0"
+                , node_FetchTemplateId = Nothing
+                , node_FetchSignatories = V.empty
+                , node_FetchStakeholders = V.empty
+                }
+              Lookup -> pure $ S.NodeNodeLookupByKey S.Node_LookupByKey
+                { node_LookupByKeyTemplateId = Nothing
+                , node_LookupByKeyKeyWithMaintainers = Nothing
+                , node_LookupByKeyContractId = "#0"
+                }
+              Rollback children -> do
+                  children' <- mapM go children
+                  pure $ S.NodeNodeRollback (S.Node_Rollback (V.fromList children'))
+              Exercise choice complete children -> do
+                  children' <- mapM go children
+                  pure $ S.NodeNodeExercise S.Node_Exercise
+                    { node_ExerciseTargetContractId = "#0"
+                    , node_ExerciseTemplateId = Nothing
+                    , node_ExerciseChoiceId = TL.pack choice
+                    , node_ExerciseActingParties = V.empty
+                    , node_ExerciseChosenValue = Nothing
+                    , node_ExerciseObservers = V.empty
+                    , node_ExerciseSignatories = V.empty
+                    , node_ExerciseStakeholders = V.empty
+                    , node_ExerciseChildren = V.fromList children'
+                    , node_ExerciseExerciseResult = if complete then Just (S.Value (Just (S.ValueSumUnit S.Empty))) else Nothing
+                    , node_ExerciseConsuming = False
+                    }
+          let node = S.Node
+                { nodeNodeId = Just nid
+                , nodeNode = Just nodeNode
+                , nodeEffectiveAt = 0
+                , nodeDisclosures = V.empty
+                , nodeReferencedBy = V.empty
+                , nodeConsumedBy = Nothing
+                , nodeRolledbackBy = Nothing
+                , nodeParent = Nothing
+                , nodeLocation = Nothing
+                }
+          modify' $ second (node :)
+          pure nid
+      nextNodeId :: State (Int, b) S.NodeId
+      nextNodeId = do
+          (i, nodes) <- get
+          let !i' = i + 1
+          put (i', nodes)
+          pure (S.NodeId (TL.pack $ show i))
+

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -151,7 +151,6 @@ message Location {
 
 // Reference to a contract instance.
 message ContractRef {
-  bool relative = 1; // True if the contract id is relative.
   string contract_id = 2;
   Identifier template_id = 3;
 }
@@ -282,14 +281,6 @@ message ScenarioError {
 message PartialTransaction {
   repeated Node nodes = 1;
   repeated NodeId roots = 2;
-  ExerciseContext exercise_context = 3; // Top-most exercise context if any.
-}
-
-message ExerciseContext {
-  ContractRef target_id = 1;
-  string choice_id = 2;
-  Location exercise_location = 3; // Location of the 'exercise' expression
-  Value chosen_value = 4;
 }
 
 message Field {
@@ -565,6 +556,7 @@ message Node {
     repeated Party signatories = 8;
     repeated Party stakeholders = 9;
     repeated NodeId children = 11;
+    Value exercise_result = 12; // None for incomplete/aborted exercise nodes.
   }
 
   message LookupByKey {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -40,8 +40,7 @@ private[lf] object PartialTransaction {
   private type ExerciseNode = Node.NodeExercises[NodeId, Value.ContractId]
 
   private final case class IncompleteTxImpl(
-      val transaction: TX,
-      val exerciseContextMaybe: Option[ExerciseNode],
+      val transaction: TX
   ) extends TxIncompleteTransaction
 
   sealed abstract class ContextInfo {
@@ -359,12 +358,13 @@ private[lf] case class PartialTransaction(
       case _: PartialTransaction.RootContextInfo => None
     }
 
+    val ptx = unwind
+
     IncompleteTxImpl(
       GenTransaction(
-        nodes,
-        ImmArray(context.children.toImmArray.toSeq.sortBy(_.index)),
-      ),
-      unwindToExercise(context.info).map(makeExNode(_)),
+        ptx.nodes,
+        ImmArray(ptx.context.children.toImmArray.toSeq.sortBy(_.index)),
+      )
     )
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/IncompleteTransaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/IncompleteTransaction.scala
@@ -14,5 +14,4 @@ trait IncompleteTransaction {
   type ExerciseNode = Node.NodeExercises[Nid, Cid]
 
   def transaction: TX
-  def exerciseContextMaybe: Option[ExerciseNode]
 }


### PR DESCRIPTION
We probably want to start displaying the full ptx on the client side
but for now this at least moves things out of speedy and into the
rendering layer where they belong.

It also fixes IncompleteTransaction to unwind properly so the roots
are really the roots.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
