### PR TITLE
Add a ContractDao benchmark for payload queries

### DIFF
--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -447,6 +447,7 @@ da_scala_benchmark_jmh(
     ],
     deps = [
         ":http-json",
+        "//daml-lf/interface",
         "//language-support/scala/bindings",
         "//ledger-service/db-backend",
         "//ledger-service/http-json-cli:base",

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
@@ -52,11 +52,12 @@ abstract class ContractDaoBenchmark extends OracleAround {
       id: Int,
       signatory: String,
       tpid: SurrogateTpId,
+      payload: JsObject = JsObject(),
   ): DBContract[SurrogateTpId, JsValue, JsValue, Seq[String]] = DBContract(
     contractId = s"#$id",
     templateId = tpid,
     key = JsNull,
-    payload = JsObject(),
+    payload = payload,
     signatories = Seq(signatory),
     observers = Seq.empty,
     agreementText = "",
@@ -71,13 +72,18 @@ abstract class ContractDaoBenchmark extends OracleAround {
       .unsafeRunSync()
   }
 
-  protected def insertBatch(signatory: String, tpid: SurrogateTpId, offset: Int) = {
+  protected def insertBatch(
+      signatory: String,
+      tpid: SurrogateTpId,
+      offset: Int,
+      payload: JsObject = JsObject(),
+  ) = {
     val driver = dao.jdbcDriver
     import driver._
     val contracts: List[DBContract[SurrogateTpId, JsValue, JsValue, Seq[String]]] =
       (0 until batchSize).map { i =>
         val n = offset + i
-        contract(n, signatory, tpid)
+        contract(n, signatory, tpid, payload)
       }.toList
     val inserted = dao
       .transact(driver.queries.insertContracts[List, JsValue, JsValue](contracts))

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http.dbbackend
+
+import com.daml.lf.data.ImmArray.ImmArraySeq
+import com.daml.lf.data.Ref
+import com.daml.lf.iface
+import com.daml.http.dbbackend.Queries.SurrogateTpId
+import com.daml.http.domain.{Party, TemplateId}
+import com.daml.http.query.ValuePredicate
+import org.openjdk.jmh.annotations._
+import scalaz.OneAnd
+import spray.json._
+
+class QueryPayloadBenchmark extends ContractDaoBenchmark {
+  @Param(Array("1", "10", "100"))
+  var extraParties: Int = _
+
+  @Param(Array("1", "100", "100"))
+  var extraPayloadValues: Int = _
+
+  private val tpid = TemplateId("-pkg-", "M", "T")
+  private var surrogateTpid: SurrogateTpId = _
+  val party = "Alice"
+
+  private[this] val dummyPackageId = Ref.PackageId.assertFromString("dummy-package-id")
+  private[this] val dummyId = Ref.Identifier(
+    dummyPackageId,
+    Ref.QualifiedName.assertFromString("Foo:Bar"),
+  )
+  private[this] val dummyTypeCon = iface.TypeCon(iface.TypeConName(dummyId), ImmArraySeq.empty)
+
+  val predicate = ValuePredicate.fromJsObject(
+    Map("v" -> JsNumber(0)),
+    dummyTypeCon,
+    Map(
+      dummyId -> iface.DefDataType(
+        ImmArraySeq.empty,
+        iface.Record(
+          ImmArraySeq(
+            (Ref.Name.assertFromString("v"), iface.TypePrim(iface.PrimType.Int64, ImmArraySeq()))
+          )
+        ),
+      )
+    ).lift,
+  )
+
+  def whereClause = predicate.toSqlWhereClause(dao.jdbcDriver)
+
+  @Setup(Level.Trial)
+  override def setup(): Unit = {
+    super.setup()
+    surrogateTpid = insertTemplate(tpid)
+
+    val parties: List[String] = party :: (0 until extraParties).map(i => s"p$i").toList
+
+    var offset = 0
+    parties.foreach { p =>
+      (0 until extraPayloadValues).foreach { v =>
+        insertBatch(p, surrogateTpid, offset, JsObject("v" -> JsNumber(v)))
+        offset += batchSize
+      }
+    }
+  }
+
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime))
+  def run(): Unit = {
+    implicit val driver: SupportedJdbcDriver = dao.jdbcDriver
+    val result = dao
+      .transact(ContractDao.selectContracts(OneAnd(Party(party), Set.empty), tpid, whereClause))
+      .unsafeRunSync()
+    assert(result.size == batchSize)
+  }
+}


### PR DESCRIPTION
This adds a very dumb benchmark which queries for equality on a single
int field.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
