### PR TITLE
Extend JSON API ContractDao query bench’s with different tpids

### DIFF
--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/InsertBenchmark.scala
@@ -5,6 +5,7 @@ package com.daml.http.dbbackend
 
 import cats.instances.list._
 import com.daml.http.dbbackend.Queries.{DBContract, SurrogateTpId}
+import com.daml.http.domain.TemplateId
 import org.openjdk.jmh.annotations._
 import scalaz.std.list._
 import spray.json._
@@ -21,18 +22,21 @@ class InsertBenchmark extends ContractDaoBenchmark {
 
   private var contractCids: List[String] = _
 
+  private var tpid: SurrogateTpId = _
+
   @Setup(Level.Trial)
   override def setup(): Unit = {
     super.setup()
+    tpid = insertTemplate(TemplateId("-pkg-", "M", "T"))
     contracts = (1 until numContracts + 1).map { i =>
       // Use negative cids to avoid collisions with other contracts
-      contract(-i, "Alice")
+      contract(-i, "Alice", tpid)
     }.toList
 
     contractCids = contracts.map(_.contractId)
 
     (0 until batches).foreach { batch =>
-      insertBatch("Alice", batch * batchSize)
+      insertBatch("Alice", tpid, batch * batchSize)
     }
     ()
   }

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
@@ -3,30 +3,48 @@
 
 package com.daml.http.dbbackend
 
-import scalaz.OneAnd
+import com.daml.http.dbbackend.Queries.SurrogateTpId
+import com.daml.http.domain.{Party, TemplateId}
 import doobie.implicits._
-import com.daml.http.domain.{Party}
 import org.openjdk.jmh.annotations._
+import scalaz.OneAnd
 
 class QueryBenchmark extends ContractDaoBenchmark {
-  @Param(Array("10"))
-  var batches: Int = _
+  @Param(Array("1", "5", "9"))
+  var extraParties: Int = _
+
+  @Param(Array("1", "5", "9"))
+  var extraTemplates: Int = _
+
+  private val tpid = TemplateId("-pkg-", "M", "T")
+  private var surrogateTpid: SurrogateTpId = _
+  val party = "Alice"
 
   @Setup(Level.Trial)
   override def setup(): Unit = {
     super.setup()
-    (0 until batches - 1).foreach { batch =>
-      insertBatch("Alice", batch * batchSize)
+    surrogateTpid = insertTemplate(tpid)
+
+    val surrogateTpids = surrogateTpid :: (0 until extraTemplates)
+      .map(i => insertTemplate(TemplateId("-pkg-", "M", s"T$i")))
+      .toList
+
+    val parties: List[String] = party :: (0 until extraParties).map(i => s"p$i").toList
+
+    var offset = 0
+    parties.foreach { p =>
+      surrogateTpids.foreach { t =>
+        insertBatch(p, t, offset)
+        offset += batchSize
+      }
     }
-    insertBatch("Bob", (batches - 1) * batchSize)
-    ()
   }
 
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime))
   def run(): Unit = {
     implicit val driver: SupportedJdbcDriver = dao.jdbcDriver
     val result = dao
-      .transact(ContractDao.selectContracts(OneAnd(Party("Bob"), Set.empty), tpid, fr"1 = 1"))
+      .transact(ContractDao.selectContracts(OneAnd(Party(party), Set.empty), tpid, fr"1 = 1"))
       .unsafeRunSync()
     assert(result.size == batchSize)
   }


### PR DESCRIPTION
This PR extends the test to test a full matrix of different party &
template id numbers. Summarizing the results, as expected we index by
party but not by template id:

Benchmark           (batchSize)  (extraParties)  (extraTemplates)  Mode  Cnt  Score   Error  Units
QueryBenchmark.run        10000               1                 0  avgt    5  0.255 ± 0.064   s/op
QueryBenchmark.run        10000              10                 0  avgt    5  0.304 ± 0.245   s/op
QueryBenchmark.run        10000             100                 0 avgt    5  0.296 ± 0.064   s/op

Benchmark           (batchSize)  (extraParties)  (extraTemplates)  Mode  Cnt  Score   Error  Units
QueryBenchmark.run        10000               0                 1  avgt    5  0.277 ± 0.037   s/op
QueryBenchmark.run        10000               0                10  avgt    5  0.479 ± 0.301   s/op
QueryBenchmark.run        10000               0               100  avgt    5  2.131 ± 0.497   s/op

We know how to fix that so I’ll get on that.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
