### PR TITLE
[Mutable cache] Resolve with full lookup on negative cache read-through lookups [DPP-501]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -84,6 +84,14 @@ final class Metrics(val registry: MetricRegistry) {
 
         val dispatcherLag: Timer = registry.timer(Prefix :+ "dispatcher_lag")
 
+        val resolveDivulgenceLookup: Counter =
+          registry.counter(Prefix :+ "resolve_divulgence_lookup")
+
+        val resolveFullLookup: Counter =
+          registry.counter(Prefix :+ "resolve_full_lookup")
+
+        val readThroughNotFound: Counter = registry.counter(Prefix :+ "read_through_not_found")
+
         val indexSequentialId = new VarGauge[Long](0L)
         registry.register(
           Prefix :+ "index_sequential_id",

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -157,6 +157,15 @@ private[platform] class MutableCacheBackedContractStore(
       case Archived(stakeholders) if nonEmptyIntersection(stakeholders, readers) =>
         Future.successful(Option.empty)
       case contractStateValue =>
+        // This flow is exercised when the readers are not stakeholders of the contract
+        // (the contract might have been divulged to the readers)
+        // OR the contract was not found in the index
+        //
+        // NOTE: The current implementation of mutable contract state cache provides an optimization aimed at performance-critical
+        //       applications that do not exercise this flow frequently (i.e. no negative contract lookups in command interpretation
+        //       or use of divulgence)
+        // TODO: Implement caching of divulged contracts for alleviating performance degradation in applications that
+        //       make use of divulgence OR applications that cause high numbers of negative contract lookups
         logger.debug(s"Checking divulgence for contractId=$contractId and readers=$readers")
         resolveDivulgenceLookup(contractStateValue, contractId, readers)
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -30,6 +30,7 @@ import com.daml.platform.store.interfaces.LedgerDaoContractsReader.{
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
 
 private[platform] class MutableCacheBackedContractStore(
@@ -124,7 +125,13 @@ private[platform] class MutableCacheBackedContractStore(
       _ <- contractsCache.putAsync(
         key = contractId,
         validAt = currentCacheSequentialId,
-        eventualValue = eventualValue,
+        eventualValue = eventualValue.transformWith {
+          case Success(NotFound) =>
+            metrics.daml.execution.cache.readThroughNotFound.inc()
+            // Don't cache negative lookups
+            Future.failed(ContractReadThroughNotFound(contractId))
+          case result => Future.fromTry(result)
+        },
       )
       value <- eventualValue
     } yield value
@@ -149,31 +156,30 @@ private[platform] class MutableCacheBackedContractStore(
         Future.successful(Some(contract))
       case Archived(stakeholders) if nonEmptyIntersection(stakeholders, readers) =>
         Future.successful(Option.empty)
-      case ContractStateValue.NotFound =>
-        logger.warn(s"Contract not found for $contractId")
-        Future.successful(Option.empty)
-      case existingContractValue: ExistingContractValue =>
+      case contractStateValue =>
         logger.debug(s"Checking divulgence for contractId=$contractId and readers=$readers")
-        resolveDivulgenceLookup(existingContractValue, contractId, readers)
+        resolveDivulgenceLookup(contractStateValue, contractId, readers)
     }
 
   private def resolveDivulgenceLookup(
-      existingContractValue: ExistingContractValue,
+      contractStateValue: ContractStateValue,
       contractId: ContractId,
       forParties: Set[Party],
   )(implicit
       loggingContext: LoggingContext
   ): Future[Option[Contract]] =
-    existingContractValue match {
+    contractStateValue match {
       case Active(contract, _, _) =>
+        metrics.daml.execution.cache.resolveDivulgenceLookup.inc()
         contractsReader.lookupActiveContractWithCachedArgument(
           forParties,
           contractId,
           contract.arg,
         )
-      case _: Archived =>
-        // We need to fetch the contract here since the archival
+      case _: Archived | NotFound =>
+        // We need to fetch the contract here since the contract creation or archival
         // may have not been divulged to the readers
+        metrics.daml.execution.cache.resolveFullLookup.inc()
         contractsReader.lookupActiveContractAndLoadArgument(
           forParties,
           contractId,
@@ -372,6 +378,11 @@ private[platform] object MutableCacheBackedContractStore {
       extends IllegalArgumentException(
         "Cannot lookup the maximum ledger time for an empty set of contract identifiers"
       )
+
+  final case class ContractReadThroughNotFound(contractId: ContractId) extends NoStackTrace {
+    override def getMessage: String =
+      s"Contract not found for contract id $contractId. This is likely due to a race condition."
+  }
 
   private[cache] class CacheIndex {
     private val offsetRef: AtomicReference[Option[(Offset, EventSequentialId)]] =

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
@@ -34,7 +34,11 @@ import com.daml.platform.store.cache.MutableCacheBackedContractStoreSpec.{
 }
 import com.daml.platform.store.dao.events.ContractStateEvent
 import com.daml.platform.store.interfaces.LedgerDaoContractsReader
-import com.daml.platform.store.interfaces.LedgerDaoContractsReader.{KeyAssigned, KeyUnassigned}
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader.{
+  ContractState,
+  KeyAssigned,
+  KeyUnassigned,
+}
 import org.mockito.MockitoSugar
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
@@ -200,6 +204,37 @@ class MutableCacheBackedContractStoreSpec
         verify(spyContractsReader).lookupContractState(cId_2, 1L)
         verify(spyContractsReader).lookupContractState(cId_3, 2L)
         verify(spyContractsReader).lookupContractState(nonExistentCId, 3L)
+        succeed
+      }
+    }
+
+    "read-through the cache without storing negative lookups" in {
+      val spyContractsReader = spy(ContractsReaderFixture())
+      for {
+        store <- contractStore(cachesSize = 1L, spyContractsReader).asFuture
+        _ = store.cacheIndex.set(unusedOffset, 1L)
+        negativeLookup_cId6 <- store.lookupActiveContract(Set(alice), cId_6)
+        positiveLookup_cId6 <- store.lookupActiveContract(Set(alice), cId_6)
+      } yield {
+        negativeLookup_cId6 shouldBe Option.empty
+        positiveLookup_cId6 shouldBe Some(contract6)
+
+        verify(spyContractsReader, times(wantedNumberOfInvocations = 2))
+          .lookupContractState(cId_6, 1L)
+        succeed
+      }
+    }
+
+    "resort to resolveDivulgenceLookup on not found" in {
+      val spyContractsReader = spy(ContractsReaderFixture())
+      for {
+        store <- contractStore(cachesSize = 1L, spyContractsReader).asFuture
+        _ = store.cacheIndex.set(unusedOffset, 1L)
+        resolvedLookup_cId7 <- store.lookupActiveContract(Set(bob), cId_7)
+      } yield {
+        resolvedLookup_cId7 shouldBe Some(contract7)
+
+        verify(spyContractsReader).lookupActiveContractAndLoadArgument(Set(bob), cId_7)
         succeed
       }
     }
@@ -383,11 +418,11 @@ object MutableCacheBackedContractStoreSpec {
   private val unusedOffset = Offset.beforeBegin
   private val Seq(alice, bob, charlie) = Seq("alice", "bob", "charlie").map(party)
   private val (
-    Seq(cId_1, cId_2, cId_3, cId_4, cId_5),
-    Seq(contract1, contract2, contract3, contract4, _),
-    Seq(t1, t2, t3, t4, _),
+    Seq(cId_1, cId_2, cId_3, cId_4, cId_5, cId_6, cId_7),
+    Seq(contract1, contract2, contract3, contract4, _, contract6, contract7),
+    Seq(t1, t2, t3, t4, _, t6, _),
   ) =
-    (1 to 5).map { id =>
+    (1 to 7).map { id =>
       (contractId(id), contract(s"id$id"), Instant.ofEpochSecond(id.toLong))
     }.unzip3
 
@@ -413,6 +448,8 @@ object MutableCacheBackedContractStoreSpec {
       .acquire()(ResourceContext(scala.concurrent.ExecutionContext.global))
 
   case class ContractsReaderFixture() extends LedgerDaoContractsReader {
+    @volatile private var initialResultForCid6 = Future.successful(Option.empty[ContractState])
+
     override def lookupKeyState(key: Key, validAt: Long)(implicit
         loggingContext: LoggingContext
     ): Future[LedgerDaoContractsReader.KeyState] = (key, validAt) match {
@@ -423,14 +460,21 @@ object MutableCacheBackedContractStoreSpec {
 
     override def lookupContractState(contractId: ContractId, validAt: Long)(implicit
         loggingContext: LoggingContext
-    ): Future[Option[LedgerDaoContractsReader.ContractState]] = (contractId, validAt) match {
-      case (`cId_1`, 0L) => activeContract(contract1, Set(alice), t1)
-      case (`cId_1`, validAt) if validAt > 0L => archivedContract(Set(alice))
-      case (`cId_2`, validAt) if validAt >= 1L => activeContract(contract2, Set(bob), t2)
-      case (`cId_3`, _) => activeContract(contract3, Set(bob), t3)
-      case (`cId_4`, _) => activeContract(contract4, Set(bob), t4)
-      case (`cId_5`, _) => archivedContract(Set(bob))
-      case _ => Future.successful(Option.empty)
+    ): Future[Option[LedgerDaoContractsReader.ContractState]] = {
+      (contractId, validAt) match {
+        case (`cId_1`, 0L) => activeContract(contract1, Set(alice), t1)
+        case (`cId_1`, validAt) if validAt > 0L => archivedContract(Set(alice))
+        case (`cId_2`, validAt) if validAt >= 1L => activeContract(contract2, Set(bob), t2)
+        case (`cId_3`, _) => activeContract(contract3, Set(bob), t3)
+        case (`cId_4`, _) => activeContract(contract4, Set(bob), t4)
+        case (`cId_5`, _) => archivedContract(Set(bob))
+        case (`cId_6`, _) =>
+          // Simulate store being populated from one query to another
+          val result = initialResultForCid6
+          initialResultForCid6 = activeContract(contract6, Set(alice), t6)
+          result
+        case _ => Future.successful(Option.empty)
+      }
     }
 
     override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
@@ -459,6 +503,7 @@ object MutableCacheBackedContractStoreSpec {
           Future.successful(Some(contract3))
         case (`cId_1`, parties) if parties.contains(charlie) =>
           Future.successful(Some(contract1))
+        case (`cId_7`, parties) if parties == Set(bob) => Future.successful(Some(contract7))
         case _ => Future.successful(Option.empty)
       }
 


### PR DESCRIPTION
When trying to resolve an input divulged contract for which the create is event is not present (i.e. the contract stakeholder is on a different participant), the mutable state cache will settle with a negative lookup and cache it. The current behavior prohibits recovery in this scenario, leading to continuous contract not found errors reported to the client.

This PR mitigates the problem by:
* Negative lookups (contracts not found) always result in a lookup with divulgence resolution `contractsReader.lookupActiveContractAndLoadArgument`. 
* Negative lookups are not cached and a warning is logged if encountered (after divulgence resolution). 
* Metrics added for counting divulgence and full lookups (for asserting the impact of more lookups due to more negative contract lookups).
* Metrics added for counting negative lookups after divulgence resolution.

**NOTE** _Due to always performing a second lookup after negative contract lookups, this change has a performance impact in applications that cause race conditions._ 

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
