### PR TITLE
Keep the participant-state API prefixed. [KVL-1002]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.api.v1.command_completion_service.CompletionEndRequest
 import com.daml.ledger.client.services.commands.CommandSubmissionFlow
 import com.daml.ledger.participant.state.index.v2._
-import com.daml.ledger.participant.state.v1.WriteService
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.data.Ref
 import com.daml.lf.engine._
@@ -71,7 +71,7 @@ private[daml] object ApiServices {
 
   final class Owner(
       participantId: Ref.ParticipantId,
-      optWriteService: Option[WriteService],
+      optWriteService: Option[state.WriteService],
       indexService: IndexService,
       authorizer: Authorizer,
       engine: Engine,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.api.auth.{AuthService, Authorizer}
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.configuration.LedgerId
-import com.daml.ledger.participant.state.v1.WriteService
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.data.Ref
 import com.daml.lf.engine.{Engine, ValueEnricher}
@@ -39,15 +39,13 @@ import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.util.{Failure, Success, Try}
 
-// Main entry point to start an index server that also hosts the ledger API.
-// See v2.ReferenceServer on how it is used.
 final class StandaloneApiServer(
     ledgerId: LedgerId,
     config: ApiServerConfig,
     commandConfig: CommandConfiguration,
     partyConfig: PartyConfiguration,
     ledgerConfig: LedgerConfiguration,
-    optWriteService: Option[WriteService],
+    optWriteService: Option[state.WriteService],
     authService: AuthService,
     healthChecks: HealthChecks,
     metrics: Metrics,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutionResult.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutionResult.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.apiserver.execution
 
-import com.daml.ledger.participant.state.v1.{SubmitterInfo, TransactionMeta}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.transaction.SubmittedTransaction
 
 /** The result of command execution.
@@ -15,13 +15,13 @@ import com.daml.lf.transaction.SubmittedTransaction
   *                                 on the ledger time, as specified through
   *                                 [[com.daml.lf.command.Commands.ledgerEffectiveTime]].
   *                                 If this value is false, then the ledger time of the resulting
-  *                                 transaction ([[TransactionMeta.ledgerEffectiveTime]]) can safely be
-  *                                 changed after command interpretation.
+  *                                 transaction ([[state.TransactionMeta.ledgerEffectiveTime]])
+  *                                 can safely be changed after command interpretation.
   * @param interpretationTimeNanos  Wall-clock time that interpretation took for the engine.
   */
 private[apiserver] final case class CommandExecutionResult(
-    submitterInfo: SubmitterInfo,
-    transactionMeta: TransactionMeta,
+    submitterInfo: state.SubmitterInfo,
+    transactionMeta: state.TransactionMeta,
     transaction: SubmittedTransaction,
     dependsOnLedgerTime: Boolean,
     interpretationTimeNanos: Long,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import com.daml.ledger.api.domain.{Commands => ApiCommands}
 import com.daml.ledger.participant.state.index.v2.{ContractStore, IndexPackagesService}
-import com.daml.ledger.participant.state.v1.{SubmitterInfo, TransactionMeta}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.crypto
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.{
@@ -73,13 +73,13 @@ private[apiserver] final class StoreBackedCommandExecutor(
         } yield {
           val interpretationTimeNanos = System.nanoTime() - start
           CommandExecutionResult(
-            submitterInfo = SubmitterInfo(
+            submitterInfo = state.SubmitterInfo(
               commands.actAs.toList,
               commands.applicationId.unwrap,
               commands.commandId.unwrap,
               commands.deduplicateUntil,
             ),
-            transactionMeta = TransactionMeta(
+            transactionMeta = state.TransactionMeta(
               commands.commands.ledgerEffectiveTime,
               commands.workflowId.map(_.unwrap),
               meta.submissionTime,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.api.domain.{LedgerId, Commands => ApiCommands}
 import com.daml.ledger.api.messages.command.submission.SubmitRequest
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.index.v2._
-import com.daml.ledger.participant.state.v1.{SubmissionResult, WriteService}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.crypto
 import com.daml.lf.data.Ref
 import com.daml.lf.engine.{Error => LfError}
@@ -41,7 +41,7 @@ private[apiserver] object ApiSubmissionService {
 
   def create(
       ledgerId: LedgerId,
-      writeService: WriteService,
+      writeService: state.WriteService,
       submissionService: IndexSubmissionService,
       partyManagementService: IndexPartyManagementService,
       timeProvider: TimeProvider,
@@ -83,7 +83,7 @@ private[apiserver] object ApiSubmissionService {
 }
 
 private[apiserver] final class ApiSubmissionService private[services] (
-    writeService: WriteService,
+    writeService: state.WriteService,
     submissionService: IndexSubmissionService,
     partyManagementService: IndexPartyManagementService,
     timeProvider: TimeProvider,
@@ -141,10 +141,10 @@ private[apiserver] final class ApiSubmissionService private[services] (
           Future.failed(DuplicateCommand.asRuntimeException)
       }
 
-  private def handleSubmissionResult(result: Try[SubmissionResult])(implicit
+  private def handleSubmissionResult(result: Try[state.SubmissionResult])(implicit
       loggingContext: LoggingContext
   ): Try[Unit] = {
-    import SubmissionResult._
+    import state.SubmissionResult._
     result match {
       case Success(Acknowledged) =>
         logger.debug("Success")
@@ -190,7 +190,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
   )(implicit
       loggingContext: LoggingContext,
       telemetryContext: TelemetryContext,
-  ): Future[SubmissionResult] =
+  ): Future[state.SubmissionResult] =
     for {
       result <- commandExecutor.execute(commands, submissionSeed)
       transactionInfo <- handleCommandExecutionResult(result)
@@ -204,7 +204,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
   )(implicit
       loggingContext: LoggingContext,
       telemetryContext: TelemetryContext,
-  ): Future[Seq[SubmissionResult]] =
+  ): Future[Seq[state.SubmissionResult]] =
     if (configuration.implicitPartyAllocation) {
       val partiesInTransaction = transaction.informees.toSeq
       for {
@@ -217,7 +217,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
 
   private def allocateParty(
       name: Ref.Party
-  )(implicit telemetryContext: TelemetryContext): Future[SubmissionResult] = {
+  )(implicit telemetryContext: TelemetryContext): Future[state.SubmissionResult] = {
     val submissionId = Ref.SubmissionId.assertFromString(UUID.randomUUID().toString)
     withEnrichedLoggingContext(logging.party(name), logging.submissionId(submissionId)) {
       implicit loggingContext =>
@@ -233,10 +233,10 @@ private[apiserver] final class ApiSubmissionService private[services] (
 
   private def submitTransaction(
       transactionInfo: CommandExecutionResult,
-      partyAllocationResults: Seq[SubmissionResult],
+      partyAllocationResults: Seq[state.SubmissionResult],
       ledgerConfig: Configuration,
-  )(implicit telemetryContext: TelemetryContext): Future[SubmissionResult] =
-    partyAllocationResults.find(_ != SubmissionResult.Acknowledged) match {
+  )(implicit telemetryContext: TelemetryContext): Future[state.SubmissionResult] =
+    partyAllocationResults.find(_ != state.SubmissionResult.Acknowledged) match {
       case Some(result) =>
         Future.successful(result)
       case None =>
@@ -263,7 +263,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
 
   private def submitTransaction(
       result: CommandExecutionResult
-  )(implicit telemetryContext: TelemetryContext): Future[SubmissionResult] = {
+  )(implicit telemetryContext: TelemetryContext): Future[state.SubmissionResult] = {
     metrics.daml.commands.validSubmissions.mark()
     writeService
       .submitTransaction(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -14,7 +14,7 @@ import com.daml.ledger.api.v1.admin.config_management_service.ConfigManagementSe
 import com.daml.ledger.api.v1.admin.config_management_service._
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
 import com.daml.ledger.participant.state.index.v2.IndexConfigManagementService
-import com.daml.ledger.participant.state.v1.{SubmissionResult, WriteConfigService}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.{Ref, Time}
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -34,7 +34,7 @@ import scala.util.{Failure, Success}
 
 private[apiserver] final class ApiConfigManagementService private (
     index: IndexConfigManagementService,
-    writeService: WriteConfigService,
+    writeService: state.WriteConfigService,
     timeProvider: TimeProvider,
     ledgerConfiguration: LedgerConfiguration,
     submissionIdGenerator: String => Ref.SubmissionId,
@@ -187,7 +187,7 @@ private[apiserver] object ApiConfigManagementService {
 
   def createApiService(
       readBackend: IndexConfigManagementService,
-      writeBackend: WriteConfigService,
+      writeBackend: state.WriteConfigService,
       timeProvider: TimeProvider,
       ledgerConfiguration: LedgerConfiguration,
       submissionIdGenerator: String => Ref.SubmissionId = augmentSubmissionId,
@@ -205,7 +205,7 @@ private[apiserver] object ApiConfigManagementService {
     )
 
   private final class SynchronousResponseStrategy(
-      writeConfigService: WriteConfigService,
+      writeConfigService: state.WriteConfigService,
       configManagementService: IndexConfigManagementService,
       ledgerEnd: Option[LedgerOffset.Absolute],
   )(implicit loggingContext: LoggingContext)
@@ -221,7 +221,7 @@ private[apiserver] object ApiConfigManagementService {
     override def submit(
         submissionId: Ref.SubmissionId,
         input: (Time.Timestamp, Configuration),
-    )(implicit telemetryContext: TelemetryContext): Future[SubmissionResult] = {
+    )(implicit telemetryContext: TelemetryContext): Future[state.SubmissionResult] = {
       val (maximumRecordTime, newConfiguration) = input
       writeConfigService
         .submitConfiguration(maximumRecordTime, submissionId, newConfiguration)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -17,7 +17,7 @@ import com.daml.ledger.participant.state.index.v2.{
   IndexTransactionsService,
   LedgerEndService,
 }
-import com.daml.ledger.participant.state.v1.{SubmissionResult, WritePackagesService}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.archive.{Dar, DarParser, Decode, GenDarReader}
 import com.daml.lf.data.Ref
 import com.daml.lf.engine.Engine
@@ -42,7 +42,7 @@ import scala.util.Try
 private[apiserver] final class ApiPackageManagementService private (
     packagesIndex: IndexPackagesService,
     transactionsService: IndexTransactionsService,
-    packagesWrite: WritePackagesService,
+    packagesWrite: state.WritePackagesService,
     managementServiceTimeout: Duration,
     engine: Engine,
     darReader: GenDarReader[Archive],
@@ -138,7 +138,7 @@ private[apiserver] object ApiPackageManagementService {
   def createApiService(
       readBackend: IndexPackagesService,
       transactionsService: IndexTransactionsService,
-      writeBackend: WritePackagesService,
+      writeBackend: state.WritePackagesService,
       managementServiceTimeout: Duration,
       engine: Engine,
       darReader: GenDarReader[Archive] = DarParser,
@@ -161,7 +161,7 @@ private[apiserver] object ApiPackageManagementService {
   private final class SynchronousResponseStrategy(
       ledgerEndService: LedgerEndService,
       packagesIndex: IndexPackagesService,
-      packagesWrite: WritePackagesService,
+      packagesWrite: state.WritePackagesService,
   )(implicit executionContext: ExecutionContext, loggingContext: LoggingContext)
       extends SynchronousResponse.Strategy[
         Dar[Archive],
@@ -174,7 +174,7 @@ private[apiserver] object ApiPackageManagementService {
 
     override def submit(submissionId: Ref.SubmissionId, dar: Dar[Archive])(implicit
         telemetryContext: TelemetryContext
-    ): Future[SubmissionResult] =
+    ): Future[state.SubmissionResult] =
       packagesWrite.uploadPackages(submissionId, dar.all, None).toScala
 
     override def entries(offset: Option[LedgerOffset.Absolute]): Source[PackageEntry, _] =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -16,7 +16,7 @@ import com.daml.ledger.participant.state.index.v2.{
   IndexTransactionsService,
   LedgerEndService,
 }
-import com.daml.ledger.participant.state.v1.{SubmissionResult, WritePartyService}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 private[apiserver] final class ApiPartyManagementService private (
     partyManagementService: IndexPartyManagementService,
     transactionService: IndexTransactionsService,
-    writeService: WritePartyService,
+    writeService: state.WritePartyService,
     managementServiceTimeout: Duration,
     submissionIdGenerator: Option[Ref.Party] => Ref.SubmissionId,
 )(implicit
@@ -139,7 +139,7 @@ private[apiserver] object ApiPartyManagementService {
   def createApiService(
       partyManagementServiceBackend: IndexPartyManagementService,
       transactionsService: IndexTransactionsService,
-      writeBackend: WritePartyService,
+      writeBackend: state.WritePartyService,
       managementServiceTimeout: Duration,
       submissionIdGenerator: Option[Ref.Party] => Ref.SubmissionId = CreateSubmissionId.withPrefix,
   )(implicit
@@ -170,7 +170,7 @@ private[apiserver] object ApiPartyManagementService {
 
   private final class SynchronousResponseStrategy(
       ledgerEndService: LedgerEndService,
-      writeService: WritePartyService,
+      writeService: state.WritePartyService,
       partyManagementService: IndexPartyManagementService,
   )(implicit executionContext: ExecutionContext, loggingContext: LoggingContext)
       extends SynchronousResponse.Strategy[
@@ -185,7 +185,7 @@ private[apiserver] object ApiPartyManagementService {
     override def submit(
         submissionId: Ref.SubmissionId,
         input: (Option[Ref.Party], Option[String]),
-    )(implicit telemetryContext: TelemetryContext): Future[SubmissionResult] = {
+    )(implicit telemetryContext: TelemetryContext): Future[state.SubmissionResult] = {
       val (party, displayName) = input
       writeService.allocateParty(party, displayName, submissionId).toScala
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
@@ -9,8 +9,8 @@ import java.util.concurrent.TimeUnit
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.api.domain.LedgerOffset
-import com.daml.ledger.participant.state.v1.SubmissionResult
 import com.daml.lf.data.Ref
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.platform.apiserver.services.admin.SynchronousResponse.{Accepted, Rejected}
 import com.daml.platform.server.api.validation.ErrorFactories
 import com.daml.telemetry.TelemetryContext
@@ -34,6 +34,7 @@ class SynchronousResponse[Input, Entry, AcceptedEntry](
       executionContext: ExecutionContext,
       materializer: Materializer,
   ): Future[AcceptedEntry] = {
+    import state.SubmissionResult
     for {
       ledgerEndBeforeRequest <- strategy.currentLedgerEnd()
       submissionResult <- strategy.submit(submissionId, input)
@@ -77,7 +78,7 @@ object SynchronousResponse {
     /** Submits a request to the ledger. */
     def submit(submissionId: Ref.SubmissionId, input: Input)(implicit
         telemetryContext: TelemetryContext
-    ): Future[SubmissionResult]
+    ): Future[state.SubmissionResult]
 
     /** Opens a stream of entries from before the submission. */
     def entries(offset: Option[LedgerOffset.Absolute]): Source[Entry, _]

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
@@ -12,8 +12,7 @@ import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.domain
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2
-import com.daml.ledger.participant.state.v1.Update
-import com.daml.ledger.participant.state.v1.Update._
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
@@ -75,6 +74,9 @@ object ExecuteUpdate {
 }
 
 trait ExecuteUpdate {
+  import state.Update._
+  import state._
+
   private val logger = ContextualizedLogger.get(this.getClass)
 
   private[indexer] implicit val loggingContext: LoggingContext
@@ -365,6 +367,7 @@ class PipelinedExecuteUpdate(
     private[indexer] val updatePreparationParallelism: Int,
 )(implicit val executionContext: ExecutionContext, val loggingContext: LoggingContext)
     extends ExecuteUpdate {
+  import state.Update._
 
   private def insertTransactionState(
       timedPipelinedUpdate: PipelinedUpdateWithTimer
@@ -480,6 +483,7 @@ class AtomicExecuteUpdate(
     private[indexer] implicit val loggingContext: LoggingContext,
     private[indexer] val executionContext: ExecutionContext,
 ) extends ExecuteUpdate {
+  import state.Update._
 
   private[indexer] val flow: ExecuteUpdateFlow =
     Flow[OffsetUpdate]

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/Indexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/Indexer.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.indexer
 
-import com.daml.ledger.participant.state.v1.ReadService
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.ResourceOwner
 
 import scala.concurrent.Future
@@ -17,7 +17,7 @@ trait Indexer {
     * @param readService the ReadService to subscribe to
     * @return a handle of IndexFeedHandle or a failed Future
     */
-  def subscription(readService: ReadService): ResourceOwner[IndexFeedHandle]
+  def subscription(readService: state.ReadService): ResourceOwner[IndexFeedHandle]
 
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -11,7 +11,7 @@ import akka.stream.scaladsl.{Flow, Keep, Sink}
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.domain.ParticipantId
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1._
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.data.Ref
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -39,7 +39,7 @@ import scala.util.control.NonFatal
 object JdbcIndexer {
   private[daml] final class Factory private[indexer] (
       config: IndexerConfig,
-      readService: ReadService,
+      readService: state.ReadService,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
       updateFlowOwnerBuilder: ExecuteUpdate.FlowOwnerBuilder,
@@ -51,7 +51,7 @@ object JdbcIndexer {
     private[daml] def this(
         serverRole: ServerRole,
         config: IndexerConfig,
-        readService: ReadService,
+        readService: state.ReadService,
         servicesExecutionContext: ExecutionContext,
         metrics: Metrics,
         lfValueTranslationCache: LfValueTranslationCache.Cache,
@@ -264,7 +264,7 @@ private[daml] class JdbcIndexer private[indexer] (
 
   import JdbcIndexer.logger
 
-  override def subscription(readService: ReadService): ResourceOwner[IndexFeedHandle] =
+  override def subscription(readService: state.ReadService): ResourceOwner[IndexFeedHandle] =
     new SubscriptionResourceOwner(readService)
 
   private def handleStateUpdate(implicit
@@ -284,12 +284,12 @@ private[daml] class JdbcIndexer private[indexer] (
 
   private def zipWithPreviousOffset(
       initialOffset: Option[Offset]
-  ): Flow[(Offset, Update), OffsetUpdate, NotUsed] =
-    Flow[(Offset, Update)]
+  ): Flow[(Offset, state.Update), OffsetUpdate, NotUsed] =
+    Flow[(Offset, state.Update)]
       .statefulMapConcat { () =>
         val previousOffsetRef = new AtomicReference(initialOffset)
 
-        { offsetUpdateTuple: (Offset, Update) =>
+        { offsetUpdateTuple: (Offset, state.Update) =>
           val (nextOffset, update) = offsetUpdateTuple
           val offsetStep =
             previousOffsetRef
@@ -302,7 +302,7 @@ private[daml] class JdbcIndexer private[indexer] (
       }
 
   private class SubscriptionResourceOwner(
-      readService: ReadService
+      readService: state.ReadService
   )(implicit loggingContext: LoggingContext)
       extends ResourceOwner[IndexFeedHandle] {
     override def acquire()(implicit context: ResourceContext): Resource[IndexFeedHandle] =

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/OffsetUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/OffsetUpdate.scala
@@ -4,29 +4,28 @@
 package com.daml.platform.indexer
 
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.Update.TransactionAccepted
-import com.daml.ledger.participant.state.v1.Update
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 
 sealed trait OffsetUpdate extends Product with Serializable {
   def offsetStep: OffsetStep
-  def update: Update
+  def update: state.Update
 }
 
 object OffsetUpdate {
-  def unapply(offsetUpdate: OffsetUpdate): Some[(OffsetStep, Update)] =
+  def unapply(offsetUpdate: OffsetUpdate): Some[(OffsetStep, state.Update)] =
     Some((offsetUpdate.offsetStep, offsetUpdate.update))
 
-  def apply(offsetStep: OffsetStep, update: Update): OffsetUpdate =
+  def apply(offsetStep: OffsetStep, update: state.Update): OffsetUpdate =
     OffsetUpdateImpl(offsetStep, update)
 
   final case class PreparedTransactionInsert(
       offsetStep: OffsetStep,
-      update: TransactionAccepted,
+      update: state.Update.TransactionAccepted,
       preparedInsert: PreparedInsert,
   ) extends OffsetUpdate
 
-  private final case class OffsetUpdateImpl(offsetStep: OffsetStep, update: Update)
+  private final case class OffsetUpdateImpl(offsetStep: OffsetStep, update: state.Update)
       extends OffsetUpdate
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -5,7 +5,7 @@ package com.daml.platform.indexer
 
 import akka.stream.Materializer
 import com.daml.ledger.api.health.{HealthStatus, ReportsHealth}
-import com.daml.ledger.participant.state.v1.ReadService
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
@@ -15,7 +15,7 @@ import com.daml.platform.store.LfValueTranslationCache
 import scala.concurrent.ExecutionContext
 
 final class StandaloneIndexerServer(
-    readService: ReadService,
+    readService: state.ReadService,
     config: IndexerConfig,
     servicesExecutionContext: ExecutionContext,
     metrics: Metrics,

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/IndexerLoggingContext.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/IndexerLoggingContext.scala
@@ -6,22 +6,15 @@ package com.daml.platform.indexer.parallel
 import java.time.{Duration, Instant}
 
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.Update
-import com.daml.ledger.participant.state.v1.Update.{
-  CommandRejected,
-  ConfigurationChangeRejected,
-  ConfigurationChanged,
-  PartyAddedToParticipant,
-  PartyAllocationRejected,
-  PublicPackageUpload,
-  PublicPackageUploadRejected,
-  TransactionAccepted,
-}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.entries.{LoggingEntries, LoggingEntry}
 
 object IndexerLoggingContext {
+  import state.Update._
+  import state._
+
   def loggingEntriesFor(
       offset: Offset,
       update: Update,

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -11,15 +11,14 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.{KillSwitch, KillSwitches, Materializer, UniqueKillSwitch}
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{ReadService, Update}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext.{withEnrichedLoggingContext, withEnrichedLoggingContextFrom}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{InstrumentedSource, Metrics}
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.indexer.ha.HaConfig
-import com.daml.platform.indexer.ha.{HaCoordinator, Handle, NoopHaCoordinator}
+import com.daml.platform.indexer.ha.{HaConfig, HaCoordinator, Handle, NoopHaCoordinator}
 import com.daml.platform.indexer.parallel.AsyncSupport._
 import com.daml.platform.indexer.{IndexFeedHandle, Indexer}
 import com.daml.platform.store.appendonlydao.DbDispatcher
@@ -27,7 +26,6 @@ import com.daml.platform.store.appendonlydao.events.{CompressionStrategy, LfValu
 import com.daml.platform.store.backend
 import com.daml.platform.store.backend.DataSourceStorageBackend.DataSourceConfig
 import com.daml.platform.store.backend.{DbDto, StorageBackend}
-import com.daml.resources
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 
 import scala.concurrent.duration.FiniteDuration
@@ -99,8 +97,10 @@ object ParallelIndexerFactory {
         else
           ResourceOwner.successful(NoopHaCoordinator)
     } yield {
-      val ingest
-          : (Long, DbDispatcher) => Source[(Offset, Update), NotUsed] => Source[Unit, NotUsed] =
+      val ingest: (
+          Long,
+          DbDispatcher,
+      ) => Source[(Offset, state.Update), NotUsed] => Source[Unit, NotUsed] =
         (initialSeqId, dbDispatcher) =>
           source =>
             BatchingParallelIngestionPipe(
@@ -141,7 +141,7 @@ object ParallelIndexerFactory {
                   },
               )
 
-      def subscribe(resourceContext: ResourceContext)(readService: ReadService): Handle = {
+      def subscribe(resourceContext: ResourceContext)(readService: state.ReadService): Handle = {
         implicit val rc: ResourceContext = resourceContext
         implicit val ec: ExecutionContext = resourceContext.executionContext
         implicit val matImplicit: Materializer = mat
@@ -215,10 +215,10 @@ object ParallelIndexerFactory {
 
   def inputMapper(
       metrics: Metrics,
-      toDbDto: Offset => Update => Iterator[DbDto],
+      toDbDto: Offset => state.Update => Iterator[DbDto],
   )(implicit
       loggingContext: LoggingContext
-  ): Iterable[((Offset, Update), Long)] => Batch[Vector[DbDto]] = { input =>
+  ): Iterable[((Offset, state.Update), Long)] => Batch[Vector[DbDto]] = { input =>
     metrics.daml.parallelIndexer.inputMapping.batchSize.update(input.size)
     input.foreach { case ((offset, update), _) =>
       withEnrichedLoggingContextFrom(IndexerLoggingContext.loggingEntriesFor(offset, update)) {
@@ -355,14 +355,10 @@ object ParallelIndexerFactory {
         }
       }
 
-  def toIndexer(
-      ingestionPipeOn: ResourceContext => ReadService => Handle
-  ): Indexer =
+  def toIndexer(ingestionPipeOn: ResourceContext => state.ReadService => Handle): Indexer =
     readService =>
       new ResourceOwner[IndexFeedHandle] {
-        override def acquire()(implicit
-            context: ResourceContext
-        ): resources.Resource[ResourceContext, IndexFeedHandle] = {
+        override def acquire()(implicit context: ResourceContext): Resource[IndexFeedHandle] = {
           Resource {
             Future {
               val handle = ingestionPipeOn(context)(readService)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -19,13 +19,7 @@ import com.daml.ledger.participant.state.index.v2.{
   CommandDeduplicationResult,
   PackageDetails,
 }
-import com.daml.ledger.participant.state.v1.{
-  DivulgedContract,
-  RejectionReason,
-  SubmitterInfo,
-  TransactionMeta,
-  Update,
-}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.lf.archive.ArchiveParser
 import com.daml.lf.data.{Ref, Time}
@@ -192,7 +186,7 @@ private class JdbcLedgerDao(
 
         val update = finalRejectionReason match {
           case None =>
-            Update.ConfigurationChanged(
+            state.Update.ConfigurationChanged(
               recordTime = Time.Timestamp.assertFromInstant(recordedAt),
               submissionId = Ref.SubmissionId.assertFromString(submissionId),
               participantId =
@@ -201,7 +195,7 @@ private class JdbcLedgerDao(
             )
 
           case Some(reason) =>
-            Update.ConfigurationChangeRejected(
+            state.Update.ConfigurationChangeRejected(
               recordTime = Time.Timestamp.assertFromInstant(recordedAt),
               submissionId = Ref.SubmissionId.assertFromString(submissionId),
               participantId =
@@ -232,7 +226,7 @@ private class JdbcLedgerDao(
               conn,
               offset,
               Some(
-                Update.PartyAddedToParticipant(
+                state.Update.PartyAddedToParticipant(
                   party = partyDetails.party,
                   displayName = partyDetails.displayName.orNull,
                   participantId = participantId,
@@ -257,7 +251,7 @@ private class JdbcLedgerDao(
             conn,
             offset,
             Some(
-              Update.PartyAllocationRejected(
+              state.Update.PartyAllocationRejected(
                 submissionId = submissionId,
                 participantId = participantId,
                 recordTime = Time.Timestamp.assertFromInstant(recordTime),
@@ -289,13 +283,13 @@ private class JdbcLedgerDao(
   }
 
   override def prepareTransactionInsert(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       workflowId: Option[Ref.WorkflowId],
       transactionId: Ref.TransactionId,
       ledgerEffectiveTime: Instant,
       offset: Offset,
       transaction: CommittedTransaction,
-      divulgedContracts: Iterable[DivulgedContract],
+      divulgedContracts: Iterable[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
   ): PreparedInsert =
     throw new UnsupportedOperationException(
@@ -318,7 +312,7 @@ private class JdbcLedgerDao(
     ) // TODO append-only: cleanup
 
   override def completeTransaction(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       transactionId: Ref.TransactionId,
       recordTime: Instant,
       offsetStep: OffsetStep,
@@ -329,13 +323,13 @@ private class JdbcLedgerDao(
 
   override def storeTransaction(
       preparedInsert: PreparedInsert,
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       transactionId: Ref.TransactionId,
       recordTime: Instant,
       ledgerEffectiveTime: Instant,
       offsetStep: OffsetStep,
       transaction: CommittedTransaction,
-      divulged: Iterable[DivulgedContract],
+      divulged: Iterable[state.DivulgedContract],
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     throw new UnsupportedOperationException(
       "not supported by append-only code"
@@ -344,7 +338,7 @@ private class JdbcLedgerDao(
   private def validate(
       ledgerEffectiveTime: Instant,
       transaction: CommittedTransaction,
-      divulged: Iterable[DivulgedContract],
+      divulged: Iterable[state.DivulgedContract],
   )(implicit connection: Connection): Option[PostCommitValidation.Rejection] =
     Timed.value(
       metrics.daml.index.db.storeTransactionDbMetrics.commitValidation,
@@ -356,10 +350,10 @@ private class JdbcLedgerDao(
     )
 
   override def storeRejection(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       recordTime: Instant,
       offsetStep: OffsetStep,
-      reason: RejectionReason,
+      reason: state.RejectionReason,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     dbDispatcher
       .executeSql(metrics.daml.index.db.storeRejectionDbMetrics) { implicit conn =>
@@ -368,7 +362,7 @@ private class JdbcLedgerDao(
           conn,
           offset,
           submitterInfo.map(someSubmitterInfo =>
-            Update.CommandRejected(
+            state.Update.CommandRejected(
               recordTime = Time.Timestamp.assertFromInstant(recordTime),
               submitterInfo = someSubmitterInfo,
               reason = reason,
@@ -393,15 +387,15 @@ private class JdbcLedgerDao(
                   appId <- tx.applicationId;
                   actAs <- if (tx.actAs.isEmpty) None else Some(tx.actAs);
                   cmdId <- tx.commandId
-                ) yield SubmitterInfo(actAs, appId, cmdId, Instant.EPOCH)
+                ) yield state.SubmitterInfo(actAs, appId, cmdId, Instant.EPOCH)
 
               sequentialIndexer.store(
                 connection,
                 offset,
                 Some(
-                  Update.TransactionAccepted(
+                  state.Update.TransactionAccepted(
                     optSubmitterInfo = submitterInfo,
-                    transactionMeta = TransactionMeta(
+                    transactionMeta = state.TransactionMeta(
                       ledgerEffectiveTime =
                         Time.Timestamp.assertFromInstant(tx.ledgerEffectiveTime),
                       workflowId = tx.workflowId,
@@ -424,9 +418,10 @@ private class JdbcLedgerDao(
                 connection,
                 offset,
                 Some(
-                  Update.CommandRejected(
+                  state.Update.CommandRejected(
                     recordTime = Time.Timestamp.assertFromInstant(recordTime),
-                    submitterInfo = SubmitterInfo(actAs, applicationId, commandId, Instant.EPOCH),
+                    submitterInfo =
+                      state.SubmitterInfo(actAs, applicationId, commandId, Instant.EPOCH),
                     reason = reason.toParticipantStateRejectionReason,
                   )
                 ),
@@ -493,7 +488,7 @@ private class JdbcLedgerDao(
           case None =>
             // Calling storePackageEntry() without providing a PackageLedgerEntry is used to copy initial packages,
             // or in the case where the submission ID is unknown (package was submitted through a different participant).
-            Update.PublicPackageUpload(
+            state.Update.PublicPackageUpload(
               archives = packages.view.map(_._1).toList,
               sourceDescription = packages.headOption.flatMap(
                 _._2.sourceDescription
@@ -510,7 +505,7 @@ private class JdbcLedgerDao(
             )
 
           case Some(PackageLedgerEntry.PackageUploadAccepted(submissionId, recordTime)) =>
-            Update.PublicPackageUpload(
+            state.Update.PublicPackageUpload(
               archives = packages.view.map(_._1).toList,
               sourceDescription = packages.headOption.flatMap(
                 _._2.sourceDescription
@@ -520,7 +515,7 @@ private class JdbcLedgerDao(
             )
 
           case Some(PackageLedgerEntry.PackageUploadRejected(submissionId, recordTime, reason)) =>
-            Update.PublicPackageUploadRejected(
+            state.Update.PublicPackageUploadRejected(
               submissionId = submissionId,
               recordTime = Time.Timestamp.assertFromInstant(recordTime),
               rejectionReason = reason,
@@ -648,13 +643,13 @@ private class JdbcLedgerDao(
     * !!! Usage of this is discouraged, with the removal of sandbox-classic this will be removed
     */
   override def storeTransaction(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       workflowId: Option[Ref.WorkflowId],
       transactionId: Ref.TransactionId,
       ledgerEffectiveTime: Instant,
       offsetStep: OffsetStep,
       transaction: CommittedTransaction,
-      divulgedContracts: Iterable[DivulgedContract],
+      divulgedContracts: Iterable[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
       recordTime: Instant,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] = {
@@ -667,9 +662,9 @@ private class JdbcLedgerDao(
           validate(ledgerEffectiveTime, transaction, divulgedContracts) match {
             case None =>
               Some(
-                Update.TransactionAccepted(
+                state.Update.TransactionAccepted(
                   optSubmitterInfo = submitterInfo,
-                  transactionMeta = TransactionMeta(
+                  transactionMeta = state.TransactionMeta(
                     ledgerEffectiveTime = Time.Timestamp.assertFromInstant(ledgerEffectiveTime),
                     workflowId = workflowId,
                     submissionTime = null, // not used for DbDto generation
@@ -688,7 +683,7 @@ private class JdbcLedgerDao(
 
             case Some(reason) =>
               submitterInfo.map(someSubmitterInfo =>
-                Update.CommandRejected(
+                state.Update.CommandRejected(
                   recordTime = Time.Timestamp.assertFromInstant(recordTime),
                   submitterInfo = someSubmitterInfo,
                   reason = reason.toStateV1RejectionReason,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/SequentialWriteDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/SequentialWriteDao.scala
@@ -6,7 +6,7 @@ package com.daml.platform.store.appendonlydao
 import java.sql.Connection
 
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.Update
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.platform.store.backend.{
   DbDto,
   IngestionStorageBackend,
@@ -17,12 +17,12 @@ import com.daml.platform.store.backend.{
 import scala.util.chaining.scalaUtilChainingOps
 
 trait SequentialWriteDao {
-  def store(connection: Connection, offset: Offset, update: Option[Update]): Unit
+  def store(connection: Connection, offset: Offset, update: Option[state.Update]): Unit
 }
 
 case class SequentialWriteDaoImpl[DB_BATCH](
     storageBackend: IngestionStorageBackend[DB_BATCH] with ParameterStorageBackend,
-    updateToDbDtos: Offset => Update => Iterator[DbDto],
+    updateToDbDtos: Offset => state.Update => Iterator[DbDto],
 ) extends SequentialWriteDao {
 
   private var lastEventSeqId: Long = _
@@ -47,7 +47,7 @@ case class SequentialWriteDaoImpl[DB_BATCH](
       case notEvent => notEvent
     }.toVector
 
-  override def store(connection: Connection, offset: Offset, update: Option[Update]): Unit =
+  override def store(connection: Connection, offset: Offset, update: Option[state.Update]): Unit =
     synchronized {
       lazyInit(connection)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -21,7 +21,7 @@ import com.daml.ledger.api.v1.transaction_service.{
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.{CommandDeduplicationResult, PackageDetails}
-import com.daml.ledger.participant.state.v1.{DivulgedContract, RejectionReason, SubmitterInfo}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref
 import com.daml.lf.transaction.{BlindingInfo, CommittedTransaction}
 import com.daml.logging.LoggingContext
@@ -244,26 +244,26 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
 
   // TODO append-only: cleanup
   def prepareTransactionInsert(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       workflowId: Option[Ref.WorkflowId],
       transactionId: Ref.TransactionId,
       ledgerEffectiveTime: Instant,
       offset: Offset,
       transaction: CommittedTransaction,
-      divulgedContracts: Iterable[DivulgedContract],
+      divulgedContracts: Iterable[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
   ): TransactionsWriter.PreparedInsert
 
   // TODO append-only: cleanup
   def storeTransaction(
       preparedInsert: PreparedInsert,
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       transactionId: Ref.TransactionId,
       recordTime: Instant,
       ledgerEffectiveTime: Instant,
       offsetStep: OffsetStep,
       transaction: CommittedTransaction,
-      divulged: Iterable[DivulgedContract],
+      divulged: Iterable[state.DivulgedContract],
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
   // TODO append-only: cleanup
@@ -278,17 +278,17 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
 
   // TODO append-only: cleanup
   def completeTransaction(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       transactionId: Ref.TransactionId,
       recordTime: Instant,
       offsetStep: OffsetStep,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
   def storeRejection(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       recordTime: Instant,
       offsetStep: OffsetStep,
-      reason: RejectionReason,
+      reason: state.RejectionReason,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
   /** !!! Please kindly not use this.
@@ -339,13 +339,13 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
     * !!! Usage of this is discouraged, with the removal of sandbox-classic this will be removed
     */
   def storeTransaction(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       workflowId: Option[Ref.WorkflowId],
       transactionId: Ref.TransactionId,
       ledgerEffectiveTime: Instant,
       offset: OffsetStep,
       transaction: CommittedTransaction,
-      divulgedContracts: Iterable[DivulgedContract],
+      divulgedContracts: Iterable[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
       recordTime: Instant,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.{CommandDeduplicationResult, PackageDetails}
-import com.daml.ledger.participant.state.v1._
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref
 import com.daml.lf.transaction.{BlindingInfo, CommittedTransaction}
 import com.daml.logging.LoggingContext
@@ -155,13 +155,13 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
 
   override def storeTransaction(
       preparedInsert: PreparedInsert,
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       transactionId: Ref.TransactionId,
       recordTime: Instant,
       ledgerEffectiveTime: Instant,
       offsetStep: OffsetStep,
       transaction: CommittedTransaction,
-      divulged: Iterable[DivulgedContract],
+      divulged: Iterable[state.DivulgedContract],
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storeTransaction,
@@ -178,13 +178,13 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
     )
 
   def prepareTransactionInsert(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       workflowId: Option[Ref.WorkflowId],
       transactionId: Ref.TransactionId,
       ledgerEffectiveTime: Instant,
       offset: Offset,
       transaction: CommittedTransaction,
-      divulgedContracts: Iterable[DivulgedContract],
+      divulgedContracts: Iterable[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
   ): TransactionsWriter.PreparedInsert =
     ledgerDao.prepareTransactionInsert(
@@ -199,10 +199,10 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
     )
 
   override def storeRejection(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       recordTime: Instant,
       offsetStep: OffsetStep,
-      reason: RejectionReason,
+      reason: state.RejectionReason,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storeRejection,
@@ -279,7 +279,7 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
     ledgerDao.storeTransactionEvents(preparedInsert)
 
   override def completeTransaction(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       transactionId: Ref.TransactionId,
       recordTime: Instant,
       offsetStep: OffsetStep,
@@ -290,13 +290,13 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
     * !!! Usage of this is discouraged, with the removal of sandbox-classic this will be removed
     */
   override def storeTransaction(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       workflowId: Option[Ref.WorkflowId],
       transactionId: Ref.TransactionId,
       ledgerEffectiveTime: Instant,
       offset: OffsetStep,
       transaction: CommittedTransaction,
-      divulgedContracts: Iterable[DivulgedContract],
+      divulgedContracts: Iterable[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
       recordTime: Instant,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTableH2.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTableH2.scala
@@ -7,7 +7,7 @@ import java.sql.Connection
 import java.time.Instant
 
 import anorm.{BatchSql, NamedParameter}
-import com.daml.ledger.participant.state.v1.DivulgedContract
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.platform.store.Conversions._
 import com.daml.platform.store.dao.events.ContractsTable.Executable
 import com.daml.platform.store.serialization.Compression
@@ -68,7 +68,7 @@ object ContractsTableH2 extends ContractsTable {
       )
     val divulgedInserts =
       for {
-        DivulgedContract(contractId, contractInst) <- info.divulgedContracts.iterator
+        state.DivulgedContract(contractId, contractInst) <- info.divulgedContracts.iterator
       } yield {
         insertContract(
           contractId = contractId,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTableOracle.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTableOracle.scala
@@ -7,7 +7,7 @@ import java.sql.Connection
 import java.time.Instant
 
 import anorm.{BatchSql, NamedParameter}
-import com.daml.ledger.participant.state.v1.DivulgedContract
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.platform.store.Conversions._
 import com.daml.platform.store.dao.events.ContractsTable.Executable
 import com.daml.platform.store.serialization.Compression
@@ -70,7 +70,7 @@ object ContractsTableOracle extends ContractsTable {
       )
     val divulgedInserts =
       for {
-        DivulgedContract(contractId, contractInst) <- info.divulgedContracts.iterator
+        state.DivulgedContract(contractId, contractInst) <- info.divulgedContracts.iterator
       } yield {
         insertContract(
           contractId = contractId,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTablePostgres.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTablePostgres.scala
@@ -6,7 +6,7 @@ package com.daml.platform.store.dao.events
 import java.sql.{Connection, Timestamp}
 
 import anorm.{Row, SimpleSql, SqlQuery}
-import com.daml.ledger.participant.state.v1.DivulgedContract
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.platform.store.dao.events.ContractsTable.Executable
 
 object ContractsTablePostgres extends ContractsTable {
@@ -51,8 +51,8 @@ object ContractsTablePostgres extends ContractsTable {
       contractsInfo: TransactionIndexing.ContractsInfo,
       serialized: TransactionIndexing.Compressed.Contracts,
   ): Executable = {
-    import com.daml.platform.store.JdbcArrayConversions._
     import com.daml.platform.store.JdbcArrayConversions.IntToSmallIntConversions._
+    import com.daml.platform.store.JdbcArrayConversions._
 
     val netCreatesSize = contractsInfo.netCreates.size
     val divulgedSize = contractsInfo.divulgedContracts.size
@@ -78,7 +78,7 @@ object ContractsTablePostgres extends ContractsTable {
     }
 
     contractsInfo.divulgedContracts.iterator.zipWithIndex.foreach {
-      case (DivulgedContract(contractId, contractInst), idx) =>
+      case (state.DivulgedContract(contractId, contractInst), idx) =>
         contractIds(idx + netCreatesSize) = contractId.coid
         templateIds(idx + netCreatesSize) = contractInst.template.toString
         stakeholders(idx + netCreatesSize) = ""

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableH2Database.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableH2Database.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 
 import anorm.{BatchSql, NamedParameter}
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.SubmitterInfo
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.ledger.EventId
 import com.daml.platform.store.Conversions._
 import com.daml.platform.store.JdbcArrayConversions.StringArrayParameterMetadata
@@ -63,7 +63,7 @@ object EventsTableH2Database extends EventsTable {
       transactionId: TransactionId,
       workflowId: Option[WorkflowId],
       ledgerEffectiveTime: Instant,
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       events: Vector[(NodeId, Node)],
       stakeholders: WitnessRelation[NodeId],
       disclosure: WitnessRelation[NodeId],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableOracle.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableOracle.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 
 import anorm.{BatchSql, NamedParameter}
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.SubmitterInfo
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.ledger.EventId
 import com.daml.platform.store.Conversions._
 import com.daml.platform.store.OracleArrayConversions._
@@ -69,7 +69,7 @@ object EventsTableOracle extends EventsTable {
       transactionId: TransactionId,
       workflowId: Option[WorkflowId],
       ledgerEffectiveTime: Instant,
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       events: Vector[(NodeId, Node)],
       stakeholders: WitnessRelation[NodeId],
       disclosure: WitnessRelation[NodeId],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionIndexing.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionIndexing.scala
@@ -6,7 +6,7 @@ package com.daml.platform.store.dao.events
 import java.time.Instant
 
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{DivulgedContract, SubmitterInfo}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.ledger.EventId
 import com.daml.lf.transaction.{BlindingInfo, CommittedTransaction}
 import com.daml.platform.store.serialization.Compression
@@ -26,7 +26,7 @@ object TransactionIndexing {
       translation: LfValueTranslation,
       transactionId: TransactionId,
       events: Vector[(NodeId, Node)],
-      divulgence: Iterable[DivulgedContract],
+      divulgence: Iterable[state.DivulgedContract],
   ): Serialized = {
 
     val createArguments = Vector.newBuilder[(NodeId, ContractId, Array[Byte])]
@@ -50,7 +50,7 @@ object TransactionIndexing {
       }
     }
 
-    for (DivulgedContract(contractId, contractInst) <- divulgence) {
+    for (state.DivulgedContract(contractId, contractInst) <- divulgence) {
       val serializedCreateArgument = translation.serialize(contractId, contractInst.arg)
       divulgedContracts += ((contractId, serializedCreateArgument))
     }
@@ -185,18 +185,20 @@ object TransactionIndexing {
       this
     }
 
-    private def visibility(contracts: Iterable[DivulgedContract]): WitnessRelation[ContractId] =
+    private def visibility(
+        contracts: Iterable[state.DivulgedContract]
+    ): WitnessRelation[ContractId] =
       Relation.from(
         contracts.map(c => c.contractId -> blinding.divulgence.getOrElse(c.contractId, Set.empty))
       )
 
     def build(
-        submitterInfo: Option[SubmitterInfo],
+        submitterInfo: Option[state.SubmitterInfo],
         workflowId: Option[WorkflowId],
         transactionId: TransactionId,
         ledgerEffectiveTime: Instant,
         offset: Offset,
-        divulgedContracts: Iterable[DivulgedContract],
+        divulgedContracts: Iterable[state.DivulgedContract],
         inactiveContracts: Set[ContractId],
     ): TransactionIndexing = {
       // Creates outside of rollback nodes.
@@ -247,7 +249,7 @@ object TransactionIndexing {
   }
 
   final case class TransactionInfo(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       workflowId: Option[WorkflowId],
       transactionId: TransactionId,
       ledgerEffectiveTime: Instant,
@@ -264,7 +266,7 @@ object TransactionIndexing {
   final case class ContractsInfo(
       netCreates: Set[Create],
       netArchives: Set[ContractId],
-      divulgedContracts: Iterable[DivulgedContract],
+      divulgedContracts: Iterable[state.DivulgedContract],
   )
 
   final case class ContractWitnessesInfo(
@@ -321,13 +323,13 @@ object TransactionIndexing {
 
   def from(
       blindingInfo: BlindingInfo,
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       workflowId: Option[WorkflowId],
       transactionId: TransactionId,
       ledgerEffectiveTime: Instant,
       offset: Offset,
       transaction: CommittedTransaction,
-      divulgedContracts: Iterable[DivulgedContract],
+      divulgedContracts: Iterable[state.DivulgedContract],
   ): TransactionIndexing = {
     transaction
       .foldInExecutionOrder(new Builder(blindingInfo))(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsWriter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsWriter.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 
 import anorm.{Row, SimpleSql}
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{DivulgedContract, SubmitterInfo}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.engine.Blinding
 import com.daml.lf.transaction.{BlindingInfo, CommittedTransaction}
 import com.daml.metrics.{Metrics, Timed}
@@ -76,13 +76,13 @@ private[platform] final class TransactionsWriter(
   private val contractWitnessesTable = ContractWitnessesTable(dbType)
 
   def prepare(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       workflowId: Option[WorkflowId],
       transactionId: TransactionId,
       ledgerEffectiveTime: Instant,
       offset: Offset,
       transaction: CommittedTransaction,
-      divulgedContracts: Iterable[DivulgedContract],
+      divulgedContracts: Iterable[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
   ): TransactionsWriter.PreparedInsert = {
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcAppendOnlyTransactionInsertion.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcAppendOnlyTransactionInsertion.scala
@@ -4,7 +4,7 @@
 package com.daml.platform.store.dao
 
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{DivulgedContract, SubmitterInfo}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.transaction.BlindingInfo
 import com.daml.platform.indexer.OffsetStep
 import com.daml.platform.store.entries.LedgerEntry
@@ -16,10 +16,10 @@ trait JdbcAppendOnlyTransactionInsertion {
   self: JdbcLedgerDaoSuite with AsyncTestSuite =>
 
   private[dao] def store(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       tx: LedgerEntry.Transaction,
       offsetStep: OffsetStep,
-      divulgedContracts: List[DivulgedContract],
+      divulgedContracts: List[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
   ): Future[(Offset, LedgerEntry.Transaction)] = {
     for {

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcAtomicTransactionInsertion.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcAtomicTransactionInsertion.scala
@@ -4,7 +4,7 @@
 package com.daml.platform.store.dao
 
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{DivulgedContract, SubmitterInfo}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.transaction.BlindingInfo
 import com.daml.platform.indexer.OffsetStep
 import com.daml.platform.store.entries.LedgerEntry
@@ -16,10 +16,10 @@ trait JdbcAtomicTransactionInsertion {
   self: JdbcLedgerDaoSuite with AsyncTestSuite =>
 
   private[dao] def store(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       tx: LedgerEntry.Transaction,
       offsetStep: OffsetStep,
-      divulgedContracts: List[DivulgedContract],
+      divulgedContracts: List[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
   ): Future[(Offset, LedgerEntry.Transaction)] = {
     val preparedTransactionInsert = ledgerDao.prepareTransactionInsert(

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
@@ -9,7 +9,7 @@ import java.util.UUID
 import akka.stream.scaladsl.Sink
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{RejectionReasonV0, SubmitterInfo}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref
 import com.daml.platform.ApiOffset
 import com.daml.platform.store.dao.JdbcLedgerDaoCompletionsSpec._
@@ -21,6 +21,8 @@ import scala.concurrent.Future
 
 private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneElement {
   this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  import state.RejectionReasonV0._
 
   behavior of "JdbcLedgerDao (completions)"
 
@@ -71,7 +73,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
     val expectedCmdId = UUID.randomUUID.toString
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      offset <- storeRejection(RejectionReasonV0.Inconsistent(""), expectedCmdId)
+      offset <- storeRejection(Inconsistent(""), expectedCmdId)
       to <- ledgerDao.lookupLedgerEnd()
       (_, response) <- ledgerDao.completions
         .getCommandCompletions(from, to, applicationId, parties)
@@ -91,7 +93,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
     val expectedCmdId = UUID.randomUUID.toString
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      _ <- storeMultiPartyRejection(RejectionReasonV0.Inconsistent(""), expectedCmdId)
+      _ <- storeMultiPartyRejection(Inconsistent(""), expectedCmdId)
       to <- ledgerDao.lookupLedgerEnd()
       // Response 1: querying as all submitters
       (_, response1) <- ledgerDao.completions
@@ -115,7 +117,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   it should "not return completions if the application id is wrong" in {
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      _ <- storeRejection(RejectionReasonV0.Inconsistent(""))
+      _ <- storeRejection(Inconsistent(""))
       to <- ledgerDao.lookupLedgerEnd()
       response <- ledgerDao.completions
         .getCommandCompletions(from, to, applicationId = "WRONG", parties)
@@ -128,7 +130,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   it should "not return completions if the parties do not match" in {
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      _ <- storeRejection(RejectionReasonV0.Inconsistent(""))
+      _ <- storeRejection(Inconsistent(""))
       to <- ledgerDao.lookupLedgerEnd()
       response1 <- ledgerDao.completions
         .getCommandCompletions(from, to, applicationId, Set("WRONG"))
@@ -145,7 +147,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   it should "not return completions if the parties do not match (multi-party submission)" in {
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      _ <- storeMultiPartyRejection(RejectionReasonV0.Inconsistent(""))
+      _ <- storeMultiPartyRejection(Inconsistent(""))
       to <- ledgerDao.lookupLedgerEnd()
       response1 <- ledgerDao.completions
         .getCommandCompletions(from, to, applicationId, Set("WRONG"))
@@ -160,14 +162,14 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   }
 
   it should "return the expected status for each rejection reason" in {
-    val reasons = List[RejectionReasonV0](
-      RejectionReasonV0.Disputed(""),
-      RejectionReasonV0.Inconsistent(""),
-      RejectionReasonV0.InvalidLedgerTime(""),
-      RejectionReasonV0.ResourcesExhausted(""),
-      RejectionReasonV0.PartyNotKnownOnLedger(""),
-      RejectionReasonV0.SubmitterCannotActViaParticipant(""),
-      RejectionReasonV0.InvalidLedgerTime(""),
+    val reasons = List[state.RejectionReasonV0](
+      Disputed(""),
+      Inconsistent(""),
+      InvalidLedgerTime(""),
+      ResourcesExhausted(""),
+      PartyNotKnownOnLedger(""),
+      SubmitterCannotActViaParticipant(""),
+      InvalidLedgerTime(""),
     )
 
     for {
@@ -189,13 +191,14 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   }
 
   private def prepareStoreRejection(
-      reason: RejectionReasonV0,
+      reason: state.RejectionReasonV0,
       commandId: String = UUID.randomUUID().toString,
   ): () => Future[Offset] = () => {
     val offset = nextOffset()
     ledgerDao
       .storeRejection(
-        submitterInfo = Some(SubmitterInfo(List(party1), applicationId, commandId, Instant.EPOCH)),
+        submitterInfo =
+          Some(state.SubmitterInfo(List(party1), applicationId, commandId, Instant.EPOCH)),
         recordTime = Instant.now,
         offsetStep = nextOffsetStep(offset),
         reason = reason,
@@ -204,14 +207,14 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   }
 
   private def storeMultiPartyRejection(
-      reason: RejectionReasonV0,
+      reason: state.RejectionReasonV0,
       commandId: String = UUID.randomUUID().toString,
   ): Future[Offset] = {
     lazy val offset = nextOffset()
     ledgerDao
       .storeRejection(
         submitterInfo = Some(
-          SubmitterInfo(List(party1, party2, party3), applicationId, commandId, Instant.EPOCH)
+          state.SubmitterInfo(List(party1, party2, party3), applicationId, commandId, Instant.EPOCH)
         ),
         recordTime = Instant.now,
         offsetStep = nextOffsetStep(offset),
@@ -221,7 +224,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   }
 
   private def storeRejection(
-      reason: RejectionReasonV0,
+      reason: state.RejectionReasonV0,
       commandId: String = UUID.randomUUID().toString,
   ): Future[Offset] = prepareStoreRejection(reason, commandId)()
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -14,8 +14,7 @@ import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2
-import com.daml.ledger.participant.state.v1
-import com.daml.ledger.participant.state.v1.{DivulgedContract, SubmitterInfo}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.test.ModelTestDar
 import com.daml.lf.archive.DarParser
 import com.daml.lf.data.Ref.{Identifier, Party}
@@ -165,10 +164,10 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
   )
 
   private[dao] def store(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       tx: LedgerEntry.Transaction,
       offsetStep: OffsetStep,
-      divulgedContracts: List[DivulgedContract],
+      divulgedContracts: List[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
   ): Future[(Offset, LedgerEntry.Transaction)]
 
@@ -635,10 +634,10 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
   }
 
   protected final def prepareInsert(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       tx: LedgerEntry.Transaction,
       offsetStep: OffsetStep,
-      divulgedContracts: List[DivulgedContract] = List.empty,
+      divulgedContracts: List[state.DivulgedContract] = List.empty,
       blindingInfo: Option[BlindingInfo] = None,
   ): TransactionsWriter.PreparedInsert =
     ledgerDao.prepareTransactionInsert(
@@ -670,7 +669,8 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
   ): Future[(Offset, LedgerEntry.Transaction)] = {
     val (offsetStep, entry) = offsetStepAndTx
     val maybeSubmitterInfo = submitterInfo(entry)
-    val divulged = divulgedContracts.keysIterator.map(c => v1.DivulgedContract(c._1, c._2)).toList
+    val divulged =
+      divulgedContracts.keysIterator.map(c => state.DivulgedContract(c._1, c._2)).toList
 
     store(maybeSubmitterInfo, entry, offsetStep, divulged, blindingInfo)
   }
@@ -679,7 +679,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
     for (
       actAs <- if (entry.actAs.isEmpty) None else Some(entry.actAs); app <- entry.applicationId;
       cmd <- entry.commandId
-    ) yield v1.SubmitterInfo(actAs, app, cmd, Instant.EPOCH)
+    ) yield state.SubmitterInfo(actAs, app, cmd, Instant.EPOCH)
 
   protected final def store(
       offsetAndTx: (Offset, LedgerEntry.Transaction)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcPipelinedTransactionInsertion.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcPipelinedTransactionInsertion.scala
@@ -4,7 +4,7 @@
 package com.daml.platform.store.dao
 
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{DivulgedContract, SubmitterInfo}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.transaction.BlindingInfo
 import com.daml.platform.indexer.OffsetStep
 import com.daml.platform.store.entries.LedgerEntry
@@ -16,10 +16,10 @@ trait JdbcPipelinedTransactionInsertion {
   self: JdbcLedgerDaoSuite with AsyncTestSuite =>
 
   private[dao] def store(
-      submitterInfo: Option[SubmitterInfo],
+      submitterInfo: Option[state.SubmitterInfo],
       tx: LedgerEntry.Transaction,
       offsetStep: OffsetStep,
-      divulgedContracts: List[DivulgedContract],
+      divulgedContracts: List[state.DivulgedContract],
       blindingInfo: Option[BlindingInfo],
   ): Future[(Offset, LedgerEntry.Transaction)] = {
     val preparedTransactionInsert =

--- a/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiConfigManagementServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiConfigManagementServiceSpec.scala
@@ -14,7 +14,7 @@ import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.api.v1.admin.config_management_service.{SetTimeModelRequest, TimeModel}
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
 import com.daml.ledger.participant.state.index.v2.IndexConfigManagementService
-import com.daml.ledger.participant.state.v1.{SubmissionResult, WriteConfigService}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.{Ref, Time}
 import com.daml.logging.LoggingContext
 import com.daml.platform.configuration.LedgerConfiguration
@@ -77,17 +77,17 @@ class ApiConfigManagementServiceSpec
     mockIndexConfigManagementService
   }
 
-  private object TestWriteConfigService extends WriteConfigService {
+  private object TestWriteConfigService extends state.WriteConfigService {
     override def submitConfiguration(
         maxRecordTime: Time.Timestamp,
         submissionId: Ref.SubmissionId,
         config: Configuration,
-    )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
+    )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] = {
       telemetryContext.setAttribute(
         anApplicationIdSpanAttribute._1,
         anApplicationIdSpanAttribute._2,
       )
-      CompletableFuture.completedFuture(SubmissionResult.Acknowledged)
+      CompletableFuture.completedFuture(state.SubmissionResult.Acknowledged)
     }
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPackageManagementServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPackageManagementServiceSpec.scala
@@ -18,7 +18,7 @@ import com.daml.ledger.api.v1.admin.package_management_service.{
   UploadDarFileRequest,
 }
 import com.daml.ledger.participant.state.index.v2.{IndexPackagesService, IndexTransactionsService}
-import com.daml.ledger.participant.state.v1.{SubmissionResult, WritePackagesService}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.archive.testing.Encode
 import com.daml.lf.archive.{Dar, GenDarReader}
 import com.daml.lf.data.Ref
@@ -99,17 +99,17 @@ class ApiPackageManagementServiceSpec
     )
   }
 
-  private object TestWritePackagesService extends WritePackagesService {
+  private object TestWritePackagesService extends state.WritePackagesService {
     override def uploadPackages(
         submissionId: Ref.SubmissionId,
         archives: List[DamlLf.Archive],
         sourceDescription: Option[String],
-    )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
+    )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] = {
       telemetryContext.setAttribute(
         anApplicationIdSpanAttribute._1,
         anApplicationIdSpanAttribute._2,
       )
-      CompletableFuture.completedFuture(SubmissionResult.Acknowledged)
+      CompletableFuture.completedFuture(state.SubmissionResult.Acknowledged)
     }
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPartyManagementServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPartyManagementServiceSpec.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.participant.state.index.v2.{
   IndexPartyManagementService,
   IndexTransactionsService,
 }
-import com.daml.ledger.participant.state.v1.{SubmissionResult, WritePartyService}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext
 import com.daml.telemetry.{TelemetryContext, TelemetrySpecBase}
@@ -74,17 +74,17 @@ class ApiPartyManagementServiceSpec
     }
   }
 
-  private object TestWritePartyService extends WritePartyService {
+  private object TestWritePartyService extends state.WritePartyService {
     override def allocateParty(
         hint: Option[Ref.Party],
         displayName: Option[String],
         submissionId: Ref.SubmissionId,
-    )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
+    )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] = {
       telemetryContext.setAttribute(
         anApplicationIdSpanAttribute._1,
         anApplicationIdSpanAttribute._2,
       )
-      CompletableFuture.completedFuture(SubmissionResult.Acknowledged)
+      CompletableFuture.completedFuture(state.SubmissionResult.Acknowledged)
     }
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
@@ -22,7 +22,7 @@ import com.daml.ledger.participant.state.index.v2.{
   IndexPartyManagementService,
   IndexSubmissionService,
 }
-import com.daml.ledger.participant.state.v1.{SubmissionResult, WriteService}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.{ResourceOwner, TestResourceContext}
 import com.daml.lf
 import com.daml.lf.command.{Commands => LfCommands}
@@ -90,7 +90,7 @@ class ApiSubmissionServiceSpec
 
   it should "allocate missing informees" in {
     val partyManagementService = mock[IndexPartyManagementService]
-    val writeService = mock[WriteService]
+    val writeService = mock[state.WriteService]
 
     when(partyManagementService.getParties(any[Seq[Ref.Party]])(any[LoggingContext]))
       .thenAnswer[Seq[Ref.Party]] { parties =>
@@ -108,7 +108,7 @@ class ApiSubmissionServiceSpec
         any[Option[Ref.Party]],
         any[Ref.SubmissionId],
       )(any[TelemetryContext])
-    ).thenReturn(completedFuture(SubmissionResult.Acknowledged))
+    ).thenReturn(completedFuture(state.SubmissionResult.Acknowledged))
 
     submissionService(
       writeService,
@@ -119,7 +119,7 @@ class ApiSubmissionServiceSpec
         results <- service.allocateMissingInformees(transaction)
       } yield {
         results should have size 100
-        all(results) should be(SubmissionResult.Acknowledged)
+        all(results) should be(state.SubmissionResult.Acknowledged)
         missingParties.foreach { party =>
           verify(writeService).allocateParty(
             eqTo(Some(Ref.Party.assertFromString(party))),
@@ -135,7 +135,7 @@ class ApiSubmissionServiceSpec
 
   it should "not allocate if all parties are already known" in {
     val partyManagementService = mock[IndexPartyManagementService]
-    val writeService = mock[WriteService]
+    val writeService = mock[state.WriteService]
 
     when(partyManagementService.getParties(any[Seq[Ref.Party]])(any[LoggingContext]))
       .thenAnswer[Seq[Ref.Party]] { parties =>
@@ -148,7 +148,7 @@ class ApiSubmissionServiceSpec
         any[Option[Ref.Party]],
         any[Ref.SubmissionId],
       )(any[TelemetryContext])
-    ).thenReturn(completedFuture(SubmissionResult.Acknowledged))
+    ).thenReturn(completedFuture(state.SubmissionResult.Acknowledged))
 
     submissionService(
       writeService,
@@ -158,7 +158,7 @@ class ApiSubmissionServiceSpec
       for {
         result <- service.allocateMissingInformees(transaction)
       } yield {
-        result shouldBe Seq.empty[SubmissionResult]
+        result shouldBe Seq.empty[state.SubmissionResult]
         verify(writeService, never).allocateParty(
           any[Option[Ref.Party]],
           any[Option[String]],
@@ -170,17 +170,17 @@ class ApiSubmissionServiceSpec
   }
 
   it should "not allocate missing informees if implicit party allocation is disabled" in {
-    val writeService = mock[WriteService]
+    val writeService = mock[state.WriteService]
 
     submissionService(
-      mock[WriteService],
+      mock[state.WriteService],
       mock[IndexPartyManagementService],
       implicitPartyAllocation = false,
     ).use { service =>
       for {
         result <- service.allocateMissingInformees(transaction)
       } yield {
-        result shouldBe Seq.empty[SubmissionResult]
+        result shouldBe Seq.empty[state.SubmissionResult]
         verify(writeService, never).allocateParty(
           any[Option[Ref.Party]],
           any[Option[String]],
@@ -193,11 +193,11 @@ class ApiSubmissionServiceSpec
 
   it should "forward SubmissionResult if it failed" in {
     val partyManagementService = mock[IndexPartyManagementService]
-    val writeService = mock[WriteService]
+    val writeService = mock[state.WriteService]
 
     val party = "party-1"
     val typedParty = Ref.Party.assertFromString(party)
-    val submissionFailure = SubmissionResult.InternalError(s"failed to allocate $party")
+    val submissionFailure = state.SubmissionResult.InternalError(s"failed to allocate $party")
     when(
       writeService.allocateParty(
         eqTo(Some(typedParty)),
@@ -237,7 +237,7 @@ class ApiSubmissionServiceSpec
 
   it should "return proper gRPC status codes for DamlLf errors" in {
     val partyManagementService = mock[IndexPartyManagementService]
-    val writeService = mock[WriteService]
+    val writeService = mock[state.WriteService]
 
     val tmplId = Ref.Identifier.assertFromString("pkgId:M:T")
 
@@ -334,7 +334,7 @@ class ApiSubmissionServiceSpec
   }
 
   private def submissionService(
-      writeService: WriteService,
+      writeService: state.WriteService,
       partyManagementService: IndexPartyManagementService,
       implicitPartyAllocation: Boolean,
       commandExecutor: CommandExecutor = null,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/LedgerConfigProviderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/LedgerConfigProviderSpec.scala
@@ -14,7 +14,7 @@ import com.daml.ledger.api.domain.{ConfigurationEntry, LedgerOffset}
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
 import com.daml.ledger.participant.state.index.v2.IndexConfigManagementService
-import com.daml.ledger.participant.state.v1.{SubmissionResult, WriteConfigService}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.ResourceContext
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
@@ -41,7 +41,7 @@ final class LedgerConfigProviderSpec
   "Ledger Config Provider" should {
     "read an existing ledger configuration from the index" in {
       val index = mock[IndexConfigManagementService]
-      val writeService = mock[WriteConfigService]
+      val writeService = mock[state.WriteConfigService]
       val configuration = configurationWith(generation = 7)
       when(index.lookupConfiguration())
         .thenReturn(Future.successful(Some(offset("0001") -> configuration)))
@@ -145,7 +145,7 @@ object LedgerConfigProviderSpec {
   private final class FakeWriteConfigService(
       delay: FiniteDuration = scala.concurrent.duration.Duration.Zero
   )(implicit materializer: Materializer)
-      extends WriteConfigService {
+      extends state.WriteConfigService {
     private var currentOffset = 0
 
     private val (queue, source) = Source
@@ -158,14 +158,14 @@ object LedgerConfigProviderSpec {
         maxRecordTime: Timestamp,
         submissionId: Ref.SubmissionId,
         config: Configuration,
-    )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+    )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] =
       CompletableFuture.supplyAsync { () =>
         Thread.sleep(delay.toMillis)
         currentOffset += 1
         queue.offer(
           offset(currentOffset.toString) -> ConfigurationEntry.Accepted(submissionId, config)
         )
-        SubmissionResult.Acknowledged
+        state.SubmissionResult.Acknowledged
       }
   }
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
@@ -12,10 +12,10 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.configuration.{Configuration, LedgerInitialConditions, LedgerTimeModel}
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{ReadService, Update}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.{ResourceOwner, TestResourceContext}
-import com.daml.lf.data.{Bytes, Ref}
 import com.daml.lf.data.Time.Timestamp
+import com.daml.lf.data.{Bytes, Ref}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.common.MismatchException
@@ -44,8 +44,10 @@ final class JdbcIndexerSpec
 
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
-  private def mockedReadService(updates: Seq[(Offset, Update)] = Seq.empty): ReadService = {
-    val readService = mock[ReadService]
+  private def mockedReadService(
+      updates: Seq[(Offset, state.Update)] = Seq.empty
+  ): state.ReadService = {
+    val readService = mock[state.ReadService]
     when(readService.getLedgerInitialConditions())
       .thenAnswer(
         Source.single(
@@ -125,7 +127,7 @@ final class JdbcIndexerSpec
         .map(_ => ())
 
     val mockedUpdates @ Seq(update1, update2, update3) =
-      (1 to 3).map(_ => mock[Update])
+      (1 to 3).map(_ => mock[state.Update])
 
     val offsets @ Seq(offset1, offset2, offset3) =
       (1 to 3).map(idx => Offset(Bytes.fromByteArray(Array(idx.toByte))))

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/parallel/ParallelIndexerFactorySpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/parallel/ParallelIndexerFactorySpec.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.Update
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
@@ -31,7 +31,7 @@ class ParallelIndexerFactorySpec extends AnyFlatSpec with Matchers {
 
   private val someTime = Instant.now
 
-  private val somePackageUploadRejected = Update.PublicPackageUploadRejected(
+  private val somePackageUploadRejected = state.Update.PublicPackageUploadRejected(
     submissionId = Ref.SubmissionId.assertFromString("abc"),
     recordTime = Timestamp.assertFromInstant(someTime),
     rejectionReason = "reason",

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/SequentialWriteDaoSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/SequentialWriteDaoSpec.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 
 import com.daml.ledger.api.domain.{LedgerId, ParticipantId}
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.Update
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.platform.store.appendonlydao.SequentialWriteDaoSpec._
@@ -139,7 +139,7 @@ object SequentialWriteDaoSpec {
   private def offset(s: String): Offset = Offset.fromHexString(Ref.HexString.assertFromString(s))
 
   private def someUpdate(key: String) = Some(
-    Update.PublicPackageUploadRejected(
+    state.Update.PublicPackageUploadRejected(
       submissionId = Ref.SubmissionId.assertFromString("abc"),
       recordTime = Timestamp.assertFromInstant(Instant.now),
       rejectionReason = key,
@@ -220,11 +220,12 @@ object SequentialWriteDaoSpec {
     event_sequential_id = 0,
   )
 
-  val singlePartyFixture: Option[Update.PublicPackageUploadRejected] = someUpdate("singleParty")
-  val partyAndCreateFixture: Option[Update.PublicPackageUploadRejected] = someUpdate(
-    "partyAndCreate"
-  )
-  val allEventsFixture: Option[Update.PublicPackageUploadRejected] = someUpdate("allEventsFixture")
+  val singlePartyFixture: Option[state.Update.PublicPackageUploadRejected] =
+    someUpdate("singleParty")
+  val partyAndCreateFixture: Option[state.Update.PublicPackageUploadRejected] =
+    someUpdate("partyAndCreate")
+  val allEventsFixture: Option[state.Update.PublicPackageUploadRejected] =
+    someUpdate("allEventsFixture")
 
   private val someUpdateToDbDtoFixture: Map[String, List[DbDto]] = Map(
     singlePartyFixture.get.rejectionReason -> List(someParty),
@@ -236,9 +237,9 @@ object SequentialWriteDaoSpec {
     ),
   )
 
-  val updateToDbDtoFixture: Offset => Update => Iterator[DbDto] =
+  val updateToDbDtoFixture: Offset => state.Update => Iterator[DbDto] =
     _ => {
-      case r: Update.PublicPackageUploadRejected =>
+      case r: state.Update.PublicPackageUploadRejected =>
         someUpdateToDbDtoFixture(r.rejectionReason).iterator
       case _ => throw new Exception
     }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
@@ -10,13 +10,7 @@ import com.daml.ledger.api.domain
 import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{
-  DivulgedContract,
-  RejectionReasonV0,
-  SubmitterInfo,
-  TransactionMeta,
-  Update,
-}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.crypto
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.ledger.EventId
@@ -49,7 +43,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
   "UpdateToDbDto" should {
 
     "handle ConfigurationChanged" in {
-      val update = Update.ConfigurationChanged(
+      val update = state.Update.ConfigurationChanged(
         someRecordTime,
         someSubmissionId,
         someParticipantId,
@@ -73,7 +67,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
 
     "handle ConfigurationChangeRejected" in {
       val rejectionReason = "Test rejection reason"
-      val update = Update.ConfigurationChangeRejected(
+      val update = state.Update.ConfigurationChangeRejected(
         someRecordTime,
         someSubmissionId,
         someParticipantId,
@@ -98,7 +92,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
 
     "handle PartyAddedToParticipant (local party)" in {
       val displayName = "Test party"
-      val update = Update.PartyAddedToParticipant(
+      val update = state.Update.PartyAddedToParticipant(
         someParty,
         displayName,
         someParticipantId,
@@ -132,7 +126,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
 
     "handle PartyAddedToParticipant (remote party)" in {
       val displayName = "Test party"
-      val update = Update.PartyAddedToParticipant(
+      val update = state.Update.PartyAddedToParticipant(
         someParty,
         displayName,
         otherParticipantId,
@@ -166,7 +160,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
 
     "handle PartyAllocationRejected" in {
       val rejectionReason = "Test party rejection reason"
-      val update = Update.PartyAllocationRejected(
+      val update = state.Update.PartyAllocationRejected(
         someSubmissionId,
         someParticipantId,
         someRecordTime,
@@ -192,7 +186,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
 
     "handle PublicPackageUpload (two archives)" in {
       val sourceDescription = "Test source description"
-      val update = Update.PublicPackageUpload(
+      val update = state.Update.PublicPackageUpload(
         List(someArchive1, someArchive2),
         Some(sourceDescription),
         someRecordTime,
@@ -233,7 +227,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
 
     "handle PublicPackageUploadRejected" in {
       val rejectionReason = "Test package rejection reason"
-      val update = Update.PublicPackageUploadRejected(
+      val update = state.Update.PublicPackageUploadRejected(
         someSubmissionId,
         someRecordTime,
         rejectionReason,
@@ -254,16 +248,16 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
     }
 
     "handle CommandRejected" in {
-      val submitterInfo = SubmitterInfo(
+      val submitterInfo = state.SubmitterInfo(
         actAs = List(someParty),
         someApplicationId,
         someCommandId,
         Instant.EPOCH,
       )
-      val update = Update.CommandRejected(
+      val update = state.Update.CommandRejected(
         someRecordTime,
         submitterInfo,
-        RejectionReasonV0.Inconsistent("test reason"),
+        state.RejectionReasonV0.Inconsistent("test reason"),
       )
       val dtos = UpdateToDbDto(someParticipantId, valueSerialization, compressionStrategy)(
         someOffset
@@ -303,7 +297,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
       )
       val createNodeId = builder.add(createNode)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = Some(submitterInfo),
         transactionMeta = transactionMeta,
         transaction = transaction,
@@ -370,7 +364,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
         .copy(agreementText = "agreement text")
       val createNodeId = builder.add(createNode)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = Some(submitterInfo),
         transactionMeta = transactionMeta,
         transaction = transaction,
@@ -447,7 +441,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
       }
       val exerciseNodeId = builder.add(exerciseNode)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = Some(submitterInfo),
         transactionMeta = transactionMeta,
         transaction = transaction,
@@ -526,7 +520,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
       }
       val exerciseNodeId = builder.add(exerciseNode)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = Some(submitterInfo),
         transactionMeta = transactionMeta,
         transaction = transaction,
@@ -631,7 +625,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
       val exerciseNodeBId = builder.add(exerciseNodeB, exerciseNodeAId)
       val exerciseNodeCId = builder.add(exerciseNodeC, exerciseNodeAId)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = Some(submitterInfo),
         transactionMeta = transactionMeta,
         transaction = transaction,
@@ -769,7 +763,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
       )
       val exerciseNodeId = builder.add(exerciseNode)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = Some(submitterInfo),
         transactionMeta = transactionMeta,
         transaction = transaction,
@@ -865,7 +859,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
       val createNodeId = builder.add(createNode)
       val exerciseNodeId = builder.add(exerciseNode)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = Some(submitterInfo),
         transactionMeta = transactionMeta,
         transaction = transaction,
@@ -981,13 +975,14 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
       )
       val exerciseNodeId = builder.add(exerciseNode)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = Some(submitterInfo),
         transactionMeta = transactionMeta,
         transaction = transaction,
         transactionId = Ref.TransactionId.assertFromString("TransactionId"),
         recordTime = someRecordTime,
-        divulgedContracts = List(DivulgedContract(createNode.coid, createNode.versionedCoinst)),
+        divulgedContracts =
+          List(state.DivulgedContract(createNode.coid, createNode.versionedCoinst)),
         blindingInfo = Some(
           BlindingInfo(
             disclosure = Map(exerciseNodeId -> Set(Ref.Party.assertFromString("disclosee"))),
@@ -1086,7 +1081,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
       builder.add(createNode, rollbackNodeId)
       builder.add(exerciseNode, rollbackNodeId)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = Some(submitterInfo),
         transactionMeta = transactionMeta,
         transaction = transaction,
@@ -1142,7 +1137,7 @@ class UpdateToDbDtoSpec extends AnyWordSpec with Matchers {
       )
       val createNodeId = builder.add(createNode)
       val transaction = builder.buildCommitted()
-      val update = Update.TransactionAccepted(
+      val update = state.Update.TransactionAccepted(
         optSubmitterInfo = None,
         transactionMeta = transactionMeta,
         transaction = transaction,
@@ -1253,13 +1248,13 @@ object UpdateToDbDtoSpec {
     .setHashFunction(DamlLf.HashFunction.SHA256)
     .setPayload(ByteString.copyFromUtf8("payload 2 (longer than the other payload)"))
     .build
-  private val someSubmitterInfo = SubmitterInfo(
+  private val someSubmitterInfo = state.SubmitterInfo(
     actAs = List(someParty),
     someApplicationId,
     someCommandId,
     Instant.ofEpochMilli(1),
   )
-  private val someTransactionMeta = TransactionMeta(
+  private val someTransactionMeta = state.TransactionMeta(
     ledgerEffectiveTime = Time.Timestamp.assertFromLong(2),
     workflowId = Some(someWorkflowId),
     submissionTime = Time.Timestamp.assertFromLong(3),

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -10,13 +10,7 @@ import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
-import com.daml.ledger.participant.state.v1.{
-  PruningResult,
-  SubmissionResult,
-  SubmitterInfo,
-  TransactionMeta,
-  WriteService,
-}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.logging.LoggingContext
@@ -29,16 +23,16 @@ import scala.compat.java8.FutureConverters
 
 private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvider: TimeProvider)(
     implicit loggingContext: LoggingContext
-) extends WriteService {
+) extends state.WriteService {
 
   override def currentHealth(): HealthStatus = ledger.currentHealth()
 
   override def submitTransaction(
-      submitterInfo: SubmitterInfo,
-      transactionMeta: TransactionMeta,
+      submitterInfo: state.SubmitterInfo,
+      transactionMeta: state.TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] =
     withEnrichedLoggingContext(
       "actAs" -> submitterInfo.actAs,
       "applicationId" -> submitterInfo.applicationId,
@@ -57,7 +51,7 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
       hint: Option[Ref.Party],
       displayName: Option[String],
       submissionId: Ref.SubmissionId,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] = {
     val party = hint.getOrElse(PartyIdGenerator.generateRandomId())
     withEnrichedLoggingContext(
       "party" -> party,
@@ -72,7 +66,7 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
       submissionId: Ref.SubmissionId,
       payload: List[DamlLf.Archive],
       sourceDescription: Option[String],
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] =
     withEnrichedLoggingContext(
       "submissionId" -> submissionId,
       "description" -> sourceDescription,
@@ -88,7 +82,7 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
       maxRecordTime: Time.Timestamp,
       submissionId: Ref.SubmissionId,
       config: Configuration,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] =
     withEnrichedLoggingContext(
       "maxRecordTime" -> maxRecordTime.toInstant,
       "submissionId" -> submissionId,
@@ -102,6 +96,6 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
   override def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
-  ): CompletionStage[PruningResult] =
-    CompletableFuture.completedFuture(PruningResult.NotPruned(Status.UNIMPLEMENTED))
+  ): CompletionStage[state.PruningResult] =
+    CompletableFuture.completedFuture(state.PruningResult.NotPruned(Status.UNIMPLEMENTED))
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -10,7 +10,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import com.daml.api.util.TimeProvider
 import com.daml.ledger.api.domain
 import com.daml.ledger.participant.state.index.v2.IndexService
-import com.daml.ledger.participant.state.v1.WriteService
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.Engine
@@ -36,7 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 private[sandbox] trait IndexAndWriteService {
   def indexService: IndexService
 
-  def writeService: WriteService
+  def writeService: state.WriteService
 }
 
 private[sandbox] object SandboxIndexAndWriteService {
@@ -141,7 +141,7 @@ private[sandbox] object SandboxIndexAndWriteService {
     } yield new IndexAndWriteService {
       override val indexService: IndexService = indexSvc
 
-      override val writeService: WriteService = writeSvc
+      override val writeService: state.WriteService = writeSvc
     }
   }
 

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Ledger.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.ledger.configuration.Configuration
-import com.daml.ledger.participant.state.v1.{SubmissionResult, SubmitterInfo, TransactionMeta}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
@@ -28,17 +28,17 @@ import scala.concurrent.Future
 private[sandbox] trait Ledger extends ReadOnlyLedger {
 
   def publishTransaction(
-      submitterInfo: SubmitterInfo,
-      transactionMeta: TransactionMeta,
+      submitterInfo: state.SubmitterInfo,
+      transactionMeta: state.TransactionMeta,
       transaction: SubmittedTransaction,
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult]
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult]
 
   // Party management
   def publishPartyAllocation(
       submissionId: Ref.SubmissionId,
       party: Ref.Party,
       displayName: Option[String],
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult]
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult]
 
   // Package management
   def uploadPackages(
@@ -46,14 +46,14 @@ private[sandbox] trait Ledger extends ReadOnlyLedger {
       knownSince: Instant,
       sourceDescription: Option[String],
       payload: List[Archive],
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult]
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult]
 
   // Configuration management
   def publishConfiguration(
       maxRecordTime: Timestamp,
       submissionId: String,
       config: Configuration,
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult]
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult]
 
 }
 

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/MeteredLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/MeteredLedger.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.ledger.configuration.Configuration
-import com.daml.ledger.participant.state.v1.{SubmissionResult, SubmitterInfo, TransactionMeta}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.SubmittedTransaction
@@ -22,10 +22,10 @@ private class MeteredLedger(ledger: Ledger, metrics: Metrics)
     with Ledger {
 
   override def publishTransaction(
-      submitterInfo: SubmitterInfo,
-      transactionMeta: TransactionMeta,
+      submitterInfo: state.SubmitterInfo,
+      transactionMeta: state.TransactionMeta,
       transaction: SubmittedTransaction,
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult] =
     Timed.future(
       metrics.daml.index.publishTransaction,
       ledger.publishTransaction(submitterInfo, transactionMeta, transaction),
@@ -35,7 +35,7 @@ private class MeteredLedger(ledger: Ledger, metrics: Metrics)
       submissionId: Ref.SubmissionId,
       party: Party,
       displayName: Option[String],
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult] =
     Timed.future(
       metrics.daml.index.publishPartyAllocation,
       ledger.publishPartyAllocation(submissionId, party, displayName),
@@ -46,7 +46,7 @@ private class MeteredLedger(ledger: Ledger, metrics: Metrics)
       knownSince: Instant,
       sourceDescription: Option[String],
       payload: List[Archive],
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult] =
     Timed.future(
       metrics.daml.index.uploadPackages,
       ledger.uploadPackages(submissionId, knownSince, sourceDescription, payload),
@@ -56,7 +56,7 @@ private class MeteredLedger(ledger: Ledger, metrics: Metrics)
       maxRecordTime: Time.Timestamp,
       submissionId: String,
       config: Configuration,
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult] =
     Timed.future(
       metrics.daml.index.publishConfiguration,
       ledger.publishConfiguration(maxRecordTime, submissionId, config),

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -39,7 +39,7 @@ import com.daml.ledger.participant.state.index.v2.{
   CommandDeduplicationResult,
   PackageDetails,
 }
-import com.daml.ledger.participant.state.v1.{SubmissionResult, SubmitterInfo, TransactionMeta}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.language.Ast
 import com.daml.lf.ledger.EventId
@@ -274,14 +274,14 @@ private[sandbox] final class InMemoryLedger(
     }
 
   override def publishTransaction(
-      submitterInfo: SubmitterInfo,
-      transactionMeta: TransactionMeta,
+      submitterInfo: state.SubmitterInfo,
+      transactionMeta: state.TransactionMeta,
       transaction: SubmittedTransaction,
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult] =
     Future.successful(
-      this.synchronized[SubmissionResult] {
+      this.synchronized[state.SubmissionResult] {
         handleSuccessfulTx(entries.nextTransactionId, submitterInfo, transactionMeta, transaction)
-        SubmissionResult.Acknowledged
+        state.SubmissionResult.Acknowledged
       }
     )
 
@@ -298,8 +298,8 @@ private[sandbox] final class InMemoryLedger(
 
   private def handleSuccessfulTx(
       transactionId: Ref.LedgerString,
-      submitterInfo: SubmitterInfo,
-      transactionMeta: TransactionMeta,
+      submitterInfo: state.SubmitterInfo,
+      transactionMeta: state.TransactionMeta,
       transaction: SubmittedTransaction,
   )(implicit loggingContext: LoggingContext): Unit = {
     val ledgerTime = transactionMeta.ledgerEffectiveTime.toInstant
@@ -353,7 +353,7 @@ private[sandbox] final class InMemoryLedger(
 
   }
 
-  private def handleError(submitterInfo: SubmitterInfo, reason: RejectionReason)(implicit
+  private def handleError(submitterInfo: state.SubmitterInfo, reason: RejectionReason)(implicit
       loggingContext: LoggingContext
   ): Unit = {
     logger.warn(s"Publishing error to ledger: ${reason.description}")
@@ -438,8 +438,8 @@ private[sandbox] final class InMemoryLedger(
       submissionId: Ref.SubmissionId,
       party: Ref.Party,
       displayName: Option[String],
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
-    Future.successful(this.synchronized[SubmissionResult] {
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult] =
+    Future.successful(this.synchronized[state.SubmissionResult] {
       val ids = acs.parties.keySet
       if (ids.contains(party)) {
         entries.publish(
@@ -463,7 +463,7 @@ private[sandbox] final class InMemoryLedger(
           )
         )
       }
-      SubmissionResult.Acknowledged
+      state.SubmissionResult.Acknowledged
     })
 
   override def partyEntries(startExclusive: Offset)(implicit
@@ -501,7 +501,7 @@ private[sandbox] final class InMemoryLedger(
       knownSince: Instant,
       sourceDescription: Option[String],
       payload: List[Archive],
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] = {
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult] = {
 
     val oldStore = packageStoreRef.get
     oldStore
@@ -514,7 +514,7 @@ private[sandbox] final class InMemoryLedger(
                 .PackageUploadRejected(submissionId, timeProvider.getCurrentTime, err)
             )
           )
-          Future.successful(SubmissionResult.Acknowledged)
+          Future.successful(state.SubmissionResult.Acknowledged)
         },
         newStore => {
           if (packageStoreRef.compareAndSet(oldStore, newStore)) {
@@ -523,7 +523,7 @@ private[sandbox] final class InMemoryLedger(
                 PackageLedgerEntry.PackageUploadAccepted(submissionId, timeProvider.getCurrentTime)
               )
             )
-            Future.successful(SubmissionResult.Acknowledged)
+            Future.successful(state.SubmissionResult.Acknowledged)
           } else {
             uploadPackages(submissionId, knownSince, sourceDescription, payload)
           }
@@ -535,7 +535,7 @@ private[sandbox] final class InMemoryLedger(
       maxRecordTime: Time.Timestamp,
       submissionId: String,
       config: Configuration,
-  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[state.SubmissionResult] =
     Future.successful {
       this.synchronized {
         val recordTime = timeProvider.getCurrentTime
@@ -568,7 +568,7 @@ private[sandbox] final class InMemoryLedger(
             entries.publish(InMemoryConfigEntry(ConfigurationEntry.Accepted(submissionId, config)))
             ledgerConfiguration = Some(config)
         }
-        SubmissionResult.Acknowledged
+        state.SubmissionResult.Acknowledged
       }
     }
 

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -17,7 +17,7 @@ import com.daml.ledger.api.testing.utils.{
 }
 import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
-import com.daml.ledger.participant.state.v1.{SubmissionResult, SubmitterInfo, TransactionMeta}
+import com.daml.ledger.participant.state.{v1 => state}
 import com.daml.ledger.resources.ResourceContext
 import com.daml.lf.crypto
 import com.daml.lf.data.{Ref, Time}
@@ -83,13 +83,13 @@ class TransactionTimeModelComplianceIT
   private[this] def publishTxAt(ledger: Ledger, ledgerTime: Instant, commandId: String) = {
     val dummyTransaction = TransactionBuilder.EmptySubmitted
 
-    val submitterInfo = SubmitterInfo(
+    val submitterInfo = state.SubmitterInfo(
       actAs = List(Ref.Party.assertFromString("submitter")),
       applicationId = Ref.LedgerString.assertFromString("appId"),
       commandId = Ref.LedgerString.assertFromString(commandId + UUID.randomUUID().toString),
       deduplicateUntil = Instant.EPOCH,
     )
-    val transactionMeta = TransactionMeta(
+    val transactionMeta = state.TransactionMeta(
       ledgerEffectiveTime = Time.Timestamp.assertFromInstant(ledgerTime),
       workflowId = Some(Ref.LedgerString.assertFromString("wfid")),
       submissionTime = Time.Timestamp.assertFromInstant(ledgerTime.plusNanos(3)),
@@ -117,7 +117,7 @@ class TransactionTimeModelComplianceIT
         .filter(_._2.completions.head.commandId == submitterInfo.commandId)
         .runWith(Sink.head)
     } yield {
-      submissionResult shouldBe SubmissionResult.Acknowledged
+      submissionResult shouldBe state.SubmissionResult.Acknowledged
       completion._2.completions.head
     }
   }
@@ -196,7 +196,7 @@ object TransactionTimeModelComplianceIT {
 
   private val recordTime = Instant.now
 
-  private val ledgerId: LedgerId = LedgerId(Ref.LedgerString.assertFromString("ledgerId"))
+  private val ledgerId = LedgerId("ledgerId")
   private val timeProvider = TimeProvider.Constant(recordTime)
 
   sealed abstract class BackendType


### PR DESCRIPTION
This makes it easier to switch from the v1 to the v2 API.

I also think it's clearer than prefixing with "v1", and the prefix may help make it clearer what we're referring to.

Extracted from #10398.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
