### PR TITLE
Limit length of package ids to 64 characters

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
@@ -307,7 +307,7 @@ private[data] final class IdStringImpl extends IdString {
     */
   override type PackageId = String
   override val PackageId: ConcatenableStringModule[PackageId, HexString] =
-    new ConcatenableMatchingStringModule("Daml-LF Package ID", "-_ ")
+    new ConcatenableMatchingStringModule("Daml-LF Package ID", "-_ ", 64)
 
   /** Used to reference to leger objects like contractIds, ledgerIds,
     * transactionId, ... We use the same type for those ids, because we

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
@@ -204,6 +204,8 @@ class RefTest extends AnyFreeSpec with Matchers with EitherValues {
     "reject too long string" in {
       Party.fromString("p" * 255) shouldBe a[Right[_, _]]
       Party.fromString("p" * 256) shouldBe a[Left[_, _]]
+      PackageId.fromString("p" * 64) shouldBe a[Right[_, _]]
+      PackageId.fromString("p" * 65) shouldBe a[Left[_, _]]
     }
   }
 

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/DamlLfEncoder.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/DamlLfEncoder.scala
@@ -29,7 +29,7 @@ private[daml] object DamlLfEncoder extends App {
     throw new Error("You should not get this error")
   }
 
-  private val pkgId = Ref.PackageId.assertFromString("-self-")
+  private val pkgId = Ref.PackageId.assertFromString("self")
 
   private def main() =
     try {

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/DamlLfEncoder.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/DamlLfEncoder.scala
@@ -29,7 +29,7 @@ private[daml] object DamlLfEncoder extends App {
     throw new Error("You should not get this error")
   }
 
-  private val pkgId = Ref.PackageId.assertFromString("self")
+  private val pkgId = Ref.PackageId.assertFromString("-self-")
 
   private def main() =
     try {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -30,7 +30,7 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
   implicit val defaultParserParameters: ParserParameters[this.type] = {
     ParserParameters(
-      defaultPackageId = Ref.PackageId.assertFromString("-pkgId-"),
+      defaultPackageId = Ref.PackageId.assertFromString("pkgId"),
       languageVersion = LanguageVersion.v1_dev,
     )
   }

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -375,17 +375,10 @@ instances when we want to avoid empty identifiers, escaping problems,
 and other similar pitfalls. ::
 
   PackageId strings
-   PackageIdString ::= ' PackageIdChars '             -- PackageIdString
-
-  Sequences of PackageId character
-    PackageIdChars ::= PackageIdChar                  -- PackageIdChars
-                    |  PackageIdChars PackageIdChar
-
-  PackageId character
-     PackageIdChar  ∈  [a-zA-Z0-9\-_ ]               -- PackageIdChar
+   PackageIdString ::= [a-zA-Z0-9\-_ ]{1,64}        -- PackageIdString
 
   PartyId strings
-     PartyIdString  ∈  [a-zA-Z0-9:\-_ ]{1,255}       -- PartyIdChar
+     PartyIdString  ∈  [a-zA-Z0-9:\-_ ]{1,255}      -- PartyIdString
 
   PackageName strings
    PackageNameString ∈ [a-zA-Z0-9:\-_]+             -- PackageNameString

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -77,7 +77,7 @@ object ValueGenerators {
 
   // generate a junk identifier
   val idGen: Gen[Identifier] = for {
-    n <- Gen.choose(1, 200)
+    n <- Gen.choose(1, 64)
     packageId <- Gen
       .listOfN(n, Gen.alphaNumChar)
       .map(s => PackageId.assertFromString(s.mkString))


### PR DESCRIPTION
In practice, you cannot use a package id that is not a valid sha256
outside of a test anyway since we validate them. However, we didn’t
enforce it at the daml-lf level which is a bit annoying.

This PR fixes this and adds a length restriction of 64
characters (i.e. 256 bytes for sha256).

We could go a bit further and also restrict the characters to valid
sha256 hashes (i.e. 64 character hex strings). I don’t feel all that
strongly about that either way. We use other characters in tests but
fixing that shouldn’t be particularly hard either. The extra
characters don’t seem to cause problem so far, so I think it’s fine to
keep that.

No changelog entry since I don’t see how a user can be affected by this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
