### PR TITLE
Backport: Avoid collision in execution log postfix (#10205)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ ARTIFACT_DIRS="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$PWD}"
 mkdir -p "${ARTIFACT_DIRS}/logs"
 
 tag_filter=""
-if [[ "$execution_log_postfix" == "_Darwin" ]]; then
+if [[ "$(uname)" == "Darwin" ]]; then
   tag_filter="-dont-run-on-darwin,-scaladoc,-pdfdocs"
 fi
 

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -32,7 +32,7 @@ steps:
     displayName: 'Platform-agnostic lints and checks'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-  - bash: ./build.sh "_$(uname)"
+  - bash: ./build.sh "_${{parameters.name}}"
     displayName: 'Build'
     env:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}


### PR DESCRIPTION
It seems like this should be harmless but the tests reliably timeout
on macos so we really need this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
