### PR TITLE
tweak ES cluster

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -10,14 +10,14 @@ terraform {
 
 provider "google" {
   project = "da-dev-gcp-daml-language"
-  region  = "us-east4"
-  zone    = "us-east4-a"
+  region  = local.region
+  zone    = local.zone
 }
 
 provider "google-beta" {
   project = "da-dev-gcp-daml-language"
-  region  = "us-east4"
-  zone    = "us-east4-a"
+  region  = local.region
+  zone    = local.zone
 }
 
 provider "secret" {


### PR DESCRIPTION
This PR contains many small changes:

- A small refactoring whereby the "es-init" machine is now
  (syntactically) integrated with the two instance groups, to cut down a
  bit on repetition.
- The feeder machine is now preemptible, because I've seen it recover
  enough times that I'm confident this will not cause any issue.
- Indices are now sharded.
- Return values from ES are filtered, cutting down a bit on network
  usage and memory requirements to produce the responses.
- Bulk uploads for a single job are now done in parallel. This results
  in about a 2x speedup for ingestion.
- crontab was changed to very minute instead of every 5 minutes.

CHANGELOG_BEGIN
CHANGELOG_END