### PR TITLE
[JSON-API] Put the request & response bodies into the log ctx if the log level is debug (for specific statements)

### DIFF
--- a/ledger-service/http-json/src/it/resources/logback.xml
+++ b/ledger-service/http-json/src/it/resources/logback.xml
@@ -3,7 +3,7 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/ledger-service/http-json/src/main/resources/logback.xml
+++ b/ledger-service/http-json/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
                 <!-- encoders are assigned the type
                     ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
                 <encoder>
-                    <pattern>%date{"dd-MM-yyyy HH:mm:ss.SSS", UTC} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+                    <pattern>%date{"dd-MM-yyyy HH:mm:ss.SSS", UTC} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
                 </encoder>
             </else>
         </if>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -44,6 +44,7 @@ import scalaz._
 import java.nio.file.Path
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext, Future}
+import ch.qos.logback.classic.{Level => LogLevel}
 
 object HttpService {
 
@@ -179,6 +180,7 @@ object HttpService {
         healthService,
         encoder,
         decoder,
+        logLevel.exists(!_.isGreaterOrEqual(LogLevel.INFO)), // Everything below DEBUG enables this
       )
 
       websocketService = new WebSocketService(

--- a/libs-scala/contextualized-logging/BUILD.bazel
+++ b/libs-scala/contextualized-logging/BUILD.bazel
@@ -13,6 +13,7 @@ da_scala_library(
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:io_spray_spray_json",
     ],
     scalacopts = ["-Xsource:2.13"],
     tags = ["maven_coordinates=com.daml:contextualized-logging:__VERSION__"],

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValueSerializer.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingValueSerializer.scala
@@ -5,8 +5,49 @@ package com.daml.logging
 
 import com.daml.logging.entries.LoggingValue
 import com.fasterxml.jackson.core.JsonGenerator
+import spray.json.{
+  JsArray,
+  JsBoolean,
+  JsFalse,
+  JsNull,
+  JsNumber,
+  JsObject,
+  JsString,
+  JsTrue,
+  JsValue,
+}
 
 private[logging] object LoggingValueSerializer {
+  def writeJsValue(jsValue: JsValue, generator: JsonGenerator): Unit = {
+    def write(jsValue: JsValue): Unit =
+      jsValue match {
+        case JsNull =>
+          generator.writeNull()
+        case JsTrue =>
+          generator.writeBoolean(true)
+        case JsFalse =>
+          generator.writeBoolean(false)
+        case JsBoolean(value) =>
+          generator.writeBoolean(value)
+        case JsNumber(value) =>
+          generator.writeNumber(value.bigDecimal)
+        case JsString(value) =>
+          generator.writeString(value)
+        case JsObject(fields) =>
+          generator.writeStartObject()
+          fields.foreach { case (key, value) =>
+            generator.writeFieldName(key)
+            write(value)
+          }
+          generator.writeEndObject()
+        case JsArray(elements) =>
+          generator.writeStartArray()
+          elements.foreach(value => write(value))
+          generator.writeEndArray()
+      }
+    write(jsValue)
+  }
+
   def writeValue(value: LoggingValue, generator: JsonGenerator): Unit = {
     value match {
       case LoggingValue.Empty =>
@@ -25,6 +66,8 @@ private[logging] object LoggingValueSerializer {
         generator.writeStartArray()
         sequence.foreach(writeValue(_, generator))
         generator.writeEndArray()
+      case LoggingValue.OfJson(jsValue) =>
+        writeJsValue(jsValue, generator)
       case LoggingValue.Nested(entries) =>
         generator.writeStartObject()
         new LoggingMarker(entries.contents).writeTo(generator)

--- a/libs-scala/logging-entries/BUILD.bazel
+++ b/libs-scala/logging-entries/BUILD.bazel
@@ -10,6 +10,9 @@ load(
 da_scala_library(
     name = "logging-entries",
     srcs = glob(["src/main/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:io_spray_spray_json",
+    ],
     scalacopts = ["-Xsource:2.13"],
     tags = ["maven_coordinates=com.daml:logging-entries:__VERSION__"],
     visibility = [

--- a/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/LoggingValue.scala
+++ b/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/LoggingValue.scala
@@ -3,6 +3,8 @@
 
 package com.daml.logging.entries
 
+import spray.json.JsValue
+
 import scala.language.implicitConversions
 
 sealed trait LoggingValue
@@ -29,6 +31,8 @@ object LoggingValue {
   final case class OfIterable(sequence: Iterable[LoggingValue]) extends LoggingValue
 
   final case class Nested(entries: LoggingEntries) extends LoggingValue
+
+  final case class OfJson(json: JsValue) extends LoggingValue
 
   @inline
   implicit def from[T](value: T)(implicit toLoggingValue: ToLoggingValue[T]): LoggingValue =

--- a/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/ToLoggingValue.scala
+++ b/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/ToLoggingValue.scala
@@ -3,6 +3,8 @@
 
 package com.daml.logging.entries
 
+import spray.json.JsValue
+
 import java.time.{Duration, Instant}
 
 trait ToLoggingValue[-T] {
@@ -12,6 +14,8 @@ trait ToLoggingValue[-T] {
 object ToLoggingValue {
   // This is not implicit because we only want to expose it for specific types.
   val ToStringToLoggingValue: ToLoggingValue[Any] = value => LoggingValue.OfString(value.toString)
+
+  implicit val `JsValue to LoggingValue`: ToLoggingValue[JsValue] = LoggingValue.OfJson(_)
 
   implicit val `String to LoggingValue`: ToLoggingValue[String] = LoggingValue.OfString(_)
 


### PR DESCRIPTION
This also readds logging of incoming requests and the responses which are being send out.

changelog_begin

- [JSON-API] Logging of the request and response bodies are now available for appropriate requests if the chosen log level is equal or lower than DEBUG. These can then be found in the logging context of the request begin & end log messages (The field names in the ctx are "request_body" and "response_body").

changelog_end

Fixes #10122

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [x] This was manually tested and worked great :star_struck: 

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
