### PR TITLE
ledger-configuration: Correct the protobuf package. [KVL-1002]

### DIFF
--- a/ledger/ledger-configuration/protobuf/BUILD.bazel
+++ b/ledger/ledger-configuration/protobuf/BUILD.bazel
@@ -5,7 +5,7 @@ load("//bazel_tools:proto.bzl", "proto_jars")
 
 proto_jars(
     name = "ledger_configuration_proto",
-    srcs = ["com/daml/ledger/participant/state/ledger_configuration.proto"],
+    srcs = ["com/daml/ledger/configuration/ledger_configuration.proto"],
     maven_artifact_prefix = "participant-state-ledger-configuration",
     maven_group = "com.daml",
     visibility = [

--- a/ledger/ledger-configuration/protobuf/com/daml/ledger/configuration/ledger_configuration.proto
+++ b/ledger/ledger-configuration/protobuf/com/daml/ledger/configuration/ledger_configuration.proto
@@ -11,10 +11,10 @@
 //
 
 syntax = "proto3";
-package com.daml.ledger.participant.state;
-option java_package = "com.daml.ledger.participant.state.protobuf";
+package com.daml.ledger.configuration;
+option java_package = "com.daml.ledger.configuration.protobuf";
 option java_multiple_files = true;
-option csharp_namespace = "Com.Daml.Ledger.Participant.State.Protobuf";
+option csharp_namespace = "Com.Daml.Ledger.Configuration.Protobuf";
 
 import "google/protobuf/duration.proto";
 

--- a/ledger/ledger-configuration/protobuf/ledger_configuration.rst
+++ b/ledger/ledger-configuration/protobuf/ledger_configuration.rst
@@ -19,9 +19,6 @@ The canonical specification compliant implementation for encoding and
 decoding ledger configurations is part of the ledger-configuration
 package in ``ledger/ledger-configuration``.
 
-For historical reasons, we have kept the package name as
-``com.daml.ledger.participant.state``.
-
 Version history
 ^^^^^^^^^^^^^^^
 

--- a/ledger/ledger-configuration/src/main/scala/com/daml/ledger/configuration/Configuration.scala
+++ b/ledger/ledger-configuration/src/main/scala/com/daml/ledger/configuration/Configuration.scala
@@ -22,8 +22,6 @@ final case class Configuration(
 
 object Configuration {
 
-  import com.daml.ledger.participant.state.protobuf
-
   /** Version history:
     * V1: initial version
     * V2: added maxDeduplicationTime

--- a/ledger/ledger-configuration/src/test/suite/scala/com/daml/ledger/configuration/ConfigurationSpec.scala
+++ b/ledger/ledger-configuration/src/test/suite/scala/com/daml/ledger/configuration/ConfigurationSpec.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.configuration
 
 import com.daml.ledger.configuration.ConfigurationSpec._
-import com.daml.ledger.configuration.protobuf.{ledger_configuration => protobuf}
+import com.daml.ledger.configuration.protobuf.{ledger_configuration => proto}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -16,12 +16,12 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
   "a ledger configuration" when {
     "decoding a v1 protobuf" should {
       "decode a valid protobuf" in {
-        val configurationBytes = protobuf.LedgerConfiguration
+        val configurationBytes = proto.LedgerConfiguration
           .of(
             version = 1,
             generation = 7,
             timeModel = Some(
-              protobuf.LedgerTimeModel.of(
+              proto.LedgerTimeModel.of(
                 avgTransactionLatency = Some(1.minute.toProtobuf),
                 minSkew = Some(30.seconds.toProtobuf),
                 maxSkew = Some(2.minutes.toProtobuf),
@@ -49,7 +49,7 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
       }
 
       "reject a missing time model" in {
-        val configurationBytes = protobuf.LedgerConfiguration
+        val configurationBytes = proto.LedgerConfiguration
           .of(
             version = 1,
             generation = 2,
@@ -66,12 +66,12 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
 
     "decoding a v2 protobuf" should {
       "decode a valid protobuf" in {
-        val configurationBytes = protobuf.LedgerConfiguration
+        val configurationBytes = proto.LedgerConfiguration
           .of(
             version = 2,
             generation = 3,
             timeModel = Some(
-              protobuf.LedgerTimeModel.of(
+              proto.LedgerTimeModel.of(
                 avgTransactionLatency = Some(30.seconds.toProtobuf),
                 minSkew = Some(20.seconds.toProtobuf),
                 maxSkew = Some(5.minutes.toProtobuf),
@@ -102,7 +102,7 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
         ("error message", "protobuf"),
         (
           "Missing time model",
-          protobuf.LedgerConfiguration.of(
+          proto.LedgerConfiguration.of(
             version = 2,
             generation = 4,
             timeModel = None,
@@ -111,11 +111,11 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
         ),
         (
           "Missing maximum command time to live",
-          protobuf.LedgerConfiguration.of(
+          proto.LedgerConfiguration.of(
             version = 2,
             generation = 1,
             timeModel = Some(
-              protobuf.LedgerTimeModel.of(
+              proto.LedgerTimeModel.of(
                 avgTransactionLatency = Some(com.google.protobuf.duration.Duration.defaultInstance),
                 minSkew = Some(com.google.protobuf.duration.Duration.defaultInstance),
                 maxSkew = Some(com.google.protobuf.duration.Duration.defaultInstance),
@@ -126,11 +126,11 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
         ),
         (
           "decodeTimeModel: requirement failed: Negative average transaction latency",
-          protobuf.LedgerConfiguration.of(
+          proto.LedgerConfiguration.of(
             version = 2,
             generation = 1,
             timeModel = Some(
-              protobuf.LedgerTimeModel.of(
+              proto.LedgerTimeModel.of(
                 avgTransactionLatency = Some((-5).seconds.toProtobuf),
                 minSkew = Some(com.google.protobuf.duration.Duration.defaultInstance),
                 maxSkew = Some(com.google.protobuf.duration.Duration.defaultInstance),
@@ -141,11 +141,11 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
         ),
         (
           "decodeTimeModel: requirement failed: Negative min skew",
-          protobuf.LedgerConfiguration.of(
+          proto.LedgerConfiguration.of(
             version = 2,
             generation = 1,
             timeModel = Some(
-              protobuf.LedgerTimeModel.of(
+              proto.LedgerTimeModel.of(
                 avgTransactionLatency = Some(com.google.protobuf.duration.Duration.defaultInstance),
                 minSkew = Some((-30).seconds.toProtobuf),
                 maxSkew = Some(com.google.protobuf.duration.Duration.defaultInstance),
@@ -156,11 +156,11 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
         ),
         (
           "decodeTimeModel: requirement failed: Negative max skew",
-          protobuf.LedgerConfiguration.of(
+          proto.LedgerConfiguration.of(
             version = 2,
             generation = 1,
             timeModel = Some(
-              protobuf.LedgerTimeModel.of(
+              proto.LedgerTimeModel.of(
                 avgTransactionLatency = Some(com.google.protobuf.duration.Duration.defaultInstance),
                 minSkew = Some(com.google.protobuf.duration.Duration.defaultInstance),
                 maxSkew = Some((-10).seconds.toProtobuf),
@@ -171,11 +171,11 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
         ),
         (
           "requirement failed: Negative maximum command time to live",
-          protobuf.LedgerConfiguration.of(
+          proto.LedgerConfiguration.of(
             version = 2,
             generation = 1,
             timeModel = Some(
-              protobuf.LedgerTimeModel.of(
+              proto.LedgerTimeModel.of(
                 avgTransactionLatency = Some(com.google.protobuf.duration.Duration.defaultInstance),
                 minSkew = Some(com.google.protobuf.duration.Duration.defaultInstance),
                 maxSkew = Some(com.google.protobuf.duration.Duration.defaultInstance),
@@ -199,7 +199,7 @@ class ConfigurationSpec extends AnyWordSpec with Matchers {
 
     "decoding a protobuf with an invalid version" should {
       "reject the protobuf" in {
-        val configurationBytes = protobuf.LedgerConfiguration
+        val configurationBytes = proto.LedgerConfiguration
           .of(
             version = 3,
             generation = 0,

--- a/ledger/ledger-configuration/src/test/suite/scala/com/daml/ledger/configuration/ConfigurationSpec.scala
+++ b/ledger/ledger-configuration/src/test/suite/scala/com/daml/ledger/configuration/ConfigurationSpec.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.configuration
 
 import com.daml.ledger.configuration.ConfigurationSpec._
-import com.daml.ledger.participant.state.protobuf.{ledger_configuration => protobuf}
+import com.daml.ledger.configuration.protobuf.{ledger_configuration => protobuf}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -19,7 +19,7 @@ import "google/protobuf/timestamp.proto";
 import "com/daml/daml_lf_dev/daml_lf.proto";
 import "com/daml/lf/transaction.proto";
 import "com/daml/lf/value.proto";
-import "com/daml/ledger/participant/state/ledger_configuration.proto";
+import "com/daml/ledger/configuration/ledger_configuration.proto";
 
 // Envelope with which we wrap all kvutils messages that are sent over the network
 // or persisted on disk. The envelope specifies the kvutils version that defines how
@@ -276,7 +276,7 @@ message DamlConfigurationSubmission {
   google.protobuf.Timestamp maximum_record_time = 3;
 
   // The new configuration that replaces the current configuration.
-  com.daml.ledger.participant.state.LedgerConfiguration configuration = 4;
+  com.daml.ledger.configuration.LedgerConfiguration configuration = 4;
 }
 
 // A log entry describing a rejected configuration change.
@@ -289,7 +289,7 @@ message DamlConfigurationRejectionEntry {
   string participant_id = 2;
 
   // The new proposed configuration that was rejected.
-  com.daml.ledger.participant.state.LedgerConfiguration configuration = 3;
+  com.daml.ledger.configuration.LedgerConfiguration configuration = 3;
 
   oneof reason {
     ParticipantNotAuthorized participant_not_authorized = 4;
@@ -312,7 +312,7 @@ message DamlConfigurationEntry {
   string participant_id = 2;
 
   // The ledger configuration.
-  com.daml.ledger.participant.state.LedgerConfiguration configuration = 3;
+  com.daml.ledger.configuration.LedgerConfiguration configuration = 3;
 }
 
 // An allocation of party name and assignment of a party to a given

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -6,13 +6,13 @@ package com.daml.ledger.participant.state.kvutils.committer
 import java.time.{Duration, Instant}
 
 import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.configuration.protobuf.LedgerConfiguration
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
 import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, configurationStateKey}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.TestHelpers.{createCommitContext, theDefaultConfig}
 import com.daml.ledger.participant.state.kvutils.committer.CommitterSpec._
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Err}
-import com.daml.ledger.participant.state.protobuf.LedgerConfiguration
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
 import com.daml.logging.entries.LoggingEntries

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
+import com.daml.ledger.configuration.protobuf.LedgerConfiguration
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlConfigurationEntry,
   DamlLogEntry,
@@ -15,7 +16,6 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.RawWriteSetComparisonSpec._
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.WriteSetComparison.rawHexString
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Envelope, Raw, Version}
-import com.daml.ledger.participant.state.protobuf.LedgerConfiguration
 import com.daml.ledger.validator.StateKeySerializationStrategy
 import com.google.protobuf.{ByteString, Empty}
 import org.scalatest.Inside


### PR DESCRIPTION
Following up from #10279.

### Changelog

- **[Integration Kit]** The _ledger_configuration.proto_ Protobuf definition has been repackaged under `com.daml.ledger.configuration`, and the Java and C# packages have been renamed accordingly. If you are using this Protobuf definition, you will need to update your imports. The Maven artifact name has not changed.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
