### PR TITLE
kvutils: Extract validators from TransactionCommitter [KVL-1015]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/DamlTransactionEntrySummary.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/DamlTransactionEntrySummary.scala
@@ -16,7 +16,7 @@ import com.daml.lf.transaction.{Transaction => Tx}
 
 import scala.jdk.CollectionConverters._
 
-private[transaction] final class DamlTransactionEntrySummary(
+private[kvutils] final class DamlTransactionEntrySummary(
     val submission: DamlTransactionEntry,
     tx: => Tx.Transaction,
 ) {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
@@ -20,11 +20,11 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 
-private[transaction] class TransactionRejector(metrics: Metrics) {
+private[transaction] class Rejections(metrics: Metrics) {
 
   private final val logger = ContextualizedLogger.get(getClass)
 
-  def reject[A](
+  def buildRejectionStep[A](
       rejectionEntry: DamlTransactionRejectionEntry.Builder,
       recordTime: Option[Timestamp],
   ): StepResult[A] = {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -5,32 +5,21 @@ package com.daml.ledger.participant.state.kvutils.committer.transaction
 
 import java.time.Instant
 
-import com.codahale.metrics.Counter
 import com.daml.ledger.participant.state.kvutils.Conversions._
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.committer.Committer._
 import com.daml.ledger.participant.state.kvutils.committer._
-import com.daml.ledger.participant.state.kvutils.committer.transaction.keys.ContractKeysValidation.validateKeys
-import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
-import com.daml.ledger.participant.state.v1.{Configuration, RejectionReasonV0, TimeModel}
-import com.daml.lf.archive
-import com.daml.lf.data.Ref.{PackageId, Party}
-import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.engine.{Blinding, Engine, Error => LfError}
-import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{
-  BlindingInfo,
-  GlobalKeyWithMaintainers,
-  Node,
-  NodeId,
-  ReplayNodeMismatch,
-  SubmittedTransaction,
-  TransactionOuterClass,
-  VersionedTransaction,
+import com.daml.ledger.participant.state.kvutils.committer.transaction.validation.{
+  ContractKeysValidator,
+  LedgerTimeValidator,
+  ModelConformanceValidator,
 }
-import com.daml.lf.value.Value
+import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
+import com.daml.ledger.participant.state.v1.{Configuration, RejectionReasonV0}
+import com.daml.lf.data.Ref.Party
+import com.daml.lf.engine.{Blinding, Engine}
+import com.daml.lf.transaction.{BlindingInfo, TransactionOuterClass}
 import com.daml.lf.value.Value.ContractId
-import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.entries.LoggingEntries
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
@@ -76,25 +65,23 @@ private[kvutils] class TransactionCommitter(
   )(implicit loggingContext: LoggingContext): DamlTransactionEntrySummary =
     DamlTransactionEntrySummary(submission.getTransactionEntry)
 
+  private val transactionRejector = new TransactionRejector(metrics)
+  private val ledgerTimeValidator = new LedgerTimeValidator(defaultConfig)
+  private val modelConformanceValidator = new ModelConformanceValidator(engine, metrics)
+
   override protected val steps: Steps[DamlTransactionEntrySummary] = Iterable(
     "authorize_submitter" -> authorizeSubmitters,
     "check_informee_parties_allocation" -> checkInformeePartiesAllocation,
     "deduplicate" -> deduplicateCommand,
-    "validate_ledger_time" -> validateLedgerTime,
-    "validate_contract_keys" -> validateKeys(transactionCommitter = this),
-    "validate_model_conformance" -> validateModelConformance,
+    "validate_ledger_time" -> ledgerTimeValidator.createValidationStep(transactionRejector),
+    "validate_contract_keys" -> ContractKeysValidator.createValidationStep(transactionRejector),
+    "validate_model_conformance" -> modelConformanceValidator.createValidationStep(
+      transactionRejector
+    ),
     "blind" -> blind,
     "trim_unnecessary_nodes" -> trimUnnecessaryNodes,
     "build_final_log_entry" -> buildFinalLogEntry,
   )
-
-  private def contractIsActive(
-      transactionEntry: DamlTransactionEntrySummary,
-      contractState: DamlContractState,
-  ): Boolean = {
-    val activeAt = Option(contractState.getActiveAt).map(parseTimestamp)
-    !contractState.hasArchivedAt && activeAt.exists(transactionEntry.ledgerEffectiveTime >= _)
-  }
 
   /** Reject duplicate commands
     */
@@ -113,11 +100,11 @@ private[kvutils] class TransactionCommitter(
             StepContinue(transactionEntry)
           } else {
             logger.trace("Transaction rejected because the command is a duplicate.")
-            reject(
-              commitContext.recordTime,
+            transactionRejector.reject(
               DamlTransactionRejectionEntry.newBuilder
                 .setSubmitterInfo(transactionEntry.submitterInfo)
                 .setDuplicateCommand(Duplicate.newBuilder.setDetails("")),
+              commitContext.recordTime,
             )
           }
         }
@@ -184,184 +171,16 @@ private[kvutils] class TransactionCommitter(
         }
 
       def rejection(reason: RejectionReasonV0): StepResult[DamlTransactionEntrySummary] =
-        reject[DamlTransactionEntrySummary](
+        transactionRejector.reject[DamlTransactionEntrySummary](
+          transactionRejector.buildRejectionEntry(transactionEntry, reason),
           commitContext.recordTime,
-          buildRejectionLogEntry(transactionEntry, reason),
         )
 
       authorizeAll(transactionEntry.submitters)
     }
   }
 
-  /** Validate ledger effective time and the command's time-to-live. */
-  private[transaction] def validateLedgerTime: Step = new Step {
-    def apply(
-        commitContext: CommitContext,
-        transactionEntry: DamlTransactionEntrySummary,
-    )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
-      val (_, config) = getCurrentConfiguration(defaultConfig, commitContext)
-      val timeModel = config.timeModel
-
-      commitContext.recordTime match {
-        case Some(recordTime) =>
-          val givenLedgerTime = transactionEntry.ledgerEffectiveTime.toInstant
-
-          timeModel
-            .checkTime(ledgerTime = givenLedgerTime, recordTime = recordTime.toInstant)
-            .fold(
-              reason =>
-                reject(
-                  commitContext.recordTime,
-                  buildRejectionLogEntry(
-                    transactionEntry,
-                    RejectionReasonV0.InvalidLedgerTime(reason),
-                  ),
-                ),
-              _ => StepContinue(transactionEntry),
-            )
-        case None => // Pre-execution: propagate the time bounds and defer the checks to post-execution.
-          val maybeDeduplicateUntil =
-            getLedgerDeduplicateUntil(transactionEntry, commitContext)
-          val minimumRecordTime = transactionMinRecordTime(
-            transactionEntry.submissionTime.toInstant,
-            transactionEntry.ledgerEffectiveTime.toInstant,
-            maybeDeduplicateUntil,
-            timeModel,
-          )
-          val maximumRecordTime = transactionMaxRecordTime(
-            transactionEntry.submissionTime.toInstant,
-            transactionEntry.ledgerEffectiveTime.toInstant,
-            timeModel,
-          )
-          commitContext.deduplicateUntil = maybeDeduplicateUntil
-          commitContext.minimumRecordTime = Some(minimumRecordTime)
-          commitContext.maximumRecordTime = Some(maximumRecordTime)
-          val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
-            .setTransactionRejectionEntry(
-              buildRejectionLogEntry(
-                transactionEntry,
-                RejectionReasonV0.InvalidLedgerTime(
-                  s"Record time is outside of valid range [$minimumRecordTime, $maximumRecordTime]"
-                ),
-              )
-            )
-            .build
-          commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
-          StepContinue(transactionEntry)
-      }
-    }
-  }
-
-  /** Validate the submission's conformance to the Daml model */
-  private def validateModelConformance: Step = new Step {
-    def apply(
-        commitContext: CommitContext,
-        transactionEntry: DamlTransactionEntrySummary,
-    )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] =
-      metrics.daml.kvutils.committer.transaction.interpretTimer.time(() => {
-        // Pull all keys from referenced contracts. We require this for 'fetchByKey' calls
-        // which are not evidenced in the transaction itself and hence the contract key state is
-        // not included in the inputs.
-        lazy val knownKeys: Map[DamlContractKey, Value.ContractId] =
-          commitContext.collectInputs {
-            case (key, Some(value))
-                if value.getContractState.hasContractKey
-                  && contractIsActive(transactionEntry, value.getContractState) =>
-              value.getContractState.getContractKey -> Conversions
-                .stateKeyToContractId(key)
-          }
-
-        try {
-          engine
-            .validate(
-              transactionEntry.submitters.toSet,
-              SubmittedTransaction(transactionEntry.transaction),
-              transactionEntry.ledgerEffectiveTime,
-              commitContext.participantId,
-              transactionEntry.submissionTime,
-              transactionEntry.submissionSeed,
-            )
-            .consume(
-              lookupContract(transactionEntry, commitContext),
-              lookupPackage(commitContext),
-              lookupKey(commitContext, knownKeys),
-            )
-            .fold(
-              err =>
-                reject[DamlTransactionEntrySummary](
-                  commitContext.recordTime,
-                  buildRejectionLogEntry(transactionEntry, rejectionReasonForValidationError(err)),
-                ),
-              _ => StepContinue[DamlTransactionEntrySummary](transactionEntry),
-            )
-        } catch {
-          case err: Err.MissingInputState =>
-            logger.warn(
-              "Model conformance validation failed due to a missing input state (most likely due to invalid state on the participant)."
-            )
-            reject(
-              commitContext.recordTime,
-              buildRejectionLogEntry(transactionEntry, RejectionReasonV0.Disputed(err.getMessage)),
-            )
-        }
-      })
-  }
-
-  private[transaction] def rejectionReasonForValidationError(
-      validationError: LfError
-  ): RejectionReasonV0 = {
-    def disputed: RejectionReasonV0 =
-      RejectionReasonV0.Disputed(validationError.msg)
-
-    def resultIsCreatedInTx(
-        tx: VersionedTransaction[NodeId, ContractId],
-        result: Option[Value.ContractId],
-    ): Boolean =
-      result.exists { contractId =>
-        tx.nodes.exists {
-          case (_, create: Node.NodeCreate[_]) => create.coid == contractId
-          case _ => false
-        }
-      }
-
-    validationError match {
-      case LfError.Validation(
-            LfError.Validation.ReplayMismatch(
-              ReplayNodeMismatch(recordedTx, recordedNodeId, replayedTx, replayedNodeId)
-            )
-          ) =>
-        // If the problem is that a key lookup has changed and the results do not involve contracts created in this transaction,
-        // then it's a consistency problem.
-
-        (recordedTx.nodes(recordedNodeId), replayedTx.nodes(replayedNodeId)) match {
-          case (
-                Node.NodeLookupByKey(
-                  recordedTemplateId,
-                  _,
-                  recordedKey,
-                  recordedResult,
-                  recordedVersion,
-                ),
-                Node.NodeLookupByKey(
-                  replayedTemplateId,
-                  _,
-                  replayedKey,
-                  replayedResult,
-                  replayedVersion,
-                ),
-              )
-              if recordedVersion == replayedVersion &&
-                recordedTemplateId == replayedTemplateId && recordedKey == replayedKey
-                && !resultIsCreatedInTx(recordedTx, recordedResult)
-                && !resultIsCreatedInTx(replayedTx, replayedResult) =>
-            RejectionReasonV0.Inconsistent(validationError.msg)
-          case _ => disputed
-        }
-      case _ => disputed
-    }
-  }
-
-  /** Validate the submission's conformance to the Daml model */
+  /** Set blinding info. */
   private[transaction] def blind: Step = new Step {
     def apply(
         commitContext: CommitContext,
@@ -473,12 +292,12 @@ private[kvutils] class TransactionCommitter(
       if (parties.forall(party => commitContext.get(partyStateKey(party)).isDefined))
         StepContinue(transactionEntry)
       else
-        reject(
-          commitContext.recordTime,
-          buildRejectionLogEntry(
+        transactionRejector.reject(
+          transactionRejector.buildRejectionEntry(
             transactionEntry,
             RejectionReasonV0.PartyNotKnownOnLedger("Not all parties known"),
           ),
+          commitContext.recordTime,
         )
     }
   }
@@ -571,25 +390,6 @@ private[kvutils] class TransactionCommitter(
     }
   }
 
-  private[transaction] def buildLogEntry(
-      transactionEntry: DamlTransactionEntrySummary,
-      commitContext: CommitContext,
-  ): DamlLogEntry = {
-    if (commitContext.preExecute) {
-      val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
-        .setTransactionRejectionEntry(
-          DamlTransactionRejectionEntry.newBuilder
-            .setSubmitterInfo(transactionEntry.submitterInfo)
-        )
-        .build
-      commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
-    }
-    buildLogEntryWithOptionalRecordTime(
-      commitContext.recordTime,
-      _.setTransactionEntry(transactionEntry.submission),
-    )
-  }
-
   private def updateContractKeyWithContractKeyState(
       ledgerEffectiveTime: ProtoTimestamp,
       key: DamlStateKey,
@@ -609,149 +409,29 @@ private[kvutils] class TransactionCommitter(
         )
         .build
   }
-
-  // Helper to lookup contract instances. We verify the activeness of
-  // contract instances here. Since we look up every contract that was
-  // an input to a transaction, we do not need to verify the inputs separately.
-  private def lookupContract(
-      transactionEntry: DamlTransactionEntrySummary,
-      commitContext: CommitContext,
-  )(
-      coid: Value.ContractId
-  ): Option[Value.ContractInst[Value.VersionedValue[Value.ContractId]]] = {
-    val stateKey = contractIdToStateKey(coid)
-    for {
-      // Fetch the state of the contract so that activeness can be checked.
-      // There is the possibility that the reinterpretation of the transaction yields a different
-      // result in a LookupByKey than the original transaction. This means that the contract state data for the
-      // contractId pointed to by that contractKey might not have been preloaded into the input state map.
-      // This is not a problem because after the transaction reinterpretation, we compare the original
-      // transaction with the reinterpreted one, and the LookupByKey node will not match.
-      // Additionally, all contract keys are checked to uphold causal monotonicity.
-      contractState <- commitContext.read(stateKey).map(_.getContractState)
-      if contractIsActive(transactionEntry, contractState)
-      contract = Conversions.decodeContractInstance(contractState.getContractInstance)
-    } yield contract
-  }
-
-  // Helper to lookup package from the state. The package contents
-  // are stored in the [[DamlLogEntry]], which we find by looking up
-  // the Daml state entry at `DamlStateKey(packageId = pkgId)`.
-  private def lookupPackage(
-      commitContext: CommitContext
-  )(pkgId: PackageId)(implicit loggingContext: LoggingContext): Option[Ast.Package] =
-    withEnrichedLoggingContext("packageId" -> pkgId) { implicit loggingContext =>
-      val stateKey = packageStateKey(pkgId)
-      for {
-        value <- commitContext
-          .read(stateKey)
-          .orElse {
-            logger.warn("Package lookup failed, package not found.")
-            throw Err.MissingInputState(stateKey)
-          }
-        pkg <- value.getValueCase match {
-          case DamlStateValue.ValueCase.ARCHIVE =>
-            // NOTE(JM): Engine only looks up packages once, compiles and caches,
-            // provided that the engine instance is persisted.
-            try {
-              Some(archive.Decode.decode(value.getArchive)._2)
-            } catch {
-              case err: archive.Error =>
-                logger.warn("Decoding the archive failed.")
-                throw Err.DecodeError("Archive", err.getMessage)
-            }
-
-          case _ =>
-            val msg = "value is not a Daml-LF archive"
-            logger.warn(s"Package lookup failed, $msg.")
-            throw Err.DecodeError("Archive", msg)
-        }
-      } yield pkg
-    }
-
-  private def lookupKey(
-      commitContext: CommitContext,
-      knownKeys: Map[DamlContractKey, Value.ContractId],
-  )(key: GlobalKeyWithMaintainers): Option[Value.ContractId] = {
-    // we don't check whether the contract is active or not, because in we might not have loaded it earlier.
-    // this is not a problem, because:
-    // a) if the lookup was negative and we actually found a contract,
-    //    the transaction validation will fail.
-    // b) if the lookup was positive and its result is a different contract,
-    //    the transaction validation will fail.
-    // c) if the lookup was positive and its result is the same contract,
-    //    - the authorization check ensures that the submitter is in fact allowed
-    //      to lookup the contract
-    //    - the separate contract keys check ensures that all contracts pointed to by
-    //    contract keys respect causal monotonicity.
-    val stateKey = Conversions.globalKeyToStateKey(key.globalKey)
-    val contractId = for {
-      stateValue <- commitContext.read(stateKey)
-      if stateValue.getContractKeyState.getContractId.nonEmpty
-    } yield decodeContractId(stateValue.getContractKeyState.getContractId)
-
-    // If the key was not in state inputs, then we look whether any of the accessed contracts has
-    // the key we're looking for. This happens with "fetchByKey" where the key lookup is not
-    // evidenced in the transaction. The activeness of the contract is checked when it is fetched.
-    contractId.orElse {
-      knownKeys.get(stateKey.getContractKey)
-    }
-  }
-
-  private[transaction] def buildRejectionLogEntry(
-      transactionEntry: DamlTransactionEntrySummary,
-      reason: RejectionReasonV0,
-  )(implicit loggingContext: LoggingContext): DamlTransactionRejectionEntry.Builder = {
-    logger.trace(s"Transaction rejected, ${reason.description}.")
-    val builder = DamlTransactionRejectionEntry.newBuilder
-    builder
-      .setSubmitterInfo(transactionEntry.submitterInfo)
-
-    reason match {
-      case RejectionReasonV0.Inconsistent(reason) =>
-        builder.setInconsistent(Inconsistent.newBuilder.setDetails(reason))
-      case RejectionReasonV0.Disputed(reason) =>
-        builder.setDisputed(Disputed.newBuilder.setDetails(reason))
-      case RejectionReasonV0.ResourcesExhausted(reason) =>
-        builder.setResourcesExhausted(ResourcesExhausted.newBuilder.setDetails(reason))
-      case RejectionReasonV0.PartyNotKnownOnLedger(reason) =>
-        builder.setPartyNotKnownOnLedger(PartyNotKnownOnLedger.newBuilder.setDetails(reason))
-      case RejectionReasonV0.SubmitterCannotActViaParticipant(details) =>
-        builder.setSubmitterCannotActViaParticipant(
-          SubmitterCannotActViaParticipant.newBuilder
-            .setDetails(details)
-        )
-      case RejectionReasonV0.InvalidLedgerTime(reason) =>
-        builder.setInvalidLedgerTime(InvalidLedgerTime.newBuilder.setDetails(reason))
-    }
-    builder
-  }
-
-  private[transaction] def reject[A](
-      recordTime: Option[Timestamp],
-      rejectionEntry: DamlTransactionRejectionEntry.Builder,
-  ): StepResult[A] = {
-    Metrics.rejections(rejectionEntry.getReasonCase.getNumber).inc()
-    StepStop(
-      buildLogEntryWithOptionalRecordTime(
-        recordTime,
-        _.setTransactionRejectionEntry(rejectionEntry),
-      )
-    )
-  }
-
-  private object Metrics {
-    val rejections: Map[Int, Counter] =
-      DamlTransactionRejectionEntry.ReasonCase.values
-        .map(v =>
-          v.getNumber -> metrics.daml.kvutils.committer.transaction
-            .rejection(v.name())
-        )
-        .toMap
-  }
 }
 
 private[kvutils] object TransactionCommitter {
+
+  def buildLogEntry(
+      transactionEntry: DamlTransactionEntrySummary,
+      commitContext: CommitContext,
+  ): DamlLogEntry = {
+    if (commitContext.preExecute) {
+      val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
+        .setTransactionRejectionEntry(
+          DamlTransactionRejectionEntry.newBuilder
+            .setSubmitterInfo(transactionEntry.submitterInfo)
+        )
+        .build
+      commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
+    }
+    buildLogEntryWithOptionalRecordTime(
+      commitContext.recordTime,
+      _.setTransactionEntry(transactionEntry.submission),
+    )
+  }
+
   // Helper to read the _current_ contract state.
   // NOTE(JM): Important to fetch from the state that is currently being built up since
   // we mark some contracts as archived and may later change their disclosure and do not
@@ -761,39 +441,4 @@ private[kvutils] object TransactionCommitter {
       .get(key)
       .getOrElse(throw Err.MissingInputState(key))
       .getContractState
-
-  @SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
-  private def transactionMinRecordTime(
-      submissionTime: Instant,
-      ledgerTime: Instant,
-      maybeDeduplicateUntil: Option[Instant],
-      timeModel: TimeModel,
-  ): Instant =
-    List(
-      maybeDeduplicateUntil
-        .map(
-          _.plus(Timestamp.Resolution)
-        ), // DeduplicateUntil defines a rejection window, endpoints inclusive
-      Some(timeModel.minRecordTime(ledgerTime)),
-      Some(timeModel.minRecordTime(submissionTime)),
-    ).flatten.max
-
-  private def transactionMaxRecordTime(
-      submissionTime: Instant,
-      ledgerTime: Instant,
-      timeModel: TimeModel,
-  ): Instant =
-    List(timeModel.maxRecordTime(ledgerTime), timeModel.maxRecordTime(submissionTime)).min
-
-  private def getLedgerDeduplicateUntil(
-      transactionEntry: DamlTransactionEntrySummary,
-      commitContext: CommitContext,
-  ): Option[Instant] =
-    for {
-      dedupEntry <- commitContext.get(commandDedupKey(transactionEntry.submitterInfo))
-      dedupTimestamp <- PartialFunction.condOpt(dedupEntry.getCommandDedup.hasDeduplicatedUntil) {
-        case true => dedupEntry.getCommandDedup.getDeduplicatedUntil
-      }
-    } yield parseTimestamp(dedupTimestamp).toInstant
-
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionRejector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionRejector.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer.transaction
+
+import com.codahale.metrics.Counter
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlTransactionRejectionEntry,
+  Disputed,
+  Inconsistent,
+  InvalidLedgerTime,
+  PartyNotKnownOnLedger,
+  ResourcesExhausted,
+  SubmitterCannotActViaParticipant,
+}
+import com.daml.ledger.participant.state.kvutils.committer.Committer.buildLogEntryWithOptionalRecordTime
+import com.daml.ledger.participant.state.kvutils.committer.{StepResult, StepStop}
+import com.daml.ledger.participant.state.v1.RejectionReasonV0
+import com.daml.lf.data.Time.Timestamp
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.metrics.Metrics
+
+private[transaction] class TransactionRejector(metrics: Metrics) {
+
+  private final val logger = ContextualizedLogger.get(getClass)
+
+  def reject[A](
+      rejectionEntry: DamlTransactionRejectionEntry.Builder,
+      recordTime: Option[Timestamp],
+  ): StepResult[A] = {
+    Metrics.rejections(rejectionEntry.getReasonCase.getNumber).inc()
+    StepStop(
+      buildLogEntryWithOptionalRecordTime(
+        recordTime,
+        _.setTransactionRejectionEntry(rejectionEntry),
+      )
+    )
+  }
+
+  def buildRejectionEntry(
+      transactionEntry: DamlTransactionEntrySummary,
+      reason: RejectionReasonV0,
+  )(implicit loggingContext: LoggingContext): DamlTransactionRejectionEntry.Builder = {
+    logger.trace(s"Transaction rejected, ${reason.description}.")
+
+    val builder = DamlTransactionRejectionEntry.newBuilder
+    builder
+      .setSubmitterInfo(transactionEntry.submitterInfo)
+
+    reason match {
+      case RejectionReasonV0.Inconsistent(reason) =>
+        builder.setInconsistent(Inconsistent.newBuilder.setDetails(reason))
+      case RejectionReasonV0.Disputed(reason) =>
+        builder.setDisputed(Disputed.newBuilder.setDetails(reason))
+      case RejectionReasonV0.ResourcesExhausted(reason) =>
+        builder.setResourcesExhausted(ResourcesExhausted.newBuilder.setDetails(reason))
+      case RejectionReasonV0.PartyNotKnownOnLedger(reason) =>
+        builder.setPartyNotKnownOnLedger(PartyNotKnownOnLedger.newBuilder.setDetails(reason))
+      case RejectionReasonV0.SubmitterCannotActViaParticipant(details) =>
+        builder.setSubmitterCannotActViaParticipant(
+          SubmitterCannotActViaParticipant.newBuilder
+            .setDetails(details)
+        )
+      case RejectionReasonV0.InvalidLedgerTime(reason) =>
+        builder.setInvalidLedgerTime(InvalidLedgerTime.newBuilder.setDetails(reason))
+    }
+    builder
+  }
+
+  private object Metrics {
+    val rejections: Map[Int, Counter] =
+      DamlTransactionRejectionEntry.ReasonCase.values
+        .map(reasonCase =>
+          reasonCase.getNumber -> metrics.daml.kvutils.committer.transaction
+            .rejection(reasonCase.name())
+        )
+        .toMap
+  }
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/KeyMonotonicityValidation.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/KeyMonotonicityValidation.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,
-  TransactionRejector,
+  Rejections,
 }
 import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepResult}
 import com.daml.ledger.participant.state.v1.RejectionReasonV0
@@ -27,7 +27,7 @@ private[validation] object KeyMonotonicityValidation {
       keys: Set[DamlStateKey],
       damlState: Map[DamlStateKey, DamlStateValue],
       transactionEntry: DamlTransactionEntrySummary,
-      transactionRejector: TransactionRejector,
+      rejections: Rejections,
   )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
     val causalKeyMonotonicity = keys.forall { key =>
       val state = damlState(key)
@@ -40,8 +40,8 @@ private[validation] object KeyMonotonicityValidation {
     if (causalKeyMonotonicity)
       StepContinue(transactionEntry)
     else
-      transactionRejector.reject(
-        transactionRejector.buildRejectionEntry(
+      rejections.buildRejectionStep(
+        rejections.buildRejectionEntry(
           transactionEntry,
           RejectionReasonV0.InvalidLedgerTime("Causal monotonicity violated"),
         ),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/KeyMonotonicityValidation.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/KeyMonotonicityValidation.scala
@@ -1,20 +1,20 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.participant.state.kvutils.committer.transaction.keys
+package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
 
 import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,
-  TransactionCommitter,
+  TransactionRejector,
 }
 import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepResult}
 import com.daml.ledger.participant.state.v1.RejectionReasonV0
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
 
-private[keys] object KeyMonotonicityValidation {
+private[validation] object KeyMonotonicityValidation {
 
   /** LookupByKey nodes themselves don't actually fetch the contract.
     * Therefore we need to do an additional check on all contract keys
@@ -23,11 +23,11 @@ private[keys] object KeyMonotonicityValidation {
     * NodeLookupByKey.
     */
   def checkContractKeysCausalMonotonicity(
-      transactionCommitter: TransactionCommitter,
       recordTime: Option[Timestamp],
       keys: Set[DamlStateKey],
       damlState: Map[DamlStateKey, DamlStateValue],
       transactionEntry: DamlTransactionEntrySummary,
+      transactionRejector: TransactionRejector,
   )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
     val causalKeyMonotonicity = keys.forall { key =>
       val state = damlState(key)
@@ -40,12 +40,12 @@ private[keys] object KeyMonotonicityValidation {
     if (causalKeyMonotonicity)
       StepContinue(transactionEntry)
     else
-      transactionCommitter.reject(
-        recordTime,
-        transactionCommitter.buildRejectionLogEntry(
+      transactionRejector.reject(
+        transactionRejector.buildRejectionEntry(
           transactionEntry,
           RejectionReasonV0.InvalidLedgerTime("Causal monotonicity violated"),
         ),
+        recordTime,
       )
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
@@ -1,0 +1,117 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
+
+import java.time.Instant
+
+import com.daml.ledger.participant.state.kvutils.Conversions.{commandDedupKey, parseTimestamp}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntry
+import com.daml.ledger.participant.state.kvutils.committer.Committer.getCurrentConfiguration
+import com.daml.ledger.participant.state.kvutils.committer.transaction.{
+  DamlTransactionEntrySummary,
+  Step,
+  TransactionRejector,
+}
+import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepResult}
+import com.daml.ledger.participant.state.v1.{Configuration, RejectionReasonV0, TimeModel}
+import com.daml.lf.data.Time.Timestamp
+import com.daml.logging.LoggingContext
+
+private[transaction] class LedgerTimeValidator(defaultConfig: Configuration)
+    extends TransactionValidator {
+
+  /** Creates a committer step that validates ledger effective time and the command's time-to-live. */
+  override def createValidationStep(rejector: TransactionRejector): Step =
+    new Step {
+      def apply(
+          commitContext: CommitContext,
+          transactionEntry: DamlTransactionEntrySummary,
+      )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
+        val (_, config) = getCurrentConfiguration(defaultConfig, commitContext)
+        val timeModel = config.timeModel
+
+        commitContext.recordTime match {
+          case Some(recordTime) =>
+            val givenLedgerTime = transactionEntry.ledgerEffectiveTime.toInstant
+
+            timeModel
+              .checkTime(ledgerTime = givenLedgerTime, recordTime = recordTime.toInstant)
+              .fold(
+                reason =>
+                  rejector.reject(
+                    rejector.buildRejectionEntry(
+                      transactionEntry,
+                      RejectionReasonV0.InvalidLedgerTime(reason),
+                    ),
+                    commitContext.recordTime,
+                  ),
+                _ => StepContinue(transactionEntry),
+              )
+          case None => // Pre-execution: propagate the time bounds and defer the checks to post-execution.
+            val maybeDeduplicateUntil =
+              getLedgerDeduplicateUntil(transactionEntry, commitContext)
+            val minimumRecordTime = transactionMinRecordTime(
+              transactionEntry.submissionTime.toInstant,
+              transactionEntry.ledgerEffectiveTime.toInstant,
+              maybeDeduplicateUntil,
+              timeModel,
+            )
+            val maximumRecordTime = transactionMaxRecordTime(
+              transactionEntry.submissionTime.toInstant,
+              transactionEntry.ledgerEffectiveTime.toInstant,
+              timeModel,
+            )
+            commitContext.deduplicateUntil = maybeDeduplicateUntil
+            commitContext.minimumRecordTime = Some(minimumRecordTime)
+            commitContext.maximumRecordTime = Some(maximumRecordTime)
+            val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
+              .setTransactionRejectionEntry(
+                rejector.buildRejectionEntry(
+                  transactionEntry,
+                  RejectionReasonV0.InvalidLedgerTime(
+                    s"Record time is outside of valid range [$minimumRecordTime, $maximumRecordTime]"
+                  ),
+                )
+              )
+              .build
+            commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
+            StepContinue(transactionEntry)
+        }
+      }
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
+  private def transactionMinRecordTime(
+      submissionTime: Instant,
+      ledgerTime: Instant,
+      maybeDeduplicateUntil: Option[Instant],
+      timeModel: TimeModel,
+  ): Instant =
+    List(
+      maybeDeduplicateUntil
+        .map(
+          _.plus(Timestamp.Resolution)
+        ), // DeduplicateUntil defines a rejection window, endpoints inclusive
+      Some(timeModel.minRecordTime(ledgerTime)),
+      Some(timeModel.minRecordTime(submissionTime)),
+    ).flatten.max
+
+  private def transactionMaxRecordTime(
+      submissionTime: Instant,
+      ledgerTime: Instant,
+      timeModel: TimeModel,
+  ): Instant =
+    List(timeModel.maxRecordTime(ledgerTime), timeModel.maxRecordTime(submissionTime)).min
+
+  private def getLedgerDeduplicateUntil(
+      transactionEntry: DamlTransactionEntrySummary,
+      commitContext: CommitContext,
+  ): Option[Instant] =
+    for {
+      dedupEntry <- commitContext.get(commandDedupKey(transactionEntry.submitterInfo))
+      dedupTimestamp <- PartialFunction.condOpt(dedupEntry.getCommandDedup.hasDeduplicatedUntil) {
+        case true => dedupEntry.getCommandDedup.getDeduplicatedUntil
+      }
+    } yield parseTimestamp(dedupTimestamp).toInstant
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
@@ -22,7 +22,7 @@ import com.daml.ledger.participant.state.kvutils.committer.transaction.{
 import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepResult}
 import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
 import com.daml.ledger.participant.state.v1.RejectionReasonV0
-import com.daml.lf.archive.{Decode, ParseError}
+import com.daml.lf.archive
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.{Engine, Error => LfError}
 import com.daml.lf.language.Ast
@@ -158,11 +158,11 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
             // NOTE(JM): Engine only looks up packages once, compiles and caches,
             // provided that the engine instance is persisted.
             try {
-              Some(Decode.decode(value.getArchive)._2)
+              Some(archive.Decode.decode(value.getArchive)._2)
             } catch {
-              case ParseError(err) =>
+              case err: archive.Error =>
                 logger.warn("Decoding the archive failed.")
-                throw Err.DecodeError("Archive", err)
+                throw Err.DecodeError("Archive", err.getMessage)
             }
 
           case _ =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
@@ -1,0 +1,260 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
+
+import com.daml.ledger.participant.state.kvutils.Conversions.{
+  contractIdToStateKey,
+  decodeContractId,
+  packageStateKey,
+  parseTimestamp,
+}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlContractKey,
+  DamlContractState,
+  DamlStateValue,
+}
+import com.daml.ledger.participant.state.kvutils.committer.transaction.{
+  DamlTransactionEntrySummary,
+  Step,
+  TransactionRejector,
+}
+import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepResult}
+import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
+import com.daml.ledger.participant.state.v1.RejectionReasonV0
+import com.daml.lf.archive.{Decode, ParseError}
+import com.daml.lf.data.Ref.PackageId
+import com.daml.lf.engine.{Engine, Error => LfError}
+import com.daml.lf.language.Ast
+import com.daml.lf.transaction.{
+  GlobalKeyWithMaintainers,
+  Node,
+  NodeId,
+  ReplayNodeMismatch,
+  SubmittedTransaction,
+  VersionedTransaction,
+}
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value.ContractId
+import com.daml.logging.LoggingContext.withEnrichedLoggingContext
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.metrics.Metrics
+
+private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Metrics)
+    extends TransactionValidator {
+  import ModelConformanceValidator._
+
+  private final val logger = ContextualizedLogger.get(getClass)
+
+  /** Creates a committer step that validates the submission's conformance to the Daml model. */
+  override def createValidationStep(rejector: TransactionRejector): Step = new Step {
+    def apply(
+        commitContext: CommitContext,
+        transactionEntry: DamlTransactionEntrySummary,
+    )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] =
+      metrics.daml.kvutils.committer.transaction.interpretTimer.time(() => {
+        // Pull all keys from referenced contracts. We require this for 'fetchByKey' calls
+        // which are not evidenced in the transaction itself and hence the contract key state is
+        // not included in the inputs.
+        lazy val knownKeys: Map[DamlContractKey, Value.ContractId] =
+          commitContext.collectInputs {
+            case (key, Some(value))
+                if value.getContractState.hasContractKey
+                  && contractIsActive(transactionEntry, value.getContractState) =>
+              value.getContractState.getContractKey -> Conversions
+                .stateKeyToContractId(key)
+          }
+
+        try {
+          engine
+            .validate(
+              transactionEntry.submitters.toSet,
+              SubmittedTransaction(transactionEntry.transaction),
+              transactionEntry.ledgerEffectiveTime,
+              commitContext.participantId,
+              transactionEntry.submissionTime,
+              transactionEntry.submissionSeed,
+            )
+            .consume(
+              lookupContract(transactionEntry, commitContext),
+              lookupPackage(commitContext),
+              lookupKey(commitContext, knownKeys),
+            )
+            .fold(
+              err =>
+                rejector.reject[DamlTransactionEntrySummary](
+                  rejector
+                    .buildRejectionEntry(
+                      transactionEntry,
+                      rejectionReasonForValidationError(err),
+                    ),
+                  commitContext.recordTime,
+                ),
+              _ => StepContinue[DamlTransactionEntrySummary](transactionEntry),
+            )
+        } catch {
+          case err: Err.MissingInputState =>
+            logger.warn(
+              "Model conformance validation failed due to a missing input state (most likely due to invalid state on the participant)."
+            )
+            rejector.reject(
+              rejector
+                .buildRejectionEntry(transactionEntry, RejectionReasonV0.Disputed(err.getMessage)),
+              commitContext.recordTime,
+            )
+        }
+      })
+  }
+
+  private def contractIsActive(
+      transactionEntry: DamlTransactionEntrySummary,
+      contractState: DamlContractState,
+  ): Boolean = {
+    val activeAt = Option(contractState.getActiveAt).map(parseTimestamp)
+    !contractState.hasArchivedAt && activeAt.exists(transactionEntry.ledgerEffectiveTime >= _)
+  }
+
+  // Helper to lookup contract instances. We verify the activeness of
+  // contract instances here. Since we look up every contract that was
+  // an input to a transaction, we do not need to verify the inputs separately.
+  private def lookupContract(
+      transactionEntry: DamlTransactionEntrySummary,
+      commitContext: CommitContext,
+  )(
+      coid: Value.ContractId
+  ): Option[Value.ContractInst[Value.VersionedValue[Value.ContractId]]] = {
+    val stateKey = contractIdToStateKey(coid)
+    for {
+      // Fetch the state of the contract so that activeness can be checked.
+      // There is the possibility that the reinterpretation of the transaction yields a different
+      // result in a LookupByKey than the original transaction. This means that the contract state data for the
+      // contractId pointed to by that contractKey might not have been preloaded into the input state map.
+      // This is not a problem because after the transaction reinterpretation, we compare the original
+      // transaction with the reinterpreted one, and the LookupByKey node will not match.
+      // Additionally, all contract keys are checked to uphold causal monotonicity.
+      contractState <- commitContext.read(stateKey).map(_.getContractState)
+      if contractIsActive(transactionEntry, contractState)
+      contract = Conversions.decodeContractInstance(contractState.getContractInstance)
+    } yield contract
+  }
+
+  // Helper to lookup package from the state. The package contents
+  // are stored in the [[DamlLogEntry]], which we find by looking up
+  // the Daml state entry at `DamlStateKey(packageId = pkgId)`.
+  private def lookupPackage(
+      commitContext: CommitContext
+  )(pkgId: PackageId)(implicit loggingContext: LoggingContext): Option[Ast.Package] =
+    withEnrichedLoggingContext("packageId" -> pkgId) { implicit loggingContext =>
+      val stateKey = packageStateKey(pkgId)
+      for {
+        value <- commitContext
+          .read(stateKey)
+          .orElse {
+            logger.warn("Package lookup failed, package not found.")
+            throw Err.MissingInputState(stateKey)
+          }
+        pkg <- value.getValueCase match {
+          case DamlStateValue.ValueCase.ARCHIVE =>
+            // NOTE(JM): Engine only looks up packages once, compiles and caches,
+            // provided that the engine instance is persisted.
+            try {
+              Some(Decode.decode(value.getArchive)._2)
+            } catch {
+              case ParseError(err) =>
+                logger.warn("Decoding the archive failed.")
+                throw Err.DecodeError("Archive", err)
+            }
+
+          case _ =>
+            val msg = "value is not a Daml-LF archive"
+            logger.warn(s"Package lookup failed, $msg.")
+            throw Err.DecodeError("Archive", msg)
+        }
+      } yield pkg
+    }
+
+  private def lookupKey(
+      commitContext: CommitContext,
+      knownKeys: Map[DamlContractKey, Value.ContractId],
+  )(key: GlobalKeyWithMaintainers): Option[Value.ContractId] = {
+    // we don't check whether the contract is active or not, because in we might not have loaded it earlier.
+    // this is not a problem, because:
+    // a) if the lookup was negative and we actually found a contract,
+    //    the transaction validation will fail.
+    // b) if the lookup was positive and its result is a different contract,
+    //    the transaction validation will fail.
+    // c) if the lookup was positive and its result is the same contract,
+    //    - the authorization check ensures that the submitter is in fact allowed
+    //      to lookup the contract
+    //    - the separate contract keys check ensures that all contracts pointed to by
+    //    contract keys respect causal monotonicity.
+    val stateKey = Conversions.globalKeyToStateKey(key.globalKey)
+    val contractId = for {
+      stateValue <- commitContext.read(stateKey)
+      if stateValue.getContractKeyState.getContractId.nonEmpty
+    } yield decodeContractId(stateValue.getContractKeyState.getContractId)
+
+    // If the key was not in state inputs, then we look whether any of the accessed contracts has
+    // the key we're looking for. This happens with "fetchByKey" where the key lookup is not
+    // evidenced in the transaction. The activeness of the contract is checked when it is fetched.
+    contractId.orElse {
+      knownKeys.get(stateKey.getContractKey)
+    }
+  }
+}
+
+private[transaction] object ModelConformanceValidator {
+  def rejectionReasonForValidationError(
+      validationError: LfError
+  ): RejectionReasonV0 = {
+    def disputed: RejectionReasonV0 =
+      RejectionReasonV0.Disputed(validationError.msg)
+
+    def resultIsCreatedInTx(
+        tx: VersionedTransaction[NodeId, ContractId],
+        result: Option[Value.ContractId],
+    ): Boolean =
+      result.exists { contractId =>
+        tx.nodes.exists {
+          case (_, create: Node.NodeCreate[_]) => create.coid == contractId
+          case _ => false
+        }
+      }
+
+    validationError match {
+      case LfError.Validation(
+            LfError.Validation.ReplayMismatch(
+              ReplayNodeMismatch(recordedTx, recordedNodeId, replayedTx, replayedNodeId)
+            )
+          ) =>
+        // If the problem is that a key lookup has changed and the results do not involve contracts created in this transaction,
+        // then it's a consistency problem.
+
+        (recordedTx.nodes(recordedNodeId), replayedTx.nodes(replayedNodeId)) match {
+          case (
+                Node.NodeLookupByKey(
+                  recordedTemplateId,
+                  _,
+                  recordedKey,
+                  recordedResult,
+                  recordedVersion,
+                ),
+                Node.NodeLookupByKey(
+                  replayedTemplateId,
+                  _,
+                  replayedKey,
+                  replayedResult,
+                  replayedVersion,
+                ),
+              )
+              if recordedVersion == replayedVersion &&
+                recordedTemplateId == replayedTemplateId && recordedKey == replayedKey
+                && !resultIsCreatedInTx(recordedTx, recordedResult)
+                && !resultIsCreatedInTx(replayedTx, replayedResult) =>
+            RejectionReasonV0.Inconsistent(validationError.msg)
+          case _ => disputed
+        }
+      case _ => disputed
+    }
+  }
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionValidator.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
+
+import com.daml.ledger.participant.state.kvutils.committer.transaction.{Step, TransactionRejector}
+
+private[transaction] trait TransactionValidator {
+  def createValidationStep(rejector: TransactionRejector): Step
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionValidator.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
 
-import com.daml.ledger.participant.state.kvutils.committer.transaction.{Step, TransactionRejector}
+import com.daml.ledger.participant.state.kvutils.committer.transaction.{Step, Rejections}
 
 private[transaction] trait TransactionValidator {
-  def createValidationStep(rejector: TransactionRejector): Step
+  def createValidationStep(rejections: Rejections): Step
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -7,12 +7,22 @@ import java.time.Duration
 import java.util.UUID
 
 import com.daml.daml_lf_dev.DamlLf
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
-import com.daml.ledger.participant.state.kvutils.committer.CommitContext
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlLogEntryId,
+  DamlSubmitterInfo,
+  DamlTransactionEntry,
+  DamlTransactionRejectionEntry,
+}
+import com.daml.ledger.participant.state.kvutils.committer.transaction.DamlTransactionEntrySummary
+import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepResult, StepStop}
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId, TimeModel}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
+import com.daml.lf.transaction.SubmittedTransaction
+import com.daml.lf.transaction.test.TransactionBuilder
 import com.google.protobuf.ByteString
+
+import scala.jdk.CollectionConverters._
 
 object TestHelpers {
   def name(value: String): Ref.Name = Ref.Name.assertFromString(value)
@@ -48,4 +58,29 @@ object TestHelpers {
       participantId: Int = 0,
   ): CommitContext =
     CommitContext(inputs, recordTime, mkParticipantId(participantId))
+
+  def createEmptyTransactionEntry(submitters: List[String]): DamlTransactionEntry =
+    createTransactionEntry(submitters, TransactionBuilder.EmptySubmitted)
+
+  def createTransactionEntry(
+      submitters: List[String],
+      tx: SubmittedTransaction,
+  ): DamlTransactionEntry =
+    DamlTransactionEntry.newBuilder
+      .setTransaction(Conversions.encodeTransaction(tx))
+      .setSubmitterInfo(
+        DamlSubmitterInfo.newBuilder
+          .setCommandId("commandId")
+          .addAllSubmitters(submitters.asJava)
+      )
+      .setSubmissionSeed(ByteString.copyFromUtf8("a" * 32))
+      .build
+
+  def getTransactionRejectionReason(
+      result: StepResult[DamlTransactionEntrySummary]
+  ): DamlTransactionRejectionEntry =
+    result
+      .asInstanceOf[StepStop]
+      .logEntry
+      .getTransactionRejectionEntry
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -83,4 +83,9 @@ object TestHelpers {
       .asInstanceOf[StepStop]
       .logEntry
       .getTransactionRejectionEntry
+
+  def lfTuple(values: String*): TransactionBuilder.Value =
+    TransactionBuilder.record(values.zipWithIndex.map { case (v, i) =>
+      s"_$i" -> v
+    }: _*)
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -3,38 +3,23 @@
 
 package com.daml.ledger.participant.state.kvutils.committer.transaction
 
-import java.time.Instant
-import java.util.UUID
-
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, configurationStateKey}
+import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
-import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
-import com.daml.ledger.participant.state.kvutils.committer.transaction.keys.ContractKeysValidation
-import com.daml.ledger.participant.state.kvutils.committer.{
-  CommitContext,
-  StepContinue,
-  StepResult,
-  StepStop,
-}
+import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepStop}
 import com.daml.ledger.participant.state.kvutils.{Conversions, committer}
-import com.daml.ledger.participant.state.v1.{Configuration, RejectionReason, RejectionReasonV0}
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.engine.{Engine, Error => LfError}
-import com.daml.lf.transaction
+import com.daml.lf.engine.Engine
 import com.daml.lf.transaction._
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.transaction.test.TransactionBuilder.{Create, Exercise}
 import com.daml.lf.value.Value
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
-import com.google.protobuf.ByteString
 import org.mockito.MockitoSugar
-import org.scalatest.Inspectors.forEvery
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.jdk.CollectionConverters._
@@ -51,28 +36,6 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
   private val aRecordTime = Timestamp(100)
   private val aDedupKey = Conversions
     .commandDedupKey(aTransactionEntrySummary.submitterInfo)
-  private val emptyConfigurationStateValue =
-    defaultConfigurationStateValueBuilder().build
-  private val inputWithTimeModelAndEmptyCommandDeduplication =
-    Map(Conversions.configurationStateKey -> Some(emptyConfigurationStateValue), aDedupKey -> None)
-  private val aSubmissionTime = createProtobufTimestamp(seconds = 1)
-  private val aLedgerEffectiveTime = createProtobufTimestamp(seconds = 2)
-  private val aDamlTransactionEntryWithSubmissionAndLedgerEffectiveTimes =
-    aDamlTransactionEntry.toBuilder
-      .setSubmissionTime(aSubmissionTime)
-      .setLedgerEffectiveTime(aLedgerEffectiveTime)
-      .build()
-  private val aDamlTransactionEntrySummaryWithSubmissionAndLedgerEffectiveTimes =
-    DamlTransactionEntrySummary(aDamlTransactionEntryWithSubmissionAndLedgerEffectiveTimes)
-  private val aDeduplicateUntil = createProtobufTimestamp(seconds = 3)
-  private val aDedupValue = DamlStateValue.newBuilder
-    .setCommandDedup(DamlCommandDedupValue.newBuilder.setDeduplicatedUntil(aDeduplicateUntil))
-    .build()
-  private val inputWithTimeModelAndCommandDeduplication =
-    Map(
-      Conversions.configurationStateKey -> Some(emptyConfigurationStateValue),
-      aDedupKey -> Some(aDedupValue),
-    )
   private val aRichTransactionTreeSummary = {
     val roots = Seq("Exercise-1", "Fetch-1", "LookupByKey-1", "Create-1")
     val nodes: Seq[TransactionOuterClass.Node] = Seq(
@@ -235,113 +198,11 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     }
   }
 
-  "validateLedgerTime" can {
-    "when the record time is not available" should {
-      "continue" in {
-        val result = transactionCommitter.validateLedgerTime(
-          contextWithTimeModelAndEmptyCommandDeduplication(),
-          aTransactionEntrySummary,
-        )
-
-        result match {
-          case StepContinue(_) => succeed
-          case StepStop(_) => fail()
-        }
-      }
-
-      "compute and correctly set the min/max ledger time and out-of-time-bounds log entry without deduplicateUntil" in {
-        val context = contextWithTimeModelAndEmptyCommandDeduplication()
-
-        transactionCommitter.validateLedgerTime(
-          context,
-          aDamlTransactionEntrySummaryWithSubmissionAndLedgerEffectiveTimes,
-        )
-
-        context.minimumRecordTime shouldEqual Some(Instant.ofEpochSecond(-28))
-        context.maximumRecordTime shouldEqual Some(Instant.ofEpochSecond(31))
-        context.deduplicateUntil shouldBe empty
-        context.outOfTimeBoundsLogEntry should not be empty
-        context.outOfTimeBoundsLogEntry.foreach { actualOutOfTimeBoundsLogEntry =>
-          actualOutOfTimeBoundsLogEntry.hasTransactionRejectionEntry shouldBe true
-          actualOutOfTimeBoundsLogEntry.getTransactionRejectionEntry.hasInvalidLedgerTime shouldBe true
-        }
-      }
-
-      "compute and correctly set the min/max ledger time and out-of-time-bounds log entry with deduplicateUntil" in {
-        val context = contextWithTimeModelAndCommandDeduplication()
-
-        transactionCommitter.validateLedgerTime(
-          context,
-          aDamlTransactionEntrySummaryWithSubmissionAndLedgerEffectiveTimes,
-        )
-
-        context.minimumRecordTime shouldEqual Some(
-          Instant.ofEpochSecond(3).plus(Timestamp.Resolution)
-        )
-        context.maximumRecordTime shouldEqual Some(Instant.ofEpochSecond(31))
-        context.deduplicateUntil shouldEqual Some(
-          Instant.ofEpochSecond(aDeduplicateUntil.getSeconds)
-        )
-        context.outOfTimeBoundsLogEntry should not be empty
-        context.outOfTimeBoundsLogEntry.foreach { actualOutOfTimeBoundsLogEntry =>
-          actualOutOfTimeBoundsLogEntry.hasTransactionRejectionEntry shouldBe true
-          actualOutOfTimeBoundsLogEntry.getTransactionRejectionEntry.hasInvalidLedgerTime shouldBe true
-        }
-      }
-    }
-
-    "produce rejection log entry if record time is outside of ledger effective time bounds" in {
-      val recordTime = Timestamp.now()
-      val recordTimeInstant = recordTime.toInstant
-      val lowerBound =
-        recordTimeInstant
-          .minus(theDefaultConfig.timeModel.minSkew)
-          .minusMillis(1)
-      val upperBound =
-        recordTimeInstant.plus(theDefaultConfig.timeModel.maxSkew).plusMillis(1)
-      val inputWithDeclaredConfig =
-        Map(Conversions.configurationStateKey -> Some(emptyConfigurationStateValue))
-
-      for (ledgerEffectiveTime <- Iterable(lowerBound, upperBound)) {
-        val context =
-          createCommitContext(recordTime = Some(recordTime), inputs = inputWithDeclaredConfig)
-        val transactionEntrySummary = DamlTransactionEntrySummary(
-          aDamlTransactionEntry.toBuilder
-            .setLedgerEffectiveTime(
-              com.google.protobuf.Timestamp.newBuilder
-                .setSeconds(ledgerEffectiveTime.getEpochSecond)
-                .setNanos(ledgerEffectiveTime.getNano)
-            )
-            .build
-        )
-        val actual = transactionCommitter.validateLedgerTime(context, transactionEntrySummary)
-
-        actual match {
-          case StepContinue(_) => fail()
-          case StepStop(actualLogEntry) =>
-            actualLogEntry.hasTransactionRejectionEntry shouldBe true
-        }
-      }
-    }
-
-    "mark config key as accessed in context" in {
-      val commitContext =
-        createCommitContext(recordTime = None, inputWithTimeModelAndCommandDeduplication)
-
-      transactionCommitter.validateLedgerTime(
-        commitContext,
-        aTransactionEntrySummary,
-      )
-
-      commitContext.getAccessedInputKeys should contain(configurationStateKey)
-    }
-  }
-
   "buildLogEntry" should {
     "set record time in log entry when it is available" in {
       val context = createCommitContext(recordTime = Some(theRecordTime))
 
-      val actual = transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
+      val actual = TransactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
 
       actual.hasRecordTime shouldBe true
       actual.getRecordTime shouldBe buildTimestamp(theRecordTime)
@@ -353,7 +214,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       val context = createCommitContext(recordTime = None)
 
       val actual =
-        transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
+        TransactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
 
       actual.hasRecordTime shouldBe false
       actual.hasTransactionEntry shouldBe true
@@ -363,7 +224,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     "produce an out-of-time-bounds rejection log entry in case pre-execution is enabled" in {
       val context = createCommitContext(recordTime = None)
 
-      transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
+      TransactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
 
       context.preExecute shouldBe true
       context.outOfTimeBoundsLogEntry should not be empty
@@ -377,7 +238,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     "not set an out-of-time-bounds rejection log entry in case pre-execution is disabled" in {
       val context = createCommitContext(recordTime = Some(aRecordTime))
 
-      transactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
+      TransactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
 
       context.preExecute shouldBe false
       context.outOfTimeBoundsLogEntry shouldBe empty
@@ -398,466 +259,6 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     }
   }
 
-  "rejectionReasonForValidationError" when {
-    def mkMismatch(
-        recorded: (Transaction.Transaction, NodeId),
-        replayed: (Transaction.Transaction, NodeId),
-    ): ReplayNodeMismatch[NodeId, Value.ContractId] =
-      ReplayNodeMismatch(recorded._1, recorded._2, replayed._1, replayed._2)
-    def mkRecordedMissing(
-        recorded: Transaction.Transaction,
-        replayed: (Transaction.Transaction, NodeId),
-    ): RecordedNodeMissing[NodeId, Value.ContractId] =
-      RecordedNodeMissing(recorded, replayed._1, replayed._2)
-    def mkReplayedMissing(
-        recorded: (Transaction.Transaction, NodeId),
-        replayed: Transaction.Transaction,
-    ): ReplayedNodeMissing[NodeId, Value.ContractId] =
-      ReplayedNodeMissing(recorded._1, recorded._2, replayed)
-
-    def checkRejectionReason(
-        mkReason: String => RejectionReason
-    )(mismatch: transaction.ReplayMismatch[NodeId, Value.ContractId]) = {
-      val replayMismatch = LfError.Validation(LfError.Validation.ReplayMismatch(mismatch))
-      transactionCommitter.rejectionReasonForValidationError(replayMismatch) shouldBe mkReason(
-        replayMismatch.msg
-      )
-    }
-
-    val createInput = create("#inputContractId")
-    val create1 = create("#someContractId")
-    val create2 = create("#otherContractId")
-
-    val exercise = txBuilder.exercise(
-      contract = createInput,
-      choice = "DummyChoice",
-      consuming = false,
-      actingParties = Set(aKeyMaintainer),
-      argument = aDummyValue,
-      byKey = false,
-    )
-    val otherKeyCreate = create(
-      contractId = "#contractWithOtherKey",
-      signatories = Seq(aKeyMaintainer),
-      keyAndMaintainer = Some("otherKey" -> aKeyMaintainer),
-    )
-
-    val lookupNodes @ Seq(lookup1, lookup2, lookupNone, lookupOther @ _) =
-      Seq(create1 -> true, create2 -> true, create1 -> false, otherKeyCreate -> true) map {
-        case (create, found) => txBuilder.lookupByKey(create, found)
-      }
-    val Seq(tx1, tx2, txNone, txOther) = lookupNodes map { node =>
-      val builder = TransactionBuilder()
-      val rootId = builder.add(exercise)
-      val lookupId = builder.add(node, rootId)
-      builder.build() -> lookupId
-    }
-
-    "there is a mismatch in lookupByKey nodes" should {
-      "report an inconsistency if the contracts are not created in the same transaction" in {
-        val inconsistentLookups = Seq(
-          mkMismatch(tx1, tx2),
-          mkMismatch(tx1, txNone),
-          mkMismatch(txNone, tx2),
-        )
-        forEvery(inconsistentLookups)(checkRejectionReason(RejectionReasonV0.Inconsistent))
-      }
-
-      "report Disputed if one of contracts is created in the same transaction" in {
-        val Seq(txC1, txC2, txCNone) = Seq(lookup1, lookup2, lookupNone) map { node =>
-          val builder = TransactionBuilder()
-          val rootId = builder.add(exercise)
-          builder.add(create1, rootId)
-          val lookupId = builder.add(node, rootId)
-          builder.build() -> lookupId
-        }
-        val Seq(tx1C, txNoneC) = Seq(lookup1, lookupNone) map { node =>
-          val builder = TransactionBuilder()
-          val rootId = builder.add(exercise)
-          val lookupId = builder.add(node, rootId)
-          builder.add(create1)
-          builder.build() -> lookupId
-        }
-        val recordedKeyInconsistent = Seq(
-          mkMismatch(txC2, txC1),
-          mkMismatch(txCNone, txC1),
-          mkMismatch(txC1, txCNone),
-          mkMismatch(tx1C, txNoneC),
-        )
-        forEvery(recordedKeyInconsistent)(checkRejectionReason(RejectionReasonV0.Disputed))
-      }
-
-      "report Disputed if the keys are different" in {
-        checkRejectionReason(RejectionReasonV0.Disputed)(mkMismatch(txOther, tx1))
-      }
-    }
-
-    "the mismatch is not between two lookup nodes" should {
-      "report Disputed" in {
-        val txExerciseOnly = {
-          val builder = TransactionBuilder()
-          builder.add(exercise)
-          builder.build()
-        }
-        val txCreate = {
-          val builder = TransactionBuilder()
-          val rootId = builder.add(exercise)
-          val createId = builder.add(create1, rootId)
-          builder.build() -> createId
-        }
-        val miscMismatches = Seq(
-          mkMismatch(txCreate, tx1),
-          mkRecordedMissing(txExerciseOnly, tx2),
-          mkReplayedMissing(tx1, txExerciseOnly),
-        )
-        forEvery(miscMismatches)(checkRejectionReason(RejectionReasonV0.Disputed))
-      }
-    }
-  }
-
-  "authorizeSubmitters" should {
-    "reject a submission when any of the submitters keys is not present in the input state" in {
-      val context = createCommitContext(
-        recordTime = None,
-        inputs = createInputs(
-          Alice -> Some(hostedParty(Alice)),
-          Bob -> Some(hostedParty(Bob)),
-        ),
-        participantId = ParticipantId,
-      )
-      val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob, Emma)))
-
-      a[MissingInputState] should be thrownBy transactionCommitter.authorizeSubmitters(
-        context,
-        tx,
-      )
-    }
-
-    "reject a submission when any of the submitters is not known" in {
-      val context = createCommitContext(
-        recordTime = None,
-        inputs = createInputs(
-          Alice -> Some(hostedParty(Alice)),
-          Bob -> None,
-        ),
-        participantId = ParticipantId,
-      )
-      val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob)))
-
-      val result = transactionCommitter.authorizeSubmitters(context, tx)
-      result shouldBe a[StepStop]
-
-      val rejectionReason =
-        getTransactionRejectionReason(result).getPartyNotKnownOnLedger.getDetails
-      rejectionReason should fullyMatch regex """Submitting party .+ not known"""
-    }
-
-    "reject a submission when any of the submitters' participant id is incorrect" in {
-      val context = createCommitContext(
-        recordTime = None,
-        inputs = createInputs(
-          Alice -> Some(hostedParty(Alice)),
-          Bob -> Some(notHostedParty(Bob)),
-        ),
-        participantId = ParticipantId,
-      )
-      val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob)))
-
-      val result = transactionCommitter.authorizeSubmitters(context, tx)
-      result shouldBe a[StepStop]
-
-      val rejectionReason =
-        getTransactionRejectionReason(result).getSubmitterCannotActViaParticipant.getDetails
-      rejectionReason should fullyMatch regex s"""Party .+ not hosted by participant ${mkParticipantId(
-        ParticipantId
-      )}"""
-    }
-
-    "allow a submission when all of the submitters are hosted on the participant" in {
-      val context = createCommitContext(
-        recordTime = None,
-        inputs = createInputs(
-          Alice -> Some(hostedParty(Alice)),
-          Bob -> Some(hostedParty(Bob)),
-          Emma -> Some(hostedParty(Emma)),
-        ),
-        participantId = ParticipantId,
-      )
-      val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob, Emma)))
-
-      val result = transactionCommitter.authorizeSubmitters(context, tx)
-      result shouldBe a[StepContinue[_]]
-    }
-
-    lazy val Alice = "alice"
-    lazy val Bob = "bob"
-    lazy val Emma = "emma"
-    lazy val ParticipantId = 0
-    lazy val OtherParticipantId = 1
-    def partyAllocation(party: String, participantId: Int): DamlPartyAllocation =
-      DamlPartyAllocation
-        .newBuilder()
-        .setParticipantId(mkParticipantId(participantId))
-        .setDisplayName(party)
-        .build()
-
-    def hostedParty(party: String): DamlPartyAllocation =
-      partyAllocation(party, ParticipantId)
-    def notHostedParty(party: String): DamlPartyAllocation =
-      partyAllocation(party, OtherParticipantId)
-    def createInputs(
-        inputs: (String, Option[DamlPartyAllocation])*
-    ): Map[DamlStateKey, Option[DamlStateValue]] =
-      inputs.map { case (party, partyAllocation) =>
-        DamlStateKey.newBuilder().setParty(party).build() -> partyAllocation
-          .map(
-            DamlStateValue.newBuilder().setParty(_).build()
-          )
-      }.toMap
-  }
-
-  "validateContractKeys" should {
-    def newCreateNodeWithFixedKey(contractId: String): Create =
-      create(contractId, signatories = Seq("Alice"), keyAndMaintainer = Some(aKey -> "Alice"))
-
-    def freshContractId: String =
-      s"testContractId-${UUID.randomUUID().toString.take(10)}"
-
-    def newLookupByKeySubmittedTransaction(
-        found: Boolean,
-        inRollback: Boolean,
-    ): SubmittedTransaction = {
-      val lookup =
-        txBuilder.lookupByKey(newCreateNodeWithFixedKey(contractId = s"#$freshContractId"), found)
-      val builder = TransactionBuilder()
-      if (inRollback) {
-        val rollback = builder.add(txBuilder.rollback())
-        builder.add(lookup, rollback)
-      } else {
-        builder.add(lookup)
-      }
-      builder.buildSubmitted()
-    }
-
-    val conflictingKey = {
-      val aCreateNode = newCreateNodeWithFixedKey("#dummy")
-      Conversions.encodeContractKey(aCreateNode.templateId, aCreateNode.key.get.key)
-    }
-
-    "return Inconsistent when a contract key resolves to a different contract ID than submitted by a participant" in {
-
-      val cases =
-        Seq(
-          ("existing global key was not found", false, Some(s"#$freshContractId")),
-          (
-            "existing global key was mapped to the wrong contract id",
-            true,
-            Some(s"#$freshContractId"),
-          ),
-          ("no global key exists but lookup succeeded", true, None),
-        )
-          .flatMap { case (name, found, contractIdAtCommitter) =>
-            Seq(false, true).map(inRollback =>
-              (name, newLookupByKeySubmittedTransaction(found, inRollback), contractIdAtCommitter)
-            )
-          }
-
-      val casesTable = Table(
-        ("name", "transaction", "contractIdAtCommitter"),
-        cases: _*
-      )
-
-      forAll(casesTable) {
-        (_, transaction: SubmittedTransaction, contractIdAtCommitter: Option[String]) =>
-          val context = commitContextWithContractStateKeys(
-            conflictingKey -> contractIdAtCommitter
-          )
-          val result = validate(context, transaction)
-          result shouldBe a[StepStop]
-
-          val rejectionReason =
-            getTransactionRejectionReason(result).getInconsistent.getDetails
-          rejectionReason should startWith("InconsistentKeys")
-      }
-    }
-
-    "return DuplicateKeys when two local contracts conflict" in {
-      val builder = TransactionBuilder()
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
-      val transaction = builder.buildSubmitted()
-      val context = commitContextWithContractStateKeys(conflictingKey -> None)
-
-      val result = validate(context, transaction)
-      result shouldBe a[StepStop]
-
-      val rejectionReason =
-        getTransactionRejectionReason(result).getInconsistent.getDetails
-      rejectionReason should startWith("DuplicateKeys")
-    }
-
-    "return DuplicateKeys when a local contract conflicts with a global contract" in {
-      val builder = TransactionBuilder()
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
-      val transaction = builder.buildSubmitted()
-      val context = commitContextWithContractStateKeys(conflictingKey -> Some(s"#$freshContractId"))
-      val result = validate(context, transaction)
-      result shouldBe a[StepStop]
-      val rejectionReason =
-        getTransactionRejectionReason(result).getInconsistent.getDetails
-      rejectionReason should startWith("DuplicateKeys")
-    }
-
-    "succeeds when a global contract gets archived before a local contract gets created" in {
-      val globalCid = s"#$freshContractId"
-      val globalCreate = newCreateNodeWithFixedKey(globalCid)
-      val context = commitContextWithContractStateKeys(conflictingKey -> Some(globalCid))
-      val builder = TransactionBuilder()
-      builder.add(archive(globalCreate, Set("Alice")))
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
-      val transaction = builder.buildSubmitted()
-      val result = validate(context, transaction)
-      result shouldBe a[StepContinue[_]]
-    }
-
-    "succeeds when a local contract gets archived before another local contract gets created" in {
-      val localCid = s"#$freshContractId"
-      val context = commitContextWithContractStateKeys(conflictingKey -> None)
-      val builder = TransactionBuilder()
-      val localCreate = newCreateNodeWithFixedKey(localCid)
-      builder.add(localCreate)
-      builder.add(archive(localCreate, Set("Alice")))
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
-      val transaction = builder.buildSubmitted()
-      val result = validate(context, transaction)
-      result shouldBe a[StepContinue[_]]
-    }
-
-    "return DuplicateKeys when a create in a rollback conflicts with a global key" in {
-      val builder = TransactionBuilder()
-      val rollback = builder.add(builder.rollback())
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"), rollback)
-      val transaction = builder.buildSubmitted()
-      val context = commitContextWithContractStateKeys(conflictingKey -> Some(s"#$freshContractId"))
-
-      val result = validate(context, transaction)
-      result shouldBe a[StepStop]
-
-      val rejectionReason =
-        getTransactionRejectionReason(result).getInconsistent.getDetails
-      rejectionReason should startWith("DuplicateKeys")
-    }
-
-    "not return DuplicateKeys between local contracts if first create is rolled back" in {
-      val builder = TransactionBuilder()
-      val rollback = builder.add(builder.rollback())
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"), rollback)
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
-
-      val transaction = builder.buildSubmitted()
-
-      val context = commitContextWithContractStateKeys(conflictingKey -> None)
-      val result = validate(context, transaction)
-      result shouldBe a[StepContinue[_]]
-    }
-
-    "return DuplicateKeys between local contracts even if second create is rolled back" in {
-      val builder = TransactionBuilder()
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
-      val rollback = builder.add(builder.rollback())
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"), rollback)
-      val transaction = builder.buildSubmitted()
-      val context = commitContextWithContractStateKeys(conflictingKey -> None)
-
-      val result = validate(context, transaction)
-      result shouldBe a[StepStop]
-
-      val rejectionReason =
-        getTransactionRejectionReason(result).getInconsistent.getDetails
-      rejectionReason should startWith("DuplicateKeys")
-    }
-
-    "return DuplicateKeys between local contracts even if the first one was archived in a rollback" in {
-      val builder = TransactionBuilder()
-      val create = newCreateNodeWithFixedKey(s"#$freshContractId")
-      builder.add(create)
-      val rollback = builder.add(builder.rollback())
-      builder.add(archive(create, Set("Alice")), rollback)
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
-      val transaction = builder.buildSubmitted()
-      val context = commitContextWithContractStateKeys(conflictingKey -> None)
-
-      val result = validate(context, transaction)
-      result shouldBe a[StepStop]
-
-      val rejectionReason =
-        getTransactionRejectionReason(result).getInconsistent.getDetails
-      rejectionReason should startWith("DuplicateKeys")
-    }
-
-    "return InconsistentKeys on conflict local and global contracts even if global was archived in a rollback" in {
-      val builder = TransactionBuilder()
-      val globalCid = s"#$freshContractId"
-      val rollback = builder.add(builder.rollback())
-      builder.add(archive(globalCid, Set("Alice")), rollback)
-      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
-      val transaction = builder.buildSubmitted()
-      val context = commitContextWithContractStateKeys(conflictingKey -> Some(globalCid))
-
-      val result = validate(context, transaction)
-      result shouldBe a[StepStop]
-
-      val rejectionReason =
-        getTransactionRejectionReason(result).getInconsistent.getDetails
-      rejectionReason should startWith("InconsistentKeys")
-    }
-
-    def validate(
-        ctx: CommitContext,
-        transaction: SubmittedTransaction,
-    )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] =
-      ContractKeysValidation.validateKeys(transactionCommitter)(
-        ctx,
-        DamlTransactionEntrySummary(createTransactionEntry(List("Alice"), transaction)),
-      )
-
-    def contractKeyState(contractId: String): DamlContractKeyState =
-      DamlContractKeyState
-        .newBuilder()
-        .setContractId(contractId)
-        .build()
-
-    def contractStateKey(contractKey: DamlContractKey): DamlStateKey =
-      DamlStateKey
-        .newBuilder()
-        .setContractKey(contractKey)
-        .build()
-
-    def contractKeyStateValue(contractId: String): DamlStateValue =
-      DamlStateValue
-        .newBuilder()
-        .setContractKeyState(contractKeyState(contractId))
-        .build()
-
-    def commitContextWithContractStateKeys(
-        contractKeyIdPairs: (DamlContractKey, Option[String])*
-    ): CommitContext =
-      createCommitContext(
-        recordTime = None,
-        inputs = contractKeyIdPairs.map { case (key, id) =>
-          contractStateKey(key) -> id.map(contractKeyStateValue)
-        }.toMap,
-      )
-  }
-
-  private def getTransactionRejectionReason(
-      result: StepResult[DamlTransactionEntrySummary]
-  ): DamlTransactionRejectionEntry =
-    result
-      .asInstanceOf[StepStop]
-      .logEntry
-      .getTransactionRejectionEntry
-
   private def createTransactionCommitter(): committer.transaction.TransactionCommitter =
     new committer.transaction.TransactionCommitter(
       theDefaultConfig,
@@ -866,12 +267,6 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       inStaticTimeMode = false,
     )
 
-  private def contextWithTimeModelAndEmptyCommandDeduplication() =
-    createCommitContext(recordTime = None, inputs = inputWithTimeModelAndEmptyCommandDeduplication)
-
-  private def contextWithTimeModelAndCommandDeduplication() =
-    createCommitContext(recordTime = None, inputs = inputWithTimeModelAndCommandDeduplication)
-
   private def newDedupValue(deduplicationTime: Timestamp): DamlStateValue =
     DamlStateValue.newBuilder
       .setCommandDedup(
@@ -879,29 +274,8 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       )
       .build
 
-  private def createProtobufTimestamp(seconds: Long) =
-    Conversions.buildTimestamp(Timestamp.assertFromInstant(Instant.ofEpochSecond(seconds)))
-
-  private def defaultConfigurationStateValueBuilder(): DamlStateValue.Builder =
-    DamlStateValue.newBuilder
-      .setConfigurationEntry(
-        DamlConfigurationEntry.newBuilder
-          .setConfiguration(Configuration.encode(theDefaultConfig))
-      )
-
   private def createEmptyTransactionEntry(submitters: List[String]): DamlTransactionEntry =
     createTransactionEntry(submitters, TransactionBuilder.EmptySubmitted)
-
-  private def createTransactionEntry(submitters: List[String], tx: SubmittedTransaction) =
-    DamlTransactionEntry.newBuilder
-      .setTransaction(Conversions.encodeTransaction(tx))
-      .setSubmitterInfo(
-        DamlSubmitterInfo.newBuilder
-          .setCommandId("commandId")
-          .addAllSubmitters(submitters.asJava)
-      )
-      .setSubmissionSeed(ByteString.copyFromUtf8("a" * 32))
-      .build
 
   private def tuple(values: String*): TransactionBuilder.Value =
     TransactionBuilder.record(values.zipWithIndex.map { case (v, i) =>

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -274,14 +274,6 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       )
       .build
 
-  private def createEmptyTransactionEntry(submitters: List[String]): DamlTransactionEntry =
-    createTransactionEntry(submitters, TransactionBuilder.EmptySubmitted)
-
-  private def tuple(values: String*): TransactionBuilder.Value =
-    TransactionBuilder.record(values.zipWithIndex.map { case (v, i) =>
-      s"_$i" -> v
-    }: _*)
-
   private def create(
       contractId: String,
       signatories: Seq[String] = Seq(aKeyMaintainer),
@@ -294,9 +286,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       argument = argument,
       signatories = signatories,
       observers = Seq.empty,
-      key = keyAndMaintainer.map { case (key, maintainer) =>
-        tuple(maintainer, key)
-      },
+      key = keyAndMaintainer.map { case (key, maintainer) => lfTuple(maintainer, key) },
     )
 
   def archive(create: Create, actingParties: Set[String]): Exercise =

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ContractKeysValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ContractKeysValidatorSpec.scala
@@ -1,0 +1,325 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
+
+import java.util.UUID
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.participant.state.kvutils.Conversions
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlContractKey,
+  DamlContractKeyState,
+  DamlStateKey,
+  DamlStateValue,
+}
+import com.daml.ledger.participant.state.kvutils.TestHelpers.{
+  createCommitContext,
+  createTransactionEntry,
+  getTransactionRejectionReason,
+}
+import com.daml.ledger.participant.state.kvutils.committer.transaction.{
+  DamlTransactionEntrySummary,
+  TransactionRejector,
+}
+import com.daml.ledger.participant.state.kvutils.committer.{
+  CommitContext,
+  StepContinue,
+  StepResult,
+  StepStop,
+}
+import com.daml.lf.data.ImmArray
+import com.daml.lf.transaction.SubmittedTransaction
+import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.transaction.test.TransactionBuilder.{Create, Exercise}
+import com.daml.lf.value.Value
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks.{forAll, _}
+import org.scalatest.wordspec.AnyWordSpec
+
+class ContractKeysValidatorSpec extends AnyWordSpec with Matchers {
+  import ContractKeysValidatorSpec._
+
+  private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
+
+  private val metrics = new Metrics(new MetricRegistry)
+  private val transactionRejector = new TransactionRejector(metrics)
+  private val txBuilder = TransactionBuilder()
+
+  private val conflictingKey = {
+    val aCreateNode = newCreateNodeWithFixedKey("#dummy")
+    Conversions.encodeContractKey(aCreateNode.templateId, aCreateNode.key.get.key)
+  }
+
+  "ContractKeysValidator" should {
+    "return Inconsistent when a contract key resolves to a different contract ID than submitted by a participant" in {
+      val cases =
+        Seq(
+          ("existing global key was not found", false, Some(s"#$freshContractId")),
+          (
+            "existing global key was mapped to the wrong contract id",
+            true,
+            Some(s"#$freshContractId"),
+          ),
+          ("no global key exists but lookup succeeded", true, None),
+        )
+          .flatMap { case (name, found, contractIdAtCommitter) =>
+            Seq(false, true).map(inRollback =>
+              (name, newLookupByKeySubmittedTransaction(found, inRollback), contractIdAtCommitter)
+            )
+          }
+
+      val casesTable = Table(
+        ("name", "transaction", "contractIdAtCommitter"),
+        cases: _*
+      )
+
+      forAll(casesTable) {
+        (_, transaction: SubmittedTransaction, contractIdAtCommitter: Option[String]) =>
+          val context = commitContextWithContractStateKeys(
+            conflictingKey -> contractIdAtCommitter
+          )
+          val result = validate(context, transaction)
+          result shouldBe a[StepStop]
+
+          val rejectionReason =
+            getTransactionRejectionReason(result).getInconsistent.getDetails
+          rejectionReason should startWith("InconsistentKeys")
+      }
+    }
+
+    "return DuplicateKeys when two local contracts conflict" in {
+      val builder = TransactionBuilder()
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
+      val transaction = builder.buildSubmitted()
+      val context = commitContextWithContractStateKeys(conflictingKey -> None)
+
+      val result = validate(context, transaction)
+      result shouldBe a[StepStop]
+
+      val rejectionReason =
+        getTransactionRejectionReason(result).getInconsistent.getDetails
+      rejectionReason should startWith("DuplicateKeys")
+    }
+
+    "return DuplicateKeys when a local contract conflicts with a global contract" in {
+      val builder = TransactionBuilder()
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
+      val transaction = builder.buildSubmitted()
+      val context = commitContextWithContractStateKeys(conflictingKey -> Some(s"#$freshContractId"))
+      val result = validate(context, transaction)
+      result shouldBe a[StepStop]
+      val rejectionReason =
+        getTransactionRejectionReason(result).getInconsistent.getDetails
+      rejectionReason should startWith("DuplicateKeys")
+    }
+
+    "succeeds when a global contract gets archived before a local contract gets created" in {
+      val globalCid = s"#$freshContractId"
+      val globalCreate = newCreateNodeWithFixedKey(globalCid)
+      val context = commitContextWithContractStateKeys(conflictingKey -> Some(globalCid))
+      val builder = TransactionBuilder()
+      builder.add(archive(globalCreate, Set("Alice")))
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
+      val transaction = builder.buildSubmitted()
+      val result = validate(context, transaction)
+      result shouldBe a[StepContinue[_]]
+    }
+
+    "succeeds when a local contract gets archived before another local contract gets created" in {
+      val localCid = s"#$freshContractId"
+      val context = commitContextWithContractStateKeys(conflictingKey -> None)
+      val builder = TransactionBuilder()
+      val localCreate = newCreateNodeWithFixedKey(localCid)
+      builder.add(localCreate)
+      builder.add(archive(localCreate, Set("Alice")))
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
+      val transaction = builder.buildSubmitted()
+      val result = validate(context, transaction)
+      result shouldBe a[StepContinue[_]]
+    }
+
+    "return DuplicateKeys when a create in a rollback conflicts with a global key" in {
+      val builder = TransactionBuilder()
+      val rollback = builder.add(builder.rollback())
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"), rollback)
+      val transaction = builder.buildSubmitted()
+      val context = commitContextWithContractStateKeys(conflictingKey -> Some(s"#$freshContractId"))
+
+      val result = validate(context, transaction)
+      result shouldBe a[StepStop]
+
+      val rejectionReason =
+        getTransactionRejectionReason(result).getInconsistent.getDetails
+      rejectionReason should startWith("DuplicateKeys")
+    }
+
+    "not return DuplicateKeys between local contracts if first create is rolled back" in {
+      val builder = TransactionBuilder()
+      val rollback = builder.add(builder.rollback())
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"), rollback)
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
+
+      val transaction = builder.buildSubmitted()
+
+      val context = commitContextWithContractStateKeys(conflictingKey -> None)
+      val result = validate(context, transaction)
+      result shouldBe a[StepContinue[_]]
+    }
+
+    "return DuplicateKeys between local contracts even if second create is rolled back" in {
+      val builder = TransactionBuilder()
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
+      val rollback = builder.add(builder.rollback())
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"), rollback)
+      val transaction = builder.buildSubmitted()
+      val context = commitContextWithContractStateKeys(conflictingKey -> None)
+
+      val result = validate(context, transaction)
+      result shouldBe a[StepStop]
+
+      val rejectionReason =
+        getTransactionRejectionReason(result).getInconsistent.getDetails
+      rejectionReason should startWith("DuplicateKeys")
+    }
+
+    "return DuplicateKeys between local contracts even if the first one was archived in a rollback" in {
+      val builder = TransactionBuilder()
+      val create = newCreateNodeWithFixedKey(s"#$freshContractId")
+      builder.add(create)
+      val rollback = builder.add(builder.rollback())
+      builder.add(archive(create, Set("Alice")), rollback)
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
+      val transaction = builder.buildSubmitted()
+      val context = commitContextWithContractStateKeys(conflictingKey -> None)
+
+      val result = validate(context, transaction)
+      result shouldBe a[StepStop]
+
+      val rejectionReason =
+        getTransactionRejectionReason(result).getInconsistent.getDetails
+      rejectionReason should startWith("DuplicateKeys")
+    }
+
+    "return InconsistentKeys on conflict local and global contracts even if global was archived in a rollback" in {
+      val builder = TransactionBuilder()
+      val globalCid = s"#$freshContractId"
+      val rollback = builder.add(builder.rollback())
+      builder.add(archive(globalCid, Set("Alice")), rollback)
+      builder.add(newCreateNodeWithFixedKey(s"#$freshContractId"))
+      val transaction = builder.buildSubmitted()
+      val context = commitContextWithContractStateKeys(conflictingKey -> Some(globalCid))
+
+      val result = validate(context, transaction)
+      result shouldBe a[StepStop]
+
+      val rejectionReason =
+        getTransactionRejectionReason(result).getInconsistent.getDetails
+      rejectionReason should startWith("InconsistentKeys")
+    }
+  }
+
+  private def newLookupByKeySubmittedTransaction(
+      found: Boolean,
+      inRollback: Boolean,
+  ): SubmittedTransaction = {
+    val lookup =
+      txBuilder.lookupByKey(newCreateNodeWithFixedKey(contractId = s"#$freshContractId"), found)
+    val builder = TransactionBuilder()
+    if (inRollback) {
+      val rollback = builder.add(txBuilder.rollback())
+      builder.add(lookup, rollback)
+    } else {
+      builder.add(lookup)
+    }
+    builder.buildSubmitted()
+  }
+
+  private def newCreateNodeWithFixedKey(contractId: String): Create =
+    create(contractId, signatories = Seq("Alice"), keyAndMaintainer = Some(aKey -> "Alice"))
+
+  private def create(
+      contractId: String,
+      signatories: Seq[String] = Seq(aKeyMaintainer),
+      argument: TransactionBuilder.Value = aDummyValue,
+      keyAndMaintainer: Option[(String, String)] = Some(aKey -> aKeyMaintainer),
+  ): TransactionBuilder.Create =
+    txBuilder.create(
+      id = contractId,
+      template = "dummyPackage:DummyModule:DummyTemplate",
+      argument = argument,
+      signatories = signatories,
+      observers = Seq.empty,
+      key = keyAndMaintainer.map { case (key, maintainer) =>
+        tuple(maintainer, key)
+      },
+    )
+
+  private def archive(create: Create, actingParties: Set[String]): Exercise =
+    txBuilder.exercise(
+      create,
+      choice = "Archive",
+      consuming = true,
+      actingParties = actingParties,
+      argument = Value.ValueRecord(None, ImmArray.empty),
+      result = Some(Value.ValueUnit),
+    )
+
+  private def archive(contractId: String, actingParties: Set[String]): Exercise =
+    archive(create(contractId), actingParties)
+
+  private def validate(
+      ctx: CommitContext,
+      transaction: SubmittedTransaction,
+  )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
+    ContractKeysValidator.createValidationStep(transactionRejector)(
+      ctx,
+      DamlTransactionEntrySummary(createTransactionEntry(List("Alice"), transaction)),
+    )
+  }
+}
+
+object ContractKeysValidatorSpec {
+  private val aKeyMaintainer = "maintainer"
+  private val aKey = "key"
+  private val aDummyValue = TransactionBuilder.record("field" -> "value")
+
+  private def freshContractId: String =
+    s"testContractId-${UUID.randomUUID().toString.take(10)}"
+
+  private def commitContextWithContractStateKeys(
+      contractKeyIdPairs: (DamlContractKey, Option[String])*
+  ): CommitContext =
+    createCommitContext(
+      recordTime = None,
+      inputs = contractKeyIdPairs.map { case (key, id) =>
+        contractStateKey(key) -> id.map(contractKeyStateValue)
+      }.toMap,
+    )
+
+  private def contractStateKey(contractKey: DamlContractKey): DamlStateKey =
+    DamlStateKey
+      .newBuilder()
+      .setContractKey(contractKey)
+      .build()
+
+  private def contractKeyStateValue(contractId: String): DamlStateValue =
+    DamlStateValue
+      .newBuilder()
+      .setContractKeyState(contractKeyState(contractId))
+      .build()
+
+  private def contractKeyState(contractId: String): DamlContractKeyState =
+    DamlContractKeyState
+      .newBuilder()
+      .setContractId(contractId)
+      .build()
+
+  private def tuple(values: String*): TransactionBuilder.Value =
+    TransactionBuilder.record(values.zipWithIndex.map { case (v, i) =>
+      s"_$i" -> v
+    }: _*)
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/KeyMonotonicityValidationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/KeyMonotonicityValidationSpec.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.participant.state.kvutils.committer.transaction.keys
+package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
 
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
 
@@ -10,9 +10,9 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.committer.StepContinue
 import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,
-  TransactionCommitter,
+  TransactionRejector,
 }
-import com.daml.ledger.participant.state.v1.{RejectionReasonV0}
+import com.daml.ledger.participant.state.v1.RejectionReasonV0
 import com.daml.logging.LoggingContext
 import com.google.protobuf.ByteString
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
@@ -40,33 +40,33 @@ class KeyMonotonicityValidationSpec
   "checkContractKeysCausalMonotonicity" should {
     "create StepContinue in case of correct keys" in {
       KeyMonotonicityValidation.checkContractKeysCausalMonotonicity(
-        mock[TransactionCommitter],
         None,
         Set(testKey),
         Map(testKey -> aStateValueActiveAt(ledgerEffectiveTime.minusSeconds(1))),
         testTransactionEntry,
+        mock[TransactionRejector],
       ) shouldBe StepContinue(testTransactionEntry)
     }
 
     "reject transaction in case of incorrect keys" in {
-      val mockTransactionCommitter = mock[TransactionCommitter]
+      val mockTransactionRejector = mock[TransactionRejector]
 
       KeyMonotonicityValidation
         .checkContractKeysCausalMonotonicity(
-          mockTransactionCommitter,
           None,
           Set(testKey),
           Map(testKey -> aStateValueActiveAt(ledgerEffectiveTime.plusSeconds(1))),
           testTransactionEntry,
+          mockTransactionRejector,
         )
 
-      verify(mockTransactionCommitter).buildRejectionLogEntry(
+      verify(mockTransactionRejector).buildRejectionEntry(
         eqTo(testTransactionEntry),
         any[RejectionReasonV0.InvalidLedgerTime],
       )(any[LoggingContext])
-      verify(mockTransactionCommitter).reject(
-        eqTo(None),
+      verify(mockTransactionRejector).reject(
         any[DamlTransactionRejectionEntry.Builder],
+        eqTo(None),
       )
       succeed
     }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/KeyMonotonicityValidationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/KeyMonotonicityValidationSpec.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.committer.StepContinue
 import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,
-  TransactionRejector,
+  Rejections,
 }
 import com.daml.ledger.participant.state.v1.RejectionReasonV0
 import com.daml.logging.LoggingContext
@@ -44,12 +44,12 @@ class KeyMonotonicityValidationSpec
         Set(testKey),
         Map(testKey -> aStateValueActiveAt(ledgerEffectiveTime.minusSeconds(1))),
         testTransactionEntry,
-        mock[TransactionRejector],
+        mock[Rejections],
       ) shouldBe StepContinue(testTransactionEntry)
     }
 
     "reject transaction in case of incorrect keys" in {
-      val mockTransactionRejector = mock[TransactionRejector]
+      val rejections = mock[Rejections]
 
       KeyMonotonicityValidation
         .checkContractKeysCausalMonotonicity(
@@ -57,14 +57,14 @@ class KeyMonotonicityValidationSpec
           Set(testKey),
           Map(testKey -> aStateValueActiveAt(ledgerEffectiveTime.plusSeconds(1))),
           testTransactionEntry,
-          mockTransactionRejector,
+          rejections,
         )
 
-      verify(mockTransactionRejector).buildRejectionEntry(
+      verify(rejections).buildRejectionEntry(
         eqTo(testTransactionEntry),
         any[RejectionReasonV0.InvalidLedgerTime],
       )(any[LoggingContext])
-      verify(mockTransactionRejector).reject(
+      verify(rejections).buildRejectionStep(
         any[DamlTransactionRejectionEntry.Builder],
         eqTo(None),
       )

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
@@ -1,0 +1,183 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
+
+import java.time.Instant
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.participant.state.kvutils.Conversions
+import com.daml.ledger.participant.state.kvutils.Conversions.configurationStateKey
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlCommandDedupValue,
+  DamlConfigurationEntry,
+  DamlStateValue,
+}
+import com.daml.ledger.participant.state.kvutils.TestHelpers.{
+  createCommitContext,
+  createEmptyTransactionEntry,
+  theDefaultConfig,
+}
+import com.daml.ledger.participant.state.kvutils.committer.transaction.{
+  DamlTransactionEntrySummary,
+  TransactionRejector,
+}
+import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepStop}
+import com.daml.ledger.participant.state.v1.Configuration
+import com.daml.lf.data.Time.Timestamp
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class LedgerTimeValidatorSpec extends AnyWordSpec with Matchers {
+
+  private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
+
+  private val metrics = new Metrics(new MetricRegistry)
+  private val transactionRejector = new TransactionRejector(metrics)
+  private val ledgerTimeValidationStep =
+    new LedgerTimeValidator(theDefaultConfig).createValidationStep(transactionRejector)
+
+  private val aDamlTransactionEntry = createEmptyTransactionEntry(List("aSubmitter"))
+  private val aTransactionEntrySummary = DamlTransactionEntrySummary(aDamlTransactionEntry)
+  private val aSubmissionTime = createProtobufTimestamp(seconds = 1)
+  private val aLedgerEffectiveTime = createProtobufTimestamp(seconds = 2)
+  private val aDamlTransactionEntryWithSubmissionAndLedgerEffectiveTimes =
+    aDamlTransactionEntry.toBuilder
+      .setSubmissionTime(aSubmissionTime)
+      .setLedgerEffectiveTime(aLedgerEffectiveTime)
+      .build()
+  private val aDamlTransactionEntrySummaryWithSubmissionAndLedgerEffectiveTimes =
+    DamlTransactionEntrySummary(aDamlTransactionEntryWithSubmissionAndLedgerEffectiveTimes)
+  private val emptyConfigurationStateValue =
+    defaultConfigurationStateValueBuilder().build
+  private val aDedupKey = Conversions
+    .commandDedupKey(aTransactionEntrySummary.submitterInfo)
+  private val inputWithTimeModelAndEmptyCommandDeduplication =
+    Map(Conversions.configurationStateKey -> Some(emptyConfigurationStateValue), aDedupKey -> None)
+  private val aDeduplicateUntil = createProtobufTimestamp(seconds = 3)
+  private val aDedupValue = DamlStateValue.newBuilder
+    .setCommandDedup(DamlCommandDedupValue.newBuilder.setDeduplicatedUntil(aDeduplicateUntil))
+    .build()
+  private val inputWithTimeModelAndCommandDeduplication =
+    Map(
+      Conversions.configurationStateKey -> Some(emptyConfigurationStateValue),
+      aDedupKey -> Some(aDedupValue),
+    )
+
+  "LedgerTimeValidator" can {
+    "when the record time is not available" should {
+      "continue" in {
+        val result = ledgerTimeValidationStep.apply(
+          contextWithTimeModelAndEmptyCommandDeduplication(),
+          aTransactionEntrySummary,
+        )
+
+        result match {
+          case StepContinue(_) => succeed
+          case StepStop(_) => fail()
+        }
+      }
+
+      "compute and correctly set the min/max ledger time and out-of-time-bounds log entry without deduplicateUntil" in {
+        val context = contextWithTimeModelAndEmptyCommandDeduplication()
+
+        ledgerTimeValidationStep.apply(
+          context,
+          aDamlTransactionEntrySummaryWithSubmissionAndLedgerEffectiveTimes,
+        )
+
+        context.minimumRecordTime shouldEqual Some(Instant.ofEpochSecond(-28))
+        context.maximumRecordTime shouldEqual Some(Instant.ofEpochSecond(31))
+        context.deduplicateUntil shouldBe empty
+        context.outOfTimeBoundsLogEntry should not be empty
+        context.outOfTimeBoundsLogEntry.foreach { actualOutOfTimeBoundsLogEntry =>
+          actualOutOfTimeBoundsLogEntry.hasTransactionRejectionEntry shouldBe true
+          actualOutOfTimeBoundsLogEntry.getTransactionRejectionEntry.hasInvalidLedgerTime shouldBe true
+        }
+      }
+
+      "compute and correctly set the min/max ledger time and out-of-time-bounds log entry with deduplicateUntil" in {
+        val context = contextWithTimeModelAndCommandDeduplication()
+
+        ledgerTimeValidationStep.apply(
+          context,
+          aDamlTransactionEntrySummaryWithSubmissionAndLedgerEffectiveTimes,
+        )
+
+        context.minimumRecordTime shouldEqual Some(
+          Instant.ofEpochSecond(3).plus(Timestamp.Resolution)
+        )
+        context.maximumRecordTime shouldEqual Some(Instant.ofEpochSecond(31))
+        context.deduplicateUntil shouldEqual Some(
+          Instant.ofEpochSecond(aDeduplicateUntil.getSeconds)
+        )
+        context.outOfTimeBoundsLogEntry should not be empty
+        context.outOfTimeBoundsLogEntry.foreach { actualOutOfTimeBoundsLogEntry =>
+          actualOutOfTimeBoundsLogEntry.hasTransactionRejectionEntry shouldBe true
+          actualOutOfTimeBoundsLogEntry.getTransactionRejectionEntry.hasInvalidLedgerTime shouldBe true
+        }
+      }
+    }
+
+    "produce rejection log entry if record time is outside of ledger effective time bounds" in {
+      val recordTime = Timestamp.now()
+      val recordTimeInstant = recordTime.toInstant
+      val lowerBound =
+        recordTimeInstant
+          .minus(theDefaultConfig.timeModel.minSkew)
+          .minusMillis(1)
+      val upperBound =
+        recordTimeInstant.plus(theDefaultConfig.timeModel.maxSkew).plusMillis(1)
+      val inputWithDeclaredConfig =
+        Map(Conversions.configurationStateKey -> Some(emptyConfigurationStateValue))
+
+      for (ledgerEffectiveTime <- Iterable(lowerBound, upperBound)) {
+        val context =
+          createCommitContext(recordTime = Some(recordTime), inputs = inputWithDeclaredConfig)
+        val transactionEntrySummary = DamlTransactionEntrySummary(
+          aDamlTransactionEntry.toBuilder
+            .setLedgerEffectiveTime(
+              com.google.protobuf.Timestamp.newBuilder
+                .setSeconds(ledgerEffectiveTime.getEpochSecond)
+                .setNanos(ledgerEffectiveTime.getNano)
+            )
+            .build
+        )
+        val actual = ledgerTimeValidationStep.apply(context, transactionEntrySummary)
+
+        actual match {
+          case StepContinue(_) => fail()
+          case StepStop(actualLogEntry) =>
+            actualLogEntry.hasTransactionRejectionEntry shouldBe true
+        }
+      }
+    }
+
+    "mark config key as accessed in context" in {
+      val commitContext =
+        createCommitContext(recordTime = None, inputWithTimeModelAndCommandDeduplication)
+
+      ledgerTimeValidationStep.apply(commitContext, aTransactionEntrySummary)
+
+      commitContext.getAccessedInputKeys should contain(configurationStateKey)
+    }
+  }
+
+  private def createProtobufTimestamp(seconds: Long) =
+    Conversions.buildTimestamp(Timestamp.assertFromInstant(Instant.ofEpochSecond(seconds)))
+
+  private def contextWithTimeModelAndEmptyCommandDeduplication() =
+    createCommitContext(recordTime = None, inputs = inputWithTimeModelAndEmptyCommandDeduplication)
+
+  private def contextWithTimeModelAndCommandDeduplication() =
+    createCommitContext(recordTime = None, inputs = inputWithTimeModelAndCommandDeduplication)
+
+  private def defaultConfigurationStateValueBuilder(): DamlStateValue.Builder =
+    DamlStateValue.newBuilder
+      .setConfigurationEntry(
+        DamlConfigurationEntry.newBuilder
+          .setConfiguration(Configuration.encode(theDefaultConfig))
+      )
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
@@ -20,7 +20,7 @@ import com.daml.ledger.participant.state.kvutils.TestHelpers.{
 }
 import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,
-  TransactionRejector,
+  Rejections,
 }
 import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepStop}
 import com.daml.ledger.participant.state.v1.Configuration
@@ -35,9 +35,9 @@ class LedgerTimeValidatorSpec extends AnyWordSpec with Matchers {
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
   private val metrics = new Metrics(new MetricRegistry)
-  private val transactionRejector = new TransactionRejector(metrics)
+  private val rejections = new Rejections(metrics)
   private val ledgerTimeValidationStep =
-    new LedgerTimeValidator(theDefaultConfig).createValidationStep(transactionRejector)
+    new LedgerTimeValidator(theDefaultConfig).createValidationStep(rejections)
 
   private val aDamlTransactionEntry = createEmptyTransactionEntry(List("aSubmitter"))
   private val aTransactionEntrySummary = DamlTransactionEntrySummary(aDamlTransactionEntry)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.participant.state.kvutils.TestHelpers.{
   createCommitContext,
   createEmptyTransactionEntry,
   getTransactionRejectionReason,
+  lfTuple,
   mkParticipantId,
   theDefaultConfig,
 }
@@ -231,9 +232,7 @@ class ModelConformanceValidatorSpec extends AnyWordSpec with Matchers with Mocki
       argument = argument,
       signatories = signatories,
       observers = Seq.empty,
-      key = keyAndMaintainer.map { case (key, maintainer) =>
-        tuple(maintainer, key)
-      },
+      key = keyAndMaintainer.map { case (key, maintainer) => lfTuple(maintainer, key) },
     )
 
   private def createTransactionCommitter(): TransactionCommitter =
@@ -301,9 +300,4 @@ object ModelConformanceValidatorSpec {
       replayed: Transaction.Transaction,
   ): ReplayedNodeMissing[NodeId, Value.ContractId] =
     ReplayedNodeMissing(recorded._1, recorded._2, replayed)
-
-  private def tuple(values: String*): TransactionBuilder.Value =
-    TransactionBuilder.record(values.zipWithIndex.map { case (v, i) =>
-      s"_$i" -> v
-    }: _*)
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
@@ -1,0 +1,309 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlPartyAllocation,
+  DamlStateKey,
+  DamlStateValue,
+}
+import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
+import com.daml.ledger.participant.state.kvutils.TestHelpers.{
+  createCommitContext,
+  createEmptyTransactionEntry,
+  getTransactionRejectionReason,
+  mkParticipantId,
+  theDefaultConfig,
+}
+import com.daml.ledger.participant.state.kvutils.committer.transaction.{
+  DamlTransactionEntrySummary,
+  TransactionCommitter,
+}
+import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepStop}
+import com.daml.ledger.participant.state.v1.{RejectionReason, RejectionReasonV0}
+import com.daml.lf.engine.{Engine, Error => LfError}
+import com.daml.lf.transaction
+import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.transaction.{
+  NodeId,
+  RecordedNodeMissing,
+  ReplayNodeMismatch,
+  ReplayedNodeMissing,
+  Transaction,
+}
+import com.daml.lf.value.Value
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import org.mockito.MockitoSugar
+import org.scalatest.Inspectors.forEvery
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ModelConformanceValidatorSpec extends AnyWordSpec with Matchers with MockitoSugar {
+  import ModelConformanceValidatorSpec._
+
+  private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
+
+  private val metrics = new Metrics(new MetricRegistry)
+  private val transactionCommitter =
+    createTransactionCommitter() // Stateless, can be shared between tests
+  private val txBuilder = TransactionBuilder()
+
+  private val createInput = create("#inputContractId")
+  private val create1 = create("#someContractId")
+  private val create2 = create("#otherContractId")
+  private val otherKeyCreate = create(
+    contractId = "#contractWithOtherKey",
+    signatories = Seq(aKeyMaintainer),
+    keyAndMaintainer = Some("otherKey" -> aKeyMaintainer),
+  )
+
+  private val exercise = txBuilder.exercise(
+    contract = createInput,
+    choice = "DummyChoice",
+    consuming = false,
+    actingParties = Set(aKeyMaintainer),
+    argument = aDummyValue,
+    byKey = false,
+  )
+
+  val lookupNodes @ Seq(lookup1, lookup2, lookupNone, lookupOther @ _) =
+    Seq(create1 -> true, create2 -> true, create1 -> false, otherKeyCreate -> true) map {
+      case (create, found) => txBuilder.lookupByKey(create, found)
+    }
+
+  val Seq(tx1, tx2, txNone, txOther) = lookupNodes map { node =>
+    val builder = TransactionBuilder()
+    val rootId = builder.add(exercise)
+    val lookupId = builder.add(node, rootId)
+    builder.build() -> lookupId
+  }
+
+  "rejectionReasonForValidationError" when {
+    "there is a mismatch in lookupByKey nodes" should {
+      "report an inconsistency if the contracts are not created in the same transaction" in {
+        val inconsistentLookups = Seq(
+          mkMismatch(tx1, tx2),
+          mkMismatch(tx1, txNone),
+          mkMismatch(txNone, tx2),
+        )
+        forEvery(inconsistentLookups)(checkRejectionReason(RejectionReasonV0.Inconsistent))
+      }
+
+      "report Disputed if one of contracts is created in the same transaction" in {
+        val Seq(txC1, txC2, txCNone) = Seq(lookup1, lookup2, lookupNone) map { node =>
+          val builder = TransactionBuilder()
+          val rootId = builder.add(exercise)
+          builder.add(create1, rootId)
+          val lookupId = builder.add(node, rootId)
+          builder.build() -> lookupId
+        }
+        val Seq(tx1C, txNoneC) = Seq(lookup1, lookupNone) map { node =>
+          val builder = TransactionBuilder()
+          val rootId = builder.add(exercise)
+          val lookupId = builder.add(node, rootId)
+          builder.add(create1)
+          builder.build() -> lookupId
+        }
+        val recordedKeyInconsistent = Seq(
+          mkMismatch(txC2, txC1),
+          mkMismatch(txCNone, txC1),
+          mkMismatch(txC1, txCNone),
+          mkMismatch(tx1C, txNoneC),
+        )
+        forEvery(recordedKeyInconsistent)(checkRejectionReason(RejectionReasonV0.Disputed))
+      }
+
+      "report Disputed if the keys are different" in {
+        checkRejectionReason(RejectionReasonV0.Disputed)(mkMismatch(txOther, tx1))
+      }
+    }
+
+    "the mismatch is not between two lookup nodes" should {
+      "report Disputed" in {
+        val txExerciseOnly = {
+          val builder = TransactionBuilder()
+          builder.add(exercise)
+          builder.build()
+        }
+        val txCreate = {
+          val builder = TransactionBuilder()
+          val rootId = builder.add(exercise)
+          val createId = builder.add(create1, rootId)
+          builder.build() -> createId
+        }
+        val miscMismatches = Seq(
+          mkMismatch(txCreate, tx1),
+          mkRecordedMissing(txExerciseOnly, tx2),
+          mkReplayedMissing(tx1, txExerciseOnly),
+        )
+        forEvery(miscMismatches)(checkRejectionReason(RejectionReasonV0.Disputed))
+      }
+    }
+  }
+
+  "authorizeSubmitters" should {
+    "reject a submission when any of the submitters keys is not present in the input state" in {
+      val context = createCommitContext(
+        recordTime = None,
+        inputs = createInputs(
+          Alice -> Some(hostedParty(Alice)),
+          Bob -> Some(hostedParty(Bob)),
+        ),
+        participantId = ParticipantId,
+      )
+      val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob, Emma)))
+
+      a[MissingInputState] should be thrownBy transactionCommitter.authorizeSubmitters(
+        context,
+        tx,
+      )
+    }
+
+    "reject a submission when any of the submitters is not known" in {
+      val context = createCommitContext(
+        recordTime = None,
+        inputs = createInputs(
+          Alice -> Some(hostedParty(Alice)),
+          Bob -> None,
+        ),
+        participantId = ParticipantId,
+      )
+      val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob)))
+
+      val result = transactionCommitter.authorizeSubmitters(context, tx)
+      result shouldBe a[StepStop]
+
+      val rejectionReason =
+        getTransactionRejectionReason(result).getPartyNotKnownOnLedger.getDetails
+      rejectionReason should fullyMatch regex """Submitting party .+ not known"""
+    }
+
+    "reject a submission when any of the submitters' participant id is incorrect" in {
+      val context = createCommitContext(
+        recordTime = None,
+        inputs = createInputs(
+          Alice -> Some(hostedParty(Alice)),
+          Bob -> Some(notHostedParty(Bob)),
+        ),
+        participantId = ParticipantId,
+      )
+      val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob)))
+
+      val result = transactionCommitter.authorizeSubmitters(context, tx)
+      result shouldBe a[StepStop]
+
+      val rejectionReason =
+        getTransactionRejectionReason(result).getSubmitterCannotActViaParticipant.getDetails
+      rejectionReason should fullyMatch regex s"""Party .+ not hosted by participant ${mkParticipantId(
+        ParticipantId
+      )}"""
+    }
+
+    "allow a submission when all of the submitters are hosted on the participant" in {
+      val context = createCommitContext(
+        recordTime = None,
+        inputs = createInputs(
+          Alice -> Some(hostedParty(Alice)),
+          Bob -> Some(hostedParty(Bob)),
+          Emma -> Some(hostedParty(Emma)),
+        ),
+        participantId = ParticipantId,
+      )
+      val tx = DamlTransactionEntrySummary(createEmptyTransactionEntry(List(Alice, Bob, Emma)))
+
+      val result = transactionCommitter.authorizeSubmitters(context, tx)
+      result shouldBe a[StepContinue[_]]
+    }
+  }
+
+  private def create(
+      contractId: String,
+      signatories: Seq[String] = Seq(aKeyMaintainer),
+      argument: TransactionBuilder.Value = aDummyValue,
+      keyAndMaintainer: Option[(String, String)] = Some(aKey -> aKeyMaintainer),
+  ): TransactionBuilder.Create =
+    txBuilder.create(
+      id = contractId,
+      template = "dummyPackage:DummyModule:DummyTemplate",
+      argument = argument,
+      signatories = signatories,
+      observers = Seq.empty,
+      key = keyAndMaintainer.map { case (key, maintainer) =>
+        tuple(maintainer, key)
+      },
+    )
+
+  private def createTransactionCommitter(): TransactionCommitter =
+    new TransactionCommitter(
+      theDefaultConfig,
+      mock[Engine],
+      metrics,
+      inStaticTimeMode = false,
+    )
+
+  private def checkRejectionReason(
+      mkReason: String => RejectionReason
+  )(mismatch: transaction.ReplayMismatch[NodeId, Value.ContractId]) = {
+    val replayMismatch = LfError.Validation(LfError.Validation.ReplayMismatch(mismatch))
+    ModelConformanceValidator.rejectionReasonForValidationError(replayMismatch) shouldBe mkReason(
+      replayMismatch.msg
+    )
+  }
+}
+
+object ModelConformanceValidatorSpec {
+  private val Alice = "alice"
+  private val Bob = "bob"
+  private val Emma = "emma"
+  private val ParticipantId = 0
+  private val OtherParticipantId = 1
+
+  private val aKeyMaintainer = "maintainer"
+  private val aKey = "key"
+  private val aDummyValue = TransactionBuilder.record("field" -> "value")
+
+  private def createInputs(
+      inputs: (String, Option[DamlPartyAllocation])*
+  ): Map[DamlStateKey, Option[DamlStateValue]] =
+    inputs.map { case (party, partyAllocation) =>
+      DamlStateKey.newBuilder().setParty(party).build() -> partyAllocation
+        .map(
+          DamlStateValue.newBuilder().setParty(_).build()
+        )
+    }.toMap
+
+  private def hostedParty(party: String): DamlPartyAllocation =
+    partyAllocation(party, ParticipantId)
+  private def notHostedParty(party: String): DamlPartyAllocation =
+    partyAllocation(party, OtherParticipantId)
+  private def partyAllocation(party: String, participantId: Int): DamlPartyAllocation =
+    DamlPartyAllocation
+      .newBuilder()
+      .setParticipantId(mkParticipantId(participantId))
+      .setDisplayName(party)
+      .build()
+
+  private def mkMismatch(
+      recorded: (Transaction.Transaction, NodeId),
+      replayed: (Transaction.Transaction, NodeId),
+  ): ReplayNodeMismatch[NodeId, Value.ContractId] =
+    ReplayNodeMismatch(recorded._1, recorded._2, replayed._1, replayed._2)
+  private def mkRecordedMissing(
+      recorded: Transaction.Transaction,
+      replayed: (Transaction.Transaction, NodeId),
+  ): RecordedNodeMissing[NodeId, Value.ContractId] =
+    RecordedNodeMissing(recorded, replayed._1, replayed._2)
+  private def mkReplayedMissing(
+      recorded: (Transaction.Transaction, NodeId),
+      replayed: Transaction.Transaction,
+  ): ReplayedNodeMissing[NodeId, Value.ContractId] =
+    ReplayedNodeMissing(recorded._1, recorded._2, replayed)
+
+  private def tuple(values: String*): TransactionBuilder.Value =
+    TransactionBuilder.record(values.zipWithIndex.map { case (v, i) =>
+      s"_$i" -> v
+    }: _*)
+}


### PR DESCRIPTION
A prerequisite PR for kvutils transaction validation refinement to make the next PR more narrow and easier to review. Basically, the `TransactionCommitter` and `TransactionCommitterSpec` had too many responsibilities, were too long, and hard to maintain.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
