### PR TITLE
Mark Java Bot tests flaky

### DIFF
--- a/language-support/java/bindings-rxjava/BUILD.bazel
+++ b/language-support/java/bindings-rxjava/BUILD.bazel
@@ -4,6 +4,7 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
+    "da_scala_test",
     "da_scala_test_suite",
 )
 load("//bazel_tools:pom_file.bzl", "pom_file")
@@ -85,12 +86,17 @@ da_scala_library(
     ],
 )
 
+bot_test = "src/test/scala/com/daml/ledger/rxjava/components/BotTest.scala"
+
 da_scala_test_suite(
     name = "bindings-java-tests",
-    srcs = glob([
-        "src/test/**/*Spec.scala",
-        "src/test/**/*Test.scala",
-    ]),
+    srcs = glob(
+        [
+            "src/test/**/*Spec.scala",
+            "src/test/**/*Test.scala",
+        ],
+        exclude = [bot_test],
+    ),
     data = [
         ":bindings-integration-tests-model-latest.dar",
     ],
@@ -108,6 +114,43 @@ da_scala_test_suite(
     },
     deps = [
         ":bindings-integration-tests-model-latest.jar",
+        ":bindings-java-tests-lib",
+        ":bindings-rxjava",
+        "//language-support/java/bindings:bindings-java",
+        "//ledger-api/grpc-definitions:ledger_api_proto_scala",
+        "//ledger/ledger-api-auth",
+        "//ledger/ledger-api-common",
+        "//libs-scala/grpc-utils",
+        "@maven//:com_google_api_grpc_proto_google_common_protos",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_grpc_grpc_core",
+        "@maven//:io_grpc_grpc_netty",
+        "@maven//:io_reactivex_rxjava2_rxjava",
+        "@maven//:org_pcollections_pcollections",
+        "@maven//:org_reactivestreams_reactive_streams",
+        "@maven//:org_slf4j_slf4j_api",
+    ],
+)
+
+da_scala_test(
+    name = "bindings-java-bot-tests",
+    srcs = [bot_test],
+    data = [
+        ":bindings-integration-tests-model-latest.dar",
+    ],
+    # See https://github.com/digital-asset/daml/issues/10273#issuecomment-882681521
+    flaky = True,
+    resources = [
+        ":src/test/resources/logback-test.xml",
+    ],
+    scala_deps = [
+        "@maven//:org_scalactic_scalactic",
+        "@maven//:org_scalatest_scalatest",
+    ],
+    versioned_scala_deps = {
+        "2.12": ["@maven//:org_scala_lang_modules_scala_collection_compat"],
+    },
+    deps = [
         ":bindings-java-tests-lib",
         ":bindings-rxjava",
         "//language-support/java/bindings:bindings-java",


### PR DESCRIPTION
See https://github.com/digital-asset/daml/issues/10273 for details on
the issue.

Summary is that the logic in the Java bots is fundamentally broken
since it modifies the pending set asynchronously so it can trigger for
the same contract multiple times.

While we can certainly fix that or hack around the bug in the tests,
given that the Java bots are deprecated, marking it flaky seems like a
better use of our time.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
