### PR TITLE
participant-integration-api: Use `Scheduler`, and add more tests to configuration initialization. [KVL-1046]

### DIFF
--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -216,6 +216,7 @@ da_scala_test_suite(
     resources = glob(["src/test/resources/**/*"]),
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
+        "@maven//:com_typesafe_akka_akka_testkit",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:com_typesafe_akka_akka_stream_testkit",
         "@maven//:org_mockito_mockito_scala",
@@ -275,6 +276,7 @@ da_scala_test_suite(
         "//libs-scala/scala-utils",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:com_github_ben_manes_caffeine_caffeine",
+        "@maven//:com_typesafe_config",
         "@maven//:com_zaxxer_HikariCP",
         "@maven//:commons_io_commons_io",
         "@maven//:io_dropwizard_metrics_metrics_core",

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -108,7 +108,13 @@ private[daml] object ApiServices {
       for {
         ledgerId <- Resource.fromFuture(indexService.getLedgerId())
         currentLedgerConfiguration <- LedgerConfigProvider
-          .owner(indexService, optWriteService, timeProvider, ledgerConfiguration)
+          .owner(
+            ledgerConfiguration,
+            indexService,
+            optWriteService,
+            timeProvider,
+            servicesExecutionContext,
+          )
           .acquire()
         services <- Resource(
           Future(createServices(ledgerId, currentLedgerConfiguration)(servicesExecutionContext))

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -105,16 +105,10 @@ private[daml] object ApiServices {
 
     override def acquire()(implicit context: ResourceContext): Resource[ApiServices] = {
       logger.info(engine.info.toString)
-
       for {
         ledgerId <- Resource.fromFuture(indexService.getLedgerId())
         currentLedgerConfiguration <- LedgerConfigProvider
-          .owner(
-            indexService,
-            optWriteService,
-            timeProvider,
-            ledgerConfiguration,
-          )(materializer, loggingContext)
+          .owner(indexService, optWriteService, timeProvider, ledgerConfiguration)
           .acquire()
         services <- Resource(
           Future(createServices(ledgerId, currentLedgerConfiguration)(servicesExecutionContext))

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigProvider.scala
@@ -12,12 +12,15 @@ import com.daml.ledger.resources.ResourceOwner
 import com.daml.logging.LoggingContext
 import com.daml.platform.configuration.LedgerConfiguration
 
+import scala.concurrent.ExecutionContext
+
 object LedgerConfigProvider {
   def owner(
+      ledgerConfiguration: LedgerConfiguration,
       index: IndexConfigManagementService,
       optWriteService: Option[state.WriteConfigService],
       timeProvider: TimeProvider,
-      ledgerConfiguration: LedgerConfiguration,
+      servicesExecutionContext: ExecutionContext,
   )(implicit
       materializer: Materializer,
       loggingContext: LoggingContext,
@@ -30,6 +33,7 @@ object LedgerConfigProvider {
         index = index,
         scheduler = scheduler,
         materializer = materializer,
+        servicesExecutionContext = servicesExecutionContext,
       )
       // Next, we provision the configuration if one does not already exist on the ledger.
       _ <- optWriteService match {
@@ -42,7 +46,7 @@ object LedgerConfigProvider {
             timeProvider = timeProvider,
             submissionIdGenerator = SubmissionIdGenerator.Random,
             scheduler = scheduler,
-            executionContext = materializer.executionContext,
+            servicesExecutionContext = servicesExecutionContext,
           )
       }
       // Finally, we wait until either an existing configuration or the provisioned configuration

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigProvisioner.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigProvisioner.scala
@@ -35,11 +35,10 @@ object LedgerConfigProvisioner {
       timeProvider: TimeProvider,
       submissionIdGenerator: SubmissionIdGenerator,
       scheduler: Scheduler,
-      executionContext: ExecutionContext,
+      servicesExecutionContext: ExecutionContext,
   )(implicit
       loggingContext: LoggingContext
   ): ResourceOwner[Unit] = {
-    implicit val ec: ExecutionContext = executionContext
     ResourceOwner
       .forCancellable(() =>
         scheduler.scheduleOnce(
@@ -49,11 +48,11 @@ object LedgerConfigProvisioner {
               if (currentLedgerConfiguration.latestConfiguration.isEmpty)
                 submitInitialConfig(writeService, timeProvider, submissionIdGenerator)(
                   ledgerConfiguration.initialConfiguration
-                )
+                )(servicesExecutionContext, loggingContext)
               ()
             }
           },
-        )
+        )(servicesExecutionContext)
       )
       .map(_ => ())
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigProvisioner.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigProvisioner.scala
@@ -12,6 +12,7 @@ import com.daml.ledger.resources.ResourceOwner
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.platform.apiserver.configuration.LedgerConfigProvisioner._
 import com.daml.platform.configuration.LedgerConfiguration
 import com.daml.telemetry.{DefaultTelemetry, SpanKind, SpanName}
 
@@ -24,7 +25,58 @@ import scala.util.{Failure, Success}
   * configuration is only written if the ledger does not already have a configuration.
   *
   * Used by the participant to initialize a new ledger.
+  *
+  * Designed to be used only through the [[owner]] constructor.
   */
+final class LedgerConfigProvisioner private (
+    currentLedgerConfiguration: CurrentLedgerConfiguration,
+    writeService: state.WriteConfigService,
+    timeProvider: TimeProvider,
+    submissionIdGenerator: SubmissionIdGenerator,
+) {
+
+  /** Submits the initial configuration immediately.
+    * The [[owner]] constructor will schedule this with a delay.
+    *
+    * There are several reasons why the change could be rejected:
+    *
+    *   - The participant is not authorized to set the configuration
+    *   - There already is a configuration, it just didn't appear in the index yet
+    *
+    * This method therefore does not try to re-submit the initial configuration in case of failure.
+    */
+  def submitInitialConfig(
+      initialConfiguration: Configuration
+  )(implicit executionContext: ExecutionContext, loggingContext: LoggingContext): Unit =
+    if (currentLedgerConfiguration.latestConfiguration.isEmpty) {
+      val submissionId = submissionIdGenerator.generate()
+      withEnrichedLoggingContext("submissionId" -> submissionId) { implicit loggingContext =>
+        logger.info("No ledger configuration found, submitting an initial configuration.")
+        DefaultTelemetry
+          .runFutureInSpan(
+            SpanName.LedgerConfigProviderInitialConfig,
+            SpanKind.Internal,
+          ) { implicit telemetryContext =>
+            val maxRecordTime =
+              Timestamp.assertFromInstant(timeProvider.getCurrentTime.plusSeconds(60))
+            FutureConverters.toScala(
+              writeService.submitConfiguration(maxRecordTime, submissionId, initialConfiguration)
+            )
+          }
+          .onComplete {
+            case Success(state.SubmissionResult.Acknowledged) =>
+              logger.info("Initial configuration submission was successful.")
+            case Success(result: state.SubmissionResult.SynchronousError) =>
+              withEnrichedLoggingContext("error" -> result) { implicit loggingContext =>
+                logger.warn("Initial configuration submission failed.")
+              }
+            case Failure(exception) =>
+              logger.error("Initial configuration submission failed.", exception)
+          }
+      }
+    }
+}
+
 object LedgerConfigProvisioner {
   private val logger = ContextualizedLogger.get(getClass)
 
@@ -36,64 +88,25 @@ object LedgerConfigProvisioner {
       submissionIdGenerator: SubmissionIdGenerator,
       scheduler: Scheduler,
       servicesExecutionContext: ExecutionContext,
-  )(implicit
-      loggingContext: LoggingContext
-  ): ResourceOwner[Unit] = {
+  )(implicit loggingContext: LoggingContext): ResourceOwner[Unit] = {
+    implicit val executionContext: ExecutionContext = servicesExecutionContext
+    val provisioner = new LedgerConfigProvisioner(
+      currentLedgerConfiguration,
+      writeService,
+      timeProvider,
+      submissionIdGenerator,
+    )
     ResourceOwner
       .forCancellable(() =>
         scheduler.scheduleOnce(
           ledgerConfiguration.initialConfigurationSubmitDelay.toNanos.nanos,
           new Runnable {
             override def run(): Unit = {
-              if (currentLedgerConfiguration.latestConfiguration.isEmpty)
-                submitInitialConfig(writeService, timeProvider, submissionIdGenerator)(
-                  ledgerConfiguration.initialConfiguration
-                )(servicesExecutionContext, loggingContext)
-              ()
+              provisioner.submitInitialConfig(ledgerConfiguration.initialConfiguration)
             }
           },
-        )(servicesExecutionContext)
+        )
       )
       .map(_ => ())
-  }
-
-  // There are several reasons why the change could be rejected:
-  // - The participant is not authorized to set the configuration
-  // - There already is a configuration, it just didn't appear in the index yet
-  // This method therefore does not try to re-submit the initial configuration in case of failure.
-  private def submitInitialConfig(
-      writeService: state.WriteConfigService,
-      timeProvider: TimeProvider,
-      submissionIdGenerator: SubmissionIdGenerator,
-  )(
-      initialConfiguration: Configuration
-  )(implicit executionContext: ExecutionContext, loggingContext: LoggingContext): Unit = {
-    val submissionId = submissionIdGenerator.generate()
-    withEnrichedLoggingContext("submissionId" -> submissionId) { implicit loggingContext =>
-      logger.info("No ledger configuration found, submitting an initial configuration.")
-      DefaultTelemetry
-        .runFutureInSpan(
-          SpanName.LedgerConfigProviderInitialConfig,
-          SpanKind.Internal,
-        ) { implicit telemetryContext =>
-          FutureConverters.toScala(
-            writeService.submitConfiguration(
-              Timestamp.assertFromInstant(timeProvider.getCurrentTime.plusSeconds(60)),
-              submissionId,
-              initialConfiguration,
-            )
-          )
-        }
-        .onComplete {
-          case Success(state.SubmissionResult.Acknowledged) =>
-            logger.info("Initial configuration submission was successful.")
-          case Success(result: state.SubmissionResult.SynchronousError) =>
-            withEnrichedLoggingContext("error" -> result) { implicit loggingContext =>
-              logger.warn("Initial configuration submission failed.")
-            }
-          case Failure(exception) =>
-            logger.error("Initial configuration submission failed.", exception)
-        }
-    }
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigProvisioner.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigProvisioner.scala
@@ -5,7 +5,6 @@ package com.daml.platform.apiserver.configuration
 
 import akka.actor.Scheduler
 import com.daml.api.util.TimeProvider
-import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.SubmissionIdGenerator
 import com.daml.ledger.participant.state.{v2 => state}
 import com.daml.ledger.resources.ResourceOwner
@@ -16,9 +15,9 @@ import com.daml.platform.configuration.LedgerConfiguration
 import com.daml.telemetry.{DefaultTelemetry, SpanKind, SpanName}
 
 import scala.compat.java8.FutureConverters
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationLong
-import scala.util.{Failure, Success}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 /** Writes a default ledger configuration to the ledger, after a configurable delay. The
   * configuration is only written if the ledger does not already have a configuration.
@@ -52,33 +51,35 @@ private[apiserver] final class LedgerConfigProvisioner private (
   // - There already is a configuration, it just didn't appear in the index yet
   // This method therefore does not try to re-submit the initial configuration in case of failure.
   private def submitInitialConfig(writeService: state.WriteConfigService): Unit = {
-    val submissionId = submissionIdGenerator.generate()
-    withEnrichedLoggingContext("submissionId" -> submissionId) { implicit loggingContext =>
-      logger.info("No ledger configuration found, submitting an initial configuration.")
-      DefaultTelemetry
-        .runFutureInSpan(
-          SpanName.LedgerConfigProviderInitialConfig,
-          SpanKind.Internal,
-        ) { implicit telemetryContext =>
-          FutureConverters.toScala(
-            writeService.submitConfiguration(
-              Timestamp.assertFromInstant(timeProvider.getCurrentTime.plusSeconds(60)),
-              submissionId,
-              ledgerConfiguration.initialConfiguration,
+    Future.fromTry(Try(submissionIdGenerator.generate())).flatMap { submissionId =>
+      withEnrichedLoggingContext("submissionId" -> submissionId) { implicit loggingContext =>
+        logger.info("No ledger configuration found, submitting an initial configuration.")
+        DefaultTelemetry
+          .runFutureInSpan(
+            SpanName.LedgerConfigProviderInitialConfig,
+            SpanKind.Internal,
+          ) { implicit telemetryContext =>
+            FutureConverters.toScala(
+              writeService.submitConfiguration(
+                Timestamp.assertFromInstant(timeProvider.getCurrentTime.plusSeconds(60)),
+                submissionId,
+                ledgerConfiguration.initialConfiguration,
+              )
             )
-          )
-        }
-        .onComplete {
-          case Success(state.SubmissionResult.Acknowledged) =>
-            logger.info("Initial configuration submission was successful.")
-          case Success(result: state.SubmissionResult.SynchronousError) =>
-            withEnrichedLoggingContext("error" -> result) { implicit loggingContext =>
-              logger.warn("Initial configuration submission failed.")
-            }
-          case Failure(exception) =>
-            logger.error("Initial configuration submission failed.", exception)
-        }(DirectExecutionContext)
+          }
+          .andThen {
+            case Success(state.SubmissionResult.Acknowledged) =>
+              logger.info("Initial configuration submission was successful.")
+            case Success(result: state.SubmissionResult.SynchronousError) =>
+              withEnrichedLoggingContext("error" -> result) { implicit loggingContext =>
+                logger.warn("Initial configuration submission failed.")
+              }
+            case Failure(exception) =>
+              logger.error("Initial configuration submission failed.", exception)
+          }
+      }
     }
+    ()
   }
 
   override def close(): Unit = {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/IndexStreamingCurrentLedgerConfigurationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/IndexStreamingCurrentLedgerConfigurationSpec.scala
@@ -176,7 +176,9 @@ final class IndexStreamingCurrentLedgerConfigurationSpec
       resource.asFuture
         .flatMap { currentLedgerConfiguration =>
           currentLedgerConfiguration.ready.isCompleted should be(false)
-          resource.release().map(_ => currentLedgerConfiguration)
+          resource
+            .release() // Will cancel reading the configuration
+            .map(_ => currentLedgerConfiguration)
         }
         .map { currentLedgerConfiguration =>
           scheduler.timePasses(5.seconds)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/IndexStreamingCurrentLedgerConfigurationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/IndexStreamingCurrentLedgerConfigurationSpec.scala
@@ -55,7 +55,13 @@ final class IndexStreamingCurrentLedgerConfigurationSpec
       val scheduler = new ExplicitlyTriggeredScheduler(null, NoLogging, null)
 
       IndexStreamingCurrentLedgerConfiguration
-        .owner(ledgerConfiguration, index, scheduler, materializer)
+        .owner(
+          ledgerConfiguration = ledgerConfiguration,
+          index = index,
+          scheduler = scheduler,
+          materializer = materializer,
+          servicesExecutionContext = system.dispatcher,
+        )
         .use { currentLedgerConfiguration =>
           currentLedgerConfiguration.ready.map { _ =>
             currentLedgerConfiguration.latestConfiguration should be(Some(currentConfiguration))
@@ -99,7 +105,13 @@ final class IndexStreamingCurrentLedgerConfigurationSpec
       val scheduler = new ExplicitlyTriggeredScheduler(null, NoLogging, null)
 
       IndexStreamingCurrentLedgerConfiguration
-        .owner(ledgerConfiguration, index, scheduler, materializer)
+        .owner(
+          ledgerConfiguration = ledgerConfiguration,
+          index = index,
+          scheduler = scheduler,
+          materializer = materializer,
+          servicesExecutionContext = system.dispatcher,
+        )
         .use { currentLedgerConfiguration =>
           currentLedgerConfiguration.ready.map { _ =>
             eventually {
@@ -123,7 +135,13 @@ final class IndexStreamingCurrentLedgerConfigurationSpec
       val scheduler = new ExplicitlyTriggeredScheduler(null, NoLogging, null)
 
       IndexStreamingCurrentLedgerConfiguration
-        .owner(ledgerConfiguration, index, scheduler, materializer)
+        .owner(
+          ledgerConfiguration = ledgerConfiguration,
+          index = index,
+          scheduler = scheduler,
+          materializer = materializer,
+          servicesExecutionContext = system.dispatcher,
+        )
         .use { currentLedgerConfiguration =>
           currentLedgerConfiguration.ready.isCompleted should be(false)
           scheduler.timePasses(1.second)
@@ -146,8 +164,13 @@ final class IndexStreamingCurrentLedgerConfigurationSpec
       )
       val scheduler = new ExplicitlyTriggeredScheduler(null, NoLogging, null)
 
-      val owner = IndexStreamingCurrentLedgerConfiguration
-        .owner(ledgerConfiguration, index, scheduler, materializer)
+      val owner = IndexStreamingCurrentLedgerConfiguration.owner(
+        ledgerConfiguration = ledgerConfiguration,
+        index = index,
+        scheduler = scheduler,
+        materializer = materializer,
+        servicesExecutionContext = system.dispatcher,
+      )
       val resource = owner.acquire()
 
       resource.asFuture
@@ -176,7 +199,7 @@ final class IndexStreamingCurrentLedgerConfigurationSpec
       val scheduler = new ExplicitlyTriggeredScheduler(null, NoLogging, null)
 
       IndexStreamingCurrentLedgerConfiguration
-        .owner(ledgerConfiguration, index, scheduler, materializer)
+        .owner(ledgerConfiguration, index, scheduler, materializer, system.dispatcher)
         .use { currentLedgerConfiguration =>
           currentLedgerConfiguration.ready.transform(Success.apply).map { result =>
             inside(result) { case Failure(exception) =>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/IndexStreamingCurrentLedgerConfigurationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/IndexStreamingCurrentLedgerConfigurationSpec.scala
@@ -48,7 +48,7 @@ final class IndexStreamingCurrentLedgerConfigurationSpec
         .thenReturn(Future.successful(Some(offset("0001") -> currentConfiguration)))
 
       IndexStreamingCurrentLedgerConfiguration
-        .owner(index, ledgerConfiguration)
+        .owner(ledgerConfiguration, index, system.scheduler, materializer)
         .use { currentLedgerConfiguration =>
           currentLedgerConfiguration.ready.map { _ =>
             currentLedgerConfiguration.latestConfiguration should be(Some(currentConfiguration))
@@ -91,7 +91,7 @@ final class IndexStreamingCurrentLedgerConfigurationSpec
         .thenReturn(Source(configurationEntries).concat(Source.never))
 
       IndexStreamingCurrentLedgerConfiguration
-        .owner(index, ledgerConfiguration)
+        .owner(ledgerConfiguration, index, system.scheduler, materializer)
         .use { currentLedgerConfiguration =>
           currentLedgerConfiguration.ready.map { _ =>
             eventually {
@@ -114,7 +114,7 @@ final class IndexStreamingCurrentLedgerConfigurationSpec
       )
 
       IndexStreamingCurrentLedgerConfiguration
-        .owner(index, ledgerConfiguration)
+        .owner(ledgerConfiguration, index, system.scheduler, materializer)
         .use { ledgerConfigProvider =>
           ledgerConfigProvider.latestConfiguration should be(None)
         }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigProvisionerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigProvisionerSpec.scala
@@ -38,6 +38,9 @@ final class LedgerConfigProvisionerSpec
   private implicit val resourceContext: ResourceContext = ResourceContext(executionContext)
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
+  override implicit val patienceConfig: PatienceConfig =
+    super.patienceConfig.copy(timeout = 1.second)
+
   "provisioning a ledger configuration" should {
     "write a ledger configuration to the index if one is not provided" in {
       val configurationToSubmit =

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigProvisionerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigProvisionerSpec.scala
@@ -70,7 +70,7 @@ final class LedgerConfigProvisionerSpec
           timeProvider = timeProvider,
           submissionIdGenerator = submissionIdGenerator,
           scheduler = scheduler,
-          executionContext = system.dispatcher,
+          servicesExecutionContext = system.dispatcher,
         )
         .use { _ =>
           verify(writeService, never).submitConfiguration(
@@ -116,7 +116,7 @@ final class LedgerConfigProvisionerSpec
           timeProvider = timeProvider,
           submissionIdGenerator = SubmissionIdGenerator.Random,
           scheduler = scheduler,
-          executionContext = system.dispatcher,
+          servicesExecutionContext = system.dispatcher,
         )
         .use { _ =>
           scheduler.timePasses(1.second)
@@ -156,7 +156,7 @@ final class LedgerConfigProvisionerSpec
         timeProvider = timeProvider,
         submissionIdGenerator = SubmissionIdGenerator.Random,
         scheduler = scheduler,
-        executionContext = system.dispatcher,
+        servicesExecutionContext = system.dispatcher,
       )
       .use { _ =>
         scheduler.scheduleOnce(
@@ -199,7 +199,7 @@ final class LedgerConfigProvisionerSpec
       timeProvider = timeProvider,
       submissionIdGenerator = SubmissionIdGenerator.Random,
       scheduler = scheduler,
-      executionContext = system.dispatcher,
+      servicesExecutionContext = system.dispatcher,
     )
     val resource = owner.acquire()
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigProvisionerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigProvisionerSpec.scala
@@ -36,7 +36,7 @@ final class LedgerConfigProvisionerSpec
   private implicit val resourceContext: ResourceContext = ResourceContext(executionContext)
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
-  "Ledger Config Provider" should {
+  "provisioning a ledger configuration" should {
     "write a ledger configuration to the index if one is not provided" in {
       val configurationToSubmit =
         Configuration(1, LedgerTimeModel.reasonableDefault, Duration.ofDays(1))
@@ -58,11 +58,13 @@ final class LedgerConfigProvisionerSpec
 
       LedgerConfigProvisioner
         .owner(
+          ledgerConfiguration = ledgerConfiguration,
           currentLedgerConfiguration = currentLedgerConfiguration,
           writeService = writeService,
           timeProvider = timeProvider,
           submissionIdGenerator = submissionIdGenerator,
-          ledgerConfiguration = ledgerConfiguration,
+          scheduler = system.scheduler,
+          executionContext = system.dispatcher,
         )
         .use { _ =>
           eventually(PatienceConfiguration.Timeout(1.second)) {
@@ -99,11 +101,13 @@ final class LedgerConfigProvisionerSpec
 
       LedgerConfigProvisioner
         .owner(
+          ledgerConfiguration = ledgerConfiguration,
           currentLedgerConfiguration = currentLedgerConfiguration,
           writeService = writeService,
           timeProvider = timeProvider,
           submissionIdGenerator = submissionIdGenerator,
-          ledgerConfiguration = ledgerConfiguration,
+          scheduler = system.scheduler,
+          executionContext = system.dispatcher,
         )
         .use { _ =>
           verify(writeService, after(1.second.toMillis.toInt).never())
@@ -141,11 +145,13 @@ final class LedgerConfigProvisionerSpec
 
     LedgerConfigProvisioner
       .owner(
+        ledgerConfiguration = ledgerConfiguration,
         currentLedgerConfiguration = currentLedgerConfiguration,
         writeService = writeService,
         timeProvider = timeProvider,
         submissionIdGenerator = submissionIdGenerator,
-        ledgerConfiguration = ledgerConfiguration,
+        scheduler = system.scheduler,
+        executionContext = system.dispatcher,
       )
       .use { _ =>
         materializer.scheduleOnce(

--- a/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/AkkaResourceOwnerFactories.scala
+++ b/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/AkkaResourceOwnerFactories.scala
@@ -3,7 +3,7 @@
 
 package com.daml.resources.akka
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, Cancellable}
 import akka.stream.Materializer
 import com.daml.resources.{AbstractResourceOwner, HasExecutionContext}
 
@@ -24,4 +24,6 @@ trait AkkaResourceOwnerFactories[Context] {
       materializer <- forMaterializer(() => Materializer(actorSystem))
     } yield materializer
 
+  def forCancellable(acquire: () => Cancellable): AbstractResourceOwner[Context, Cancellable] =
+    new CancellableResourceOwner(acquire)
 }

--- a/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/AkkaResourceOwnerFactories.scala
+++ b/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/AkkaResourceOwnerFactories.scala
@@ -24,6 +24,6 @@ trait AkkaResourceOwnerFactories[Context] {
       materializer <- forMaterializer(() => Materializer(actorSystem))
     } yield materializer
 
-  def forCancellable(acquire: () => Cancellable): AbstractResourceOwner[Context, Cancellable] =
+  def forCancellable[C <: Cancellable](acquire: () => C): AbstractResourceOwner[Context, C] =
     new CancellableResourceOwner(acquire)
 }

--- a/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/CancellableResourceOwner.scala
+++ b/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/CancellableResourceOwner.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.resources.akka
+
+import akka.actor.Cancellable
+import com.daml.resources.{AbstractResourceOwner, HasExecutionContext, ReleasableResource, Resource}
+
+import scala.concurrent.Future
+
+class CancellableResourceOwner[Context: HasExecutionContext](acquireCancellable: () => Cancellable)
+    extends AbstractResourceOwner[Context, Cancellable] {
+  override def acquire()(implicit context: Context): Resource[Context, Cancellable] =
+    ReleasableResource(Future(acquireCancellable()))(cancellable =>
+      Future(cancellable.cancel()).map(_ => ())
+    )
+}

--- a/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/CancellableResourceOwner.scala
+++ b/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/CancellableResourceOwner.scala
@@ -8,9 +8,10 @@ import com.daml.resources.{AbstractResourceOwner, HasExecutionContext, Releasabl
 
 import scala.concurrent.Future
 
-class CancellableResourceOwner[Context: HasExecutionContext](acquireCancellable: () => Cancellable)
-    extends AbstractResourceOwner[Context, Cancellable] {
-  override def acquire()(implicit context: Context): Resource[Context, Cancellable] =
+class CancellableResourceOwner[C <: Cancellable, Context: HasExecutionContext](
+    acquireCancellable: () => C
+) extends AbstractResourceOwner[Context, C] {
+  override def acquire()(implicit context: Context): Resource[Context, C] =
     ReleasableResource(Future(acquireCancellable()))(cancellable =>
       Future(cancellable.cancel()).map(_ => ())
     )


### PR DESCRIPTION
This modifies the `IndexStreamingCurrentLedgerConfiguration` and `LedgerConfigProvisioner` classes to:

- switch out calls to `materializer.scheduleOnce` for `scheduler.scheduleOnce`,
- use the returned `Cancellation` to cancel scheduled tasks,
- use the services execution context instead of (ab)using the materializer,
- add a couple of clauses to handle exceptions (with `logger.error`),
- use the Akka TestKit scheduler in tests, and
- increase test coverage around shutting down.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
