### PR TITLE
fix besu listing

### DIFF
--- a/docs/source/deploy/index.rst
+++ b/docs/source/deploy/index.rst
@@ -33,12 +33,12 @@ for production use today.
    * - `Sextant for Daml <https://blockchaintp.com/sextant/daml/>`__
      - `Amazon QLDB <https://aws.amazon.com/qldb/>`__
      - `Blockchain Technology Partners <https://blockchaintp.com/>`__
+   * - `Sextant for Daml <https://blockchaintp.com/sextant/daml/>`__
+     - `Hyperledger Besu <https://besu.hyperledger.org/>`__
+     - `Blockchain Technology Partners <https://blockchaintp.com/>`__
    * - `Daml Hub <https://hub.daml.com/>`__
      - `Managed cloud enviroment <https://hub.daml.com/>`__
      - `Digital Asset <https://digitalasset.com/>`__
-   * - `Hyperledger Besu <https://besu.hyperledger.org/>`__
-     - `Blockchain Technology Partners <https://blockchaintp.com/>`__
-     - `Press release, March 2020 <https://hub.digitalasset.com/press-release/ethereum-compatible-hyperledger-besu-now-has-enterprise-grade-daml-smart-contracts>`__
 
 .. _deploy-ref_open_source:
 


### PR DESCRIPTION
The current entry has been moved from "open-source integrations" to "commercial integrations" in 73b38f8add. However, the move was done verbatim, while the format for the two tables is different, making the Besu listing stick out a bit. Moreover, since the listing was added the URL of the press release has changed, landing people on the front page of the DA blog (from which it is possible to find the relevant press release, but quite frankly googling for it is faster).

For the record, I still think this page should be hosted elsewhere as the docs release cycle doesn't offer enough dynamism for it.

CHANGELOG_BEGIN
CHANGELOG_END