### PR TITLE
[JSON-API] Small refactoring to start using akka http routes internally

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -14,7 +14,7 @@ import akka.http.scaladsl.model.headers.{
   `X-Forwarded-Proto`,
 }
 import akka.http.scaladsl.server.Directives.extractClientIP
-import akka.http.scaladsl.server.{RequestContext, Route, RouteResult}
+import akka.http.scaladsl.server.{Rejection, RequestContext, Route, RouteResult}
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Source}
 import akka.util.ByteString
@@ -164,7 +164,7 @@ class Endpoints(
       }
       .applyOrElse[HttpRequest, Future[RouteResult]](
         ctx.request,
-        _ => Future(RouteResult.Rejected(Seq.empty)),
+        _ => Future(RouteResult.Rejected(Seq.empty[Rejection])),
       )
   }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -15,6 +15,7 @@ import akka.http.scaladsl.model.headers.{
 }
 import akka.http.scaladsl.server.Directives.extractClientIP
 import akka.http.scaladsl.server.{Rejection, RequestContext, Route, RouteResult}
+import akka.http.scaladsl.server.RouteResult._
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Source}
 import akka.util.ByteString
@@ -160,12 +161,12 @@ class Endpoints(
               logger.trace(s"Processed request after ${System.nanoTime() - t0}ns")
               logger.info(s"Responding to client with HTTP ${res.status}")
             }
-          } yield RouteResult.Complete(res)
+          } yield Complete(res)
         })
       }
       .applyOrElse[HttpRequest, Future[RouteResult]](
         ctx.request,
-        _ => Future(RouteResult.Rejected(Seq.empty[Rejection])),
+        _ => Future(Rejected(Seq.empty[Rejection])),
       )
   }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -47,7 +47,8 @@ import scala.util.Try
 import scala.util.control.NonFatal
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import com.daml.metrics.{Metrics, Timed}
-import scala.collection.immutable.Seq
+
+import scala.collection.immutable
 
 class Endpoints(
     allowNonHttps: Boolean,
@@ -166,7 +167,7 @@ class Endpoints(
       }
       .applyOrElse[HttpRequest, Future[RouteResult]](
         ctx.request,
-        _ => Future(Rejected(Seq.empty[Rejection])),
+        _ => Future(Rejected(immutable.Seq.empty[Rejection])),
       )
   }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -46,6 +46,7 @@ import scala.util.Try
 import scala.util.control.NonFatal
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import com.daml.metrics.{Metrics, Timed}
+import scala.collection.immutable.Seq
 
 class Endpoints(
     allowNonHttps: Boolean,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
@@ -4,6 +4,8 @@
 package com.daml.http
 
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.RouteResult.Complete
+import akka.http.scaladsl.server.{RequestContext, Route}
 import akka.util.ByteString
 import com.daml.http.domain.{JwtPayload, JwtWritePayload}
 import com.daml.http.json.SprayJson
@@ -104,10 +106,13 @@ object EndpointsCompanion {
       }
   }
 
-  lazy val notFound: PartialFunction[HttpRequest, Future[HttpResponse]] = {
-    case HttpRequest(method, uri, _, _, _) =>
-      Future.successful(httpResponseError(NotFound(s"${method: HttpMethod}, uri: ${uri: Uri}")))
-  }
+  lazy val notFound: Route = (ctx: RequestContext) =>
+    ctx.request match {
+      case HttpRequest(method, uri, _, _, _) =>
+        Future.successful(
+          Complete(httpResponseError(NotFound(s"${method: HttpMethod}, uri: ${uri: Uri}")))
+        )
+    }
 
   private[http] def httpResponseError(error: Error): HttpResponse = {
     import com.daml.http.json.JsonProtocol._

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -200,9 +200,12 @@ object HttpService {
           websocketEndpoints.transactionWebSocket,
         )
 
-      allEndpoints = staticContentConfig.cata(
-        c => concat(StaticContentEndpoints.all(c), defaultEndpoints),
-        defaultEndpoints,
+      allEndpoints = concat(
+        staticContentConfig.cata(
+          c => concat(StaticContentEndpoints.all(c), defaultEndpoints),
+          defaultEndpoints,
+        ),
+        EndpointsCompanion.notFound,
       )
 
       binding <- liftET[Error](

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -93,6 +93,7 @@ object HttpService {
       maxInboundMessageSize = maxInboundMessageSize,
     )
 
+    import akka.http.scaladsl.server.Directives._
     val bindingEt: EitherT[Future, Error, ServerBinding] = for {
       client <- eitherT(
         ledgerClient(
@@ -194,14 +195,13 @@ object HttpService {
       )
 
       defaultEndpoints =
-        jsonEndpoints.all orElse
-          websocketEndpoints.transactionWebSocket orElse
-          EndpointsCompanion.notFound
+        concat(
+          jsonEndpoints.all,
+          websocketEndpoints.transactionWebSocket,
+        )
 
       allEndpoints = staticContentConfig.cata(
-        c =>
-          StaticContentEndpoints.all(c) orElse
-            defaultEndpoints,
+        c => concat(StaticContentEndpoints.all(c), defaultEndpoints),
         defaultEndpoints,
       )
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/StaticContentEndpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/StaticContentEndpoints.scala
@@ -13,6 +13,7 @@ import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import scalaz.syntax.show._
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.collection.immutable.Seq
 
 object StaticContentEndpoints {
   def all(config: StaticContentConfig)(implicit

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/StaticContentEndpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/StaticContentEndpoints.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
 import akka.http.scaladsl.server.directives.ContentTypeResolver.Default
-import akka.http.scaladsl.server.{Directives, RequestContext, Route, RouteResult}
+import akka.http.scaladsl.server.{Directives, Rejection, RequestContext, Route, RouteResult}
 import com.daml.http.util.Logging.InstanceUUID
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import scalaz.syntax.show._
@@ -26,7 +26,7 @@ object StaticContentEndpoints {
       )
       .applyOrElse[HttpRequest, Future[RouteResult]](
         ctx.request,
-        _ => Future(Rejected(Seq.empty)),
+        _ => Future(Rejected(Seq.empty[Rejection])),
       )
 }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
@@ -21,6 +21,8 @@ import com.daml.http.util.Logging.{InstanceUUID, RequestID, extendWithRequestIdL
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import com.daml.metrics.Metrics
 
+import scala.collection.immutable.Seq
+
 object WebsocketEndpoints {
   private[http] val tokenPrefix: String = "jwt.token."
   private[http] val wsProtocol: String = "daml.ws.auth"

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
@@ -14,7 +14,7 @@ import scalaz.\/
 
 import scala.concurrent.{ExecutionContext, Future}
 import EndpointsCompanion._
-import akka.http.scaladsl.server.{RequestContext, Route, RouteResult}
+import akka.http.scaladsl.server.{Rejection, RequestContext, Route, RouteResult}
 import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
 import com.daml.http.domain.JwtPayload
 import com.daml.http.util.Logging.{InstanceUUID, RequestID, extendWithRequestIdLogCtx}
@@ -117,7 +117,7 @@ class WebsocketEndpoints(
       }
       .applyOrElse[HttpRequest, Future[RouteResult]](
         ctx.request,
-        _ => Future(Rejected(Seq.empty)),
+        _ => Future(Rejected(Seq.empty[Rejection])),
       )
   }
 


### PR DESCRIPTION
One step towards using routes and directives more in the json api internally. I'm doing this refactoring incrementally in small steps so you folks here can still follow what happens and I don't get lost in the refactoring madness :smile_cat: 

I don't know yet whether the tests pass, I'll let the CI figure out (go CI gooo :car:).

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
