### PR TITLE
Windows dev-env Powershell 7 compatibility

### DIFF
--- a/dev-env/windows/libexec/core.ps1
+++ b/dev-env/windows/libexec/core.ps1
@@ -49,7 +49,7 @@ function da_clear_buckets {
 
 function da_sync_buckets([String] $Directory) {
     da_clear_buckets
-    $files = Get-ChildItem $Directory | Where-Object {$_.Name -like '*.json'}
+    $files = Get-ChildItem -Path $Directory -Name | Where-Object {$_ -like '*.json'}
     ForEach ($file in $files) {
         Get-Content "$Directory\$file" | Set-Content "$scoopInstallDir\buckets\dadew\$file"
     }

--- a/dev-env/windows/libexec/install.ps1
+++ b/dev-env/windows/libexec/install.ps1
@@ -27,7 +27,6 @@ function da_install {
 
         Add-Type -AssemblyName System.IO.Compression.FileSystem
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
 
         Remove-Item $scoopTmpDir -Recurse -Force -ErrorAction Ignore
         New-Item -ItemType Directory -Force -Path $scoopTmpDir | Out-null


### PR DESCRIPTION
Testing a build of the daml repository on Windows server 2019 revealed that the Windows dev-env is not compatible with the later Powershell version 7 installed on that Windows version. This PR fixes the offending code.

- `Get-ChildItem` was used to list all manifest files assuming that it would return relative paths. However, on the later Windows version absolute paths are returned. Fixed by passing `-Name` to only return the filename (the listing is non-recursive).
- SSL certificate validation was disabled in a way that triggered the issue described in PowerShell/PowerShell#13597. An installation from scratch works without the validation check disabled, so it seems that this is no longer required.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
