### PR TITLE
KV: Fix KV's TransactionCommitter's rejection trace logs [KVL-1023]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
@@ -34,7 +34,7 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
       submissionSeed: crypto.Hash,
       ledgerConfiguration: Configuration,
   )(implicit
-      ec: ExecutionContext,
+      executionContext: ExecutionContext,
       loggingContext: LoggingContext,
   ): Future[Either[ErrorCause, CommandExecutionResult]] =
     loop(commands, submissionSeed, ledgerConfiguration, maxRetries)
@@ -45,9 +45,9 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
       ledgerConfiguration: Configuration,
       retriesLeft: Int,
   )(implicit
-      ec: ExecutionContext,
+      executionContext: ExecutionContext,
       loggingContext: LoggingContext,
-  ): Future[Either[ErrorCause, CommandExecutionResult]] = {
+  ): Future[Either[ErrorCause, CommandExecutionResult]] =
     delegate
       .execute(commands, submissionSeed, ledgerConfiguration)
       .flatMap {
@@ -60,15 +60,13 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
           // and advance output time or re-execute the command if necessary.
           val usedContractIds: Set[ContractId] = cer.transaction
             .inputContracts[ContractId]
-            .collect { case id: ContractId =>
-              id
-            }
+            .collect { case id: ContractId => id }
           if (usedContractIds.isEmpty)
             Future.successful(Right(cer))
           else
             contractStore
               .lookupMaximumLedgerTime(usedContractIds)
-              .flatMap(maxUsedInstant => {
+              .flatMap { maxUsedInstant =>
                 val maxUsedTime = maxUsedInstant.map(Time.Timestamp.assertFromInstant)
                 if (maxUsedTime.forall(_ <= commands.commands.ledgerEffectiveTime)) {
                   Future.successful(Right(cer))
@@ -82,16 +80,12 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
                   logger.debug(
                     s"Restarting the computation with new ledger effective time $maxUsedTime"
                   )
-                  loop(
-                    advanceInputTime(commands, maxUsedTime),
-                    submissionSeed,
-                    ledgerConfiguration,
-                    retriesLeft - 1,
-                  )
+                  val advancedCommands = advanceInputTime(commands, maxUsedTime)
+                  loop(advancedCommands, submissionSeed, ledgerConfiguration, retriesLeft - 1)
                 } else {
                   Future.successful(Left(ErrorCause.LedgerTime(maxRetries)))
                 }
-              })
+              }
               .recover {
                 // An error while looking up the maximum ledger time for the used contracts
                 // most likely means that one of the contracts is already not active anymore,
@@ -106,7 +100,6 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
                   Left(ErrorCause.LedgerTime(maxRetries - retriesLeft))
               }
       }
-  }
 
   // Does nothing if `newTime` is empty. This happens if the transaction only regarded divulged contracts.
   private[this] def advanceOutputTime(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
@@ -24,18 +24,18 @@ private[transaction] class Rejections(metrics: Metrics) {
 
   private final val logger = ContextualizedLogger.get(getClass)
 
-  def buildImmediateRejectionStep[A](
+  def reject[A](
       transactionEntry: DamlTransactionEntrySummary,
       rejection: Rejection,
       recordTime: Option[Timestamp],
   )(implicit loggingContext: LoggingContext): StepResult[A] =
-    buildImmediateRejectionStep(
+    reject(
       buildRejectionEntry(transactionEntry, rejection),
       rejection.description,
       recordTime,
     )
 
-  def buildImmediateRejectionStep[A](
+  def reject[A](
       rejectionEntry: DamlTransactionRejectionEntry.Builder,
       rejectionDescription: String,
       recordTime: Option[Timestamp],

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
@@ -53,7 +53,7 @@ private[transaction] class Rejections(metrics: Metrics) {
   def buildRejectionEntry(
       transactionEntry: DamlTransactionEntrySummary,
       rejection: Rejection,
-  )(implicit loggingContext: LoggingContext): DamlTransactionRejectionEntry.Builder = {
+  ): DamlTransactionRejectionEntry.Builder = {
     val builder = DamlTransactionRejectionEntry.newBuilder
     builder
       .setSubmitterInfo(transactionEntry.submitterInfo)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
@@ -22,7 +22,7 @@ import com.daml.metrics.Metrics
 
 private[transaction] class Rejections(metrics: Metrics) {
 
-  private final val logger = ContextualizedLogger.get(getClass)
+  final private val logger = ContextualizedLogger.get(getClass)
 
   def reject[A](
       transactionEntry: DamlTransactionEntrySummary,
@@ -50,7 +50,13 @@ private[transaction] class Rejections(metrics: Metrics) {
     )
   }
 
-  def buildRejectionEntry(
+  def preExecutionOutOfTimeBoundsRejectionEntry(
+      transactionEntry: DamlTransactionEntrySummary,
+      rejection: Rejection,
+  ): DamlTransactionRejectionEntry =
+    buildRejectionEntry(transactionEntry, rejection).build
+
+  private def buildRejectionEntry(
       transactionEntry: DamlTransactionEntrySummary,
       rejection: Rejection,
   ): DamlTransactionRejectionEntry.Builder = {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.committer.transaction
 
+import java.time.Instant
+
 import com.codahale.metrics.Counter
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlTransactionRejectionEntry,
@@ -52,9 +54,13 @@ private[transaction] class Rejections(metrics: Metrics) {
 
   def preExecutionOutOfTimeBoundsRejectionEntry(
       transactionEntry: DamlTransactionEntrySummary,
-      rejection: Rejection,
+      minimumRecordTime: Instant,
+      maximumRecordTime: Instant,
   ): DamlTransactionRejectionEntry =
-    buildRejectionEntry(transactionEntry, rejection).build
+    buildRejectionEntry(
+      transactionEntry,
+      Rejection.RecordTimeOutOfRange(minimumRecordTime, maximumRecordTime),
+    ).build
 
   private def buildRejectionEntry(
       transactionEntry: DamlTransactionEntrySummary,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -155,15 +155,15 @@ private[kvutils] class TransactionCommitter(
             None
           case Some(_) =>
             Some(
-              immediateRejectionStep(
+              reject(
                 Rejection.SubmitterCannotActViaParticipant(submitter, commitContext.participantId)
               )
             )
           case None =>
-            Some(immediateRejectionStep(Rejection.SubmittingPartyNotKnownOnLedger(submitter)))
+            Some(reject(Rejection.SubmittingPartyNotKnownOnLedger(submitter)))
         }
 
-      def immediateRejectionStep(reason: Rejection): StepResult[DamlTransactionEntrySummary] =
+      def reject(reason: Rejection): StepResult[DamlTransactionEntrySummary] =
         rejections.reject(
           transactionEntry,
           reason,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -98,11 +98,11 @@ private[kvutils] class TransactionCommitter(
           if (dedupEntry.forall(isAfterDeduplicationTime(submissionTime, _))) {
             StepContinue(transactionEntry)
           } else {
-            logger.trace("Transaction rejected because the command is a duplicate.")
-            rejections.buildRejectionStep(
+            rejections.buildImmediateRejectionStep(
               DamlTransactionRejectionEntry.newBuilder
                 .setSubmitterInfo(transactionEntry.submitterInfo)
                 .setDuplicateCommand(Duplicate.newBuilder.setDetails("")),
+              "the command is a duplicate",
               commitContext.recordTime,
             )
           }
@@ -155,16 +155,16 @@ private[kvutils] class TransactionCommitter(
             None
           case Some(_) =>
             Some(
-              rejection(
+              immediateRejectionStep(
                 Rejection.SubmitterCannotActViaParticipant(submitter, commitContext.participantId)
               )
             )
           case None =>
-            Some(rejection(Rejection.SubmittingPartyNotKnownOnLedger(submitter)))
+            Some(immediateRejectionStep(Rejection.SubmittingPartyNotKnownOnLedger(submitter)))
         }
 
-      def rejection(reason: Rejection): StepResult[DamlTransactionEntrySummary] =
-        rejections.buildRejectionStep(
+      def immediateRejectionStep(reason: Rejection): StepResult[DamlTransactionEntrySummary] =
+        rejections.buildImmediateRejectionStep(
           transactionEntry,
           reason,
           commitContext.recordTime,
@@ -286,7 +286,7 @@ private[kvutils] class TransactionCommitter(
       if (missingParties.isEmpty)
         StepContinue(transactionEntry)
       else
-        rejections.buildRejectionStep(
+        rejections.buildImmediateRejectionStep(
           transactionEntry,
           Rejection.PartiesNotKnownOnLedger(missingParties),
           commitContext.recordTime,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -98,7 +98,7 @@ private[kvutils] class TransactionCommitter(
           if (dedupEntry.forall(isAfterDeduplicationTime(submissionTime, _))) {
             StepContinue(transactionEntry)
           } else {
-            rejections.buildImmediateRejectionStep(
+            rejections.reject(
               DamlTransactionRejectionEntry.newBuilder
                 .setSubmitterInfo(transactionEntry.submitterInfo)
                 .setDuplicateCommand(Duplicate.newBuilder.setDetails("")),
@@ -164,7 +164,7 @@ private[kvutils] class TransactionCommitter(
         }
 
       def immediateRejectionStep(reason: Rejection): StepResult[DamlTransactionEntrySummary] =
-        rejections.buildImmediateRejectionStep(
+        rejections.reject(
           transactionEntry,
           reason,
           commitContext.recordTime,
@@ -286,7 +286,7 @@ private[kvutils] class TransactionCommitter(
       if (missingParties.isEmpty)
         StepContinue(transactionEntry)
       else
-        rejections.buildImmediateRejectionStep(
+        rejections.reject(
           transactionEntry,
           Rejection.PartiesNotKnownOnLedger(missingParties),
           commitContext.recordTime,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
@@ -40,7 +40,7 @@ private[transaction] class LedgerTimeValidator(defaultConfig: Configuration)
               .checkTime(ledgerTime = givenLedgerTime, recordTime = recordTime.toInstant)
               .fold(
                 outOfRange =>
-                  rejections.buildImmediateRejectionStep(
+                  rejections.reject(
                     transactionEntry,
                     Rejection.LedgerTimeOutOfRange(outOfRange),
                     commitContext.recordTime,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
@@ -66,7 +66,7 @@ private[transaction] class LedgerTimeValidator(defaultConfig: Configuration)
             commitContext.maximumRecordTime = Some(maximumRecordTime)
             val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
               .setTransactionRejectionEntry(
-                rejections.buildRejectionEntry(
+                rejections.preExecutionOutOfTimeBoundsRejectionEntry(
                   transactionEntry,
                   Rejection.RecordTimeOutOfRange(minimumRecordTime, maximumRecordTime),
                 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
@@ -40,7 +40,7 @@ private[transaction] class LedgerTimeValidator(defaultConfig: Configuration)
               .checkTime(ledgerTime = givenLedgerTime, recordTime = recordTime.toInstant)
               .fold(
                 outOfRange =>
-                  rejections.buildRejectionStep(
+                  rejections.buildImmediateRejectionStep(
                     transactionEntry,
                     Rejection.LedgerTimeOutOfRange(outOfRange),
                     commitContext.recordTime,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
@@ -68,7 +68,8 @@ private[transaction] class LedgerTimeValidator(defaultConfig: Configuration)
               .setTransactionRejectionEntry(
                 rejections.preExecutionOutOfTimeBoundsRejectionEntry(
                   transactionEntry,
-                  Rejection.RecordTimeOutOfRange(minimumRecordTime, maximumRecordTime),
+                  minimumRecordTime,
+                  maximumRecordTime,
                 )
               )
               .build

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
@@ -99,7 +99,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
           )
           .left
           .map(error =>
-            rejections.buildRejectionStep(
+            rejections.buildImmediateRejectionStep(
               transactionEntry,
               Rejection.ValidationFailure(error),
               commitContext.recordTime,
@@ -113,7 +113,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
           "Model conformance validation failed due to a missing input state (most likely due to invalid state on the participant).",
           missingInputErr,
         )
-        rejections.buildRejectionStep(
+        rejections.buildImmediateRejectionStep(
           transactionEntry,
           Rejection.MissingInputState(key),
           commitContext.recordTime,
@@ -123,7 +123,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
           "Model conformance validation failed most likely due to invalid state on the participant.",
           err,
         )
-        rejections.buildRejectionStep(
+        rejections.buildImmediateRejectionStep(
           transactionEntry,
           Rejection.InvalidParticipantState(err),
           commitContext.recordTime,
@@ -220,7 +220,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
     if (isCausallyMonotonic)
       StepContinue(transactionEntry)
     else
-      rejections.buildRejectionStep(
+      rejections.buildImmediateRejectionStep(
         transactionEntry,
         Rejection.CausalMonotonicityViolated,
         commitContext.recordTime,
@@ -243,6 +243,6 @@ private[transaction] object ModelConformanceValidator {
       case InconsistentKeys(_) =>
         Rejection.InternallyInconsistentTransaction.InconsistentKeys
     }
-    rejections.buildRejectionStep(transactionEntry, rejection, recordTime)
+    rejections.buildImmediateRejectionStep(transactionEntry, rejection, recordTime)
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
@@ -99,7 +99,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
           )
           .left
           .map(error =>
-            rejections.buildImmediateRejectionStep(
+            rejections.reject(
               transactionEntry,
               Rejection.ValidationFailure(error),
               commitContext.recordTime,
@@ -113,7 +113,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
           "Model conformance validation failed due to a missing input state (most likely due to invalid state on the participant).",
           missingInputErr,
         )
-        rejections.buildImmediateRejectionStep(
+        rejections.reject(
           transactionEntry,
           Rejection.MissingInputState(key),
           commitContext.recordTime,
@@ -123,7 +123,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
           "Model conformance validation failed most likely due to invalid state on the participant.",
           err,
         )
-        rejections.buildImmediateRejectionStep(
+        rejections.reject(
           transactionEntry,
           Rejection.InvalidParticipantState(err),
           commitContext.recordTime,
@@ -220,7 +220,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
     if (isCausallyMonotonic)
       StepContinue(transactionEntry)
     else
-      rejections.buildImmediateRejectionStep(
+      rejections.reject(
         transactionEntry,
         Rejection.CausalMonotonicityViolated,
         commitContext.recordTime,
@@ -243,6 +243,6 @@ private[transaction] object ModelConformanceValidator {
       case InconsistentKeys(_) =>
         Rejection.InternallyInconsistentTransaction.InconsistentKeys
     }
-    rejections.buildImmediateRejectionStep(transactionEntry, rejection, recordTime)
+    rejections.reject(transactionEntry, rejection, recordTime)
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
@@ -106,7 +106,7 @@ private[transaction] object TransactionConsistencyValidator extends TransactionV
           case Inconsistent =>
             Rejection.ExternallyInconsistentTransaction.InconsistentKeys
         }
-        rejections.buildImmediateRejectionStep(
+        rejections.reject(
           transactionEntry,
           rejection,
           commitContext.recordTime,
@@ -132,7 +132,7 @@ private[transaction] object TransactionConsistencyValidator extends TransactionV
     if (areContractsConsistent)
       StepContinue(transactionEntry)
     else
-      rejections.buildImmediateRejectionStep(
+      rejections.reject(
         transactionEntry,
         Rejection.ExternallyInconsistentTransaction.InconsistentContracts,
         commitContext.recordTime,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
@@ -106,7 +106,7 @@ private[transaction] object TransactionConsistencyValidator extends TransactionV
           case Inconsistent =>
             Rejection.ExternallyInconsistentTransaction.InconsistentKeys
         }
-        rejections.buildRejectionStep(transactionEntry, rejection, commitContext.recordTime)
+        rejections.buildImmediateRejectionStep(transactionEntry, rejection, commitContext.recordTime)
     }
   }
 
@@ -128,7 +128,7 @@ private[transaction] object TransactionConsistencyValidator extends TransactionV
     if (areContractsConsistent)
       StepContinue(transactionEntry)
     else
-      rejections.buildRejectionStep(
+      rejections.buildImmediateRejectionStep(
         transactionEntry,
         Rejection.ExternallyInconsistentTransaction.InconsistentContracts,
         commitContext.recordTime,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
@@ -106,7 +106,11 @@ private[transaction] object TransactionConsistencyValidator extends TransactionV
           case Inconsistent =>
             Rejection.ExternallyInconsistentTransaction.InconsistentKeys
         }
-        rejections.buildImmediateRejectionStep(transactionEntry, rejection, commitContext.recordTime)
+        rejections.buildImmediateRejectionStep(
+          transactionEntry,
+          rejection,
+          commitContext.recordTime,
+        )
     }
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/TimeBasedWriteSetSelector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/TimeBasedWriteSetSelector.scala
@@ -5,6 +5,10 @@ package com.daml.ledger.validator.preexecution
 
 import java.time.Instant
 
+import com.daml.ledger.configuration.LedgerTimeModel.OutOfRange
+import com.daml.ledger.participant.state.kvutils.committer.transaction.Rejection
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+
 /** Selects a write set from a [[PreExecutionOutput]] based on the current time.
   * If the current time is within the bounds specified by the output, the success write set is
   * chosen, otherwise, the out-of-time-bounds write set is chosen.
@@ -12,14 +16,21 @@ import java.time.Instant
 final class TimeBasedWriteSetSelector[ReadSet, WriteSet](now: () => Instant)
     extends WriteSetSelector[ReadSet, WriteSet] {
 
+  final private val logger = ContextualizedLogger.get(getClass)
+
   override def selectWriteSet(
       preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet]
-  ): WriteSet = {
+  )(implicit loggingContext: LoggingContext): WriteSet = {
     val recordTime = now()
+    val minRecordTime = preExecutionOutput.minRecordTime.getOrElse(Instant.MIN)
+    val maxRecordTime = preExecutionOutput.maxRecordTime.getOrElse(Instant.MAX)
     val withinTimeBounds =
-      !recordTime.isBefore(preExecutionOutput.minRecordTime.getOrElse(Instant.MIN)) &&
-        !recordTime.isAfter(preExecutionOutput.maxRecordTime.getOrElse(Instant.MAX))
+      !recordTime.isBefore(minRecordTime) &&
+        !recordTime.isAfter(maxRecordTime)
     if (withinTimeBounds) {
+      val rejectionReason =
+        Rejection.LedgerTimeOutOfRange(OutOfRange(recordTime, minRecordTime, maxRecordTime))
+      logger.trace(s"Transaction rejected at post-execution, ${rejectionReason.description}")
       preExecutionOutput.successWriteSet
     } else {
       preExecutionOutput.outOfTimeBoundsWriteSet

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/TimeBasedWriteSetSelector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/TimeBasedWriteSetSelector.scala
@@ -29,7 +29,7 @@ final class TimeBasedWriteSetSelector[ReadSet, WriteSet](now: () => Instant)
         !recordTime.isAfter(maxRecordTime)
     if (withinTimeBounds) {
       val rejectionReason =
-        Rejection.LedgerTimeOutOfRange(OutOfRange(recordTime, minRecordTime, maxRecordTime))
+        Rejection.RecordTimeOutOfRange(minRecordTime, maxRecordTime)
       logger.trace(s"Transaction rejected at post-execution, ${rejectionReason.description}")
       preExecutionOutput.successWriteSet
     } else {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/TimeBasedWriteSetSelector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/TimeBasedWriteSetSelector.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.validator.preexecution
 
 import java.time.Instant
 
-import com.daml.ledger.configuration.LedgerTimeModel.OutOfRange
 import com.daml.ledger.participant.state.kvutils.committer.transaction.Rejection
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/WriteSetSelector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/WriteSetSelector.scala
@@ -3,9 +3,12 @@
 
 package com.daml.ledger.validator.preexecution
 
-/** Selects a write set from a [[PreExecutionOutput]]. */
+import com.daml.logging.LoggingContext
+
 trait WriteSetSelector[ReadSet, WriteSet] {
 
-  def selectWriteSet(preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet]): WriteSet
+  def selectWriteSet(preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet])(implicit
+      loggingContext: LoggingContext
+  ): WriteSet
 
 }


### PR DESCRIPTION
## Description

- A trace-level log line saying that the transaction has been rejected was being wrongly produced even when the rejection log entry was being created for pre-execution. This is fixed by logging only in functions that are being used to reject a transaction immediately.
- Renamed around a bit to clarify when we're rejecting immediately (and logging and updating metrics).
- Added a rejection trace log in the post-executor too.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
