### PR TITLE
Add a benchmark for contract insertion in the JSON API

### DIFF
--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
@@ -3,7 +3,6 @@
 
 package com.daml.http.dbbackend
 
-import scalaz.std.list._
 import cats.instances.list._
 import doobie.util.log.LogHandler
 import com.daml.doobie.logging.Slf4jLogHandler
@@ -12,6 +11,7 @@ import com.daml.http.domain.TemplateId
 import com.daml.testing.oracle, oracle.{OracleAround, User}
 import org.openjdk.jmh.annotations._
 import scala.concurrent.ExecutionContext
+import scalaz.std.list._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http.dbbackend
+
+import cats.instances.list._
+import com.daml.http.dbbackend.Queries.{DBContract, SurrogateTpId}
+import org.openjdk.jmh.annotations._
+import scalaz.std.list._
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+class InsertBenchmark extends ContractDaoBenchmark {
+  @Param(Array("1", "3", "5", "7", "9"))
+  var batches: Int = _
+
+  @Param(Array("1000"))
+  var numContracts: Int = _
+
+  private var contracts: List[DBContract[SurrogateTpId, JsValue, JsValue, Seq[String]]] = _
+
+  private var contractCids: List[String] = _
+
+  @Setup(Level.Trial)
+  override def setup(): Unit = {
+    super.setup()
+    contracts = (1 until numContracts + 1).map { i =>
+      // Use negative cids to avoid collisions with other contracts
+      contract(-i, "Alice")
+    }.toList
+
+    contractCids = contracts.map(_.contractId)
+
+    (0 until batches).foreach { batch =>
+      insertBatch("Alice", batch * batchSize)
+    }
+    ()
+  }
+
+  @TearDown(Level.Invocation)
+  def dropContracts: Unit = {
+    val deleted = dao.transact(dao.jdbcDriver.queries.deleteContracts(contractCids)).unsafeRunSync()
+    assert(deleted == numContracts)
+  }
+
+  @Benchmark
+  def run(): Unit = {
+    val driver: SupportedJdbcDriver = dao.jdbcDriver
+    import driver._
+    val inserted = dao.transact(driver.queries.insertContracts(contracts)).unsafeRunSync()
+    assert(inserted == numContracts)
+  }
+}

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
@@ -43,7 +43,7 @@ class InsertBenchmark extends ContractDaoBenchmark {
     assert(deleted == numContracts)
   }
 
-  @Benchmark
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime))
   def run(): Unit = {
     val driver: SupportedJdbcDriver = dao.jdbcDriver
     import driver._

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
@@ -22,7 +22,7 @@ class QueryBenchmark extends ContractDaoBenchmark {
     ()
   }
 
-  @Benchmark
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime))
   def run(): Unit = {
     implicit val driver: SupportedJdbcDriver = dao.jdbcDriver
     val result = dao


### PR DESCRIPTION
Unfortunately the results seem to match up with my initial benchmark
in #10234

Benchmark            (batchSize)  (batches)  (numContracts)  Mode  Cnt     Score     Error  Units
InsertBenchmark.run         1000          1            1000  avgt    5   336.674 ±  42.058  ms/op
InsertBenchmark.run         1000          3            1000  avgt    5   787.086 ± 223.018  ms/op
InsertBenchmark.run         1000          5            1000  avgt    5  1181.041 ± 317.017  ms/op
InsertBenchmark.run         1000          7            1000  avgt    5  1531.185 ± 341.060  ms/op
InsertBenchmark.run         1000          9            1000  avgt    5  1945.345 ± 436.352  ms/op

Score should ideally be more or less constant but it goes up very
significantly as the total ACS size changes

fixes #10245

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
