### PR TITLE
Ignore failure to upload log failures

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -40,6 +40,7 @@ steps:
 
   - task: PublishBuildArtifacts@1
     condition: succeededOrFailed()
+    continueOnError: true
     inputs:
       pathtoPublish: '$(Build.StagingDirectory)/logs'
       artifactName: 'Bazel Logs'


### PR DESCRIPTION
This has now screwed us over for two releases (1.14 and currently
blocking 1.15) because we didn’t backport the change. While we could
backport this, it is annoying and provides little to no benefit given
that a failure here is harmless so let’s just ignore failures here.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
