### PR TITLE
Allow imports of internal modules

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -75,6 +75,7 @@
 
 module DA.Daml.LFConversion
     ( convertModule
+    , convertModuleName
     , sourceLocToRange
     , convertRationalBigNumeric -- exposed for festing
     , runConvertM -- exposed for testing

--- a/compiler/damlc/daml-preprocessor/BUILD.bazel
+++ b/compiler/damlc/daml-preprocessor/BUILD.bazel
@@ -35,6 +35,8 @@ da_haskell_library(
         "//compiler/daml-lf-ast",
         "//compiler/daml-lf-proto",
         "//compiler/daml-lf-tools",
+        "//compiler/damlc/daml-lf-conversion",
+        "//compiler/damlc/stable-packages:stable-packages-lib",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -8,9 +8,11 @@ module DA.Daml.Preprocessor
   , noPreprocessor
   ) where
 
+import           DA.Daml.LFConversion (convertModuleName)
 import           DA.Daml.Preprocessor.Records
 import           DA.Daml.Preprocessor.Generics
 import           DA.Daml.Preprocessor.EnumType
+import           DA.Daml.StablePackages (stablePackageByModuleName)
 
 import Development.IDE.Types.Options
 import qualified "ghc-lib" GHC
@@ -46,6 +48,11 @@ isInternal (GHC.moduleNameString -> x)
       , "DA.Types"
       , "DA.Time.Types"
       ]
+
+isUnstableInternal :: GHC.ModuleName -> Bool
+isUnstableInternal moduleName =
+  isInternal moduleName &&
+    convertModuleName moduleName `Map.notMember` stablePackageByModuleName
 
 preprocessorExceptions :: Set.Set GHC.ModuleName
 preprocessorExceptions = Set.fromList $ map GHC.mkModuleName
@@ -163,8 +170,8 @@ checkModuleName (GHC.L _ m)
 -- | We ban people from importing modules such
 checkImports :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
 checkImports x =
-    [ (ss, "Import of internal module " ++ GHC.moduleNameString m ++ " is not allowed.")
-    | GHC.L ss GHC.ImportDecl{ideclName=GHC.L _ m} <- GHC.hsmodImports $ GHC.unLoc x, isInternal m]
+    [ (ss, "Import of unstable internal module " ++ GHC.moduleNameString m ++ " is not allowed.")
+    | GHC.L ss GHC.ImportDecl{ideclName=GHC.L _ m} <- GHC.hsmodImports $ GHC.unLoc x, isUnstableInternal m]
 
 -- | Emit a warning if the "daml 1.2" version header is present.
 checkDamlHeader :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -170,7 +170,7 @@ checkModuleName (GHC.L _ m)
 -- | We ban people from importing modules such
 checkImports :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
 checkImports x =
-    [ (ss, "Import of unstable internal module " ++ GHC.moduleNameString m ++ " is not allowed.")
+    [ (ss, "Import of internal module " ++ GHC.moduleNameString m ++ " is not allowed.")
     | GHC.L ss GHC.ImportDecl{ideclName=GHC.L _ m} <- GHC.hsmodImports $ GHC.unLoc x, isUnstableInternal m]
 
 -- | Emit a warning if the "daml 1.2" version header is present.

--- a/compiler/damlc/tests/daml-test-files/InternalImport.daml
+++ b/compiler/damlc/tests/daml-test-files/InternalImport.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=10:1-10:39; Import of unstable internal module DA.Internal.RebindableSyntax is not allowed.
+-- @ERROR range=10:1-10:39; Import of internal module DA.Internal.RebindableSyntax is not allowed.
 
 
 module InternalImport where

--- a/compiler/damlc/tests/daml-test-files/InternalImport.daml
+++ b/compiler/damlc/tests/daml-test-files/InternalImport.daml
@@ -1,9 +1,10 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:1-9:28; Import of internal module DA.Internal.Template is not allowed.
+-- @ERROR range=10:1-10:39; Import of unstable internal module DA.Internal.RebindableSyntax is not allowed.
 
 
 module InternalImport where
 
-import DA.Internal.Template
+import DA.Internal.Template ()
+import DA.Internal.RebindableSyntax ()


### PR DESCRIPTION
As discussed in https://github.com/digital-asset/daml/pull/10391#discussion_r675526700 changes the Daml compiler to no longer error on imports of internal modules.
Closes #10391
Closes #10379

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
