### PR TITLE
[In-memory fan-out] CLI parameters update

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -510,7 +510,7 @@ object Config {
           .optional()
           .hidden()
           .text(
-            "Experimental contract state cache for command execution. Should not be used in production."
+            "Experimental contract state cache for command execution. Must be enabled in conjunction with index-append-only-schema-unsafe. Should not be used in production."
           )
           .action((_, config) => config.copy(enableMutableContractStateCache = true))
 
@@ -518,9 +518,23 @@ object Config {
           .optional()
           .hidden()
           .text(
-            "Experimental buffer for Ledger API streaming queries. Should not be used in production."
+            "Experimental buffer for Ledger API streaming queries. Must be enabled in conjunction with index-append-only-schema-unsafe and mutable-contract-state-cache-unsafe. Should not be used in production."
           )
           .action((_, config) => config.copy(enableInMemoryFanOutForLedgerApi = true))
+
+        checkConfig(c =>
+          if (c.enableMutableContractStateCache && !c.enableAppendOnlySchema)
+            failure(
+              "mutable-contract-state-cache-unsafe must be enabled in conjunction with index-append-only-schema-unsafe."
+            )
+          else if (
+            c.enableInMemoryFanOutForLedgerApi && !(c.enableMutableContractStateCache && c.enableAppendOnlySchema)
+          )
+            failure(
+              "buffered-ledger-api-streams-unsafe must be enabled in conjunction with index-append-only-schema-unsafe and mutable-contract-state-cache-unsafe."
+            )
+          else success
+        )
       }
     extraOptions(parser)
     parser

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -522,13 +522,13 @@ object Config {
           )
           .action((_, config) => config.copy(enableInMemoryFanOutForLedgerApi = true))
 
-        checkConfig(c =>
-          if (c.enableMutableContractStateCache && !c.enableAppendOnlySchema)
+        checkConfig(config =>
+          if (config.enableMutableContractStateCache && !config.enableAppendOnlySchema)
             failure(
               "mutable-contract-state-cache-unsafe must be enabled in conjunction with index-append-only-schema-unsafe."
             )
           else if (
-            c.enableInMemoryFanOutForLedgerApi && !(c.enableMutableContractStateCache && c.enableAppendOnlySchema)
+            config.enableInMemoryFanOutForLedgerApi && !(config.enableMutableContractStateCache && config.enableAppendOnlySchema)
           )
             failure(
               "buffered-ledger-api-streams-unsafe must be enabled in conjunction with index-append-only-schema-unsafe and mutable-contract-state-cache-unsafe."

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
@@ -44,5 +44,5 @@ object ParticipantConfig {
   val DefaultMaxContractStateCacheSize: Long = 100000L
   val DefaultMaxContractKeyStateCacheSize: Long = 100000L
 
-  val DefaultMaxTransactionsInMemoryFanOutBufferSize: Long = 1000L
+  val DefaultMaxTransactionsInMemoryFanOutBufferSize: Long = 10000L
 }


### PR DESCRIPTION
Updates for parameter configuration for in-memory fan-out and mutable contract state cache:
* Enforce consistency for experimental CLI parameters for append-only, mutable state cache and in-memory fan-out
* Set default in-memory fan-out buffer size to 10K.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
