### PR TITLE
ci/windows: disable spool

### DIFF
--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -13,7 +13,19 @@ locals {
       suffix     = "",
       size       = 6,
       assignment = "default",
+      extra      = "",
     },
+    {
+      suffix     = "-no-spool",
+      size       = 1,
+      assignment = "default",
+      extra      = <<EOF
+
+# Disable Print Sppoler service (security)
+Stop-Service -Name Spooler -Force
+Set-Service -Name Spooler -StartupType Disabled
+EOF
+    }
   ]
 }
 
@@ -83,7 +95,7 @@ Set-StrictMode -Version latest
 $ErrorActionPreference = 'Stop'
 
 # Disable Windows Defender to speed up disk access
-Set-MpPreference -DisableRealtimeMonitoring $true
+Set-MpPreference -DisableRealtimeMonitoring $true${local.w[count.index].extra}
 
 # Enable long paths
 Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name LongPathsEnabled -Type DWord -Value 1

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -16,7 +16,7 @@ locals {
       extra      = "",
     },
     {
-      suffix     = "-no-spool",
+      suffix     = "-t",
       size       = 6,
       assignment = "default",
       extra      = <<EOF

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -17,7 +17,7 @@ locals {
     },
     {
       suffix     = "-no-spool",
-      size       = 1,
+      size       = 6,
       assignment = "default",
       extra      = <<EOF
 

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -13,24 +13,7 @@ locals {
       suffix     = "",
       size       = 6,
       assignment = "default",
-      extra      = <<EOF
-
-# Disable Print Spooler service (security)
-Stop-Service -Name Spooler -Force
-Set-Service -Name Spooler -StartupType Disabled
-EOF
     },
-    {
-      suffix     = "-t",
-      size       = 6,
-      assignment = "default",
-      extra      = <<EOF
-# Disable Print Sppoler service (security)
-Stop-Service -Name Spooler -Force
-Set-Service -Name Spooler -StartupType Disabled
-
-EOF
-    }
   ]
 }
 
@@ -101,7 +84,11 @@ $ErrorActionPreference = 'Stop'
 
 # Disable Windows Defender to speed up disk access
 Set-MpPreference -DisableRealtimeMonitoring $true
-${local.w[count.index].extra}
+
+# Disable Print Spooler service (security)
+Stop-Service -Name Spooler -Force
+Set-Service -Name Spooler -StartupType Disabled
+
 # Enable long paths
 Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name LongPathsEnabled -Type DWord -Value 1
 

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -13,17 +13,22 @@ locals {
       suffix     = "",
       size       = 6,
       assignment = "default",
-      extra      = "",
+      extra      = <<EOF
+
+# Disable Print Spooler service (security)
+Stop-Service -Name Spooler -Force
+Set-Service -Name Spooler -StartupType Disabled
+EOF
     },
     {
       suffix     = "-t",
       size       = 6,
       assignment = "default",
       extra      = <<EOF
-
 # Disable Print Sppoler service (security)
 Stop-Service -Name Spooler -Force
 Set-Service -Name Spooler -StartupType Disabled
+
 EOF
     }
   ]
@@ -95,8 +100,8 @@ Set-StrictMode -Version latest
 $ErrorActionPreference = 'Stop'
 
 # Disable Windows Defender to speed up disk access
-Set-MpPreference -DisableRealtimeMonitoring $true${local.w[count.index].extra}
-
+Set-MpPreference -DisableRealtimeMonitoring $true
+${local.w[count.index].extra}
 # Enable long paths
 Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name LongPathsEnabled -Type DWord -Value 1
 


### PR DESCRIPTION
We're not expecting to print anything, and @RPS5' security newsletter
says this is a vector of attack.

CHANGELOG_BEGIN
CHANGELOG_END