### PR TITLE
Report divulgence warning at commit location.

### DIFF
--- a/compiler/damlc/tests/daml-test-files/DiscloseViaChoiceObserver.daml
+++ b/compiler/damlc/tests/daml-test-files/DiscloseViaChoiceObserver.daml
@@ -4,7 +4,7 @@
 module DiscloseViaChoiceObserver where
 
 -- @SINCE-LF 1.11
--- @WARN range=27:1-27:5; Use of divulged contracts is deprecated
+-- @WARN range=37:15-37:67; Use of divulged contracts is deprecated
 
 -- This example demonstrates the canonical use of choice-observers to achieve disclosure.
 

--- a/compiler/damlc/tests/daml-test-files/Divulgence.daml
+++ b/compiler/damlc/tests/daml-test-files/Divulgence.daml
@@ -44,8 +44,8 @@ template DisclosureDelegation
         do
           fetch secretCid -- actor will divulge secretCid to p
 
--- @WARN range=49:1-49:5; Use of divulged contracts is deprecated
--- @WARN range=49:1-49:5; Use of divulged contracts is deprecated
+-- @WARN range=84:3-85:20; Use of divulged contracts is deprecated
+-- @WARN range=88:3-89:46; Use of divulged contracts is deprecated
 main = scenario do
   me <- getParty "Me"
   spy <- getParty "Spy"

--- a/compiler/damlc/tests/daml-test-files/Divulgence.daml
+++ b/compiler/damlc/tests/daml-test-files/Divulgence.daml
@@ -44,7 +44,8 @@ template DisclosureDelegation
         do
           fetch secretCid -- actor will divulge secretCid to p
 
--- @WARN range=48:1-48:5; Use of divulged contracts is deprecated
+-- @WARN range=49:1-49:5; Use of divulged contracts is deprecated
+-- @WARN range=49:1-49:5; Use of divulged contracts is deprecated
 main = scenario do
   me <- getParty "Me"
   spy <- getParty "Spy"

--- a/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionSemantics.daml
@@ -4,7 +4,7 @@
 -- @SINCE-LF-FEATURE DAML_EXCEPTIONS
 -- @ERROR range=131:1-131:23; Unhandled exception: ExceptionSemantics:E
 -- @ERROR range=146:1-146:25; Unhandled exception: DA.Exception.ArithmeticError:ArithmeticError@cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a with message = "ArithmeticError while evaluating (DIV_INT64 1 0)."
--- @WARN range=172:1-172:11; Use of divulged contracts is deprecated
+-- @WARN range=180:3-180:43; Use of divulged contracts is deprecated
 -- @ERROR range=183:1-183:11; Attempt to exercise a consumed contract
 module ExceptionSemantics where
 

--- a/compiler/damlc/tests/daml-test-files/MoreChoiceObserverDivulgence.daml
+++ b/compiler/damlc/tests/daml-test-files/MoreChoiceObserverDivulgence.daml
@@ -30,7 +30,7 @@ template Divulger with
         _ <- fetch id
         pure ()
 
--- @WARN range=35:1-35:5; Use of divulged contracts is deprecated
+-- @WARN range=47:15-47:67; Use of divulged contracts is deprecated
 test : Scenario ()
 test = scenario do
     alice <- getParty "Alice"

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -22,6 +22,8 @@ module DA.Daml.LF.ScenarioServiceClient
   , LowLevel.BackendError(..)
   , LowLevel.Error(..)
   , LowLevel.ScenarioResult(..)
+  , LowLevel.WarningMessage(..)
+  , LowLevel.Location(..)
   , Hash
   , encodeModule
   ) where

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -22,6 +22,8 @@ module DA.Daml.LF.ScenarioServiceClient.LowLevel
   , runScenario
   , runScript
   , SS.ScenarioResult(..)
+  , SS.WarningMessage(..)
+  , SS.Location(..)
   , encodeScenarioModule
   , ScenarioServiceException(..)
   ) where

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -388,7 +388,8 @@ message TraceMessage {
 }
 
 message WarningMessage {
-  string message = 1;
+  Location commitLocation = 1; // optional
+  string message = 2;
 }
 
 // The scenario interpretation result.

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -7,7 +7,7 @@ package scenario
 import com.daml.lf.data.{ImmArray, Numeric, Ref}
 import com.daml.lf.ledger.EventId
 import com.daml.lf.scenario.api.{v1 => proto}
-import com.daml.lf.speedy.{SError, SValue, TraceLog, WarningLog}
+import com.daml.lf.speedy.{SError, SValue, TraceLog, Warning, WarningLog}
 import com.daml.lf.transaction.{GlobalKey, IncompleteTransaction, Node => N, NodeId}
 import com.daml.lf.ledger._
 import com.daml.lf.value.{Value => V}
@@ -275,9 +275,10 @@ final class Conversions(
     builder.setMessage(msgAndLoc._1).build
   }
 
-  private[this] def convertSWarningMessage(msg: String): proto.WarningMessage = {
+  private[this] def convertSWarningMessage(warning: Warning): proto.WarningMessage = {
     val builder = proto.WarningMessage.newBuilder
-    builder.setMessage(msg).build
+    warning.commitLocation.map(loc => builder.setCommitLocation(convertLocation(loc)))
+    builder.setMessage(warning.message).build
   }
 
   def convertFailedAuthorization(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -752,7 +752,10 @@ private[lf] object Speedy {
         case SVisibleToStakeholders.Visible => ()
         case SVisibleToStakeholders.NotVisible(actAs, readAs) =>
           this.warningLog.add(
-            s"Tried to fetch or exercise ${contract.templateId} contract ${cid} but none of the reading parties actAs = ${actAs}, readAs = ${readAs} are a stakeholder ${contract.stakeholders}. Use of divulged contracts is deprecated and incompatible with pruning"
+            Warning(
+              commitLocation = onLedger.commitLocation,
+              message = s"Tried to fetch or exercise ${contract.templateId} contract ${cid} but none of the reading parties actAs = ${actAs}, readAs = ${readAs} are a stakeholder ${contract.stakeholders}. Use of divulged contracts is deprecated and incompatible with pruning"
+            )
           )
       }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -782,6 +782,7 @@ private[lf] object Speedy {
         traceLog: TraceLog = newTraceLog,
         warningLog: WarningLog = newWarningLog,
         contractKeyUniqueness: ContractKeyUniquenessMode = ContractKeyUniquenessMode.On,
+        commitLocation: Option[Location] = None,
     ): Machine = {
       val pkg2TxVersion =
         compiledPackages.interface.packageLanguageVersion.andThen(
@@ -802,7 +803,7 @@ private[lf] object Speedy {
             .initial(pkg2TxVersion, contractKeyUniqueness, submissionTime, initialSeeding),
           committers = committers,
           readAs = readAs,
-          commitLocation = None,
+          commitLocation = commitLocation,
           dependsOnTime = false,
           globalDiscriminators = globalCids.collect { case V.ContractId.V1(discriminator, _) =>
             discriminator

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -754,7 +754,8 @@ private[lf] object Speedy {
           this.warningLog.add(
             Warning(
               commitLocation = onLedger.commitLocation,
-              message = s"Tried to fetch or exercise ${contract.templateId} contract ${cid} but none of the reading parties actAs = ${actAs}, readAs = ${readAs} are a stakeholder ${contract.stakeholders}. Use of divulged contracts is deprecated and incompatible with pruning"
+              message =
+                s"Tried to fetch or exercise ${contract.templateId} contract ${cid} but none of the reading parties actAs = ${actAs}, readAs = ${readAs} are a stakeholder ${contract.stakeholders}. Use of divulged contracts is deprecated and incompatible with pruning",
             )
           )
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/WarningLog.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/WarningLog.scala
@@ -8,10 +8,10 @@ import scala.collection.mutable.ArrayBuffer
 import com.daml.lf.data.Ref.Location
 
 private[lf] final case class Warning(
-  commitLocation: Option[Location],
-  message: String
+    commitLocation: Option[Location],
+    message: String,
 ) {
-  def messageWithLocation : String =
+  def messageWithLocation: String =
     s"${Pretty.prettyLoc(commitLocation).renderWideStream.mkString}: $message"
 }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/WarningLog.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/WarningLog.scala
@@ -5,14 +5,23 @@ package com.daml.lf.speedy
 
 import org.slf4j.Logger
 import scala.collection.mutable.ArrayBuffer
+import com.daml.lf.data.Ref.Location
+
+private[lf] final case class Warning(
+  commitLocation: Option[Location],
+  message: String
+) {
+  def messageWithLocation : String =
+    s"${Pretty.prettyLoc(commitLocation).renderWideStream.mkString}: $message"
+}
 
 private[lf] final class WarningLog(logger: Logger) {
-  private[this] val buffer = new ArrayBuffer[String](initialSize = 10)
+  private[this] val buffer = new ArrayBuffer[Warning](initialSize = 10)
 
-  def add(message: String): Unit = {
-    logger.warn(message)
-    buffer += message
+  def add(warning: Warning): Unit = {
+    logger.warn(warning.messageWithLocation)
+    buffer += warning
   }
 
-  def iterator: Iterator[String] = buffer.iterator
+  def iterator: Iterator[Warning] = buffer.iterator
 }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -404,6 +404,7 @@ object ScenarioRunner {
       readAs = readAs,
       traceLog = traceLog,
       warningLog = warningLog,
+      commitLocation = location,
     )
     val onLedger = ledgerMachine.withOnLedger(NameOf.qualifiedNameOfCurrentFunc)(identity)
     @tailrec


### PR DESCRIPTION
This PR records the commitLocation when the warning is generated, and uses it when creating the diagnostic.

Part of #9947, follow up from #10289