### PR TITLE
Warn on DA.Exception import

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Exception.daml
@@ -6,7 +6,9 @@
 #ifndef DAML_EXCEPTIONS
 
 -- | HIDE
-module DA.Exception where
+module DA.Exception
+  {-# WARNING "Your target Daml-LF version is too old for exceptions. You need Daml-LF 1.14 or newer" #-}
+  where
 
 #else
 

--- a/compiler/damlc/tests/daml-test-files/ExceptionImport.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionImport.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @UNTIL-LF 1.13
+-- @WARN too old for exceptions
+
+-- | Test that DA.Assert throws AssertionFailed on failure.
+module ExceptionImport where
+
+import DA.Exception ()


### PR DESCRIPTION
We had a few confused users that imported that module and got weird
errors. The warning should hopefully make things a bit clearer. We
could do this for other modules as well but I’ll leave that for
separate PRs.

changelog_begin

- [Daml Compiler] Importing DA.Exception on LF < 1.14 now produces a
warning that exceptions require Daml-LF >= 1.14.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
