### PR TITLE
Disable autocommit for hikariCP for http-json-api db conn

### DIFF
--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Connection.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Connection.scala
@@ -69,6 +69,7 @@ object ConnectionPool {
     val c = new HikariConfig()
     c.setJdbcUrl(cfg.url)
     c.setUsername(cfg.user)
+    c.setAutoCommit(false)
     c.setPassword(cfg.password)
     c.setMinimumIdle(MinIdle)
     c.setPoolName("json-api-jdbc-pool")


### PR DESCRIPTION
Disable autocommit for hikariCP for http-json-api db conn pool,  this seems to have performance impact due to resets when conn is returned to the pool.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
