### PR TITLE
[JSON-API] Log json request & response bodies in debug

### DIFF
--- a/ledger-service/http-json/src/main/resources/logback.xml
+++ b/ledger-service/http-json/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
                 <!-- encoders are assigned the type
                     ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
                 <encoder>
-                    <pattern>%date{"dd-MM-yyyy HH:mm:ss.SSS", UTC} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+                    <pattern>%date{"dd-MM-yyyy HH:mm:ss.SSS", UTC} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
                 </encoder>
             </else>
         </if>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -15,7 +15,7 @@ import akka.http.scaladsl.model.headers.{
 }
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives.extractClientIP
-import akka.http.scaladsl.server.{Directive, Directive0, PathMatcher, Route}
+import akka.http.scaladsl.server.{Directive0, PathMatcher, Route}
 import akka.http.scaladsl.server.RouteResult._
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Source}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -10,10 +10,12 @@ import akka.http.scaladsl.model.headers.{
   ModeledCustomHeader,
   ModeledCustomHeaderCompanion,
   OAuth2BearerToken,
+  `Content-Type`,
   `X-Forwarded-Proto`,
 }
+import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives.extractClientIP
-import akka.http.scaladsl.server.{Directive0, Route}
+import akka.http.scaladsl.server.{Directive, Directive0, PathMatcher, Route}
 import akka.http.scaladsl.server.RouteResult._
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Source}
@@ -77,17 +79,84 @@ class Endpoints(
   private def toRoute(res: => Future[Error \/ SearchResult[Error \/ JsValue]]): Route =
     responseToRoute(httpResponse(res))
 
+  // Always put this directive after a path to ensure
+  // that you don't log request bodies multiple times (simply because a matching test was made multiple times).
+  // TL;DR JUST PUT THIS THING AFTER YOUR FINAL PATH MATCHING
+  def logJsonRequestAndResult(implicit
+      lc: LoggingContextOf[InstanceUUID with RequestID]
+  ): Directive0 =
+    extractRequest & extractClientIP tflatMap { case (request, remoteAddress) =>
+      def logWithHttpMessageBodyIfAvailable(
+          httpMessage: HttpMessage,
+          msg: String,
+          bodyKind: String,
+      ): Future[Unit] =
+        if (
+          httpMessage
+            .header[`Content-Type`]
+            .map(_.contentType)
+            .contains(ContentTypes.`application/json`)
+        )
+          httpMessage
+            .entity()
+            .toStrict(maxTimeToCollectRequest)
+            .map(_.data.utf8String)
+            .map(_.parseJson)
+            .map(body =>
+              withEnrichedLoggingContext(
+                LoggingContextOf.label[RequestEntity],
+                s"$bodyKind-body" -> body,
+              )
+                .run(implicit lc => logger.debug(msg))
+            )
+            .recover { case ex =>
+              logger.error("Failed to extract body for logging", ex)
+            }
+        else Future.successful(logger.debug(msg))
+      mapRouteResultFuture { responseF =>
+        for {
+          _ <- logWithHttpMessageBodyIfAvailable(
+            request,
+            s"Incoming ${request.method} request on ${request.uri} from $remoteAddress",
+            "request",
+          )
+          response <- responseF
+          _ <- response match {
+            case Complete(httpResponse) =>
+              logWithHttpMessageBodyIfAvailable(
+                httpResponse,
+                s"Responding to client with HTTP ${httpResponse.status}",
+                "response",
+              )
+            case _ =>
+              Future.failed _ apply
+                new RuntimeException(
+                  """Logging the request & response should never happen on routes which get rejected.
+                    |Make sure to place the directive only at places where a match is guaranteed (e.g. after the path directive).""".stripMargin
+                )
+          }
+        } yield response
+      }
+    }
+
   def all(implicit
       lc0: LoggingContextOf[InstanceUUID],
       metrics: Metrics,
-  ): Route = extractClientIP & extractRequest apply { (remoteAddress, req) =>
+  ): Route = extractRequest apply { req =>
     implicit val lc: LoggingContextOf[InstanceUUID with RequestID] =
       extendWithRequestIdLogCtx(identity)(lc0)
     import metrics.daml.HttpJsonApi._
+    def path[L](pm: PathMatcher[L]) = server.Directives.path(pm) & logJsonRequestAndResult
     def withTimer(timer: Timer) =
-      Directive[Unit] { (fn: Unit => Route) =>
-        logger.info(s"Incoming request on ${req.uri} from $remoteAddress")
-        fn(()).andThen(res => Timed.future(timer, res))
+      Directive { (fn: Unit => Route) =>
+        val t0 = System.nanoTime
+        metrics.daml.HttpJsonApi.httpRequestThroughput.mark()
+        fn(()).andThen(res =>
+          for {
+            res <- Timed.future(timer, res)
+            _ = logger.trace(s"Processed request after ${System.nanoTime() - t0}ns")
+          } yield res
+        )
       }
     val withCmdSubmitTimer: Directive0 = withTimer(commandSubmissionTimer)
     val withFetchTimer: Directive0 = withTimer(fetchTimer)

--- a/libs-scala/contextualized-logging/BUILD.bazel
+++ b/libs-scala/contextualized-logging/BUILD.bazel
@@ -13,6 +13,7 @@ da_scala_library(
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:io_spray_spray_json",
     ],
     scalacopts = ["-Xsource:2.13"],
     tags = ["maven_coordinates=com.daml:contextualized-logging:__VERSION__"],

--- a/libs-scala/logging-entries/BUILD.bazel
+++ b/libs-scala/logging-entries/BUILD.bazel
@@ -10,6 +10,9 @@ load(
 da_scala_library(
     name = "logging-entries",
     srcs = glob(["src/main/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:io_spray_spray_json",
+    ],
     scalacopts = ["-Xsource:2.13"],
     tags = ["maven_coordinates=com.daml:logging-entries:__VERSION__"],
     visibility = [

--- a/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/LoggingValue.scala
+++ b/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/LoggingValue.scala
@@ -3,6 +3,8 @@
 
 package com.daml.logging.entries
 
+import spray.json.JsValue
+
 import scala.language.implicitConversions
 
 sealed trait LoggingValue
@@ -29,6 +31,8 @@ object LoggingValue {
   final case class OfIterable(sequence: Iterable[LoggingValue]) extends LoggingValue
 
   final case class Nested(entries: LoggingEntries) extends LoggingValue
+
+  final case class OfJson(json: JsValue) extends LoggingValue
 
   @inline
   implicit def from[T](value: T)(implicit toLoggingValue: ToLoggingValue[T]): LoggingValue =

--- a/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/ToLoggingValue.scala
+++ b/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/ToLoggingValue.scala
@@ -3,6 +3,8 @@
 
 package com.daml.logging.entries
 
+import spray.json.JsValue
+
 import java.time.{Duration, Instant}
 
 trait ToLoggingValue[-T] {
@@ -12,6 +14,8 @@ trait ToLoggingValue[-T] {
 object ToLoggingValue {
   // This is not implicit because we only want to expose it for specific types.
   val ToStringToLoggingValue: ToLoggingValue[Any] = value => LoggingValue.OfString(value.toString)
+
+  implicit val `JsValue to LoggingValue`: ToLoggingValue[JsValue] = LoggingValue.OfJson(_)
 
   implicit val `String to LoggingValue`: ToLoggingValue[String] = LoggingValue.OfString(_)
 


### PR DESCRIPTION
This also readds logging of incoming requests and the responses which are being send out.

changelog_begin

- [JSON-API] You can now find for appropriate requests in the debug logs the request and response body within the logging context (The field names are "request-body" and "response-body")

changelog_end

Fixes #10122

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [x] This was manually tested and worked great :star_struck: 

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
