### PR TITLE
debug macos

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -44,4 +44,14 @@ steps:
         echo "Done."
         df -h .
     fi
+
+    ## More temp debugging
+    for path in $MPS; do
+      if ! ($CMD | grep -F "$path"); then
+        echo "$path is not a mount point, aborting"
+        echo "Please ping @gary on Slack."
+        exit 1
+      fi
+    done
+    ## End more debugging
   displayName: clean-up disk cache


### PR DESCRIPTION
We've finally caught a failure, but I still don't understand what happens. The [last successful](https://dev.azure.com/digitalasset/adadc18a-d7df-446a-aacb-86042c1619c6/_apis/build/builds/83599/logs/98) run seems to have correctly mounted the partitions, while the [first failed one](https://dev.azure.com/digitalasset/adadc18a-d7df-446a-aacb-86042c1619c6/_apis/build/builds/83600/logs/94) clearly does not see any partition mounted. Hopefully this will allow us to determine whether the first one is wrong or something happens in-between.