### PR TITLE
Handle post-execution conflicts in the pre-execution workflow [KVL-806]

### DIFF
--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -64,7 +64,6 @@ da_scala_library(
         "//libs-scala/resources",
         "//libs-scala/resources-akka",
         "//libs-scala/resources-grpc",
-        "//libs-scala/timer-utils",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_dropwizard_metrics_metrics_core",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -93,7 +93,9 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
           submissionResult
         }
         submissionResult.recover { case _: ConflictDetectedException =>
-          logger.error("Conflict detected during post-execution, acknowledging but dropping the submission.")
+          logger.error(
+            "Conflict detected during post-execution, acknowledging but dropping the submission."
+          )
           SubmissionResult.Acknowledged // But it will simply be dropped.
         }
       }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -93,7 +93,7 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
           submissionAggregator.finish()
           submissionResult
         }).recover { case _: ConflictDetectedException =>
-          logger.error("Too many conflicts detected during post-execution. Giving up.")
+          logger.error("Conflict detected during post-execution, acknowledging but dropping the submission.")
           SubmissionResult.Acknowledged // But it will simply be dropped.
         }
       }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -90,16 +90,14 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
             ),
           )
         } yield {
+          submissionAggregator.finish()
           submissionResult
         }).transform {
           case Failure(_: ConflictDetectedException) =>
             logger.error("Too many conflicts detected during post-execution. Giving up.")
             Success(SubmissionResult.Acknowledged) // But it will simply be dropped.
-          case result => result
-        }.map(result => {
-          submissionAggregator.finish()
-          result
-        })
+          case result: Success[SubmissionResult] => result
+        }
       }
     }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -92,11 +92,9 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
         } yield {
           submissionAggregator.finish()
           submissionResult
-        }).transform {
-          case Failure(_: ConflictDetectedException) =>
-            logger.error("Too many conflicts detected during post-execution. Giving up.")
-            Success(SubmissionResult.Acknowledged) // But it will simply be dropped.
-          case result: Success[SubmissionResult] => result
+        }).recover { case _: ConflictDetectedException =>
+          logger.error("Too many conflicts detected during post-execution. Giving up.")
+          SubmissionResult.Acknowledged // But it will simply be dropped.
         }
       }
     }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
@@ -12,6 +12,8 @@ import com.daml.lf.data.Ref
 import com.daml.lf.value.ValueOuterClass.Identifier
 import com.google.protobuf.{ByteString, Empty}
 
+import scala.concurrent.{ExecutionContext, Future}
+
 private[ledger] object TestHelper {
 
   lazy val aParticipantId: Ref.ParticipantId = Ref.ParticipantId.assertFromString("aParticipantId")
@@ -86,4 +88,12 @@ private[ledger] object TestHelper {
     DamlStateValue.newBuilder
       .setContractKeyState(DamlContractKeyState.newBuilder.setContractId(contractId))
       .build
+
+  class FakeStateAccess[LogResult](mockStateOperations: LedgerStateOperations[LogResult])
+      extends LedgerStateAccess[LogResult] {
+    override def inTransaction[T](
+        body: LedgerStateOperations[LogResult] => Future[T]
+    )(implicit executionContext: ExecutionContext): Future[T] =
+      body(mockStateOperations)
+  }
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
@@ -6,6 +6,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, Daml
 import com.daml.ledger.validator.HasDamlStateValue
 import com.daml.ledger.validator.reading.StateReader
 
+import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 
 object PreExecutionTestHelper {

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
@@ -1,0 +1,34 @@
+package com.daml.ledger.validator.preexecution
+
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.validator.HasDamlStateValue
+import com.daml.ledger.validator.reading.StateReader
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object PreExecutionTestHelper {
+
+  final case class TestValue(value: Option[DamlStateValue])
+
+  final case class TestReadSet(keys: Set[DamlStateKey])
+
+  final case class TestWriteSet(value: String)
+
+  def createLedgerStateReader(
+      inputState: Map[DamlStateKey, Option[DamlStateValue]]
+  ): StateReader[DamlStateKey, TestValue] = {
+    val wrappedInputState = inputState.view.mapValues(TestValue(_)).toMap
+    new StateReader[DamlStateKey, TestValue] {
+      override def read(
+          keys: Iterable[DamlStateKey]
+      )(implicit executionContext: ExecutionContext): Future[Seq[TestValue]] =
+        Future.successful(keys.view.map(wrappedInputState).toVector)
+    }
+  }
+
+  object TestValue {
+    implicit object `TestValue has DamlStateValue` extends HasDamlStateValue[TestValue] {
+      override def damlStateValue(value: TestValue): Option[DamlStateValue] = value.value
+    }
+  }
+}

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
@@ -1,3 +1,5 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.daml.ledger.validator.preexecution
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -12,7 +12,12 @@ import com.daml.ledger.participant.state.kvutils.wire.{DamlSubmission, DamlSubmi
 import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.validator.ArgumentMatchers.anyExecutionContext
 import com.daml.ledger.validator.SubmissionValidatorSpec._
-import com.daml.ledger.validator.TestHelper.{aLogEntry, aLogEntryId, aParticipantId}
+import com.daml.ledger.validator.TestHelper.{
+  FakeStateAccess,
+  aLogEntry,
+  aLogEntryId,
+  aParticipantId,
+}
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.Engine
@@ -24,7 +29,7 @@ import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.Try
 
 class SubmissionValidatorSpec
@@ -350,11 +355,4 @@ object SubmissionValidatorSpec {
   private def newRecordTime(): Timestamp =
     Timestamp.assertFromInstant(Clock.systemUTC().instant())
 
-  private class FakeStateAccess[LogResult](mockStateOperations: LedgerStateOperations[LogResult])
-      extends LedgerStateAccess[LogResult] {
-    override def inTransaction[T](
-        body: LedgerStateOperations[LogResult] => Future[T]
-    )(implicit executionContext: ExecutionContext): Future[T] =
-      body(mockStateOperations)
-  }
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -18,10 +18,15 @@ import com.daml.ledger.participant.state.kvutils.{
   Raw,
   TestHelpers,
 }
-import com.daml.ledger.validator.HasDamlStateValue
 import com.daml.ledger.validator.TestHelper._
 import com.daml.ledger.validator.ValidationFailed.ValidationError
 import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidatorSpec._
+import com.daml.ledger.validator.preexecution.PreExecutionTestHelper.{
+  TestReadSet,
+  TestValue,
+  TestWriteSet,
+  createLedgerStateReader,
+}
 import com.daml.ledger.validator.reading.StateReader
 import com.daml.lf.data.Ref.ParticipantId
 import com.daml.lf.data.Time.Timestamp
@@ -32,7 +37,6 @@ import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 
@@ -144,18 +148,6 @@ object PreExecutingSubmissionValidatorSpec {
 
   private val metrics = new Metrics(new MetricRegistry)
 
-  private final case class TestValue(value: Option[DamlStateValue])
-
-  private object TestValue {
-    implicit object `TestValue has DamlStateValue` extends HasDamlStateValue[TestValue] {
-      override def damlStateValue(value: TestValue): Option[DamlStateValue] = value.value
-    }
-  }
-
-  private final case class TestReadSet(keys: Set[DamlStateKey])
-
-  private final case class TestWriteSet(value: String)
-
   private def anEnvelope(expectedReadSet: Set[DamlStateKey] = Set.empty): Raw.Envelope = {
     val submission = DamlSubmission
       .newBuilder()
@@ -227,18 +219,6 @@ object PreExecutingSubmissionValidatorSpec {
       mockCommitStrategy,
       metrics = metrics,
     )
-  }
-
-  private def createLedgerStateReader(
-      inputState: Map[DamlStateKey, Option[DamlStateValue]]
-  ): StateReader[DamlStateKey, TestValue] = {
-    val wrappedInputState = inputState.view.mapValues(TestValue(_)).toMap
-    new StateReader[DamlStateKey, TestValue] {
-      override def read(
-          keys: Iterable[DamlStateKey]
-      )(implicit executionContext: ExecutionContext): Future[Seq[TestValue]] =
-        Future.successful(keys.view.map(wrappedInputState).toVector)
-    }
   }
 
   private def verifyReadSet(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
@@ -61,12 +61,12 @@ class PreExecutingValidatingCommitterSpec
           Instant.now(),
           new FakeStateAccess(mock[LedgerStateOperations[Unit]]),
         )
-        .map(result => {
+        .map { result =>
           verify(fixture.postExecutionWriter)
             .write(any[TestWriteSet], any[LedgerStateWriteOperations[Long]])(any[ExecutionContext])
           verify(submissionAggregator).finish()
           result shouldBe SubmissionResult.Acknowledged
-        })
+        }
     }
 
     "drop transaction when post execution conflicts are detected" in {
@@ -90,12 +90,12 @@ class PreExecutingValidatingCommitterSpec
           Instant.now(),
           new FakeStateAccess(mock[LedgerStateOperations[Unit]]),
         )
-        .map(result => {
+        .map { result =>
           verify(fixture.postExecutionWriter, never)
             .write(any[TestWriteSet], any[LedgerStateWriteOperations[Long]])(any[ExecutionContext])
           verify(submissionAggregator).finish()
           result shouldBe SubmissionResult.Acknowledged
-        })
+        }
     }
   }
 
@@ -103,6 +103,7 @@ class PreExecutingValidatingCommitterSpec
 
 object PreExecutingValidatingCommitterSpec {
 
+  import ArgumentMatchersSugar._
   import MockitoSugar._
   import PreExecutionTestHelper._
 
@@ -128,23 +129,22 @@ object PreExecutingValidatingCommitterSpec {
     def validatorReturnsSuccess = {
       when(
         validator.validate(
-          ArgumentMatchersSugar.any[Raw.Envelope],
-          ArgumentMatchersSugar.any[ParticipantId],
-          ArgumentMatchersSugar.any[StateReader[DamlStateKey, TestValue]],
-        )(ArgumentMatchersSugar.any[ExecutionContext], ArgumentMatchersSugar.any[LoggingContext])
-      )
-        .thenReturn(
-          Future.successful(
-            PreExecutionOutput(
-              None,
-              None,
-              TestWriteSet(""),
-              TestWriteSet(""),
-              TestReadSet(Set.empty),
-              Set.empty,
-            )
+          any[Raw.Envelope],
+          any[ParticipantId],
+          any[StateReader[DamlStateKey, TestValue]],
+        )(any[ExecutionContext], any[LoggingContext])
+      ).thenReturn(
+        Future.successful(
+          PreExecutionOutput(
+            None,
+            None,
+            TestWriteSet(""),
+            TestWriteSet(""),
+            TestReadSet(Set.empty),
+            Set.empty,
           )
         )
+      )
     }
   }
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
@@ -93,7 +93,7 @@ class PreExecutingValidatingCommitterSpec
         .map { result =>
           verify(fixture.postExecutionWriter, never)
             .write(any[TestWriteSet], any[LedgerStateWriteOperations[Long]])(any[ExecutionContext])
-          verify(submissionAggregator).finish()
+          verify(submissionAggregator, never).finish()
           result shouldBe SubmissionResult.Acknowledged
         }
     }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
@@ -1,0 +1,150 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.daml.ledger.validator.preexecution
+
+import java.time.Instant
+
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.Raw
+import com.daml.ledger.participant.state.kvutils.`export`.{
+  LedgerDataExporter,
+  SubmissionAggregator,
+  SubmissionInfo,
+}
+import com.daml.ledger.participant.state.v1.SubmissionResult
+import com.daml.ledger.validator.TestHelper.{FakeStateAccess, aParticipantId}
+import com.daml.ledger.validator.reading.StateReader
+import com.daml.ledger.validator.{LedgerStateOperations, LedgerStateWriteOperations}
+import com.daml.lf.data.Ref.ParticipantId
+import com.daml.logging.LoggingContext
+import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class PreExecutingValidatingCommitterSpec
+    extends AsyncWordSpec
+    with Matchers
+    with MockitoSugar
+    with ArgumentMatchersSugar {
+
+  import PreExecutingValidatingCommitterSpec._
+  import PreExecutionTestHelper._
+
+  "commit" should {
+
+    "write the transactions when no post execution conflicts are detected" in {
+      val fixture = new ValidatingCommitterFixture
+      fixture.validatorReturnsSuccess
+      when(
+        fixture.conflictDetector.detectConflicts(
+          any[PreExecutionOutput[TestReadSet, TestWriteSet]],
+          any[StateReader[DamlStateKey, TestValue]],
+        )(any[ExecutionContext])
+      )
+        .thenReturn(Future.unit)
+      val submissionAggregator = mock[SubmissionAggregator]
+      when(fixture.ledgerDataExporter.addSubmission(any[SubmissionInfo]))
+        .thenReturn(submissionAggregator)
+      when(
+        fixture.postExecutionWriter.write(any[TestWriteSet], any[LedgerStateWriteOperations[Long]])(
+          any[ExecutionContext]
+        )
+      )
+        .thenReturn(Future.successful(SubmissionResult.Acknowledged))
+      fixture.committer
+        .commit(
+          aParticipantId,
+          "corid",
+          Raw.Envelope.empty,
+          Instant.now(),
+          new FakeStateAccess(mock[LedgerStateOperations[Unit]]),
+        )
+        .map(result => {
+          verify(fixture.postExecutionWriter)
+            .write(any[TestWriteSet], any[LedgerStateWriteOperations[Long]])(any[ExecutionContext])
+          verify(submissionAggregator).finish()
+          result shouldBe SubmissionResult.Acknowledged
+        })
+    }
+
+    "drop transaction when post execution conflicts are detected" in {
+      val fixture = new ValidatingCommitterFixture
+      fixture.validatorReturnsSuccess
+      when(
+        fixture.conflictDetector.detectConflicts(
+          any[PreExecutionOutput[TestReadSet, TestWriteSet]],
+          any[StateReader[DamlStateKey, TestValue]],
+        )(any[ExecutionContext])
+      )
+        .thenReturn(Future.failed(new ConflictDetectedException()))
+      val submissionAggregator = mock[SubmissionAggregator]
+      when(fixture.ledgerDataExporter.addSubmission(any[SubmissionInfo]))
+        .thenReturn(submissionAggregator)
+      fixture.committer
+        .commit(
+          aParticipantId,
+          "corid",
+          Raw.Envelope.empty,
+          Instant.now(),
+          new FakeStateAccess(mock[LedgerStateOperations[Unit]]),
+        )
+        .map(result => {
+          verify(fixture.postExecutionWriter, never)
+            .write(any[TestWriteSet], any[LedgerStateWriteOperations[Long]])(any[ExecutionContext])
+          verify(submissionAggregator).finish()
+          result shouldBe SubmissionResult.Acknowledged
+        })
+    }
+  }
+
+}
+
+object PreExecutingValidatingCommitterSpec {
+
+  import MockitoSugar._
+  import PreExecutionTestHelper._
+
+  class ValidatingCommitterFixture {
+
+    val validator = mock[PreExecutingSubmissionValidator[TestValue, TestReadSet, TestWriteSet]]
+    val conflictDetector =
+      mock[PostExecutionConflictDetector[DamlStateKey, TestValue, TestReadSet, TestWriteSet]]
+    val postExecutionWriter = mock[PostExecutionWriter[TestWriteSet]]
+    val writeSetSelector = mock[WriteSetSelector[TestReadSet, TestWriteSet]]
+    val ledgerDataExporter = mock[LedgerDataExporter]
+
+    val committer =
+      new PreExecutingValidatingCommitter(
+        _ => createLedgerStateReader(Map.empty),
+        validator,
+        conflictDetector,
+        writeSetSelector,
+        postExecutionWriter,
+        ledgerDataExporter,
+      )
+
+    def validatorReturnsSuccess = {
+      when(
+        validator.validate(
+          ArgumentMatchersSugar.any[Raw.Envelope],
+          ArgumentMatchersSugar.any[ParticipantId],
+          ArgumentMatchersSugar.any[StateReader[DamlStateKey, TestValue]],
+        )(ArgumentMatchersSugar.any[ExecutionContext], ArgumentMatchersSugar.any[LoggingContext])
+      )
+        .thenReturn(
+          Future.successful(
+            PreExecutionOutput(
+              None,
+              None,
+              TestWriteSet(""),
+              TestWriteSet(""),
+              TestReadSet(Set.empty),
+              Set.empty,
+            )
+          )
+        )
+    }
+  }
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
@@ -36,7 +36,7 @@ class PreExecutingValidatingCommitterSpec
 
     "write the transactions when no post execution conflicts are detected" in {
       val fixture = new ValidatingCommitterFixture
-      fixture.validatorReturnsSuccess
+      fixture.validatorReturnsSuccess()
       when(
         fixture.conflictDetector.detectConflicts(
           any[PreExecutionOutput[TestReadSet, TestWriteSet]],
@@ -71,7 +71,7 @@ class PreExecutingValidatingCommitterSpec
 
     "drop transaction when post execution conflicts are detected" in {
       val fixture = new ValidatingCommitterFixture
-      fixture.validatorReturnsSuccess
+      fixture.validatorReturnsSuccess()
       when(
         fixture.conflictDetector.detectConflicts(
           any[PreExecutionOutput[TestReadSet, TestWriteSet]],
@@ -126,7 +126,7 @@ object PreExecutingValidatingCommitterSpec {
         ledgerDataExporter,
       )
 
-    def validatorReturnsSuccess = {
+    def validatorReturnsSuccess() = {
       when(
         validator.validate(
           any[Raw.Envelope],


### PR DESCRIPTION
### Pull Request Checklist

During the pre-execution workflow, we were ignoring the `ConflictDetectedException` that was being thrown by the PostExecutionConflictDetector. This also meanth that the retry we had around was meaningless.
The decision was takent to remove the retries all together and fix the flaw by returning success for the transaction without writing the write set.

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
