### PR TITLE
Fix status check in collect_build_data

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -562,9 +562,9 @@ jobs:
         # succeed.
         #
         # release only run on releases and is skipped otherwise.
-        if [[ "$(Linux.status)" != "Succeeded"
+        if [[ (!("$(Linux.status)" == "Succeeded" || "$(Linux.status)" == "SucceededWithIssues")
             || "$(Linux_oracle.status)" != "Succeeded"
-            || "$(macOS.status)" != "Succeeded"
+            || !("$(macOS.status)" == "Succeeded" || "$(macOS.status)" == "SucceededWithIssues")
             || "$(Windows.status)" != "Succeeded"
             || ("$(is_release)" == "false" && "$(compatibility_linux.status)" != "Succeeded")
             || ("$(is_release)" == "false" && "$(Linux_scala_2_12.status)" != "Succeeded")

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -562,7 +562,7 @@ jobs:
         # succeed.
         #
         # release only run on releases and is skipped otherwise.
-        if [[ (!("$(Linux.status)" == "Succeeded" || "$(Linux.status)" == "SucceededWithIssues")
+        if [[ !("$(Linux.status)" == "Succeeded" || "$(Linux.status)" == "SucceededWithIssues")
             || "$(Linux_oracle.status)" != "Succeeded"
             || !("$(macOS.status)" == "Succeeded" || "$(macOS.status)" == "SucceededWithIssues")
             || "$(Windows.status)" != "Succeeded"


### PR DESCRIPTION
follow up to #10270 which caused the linux & macos builds to go
through but then screwed us over in collect_build_data. I hate CI.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
