### PR TITLE
detect mount issue earlier

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -16,9 +16,11 @@ steps:
     case "$UNAME" in
     Darwin)
       MPS="/var/tmp/_bazel_vsts /Users/vsts/.bazel-cache"
+      CMD="hdiutil info"
       ;;
     Linux)
       MPS="/home/vsts/.cache/bazel /home/vsts/.bazel-cache"
+      CMD="mount"
       ;;
     *)
       echo "Unexpected uname: $UNAME"
@@ -27,7 +29,7 @@ steps:
     esac
 
     for path in $MPS; do
-      if ! (mount | grep $path); then
+      if ! ($CMD | grep -F "$path"); then
         echo "$path is not a mount point, aborting"
         echo "Please ping @gary on Slack."
         exit 1

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -10,6 +10,31 @@ steps:
     exec 1> >(while IFS= read -r line; do echo "$(date -uIs) [out]: $line"; done)
     exec 2> >(while IFS= read -r line; do echo "$(date -uIs) [err]: $line"; done >&2)
 
+    ## START temp debug
+    UNAME=$(uname)
+
+    case "$UNAME" in
+    Darwin)
+      MPS="/var/tmp/_bazel_vsts /Users/vsts/.bazel-cache"
+      ;;
+    Linux)
+      MPS="/home/vsts/.cache/bazel /home/vsts/.bazel-cache"
+      ;;
+    *)
+      echo "Unexpected uname: $UNAME"
+      MPS=
+      ;;
+    esac
+
+    for path in $MPS; do
+      if ! (mount | grep $path); then
+        echo "$path is not a mount point, aborting"
+        echo "Please ping @gary on Slack."
+        exit 1
+      fi
+    done
+    ## END temp debug
+
     df -h .
     if [ $(df -m . | sed 1d | awk '{print $4}') -lt 50000 ]; then
         echo "Disk full, cleaning up..."


### PR DESCRIPTION
When machine disks are full, we can't clean the Bazel cache if it happens to not be a mount point. I don't quite understand yet why it's not a mount point, but maybe I'll be able to investigate more if we catch the issue early, rather than waiting for the disk to be full and the clean-up to fail.

CHANGELOG_BEGIN
CHANGELOG_END