### PR TITLE
treat exerciseResult structurally for isReplayedBy

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
@@ -55,7 +55,7 @@ private final class Validation[Nid, Cid](implicit ECid: Equal[Cid]) {
       replayed: Option[Value[Cid]],
   ) =
     (recorded, replayed) match {
-      case (None, _) => true
+      case (None, None) => true
       case (Some(recordedValue), Some(replayedValue)) =>
         valueIsReplayedBy(recordedValue, replayedValue)
       case _ => false

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
@@ -406,24 +406,17 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   private val tweakExerciseChoiceObservers = Tweak[Node] { case ne: Node.NodeExercises[_, _] =>
     tweakPartySet.run(ne.choiceObservers).map { x => ne.copy(choiceObservers = x) }
   }
-  private val tweakExerciseExerciseResultSome = Tweak[Node] {
-    case ne: Node.NodeExercises[_, _] => //sig
-      ne.exerciseResult match {
-        case None => Nil
-        case Some(v) =>
-          List(
-            ne.copy(exerciseResult = Some(changeValue(v))),
-            ne.copy(exerciseResult = None),
-          )
-      }
+  private val tweakExerciseExerciseResult = Tweak[Node] { case ne: Node.NodeExercises[_, _] =>
+    ne.exerciseResult match {
+      case None => List(ne.copy(exerciseResult = Some(samValue1)))
+      case Some(v) =>
+        List(
+          ne.copy(exerciseResult = Some(changeValue(v))),
+          ne.copy(exerciseResult = None),
+        )
+    }
   }
-  private val tweakExerciseExerciseResultNone = Tweak[Node] {
-    case ne: Node.NodeExercises[_, _] => //insig
-      ne.exerciseResult match {
-        case Some(_) => Nil
-        case None => List(ne.copy(exerciseResult = Some(samValue1)))
-      }
-  }
+
   private def tweakExerciseKey(tweakOptKeyMaintainers: Tweak[OKWM]) = Tweak[Node] {
     case ne: Node.NodeExercises[_, _] =>
       tweakOptKeyMaintainers.run(ne.key).map { x => ne.copy(key = x) }
@@ -447,7 +440,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
       "tweakExerciseStakeholders" -> tweakExerciseStakeholders,
       "tweakExerciseSignatories" -> tweakExerciseSignatories,
       "tweakExerciseChoiceObservers" -> tweakExerciseChoiceObservers,
-      "tweakExerciseExerciseResult(Some)" -> tweakExerciseExerciseResultSome,
+      "tweakExerciseExerciseResult" -> tweakExerciseExerciseResult,
       "tweakExerciseKey(Some)" -> tweakExerciseKey(tweakOptKeyMaintainersSome),
       "tweakExerciseByKey(New Version)" -> tweakExerciseByKey(versionSinceMinByKey),
       "tweakExerciseVersion" -> tweakExerciseVersion,
@@ -455,7 +448,6 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
 
   private val insigExeTweaks =
     Map(
-      "tweakExerciseExerciseResult(None)" -> tweakExerciseExerciseResultNone,
       "tweakExerciseKey(None)" -> tweakExerciseKey(tweakOptKeyMaintainersNone),
       "tweakExerciseByKey(Old Version)" -> tweakExerciseByKey(versionBeforeMinByKey),
     )


### PR DESCRIPTION

older versions of LF didn’t have the exerciseResult https://github.com/digital-asset/daml/commit/d725d50be98ce064c39d760d3658dced853b2427 so once the engine needed to produce this, we needed to allow for the recorded to not be present while the engine produces it. However, we don’t support that LF version anymore and on the other hand, with rollback nodes, the exerciseResult has become optional again so I think this is just broken and shouldn’t allow for None, Some(_).


CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
