### PR TITLE
[JSON-API] Add option for setting a table prefix

### DIFF
--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -40,6 +40,8 @@ sealed abstract class Queries(tablePrefix: String) {
   /** for use when generating predicates */
   protected[this] val contractColumnName: Fragment = sql"payload"
 
+  protected[this] val tablePrefixFr = Fragment.const0(tablePrefix)
+
   /** Table names with prefix * */
 
   val contractTableNameRaw = s"${tablePrefix}contract"
@@ -61,7 +63,7 @@ sealed abstract class Queries(tablePrefix: String) {
     sql"""
       CREATE TABLE
         $contractTableName
-        (contract_id $contractIdType NOT NULL CONSTRAINT contract_k PRIMARY KEY
+        (contract_id $contractIdType NOT NULL CONSTRAINT ${tablePrefixFr}contract_k PRIMARY KEY
         ,tpid $bigIntType NOT NULL REFERENCES $templateIdTableName (tpid)
         ,${jsonColumn(sql"key")}
         ,${jsonColumn(contractColumnName)}
@@ -106,7 +108,7 @@ sealed abstract class Queries(tablePrefix: String) {
     sql"""
       CREATE TABLE
         $templateIdTableName
-        (tpid $bigSerialType NOT NULL CONSTRAINT template_id_k PRIMARY KEY
+        (tpid $bigSerialType NOT NULL CONSTRAINT ${tablePrefixFr}template_id_k PRIMARY KEY
         ,package_id $packageIdType NOT NULL
         ,template_module_name $nameType NOT NULL
         ,template_entity_name $nameType NOT NULL

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -27,7 +27,7 @@ import cats.syntax.applicative._
 import cats.syntax.functor._
 import doobie.free.connection
 
-sealed abstract class Queries(val tablePrefix: String) {
+sealed abstract class Queries(tablePrefix: String) {
   import Queries.{Implicits => _, _}, InitDdl._
   import Queries.Implicits._
 

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -741,7 +741,7 @@ private final class OracleQueries(tablePrefix: String) extends Queries(tablePref
     contractStakeholdersViewNameRaw,
     sql"""CREATE MATERIALIZED VIEW $contractStakeholdersViewName
           BUILD IMMEDIATE REFRESH FAST ON STATEMENT AS
-          SELECT contract_id, tpid, stakeholder FROM contract,
+          SELECT contract_id, tpid, stakeholder FROM $contractTableName,
                  json_table(json_array(signatories, observers), '$$[*][*]'
                     columns (stakeholder $partyType path '$$'))""",
   )

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -762,7 +762,7 @@ private final class OracleQueries(tablePrefix: String) extends Queries(tablePref
               )""".query[Boolean].unique
       version <-
         if (!doesTableExist) connection.pure(None)
-        else sql"SELECT version FROM $$jsonApiSchemaVersionTableName".query[Int].option
+        else sql"SELECT version FROM $jsonApiSchemaVersionTableName".query[Int].option
     } yield version
   }
 

--- a/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceOracleInt.scala
+++ b/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceOracleInt.scala
@@ -14,7 +14,7 @@ trait HttpServiceOracleInt extends AbstractHttpServiceIntegrationTestFuns with O
 
   override final def jdbcConfig: Option[JdbcConfig] = Some(jdbcConfig_)
 
-  protected[this] lazy val jdbcConfig_ = JdbcConfig(
+  protected[this] def jdbcConfig_ = JdbcConfig(
     driver = "oracle.jdbc.OracleDriver",
     url = oracleJdbcUrl,
     user = oracleUser,

--- a/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleTablePrefixIntTest.scala
+++ b/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleTablePrefixIntTest.scala
@@ -3,7 +3,6 @@
 
 package com.daml.http
 
-class HttpServiceWithOracleTablePrefixIntTest
-    extends HttpServiceWithOracleIntTest {
+class HttpServiceWithOracleTablePrefixIntTest extends HttpServiceWithOracleIntTest {
   override def jdbcConfig_ = super.jdbcConfig_.copy(tablePrefix = "some_nice_prefix_")
 }

--- a/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleTablePrefixIntTest.scala
+++ b/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleTablePrefixIntTest.scala
@@ -4,19 +4,6 @@
 package com.daml.http
 
 class HttpServiceWithOracleTablePrefixIntTest
-    extends AbstractHttpServiceIntegrationTest
-    with HttpServiceOracleInt {
-
-  override def staticContentConfig: Option[StaticContentConfig] = None
-
-  override def wsConfig: Option[WebsocketConfig] = None
-
-  override lazy val jdbcConfig_ = JdbcConfig(
-    driver = "org.postgresql.Driver",
-    url = postgresDatabase.url,
-    user = "test",
-    password = "",
-    tablePrefix = "some_nice_prefix_",
-    dbStartupMode = DbStartupMode.CreateOnly,
-  )
+    extends HttpServiceWithOracleIntTest {
+  override def jdbcConfig_ = super.jdbcConfig_.copy(tablePrefix = "some_nice_prefix_")
 }

--- a/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleTablePrefixIntTest.scala
+++ b/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleTablePrefixIntTest.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http
+
+class HttpServiceWithOracleTablePrefixIntTest
+    extends AbstractHttpServiceIntegrationTest
+    with HttpServiceOracleInt {
+
+  override def staticContentConfig: Option[StaticContentConfig] = None
+
+  override def wsConfig: Option[WebsocketConfig] = None
+
+  override lazy val jdbcConfig_ = JdbcConfig(
+    driver = "org.postgresql.Driver",
+    url = postgresDatabase.url,
+    user = "test",
+    password = "",
+    tablePrefix = "some_nice_prefix_",
+    dbStartupMode = DbStartupMode.CreateOnly,
+  )
+}

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -328,6 +328,7 @@ alias(
             "@maven//:org_typelevel_cats_core",
             "@maven//:org_typelevel_cats_effect",
             "@maven//:org_typelevel_cats_free",
+            "@maven//:org_typelevel_cats_kernel",
             "@maven//:org_scala_lang_modules_scala_collection_compat",
         ],
         scalacopts = hj_scalacopts,

--- a/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
@@ -18,7 +18,7 @@ trait HttpServicePostgresInt extends AbstractHttpServiceIntegrationTestFuns with
   protected lazy val dao = dbbackend.ContractDao(jdbcConfig_, poolSize = PoolSize.Integration)
 
   // has to be lazy because postgresFixture is NOT initialized yet
-  protected[this] lazy val jdbcConfig_ = JdbcConfig(
+  protected[this] def jdbcConfig_ = JdbcConfig(
     driver = "org.postgresql.Driver",
     url = postgresDatabase.url,
     user = "test",

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresTablePrefixIntTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresTablePrefixIntTest.scala
@@ -5,12 +5,5 @@ package com.daml.http
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class HttpServiceWithPostgresTablePrefixIntTest extends HttpServiceWithPostgresIntTest {
-  override lazy val jdbcConfig_ = JdbcConfig(
-    driver = "org.postgresql.Driver",
-    url = postgresDatabase.url,
-    user = "test",
-    password = "",
-    tablePrefix = "some_nice_prefix_",
-    dbStartupMode = DbStartupMode.CreateOnly,
-  )
+  override def jdbcConfig_ = super.jdbcConfig_.copy(tablePrefix = "some_nice_prefix_")
 }

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresTablePrefixIntTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresTablePrefixIntTest.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+class HttpServiceWithPostgresTablePrefixIntTest extends HttpServiceWithPostgresIntTest {
+  override lazy val jdbcConfig_ = JdbcConfig(
+    driver = "org.postgresql.Driver",
+    url = postgresDatabase.url,
+    user = "test",
+    password = "",
+    tablePrefix = "some_nice_prefix_",
+    dbStartupMode = DbStartupMode.CreateOnly,
+  )
+}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/DbStartupOps.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/DbStartupOps.scala
@@ -7,6 +7,7 @@ import com.daml.http.dbbackend.ContractDao
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import cats.effect.IO
 import com.daml.http.util.Logging.InstanceUUID
+import doobie.LogHandler
 
 object DbStartupOps {
 
@@ -24,6 +25,7 @@ object DbStartupOps {
   def getDbVersionState(implicit
       dao: ContractDao,
       lc: LoggingContextOf[InstanceUUID],
+      log: LogHandler,
   ): IO[Either[Throwable, DbVersionState]] = {
     import dao.jdbcDriver, scalaz.Scalaz._
     for {
@@ -61,6 +63,7 @@ object DbStartupOps {
       _dao: ContractDao = dao,
       lc: LoggingContextOf[InstanceUUID],
   ): IO[Boolean] = {
+    import dao.logHandler
     def checkDbVersionStateAnd(createOrUpdate: Boolean): IO[Boolean] = {
       val ioFalse = IO.pure(false)
       val dbVersionState = getDbVersionState

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -66,7 +66,7 @@ class ContractDao private (
 
 object ContractDao {
   import ConnectionPool.PoolSize
-  private[this] val supportedJdbcDrivers = Map(
+  private[this] val supportedJdbcDrivers = Map[String, String => SupportedJdbcDriver](
     "org.postgresql.Driver" -> SupportedJdbcDriver.Postgres,
     "oracle.jdbc.OracleDriver" -> SupportedJdbcDriver.Oracle,
   )
@@ -83,7 +83,7 @@ object ContractDao {
       throw new IllegalArgumentException(
         s"JDBC driver ${cfg.driver} is not one of ${supportedJdbcDrivers.keySet}"
       ),
-    )
+    )(cfg.tablePrefix)
     //pool for connections awaiting database access
     val es = Executors.newWorkStealingPool(poolSize)
     val (ds, conn) = ConnectionPool.connect(cfg, poolSize)(ExecutionContext.fromExecutor(es), cs)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/SupportedJdbcDriver.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/SupportedJdbcDriver.scala
@@ -31,23 +31,25 @@ object SupportedJdbcDriver {
     type SqlInterpol = SI
   }
 
-  val Postgres: SupportedJdbcDriver = {
+  def Postgres(tablePrefix: String = ""): SupportedJdbcDriver = {
     import doobie.postgres.implicits._
     import doobie.postgres.sqlstate.{class23 => postgres_class23}
-    implicit val ipol: Queries.Postgres.SqlInterpol = new Queries.SqlInterpolation.StringArray()
+    val queries = Queries.Postgres(tablePrefix)
+    implicit val ipol: queries.SqlInterpol = new Queries.SqlInterpolation.StringArray()
     new Instance(
       label = "PostgreSQL",
-      queries = Queries.Postgres,
+      queries,
       retrySqlStates =
         Set(postgres_class23.UNIQUE_VIOLATION.value, ContractDao.StaleOffsetException.SqlState),
     )
   }
 
-  val Oracle: SupportedJdbcDriver = {
-    implicit val ipol: Queries.Oracle.SqlInterpol = new Queries.SqlInterpolation.Unused()
+  def Oracle(tablePrefix: String = ""): SupportedJdbcDriver = {
+    val queries = Queries.Oracle(tablePrefix)
+    implicit val ipol: queries.SqlInterpol = new Queries.SqlInterpolation.Unused()
     new Instance(
       label = "Oracle",
-      queries = Queries.Oracle,
+      queries,
       // all oracle class 23 errors yield 23000; if we want to check for *unique*
       // violation specifically we'll have to look at something other than the SQLState.
       // All other class 23 errors indicate a bug, which should exhaust the retry loop anyway

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
@@ -19,6 +19,7 @@ final class CliSpec extends AnyFreeSpec with Matchers {
     "jdbc:postgresql://localhost:5432/test?&ssl=true",
     "postgres",
     "password",
+    tablePrefix = "",
     DbStartupMode.StartOnly,
   )
   val jdbcConfigString =
@@ -88,6 +89,14 @@ final class CliSpec extends AnyFreeSpec with Matchers {
     "should get None when neither CLI nor env variable are provided" in {
       val config = configParser(sharedOptions).getOrElse(fail())
       config.jdbcConfig shouldBe None
+    }
+
+    "should get the table prefix if specified" in {
+      val prefix = "some_fancy_prefix_"
+      val config = configParser(
+        Seq("--query-store-jdbc-config", s"$jdbcConfigString,tablePrefix=$prefix") ++ sharedOptions
+      ).getOrElse(fail())
+      config.jdbcConfig shouldBe Some(jdbcConfig.copy(tablePrefix = prefix))
     }
 
     "DbStartupMode" - {

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -299,8 +299,8 @@ class ValuePredicateTest
       forEvery(
         Table(
           "backend" -> "sql",
-          dbbackend.SupportedJdbcDriver.Postgres -> postgreSql,
-          dbbackend.SupportedJdbcDriver.Oracle -> oracleSql,
+          dbbackend.SupportedJdbcDriver.Postgres() -> postgreSql,
+          dbbackend.SupportedJdbcDriver.Oracle() -> oracleSql,
         )
       ) { (backend, sql: doobie.Fragment) =>
         // we aren't running the SQL, just looking at it


### PR DESCRIPTION
Should fix #10390

changelog_begin

- [JSON-API] A table prefix can now be specified in the jdbc config via `tablePrefix=<YourFancyTablePrefix>`. This was added to allow running multiple instances of the json api without having collisions (independent of the chosen database).

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
