### PR TITLE
[In-memory fan-out] Handle `null` submitters in getTransactionLogUpdates

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
@@ -866,7 +866,7 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
       int("create_argument_compression").? ~
       array[String]("tree_event_witnesses") ~
       array[String]("flat_event_witnesses") ~
-      array[String]("submitters") ~
+      array[String]("submitters").? ~
       str("exercise_choice").? ~
       binaryStream("exercise_argument").? ~
       int("exercise_argument_compression").? ~
@@ -900,7 +900,7 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
           createArgumentCompression,
           treeEventWitnesses.toSet,
           flatEventWitnesses.toSet,
-          submitters.toSet,
+          submitters.map(_.toSet).getOrElse(Set.empty),
           exerciseChoice,
           exerciseArgument,
           exerciseArgumentCompression,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -292,6 +292,11 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
     )
   }
 
+  protected final def noSubmitterInfo(
+      transaction: LedgerEntry.Transaction
+  ): LedgerEntry.Transaction =
+    transaction.copy(commandId = None, actAs = List.empty, applicationId = None)
+
   protected final def fromTransaction(
       transaction: CommittedTransaction,
       actAs: List[Party] = List(alice),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionLogUpdatesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionLogUpdatesSpec.scala
@@ -50,7 +50,7 @@ private[dao] trait JdbcLedgerDaoTransactionLogUpdatesSpec
   it should "return the correct transaction log updates" in {
     for {
       from <- ledgerDao.lookupLedgerEndOffsetAndSequentialId()
-      (offset1, t1) <- store(singleCreate)
+      (offset1, t1) <- store(singleCreate(create(_), List.empty))
       (offset2, t2) <- store(txCreateContractWithKey(alice, "some-key"))
       (offset3, t3) <- store(
         singleExercise(
@@ -124,6 +124,9 @@ private[dao] trait JdbcLedgerDaoTransactionLogUpdatesSpec
             actualEventsById.get(expectedEventId)
           actualCreated.contractId shouldBe nodeCreate.coid
           actualCreated.templateId shouldBe nodeCreate.templateId
+          actualCreated.submitters should contain theSameElementsAs expected.actAs
+            .map(_.toString)
+            .toSet
           actualCreated.treeEventWitnesses shouldBe nodeCreate.informeesOfNode
           actualCreated.flatEventWitnesses shouldBe nodeCreate.stakeholders
           actualCreated.createSignatories shouldBe nodeCreate.signatories
@@ -139,6 +142,9 @@ private[dao] trait JdbcLedgerDaoTransactionLogUpdatesSpec
 
           actualExercised.contractId shouldBe nodeExercises.targetCoid
           actualExercised.templateId shouldBe nodeExercises.templateId
+          actualExercised.submitters should contain theSameElementsAs expected.actAs
+            .map(_.toString)
+            .toSet
           if (actualExercised.consuming)
             actualExercised.flatEventWitnesses shouldBe nodeExercises.stakeholders
           else


### PR DESCRIPTION
Handle `null` submitters in `getTransactionLogUpdates`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
