### PR TITLE
participant-state-index: Use `Ref` directly. [KVL-1002]

### DIFF
--- a/ledger/participant-state-index/BUILD.bazel
+++ b/ledger/participant-state-index/BUILD.bazel
@@ -30,7 +30,6 @@ da_scala_library(
         "//ledger/ledger-api-health",
         "//ledger/ledger-configuration",
         "//ledger/ledger-offset",
-        "//ledger/participant-state",
         "//libs-scala/contextualized-logging",
         "@maven//:com_google_protobuf_protobuf_java",
     ],

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.participant.state.index.v2
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.api.domain.{LedgerOffset, PartyDetails, PartyEntry}
-import com.daml.ledger.participant.state.v1.{ParticipantId, Party}
+import com.daml.lf.data.Ref.{ParticipantId, Party}
 import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future


### PR DESCRIPTION
This avoids the dependency on _participant-state_.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
