### PR TITLE
[JSON-API] Perf gatling MultiUserQueryScenario

### DIFF
--- a/ledger-service/http-json-perf/README.md
+++ b/ledger-service/http-json-perf/README.md
@@ -16,10 +16,11 @@ Gatling scenarios extend from `io.gatling.core.scenario.Simulation`:
 - `com.daml.http.perf.scenario.SyncQueryConstantAcs`
 - `com.daml.http.perf.scenario.SyncQueryNewAcs`
 - `com.daml.http.perf.scenario.SyncQueryVariableAcs`
+- `com.daml.http.perf.scenario.MultiUserQueryScenario`
 
 # 2. Running Gatling Scenarios from Bazel
 
-## 2.2. Help
+## 2.1. Help
 ```
 $ bazel run //ledger-service/http-json-perf:http-json-perf-binary -- --help
 ```
@@ -31,6 +32,44 @@ $ bazel run //ledger-service/http-json-perf:http-json-perf-binary -- \
 --dars="${PWD}/bazel-bin/docs/quickstart-model.dar" \
 --reports-dir=/home/leos/tmp/results/ \
 --jwt="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU"
+```
+
+## 2.3 Running MultiUserQueryScenario
+
+Preferably retain the data between runs to specifically focus on testing query performance.
+use `RETAIN_DATA` and `USE_DEFAULT_USER` env vars to use a static user(`ORACLE_USER`) and preserve data.
+This scenario uses a single template `KeyedIou` defined in `LargeAcs.daml`.
+
+We can control a few scenario parameters i.e `NUM_RECORDS` `NUM_QUERIES` `NUM_READERS` `NUM_WRITERS` via env variables
+
+
+
+1. Populate Cache
+
+```
+
+USE_DEFAULT_USER=true RETAIN_DATA=true RUN_MODE="populateCache" bazel run //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.MultiUserQueryScenario --jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU --dars=$PWD/bazel-bin/ledger-service/http-json-perf/LargeAcs.dar --query-store-index oracle
+
+```
+
+2. Fetch By Key
+
+Query contracts by the defined key field.
+
+```
+
+USE_DEFAULT_USER=true RETAIN_DATA=true RUN_MODE="fetchByKey" NUM_QUERIES=100 bazel run //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.MultiUserQueryScenario --jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU --dars=$PWD/bazel-bin/ledger-service/http-json-perf/LargeAcs.dar --query-store-index oracle
+
+```
+
+3. Fetch By Query
+
+Query contracts by a field on the payload which is the `id` in this case.
+
+```
+
+USE_DEFAULT_USER=true RETAIN_DATA=true RUN_MODE="fetchByQuery" bazel run //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.MultiUserQueryScenario --jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU --dars=$PWD/bazel-bin/ledger-service/http-json-perf/LargeAcs.dar --query-store-index oracle
+
 ```
 
 # 3. Running Gatling Scenarios Manually

--- a/ledger-service/http-json-perf/daml/LargeAcs.daml
+++ b/ledger-service/http-json-perf/daml/LargeAcs.daml
@@ -114,3 +114,18 @@ template NotIou
 
 data WhichTemplate = UseIou | UseNotIou
   deriving (Eq, Show)
+
+template KeyedIou
+  with
+    id: Int
+    issuer : Party
+    owner : Party
+    currency : Text
+    amount : Decimal
+    observers : [Party]
+  where
+    signatory issuer, owner
+    observer observers
+
+    key (issuer, id): (Party, Int)
+    maintainer key._1

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
@@ -199,17 +199,33 @@ object Main extends StrictLogging {
     )
 
     private[this] final class OracleRunner extends OracleAround {
+
+      private val defaultUser = "ORACLE_USER"
+      private val retainData = sys.env.get("RETAIN_DATA").exists(_ equalsIgnoreCase "true")
+      private val useDefaultUser = sys.env.get("USE_DEFAULT_USER").exists(_ equalsIgnoreCase "true")
       type St = oracle.User
 
       def start() = Try {
         connectToOracle()
-        createNewRandomUser(): St
+        if (useDefaultUser) createNewUser(defaultUser) else createNewRandomUser(): St
       }
 
-      def jdbcConfig(user: St) =
-        JdbcConfig("oracle.jdbc.OracleDriver", oracleJdbcUrl, user.name, user.pwd)
+      def jdbcConfig(user: St) = {
+        import DbStartupMode._
+        val startupMode: DbStartupMode = if (retainData) CreateIfNeededAndStart else CreateAndStart
+        JdbcConfig(
+          "oracle.jdbc.OracleDriver",
+          oracleJdbcUrl,
+          user.name,
+          user.pwd,
+          dbStartupMode = startupMode,
+          connectionTimeout = 15000, // increase value for performance tests
+        )
+      }
 
-      def stop(user: St) = Try(dropUser(user.name))
+      def stop(user: St) = {
+        if (retainData) Success((): Unit) else Try(dropUser(user.name))
+      }
     }
 
     def lookup(q: QueryStoreIndex): Option[T] = q match {

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/MultiUserQueryScenario.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/MultiUserQueryScenario.scala
@@ -1,0 +1,142 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http.perf.scenario
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+private[scenario] trait HasRandomCurrency {
+  private val rng = new scala.util.Random(123456789)
+  final val currencies = List("USD", "GBP", "EUR", "CHF", "AUD")
+
+  def randomCurrency(): String = {
+    this.synchronized { rng.shuffle(currencies).head }
+  }
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+class MultiUserQueryScenario
+    extends Simulation
+    with SimulationConfig
+    with HasRandomAmount
+    with HasRandomCurrency {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  //hardcoded for now , needs to be made configurable on cli
+  private val numRecords = 100000
+  private val numQueries = 1000
+  private val numWriters = 10
+  private val numReaders = 100
+
+  private val msgIds = Range(0, numRecords).toList
+  private val msgIdIter = msgIds.iterator
+
+  def incrementalId = msgIdIter.next()
+  def queryId: Int = Random.shuffle(msgIds).head
+
+  private val createRequest =
+    http("CreateCommand")
+      .post("/v1/create")
+      .body(StringBody("""{
+  "templateId": "LargeAcs:KeyedIou",
+  "payload": {
+    "id": "${id}",
+    "issuer": "Alice",
+    "owner": "Alice",
+    "currency": "${currency}",
+    "amount": "${amount}",
+    "observers": []
+  }
+}"""))
+
+  private val queryRequest =
+    http("SyncIdQueryRequest")
+      .post("/v1/query")
+      .body(StringBody("""{
+          "templateIds": ["LargeAcs:KeyedIou"],
+          "query": {"id": "${id}"}
+      }"""))
+
+  private val writeScn = scenario("Write100kContracts")
+    .repeat(numRecords / numWriters) {
+      feed(
+        Iterator.continually(
+          Map(
+            "id" -> String.valueOf(incrementalId),
+            "currency" -> randomCurrency(),
+            "amount" -> randomAmount(),
+          )
+        )
+      )
+        .exec(createRequest)
+    }
+
+  private val idReadScn = scenario("MultipleReadersQueryScenario")
+    .repeat(numQueries / numReaders) {
+      feed(Iterator.continually(Map("id" -> String.valueOf(queryId))))
+        .exec(queryRequest)
+    }
+
+  private val fetchRequest =
+    http("SyncFetchRequest")
+      .post("/v1/fetch")
+      .body(StringBody("""{
+          "templateId": "LargeAcs:KeyedIou",
+          "key": {
+            "_1": "Alice",
+            "_2": "${id}"
+          }
+      }"""))
+
+  private val currencyQueryRequest =
+    http("SyncCurrQueryRequest")
+      .post("/v1/query")
+      .body(StringBody("""{
+          "templateIds": ["LargeAcs:KeyedIou"],
+          "query": {"currency": "${currency}"}
+      }"""))
+
+  // Scenario to fetch a subset of the ACS population
+  private val currQueryScn = scenario("MultipleReadersCurrQueryScenario")
+    .repeat(numQueries / numReaders) {
+      feed(Iterator.continually(Map("currency" -> randomCurrency())))
+        .exec(currencyQueryRequest)
+    }
+
+  //fetch by key scenario
+  private val fetchScn = scenario("MultipleReadersFetchScenario")
+    .repeat(numQueries / numReaders) {
+      feed(Iterator.continually(Map("id" -> String.valueOf(queryId))))
+        .exec(fetchRequest)
+    }
+
+  logger.debug(s"Scenarios defined $fetchScn $currQueryScn $idReadScn $writeScn")
+  setUp(
+    writeScn
+      .inject(atOnceUsers(numWriters))
+      .andThen(
+//      fetchScn.inject(
+//        nothingFor(5.seconds),
+//        atOnceUsers(numReaders/2),
+//        rampUsers(numReaders/2).during(10.seconds)).andThen(
+//        idReadScn.inject(
+//          nothingFor(2.seconds),
+//          atOnceUsers(numReaders)).andThen(
+//          currQueryScn.inject(
+//            nothingFor(2.seconds),
+//            atOnceUsers(numReaders))
+//        )
+//      )
+        idReadScn.inject(nothingFor(5.seconds), atOnceUsers(numReaders))
+//      fetchScn.inject(
+//        nothingFor(5.seconds),
+//        atOnceUsers(numReaders))
+      )
+  ).protocols(httpProtocol)
+}

--- a/libs-scala/db-utils/src/main/scala/com/digitalasset/http/dbbackend/DBConfig.scala
+++ b/libs-scala/db-utils/src/main/scala/com/digitalasset/http/dbbackend/DBConfig.scala
@@ -27,6 +27,9 @@ final case class JdbcConfig(
     createSchema: Boolean = false,
     tablePrefix: String = "",
     dbStartupMode: DbStartupMode = DbStartupMode.StartOnly,
+    minIdle: Int = JdbcConfig.MinIdle,
+    connectionTimeout: Long = JdbcConfig.ConnectionTimeout,
+    idleTimeout: Long = JdbcConfig.IdleTimeout,
 )
 
 abstract class ConfigCompanion[A, ReadCtx](name: String) {
@@ -83,6 +86,10 @@ abstract class ConfigCompanion[A, ReadCtx](name: String) {
 object JdbcConfig
     extends ConfigCompanion[JdbcConfig, DBConfig.SupportedJdbcDriverNames]("JdbcConfig")
     with StrictLogging {
+
+  final val MinIdle = 8
+  final val IdleTimeout = 10000L // ms, minimum according to log, defaults to 600s
+  final val ConnectionTimeout = 5000L
 
   implicit val showInstance: Show[JdbcConfig] = Show.shows(a =>
     s"JdbcConfig(driver=${a.driver}, url=${a.url}, user=${a.user}, start-mode=${a.dbStartupMode})"

--- a/libs-scala/oracle-testing/src/main/scala/testing/oracle/OracleAround.scala
+++ b/libs-scala/oracle-testing/src/main/scala/testing/oracle/OracleAround.scala
@@ -34,8 +34,19 @@ trait OracleAround {
     createNewUser(u.toUpperCase)
   }
 
-  protected def createNewUser(name: String): User = {
-    val pwd = "hunter2"
+  protected def checkUserExists(con: Connection, name: String): Boolean = {
+    Using(con.createStatement()) { stmt =>
+      val res = stmt.executeQuery(
+        s"""SELECT count(*) AS user_count FROM all_users WHERE username='${name.toUpperCase}'"""
+      )
+      val count = if (res.next()) {
+        res.getInt("user_count")
+      } else 0
+      count > 0
+    }.get
+  }
+
+  protected def createNewUser(name: String, pwd: String = "hunter2"): User = {
     Using.Manager { use =>
       val con = use(
         DriverManager.getConnection(
@@ -44,18 +55,20 @@ trait OracleAround {
           systemPwd,
         )
       )
-      val stmt = con.createStatement()
-      stmt.execute(s"""create user $name identified by $pwd""")
-      stmt.execute(s"""grant connect, resource to $name""")
-      stmt.execute(
-        s"""grant create table, create materialized view, create view, create procedure, create sequence, create type to $name"""
-      )
-      stmt.execute(s"""alter user $name quota unlimited on users""")
+      if (!checkUserExists(con, name)) {
+        val stmt = con.createStatement()
+        stmt.execute(s"""create user $name identified by $pwd""")
+        stmt.execute(s"""grant connect, resource to $name""")
+        stmt.execute(
+          s"""grant create table, create materialized view, create view, create procedure, create sequence, create type to $name"""
+        )
+        stmt.execute(s"""alter user $name quota unlimited on users""")
 
-      // for DBMS_LOCK access
-      stmt.execute(s"""GRANT EXECUTE ON SYS.DBMS_LOCK TO $name""")
-      stmt.execute(s"""GRANT SELECT ON V_$$MYSTAT TO $name""")
-      stmt.execute(s"""GRANT SELECT ON V_$$LOCK TO $name""")
+        // for DBMS_LOCK access
+        stmt.execute(s"""GRANT EXECUTE ON SYS.DBMS_LOCK TO $name""")
+        stmt.execute(s"""GRANT SELECT ON V_$$MYSTAT TO $name""")
+        stmt.execute(s"""GRANT SELECT ON V_$$LOCK TO $name""")
+      } else false
     }.get
     User(name, pwd)
   }


### PR DESCRIPTION
The multi-user scenario used for connection pool testing.

#### Oracle docker vm properties
```
vCPU: 8
mem: 8GB
swap: 2GB
```

#### Miscellaneous Notes

 - Fetch by key run Mode was slower then simple id Queries, need to re-evaluate if its specific to the daml design. Also needed tuning akka timeouts.

https://docs.google.com/spreadsheets/d/1HNqzOlMJX0X963DSGDZAYmk3JbWJHwvCbC4TtkUP9iQ/edit?usp=sharing
----
CHANGELOG_BEGIN
CHANGELOG_END


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
