### PR TITLE
participant-integration-api: Fix completion debug log output.

### DIFF
--- a/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/LoggingValue.scala
+++ b/libs-scala/logging-entries/src/main/scala/com/daml/logging/entries/LoggingValue.scala
@@ -32,6 +32,10 @@ object LoggingValue {
 
   final case class Nested(entries: LoggingEntries) extends LoggingValue
 
+  object Nested {
+    def fromEntries(entries: LoggingEntry*): Nested = Nested(LoggingEntries(entries: _*))
+  }
+
   final case class OfJson(json: JsValue) extends LoggingValue
 
   @inline


### PR DESCRIPTION
So it doesn't embed Scala class names.

**Before:**

```
DEBUG c.d.p.a.s.ApiCommandCompletionService - Responding with completions: List(LoggingEntries(Map(commandId -> OfString(SemanticDoubleSpendBasic-alpha-2992c8731c2f-command-1), statusCode -> OfString(0)))), context: {parties: ["SemanticDoubleSpendBasic-alpha-2992c8731c2f-party-1"], offset: "000000000000000a0000000000000000"}
```

**After:**

```
DEBUG c.d.p.a.s.ApiCommandCompletionService - Responding with completions: [{commandId: SemanticDoubleSpendBasic-alpha-29a7c9d39f7b-command-1, statusCode: 0}], context: {parties: ["SemanticDoubleSpendBasic-alpha-29a7c9d39f7b-party-1"], offset: "000000000000000a0000000000000000"}
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
