### PR TITLE
Refresh json API materialized view on statement

### DIFF
--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -627,14 +627,10 @@ private object OracleQueries extends Queries {
         ,${jsonColumn(sql"observers")}
         """
 
-  private[this] def stakeholdersPrep = DoMagicSetup(
-    sql"""CREATE MATERIALIZED VIEW LOG ON contract"""
-  )
-
   private[this] def stakeholdersView = CreateMaterializedView(
     "contract_stakeholders",
     sql"""CREATE MATERIALIZED VIEW contract_stakeholders
-          BUILD IMMEDIATE REFRESH FAST ON COMMIT AS
+          BUILD IMMEDIATE REFRESH FAST ON STATEMENT AS
           SELECT contract_id, stakeholder FROM contract,
                  json_table(json_array(signatories, observers), '$$[*][*]'
                     columns (stakeholder $partyType path '$$'))""",
@@ -645,7 +641,7 @@ private object OracleQueries extends Queries {
   )
 
   protected[this] override def initDatabaseDdls =
-    super.initDatabaseDdls ++ Seq(stakeholdersPrep, stakeholdersView, stakeholdersIndex)
+    super.initDatabaseDdls ++ Seq(stakeholdersView, stakeholdersIndex)
 
   protected[this] type DBContractKey = JsValue
 


### PR DESCRIPTION
I haven’t found any conclusive information as to why ON COMMIT doesn’t
work incrementally but
https://docs.oracle.com/en/database/oracle/oracle-database/19/adjsn/json-query-rewrite-use-materialized-view-json_table.html#GUID-8B0922ED-C0D1-45BD-9588-B7719BE4ECF0
recommends that for rewriting (which isn’t what we do here but both
involve a materialized view on json_table).

Benchmarks:

before:
InsertBenchmark.run         1000          1            1000  avgt    5  0.327 ± 0.040   s/op
InsertBenchmark.run         1000          3            1000  avgt    5  0.656 ± 0.043   s/op
InsertBenchmark.run         1000          5            1000  avgt    5  1.034 ± 0.051   s/op
InsertBenchmark.run         1000          7            1000  avgt    5  1.416 ± 0.106   s/op
InsertBenchmark.run         1000          9            1000  avgt    5  1.734 ± 0.143   s/op
QueryBenchmark.run          1000         10             N/A  avgt    5  0.071 ± 0.016   s/op

After:
Benchmark            (batchSize)  (batches)  (numContracts)  Mode  Cnt  Score   Error  Units
InsertBenchmark.run         1000          1            1000  avgt    5  0.217 ± 0.034   s/op
InsertBenchmark.run         1000          3            1000  avgt    5  0.232 ± 0.027   s/op
InsertBenchmark.run         1000          5            1000  avgt    5  0.226 ± 0.051   s/op
InsertBenchmark.run         1000          7            1000  avgt    5  0.225 ± 0.048   s/op
InsertBenchmark.run         1000          9            1000  avgt    5  0.232 ± 0.021   s/op
QueryBenchmark.run          1000         10             N/A  avgt    5 0.080 ± 0.014   s/op

The difference in query times is just noise and changes across runs.

So we get the expected behavior of inserts being independent of the
total ACS size now. We could still explore if we gain something by
avoiding the materialized view to reduce constant factors but that’s
much less of an issue.

fixes #10243

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
