### PR TITLE
[Docs] Update to a newer gpg keyserver because the old one is deprecated

### DIFF
--- a/docs/source/getting-started/manual-download.rst
+++ b/docs/source/getting-started/manual-download.rst
@@ -17,7 +17,7 @@ To do that:
    Security Public Key imported into your keychain. Once you have ``gpg``
    installed, you can import the key by running::
 
-     gpg --keyserver pool.sks-keyservers.net --search 4911A8DFE976ACDFA07130DBE8372C0C1C734C51
+     gpg --keyserver https://keys.openpgp.org --search 4911A8DFE976ACDFA07130DBE8372C0C1C734C51
 
    This should come back with a key belonging to ``Digital Asset Holdings, LLC
    <security@digitalasset.com>``, created on 2019-05-16 and expiring on


### PR DESCRIPTION
Fixes #10448

If I execute the command with the new keyserver it returns:
```
~ gpg --keyserver https://keys.openpgp.org --search 4911A8DFE976ACDFA07130DBE8372C0C1C734C51
gpg: data source: https://keys.openpgp.org:443
(1)	  2048 bit RSA key E8372C0C1C734C51, erzeugt: 2019-05-16
```

The date seems to be right, but I'm confused it doesn't show that it's from DA. However I'm no gpg expert, so is this result fine @nycnewman?

changelog_begin

- [Docs] The manual install instructions now use a different gpg keyserver because the old one is deprecated / not reachable anymore

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
