### PR TITLE
LF: drop old serializability check for Values.

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -918,7 +918,7 @@ private[lf] object SBuiltin {
       mbKey.foreach { case Node.KeyWithMaintainers(key, maintainers) =>
         if (maintainers.isEmpty)
           throw SErrorDamlException(
-            IE.CreateEmptyContractKeyMaintainers(templateId, createArg.toValue, key)
+            IE.CreateEmptyContractKeyMaintainers(templateId, createArgValue, key)
           )
       }
       val auth = machine.auth
@@ -933,7 +933,6 @@ private[lf] object SBuiltin {
           stakeholders = sigs union obs,
           key = mbKey,
         )
-        .fold(err => crash(err), identity)
 
       machine.addLocalContract(coid, templateId, createArg, sigs, obs, mbKey)
       onLedger.ptx = newPtx
@@ -993,7 +992,6 @@ private[lf] object SBuiltin {
           byKey = byKey,
           chosenValue = arg,
         )
-        .fold(err => crash(err), identity)
       checkAborted(onLedger.ptx)
       machine.returnValue = SUnit
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -41,19 +41,18 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   private[this] implicit class PartialTransactionExtra(val ptx: PartialTransaction) {
 
     def insertCreate_ : PartialTransaction =
-      ptx.insertCreate(
-        Authorize(Set(party)),
-        templateId,
-        Value.ValueUnit,
-        "agreement",
-        None,
-        Set(party),
-        Set.empty,
-        None,
-      ) match {
-        case Right((_, newPtx)) => newPtx
-        case Left(_) => sys.error("unexpected error")
-      }
+      ptx
+        .insertCreate(
+          Authorize(Set(party)),
+          templateId,
+          Value.ValueUnit,
+          "agreement",
+          None,
+          Set(party),
+          Set.empty,
+          None,
+        )
+        ._2
 
     def beginExercises_ : PartialTransaction =
       ptx.beginExercises(
@@ -70,11 +69,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
         mbKey = None,
         byKey = false,
         chosenValue = Value.ValueUnit,
-      ) match {
-        case Right(value) => value
-        case Left(_) =>
-          sys.error("unexpected failing beginExercises")
-      }
+      )
 
     def endExercises_ : PartialTransaction =
       ptx.endExercises(Value.ValueUnit)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -32,24 +32,6 @@ class ValueSpec
     with ScalaCheckPropertyChecks {
   import ValueSpec._
 
-  "serialize" - {
-    val exceedsNesting = (1 to MAXIMUM_NESTING + 1).foldRight[Value[Nothing]](ValueInt64(42)) {
-      case (_, v) => ValueVariant(None, Ref.Name.assertFromString("foo"), v)
-    }
-    val exceedsNestingError = s"exceeds maximum nesting value of $MAXIMUM_NESTING"
-    val matchesNesting = (1 to MAXIMUM_NESTING).foldRight[Value[Nothing]](ValueInt64(42)) {
-      case (_, v) => ValueVariant(None, Ref.Name.assertFromString("foo"), v)
-    }
-
-    "rejects excessive nesting" in {
-      exceedsNesting.serializable() shouldBe ImmArray(exceedsNestingError)
-    }
-
-    "accepts just right nesting" in {
-      matchesNesting.serializable() shouldBe ImmArray.empty
-    }
-  }
-
   "VersionedValue" - {
 
     val pkgId = Ref.PackageId.assertFromString("pkgId")


### PR DESCRIPTION
We drop this check for the following reasons:

* Its only usage was inside the transaction builder, this is subsumed
  by the check we added in the SValue to Value translation (#10370)

* It seems to origianl check more that nesting (and so to be
  overcomplicate)

* It was used in non-consitent way. It was used to check create
  arguments and choice arguments, but niether choice result nor
  contract key.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
