### PR TITLE
legder-api: add flag to prune all divulged contracts

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
@@ -58,7 +58,7 @@ message PruneRequest {
   // Participant node operators SHOULD set this flag to avoid leaking
   // storage due to accumulating unarchived divulged contracts PROVIDED no
   // application using this participant node relies on divulgence.
-  bool prune_all_divulged_contracts = 2;
+  bool prune_all_divulged_contracts = 3;
 
   // Unique submission identifier.
   // Optional, defaults to a random identifier, used for logging.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
@@ -39,8 +39,26 @@ service ParticipantPruningService {
 }
 
 message PruneRequest {
-  // Inclusive offset up to and at which the ledger is to be pruned.
+  // Inclusive offset up to which the ledger is to be pruned.
+  // By default the following data is pruned:
+  //   1. All normal and divulged contracts that have been archived before
+  //   `  prune_up_to`.
+  //   2. All transaction events and completions before `prune_up_to`
   string prune_up_to = 1;
+
+  // Prune all divulged contracts created before `prune_up_to` independent of
+  // whether they were archived before `prune_up_to`. Useful to avoid leaking
+  // storage on participant nodes that can see a divulged contract but not its
+  // archival.
+  //
+  // Application developers SHOULD write their Daml applications
+  // such that they do not rely on divulged contracts; i.e., no warnings from
+  // using divulged contracts are emitted.
+  //
+  // Participant node operators SHOULD set this flag to avoid leaking
+  // storage due to accumulating unarchived divulged contracts PROVIDED no
+  // application using this participant node relies on divulgence.
+  bool prune_all_divulged_contracts = 2;
 
   // Unique submission identifier.
   // Optional, defaults to a random identifier, used for logging.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
@@ -53,7 +53,7 @@ message PruneRequest {
   //
   // Application developers SHOULD write their Daml applications
   // such that they do not rely on divulged contracts; i.e., no warnings from
-  // using divulged contracts are emitted.
+  // using divulged contracts as inputs to transactions are emitted.
   //
   // Participant node operators SHOULD set this flag to avoid leaking
   // storage due to accumulating unarchived divulged contracts PROVIDED no


### PR DESCRIPTION
Context: draft PR to discuss Ledger API changes to allow plugging the storage leak from not pruning unarchived, but stale divulged contracts in a backwards-compatible way.

TODO:
- [ ] complete design doc that this PR is part of
- [ ] move changelog entry from below to commit

CHANGELOG_BEGIN
Ledger API Server: pruning takes a new flag to force it to delete all divulged contracts up to the pruning offset instead of only the ones for which there is an consuming exercise event before the pruning offset. 

We recommend always setting this flag when pruning participant nodes whose applications do not rely on divulgence, which should be the default for newly built applications. Otherwise, storage can be leaked on participant nodes that see a divulged contract, but not its consuming exercise. 

For example in the second scenario of https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts, the creation of `Iou $Bank P` is visible to A's node, but not its consumption by `P`s request to settle it. Thus, the create event for `Iou $Bank P` would never get pruned on A's node unless the flag to prune all divulged events is set on the pruning request to A's node.

Note that using divulged contracts as part of command interpretation is deprecated. Once support for divulged contracts has been removed, this flag can always be set to true without impairing the Daml applications that run on a participant node.
CHANGELOG_END


FYI: @bame-da @matthiasS-da @mziolekda @tudor-da @gerolf-da 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
