### PR TITLE
Ledger API Test Tool: add a `--max-connection-attempts` command line option [KVL-977]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -77,6 +77,7 @@ object Cli {
 
     arg[(String, Int)]("[endpoints...]")(endpointRead)
       .action((address, config) => config.copy(participants = config.participants :+ address))
+      .unbounded()
       .optional()
       .text("""Addresses of the participants to test, specified as `<host>:<port>`.""")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -77,9 +77,14 @@ object Cli {
 
     arg[(String, Int)]("[endpoints...]")(endpointRead)
       .action((address, config) => config.copy(participants = config.participants :+ address))
-      .unbounded()
       .optional()
       .text("""Addresses of the participants to test, specified as `<host>:<port>`.""")
+
+    arg[Int]("max-connection-attempts")
+      .action((maxConnectionAttempts, config) => config.copy(maxConnectionAttempts = maxConnectionAttempts))
+      .unbounded()
+      .optional()
+      .text("Number of connection attempts to the participants. Applied to all endpoints.")
 
     // FIXME Make client_server_test more flexible and remove this deprecated option
     opt[String]("target-port")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -82,7 +82,6 @@ object Cli {
 
     arg[Int]("max-connection-attempts")
       .action((maxConnectionAttempts, config) => config.copy(maxConnectionAttempts = maxConnectionAttempts))
-      .unbounded()
       .optional()
       .text("Number of connection attempts to the participants. Applied to all endpoints.")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -81,7 +81,9 @@ object Cli {
       .text("""Addresses of the participants to test, specified as `<host>:<port>`.""")
 
     arg[Int]("max-connection-attempts")
-      .action((maxConnectionAttempts, config) => config.copy(maxConnectionAttempts = maxConnectionAttempts))
+      .action((maxConnectionAttempts, config) =>
+        config.copy(maxConnectionAttempts = maxConnectionAttempts)
+      )
       .optional()
       .text("Number of connection attempts to the participants. Applied to all endpoints.")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -13,6 +13,7 @@ import scala.concurrent.duration.FiniteDuration
 
 final case class Config(
     participants: Vector[(String, Int)],
+    maxConnectionAttempts: Int,
     darPackages: List[File],
     mustFail: Boolean,
     verbose: Boolean,
@@ -35,6 +36,7 @@ final case class Config(
 object Config {
   val default: Config = Config(
     participants = Vector.empty,
+    maxConnectionAttempts = 10,
     darPackages = Nil,
     mustFail = false,
     verbose = false,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -209,6 +209,7 @@ object LedgerApiTestTool {
         new LedgerTestCasesRunner(
           testCases = cases,
           participants = participants,
+          maxConnectionAttempts = config.maxConnectionAttempts,
           partyAllocation = config.partyAllocation,
           shuffleParticipants = config.shuffleParticipants,
           timeoutScaleFactor = config.timeoutScaleFactor,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -53,7 +53,7 @@ final class LedgerTestCasesRunner(
 ) {
   private[this] val verifyRequirements: Try[Unit] =
     Try {
-      require(maxConnectionAttempts > 0, "The connection attempts must be strictly positive")
+      require(maxConnectionAttempts > 0, "The number of connection attempts must be strictly positive")
       require(timeoutScaleFactor > 0, "The timeout scale factor must be strictly positive")
       require(identifierSuffix.nonEmpty, "The identifier suffix cannot be an empty string")
     }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -53,7 +53,10 @@ final class LedgerTestCasesRunner(
 ) {
   private[this] val verifyRequirements: Try[Unit] =
     Try {
-      require(maxConnectionAttempts > 0, "The number of connection attempts must be strictly positive")
+      require(
+        maxConnectionAttempts > 0,
+        "The number of connection attempts must be strictly positive",
+      )
       require(timeoutScaleFactor > 0, "The timeout scale factor must be strictly positive")
       require(identifierSuffix.nonEmpty, "The identifier suffix cannot be an empty string")
     }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -42,6 +42,7 @@ object LedgerTestCasesRunner {
 final class LedgerTestCasesRunner(
     testCases: Vector[LedgerTestCase],
     participants: Vector[Channel],
+    maxConnectionAttempts: Int = 10,
     partyAllocation: PartyAllocationConfiguration = ClosedWorldWaitingForAllParticipants,
     shuffleParticipants: Boolean = false,
     timeoutScaleFactor: Double = 1.0,
@@ -52,6 +53,7 @@ final class LedgerTestCasesRunner(
 ) {
   private[this] val verifyRequirements: Try[Unit] =
     Try {
+      require(maxConnectionAttempts > 0, "The connection attempts must be strictly positive")
       require(timeoutScaleFactor > 0, "The timeout scale factor must be strictly positive")
       require(identifierSuffix.nonEmpty, "The identifier suffix cannot be an empty string")
     }
@@ -189,7 +191,7 @@ final class LedgerTestCasesRunner(
       executionContext: ExecutionContext,
   ): Future[Vector[LedgerTestSummary]] = {
     val (concurrentTestCases, sequentialTestCases) = testCases.partition(_.runConcurrently)
-    ParticipantSession(partyAllocation, participants, commandInterceptors)
+    ParticipantSession(partyAllocation, participants, maxConnectionAttempts, commandInterceptors)
       .flatMap { sessions =>
         val ledgerSession = LedgerSession(sessions, shuffleParticipants)
         val testResults =

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
@@ -66,7 +66,6 @@ object ParticipantSession {
     Future.traverse(participants) { participant =>
       val services = new LedgerServices(participant, commandInterceptors)
       for {
-        // Keep retrying for about a minute.
         ledgerId <- RetryStrategy
           .exponentialBackoff(attempts = maxConnectionAttempts, 100.millis) { (attempt, wait) =>
             services.identity

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
@@ -58,6 +58,7 @@ object ParticipantSession {
   def apply(
       partyAllocation: PartyAllocationConfiguration,
       participants: Vector[Channel],
+      maxConnectionAttempts: Int,
       commandInterceptors: Seq[ClientInterceptor],
   )(implicit
       executionContext: ExecutionContext
@@ -67,7 +68,7 @@ object ParticipantSession {
       for {
         // Keep retrying for about a minute.
         ledgerId <- RetryStrategy
-          .exponentialBackoff(10, 100.millis) { (attempt, wait) =>
+          .exponentialBackoff(attempts = maxConnectionAttempts, 100.millis) { (attempt, wait) =>
             services.identity
               .getLedgerIdentity(new GetLedgerIdentityRequest)
               .map(_.ledgerId)


### PR DESCRIPTION
## Description

This actually originates from failed runs against ledgers that take a long time to spin up:

```
2021-07-15 10:34:18.341 CEST
conformance-test
Picked up JAVA_TOOL_OPTIONS: -XX:+UseContainerSupport -XX:InitialRAMPercentage=75.0 -XX:MinRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0
Error
2021-07-15 10:34:23.159 CEST
conformance-test
2021-07-15T08:34:23.158Z INFO c.d.l.a.t.LedgerApiTestTool@[main] - Setting up managed channel to participant at localhost:6865...
Error
2021-07-15 10:34:30.859 CEST
conformance-test
2021-07-15T08:34:30.859Z INFO c.d.l.a.t.i.p.ParticipantSession@[kka.actor.default-dispatcher-6] - Could not connect to the participant (attempt #1). Trying again in 100 milliseconds...
...
2021-07-15T08:35:22.066Z INFO c.d.l.a.t.i.p.ParticipantSession@[kka.actor.default-dispatcher-6] - Could not connect to the participant (attempt #10). Trying again in 51200 milliseconds...
Error
2021-07-15 10:35:22.068 CEST
conformance-test
2021-07-15T08:35:22.068Z ERROR c.d.l.a.t.LedgerApiTestTool@[pool-1-thread-1] - Could not connect to the participant: UNAVAILABLE: io exception
```

CHANGELOG_BEGIN

- [Integration Kit] Add a `--max-connection-attempts` command line option to the Ledger API Test Tool.

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
