### PR TITLE
Indexer db MigrateOnEmptySchemaAndStart startup mode and migrateOnly hook

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerStartupMode.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerStartupMode.scala
@@ -13,8 +13,8 @@ object IndexerStartupMode {
 
   case object ResetAndStart extends IndexerStartupMode
 
-  case object MigrateOnly extends IndexerStartupMode
-
   case object ValidateAndWaitOnly extends IndexerStartupMode
+
+  case object MigrateOnEmptySchemaAndStart extends IndexerStartupMode
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -93,6 +93,13 @@ object JdbcIndexer {
       flywayMigrations
         .validateAndWaitOnly(config.enableAppendOnlySchema)
 
+    def migrateOnEmptySchema()(implicit
+        resourceContext: ResourceContext
+    ): Future[ResourceOwner[Indexer]] =
+      flywayMigrations
+        .migrateOnEmptySchema(config.enableAppendOnlySchema)
+        .flatMap(_ => initialized(resetSchema = false))(resourceContext.executionContext)
+
     private[this] def initializedMutatingSchema(
         resetSchema: Boolean
     )(implicit resourceContext: ResourceContext): Future[ResourceOwner[Indexer]] =

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -55,6 +55,7 @@ object JdbcIndexer {
         servicesExecutionContext: ExecutionContext,
         metrics: Metrics,
         lfValueTranslationCache: LfValueTranslationCache.Cache,
+        additionalMigrationPaths: Seq[String] = Seq.empty,
     )(implicit materializer: Materializer, loggingContext: LoggingContext) =
       this(
         config,
@@ -63,7 +64,7 @@ object JdbcIndexer {
         metrics,
         ExecuteUpdate.owner,
         serverRole,
-        new FlywayMigrations(config.jdbcUrl),
+        new FlywayMigrations(config.jdbcUrl, additionalMigrationPaths),
         lfValueTranslationCache,
       )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -20,6 +20,7 @@ final class StandaloneIndexerServer(
     servicesExecutionContext: ExecutionContext,
     metrics: Metrics,
     lfValueTranslationCache: LfValueTranslationCache.Cache,
+    additionalMigrationPaths: Seq[String] = Seq.empty,
 )(implicit materializer: Materializer, loggingContext: LoggingContext)
     extends ResourceOwner[ReportsHealth] {
 
@@ -33,6 +34,7 @@ final class StandaloneIndexerServer(
       servicesExecutionContext,
       metrics,
       lfValueTranslationCache,
+      additionalMigrationPaths,
     )
     val indexer = RecoveringIndexer(
       materializer.system.scheduler,
@@ -94,7 +96,7 @@ final class StandaloneIndexerServer(
       .map { case (indexerHealthReporter, _) => indexerHealthReporter }
 }
 
-object StandaloneIndexerServerCanton {
+object StandaloneIndexerServer {
 
   // Separate entry point for migrateOnly that serves as an operations rather than a startup command. As such it
   // does not require any of the configurations of a full-fledged indexer except for the jdbc url.
@@ -103,8 +105,9 @@ object StandaloneIndexerServerCanton {
       // TODO append-only: remove after removing support for the current (mutating) schema
       enableAppendOnlySchema: Boolean,
       allowExistingSchema: Boolean = false,
+      additionalMigrationPaths: Seq[String] = Seq.empty,
   )(implicit rc: ResourceContext, loggingContext: LoggingContext): Future[Unit] = {
-    val flywayMigrations = new FlywayMigrations(jdbcUrl)
+    val flywayMigrations = new FlywayMigrations(jdbcUrl, additionalMigrationPaths)
     flywayMigrations.migrate(allowExistingSchema, enableAppendOnlySchema)
   }
 }


### PR DESCRIPTION
Implementing `MigrateOnEmptySchemaAndStart` indexer startup mode and `MigrateOnly` hook per @nmarton-da 's spec. MigrateOnly is not a "real" startup mode as it is an operations command that does not carry with it the "indexer config", so adding a separate `StandaloneIndexerServerCanton.migrateOnly` function that goes directly against `FlywayMigrations` bypassing the `JdbcIndexer[Factory`. That seems to still be in the spirit of the spec that says: "Suggestion using FlywayMigrations directly in StandaloneIndexerServer".

The `additionalMigrationPaths` parameter has been added to enable testing of the migration modes in the canton repo.

cc @soren-da

changelog_begin
Indexer: The indexer now supports the MigrateOnEmptySchemaAndStart startup mode that only performs migrations
on brand-new databases. In addition "real upgrades" are now supported via a new "StandaloneIndexerServer.migrateOnly"
entry point. Also removing the old `MigrateOnly` startup mode that was not implemented.
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
