### PR TITLE
Register divulgence warning as a diagnostic

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -906,12 +906,11 @@ toDiagnostic ::
     -> Either SS.Error SS.ScenarioResult
     -> Maybe FileDiagnostic
 toDiagnostic file world range = \case
-    Right (SS.scenarioResultWarnings -> warnings)
-        | V.null warnings -> Nothing
-        | otherwise -> Just $
-            mkDiagnostic DsWarning (LF.prettyWarningMessages warnings)
-    Left err -> Just $
-        mkDiagnostic DsError (formatScenarioError world err)
+    Left err -> Just $ mkDiagnostic DsError $ formatScenarioError world err
+    Right SS.ScenarioResult{..}
+        | V.null scenarioResultWarnings -> Nothing
+        | otherwise -> Just $ mkDiagnostic DsWarning $
+            LF.prettyWarningMessages scenarioResultWarnings
   where
     mkDiagnostic severity pretty = (file, ShowDiag, ) $ Diagnostic
         { _range = range

--- a/compiler/damlc/tests/daml-test-files/DiscloseViaChoiceObserver.daml
+++ b/compiler/damlc/tests/daml-test-files/DiscloseViaChoiceObserver.daml
@@ -4,6 +4,7 @@
 module DiscloseViaChoiceObserver where
 
 -- @SINCE-LF 1.11
+-- @WARN range=27:1-27:5; Use of divulged contracts is deprecated
 
 -- This example demonstrates the canonical use of choice-observers to achieve disclosure.
 

--- a/compiler/damlc/tests/daml-test-files/Divulgence.daml
+++ b/compiler/damlc/tests/daml-test-files/Divulgence.daml
@@ -44,7 +44,7 @@ template DisclosureDelegation
         do
           fetch secretCid -- actor will divulge secretCid to p
 
-
+-- @WARN range=48:1-48:5; Use of divulged contracts is deprecated
 main = scenario do
   me <- getParty "Me"
   spy <- getParty "Spy"

--- a/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
@@ -2,9 +2,10 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SINCE-LF-FEATURE DAML_EXCEPTIONS
--- @ERROR range=130:1-130:23; Unhandled exception: ExceptionSemantics:E
--- @ERROR range=145:1-145:25; Unhandled exception: DA.Exception.ArithmeticError:ArithmeticError@cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a with message = "ArithmeticError while evaluating (DIV_INT64 1 0)."
--- @ERROR range=182:1-182:11; Attempt to exercise a consumed contract
+-- @ERROR range=131:1-131:23; Unhandled exception: ExceptionSemantics:E
+-- @ERROR range=146:1-146:25; Unhandled exception: DA.Exception.ArithmeticError:ArithmeticError@cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a with message = "ArithmeticError while evaluating (DIV_INT64 1 0)."
+-- @WARN range=172:1-172:11; Use of divulged contracts is deprecated
+-- @ERROR range=183:1-183:11; Attempt to exercise a consumed contract
 module ExceptionSemantics where
 
 import DA.Exception

--- a/compiler/damlc/tests/daml-test-files/MoreChoiceObserverDivulgence.daml
+++ b/compiler/damlc/tests/daml-test-files/MoreChoiceObserverDivulgence.daml
@@ -30,6 +30,7 @@ template Divulger with
         _ <- fetch id
         pure ()
 
+-- @WARN range=35:1-35:5; Use of divulged contracts is deprecated
 test : Scenario ()
 test = scenario do
     alice <- getParty "Alice"

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -7,6 +7,7 @@ module DA.Daml.LF.PrettyScenario
   ( prettyScenarioResult
   , prettyScenarioError
   , prettyBriefScenarioError
+  , prettyWarningMessages
   , renderScenarioResult
   , renderScenarioError
   , lookupDefLocation
@@ -124,6 +125,11 @@ parseNodeId =
   where
     dropHash s = fromMaybe s $ stripPrefix "#" s
 
+prettyWarningMessages
+  :: V.Vector WarningMessage -> Doc SyntaxClass
+prettyWarningMessages warnings
+  = vcat (map prettyWarningMessage (V.toList warnings))
+
 prettyScenarioResult
   :: LF.World -> ScenarioResult -> Doc SyntaxClass
 prettyScenarioResult world (ScenarioResult steps nodes retValue _finaltime traceLog warnings) =
@@ -136,7 +142,7 @@ prettyScenarioResult world (ScenarioResult steps nodes retValue _finaltime trace
         $ filter isActive (V.toList nodes)
 
       ppTrace = vcat $ map prettyTraceMessage (V.toList traceLog)
-      ppWarnings = vcat $ map prettyWarningMessage (V.toList warnings)
+      ppWarnings = prettyWarningMessages warnings
   in vsep
     [ label_ "Transactions: " ppSteps
     , label_ "Active contracts: " ppActive


### PR DESCRIPTION
With this PR, the divulgence warnings for a scenario are registered as a diagnostic
when there isn't a scenario error. (Rationale: Scenario errors already
include the warnings in their text, after trace log entries.)

Part of #9947, follow up from #10253

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
