### PR TITLE
Indexer ValidateAndWaitOnly startup mode for canton participant HA

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerStartupMode.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerStartupMode.scala
@@ -15,4 +15,6 @@ object IndexerStartupMode {
 
   case object MigrateOnly extends IndexerStartupMode
 
+  case object ValidateAndWaitOnly extends IndexerStartupMode
+
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -87,6 +87,13 @@ object JdbcIndexer {
         resourceContext: ResourceContext
     ): Future[ResourceOwner[Indexer]] = initialized(resetSchema = true)
 
+    def validateAndWaitOnly()(implicit
+        resourceContext: ResourceContext
+    ): Future[ResourceOwner[Indexer]] =
+      flywayMigrations
+        .validateAndWaitOnly(config.enableAppendOnlySchema)
+        .flatMap(_ => initialized(resetSchema = false))(resourceContext.executionContext)
+
     private[this] def initializedMutatingSchema(
         resetSchema: Boolean
     )(implicit resourceContext: ResourceContext): Future[ResourceOwner[Indexer]] =

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -89,10 +89,9 @@ object JdbcIndexer {
 
     def validateAndWaitOnly()(implicit
         resourceContext: ResourceContext
-    ): Future[ResourceOwner[Indexer]] =
+    ): Future[Unit] =
       flywayMigrations
         .validateAndWaitOnly(config.enableAppendOnlySchema)
-        .flatMap(_ => initialized(resetSchema = false))(resourceContext.executionContext)
 
     private[this] def initializedMutatingSchema(
         resetSchema: Boolean

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -69,6 +69,13 @@ final class StandaloneIndexerServer(
             logger.debug("Waiting for the indexer to initialize the database.")
             healthReporter
           }
+      case IndexerStartupMode.ValidateAndWaitOnly =>
+        Resource
+          .fromFuture(indexerFactory.validateAndWaitOnly())
+          .map[ReportsHealth] { _ =>
+            logger.debug("Waiting for the indexer to validate the schema migrations.")
+            () => HealthStatus.healthy
+          }
     }
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
@@ -83,14 +83,14 @@ private[platform] class FlywayMigrations(jdbcUrl: String)(implicit loggingContex
       @tailrec
       def flywayMigrationDone(
           retries: Int,
-          needLessThan: Option[Int],
+          pendingMigrationsSoFar: Option[Int],
       ): Unit = {
         val pendingMigrations = flyway.info().pending().length
         if (pendingMigrations == 0) {
           ()
         } else if (retries <= 0) {
           throw ExhaustedRetries(pendingMigrations)
-        } else if (needLessThan.exists(pendingMigrations >= _)) {
+        } else if (pendingMigrationsSoFar.exists(pendingMigrations >= _)) {
           throw StoppedProgressing(pendingMigrations)
         } else {
           logger.debug(


### PR DESCRIPTION
Port of change from canton: https://github.com/DACH-NY/canton/pull/6556 but avoids reuse of existing indexer startup mode.

Implementation per "Design: Indexer HA Support for Canton" doc. - fyi @dasormeter , @nmarton-da , @mziolekda , @soren-da


### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
