### PR TITLE
Make ledger API test tool's 'max-connection-attempts' into an option [KVL-977]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -81,7 +81,7 @@ object Cli {
       .optional()
       .text("""Addresses of the participants to test, specified as `<host>:<port>`.""")
 
-    arg[Int]("max-connection-attempts")
+    opt[Int]("max-connection-attempts")
       .action((maxConnectionAttempts, config) =>
         config.copy(maxConnectionAttempts = maxConnectionAttempts)
       )


### PR DESCRIPTION
Unintentionally made into an arg as part of #10297 (which seems OK but it's inconvenient), this change turns it into an option (as originally intended).

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
