### PR TITLE
LF: use Either by default in all archive reader API

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
@@ -224,7 +224,7 @@ class ReplService(
       req: LoadPackageRequest,
       respObs: StreamObserver[LoadPackageResponse],
   ): Unit = {
-    val (pkgId, pkg) = archive.ArchiveDecoder.fromByteString(req.getPackage)
+    val (pkgId, pkg) = archive.ArchiveDecoder.assertFromByteString(req.getPackage)
     val newSignatures = signatures.updated(pkgId, AstUtil.toSignature(pkg))
     val newCompiledDefinitions = compiledDefinitions ++
       new Compiler(new language.Interface(newSignatures), compilerConfig)
@@ -240,7 +240,7 @@ class ReplService(
       respObs: StreamObserver[RunScriptResponse],
   ): Unit = {
     val lfVer = LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor(req.getMinor))
-    val mod = archive.moduleDecoder(lfVer, homePackageId).fromByteString(req.getDamlLf1)
+    val mod = archive.moduleDecoder(lfVer, homePackageId).assertFromByteString(req.getDamlLf1)
     val pkg = Package((mainModules + (mod.name -> mod)).values, Seq(), lfVer, None)
     // TODO[AH] Provide daml-script package id from REPL client.
     val Some(scriptPackageId) = this.signatures.collectFirst {

--- a/compiler/scenario-service/server/BUILD.bazel
+++ b/compiler/scenario-service/server/BUILD.bazel
@@ -30,7 +30,6 @@ da_scala_binary(
     deps = [
         "//compiler/scenario-service/protos:scenario_service_java_proto",
         "//daml-lf/archive:daml_lf_archive_reader",
-        "//daml-lf/archive:daml_lf_dev_archive_proto_java",
         "//daml-lf/data",
         "//daml-lf/interpreter",
         "//daml-lf/language",

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -87,15 +87,13 @@ class Context(val contextId: Context.ContextId, languageVersion: LanguageVersion
   ): Unit = synchronized {
 
     val newModules = loadModules.map(module =>
-      archive.moduleDecoder(languageVersion, homePackageId).fromByteString(module.getDamlLf1)
+      archive.moduleDecoder(languageVersion, homePackageId).assertFromByteString(module.getDamlLf1)
     )
     modules --= unloadModules
     newModules.foreach(mod => modules += mod.name -> mod)
 
     val newPackages =
-      loadPackages.map { bytes =>
-        archive.Decode.decodeArchive(archive.ArchiveParser.fromByteString(bytes))
-      }.toMap
+      loadPackages.map(archive.ArchiveDecoder.assertFromByteString).toMap
 
     val modulesToCompile =
       if (unloadPackages.nonEmpty || newPackages.nonEmpty) {

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -13,6 +13,7 @@ import com.daml.lf.data.{Decimal, ImmArray, Numeric, Struct, Time}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.Util._
 import com.daml.lf.language.{LanguageVersion => LV}
+import com.daml.nameof.NameOf
 
 import scala.Ordering.Implicits.infixOrderingOps
 import scala.collection.compat._
@@ -29,7 +30,7 @@ private[archive] class DecodeV1(minor: LV.Minor) {
       packageId: PackageId,
       lfPackage: PLF.Package,
       onlySerializableDataDefs: Boolean,
-  ): Package = {
+  ): Either[Error, Package] = attempt(NameOf.qualifiedNameOfCurrentFunc) {
     val internedStrings: ImmArraySeq[String] = ImmArraySeq(
       lfPackage.getInternedStringsList.asScala.toSeq: _*
     )
@@ -90,7 +91,10 @@ private[archive] class DecodeV1(minor: LV.Minor) {
   // each LF scenario module is wrapped in a distinct proto package
   type ProtoScenarioModule = PLF.Package
 
-  def decodeScenarioModule(packageId: PackageId, lfScenarioModule: ProtoScenarioModule): Module = {
+  def decodeScenarioModule(
+      packageId: PackageId,
+      lfScenarioModule: ProtoScenarioModule,
+  ): Either[Error, Module] = attempt(NameOf.qualifiedNameOfCurrentFunc) {
 
     val internedStrings =
       ImmArray(lfScenarioModule.getInternedStringsList.asScala).toSeq

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/GenDarReader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/GenDarReader.scala
@@ -81,8 +81,7 @@ private[archive] final class GenDarReaderImpl[A](reader: GenReader[A]) extends G
       darStream: ZipInputStream,
       entrySizeThreshold: Int,
   ): Either[Error, ZipEntries] =
-    attempt(
-      NameOf.qualifiedNameOfCurrentFunc,
+    attempt(NameOf.qualifiedNameOfCurrentFunc)(
       ZipEntries(
         name,
         Iterator
@@ -90,7 +89,7 @@ private[archive] final class GenDarReaderImpl[A](reader: GenReader[A]) extends G
           .takeWhile(_ != null)
           .map(entry => slurpWithCaution(entry.getName, darStream, entrySizeThreshold))
           .toMap,
-      ),
+      )
     )
 
   private[this] def parseAll(getPayload: String => Either[Error, Bytes])(
@@ -101,9 +100,7 @@ private[archive] final class GenDarReaderImpl[A](reader: GenReader[A]) extends G
   private[this] def parseOne(
       getPayload: String => Either[Error, Bytes]
   )(s: String): Either[Error, A] =
-    getPayload(s).flatMap(bytes =>
-      attempt(NameOf.qualifiedNameOfCurrentFunc, reader.fromBytes(bytes))
-    )
+    getPayload(s).flatMap(reader.fromBytes)
 
 }
 

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/GenReader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/GenReader.scala
@@ -8,27 +8,37 @@ import com.google.protobuf.{ByteString, CodedInputStream}
 
 import scala.util.Using
 
-final class GenReader[X] private[archive] (val fromCodedInputStream: CodedInputStream => X) {
+final class GenReader[X] private[archive] (
+    val fromCodedInputStream: CodedInputStream => Either[Error, X]
+) {
 
-  def fromInputStream(is: java.io.InputStream): X =
+  def fromInputStream(is: java.io.InputStream): Either[Error, X] =
     fromCodedInputStream(CodedInputStream.newInstance(is))
 
-  def fromByteArray(bytes: Array[Byte]): X =
+  def fromByteArray(bytes: Array[Byte]): Either[Error, X] =
     fromCodedInputStream(CodedInputStream.newInstance(bytes))
 
-  def fromByteString(bytes: ByteString): X =
+  @throws[Error]
+  def assertFromByteArray(bytes: Array[Byte]): X =
+    assertRight(fromByteArray(bytes))
+
+  def fromByteString(bytes: ByteString): Either[Error, X] =
     fromCodedInputStream(CodedInputStream.newInstance(bytes.asReadOnlyByteBuffer()))
 
-  def fromBytes(bytes: data.Bytes): X =
+  @throws[Error]
+  def assertFromByteString(bytes: ByteString) =
+    assertRight(fromByteString(bytes))
+
+  def fromBytes(bytes: data.Bytes): Either[Error, X] =
     fromByteString(bytes.toByteString)
 
-  def fromFile(file: java.nio.file.Path): X =
+  def fromFile(file: java.nio.file.Path): Either[Error, X] =
     Using.resource(java.nio.file.Files.newInputStream(file))(fromInputStream)
 
-  def fromFile(file: java.io.File): X =
+  def fromFile(file: java.io.File): Either[Error, X] =
     fromFile(file.toPath)
 
-  private[archive] def andThen[Y](f: X => Y): GenReader[Y] =
-    new GenReader(x => f(fromCodedInputStream(x)))
+  private[archive] def andThen[Y](f: X => Either[Error, Y]): GenReader[Y] =
+    new GenReader(fromCodedInputStream(_).flatMap(f))
 
 }

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/UniversalArchiveReader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/UniversalArchiveReader.scala
@@ -4,8 +4,6 @@
 package com.daml.lf
 package archive
 
-import com.daml.nameof.NameOf
-
 import java.io.File
 
 /** Can parse DARs and DALFs.
@@ -23,7 +21,7 @@ final class GenUniversalArchiveReader[A](
       case SupportedFileType.DarFile =>
         GenDarReader(reader).readArchiveFromFile(file, entrySizeThreshold)
       case SupportedFileType.DalfFile =>
-        attempt(NameOf.qualifiedNameOfCurrentFunc, Dar(reader.fromFile(file), List.empty))
+        reader.fromFile(file).map(Dar(_, List.empty))
     }
 
   @throws[Error]

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeMain.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeMain.scala
@@ -25,7 +25,7 @@ object DecodeMain extends App {
     val archives = DarReader.assertReadArchiveFromFile(new File(args(0)))
     val t1 = System.nanoTime()
 
-    val _: (Ref.PackageId, Ast.Package) = Decode.decodeArchivePayload(archives.main)
+    val _: (Ref.PackageId, Ast.Package) = Decode.assertDecodeArchivePayload(archives.main)
     val t2 = System.nanoTime()
 
     println(s"parseFrom in ${toMillis(t0, t1)}ms, decoded in ${toMillis(t1, t2)}ms.")

--- a/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
+++ b/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
@@ -162,7 +162,7 @@ class EncodeV1Spec extends AnyWordSpec with Matchers with TableDrivenPropertyChe
       validate(pkgId, pkg)
       val archive =
         Encode.encodeArchive(pkgId -> pkg, defaultParserParameters.languageVersion)
-      val (hash, decodedPackage) = Decode.decodeArchive(archive)
+      val (hash, decodedPackage) = Decode.assertDecodeArchive(archive)
 
       val pkg1 = normalize(decodedPackage, hash, pkgId)
       pkg shouldBe pkg1

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/DamlLfArchiveReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/DamlLfArchiveReader.scala
@@ -8,29 +8,25 @@ package reader
 import com.daml.lf.data.Ref
 import com.daml.lf.language.Ast
 import com.daml.daml_lf_dev.DamlLf
-import com.daml.lf.archive.{ArchivePayload, Decode, Reader}
-import com.google.protobuf.InvalidProtocolBufferException
 import scalaz.\/
 
 object DamlLfArchiveReader {
 
-  def readPackage(lf: DamlLf.Archive): String \/ (Ref.PackageId, Ast.Package) =
-    readPayload(lf) flatMap readPackage
+  private[this] def fromEither[X](either: Either[archive.Error, X]) =
+    \/.fromEither(either).leftMap(err => s"Cannot parse archive: $err")
 
-  private[this] def readPayload(lf: DamlLf.Archive): String \/ ArchivePayload =
-    \/.attempt(Reader.readArchive(lf))(errorMessage)
+  def readPackage(lf: DamlLf.Archive): String \/ (Ref.PackageId, Ast.Package) =
+    fromEither(archive.Reader.readArchive(lf)) flatMap readPackage
+
+  def readPackage(
+      packageId: Ref.PackageId,
+      lf: DamlLf.ArchivePayload,
+  ): String \/ (Ref.PackageId, Ast.Package) =
+    fromEither(archive.Reader.readArchivePayload(packageId, lf)) flatMap readPackage
 
   private[iface] def readPackage(
-      payLoad: ArchivePayload
+      payLoad: archive.ArchivePayload
   ): String \/ (Ref.PackageId, Ast.Package) =
-    \/.attempt(Decode.decodeArchivePayload(payLoad, onlySerializableDataDefs = true))(
-      errorMessage
-    )
-
-  private def errorMessage(t: Throwable): String = t match {
-    case x: InvalidProtocolBufferException => s"Cannot parse protocol message: ${x.getMessage}"
-    case err: archive.Error => s"Cannot parse archive: $err"
-    case _ => s"Unexpected exception: ${t.getMessage}"
-  }
+    fromEither(archive.Decode.decodeArchivePayload(payLoad, onlySerializableDataDefs = true))
 
 }

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -6,7 +6,7 @@ package iface
 package reader
 
 import com.daml.daml_lf_dev.DamlLf
-import com.daml.lf.archive.{ArchivePayload, Reader}
+import com.daml.lf.archive.ArchivePayload
 import scalaz.{Enum => _, _}
 import scalaz.syntax.monoid._
 import scalaz.syntax.traverse._
@@ -84,7 +84,7 @@ object InterfaceReader {
       packageId: Ref.PackageId,
       damlLf: DamlLf.ArchivePayload,
   ): (Errors[ErrorLoc, InvalidDataTypeDefinition], iface.Interface) =
-    readInterface(Reader.readArchivePayload(packageId, damlLf))
+    readInterface(() => DamlLfArchiveReader.readPackage(packageId, damlLf))
 
   def readInterface(
       payload: ArchivePayload

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
@@ -25,6 +25,15 @@ sealed abstract class LanguageMajorVersion(val pretty: String, minorAscending: N
 
   final def supportsMinorVersion(fromLFFile: String): Boolean =
     isAcceptedVersion(fromLFFile).isDefined
+
+  final def toVersion(minorVersion: String) =
+    if (supportsMinorVersion(minorVersion)) {
+      Right(LanguageVersion(this, LanguageMinorVersion(minorVersion)))
+    } else {
+      val supportedVersions = acceptedVersions.map(v => s"$this.${v.identifier}")
+      Left(s"LF $this.$minorVersion unsupported. Supported LF versions are ${supportedVersions
+        .mkString(",")}")
+    }
 }
 
 object LanguageMajorVersion {

--- a/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
@@ -32,7 +32,8 @@ object Dependencies {
         case p :: todo =>
           client.packageClient.getPackage(p).flatMap { pkgResp =>
             val pkgId = PackageId.assertFromString(pkgResp.hash)
-            val pkg = archive.archivePayloadDecoder(pkgId).fromByteString(pkgResp.archivePayload)
+            val pkg =
+              archive.archivePayloadDecoder(pkgId).assertFromByteString(pkgResp.archivePayload)._2
             go(todo ++ pkg.directDeps, acc + (pkgId -> ((pkgResp.archivePayload, pkg))))
           }
       }

--- a/ledger-service/utils/src/main/scala/com/digitalasset/ledger/service/LedgerReader.scala
+++ b/ledger-service/utils/src/main/scala/com/digitalasset/ledger/service/LedgerReader.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.service
 
-import com.daml.lf.archive.ArchivePayloadParser
+import com.daml.lf.archive
 import com.daml.lf.data.Ref.{Identifier, PackageId}
 import com.daml.lf.iface.reader.InterfaceReader
 import com.daml.lf.iface.{DefDataType, Interface}
@@ -68,7 +68,7 @@ object LedgerReader {
   ): Error \/ Interface = {
     import packageResponse._
     \/.attempt {
-      val payload = ArchivePayloadParser.fromByteString(archivePayload)
+      val payload = archive.ArchivePayloadParser.assertFromByteString(archivePayload)
       val (errors, out) =
         InterfaceReader.readInterface(PackageId.assertFromString(hash), payload)
       (if (!errors.empty) -\/("Errors reading LF archive:\n" + errors.toString)

--- a/ledger/participant-integration-api/src/main/scala/platform/packages/DeduplicatingPackageLoader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/packages/DeduplicatingPackageLoader.scala
@@ -45,7 +45,7 @@ private[platform] class DeduplicatingPackageLoader() {
           metric,
           delegate(packageId)
             .flatMap(archiveO =>
-              Future.fromTry(Try(archiveO.map(archive => Decode.decodeArchive(archive)._2)))
+              Future.fromTry(Try(archiveO.map(archive => Decode.assertDecodeArchive(archive)._2)))
             ),
         )
       future.onComplete {

--- a/ledger/participant-integration-api/src/main/scala/platform/packages/InMemoryPackageStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/packages/InMemoryPackageStore.scala
@@ -97,7 +97,7 @@ private[platform] case class InMemoryPackageStore(
     archives
       .traverse(proto =>
         try {
-          Right((proto, archive.Decode.decodeArchive(proto)._2))
+          Right((proto, archive.Decode.assertDecodeArchive(proto)._2))
         } catch {
           case err: archive.Error => Left(s"Could not parse archive ${proto.getHash}: $err")
         }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -169,7 +169,7 @@ private[platform] abstract class BaseLedger(
     ledgerDao
       .getLfArchive(packageId)
       .flatMap(archiveO =>
-        Future.fromTry(Try(archiveO.map(archive => Decode.decodeArchive(archive)._2)))
+        Future.fromTry(Try(archiveO.map(archive => Decode.assertDecodeArchive(archive)._2)))
       )(
         DEC
       )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -464,7 +464,7 @@ private class JdbcLedgerDao(
   )(implicit loggingContext: LoggingContext): Future[Option[Archive]] =
     dbDispatcher
       .executeSql(metrics.daml.index.db.loadArchive)(storageBackend.lfArchive(packageId))
-      .map(_.map(data => ArchiveParser.fromByteArray(data)))(
+      .map(_.map(data => ArchiveParser.assertFromByteArray(data)))(
         servicesExecutionContext
       )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -692,7 +692,7 @@ private class JdbcLedgerDao(
           )
           .as[Option[Array[Byte]]](SqlParser.byteArray("package").singleOpt)
       }
-      .map(_.map(data => ArchiveParser.fromByteArray(data)))(
+      .map(_.map(data => ArchiveParser.assertFromByteArray(data)))(
         servicesExecutionContext
       )
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -193,7 +193,7 @@ final private[kvutils] class PackageCommitter(
       archives
         .foldLeft[Result](Right(Map.empty)) { (acc, arch) =>
           try {
-            acc.map(_ + lf.archive.Decode.decodeArchive(arch))
+            acc.map(_ + lf.archive.Decode.assertDecodeArchive(arch))
           } catch {
             case NonFatal(e) =>
               Left(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
@@ -154,13 +154,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
           case DamlStateValue.ValueCase.ARCHIVE =>
             // NOTE(JM): Engine only looks up packages once, compiles and caches,
             // provided that the engine instance is persisted.
-            try {
-              Some(archive.Decode.decodeArchive(value.getArchive)._2)
-            } catch {
-              case err: archive.Error =>
-                logger.warn("Decoding the archive failed.")
-                throw Err.DecodeError("Archive", err.getMessage)
-            }
+            Some(archive.Decode.assertDecodeArchive(value.getArchive)._2)
 
           case _ =>
             val msg = "value is not a Daml-LF archive"

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
@@ -154,7 +154,12 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
           case DamlStateValue.ValueCase.ARCHIVE =>
             // NOTE(JM): Engine only looks up packages once, compiles and caches,
             // provided that the engine instance is persisted.
-            Some(archive.Decode.assertDecodeArchive(value.getArchive)._2)
+            archive.Decode.decodeArchive(value.getArchive) match {
+              case Right((_, pkg)) => pkg
+              case Left(err) =>
+                logger.warn("Decoding the archive failed.")
+                throw Err.DecodeError("Archive", err.getMessage)
+            }
 
           case _ =>
             val msg = "value is not a Daml-LF archive"

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -724,7 +724,7 @@ object ParticipantStateIntegrationSpecBase {
     archives
       .sortBy(_.getSerializedSize) // look at the smallest archives first to limit decoding work
       .iterator
-      .filter(Decode.decodeArchive(_)._2.directDeps.isEmpty)
+      .filter(Decode.assertDecodeArchive(_)._2.directDeps.isEmpty)
       .take(2)
       .toList
 

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/SimplePackage.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/SimplePackage.scala
@@ -24,7 +24,7 @@ class SimplePackage(testDar: TestDar) {
     (Ref.PackageId.assertFromString(archive.getHash), archive)
   }.toMap
 
-  val packages: Map[Ref.PackageId, Ast.Package] = dar.all.map(Decode.decodeArchive(_)).toMap
+  val packages: Map[Ref.PackageId, Ast.Package] = dar.all.map(Decode.assertDecodeArchive(_)).toMap
 
   val mainArchive: DamlLf.Archive = dar.main
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
@@ -51,8 +51,7 @@ class PackageCommitterSpec extends AnyWordSpec with Matchers with ParallelTestEx
         }
       """
     )
-    pkgWithId = Decode.decodeArchive(archive)
-    (pkgId, pkg) = pkgWithId
+    (pkgId, pkg) = Decode.assertDecodeArchive(archive)
   } yield (pkg, pkgId, archive)
 
   // [libraryArchive] contains another well-typed and self-consistent package
@@ -65,7 +64,7 @@ class PackageCommitterSpec extends AnyWordSpec with Matchers with ParallelTestEx
         }
       """
   )
-  val (libraryPackageId, libraryPackage) = Decode.decodeArchive(libraryArchive)
+  val (libraryPackageId, libraryPackage) = Decode.assertDecodeArchive(libraryArchive)
 
   // [dependentArchive] contains a well-typed package that depends on [libraryArchive]
   private[this] val dependentArchive = encodePackage(
@@ -77,7 +76,7 @@ class PackageCommitterSpec extends AnyWordSpec with Matchers with ParallelTestEx
         }
       """
   )
-  val (dependentPackageId, _) = Decode.decodeArchive(dependentArchive)
+  val (dependentPackageId, _) = Decode.assertDecodeArchive(dependentArchive)
 
   private[this] val participantId = Ref.ParticipantId.assertFromString("participant")
 

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/BenchmarkWithLedgerExport.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/BenchmarkWithLedgerExport.scala
@@ -42,7 +42,7 @@ abstract class BenchmarkWithLedgerExport {
         case Envelope.SubmissionMessage(submission)
             if submission.getPayloadCase == DamlSubmission.PayloadCase.PACKAGE_UPLOAD_ENTRY =>
           for (archive <- submission.getPackageUploadEntry.getArchivesList.asScala) {
-            builder += Decode.decodeArchive(archive)
+            builder += Decode.assertDecodeArchive(archive)
           }
         case Envelope.SubmissionMessage(submission)
             if submission.getPayloadCase == DamlSubmission.PayloadCase.TRANSACTION_ENTRY =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformSubscriber.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformSubscriber.scala
@@ -301,7 +301,7 @@ class PlatformSubscriber(
   }
 
   private def decodePackage(res: GetPackageResponse) = {
-    val payload = ArchivePayloadParser.fromByteString(res.archivePayload)
+    val payload = ArchivePayloadParser.assertFromByteString(res.archivePayload)
     val (errors, out) =
       InterfaceReader.readInterface(DamlLfRef.PackageId.assertFromString(res.hash), payload)
     if (!errors.equals(Errors.zeroErrors)) {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -71,7 +71,7 @@ class Server(
   private def addPackagesInMemory(pkgs: List[(PackageId, DamlLf.ArchivePayload)]): Unit = {
     // We store decoded packages in memory
     val pkgMap = pkgs.map { case (pkgId, payload) =>
-      Decode.decodeArchivePayload(Reader.readArchivePayload(pkgId, payload))
+      Decode.assertDecodeArchivePayload(Reader.readArchivePayload(pkgId, payload).toTry.get)
     }.toMap
 
     // `addPackage` returns a ResultNeedPackage if a dependency is not yet uploaded.

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
@@ -26,7 +26,7 @@ import com.daml.doobie.logging.Slf4jLogHandler
 import javax.sql.DataSource
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 import scala.language.existentials
 import scala.util.control.NonFatal
 
@@ -182,10 +182,10 @@ abstract class DbTriggerDao protected (
   ): Either[String, (PackageId, DamlLf.ArchivePayload)] =
     for {
       pkgId <- PackageId.fromString(pkgIdString)
-      payload <- Try(ArchivePayloadParser.fromByteArray(pkgPayload)) match {
-        case Failure(err) => Left(s"Failed to parse package with id $pkgId.\n" ++ err.toString)
-        case Success(pkg) => Right(pkg)
-      }
+      payload <- ArchivePayloadParser
+        .fromByteArray(pkgPayload)
+        .left
+        .map(err => s"Failed to parse package with id $pkgId.\n" + err.toString)
     } yield (pkgId, payload)
 
   private def selectAllTriggers: ConnectionIO[Vector[RunningTrigger]] = {


### PR DESCRIPTION
This is a follow up of #10277.
This is part of #9974.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
