### PR TITLE
tf: refactor appr var

### DIFF
--- a/infra/data_bucket.tf
+++ b/infra/data_bucket.tf
@@ -46,10 +46,8 @@ resource "google_storage_bucket_iam_member" "data_read" {
 }
 
 // allow read access for appr team, as requested by Moritz
-variable "appr" {
-  description = "Application Runtime team members"
-
-  default = [
+locals {
+  appr_team = [
     "user:akshay.shirahatti@digitalasset.com",
     "user:andreas.herrmann@digitalasset.com",
     "user:gary.verhaegen@digitalasset.com",
@@ -61,8 +59,8 @@ variable "appr" {
 }
 
 resource "google_storage_bucket_iam_member" "appr" {
-  count  = length(var.appr)
-  bucket = google_storage_bucket.data.name
-  role   = "roles/storage.objectViewer"
-  member = var.appr[count.index]
+  for_each = toset(local.appr_team)
+  bucket   = google_storage_bucket.data.name
+  role     = "roles/storage.objectViewer"
+  member   = each.key
 }


### PR DESCRIPTION
Two changes at the Terraform level, both with no impact on the actual
GCP state:

- There is no reason to make this value a `variable`: variables in
  Terraforma are meant to be supplied at the CLI. `local` is the right
  abstraction here (i.e. set in the file directly).
- Using an unordered `for_each` set rather than a list so we don't have
  positional identity, meaning when adding someone at the top we don't
  need to destroy and recreate everyone else.

CHANGELOG_BEGIN
CHANGELOG_END