### PR TITLE
Ensure lookupMaximumLedgerTime contention failures are propagated normally [DPP-481]

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
@@ -297,23 +297,33 @@ class MutableCacheBackedContractStoreSpec
       }
     }
 
-    "fail if one of the contract ids doesn't have an associated active contract" in {
-      recoverToSucceededIf[ContractNotFound] {
-        for {
-          store <- contractStore(cachesSize = 0L).asFuture
-          _ = store.cacheIndex.set(unusedOffset, 2L)
-          _ <- store.lookupMaximumLedgerTime(Set(cId_1, cId_2))
-        } yield succeed
-      }
+    "fail if one of the cached contract ids doesn't have an associated active contract" in {
+      for {
+        store <- contractStore(cachesSize = 1L).asFuture
+        _ = store.cacheIndex.set(unusedOffset, 2L)
+        // populate the cache
+        _ <- store.lookupActiveContract(Set(bob), cId_5)
+        assertion <- recoverToSucceededIf[ContractNotFound](
+          store.lookupMaximumLedgerTime(Set(cId_1, cId_5))
+        )
+      } yield assertion
+    }
+
+    "fail if one of the fetched contract ids doesn't have an associated active contract" in {
+      for {
+        store <- contractStore(cachesSize = 0L).asFuture
+        _ = store.cacheIndex.set(unusedOffset, 2L)
+        assertion <- recoverToSucceededIf[IllegalArgumentException](
+          store.lookupMaximumLedgerTime(Set(cId_1, cId_5))
+        )
+      } yield assertion
     }
 
     "fail if the requested contract id set is empty" in {
-      recoverToSucceededIf[EmptyContractIds] {
-        for {
-          store <- contractStore(cachesSize = 0L).asFuture
-          _ <- store.lookupMaximumLedgerTime(Set.empty)
-        } yield succeed
-      }
+      for {
+        store <- contractStore(cachesSize = 0L).asFuture
+        _ <- recoverToSucceededIf[EmptyContractIds](store.lookupMaximumLedgerTime(Set.empty))
+      } yield succeed
     }
   }
 
@@ -373,11 +383,11 @@ object MutableCacheBackedContractStoreSpec {
   private val unusedOffset = Offset.beforeBegin
   private val Seq(alice, bob, charlie) = Seq("alice", "bob", "charlie").map(party)
   private val (
-    Seq(cId_1, cId_2, cId_3, cId_4),
-    Seq(contract1, contract2, contract3, contract4),
-    Seq(t1, t2, t3, t4),
+    Seq(cId_1, cId_2, cId_3, cId_4, cId_5),
+    Seq(contract1, contract2, contract3, contract4, _),
+    Seq(t1, t2, t3, t4, _),
   ) =
-    (1 to 4).map { id =>
+    (1 to 5).map { id =>
       (contractId(id), contract(s"id$id"), Instant.ofEpochSecond(id.toLong))
     }.unzip3
 
@@ -419,6 +429,7 @@ object MutableCacheBackedContractStoreSpec {
       case (`cId_2`, validAt) if validAt >= 1L => activeContract(contract2, Set(bob), t2)
       case (`cId_3`, _) => activeContract(contract3, Set(bob), t3)
       case (`cId_4`, _) => activeContract(contract4, Set(bob), t4)
+      case (`cId_5`, _) => archivedContract(Set(bob))
       case _ => Future.successful(Option.empty)
     }
 
@@ -429,7 +440,12 @@ object MutableCacheBackedContractStoreSpec {
         Future.successful(Some(t4))
       case set if set.isEmpty =>
         Future.failed(EmptyContractIds())
-      case _ => Future.failed(ContractNotFound(ids))
+      case _ =>
+        Future.failed(
+          new IllegalArgumentException(
+            s"The following contracts have not been found: ${ids.map(_.coid).mkString(", ")}"
+          )
+        )
     }
 
     override def lookupActiveContractAndLoadArgument(


### PR DESCRIPTION
This PR fixes a bug that bubbles up a contention-driven exception instead of passing it down via a failed Future. The issue manifests itself as a unhandled failure to the server instead of a handled submission result in `ApiSubmissionService`. 

The fix allows to return a `ContractNotFound` wrapped in a `Future` instead of throwing when a `lookupMaximumLedgerTime` hits a cached archived/not found contract.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
