### PR TITLE
Stop printing stacktrace on logging setup failures

### DIFF
--- a/ledger-service/cli-opts/src/main/scala/cliopts/Logging.scala
+++ b/ledger-service/cli-opts/src/main/scala/cliopts/Logging.scala
@@ -30,7 +30,6 @@ object Logging {
             System.err.println(
               s"reconfigured failed using url $path: $je"
             )
-            je.printStackTrace(System.err)
         } finally stream.close()
       }
     System.getProperty("logback.configurationFile") match {


### PR DESCRIPTION
Printing stacktraces is consider an antipattern by some people and
gets flagged by VeraCode. While this shouldn’t actually be an issue
here, it is also not super useful so dropping it is easier than
arguing that this is a false positive.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
