### PR TITLE
refresh es cluster

### DIFF
--- a/infra/es_cluster.tf
+++ b/infra/es_cluster.tf
@@ -12,13 +12,13 @@ locals {
     {
       suffix         = "-blue",
       ubuntu_version = "2004",
-      size           = 5,
+      size           = 0,
       init           = "[]",
     },
     {
       suffix         = "-green",
       ubuntu_version = "2004",
-      size           = 0,
+      size           = 5,
       init           = "[]",
     },
     {


### PR DESCRIPTION
The cluster died yesterday. As part of recovery, I connected to the machines and made manual changes. To ensure that we get back to a known, documented setup I then proceeded to do a full blue -> green migration, having not tainted any of the green machines with manual interventions.

CHANGELOG_BEGIN
CHANGELOG_END