### PR TITLE
Stop swallowing error message in non-repudiation conformance tests

### DIFF
--- a/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
+++ b/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
@@ -26,7 +26,7 @@ import com.daml.nonrepudiation.testing._
 import com.daml.testing.postgresql.PostgresAroundAll
 import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
 import io.grpc.netty.NettyChannelBuilder
-import org.scalatest.OptionValues
+import org.scalatest.{Inside, OptionValues}
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -36,7 +36,8 @@ final class NonRepudiationProxyConformance
     extends AsyncFlatSpec
     with Matchers
     with OptionValues
-    with PostgresAroundAll {
+    with PostgresAroundAll
+    with Inside {
 
   behavior of "NonRepudiationProxy"
 
@@ -102,7 +103,9 @@ final class NonRepudiationProxyConformance
       runner.runTests.map { summaries =>
         summaries.foldLeft(succeed) { case (_, LedgerTestSummary(_, name, description, result)) =>
           withClue(s"$name: $description") {
-            result.toOption.value shouldBe a[Result.Succeeded]
+            inside(result) { case Right(r) =>
+              r shouldBe a[Result.Succeeded]
+            }
           }
         }
       }


### PR DESCRIPTION
They failed on CI but it’s impossible to say what actually fails atm
because toOption drops the error.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
