### PR TITLE
[Divulgence pruning] Conformance tests implementation [DPP-484]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
@@ -11,8 +11,11 @@ import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.transaction.TransactionTree
+import com.daml.ledger.client.binding
+import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.client.binding.Primitive.Party
 import com.daml.ledger.test.model.Test.Dummy
+import com.daml.ledger.test.semantic.DivulgenceTests._
 import io.grpc.Status
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -525,6 +528,127 @@ class ParticipantPruningIT extends LedgerTestSuite {
       assert(emptyPrunedFlatWillFail.isEmpty)
     }
   })
+
+  test(
+    "PRRetroactiveDivulgences",
+    "Divulgence pruning succeeds",
+    allocate(SingleParty, SingleParty),
+    runConcurrently = false,
+  )(implicit ec => { case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
+    for {
+      contract <- alpha.create(alice, Contract(alice))
+      divulgenceHelper <- alpha.create(alice, DivulgenceHelper(alice, bob))
+
+      divulgence <- beta.exerciseAndGetContract[Divulgence](bob, divulgenceHelper.exerciseSign)
+
+      // Retroactively divulge Alice's contract to bob
+      _ <- alpha.exercise(
+        alice,
+        divulgence.exerciseDivulge(_, contract),
+      )
+
+      _ <- divulgencePruneAndCheck(alice, bob, alpha, beta, contract, divulgence)
+    } yield ()
+  })
+
+  test(
+    "PRLocalAndNonLocalRetroactiveDivulgences",
+    "Divuglence pruning succeeds if first divulgence is not a disclosure but happens in the same transaction as the create",
+    allocate(SingleParty, SingleParty),
+    runConcurrently = false,
+  )(implicit ec => { case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
+    for {
+      divulgenceHelper <- alpha.create(alice, DivulgenceHelper(alice, bob))
+
+      divulgence <- beta.exerciseAndGetContract[Divulgence](bob, divulgenceHelper.exerciseSign)
+
+      divulgeNotDiscloseTemplate <- alpha.create(alice, DivulgeNotDiscloseTemplate(alice, bob))
+
+      // Alice creates and divulges without disclosure a contract to Bob
+      contract <- alpha.exerciseAndGetContract[Contract](
+        alice,
+        divulgeNotDiscloseTemplate.exerciseDivulgeNoDisclose(_, divulgence),
+      )
+
+      _ <- divulgencePruneAndCheck(alice, bob, alpha, beta, contract, divulgence)
+    } yield ()
+  })
+
+  test(
+    "PRDisclosureAndRetroactiveDivulgence",
+    "Disclosure pruning succeeds",
+    allocate(SingleParty, SingleParty),
+    runConcurrently = false,
+  )(implicit ec => { case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
+    for {
+      divulgenceHelper <- alpha.create(alice, DivulgenceHelper(alice, bob))
+
+      divulgence <- beta.exerciseAndGetContract[Divulgence](bob, divulgenceHelper.exerciseSign)
+
+      // Alice's contract creation is disclosed to Bob
+      contract <- alpha.exerciseAndGetContract[Contract](
+        alice,
+        divulgence.exerciseCreateAndDisclose,
+      )
+      _ <- divulgencePruneAndCheck(alice, bob, alpha, beta, contract, divulgence)
+    } yield ()
+  })
+
+  private def divulgencePruneAndCheck(
+      alice: Party,
+      bob: Party,
+      alpha: ParticipantTestContext,
+      beta: ParticipantTestContext,
+      contract: Primitive.ContractId[Contract],
+      divulgence: binding.Primitive.ContractId[Divulgence],
+  )(implicit ec: ExecutionContext) =
+    for {
+      // Check that Bob can fetch the contract
+      _ <- beta.exerciseAndGetContract[Dummy](
+        bob,
+        divulgence.exerciseCanFetch(_, contract),
+      )
+
+      offsetAfter_divulgence_1 <- beta.currentEnd()
+
+      // Alice re-divulges the contract to Bob
+      _ <- alpha.exerciseAndGetContract[Contract](
+        alice,
+        divulgence.exerciseDivulge(_, contract),
+      )
+
+      // Check that Bob can fetch the contract
+      _ <- beta.exerciseAndGetContract[Dummy](
+        bob,
+        divulgence.exerciseCanFetch(_, contract),
+      )
+      offsetAfter_divulgence_2 <- beta.currentEnd()
+
+      _ <- beta.prune(offsetAfter_divulgence_1)
+      // Check that Bob can still fetch the contract after pruning the first transaction
+      _ <- beta.exerciseAndGetContract[Dummy](
+        bob,
+        divulgence.exerciseCanFetch(_, contract),
+      )
+
+      _ <- beta.prune(offsetAfter_divulgence_2)
+      // TODO divulgence pruning: Remove - The following assertion should fail once full divulgence pruning
+      //                          is implemented in the participant
+      _ <- beta
+        .exerciseAndGetContract[Dummy](
+          bob,
+          divulgence.exerciseCanFetch(_, contract),
+        )
+
+      // TODO divulgence pruning: Un-comment the assertion below to make tests pass once
+      //                          full divulgence pruning is implemented in the participant
+//      _ <- beta
+//        .exerciseAndGetContract[Dummy](
+//          bob,
+//          divulgence.exerciseCanFetch(_, contract),
+//        )
+//        .mustFail("Bob cannot access the divulged contract after the second pruning")
+    } yield ()
 
   private def populateLedgerAndGetOffsets(participant: ParticipantTestContext, submitter: Party)(
       implicit ec: ExecutionContext

--- a/ledger/test-common/src/main/daml/semantic/DivulgenceTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/DivulgenceTests.daml
@@ -15,6 +15,7 @@ template Divulgence
     divulger: Party
   where
     signatory divulgee, divulger
+
     controller divulger can
       nonconsuming Divulge: ()
         with contractId: ContractId Contract
@@ -22,8 +23,10 @@ template Divulgence
           do create Dummy with holder=divulger
              fetch contractId
              return ()
+
       nonconsuming CreateAndDisclose: ContractId Contract
           do create Contract with party=divulger
+
     controller divulgee can
       nonconsuming CanFetch: ContractId Dummy
         with contractId: ContractId Contract
@@ -31,14 +34,15 @@ template Divulgence
              -- create an event so the transaction is visible on the GetTransactionTrees endpoint
              create Dummy with holder=divulgee
 
-template DivulgenceHelper
+template DivulgenceProposal
   with
     sig: Party
     other: Party
   where
     signatory sig
+
     controller other can
-      Sign: ContractId Divulgence
+      Accept: ContractId Divulgence
           do create Divulgence with divulger=sig, divulgee=other
 
 template DivulgeNotDiscloseTemplate
@@ -47,13 +51,16 @@ template DivulgeNotDiscloseTemplate
     divulgee: Party
   where
     signatory divulger
+
     controller divulger can
       nonconsuming DivulgeNoDisclose: ()
-        with divulgenceHelper: ContractId Divulgence
+        with divulgence: ContractId Divulgence
           do contract <- create Contract with party=divulger
-             exercise divulgenceHelper Divulge with contractId=contract
+             exercise divulgence Divulge with contractId=contract
              return ()
 
+-- Dummy contracts are used to signal transactions on the TransactionTree service.
+-- It is structurally equal to the `Contract` template, but kept separate for the signalling purpose.
 template Dummy
   with
     holder: Party

--- a/ledger/test-common/src/main/daml/semantic/DivulgenceTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/DivulgenceTests.daml
@@ -1,0 +1,61 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DivulgenceTests where
+
+template Contract
+  with
+    party: Party
+  where
+    signatory party
+
+template Divulgence
+  with
+    divulgee: Party
+    divulger: Party
+  where
+    signatory divulgee, divulger
+    controller divulger can
+      nonconsuming Divulge: ()
+        with contractId: ContractId Contract
+          -- create an event so the transaction is visible on the GetTransactionTrees endpoint
+          do create Dummy with holder=divulger
+             fetch contractId
+             return ()
+      nonconsuming CreateAndDisclose: ContractId Contract
+          do create Contract with party=divulger
+    controller divulgee can
+      nonconsuming CanFetch: ContractId Dummy
+        with contractId: ContractId Contract
+          do fetch contractId
+             -- create an event so the transaction is visible on the GetTransactionTrees endpoint
+             create Dummy with holder=divulgee
+
+template DivulgenceHelper
+  with
+    sig: Party
+    other: Party
+  where
+    signatory sig
+    controller other can
+      Sign: ContractId Divulgence
+          do create Divulgence with divulger=sig, divulgee=other
+
+template DivulgeNotDiscloseTemplate
+  with
+    divulger: Party
+    divulgee: Party
+  where
+    signatory divulger
+    controller divulger can
+      nonconsuming DivulgeNoDisclose: ()
+        with divulgenceHelper: ContractId Divulgence
+          do contract <- create Contract with party=divulger
+             exercise divulgenceHelper Divulge with contractId=contract
+             return ()
+
+template Dummy
+  with
+    holder: Party
+  where
+    signatory holder


### PR DESCRIPTION
Implements conformance tests for asserting the state of divulgence pruning in the `participant-integration-api`:
* The current test implementation asserts that divulgence events are not pruned
* A commented assertion, marked with **TODO** in the tests, asserts the future expectation when performing divulgence pruning: all divulgence and disclosure events are pruned up to the pruned offset.

CHANGELOG_BEGIN
* integration-kit: extended the Ledger API test tool with tests for the pruning of all divulgence events.

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
