### PR TITLE
Patch export filtering of GHC.Types.[] in damldocs

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -101,7 +101,7 @@ extractDocs extractOpts diagsLogger ideOpts fp = do
                 = MS.elems . MS.withoutKeys typeMap . Set.unions
                 $ dc_templates : MS.elems dc_choices
 
-            md_adts = mapMaybe (filterTypeByExports dc_exports) adts
+            md_adts = mapMaybe (filterTypeByExports md_name dc_exports) adts
 
         in ModuleDoc {..}
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Exports.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Exports.hs
@@ -118,8 +118,11 @@ exportsField (ExportOnly xs) ty field =
     Set.member (ExportedTypeAll ty) xs
     || Set.member (ExportedFunction field) xs
 
-filterTypeByExports :: ExportSet -> ADTDoc -> Maybe ADTDoc
-filterTypeByExports exports ad = do
+filterTypeByExports :: Modulename -> ExportSet -> ADTDoc -> Maybe ADTDoc
+filterTypeByExports (Modulename "GHC.Types") _ ad@ADTDoc{ad_name = Typename "[]"} = Just ad
+    -- GHC.Types.[] cannot be exported explicitly,
+    -- so we skip the export filtering for this type.
+filterTypeByExports _ exports ad = do
     guard (exportsType exports (ad_name ad))
     case ad of
         TypeSynDoc{} -> Just ad


### PR DESCRIPTION
The type isn't explicitly exported in GHC.Types but it should still be exported.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
