### PR TITLE
remove duplicated rule in create-daml-app dlint

### DIFF
--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -75,16 +75,6 @@ genrule(
                     cp "$$SRC/default-$$f" "$$OUT/$$d/.$$f"
                 fi
             done
-            # We avoid introducing infix syntax in the GSG so we disable
-            # the lint there.
-            if [ "$$d" = "create-daml-app" ]; then
-              cat >> $$OUT/$$d/.dlint.yaml <<EOF
-
-# This rule is enabled by default but we avoid
-# infix syntax here to keep things simple.
-- ignore: {name: Use infix }
-EOF
-            fi
         done
 
         ## special cases we should work to remove


### PR DESCRIPTION
When opening #10342 I was only aware of the `.gitignore`; @cocreature's comment made me find out the `.dlint.yaml`, and then, testing it, I realized we ended up with the ignore rule twice. It does not seem to be causing any issue in cursory tests, but still, I think it's worth cleaning up.

CHANGELOG_BEGIN
CHANGELOG_END