### PR TITLE
[JSON-API] Shutdown on startup if the db connection is invalid

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -123,6 +123,18 @@ object Main {
             terminate()
             System.exit(ErrorCodes.StartupError)
         }
+      case (Some(dao), _) =>
+        Try(dao.isValid(120).unsafeRunSync()).toEither match {
+          case Right(false) =>
+            logger.error("Database connection is not valid.")
+            terminate()
+            System.exit(ErrorCodes.StartupError)
+          case Left(e) =>
+            logger.error("Failed to connect to the database", e)
+            terminate()
+            System.exit(ErrorCodes.StartupError)
+          case _ =>
+        }
       case _ =>
     }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -133,7 +133,7 @@ object Main {
             logger.error("Failed to connect to the database", e)
             terminate()
             System.exit(ErrorCodes.StartupError)
-          case _ =>
+          case Right(true) =>
         }
       case _ =>
     }


### PR DESCRIPTION
Should fix #10241

changelog_begin

- [JSON-API] The json api now correctly shutdowns at startup if the provided db connection is invalid in case of `createSchema=false`

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
