### PR TITLE
Export import

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -35,6 +35,7 @@ import           System.FilePath (splitDirectories)
 import qualified Data.Generics.Uniplate.Data as Uniplate
 
 
+-- Keep in sync with isInternalModule in daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
 isInternal :: GHC.ModuleName -> Bool
 isInternal (GHC.moduleNameString -> x)
   = "DA.Internal." `isPrefixOf` x ||

--- a/daml-script/export/src/main/scala/com/daml/script/export/Export.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Export.scala
@@ -9,7 +9,6 @@ import java.nio.file.{Files, Path}
 import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
 import com.daml.ledger.api.v1.event.CreatedEvent
 import com.daml.ledger.api.v1.transaction.TransactionTree
-import com.daml.ledger.api.v1.value.Value.Sum
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.language.Ast
 import com.daml.script.export.TreeUtils.{
@@ -22,8 +21,7 @@ import com.daml.script.export.TreeUtils.{
   partiesInTree,
   topoSortAcs,
   treeCreatedCids,
-  treeRefs,
-  valueRefs,
+  moduleRefs,
 }
 import com.google.protobuf.ByteString
 import scalaz.std.iterable._
@@ -74,15 +72,6 @@ object Export {
       moduleRefs = refs ++ timeRefs ++ partiesModuleRefs ++ unknownContractModuleRefs,
       actions = actions,
     )
-  }
-
-  private def moduleRefs(
-      acs: Iterable[CreatedEvent],
-      trees: Iterable[TransactionTree],
-  ): Set[String] = {
-    val fromAcs = acs.foldMap(ev => valueRefs(Sum.Record(ev.getCreateArguments)))
-    val fromTrees = trees.foldMap(treeRefs(_))
-    (fromAcs ++ fromTrees).map(_.moduleName)
   }
 
   private def partyMapping(parties: Set[Party]): Map[Party, String] = {

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -446,7 +446,17 @@ object TreeUtils {
   ): Set[String] = {
     val fromAcs = acs.foldMap(ev => valueRefs(Sum.Record(ev.getCreateArguments)))
     val fromTrees = trees.foldMap(treeRefs(_))
-    (fromAcs ++ fromTrees).map(_.moduleName)
+    (fromAcs ++ fromTrees)
+      .map(_.moduleName)
+      .filterNot(isInternalModule)
+  }
+
+  private def isInternalModule(moduleName: String): Boolean = {
+    // Keep in sync with isInternal in compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+    moduleName.startsWith("DA.Internal.") ||
+    moduleName.startsWith("GHC.") ||
+    Set("Control.Exception.Base", "Data.String", "LibraryModules", "DA.Types", "DA.Time.Types")
+      .contains(moduleName)
   }
 
   def treeRefs(t: TransactionTree): Set[Identifier] =

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -440,6 +440,15 @@ object TreeUtils {
     )
   }
 
+  def moduleRefs(
+      acs: Iterable[CreatedEvent],
+      trees: Iterable[TransactionTree],
+  ): Set[String] = {
+    val fromAcs = acs.foldMap(ev => valueRefs(Sum.Record(ev.getCreateArguments)))
+    val fromTrees = trees.foldMap(treeRefs(_))
+    (fromAcs ++ fromTrees).map(_.moduleName)
+  }
+
   def treeRefs(t: TransactionTree): Set[Identifier] =
     t.eventsById.values.foldMap(e => evRefs(e.kind))
 

--- a/daml-script/export/src/test/scala/com/daml/script/export/ExportModuleRefsSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ExportModuleRefsSpec.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.export
+
+import com.daml.ledger.api.refinements.ApiTypes.ContractId
+import com.daml.ledger.api.v1.transaction.TransactionTree
+import com.daml.script.`export`.TestData
+import com.daml.ledger.api.v1.value.{Identifier, Value, Variant}
+import com.daml.script.`export`.TestData.Created
+import com.daml.script.export.TreeUtils.moduleRefs
+import com.google.protobuf
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ExportModuleRefsSpec extends AnyFreeSpec with Matchers {
+  "module references" - {
+    "handles empty case" in {
+      val acs = TestData
+        .ACS(Seq.empty[Created])
+        .toACS
+      val trees = Seq.empty[TransactionTree]
+      val refs = moduleRefs(acs.values, trees)
+      refs shouldBe empty
+    }
+    "merges ACS and trees references" in {
+      val acs = TestData
+        .ACS(
+          Seq(
+            TestData.Created(
+              ContractId("acs1"),
+              templateId = Identifier("package-a", "ModuleA", "TemplateA"),
+            ),
+            TestData.Created(
+              ContractId("acs2"),
+              templateId = Identifier("package-b", "ModuleB", "TemplateB"),
+            ),
+          )
+        )
+        .toACS
+      val trees = Seq(
+        TestData
+          .Tree(
+            Seq(
+              TestData.Exercised(
+                ContractId("acs2"),
+                Seq(
+                  TestData.Created(
+                    ContractId("tree1"),
+                    templateId = Identifier("package-c", "ModuleC", "TemplateC"),
+                  )
+                ),
+                choiceArgument = Value().withVariant(
+                  Variant(
+                    Some(Identifier("package-d", "ModuleD", "ChoiceD")),
+                    "ChoiceD",
+                    Some(Value().withUnit(protobuf.empty.Empty())),
+                  )
+                ),
+              )
+            )
+          ),
+        TestData
+          .Tree(
+            Seq(
+              TestData.Exercised(
+                ContractId("tree1"),
+                Seq.empty[TestData.Event],
+                choiceArgument = Value().withVariant(
+                  Variant(
+                    Some(Identifier("package-e", "ModuleE", "ChoiceE")),
+                    "ChoiceE",
+                    Some(Value().withUnit(protobuf.empty.Empty())),
+                  )
+                ),
+              )
+            )
+          ),
+      ).map(_.toTransactionTree)
+      val refs = moduleRefs(acs.values, trees)
+      refs should contain only ("ModuleA", "ModuleB", "ModuleC", "ModuleD", "ModuleE")
+    }
+  }
+}

--- a/daml-script/export/src/test/scala/com/daml/script/export/ExportModuleRefsSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ExportModuleRefsSpec.scala
@@ -5,9 +5,7 @@ package com.daml.script.export
 
 import com.daml.ledger.api.refinements.ApiTypes.ContractId
 import com.daml.ledger.api.v1.transaction.TransactionTree
-import com.daml.script.`export`.TestData
 import com.daml.ledger.api.v1.value.{Identifier, Value, Variant}
-import com.daml.script.`export`.TestData.Created
 import com.daml.script.export.TreeUtils.moduleRefs
 import com.google.protobuf
 import org.scalatest.freespec.AnyFreeSpec
@@ -17,7 +15,7 @@ class ExportModuleRefsSpec extends AnyFreeSpec with Matchers {
   "module references" - {
     "handles empty case" in {
       val acs = TestData
-        .ACS(Seq.empty[Created])
+        .ACS(Seq.empty[TestData.Created])
         .toACS
       val trees = Seq.empty[TransactionTree]
       val refs = moduleRefs(acs.values, trees)

--- a/daml-script/export/src/test/scala/com/daml/script/export/TestData.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/TestData.scala
@@ -30,15 +30,15 @@ object TestData {
       createArguments: Seq[RecordField] = Seq.empty,
       submitters: Seq[Party] = defaultParties,
       contractKey: Option[Value] = None,
+      templateId: Identifier = defaultTemplateId,
   ) extends Event {
     def toCreatedEvent(eventId: String): CreatedEvent = {
       CreatedEvent(
         eventId = eventId,
-        templateId = Some(defaultTemplateId),
+        templateId = Some(templateId),
         contractId = ContractId.unwrap(contractId),
         signatories = Party.unsubst(submitters),
-        createArguments =
-          Some(Record(recordId = Some(defaultTemplateId), fields = createArguments)),
+        createArguments = Some(Record(recordId = Some(templateId), fields = createArguments)),
         contractKey = contractKey,
       )
     }


### PR DESCRIPTION
Closes #10379 

Avoids imports of internal modules in the generated Daml ledger export script.

- Factor out `moduleRefs` which constructs the set of module imports based on references in ACS and transaction tree.
- Adds unit tests for `moduleRefs`.
- Filters out internal modules according to `isInternal` in `compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
