### PR TITLE
Don't fail if logs directory exists already on Windows

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -14,7 +14,11 @@ if (!(Test-Path .\.bazelrc.local)) {
 
 $ARTIFACT_DIRS = if ("$env:BUILD_ARTIFACTSTAGINGDIRECTORY") { $env:BUILD_ARTIFACTSTAGINGDIRECTORY } else { Get-Location }
 
-mkdir -p ${ARTIFACT_DIRS}/logs
+if (!(Test-Path ${ARTIFACT_DIRS}/logs)) {
+    mkdir -p ${ARTIFACT_DIRS}/logs
+} elseif (Test-Path ${ARTIFACT_DIRS}/logs -PathType Leaf) {
+    throw ("Cannot create directory '${ARTIFACT_DIRS}/logs'. Conflicting file.")
+}
 
 # If a previous build was forcefully terminated, then stack's lock file might
 # not have been cleaned up properly leading to errors of the form


### PR DESCRIPTION
When testing `build.ps1` manually on Windows it can fail due to the presence of a previously created `logs/` directory. This PR changes `build.ps1` so that an already existing `logs` directory will not cause a failure. Bazel will subsequently overwrite previously generated execlogs.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
