### PR TITLE
Fetch actingParties always non-empty for supported versions (>=1.6)

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
@@ -243,7 +243,7 @@ private final class Validation[Nid, Cid](implicit ECid: Equal[Cid]) {
                 if version1 == version2 &&
                   coid1 === coid2 &&
                   templateId1 == templateId2 &&
-                  (actingParties1.isEmpty || actingParties1 == actingParties2) &&
+                  actingParties1 == actingParties2 &&
                   signatories1 == signatories2 &&
                   stakeholders1 == stakeholders2 &&
                   (key1.isEmpty || keyIsReplayedBy(key1, key2)) &&

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
@@ -310,13 +310,8 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   private val tweakFetchTemplateId = Tweak.single[Node] { case nf: Node.NodeFetch[_] =>
     nf.copy(templateId = changeTemplateId(nf.templateId))
   }
-  private val tweakFetchActingPartiesEmpty = Tweak[Node] {
-    case nf: Node.NodeFetch[_] if nf.actingParties.isEmpty => //insig
-      tweakPartySet.run(nf.actingParties).map { x => nf.copy(actingParties = x) }
-  }
-  private val tweakFetchActingPartiesNonEmpty = Tweak[Node] {
-    case nf: Node.NodeFetch[_] if nf.actingParties.nonEmpty => //sig
-      tweakPartySet.run(nf.actingParties).map { x => nf.copy(actingParties = x) }
+  private val tweakFetchActingPartiesNonEmpty = Tweak[Node] { case nf: Node.NodeFetch[_] =>
+    tweakPartySet.run(nf.actingParties).map { x => nf.copy(actingParties = x) }
   }
   private val tweakFetchSignatories = Tweak[Node] { case nf: Node.NodeFetch[_] =>
     tweakPartySet.run(nf.signatories).map { x => nf.copy(signatories = x) }
@@ -340,7 +335,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
     Map(
       "tweakFetchCoid" -> tweakFetchCoid,
       "tweakFetchTemplateId" -> tweakFetchTemplateId,
-      "tweakFetchActingParties(Non-empty)" -> tweakFetchActingPartiesNonEmpty,
+      "tweakFetchActingParties" -> tweakFetchActingPartiesNonEmpty,
       "tweakFetchSignatories" -> tweakFetchSignatories,
       "tweakFetchStakeholders" -> tweakFetchStakeholders,
       "tweakFetchKey(Some)" -> tweakFetchKey(tweakOptKeyMaintainersSome),
@@ -350,7 +345,6 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
 
   private val insigFetchTweaks =
     Map(
-      "tweakFetchActingParties(Empty)" -> tweakFetchActingPartiesEmpty,
       "tweakFetchKey(None)" -> tweakFetchKey(tweakOptKeyMaintainersNone),
       "tweakFetchByKey(Old Version)" -> tweakFetchByKey(versionBeforeMinByKey),
     )


### PR DESCRIPTION
Fetch `actingParties` always non-empty for supported versions (>=1.6)

- so there is no need to special case `isReplayedBy` for the empty-set

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
