### PR TITLE
Reactive canton conformance test aginst LF 1.13

### DIFF
--- a/daml-lf/encoder/BUILD.bazel
+++ b/daml-lf/encoder/BUILD.bazel
@@ -137,7 +137,7 @@ object TestDar {
     val fileName = \"daml-lf/encoder/test-%s.dar\"
 }
 EOF
-""" % lf_version_configuration.get(keyword),
+""" % version,
         ),
         da_scala_library(
             name = "testing-dar-lookup-lib-%s" % keyword,
@@ -147,7 +147,8 @@ EOF
             visibility = ["//visibility:public"],
         ),
     ]
-    for keyword in ["latest"]
+    for (keyword, version) in lf_version_configuration.items()
+    if keyword in ["latest"]
 ]
 
 [

--- a/daml-lf/encoder/BUILD.bazel
+++ b/daml-lf/encoder/BUILD.bazel
@@ -12,7 +12,6 @@ load(
     "//daml-lf/language:daml-lf.bzl",
     "ENCODER_LF_VERSIONS",
     "lf_version_configuration",
-    "lf_version_configuration_versions",
     "mangle_for_java",
 )
 
@@ -129,8 +128,8 @@ da_scala_binary(
 [
     [
         genrule(
-            name = "testing-dar-lookup-scala-%s" % lf_version,
-            outs = ["TestDars-%s.scala" % mangle_for_java(lf_version)],
+            name = "testing-dar-lookup-scala-%s" % keyword,
+            outs = ["TestDars-%s.scala" % mangle_for_java(keyword)],
             cmd = """
 cat > $@ <<EOF
 package com.daml.lf.archive.testing
@@ -138,29 +137,25 @@ object TestDar {
     val fileName = \"daml-lf/encoder/test-%s.dar\"
 }
 EOF
-""" % lf_version,
+""" % lf_version_configuration.get(keyword),
         ),
         da_scala_library(
-            name = "testing-dar-lookup-lib-%s" % lf_version,
-            srcs = ["testing-dar-lookup-scala-%s" % lf_version],
+            name = "testing-dar-lookup-lib-%s" % keyword,
+            srcs = ["testing-dar-lookup-scala-%s" % keyword],
             # generated_srcs is required for scaladocF
-            generated_srcs = ["testing-dar-lookup-scala-%s" % lf_version],
+            generated_srcs = ["testing-dar-lookup-scala-%s" % keyword],
             visibility = ["//visibility:public"],
         ),
     ]
-    for lf_version in lf_version_configuration_versions
+    for keyword in ["latest"]
 ]
 
 [
     alias(
-        name = "testing-dar%s-%s" % (name, keyword),
-        actual = ":testing-dar%s-%s" % (name, version),
+        name = "testing-dar-%s" % keyword,
+        actual = ":testing-dar-%s" % version,
         visibility = ["//visibility:public"],
     )
-    for name in [
-        "",
-        "-lookup-lib",
-    ]
     for (keyword, version) in lf_version_configuration.items()
 ]
 

--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -4,6 +4,8 @@
 # The following dictionary alias LF versions to keywords:
 # - "legacy" is the keyword for last LF version that supports legacy
 #    contract ID scheme,
+# - "no-exceptions" is a keyword for the last version that does not
+#   support exceptions (can be dropped without notice),
 # - "default" is the keyword for the default compiler output,
 # - "latest" is the keyword for the latest stable LF version,
 # - "preview" is the keyword fort he next LF version, *not stable*,

--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -18,16 +18,14 @@
 
 lf_version_configuration = {
     "legacy": "1.8",
+    # TODO (MK) Drop no-exception once Canton fully supports exceptions.
+    "no-exceptions": "1.13",
     "default": "1.14",
     "latest": "1.14",
     "dev": "1.dev",
 }
 
-# TODO (MK) Drop 1.13 once Canton fully supports exceptions.
-test_tool_lf_version_configuration = dict({"no-exceptions": "1.13"}, **lf_version_configuration)
-
 lf_version_configuration_versions = depset(lf_version_configuration.values()).to_list()
-test_tool_lf_version_configuration_versions = depset(test_tool_lf_version_configuration.values()).to_list()
 
 # aggregates a list of version keywords and versions:
 # 1. converts keyword in version

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -62,7 +62,7 @@ conformance_test(
         "@jdk11_nix//:bin/java",
     ],
     lf_versions = [
-        "legacy",
+        "no-exceptions",
         # FIXME: replace the previous line by the following ones once canton-test-runner supports LF 1.14
         # "default",
         # "latest",
@@ -105,7 +105,7 @@ conformance_test(
         "@jdk11_nix//:bin/java",
     ],
     lf_versions = [
-        "legacy",
+        "no-exceptions",
         # FIXME: replace the previous line by the following ones once canton-test-runner supports LF 1.14
         #  "default",
         #  "latest",

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -7,8 +7,8 @@ load(
 )
 load(
     "//daml-lf/language:daml-lf.bzl",
-    lf_version_configuration = "test_tool_lf_version_configuration",
-    lf_version_configuration_versions = "test_tool_lf_version_configuration_versions",
+    "lf_version_configuration",
+    "lf_version_configuration_versions",
 )
 load(
     "//bazel_tools:scala.bzl",

--- a/ledger/ledger-api-test-tool/util.bzl
+++ b/ledger/ledger-api-test-tool/util.bzl
@@ -5,10 +5,6 @@ load(
     "//daml-lf/language:daml-lf.bzl",
     "versions",
 )
-load(
-    "//daml-lf/language:daml-lf.bzl",
-    "lf_version_configuration",
-)
 
 exceptions_suites = [
     "src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionsIT.scala",

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -11,11 +11,6 @@ load(
 load("//ledger/ledger-api-test-tool:conformance.bzl", "server_conformance_test")
 load("@os_info//:os_info.bzl", "is_windows")
 load("@build_environment//:configuration.bzl", "mvn_version")
-load(
-    "//daml-lf/language:daml-lf.bzl",
-    "lf_version_configuration",
-    "lf_version_configuration_versions",
-)
 
 alias(
     name = "sandbox-classic",

--- a/ledger/test-common/BUILD.bazel
+++ b/ledger/test-common/BUILD.bazel
@@ -14,8 +14,8 @@ load("@scala_version//:index.bzl", "scala_major_version")
 load("@scala_version//:index.bzl", "scala_major_version")
 load(
     "//daml-lf/language:daml-lf.bzl",
-    lf_version_configuration = "test_tool_lf_version_configuration",
-    lf_version_configuration_versions = "test_tool_lf_version_configuration_versions",
+    "lf_version_configuration",
+    "lf_version_configuration_versions",
 )
 load("//ledger/test-common:test-common.bzl", "da_scala_dar_resources_library")
 


### PR DESCRIPTION
Now we compile the conformance test for 1.13, we can run conton
against 1.13.

follow up of #10456

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
