### PR TITLE
[JSON-API] compile time check that we added new config fields to the logging

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ConfigOps.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ConfigOps.scala
@@ -1,0 +1,109 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http
+
+import com.daml.cliopts.Logging.LogEncoder
+import com.daml.ledger.api.tls.TlsConfiguration
+import shapeless.{FieldPoly, LabelledGeneric}
+
+import java.nio.file.Path
+import scala.concurrent.duration.FiniteDuration
+import ch.qos.logback.classic.{Level => LogLevel}
+import com.daml.metrics.MetricsReporter
+import shapeless.labelled.FieldType
+import scalaz.syntax.show._
+import scalaz.std.anyVal._
+import scalaz.std.option._
+
+// This compile time checks that all fields of the Config case class
+// have a fitting implementation for displaying it on the command line.
+object ConfigOps {
+
+  // The signatures would make this code very unreadable
+  @SuppressWarnings(Array("org.wartremover.warts.ExplicitImplicitTypes"))
+  private object matcher extends FieldPoly {
+    type Field[Name, Typ] = Typ with FieldType[Symbol with shapeless.tag.Tagged[Name], Typ]
+    val W = shapeless.Witness
+
+    implicit def ledgerHost = at[Field[W.`"ledgerHost"`.T, String]](value => s"ledgerHost=$value")
+
+    implicit def ledgerPort = at[Field[W.`"ledgerPort"`.T, Int]](value => s"ledgerPort=$value")
+
+    implicit def address = at[Field[W.`"address"`.T, String]](value => s"address=$value")
+
+    implicit def httpPort = at[Field[W.`"httpPort"`.T, Int]](value => s"httpPort=$value")
+
+    implicit def portFile = at[Field[W.`"portFile"`.T, Option[Path]]](value => s"portFile=$value")
+
+    implicit def packageReloadInterval =
+      at[Field[W.`"packageReloadInterval"`.T, FiniteDuration]](value =>
+        s"packageReloadInterval=$value"
+      )
+
+    implicit def packageMaxInboundMessageSize =
+      at[Field[W.`"packageMaxInboundMessageSize"`.T, Option[Int]]](value =>
+        s"packageMaxInboundMessageSize=$value"
+      )
+
+    implicit def maxInboundMessageSize =
+      at[Field[W.`"maxInboundMessageSize"`.T, Int]](value => s"maxInboundMessageSize=$value")
+
+    implicit def healthTimeoutSeconds =
+      at[Field[W.`"healthTimeoutSeconds"`.T, Int]](value => s"healthTimeoutSeconds=$value")
+
+    implicit def tlsConfig =
+      at[Field[W.`"tlsConfig"`.T, TlsConfiguration]](value => s"tlsConfig=$value")
+
+    implicit def jdbcConfig =
+      at[Field[W.`"jdbcConfig"`.T, Option[JdbcConfig]]](value =>
+        s"jdbcConfig=${(value: Option[JdbcConfig]).shows}"
+      )
+
+    implicit def staticContentConfig =
+      at[Field[W.`"staticContentConfig"`.T, Option[StaticContentConfig]]](value =>
+        s"staticContentConfig=${(value: Option[StaticContentConfig]).shows}"
+      )
+
+    implicit def allowNonHttps =
+      at[Field[W.`"allowNonHttps"`.T, Boolean]](value => s"allowNonHttps=${(value: Boolean).shows}")
+
+    implicit def accessTokenFile =
+      at[Field[W.`"accessTokenFile"`.T, Option[Path]]](value => s"accessTokenFile=$value")
+
+    implicit def wsConfig =
+      at[Field[W.`"wsConfig"`.T, Option[WebsocketConfig]]](value =>
+        s"wsConfig=${(value: Option[WebsocketConfig]).shows}"
+      )
+
+    implicit def nonRepudiation =
+      at[Field[W.`"nonRepudiation"`.T, nonrepudiation.Configuration.Cli]](value =>
+        List(
+          s"nonRepudiationCertificateFile=${value.certificateFile: Option[Path]}",
+          s"nonRepudiationPrivateKeyFile=${value.privateKeyFile: Option[Path]}",
+          s"nonRepudiationPrivateKeyAlgorithm=${value.privateKeyAlgorithm: Option[String]}",
+        ).mkString(", ")
+      )
+    implicit def logLevel =
+      at[Field[W.`"logLevel"`.T, Option[LogLevel]]](value => s"logLevel=$value")
+
+    implicit def logEncoder =
+      at[Field[W.`"logEncoder"`.T, LogEncoder]](value => s"logEncoder=$value")
+
+    implicit def metricsReporter =
+      at[Field[W.`"metricsReporter"`.T, Option[MetricsReporter]]](value =>
+        s"metricsReporter=$value"
+      )
+
+    implicit def metricsReportingInterval =
+      at[Field[W.`"metricsReportingInterval"`.T, FiniteDuration]](value =>
+        s"metricsReportingInterval=$value"
+      )
+  }
+
+  def cliString(config: Config) = {
+    val genericConfig = LabelledGeneric[Config]
+    val it = genericConfig.to(config)
+    it.map(matcher).mkString("Config(", ", ", ")")
+  }
+}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -3,7 +3,6 @@
 
 package com.daml.http
 
-import java.nio.file.Path
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
 import akka.stream.Materializer
@@ -13,9 +12,6 @@ import com.daml.runtime.JdbcDrivers
 import com.daml.scalautil.Statement.discard
 import com.daml.http.dbbackend.ContractDao
 import scalaz.{-\/, \/, \/-}
-import scalaz.std.anyVal._
-import scalaz.std.option._
-import scalaz.syntax.show._
 import com.daml.cliopts.{GlobalLogLevel, Logging}
 import com.daml.http.util.Logging.{InstanceUUID, instanceUUIDLogCtx}
 import com.daml.ledger.resources.ResourceContext
@@ -70,24 +66,7 @@ object Main {
   }
 
   private def main(config: Config)(implicit lc: LoggingContextOf[InstanceUUID]): Unit = {
-    logger.info(
-      s"Config(ledgerHost=${config.ledgerHost: String}, ledgerPort=${config.ledgerPort: Int}" +
-        s", address=${config.address: String}, httpPort=${config.httpPort: Int}" +
-        s", portFile=${config.portFile: Option[Path]}" +
-        s", packageReloadInterval=${config.packageReloadInterval: FiniteDuration}" +
-        s", packageMaxInboundMessageSize=${config.packageMaxInboundMessageSize: Option[Int]}" +
-        s", maxInboundMessageSize=${config.maxInboundMessageSize: Int}" +
-        s", tlsConfig=${config.tlsConfig}" +
-        s", jdbcConfig=${config.jdbcConfig.shows}" +
-        s", staticContentConfig=${config.staticContentConfig.shows}" +
-        s", allowNonHttps=${config.allowNonHttps.shows}" +
-        s", accessTokenFile=${config.accessTokenFile: Option[Path]}" +
-        s", wsConfig=${config.wsConfig.shows}" +
-        s", nonRepudiationCertificateFile=${config.nonRepudiation.certificateFile: Option[Path]}" +
-        s", nonRepudiationPrivateKeyFile=${config.nonRepudiation.privateKeyFile: Option[Path]}" +
-        s", nonRepudiationPrivateKeyAlgorithm=${config.nonRepudiation.privateKeyAlgorithm: Option[String]}" +
-        ")"
-    )
+    logger.info(ConfigOps.cliString(config))
 
     implicit val asys: ActorSystem = ActorSystem("http-json-ledger-api")
     implicit val mat: Materializer = Materializer(asys)


### PR DESCRIPTION
This ensures that whenever we add new config fields, they will never be forgotten to appear in the initial logging again. Also implicitly adds all the fields I forgot to add.

In the end I just want to avoid to have to think about even more places as soon as I introduce a new config field again.

PS: I'm pretty sure that the code could be even shorter, however my missing knowledge about shapeless brought me only this far in this short amount of time.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
