### PR TITLE
bug fix: there are no insignificant lookup tweaks!

### DIFF
--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
@@ -367,14 +367,9 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   private val sigLookupTweaks =
     Map(
       "tweakLookupTemplateId" -> tweakLookupTemplateId,
-      "tweakLookupKey(None)" -> tweakLookupKey,
+      "tweakLookupKey" -> tweakLookupKey,
       "tweakLookupResult" -> tweakLookupResult,
       "tweakLookupVersion" -> tweakLookupVersion,
-    )
-
-  private val insigLookupTweaks =
-    Map(
-      "tweakExerciseKey(None)" -> tweakExerciseKey(tweakOptKeyMaintainersNone)
     )
 
   //--[Exercise node tweaks]--
@@ -483,7 +478,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   }
 
   private def insignificantTweaks: Map[String, Tweak[VTX]] = {
-    (insigFetchTweaks ++ insigLookupTweaks ++ insigExeTweaks)
+    (insigFetchTweaks ++ insigExeTweaks)
       .map { case (name, tw) => (name, tweakTxNodes(tw)) }
   }
 


### PR DESCRIPTION
Noticed a cut&paste typo bug  in `ValidationSpec`. Fixed.
- There are no insignificant tweaks! to `NodeLookupByKey`

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
