### PR TITLE
[JSON-API] Change tests to run on the same db instance with different table prefixes

### DIFF
--- a/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceOracleInt.scala
+++ b/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceOracleInt.scala
@@ -11,14 +11,13 @@ import org.scalatest.matchers.should.Matchers
 
 trait HttpServiceOracleInt extends AbstractHttpServiceIntegrationTestFuns with OracleAroundAll {
   this: AsyncTestSuite with Matchers with Inside =>
-
-  override final def jdbcConfig: Option[JdbcConfig] = Some(jdbcConfig_)
-
-  protected[this] def jdbcConfig_ = JdbcConfig(
+  protected[this] lazy val jdbcConfig_ = JdbcConfig(
     driver = "oracle.jdbc.OracleDriver",
     url = oracleJdbcUrl,
     user = oracleUser,
     password = oraclePwd,
     dbStartupMode = DbStartupMode.CreateOnly,
   )
+
+  protected[this] lazy val jdbcConfig: Option[JdbcConfig] = Some(jdbcConfig_)
 }

--- a/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleIntTest.scala
+++ b/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleIntTest.scala
@@ -10,4 +10,9 @@ class HttpServiceWithOracleIntTest
   override def staticContentConfig: Option[StaticContentConfig] = None
 
   override def wsConfig: Option[WebsocketConfig] = None
+
+  "Without table prefix" - httpServiceIntegrationTests(this.jdbcConfig)
+  "With table prefix" - httpServiceIntegrationTests(
+    this.jdbcConfig.map(_.copy(tablePrefix = "some_fancy_prefix_"))
+  )
 }

--- a/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleTablePrefixIntTest.scala
+++ b/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceWithOracleTablePrefixIntTest.scala
@@ -1,8 +1,0 @@
-// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-package com.daml.http
-
-class HttpServiceWithOracleTablePrefixIntTest extends HttpServiceWithOracleIntTest {
-  override def jdbcConfig_ = super.jdbcConfig_.copy(tablePrefix = "some_nice_prefix_")
-}

--- a/ledger-service/http-json-oracle/src/it/scala/http/WebsocketServiceWithOracleIntTest.scala
+++ b/ledger-service/http-json-oracle/src/it/scala/http/WebsocketServiceWithOracleIntTest.scala
@@ -5,4 +5,9 @@ package com.daml.http
 
 final class WebsocketServiceWithOracleIntTest
     extends AbstractWebsocketServiceIntegrationTest
-    with HttpServiceOracleInt
+    with HttpServiceOracleInt {
+  "Without table prefix" - websocketServiceIntegrationTests(this.jdbcConfig)
+  "With table prefix" - websocketServiceIntegrationTests(
+    Some(this.jdbcConfig_.copy(tablePrefix = "some_fancy_prefix_"))
+  )
+}

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -315,6 +315,7 @@ alias(
         ],
         resources = glob(["src/it/resources/**/*"]),
         scala_deps = [
+            "@maven//:com_github_scopt_scopt",
             "@maven//:com_chuusai_shapeless",
             "@maven//:com_typesafe_akka_akka_http_core",
             "@maven//:com_typesafe_scala_logging_scala_logging",

--- a/ledger-service/http-json/src/it/edition/ce/com/daml/http/NonRepudiationTest.scala
+++ b/ledger-service/http-json/src/it/edition/ce/com/daml/http/NonRepudiationTest.scala
@@ -13,19 +13,20 @@ final class NonRepudiationTest extends AbstractNonRepudiationTest {
 
   import HttpServiceTestFixture._
 
-  "fail to work through the non-repudiation proxy" in withSetup { (db, uri, encoder) =>
-    val expectedParty = "Alice"
-    val expectedNumber = "abc123"
-    val expectedCommandId = UUID.randomUUID.toString
-    val meta = Some(domain.CommandMeta(commandId = Some(domain.CommandId(expectedCommandId))))
-    val domainParty = domain.Party(expectedParty)
-    val command = accountCreateCommand(domainParty, expectedNumber).copy(meta = meta)
-    postCreateCommand(command, encoder, uri)
-      .flatMap { case (status, _) =>
-        status shouldBe StatusCodes.InternalServerError
-        val payloads = db.signedPayloads.get(CommandIdString.wrap(expectedCommandId))
-        payloads shouldBe empty
-      }
+  "fail to work through the non-repudiation proxy" in withSetup(jdbcConfig = None) {
+    (db, uri, encoder) =>
+      val expectedParty = "Alice"
+      val expectedNumber = "abc123"
+      val expectedCommandId = UUID.randomUUID.toString
+      val meta = Some(domain.CommandMeta(commandId = Some(domain.CommandId(expectedCommandId))))
+      val domainParty = domain.Party(expectedParty)
+      val command = accountCreateCommand(domainParty, expectedNumber).copy(meta = meta)
+      postCreateCommand(command, encoder, uri)
+        .flatMap { case (status, _) =>
+          status shouldBe StatusCodes.InternalServerError
+          val payloads = db.signedPayloads.get(CommandIdString.wrap(expectedCommandId))
+          payloads shouldBe empty
+        }
   }
 
 }

--- a/ledger-service/http-json/src/it/edition/ee/com/daml/http/NonRepudiationTest.scala
+++ b/ledger-service/http-json/src/it/edition/ee/com/daml/http/NonRepudiationTest.scala
@@ -14,7 +14,7 @@ final class NonRepudiationTest extends AbstractNonRepudiationTest {
 
   import HttpServiceTestFixture._
 
-  "correctly sign a command" in withSetup { (db, uri, encoder) =>
+  "correctly sign a command" in withSetup(jdbcConfig = None) { (db, uri, encoder) =>
     val expectedParty = "Alice"
     val expectedNumber = "abc123"
     val expectedCommandId = UUID.randomUUID.toString

--- a/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
@@ -3,7 +3,6 @@
 
 package com.daml.http
 
-import com.daml.http.dbbackend.ConnectionPool.PoolSize
 import com.daml.testing.postgresql.PostgresAroundAll
 import org.scalatest.Inside
 import org.scalatest.AsyncTestSuite
@@ -12,13 +11,8 @@ import org.scalatest.matchers.should.Matchers
 trait HttpServicePostgresInt extends AbstractHttpServiceIntegrationTestFuns with PostgresAroundAll {
   this: AsyncTestSuite with Matchers with Inside =>
 
-  override final def jdbcConfig: Option[JdbcConfig] = Some(jdbcConfig_)
-
-  // has to be lazy because jdbcConfig_ is NOT initialized yet
-  protected lazy val dao = dbbackend.ContractDao(jdbcConfig_, poolSize = PoolSize.Integration)
-
   // has to be lazy because postgresFixture is NOT initialized yet
-  protected[this] def jdbcConfig_ = JdbcConfig(
+  protected[this] lazy val jdbcConfig_ = JdbcConfig(
     driver = "org.postgresql.Driver",
     url = postgresDatabase.url,
     user = "test",
@@ -26,8 +20,5 @@ trait HttpServicePostgresInt extends AbstractHttpServiceIntegrationTestFuns with
     dbStartupMode = DbStartupMode.CreateOnly,
   )
 
-  override protected def afterAll(): Unit = {
-    dao.close()
-    super.afterAll()
-  }
+  protected[this] lazy val jdbcConfig: Option[JdbcConfig] = Some(jdbcConfig_)
 }

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresTablePrefixIntTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresTablePrefixIntTest.scala
@@ -1,9 +1,0 @@
-// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-package com.daml.http
-
-@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-class HttpServiceWithPostgresTablePrefixIntTest extends HttpServiceWithPostgresIntTest {
-  override def jdbcConfig_ = super.jdbcConfig_.copy(tablePrefix = "some_nice_prefix_")
-}

--- a/ledger-service/http-json/src/it/scala/http/TlsTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/TlsTest.scala
@@ -19,15 +19,13 @@ class TlsTest
     with Inside
     with AbstractHttpServiceIntegrationTestFuns {
 
-  override def jdbcConfig = None
-
   override def staticContentConfig = None
 
   override def useTls = UseTls.Tls
 
   override def wsConfig: Option[WebsocketConfig] = None
 
-  "connect normally with tls on" in withHttpService { (uri: Uri, _, _) =>
+  "connect normally with tls on" in withHttpService(jdbcConfig = None) { (uri: Uri, _, _) =>
     getRequest(uri = uri.withPath(Uri.Path("/v1/query")))
       .flatMap { case (status, output) =>
         status shouldBe StatusCodes.OK

--- a/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
@@ -4,9 +4,16 @@
 package com.daml.http
 
 final class WebsocketServiceIntegrationTest extends AbstractWebsocketServiceIntegrationTest {
-  override def jdbcConfig = None
+  override protected def testId: String = getClass.getSimpleName
+  websocketServiceIntegrationTests(jdbcConfig = None)
 }
 
 final class WebsocketServiceWithPostgresIntTest
     extends AbstractWebsocketServiceIntegrationTest
-    with HttpServicePostgresInt
+    with HttpServicePostgresInt {
+  override protected def testId: String = getClass.getSimpleName
+  "Without table prefix" - websocketServiceIntegrationTests(this.jdbcConfig)
+  "With table prefix" - websocketServiceIntegrationTests(
+    Some(this.jdbcConfig_.copy(tablePrefix = "some_fancy_prefix_"))
+  )
+}

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -30,10 +30,10 @@ import com.daml.ledger.client.{LedgerClient => DamlLedgerClient}
 import com.daml.ledger.service.MetadataReader
 import com.daml.ledger.test.ModelTestDar
 import com.daml.platform.participant.util.LfEngineToApi.lfValueToApiValue
-import com.daml.http.util.Logging.{instanceUUIDLogCtx}
+import com.daml.http.util.Logging.instanceUUIDLogCtx
 import com.typesafe.scalalogging.StrictLogging
 import org.scalatest._
-import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.freespec.AsyncFreeSpecLike
 import org.scalatest.matchers.should.Matchers
 import scalaz.std.list._
 import scalaz.std.scalaFuture._
@@ -78,8 +78,6 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
   import json.JsonProtocol._
   import HttpServiceTestFixture._
 
-  def jdbcConfig: Option[JdbcConfig]
-
   def staticContentConfig: Option[StaticContentConfig]
 
   def useTls: UseTls
@@ -111,22 +109,9 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
   import tag.@@ // used for subtyping to make `AHS ec` beat executionContext
   implicit val `AHS ec`: ExecutionContext @@ this.type = tag[this.type](`AHS asys`.dispatcher)
 
-  protected def withHttpServiceAndClient[A](
-      testFn: (Uri, DomainJsonEncoder, DomainJsonDecoder, DamlLedgerClient) => Future[A]
-  ): Future[A] =
-    HttpServiceTestFixture.withLedger[A](List(dar1, dar2), testId, None, useTls) {
-      case (ledgerPort, _) =>
-        HttpServiceTestFixture.withHttpService[A](
-          testId,
-          ledgerPort,
-          jdbcConfig,
-          staticContentConfig,
-          useTls = useTls,
-          wsConfig = wsConfig,
-        )(testFn)
-    }
-
-  protected def withHttpServiceAndClient[A](maxInboundMessageSize: Int)(
+  protected def withHttpServiceAndClient[A](jdbcConfig: => Option[JdbcConfig] = None)(
+      maxInboundMessageSize: Int = StartSettings.DefaultMaxInboundMessageSize
+  )(
       testFn: (Uri, DomainJsonEncoder, DomainJsonDecoder, DamlLedgerClient) => Future[A]
   ): Future[A] =
     HttpServiceTestFixture.withLedger[A](List(dar1, dar2), testId, None, useTls) {
@@ -142,10 +127,10 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
         )(testFn)
     }
 
-  protected def withHttpService[A](
+  protected def withHttpService[A](jdbcConfig: => Option[JdbcConfig] = None)(
       f: (Uri, DomainJsonEncoder, DomainJsonDecoder) => Future[A]
   ): Future[A] =
-    withHttpServiceAndClient((a, b, c, _) => f(a, b, c))
+    withHttpServiceAndClient(jdbcConfig)()((a, b, c, _) => f(a, b, c))
 
   protected def withLedger[A](testFn: DamlLedgerClient => Future[A]): Future[A] =
     HttpServiceTestFixture.withLedger[A](List(dar1, dar2), testId) { case (_, client) =>
@@ -576,8 +561,8 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-abstract class AbstractHttpServiceIntegrationTest
-    extends AsyncFreeSpec
+trait AbstractHttpServiceIntegrationTest
+    extends AsyncFreeSpecLike
     with Matchers
     with Inside
     with StrictLogging
@@ -588,14 +573,7 @@ abstract class AbstractHttpServiceIntegrationTest
 
   override final def useTls = UseTls.NoTls
 
-  "query GET empty results" in withHttpService { (uri: Uri, _, _) =>
-    searchAllExpectOk(uri).flatMap { case vector =>
-      vector should have size 0L
-    }
-
-  }
-
-  protected val searchDataSet: List[domain.CreateCommand[v.Record, OptionalPkg]] =
+  val searchDataSet: List[domain.CreateCommand[v.Record, OptionalPkg]] =
     List(
       iouCreateCommand(amount = "111.11", currency = "EUR"),
       iouCreateCommand(amount = "222.22", currency = "EUR"),
@@ -603,727 +581,724 @@ abstract class AbstractHttpServiceIntegrationTest
       iouCreateCommand(amount = "444.44", currency = "BTC"),
     )
 
-  "query GET" in withHttpService { (uri: Uri, encoder, _) =>
-    searchDataSet.traverse(c => postCreateCommand(c, encoder, uri)).flatMap { rs =>
-      rs.map(_._1) shouldBe List.fill(searchDataSet.size)(StatusCodes.OK)
-
-      getRequest(uri = uri.withPath(Uri.Path("/v1/query")))
-        .flatMap { case (status, output) =>
-          status shouldBe StatusCodes.OK
-          assertStatus(output, StatusCodes.OK)
-          inside(output) { case JsObject(fields) =>
-            inside(fields.get("result")) { case Some(JsArray(vector)) =>
-              vector should have size searchDataSet.size.toLong
-            }
-          }
-        }: Future[Assertion]
-    }
-  }
-
-  "multi-party query GET" in withHttpService { (uri, encoder, _) =>
-    for {
-      _ <- postCreateCommand(
-        accountCreateCommand(owner = domain.Party("Alice"), number = "42"),
-        encoder,
-        uri,
-      ).map(r => r._1 shouldBe StatusCodes.OK)
-      _ <- postCreateCommand(
-        accountCreateCommand(owner = domain.Party("Bob"), number = "23"),
-        encoder,
-        uri,
-        headers = headersWithPartyAuth(List("Bob")),
-      ).map(r => r._1 shouldBe StatusCodes.OK)
-      _ <- searchAllExpectOk(uri, headersWithPartyAuth(List("Alice"))).map(cs =>
-        cs should have size 1
-      )
-      _ <- searchAllExpectOk(uri, headersWithPartyAuth(List("Bob"))).map(cs =>
-        cs should have size 1
-      )
-      _ <- searchAllExpectOk(uri, headersWithPartyAuth(List("Alice", "Bob"))).map(cs =>
-        cs should have size 2
-      )
-    } yield succeed
-  }
-
-  "query POST with empty query" in withHttpService { (uri, encoder, _) =>
-    searchExpectOk(
-      searchDataSet,
-      jsObject("""{"templateIds": ["Iou:Iou"]}"""),
-      uri,
-      encoder,
-    ).map { acl: List[domain.ActiveContract[JsValue]] =>
-      acl.size shouldBe searchDataSet.size
-    }
-  }
-
-  "multi-party query POST with empty query" in withHttpService { (uri, encoder, _) =>
-    for {
-      aliceAccountResp <- postCreateCommand(
-        accountCreateCommand(owner = domain.Party("Alice"), number = "42"),
-        encoder,
-        uri,
-      )
-      _ = aliceAccountResp._1 shouldBe StatusCodes.OK
-      bobAccountResp <- postCreateCommand(
-        accountCreateCommand(owner = domain.Party("Bob"), number = "23"),
-        encoder,
-        uri,
-        headers = headersWithPartyAuth(List("Bob")),
-      )
-      _ = bobAccountResp._1 shouldBe StatusCodes.OK
-      _ <- searchExpectOk(
-        List(),
-        jsObject("""{"templateIds": ["Account:Account"]}"""),
-        uri,
-        encoder,
-        headers = headersWithPartyAuth(List("Alice")),
-      )
-        .map(acl => acl.size shouldBe 1)
-      _ <- searchExpectOk(
-        List(),
-        jsObject("""{"templateIds": ["Account:Account"]}"""),
-        uri,
-        encoder,
-        headers = headersWithPartyAuth(List("Bob")),
-      )
-        .map(acl => acl.size shouldBe 1)
-      _ <- searchExpectOk(
-        List(),
-        jsObject("""{"templateIds": ["Account:Account"]}"""),
-        uri,
-        encoder,
-        headers = headersWithPartyAuth(List("Alice", "Bob")),
-      )
-        .map(acl => acl.size shouldBe 2)
-    } yield {
-      assert(true)
-    }
-  }
-
-  "query with query, one field" in withHttpService { (uri, encoder, _) =>
-    searchExpectOk(
-      searchDataSet,
-      jsObject("""{"templateIds": ["Iou:Iou"], "query": {"currency": "EUR"}}"""),
-      uri,
-      encoder,
-    ).map { acl: List[domain.ActiveContract[JsValue]] =>
-      acl.size shouldBe 2
-      acl.map(a => objectField(a.payload, "currency")) shouldBe List.fill(2)(Some(JsString("EUR")))
-    }
-  }
-
-  "query returns unknown Template IDs as warnings" in withHttpService { (uri, encoder, _) =>
-    val query =
-      jsObject(
-        """{"templateIds": ["Iou:Iou", "UnknownModule:UnknownEntity"], "query": {"currency": "EUR"}}"""
+  protected def httpServiceIntegrationTests(jdbcConfig: => Option[JdbcConfig]) = {
+    def withHttpService = this.withHttpService[Assertion](jdbcConfig)(_)
+    def withHttpServiceAndClient(
+        maxInboundMessageSize: Int = StartSettings.DefaultMaxInboundMessageSize
+    )(testFn: (Uri, DomainJsonEncoder, DomainJsonDecoder, DamlLedgerClient) => Future[Assertion]) =
+      this.withHttpServiceAndClient[Assertion](jdbcConfig = jdbcConfig)(maxInboundMessageSize)(
+        testFn
       )
 
-    search(List(), query, uri, encoder).map { response =>
-      inside(response) { case domain.OkResponse(acl, warnings, StatusCodes.OK) =>
-        acl.size shouldBe 0
-        warnings shouldBe Some(
-          domain.UnknownTemplateIds(List(domain.TemplateId(None, "UnknownModule", "UnknownEntity")))
-        )
+    "query GET empty results" in withHttpService { (uri: Uri, _, _) =>
+      searchAllExpectOk(uri).flatMap { case vector =>
+        vector should have size 0L
       }
+
     }
-  }
 
-  "query returns unknown Template IDs as warnings and error" in withHttpService {
-    (uri, encoder, _) =>
-      search(
-        searchDataSet,
-        jsObject("""{"templateIds": ["AAA:BBB", "XXX:YYY"]}"""),
-        uri,
-        encoder,
-      ).map { response =>
-        inside(response) { case domain.ErrorResponse(errors, warnings, StatusCodes.BadRequest) =>
-          errors shouldBe List(ErrorMessages.cannotResolveAnyTemplateId)
-          inside(warnings) { case Some(domain.UnknownTemplateIds(unknownTemplateIds)) =>
-            unknownTemplateIds.toSet shouldBe Set(
-              domain.TemplateId(None, "AAA", "BBB"),
-              domain.TemplateId(None, "XXX", "YYY"),
-            )
-          }
-        }
-      }
-  }
+    "query GET" in withHttpService { (uri: Uri, encoder, _) =>
+      searchDataSet.traverse(c => postCreateCommand(c, encoder, uri)).flatMap { rs =>
+        rs.map(_._1) shouldBe List.fill(searchDataSet.size)(StatusCodes.OK)
 
-  "query with query, can use number or string for numeric field" in withHttpService {
-    (uri, encoder, _) =>
-      import scalaz.std.scalaFuture._
-
-      searchDataSet.traverse(c => postCreateCommand(c, encoder, uri)).flatMap {
-        rs: List[(StatusCode, JsValue)] =>
-          rs.map(_._1) shouldBe List.fill(searchDataSet.size)(StatusCodes.OK)
-
-          def queryAmountAs(s: String) =
-            jsObject(s"""{"templateIds": ["Iou:Iou"], "query": {"amount": $s}}""")
-
-          val queryAmountAsString = queryAmountAs("\"111.11\"")
-          val queryAmountAsNumber = queryAmountAs("111.11")
-
-          List(
-            postJsonRequest(uri.withPath(Uri.Path("/v1/query")), queryAmountAsString),
-            postJsonRequest(uri.withPath(Uri.Path("/v1/query")), queryAmountAsNumber),
-          ).sequence.flatMap { rs: List[(StatusCode, JsValue)] =>
-            rs.map(_._1) shouldBe List.fill(2)(StatusCodes.OK)
-            inside(rs.map(_._2)) { case List(jsVal1, jsVal2) =>
-              jsVal1 shouldBe jsVal2
-              val acl1: List[domain.ActiveContract[JsValue]] = activeContractList(jsVal1)
-              val acl2: List[domain.ActiveContract[JsValue]] = activeContractList(jsVal2)
-              acl1 shouldBe acl2
-              inside(acl1) { case List(ac) =>
-                objectField(ac.payload, "amount") shouldBe Some(JsString("111.11"))
+        getRequest(uri = uri.withPath(Uri.Path("/v1/query")))
+          .flatMap { case (status, output) =>
+            status shouldBe StatusCodes.OK
+            assertStatus(output, StatusCodes.OK)
+            inside(output) { case JsObject(fields) =>
+              inside(fields.get("result")) { case Some(JsArray(vector)) =>
+                vector should have size searchDataSet.size.toLong
               }
             }
-          }
-      }: Future[Assertion]
-  }
+          }: Future[Assertion]
+      }
+    }
 
-  private[this] def randomTextN(n: Int) = {
-    import org.scalacheck.Gen
-    Gen
-      .buildableOfN[String, Char](n, Gen.alphaNumChar)
-      .sample
-      .getOrElse(sys.error(s"can't generate ${n}b string"))
-  }
+    "multi-party query GET" in withHttpService { (uri, encoder, _) =>
+      for {
+        _ <- postCreateCommand(
+          accountCreateCommand(owner = domain.Party("Alice"), number = "42"),
+          encoder,
+          uri,
+        ).map(r => r._1 shouldBe StatusCodes.OK)
+        _ <- postCreateCommand(
+          accountCreateCommand(owner = domain.Party("Bob"), number = "23"),
+          encoder,
+          uri,
+          headers = headersWithPartyAuth(List("Bob")),
+        ).map(r => r._1 shouldBe StatusCodes.OK)
+        _ <- searchAllExpectOk(uri, headersWithPartyAuth(List("Alice"))).map(cs =>
+          cs should have size 1
+        )
+        _ <- searchAllExpectOk(uri, headersWithPartyAuth(List("Bob"))).map(cs =>
+          cs should have size 1
+        )
+        _ <- searchAllExpectOk(uri, headersWithPartyAuth(List("Alice", "Bob"))).map(cs =>
+          cs should have size 2
+        )
+      } yield succeed
+    }
 
-  Seq(
-    "& " -> "& bar",
-    "1kb of data" -> randomTextN(1000),
-    "2kb of data" -> randomTextN(2000),
-    "3kb of data" -> randomTextN(3000),
-    "4kb of data" -> randomTextN(4000),
-    "5kb of data" -> randomTextN(5000),
-  ).foreach { case (testLbl, testCurrency) =>
-    s"query record contains handles '$testLbl' strings properly" in withHttpService {
-      (uri, encoder, _) =>
-        searchExpectOk(
-          searchDataSet :+ iouCreateCommand(currency = testCurrency),
-          jsObject(
-            s"""{"templateIds": ["Iou:Iou"], "query": {"currency": ${testCurrency.toJson}}}"""
-          ),
+    "query POST with empty query" in withHttpService { (uri, encoder, _) =>
+      searchExpectOk(
+        searchDataSet,
+        jsObject("""{"templateIds": ["Iou:Iou"]}"""),
+        uri,
+        encoder,
+      ).map { acl: List[domain.ActiveContract[JsValue]] =>
+        acl.size shouldBe searchDataSet.size
+      }
+    }
+
+    "multi-party query POST with empty query" in withHttpService { (uri, encoder, _) =>
+      for {
+        aliceAccountResp <- postCreateCommand(
+          accountCreateCommand(owner = domain.Party("Alice"), number = "42"),
+          encoder,
+          uri,
+        )
+        _ = aliceAccountResp._1 shouldBe StatusCodes.OK
+        bobAccountResp <- postCreateCommand(
+          accountCreateCommand(owner = domain.Party("Bob"), number = "23"),
+          encoder,
+          uri,
+          headers = headersWithPartyAuth(List("Bob")),
+        )
+        _ = bobAccountResp._1 shouldBe StatusCodes.OK
+        _ <- searchExpectOk(
+          List(),
+          jsObject("""{"templateIds": ["Account:Account"]}"""),
           uri,
           encoder,
-        ).map(inside(_) { case Seq(domain.ActiveContract(_, _, _, JsObject(fields), _, _, _)) =>
-          fields.get("currency") should ===(Some(JsString(testCurrency)))
-        })
+          headers = headersWithPartyAuth(List("Alice")),
+        )
+          .map(acl => acl.size shouldBe 1)
+        _ <- searchExpectOk(
+          List(),
+          jsObject("""{"templateIds": ["Account:Account"]}"""),
+          uri,
+          encoder,
+          headers = headersWithPartyAuth(List("Bob")),
+        )
+          .map(acl => acl.size shouldBe 1)
+        _ <- searchExpectOk(
+          List(),
+          jsObject("""{"templateIds": ["Account:Account"]}"""),
+          uri,
+          encoder,
+          headers = headersWithPartyAuth(List("Alice", "Bob")),
+        )
+          .map(acl => acl.size shouldBe 2)
+      } yield {
+        assert(true)
+      }
     }
-  }
 
-  "query with query, two fields" in withHttpService { (uri, encoder, _) =>
-    searchExpectOk(
-      searchDataSet,
-      jsObject(
-        """{"templateIds": ["Iou:Iou"], "query": {"currency": "EUR", "amount": "111.11"}}"""
-      ),
-      uri,
-      encoder,
-    ).map { acl: List[domain.ActiveContract[JsValue]] =>
-      acl.size shouldBe 1
-      acl.map(a => objectField(a.payload, "currency")) shouldBe List(Some(JsString("EUR")))
-      acl.map(a => objectField(a.payload, "amount")) shouldBe List(Some(JsString("111.11")))
-    }
-  }
-
-  "query with query, no results" in withHttpService { (uri, encoder, _) =>
-    searchExpectOk(
-      searchDataSet,
-      jsObject(
-        """{"templateIds": ["Iou:Iou"], "query": {"currency": "RUB", "amount": "666.66"}}"""
-      ),
-      uri,
-      encoder,
-    ).map { acl: List[domain.ActiveContract[JsValue]] =>
-      acl.size shouldBe 0
-    }
-  }
-
-  "query with invalid JSON query should return error" in withHttpService { (uri, _, _) =>
-    postJsonStringRequest(uri.withPath(Uri.Path("/v1/query")), "{NOT A VALID JSON OBJECT")
-      .flatMap { case (status, output) =>
-        status shouldBe StatusCodes.BadRequest
-        assertStatus(output, StatusCodes.BadRequest)
-      }: Future[Assertion]
-  }
-
-  protected def searchAllExpectOk(
-      uri: Uri,
-      headers: List[HttpHeader] = headersWithAuth,
-  ): Future[List[domain.ActiveContract[JsValue]]] =
-    searchAll(uri, headers).map(expectOk(_))
-
-  protected def searchAll(
-      uri: Uri,
-      headers: List[HttpHeader],
-  ): Future[domain.SyncResponse[List[domain.ActiveContract[JsValue]]]] = {
-    getRequest(uri = uri.withPath(Uri.Path("/v1/query")), headers)
-      .flatMap { case (_, output) =>
-        FutureUtil.toFuture(
-          decode1[domain.SyncResponse, List[domain.ActiveContract[JsValue]]](output)
+    "query with query, one field" in withHttpService { (uri, encoder, _) =>
+      searchExpectOk(
+        searchDataSet,
+        jsObject("""{"templateIds": ["Iou:Iou"], "query": {"currency": "EUR"}}"""),
+        uri,
+        encoder,
+      ).map { acl: List[domain.ActiveContract[JsValue]] =>
+        acl.size shouldBe 2
+        acl.map(a => objectField(a.payload, "currency")) shouldBe List.fill(2)(
+          Some(JsString("EUR"))
         )
       }
-  }
+    }
 
-  "create IOU" in withHttpService { (uri, encoder, _) =>
-    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
+    "query returns unknown Template IDs as warnings" in withHttpService { (uri, encoder, _) =>
+      val query =
+        jsObject(
+          """{"templateIds": ["Iou:Iou", "UnknownModule:UnknownEntity"], "query": {"currency": "EUR"}}"""
+        )
 
-    postCreateCommand(command, encoder, uri).flatMap { case (status, output) =>
-      status shouldBe StatusCodes.OK
-      assertStatus(output, StatusCodes.OK)
-      val activeContract = getResult(output)
-      assertActiveContract(activeContract)(command, encoder)
-    }: Future[Assertion]
-  }
-
-  "create IOU should fail if authorization header is missing" in withHttpService {
-    (uri, encoder, _) =>
-      val command: domain.CreateCommand[v.Record, OptionalPkg] =
-        iouCreateCommand()
-      val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
-
-      postJsonRequest(uri.withPath(Uri.Path("/v1/create")), input, List()).flatMap {
-        case (status, output) =>
-          status shouldBe StatusCodes.Unauthorized
-          assertStatus(output, StatusCodes.Unauthorized)
-          expectedOneErrorMessage(output) should include(
-            "missing Authorization header with OAuth 2.0 Bearer Token"
+      search(List(), query, uri, encoder).map { response =>
+        inside(response) { case domain.OkResponse(acl, warnings, StatusCodes.OK) =>
+          acl.size shouldBe 0
+          warnings shouldBe Some(
+            domain.UnknownTemplateIds(
+              List(domain.TemplateId(None, "UnknownModule", "UnknownEntity"))
+            )
           )
-      }: Future[Assertion]
-  }
+        }
+      }
+    }
 
-  "create IOU should support extra readAs parties" in withHttpService { (uri, encoder, _) =>
-    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
-    val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
+    "query returns unknown Template IDs as warnings and error" in withHttpService {
+      (uri, encoder, _) =>
+        search(
+          searchDataSet,
+          jsObject("""{"templateIds": ["AAA:BBB", "XXX:YYY"]}"""),
+          uri,
+          encoder,
+        ).map { response =>
+          inside(response) { case domain.ErrorResponse(errors, warnings, StatusCodes.BadRequest) =>
+            errors shouldBe List(ErrorMessages.cannotResolveAnyTemplateId)
+            inside(warnings) { case Some(domain.UnknownTemplateIds(unknownTemplateIds)) =>
+              unknownTemplateIds.toSet shouldBe Set(
+                domain.TemplateId(None, "AAA", "BBB"),
+                domain.TemplateId(None, "XXX", "YYY"),
+              )
+            }
+          }
+        }
+    }
 
-    postJsonRequest(
-      uri.withPath(Uri.Path("/v1/create")),
-      input,
-      headers = headersWithPartyAuth(actAs = List("Alice"), readAs = List("Bob")),
-    ).flatMap { case (status, output) =>
-      status shouldBe StatusCodes.OK
-      assertStatus(output, StatusCodes.OK)
-      val activeContract = getResult(output)
-      assertActiveContract(activeContract)(command, encoder)
-    }: Future[Assertion]
-  }
+    "query with query, can use number or string for numeric field" in withHttpService {
+      (uri, encoder, _) =>
+        import scalaz.std.scalaFuture._
 
-  "create IOU with unsupported templateId should return proper error" in withHttpService {
-    (uri, encoder, _) =>
-      val command: domain.CreateCommand[v.Record, OptionalPkg] =
-        iouCreateCommand().copy(templateId = domain.TemplateId(None, "Iou", "Dummy"))
-      val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
+        searchDataSet.traverse(c => postCreateCommand(c, encoder, uri)).flatMap {
+          rs: List[(StatusCode, JsValue)] =>
+            rs.map(_._1) shouldBe List.fill(searchDataSet.size)(StatusCodes.OK)
 
-      postJsonRequest(uri.withPath(Uri.Path("/v1/create")), input).flatMap {
-        case (status, output) =>
+            def queryAmountAs(s: String) =
+              jsObject(s"""{"templateIds": ["Iou:Iou"], "query": {"amount": $s}}""")
+
+            val queryAmountAsString = queryAmountAs("\"111.11\"")
+            val queryAmountAsNumber = queryAmountAs("111.11")
+
+            List(
+              postJsonRequest(uri.withPath(Uri.Path("/v1/query")), queryAmountAsString),
+              postJsonRequest(uri.withPath(Uri.Path("/v1/query")), queryAmountAsNumber),
+            ).sequence.flatMap { rs: List[(StatusCode, JsValue)] =>
+              rs.map(_._1) shouldBe List.fill(2)(StatusCodes.OK)
+              inside(rs.map(_._2)) { case List(jsVal1, jsVal2) =>
+                jsVal1 shouldBe jsVal2
+                val acl1: List[domain.ActiveContract[JsValue]] = activeContractList(jsVal1)
+                val acl2: List[domain.ActiveContract[JsValue]] = activeContractList(jsVal2)
+                acl1 shouldBe acl2
+                inside(acl1) { case List(ac) =>
+                  objectField(ac.payload, "amount") shouldBe Some(JsString("111.11"))
+                }
+              }
+            }
+        }: Future[Assertion]
+    }
+
+    def randomTextN(n: Int) = {
+      import org.scalacheck.Gen
+      Gen
+        .buildableOfN[String, Char](n, Gen.alphaNumChar)
+        .sample
+        .getOrElse(sys.error(s"can't generate ${n}b string"))
+    }
+
+    Seq(
+      "& " -> "& bar",
+      "1kb of data" -> randomTextN(1000),
+      "2kb of data" -> randomTextN(2000),
+      "3kb of data" -> randomTextN(3000),
+      "4kb of data" -> randomTextN(4000),
+      "5kb of data" -> randomTextN(5000),
+    ).foreach { case (testLbl, testCurrency) =>
+      s"query record contains handles '$testLbl' strings properly" in withHttpService {
+        (uri, encoder, _) =>
+          searchExpectOk(
+            searchDataSet :+ iouCreateCommand(currency = testCurrency),
+            jsObject(
+              s"""{"templateIds": ["Iou:Iou"], "query": {"currency": ${testCurrency.toJson}}}"""
+            ),
+            uri,
+            encoder,
+          ).map(inside(_) { case Seq(domain.ActiveContract(_, _, _, JsObject(fields), _, _, _)) =>
+            fields.get("currency") should ===(Some(JsString(testCurrency)))
+          })
+      }
+    }
+
+    "query with query, two fields" in withHttpService { (uri, encoder, _) =>
+      searchExpectOk(
+        searchDataSet,
+        jsObject(
+          """{"templateIds": ["Iou:Iou"], "query": {"currency": "EUR", "amount": "111.11"}}"""
+        ),
+        uri,
+        encoder,
+      ).map { acl: List[domain.ActiveContract[JsValue]] =>
+        acl.size shouldBe 1
+        acl.map(a => objectField(a.payload, "currency")) shouldBe List(Some(JsString("EUR")))
+        acl.map(a => objectField(a.payload, "amount")) shouldBe List(Some(JsString("111.11")))
+      }
+    }
+
+    "query with query, no results" in withHttpService { (uri, encoder, _) =>
+      searchExpectOk(
+        searchDataSet,
+        jsObject(
+          """{"templateIds": ["Iou:Iou"], "query": {"currency": "RUB", "amount": "666.66"}}"""
+        ),
+        uri,
+        encoder,
+      ).map { acl: List[domain.ActiveContract[JsValue]] =>
+        acl.size shouldBe 0
+      }
+    }
+
+    "query with invalid JSON query should return error" in withHttpService { (uri, _, _) =>
+      postJsonStringRequest(uri.withPath(Uri.Path("/v1/query")), "{NOT A VALID JSON OBJECT")
+        .flatMap { case (status, output) =>
           status shouldBe StatusCodes.BadRequest
           assertStatus(output, StatusCodes.BadRequest)
-          val unknownTemplateId: OptionalPkg =
-            domain.TemplateId(None, command.templateId.moduleName, command.templateId.entityName)
-          expectedOneErrorMessage(output) should include(
-            s"Cannot resolve template ID, given: ${unknownTemplateId: OptionalPkg}"
+        }: Future[Assertion]
+    }
+
+    def searchAllExpectOk(
+        uri: Uri,
+        headers: List[HttpHeader] = headersWithAuth,
+    ): Future[List[domain.ActiveContract[JsValue]]] =
+      searchAll(uri, headers).map(expectOk(_))
+
+    def searchAll(
+        uri: Uri,
+        headers: List[HttpHeader],
+    ): Future[domain.SyncResponse[List[domain.ActiveContract[JsValue]]]] = {
+      getRequest(uri = uri.withPath(Uri.Path("/v1/query")), headers)
+        .flatMap { case (_, output) =>
+          FutureUtil.toFuture(
+            decode1[domain.SyncResponse, List[domain.ActiveContract[JsValue]]](output)
           )
+        }
+    }
+
+    "create IOU" in withHttpService { (uri, encoder, _) =>
+      val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
+
+      postCreateCommand(command, encoder, uri).flatMap { case (status, output) =>
+        status shouldBe StatusCodes.OK
+        assertStatus(output, StatusCodes.OK)
+        val activeContract = getResult(output)
+        assertActiveContract(activeContract)(command, encoder)
       }: Future[Assertion]
-  }
+    }
 
-  "exercise IOU_Transfer" in withHttpService { (uri, encoder, decoder) =>
-    val create: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
-    postCreateCommand(create, encoder, uri)
-      .flatMap { case (createStatus, createOutput) =>
-        createStatus shouldBe StatusCodes.OK
-        assertStatus(createOutput, StatusCodes.OK)
+    "create IOU should fail if authorization header is missing" in withHttpService {
+      (uri, encoder, _) =>
+        val command: domain.CreateCommand[v.Record, OptionalPkg] =
+          iouCreateCommand()
+        val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
 
-        val contractId = getContractId(getResult(createOutput))
-        val exercise: domain.ExerciseCommand[v.Value, domain.EnrichedContractId] =
-          iouExerciseTransferCommand(contractId)
-        val exerciseJson: JsValue = encodeExercise(encoder)(exercise)
-
-        postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), exerciseJson)
-          .flatMap { case (exerciseStatus, exerciseOutput) =>
-            exerciseStatus shouldBe StatusCodes.OK
-            assertStatus(exerciseOutput, StatusCodes.OK)
-            assertExerciseResponseNewActiveContract(
-              getResult(exerciseOutput),
-              create,
-              exercise,
-              decoder,
-              uri,
+        postJsonRequest(uri.withPath(Uri.Path("/v1/create")), input, List()).flatMap {
+          case (status, output) =>
+            status shouldBe StatusCodes.Unauthorized
+            assertStatus(output, StatusCodes.Unauthorized)
+            expectedOneErrorMessage(output) should include(
+              "missing Authorization header with OAuth 2.0 Bearer Token"
             )
-          }
-      }: Future[Assertion]
-  }
+        }: Future[Assertion]
+    }
 
-  "create-and-exercise IOU_Transfer" in withHttpService { (uri, encoder, _) =>
-    val cmd: domain.CreateAndExerciseCommand[v.Record, v.Value, OptionalPkg] =
-      iouCreateAndExerciseTransferCommand()
+    "create IOU should support extra readAs parties" in withHttpService { (uri, encoder, _) =>
+      val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
+      val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
 
-    val json: JsValue = encoder.encodeCreateAndExerciseCommand(cmd).valueOr(e => fail(e.shows))
-
-    postJsonRequest(uri.withPath(Uri.Path("/v1/create-and-exercise")), json)
-      .flatMap { case (status, output) =>
+      postJsonRequest(
+        uri.withPath(Uri.Path("/v1/create")),
+        input,
+        headers = headersWithPartyAuth(actAs = List("Alice"), readAs = List("Bob")),
+      ).flatMap { case (status, output) =>
         status shouldBe StatusCodes.OK
-        inside(
-          decode1[domain.OkResponse, domain.ExerciseResponse[JsValue]](output)
-        ) { case \/-(response) =>
-          response.status shouldBe StatusCodes.OK
-          response.warnings shouldBe empty
-          inside(response.result.events) {
-            case List(
-                  domain.Contract(\/-(created0)),
-                  domain.Contract(-\/(archived0)),
-                  domain.Contract(\/-(created1)),
-                ) =>
-              assertTemplateId(created0.templateId, cmd.templateId)
-              assertTemplateId(archived0.templateId, cmd.templateId)
-              archived0.contractId shouldBe created0.contractId
-              assertTemplateId(created1.templateId, domain.TemplateId(None, "Iou", "IouTransfer"))
-              asContractId(response.result.exerciseResult) shouldBe created1.contractId
-          }
-        }
+        assertStatus(output, StatusCodes.OK)
+        val activeContract = getResult(output)
+        assertActiveContract(activeContract)(command, encoder)
       }: Future[Assertion]
-  }
+    }
 
-  private def assertExerciseResponseNewActiveContract(
-      exerciseResponse: JsValue,
-      createCmd: domain.CreateCommand[v.Record, OptionalPkg],
-      exerciseCmd: domain.ExerciseCommand[v.Value, domain.EnrichedContractId],
-      decoder: DomainJsonDecoder,
-      uri: Uri,
-  ): Future[Assertion] = {
-    inside(SprayJson.decode[domain.ExerciseResponse[JsValue]](exerciseResponse)) {
-      case \/-(domain.ExerciseResponse(JsString(exerciseResult), List(contract1, contract2))) => {
-        // checking contracts
-        inside(contract1) { case domain.Contract(-\/(archivedContract)) =>
-          (archivedContract.contractId.unwrap: String) shouldBe (exerciseCmd.reference.contractId.unwrap: String)
-        }
-        inside(contract2) { case domain.Contract(\/-(activeContract)) =>
-          assertActiveContract(decoder, activeContract, createCmd, exerciseCmd)
-        }
-        // checking exerciseResult
-        exerciseResult.length should be > (0)
-        val newContractLocator = domain.EnrichedContractId(
-          Some(domain.TemplateId(None, "Iou", "IouTransfer")),
-          domain.ContractId(exerciseResult),
-        )
-        postContractsLookup(newContractLocator, uri).flatMap { case (status, output) =>
+    "create IOU with unsupported templateId should return proper error" in withHttpService {
+      (uri, encoder, _) =>
+        val command: domain.CreateCommand[v.Record, OptionalPkg] =
+          iouCreateCommand().copy(templateId = domain.TemplateId(None, "Iou", "Dummy"))
+        val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
+
+        postJsonRequest(uri.withPath(Uri.Path("/v1/create")), input).flatMap {
+          case (status, output) =>
+            status shouldBe StatusCodes.BadRequest
+            assertStatus(output, StatusCodes.BadRequest)
+            val unknownTemplateId: OptionalPkg =
+              domain.TemplateId(None, command.templateId.moduleName, command.templateId.entityName)
+            expectedOneErrorMessage(output) should include(
+              s"Cannot resolve template ID, given: ${unknownTemplateId: OptionalPkg}"
+            )
+        }: Future[Assertion]
+    }
+
+    "exercise IOU_Transfer" in withHttpService { (uri, encoder, decoder) =>
+      val create: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
+      postCreateCommand(create, encoder, uri)
+        .flatMap { case (createStatus, createOutput) =>
+          createStatus shouldBe StatusCodes.OK
+          assertStatus(createOutput, StatusCodes.OK)
+
+          val contractId = getContractId(getResult(createOutput))
+          val exercise: domain.ExerciseCommand[v.Value, domain.EnrichedContractId] =
+            iouExerciseTransferCommand(contractId)
+          val exerciseJson: JsValue = encodeExercise(encoder)(exercise)
+
+          postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), exerciseJson)
+            .flatMap { case (exerciseStatus, exerciseOutput) =>
+              exerciseStatus shouldBe StatusCodes.OK
+              assertStatus(exerciseOutput, StatusCodes.OK)
+              assertExerciseResponseNewActiveContract(
+                getResult(exerciseOutput),
+                create,
+                exercise,
+                decoder,
+                uri,
+              )
+            }
+        }: Future[Assertion]
+    }
+
+    "create-and-exercise IOU_Transfer" in withHttpService { (uri, encoder, _) =>
+      val cmd: domain.CreateAndExerciseCommand[v.Record, v.Value, OptionalPkg] =
+        iouCreateAndExerciseTransferCommand()
+
+      val json: JsValue = encoder.encodeCreateAndExerciseCommand(cmd).valueOr(e => fail(e.shows))
+
+      postJsonRequest(uri.withPath(Uri.Path("/v1/create-and-exercise")), json)
+        .flatMap { case (status, output) =>
           status shouldBe StatusCodes.OK
-          assertStatus(output, StatusCodes.OK)
-          getContractId(getResult(output)) shouldBe newContractLocator.contractId
-        }: Future[Assertion]
-      }
-    }
-  }
-
-  "exercise IOU_Transfer with unknown contractId should return proper error" in withHttpService {
-    (uri, encoder, _) =>
-      val contractId = lar.ContractId("#NonExistentContractId")
-      val exerciseJson: JsValue = encodeExercise(encoder)(iouExerciseTransferCommand(contractId))
-      postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), exerciseJson)
-        .flatMap { case (status, output) =>
-          status shouldBe StatusCodes.InternalServerError
-          assertStatus(output, StatusCodes.InternalServerError)
-          expectedOneErrorMessage(output) should include(
-            "Contract could not be found with id ContractId(#NonExistentContractId)"
-          )
-        }: Future[Assertion]
-  }
-
-  "exercise Archive" in withHttpService { (uri, encoder, _) =>
-    val create: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
-    postCreateCommand(create, encoder, uri)
-      .flatMap { case (createStatus, createOutput) =>
-        createStatus shouldBe StatusCodes.OK
-        assertStatus(createOutput, StatusCodes.OK)
-
-        val contractId = getContractId(getResult(createOutput))
-        val templateId = domain.TemplateId(None, "Iou", "Iou")
-        val reference = domain.EnrichedContractId(Some(templateId), contractId)
-        val exercise = archiveCommand(reference)
-        val exerciseJson: JsValue = encodeExercise(encoder)(exercise)
-
-        postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), exerciseJson)
-          .flatMap { case (exerciseStatus, exerciseOutput) =>
-            exerciseStatus shouldBe StatusCodes.OK
-            assertStatus(exerciseOutput, StatusCodes.OK)
-            val exercisedResponse: JsObject = getResult(exerciseOutput).asJsObject
-            assertExerciseResponseArchivedContract(exercisedResponse, exercise)
+          inside(
+            decode1[domain.OkResponse, domain.ExerciseResponse[JsValue]](output)
+          ) { case \/-(response) =>
+            response.status shouldBe StatusCodes.OK
+            response.warnings shouldBe empty
+            inside(response.result.events) {
+              case List(
+                    domain.Contract(\/-(created0)),
+                    domain.Contract(-\/(archived0)),
+                    domain.Contract(\/-(created1)),
+                  ) =>
+                assertTemplateId(created0.templateId, cmd.templateId)
+                assertTemplateId(archived0.templateId, cmd.templateId)
+                archived0.contractId shouldBe created0.contractId
+                assertTemplateId(created1.templateId, domain.TemplateId(None, "Iou", "IouTransfer"))
+                asContractId(response.result.exerciseResult) shouldBe created1.contractId
+            }
           }
-      }: Future[Assertion]
-  }
+        }: Future[Assertion]
+    }
 
-  "should support multi-party command submissions" in withHttpService { (uri, encoder, _) =>
-    val newDar = AbstractHttpServiceIntegrationTestFuns.dar3
-    for {
-      _ <- Http()
-        .singleRequest(
-          HttpRequest(
-            method = HttpMethods.POST,
-            uri = uri.withPath(Uri.Path("/v1/packages")),
-            headers = authorizationHeader(jwtAdminNoParty),
-            entity = HttpEntity.fromFile(ContentTypes.`application/octet-stream`, newDar),
-          )
-        )
-      // multi-party actAs on create
-      cid <- postCreateCommand(
-        multiPartyCreateCommand(List("Alice", "Bob"), ""),
-        encoder,
-        uri,
-        headersWithPartyAuth(List("Alice", "Bob")),
-      ).map { case (status, output) =>
-        status shouldBe StatusCodes.OK
-        getContractId(getResult(output))
-      }
-      // multi-party actAs on exercise
-      cidMulti <- postJsonRequest(
-        uri.withPath(Uri.Path("/v1/exercise")),
-        encodeExercise(encoder)(multiPartyAddSignatories(cid, List("Charlie", "David"))),
-        headersWithPartyAuth(List("Alice", "Bob", "Charlie", "David")),
-      ).map { case (status, output) =>
-        status shouldBe StatusCodes.OK
-        inside(getChild(getResult(output), "exerciseResult")) { case JsString(c) =>
-          lar.ContractId(c)
-        }
-      }
-      // create a contract only visible to Alice
-      cid <- postCreateCommand(
-        multiPartyCreateCommand(List("Alice"), ""),
-        encoder,
-        uri,
-        headersWithPartyAuth(List("Alice")),
-      ).map { case (status, output) =>
-        status shouldBe StatusCodes.OK
-        getContractId(getResult(output))
-      }
-      _ <- postJsonRequest(
-        uri.withPath(Uri.Path("/v1/exercise")),
-        encodeExercise(encoder)(multiPartyFetchOther(cidMulti, cid, List("Charlie"))),
-        headersWithPartyAuth(List("Charlie"), readAs = List("Alice")),
-      ).map { case (status, _) =>
-        status shouldBe StatusCodes.OK
-      }
-    } yield succeed
-  }
-
-  private def assertExerciseResponseArchivedContract(
-      exerciseResponse: JsValue,
-      exercise: domain.ExerciseCommand[v.Value, domain.EnrichedContractId],
-  ): Assertion = {
-    inside(exerciseResponse) { case result @ JsObject(_) =>
-      inside(SprayJson.decode[domain.ExerciseResponse[JsValue]](result)) {
-        case \/-(domain.ExerciseResponse(exerciseResult, List(contract1))) =>
-          exerciseResult shouldBe JsObject()
+    def assertExerciseResponseNewActiveContract(
+        exerciseResponse: JsValue,
+        createCmd: domain.CreateCommand[v.Record, OptionalPkg],
+        exerciseCmd: domain.ExerciseCommand[v.Value, domain.EnrichedContractId],
+        decoder: DomainJsonDecoder,
+        uri: Uri,
+    ): Future[Assertion] = {
+      inside(SprayJson.decode[domain.ExerciseResponse[JsValue]](exerciseResponse)) {
+        case \/-(domain.ExerciseResponse(JsString(exerciseResult), List(contract1, contract2))) => {
+          // checking contracts
           inside(contract1) { case domain.Contract(-\/(archivedContract)) =>
-            (archivedContract.contractId.unwrap: String) shouldBe (exercise.reference.contractId.unwrap: String)
+            (archivedContract.contractId.unwrap: String) shouldBe (exerciseCmd.reference.contractId.unwrap: String)
           }
+          inside(contract2) { case domain.Contract(\/-(activeContract)) =>
+            assertActiveContract(decoder, activeContract, createCmd, exerciseCmd)
+          }
+          // checking exerciseResult
+          exerciseResult.length should be > (0)
+          val newContractLocator = domain.EnrichedContractId(
+            Some(domain.TemplateId(None, "Iou", "IouTransfer")),
+            domain.ContractId(exerciseResult),
+          )
+          postContractsLookup(newContractLocator, uri).flatMap { case (status, output) =>
+            status shouldBe StatusCodes.OK
+            assertStatus(output, StatusCodes.OK)
+            getContractId(getResult(output)) shouldBe newContractLocator.contractId
+          }: Future[Assertion]
+        }
       }
     }
-  }
 
-  "should be able to serialize and deserialize domain commands" in withLedger { client =>
-    instanceUUIDLogCtx(implicit lc =>
-      jsonCodecs(client).map { case (encoder, decoder) =>
-        testCreateCommandEncodingDecoding(encoder, decoder)
-        testExerciseCommandEncodingDecoding(encoder, decoder)
-      }: Future[Assertion]
-    )
-  }
+    "exercise IOU_Transfer with unknown contractId should return proper error" in withHttpService {
+      (uri, encoder, _) =>
+        val contractId = lar.ContractId("#NonExistentContractId")
+        val exerciseJson: JsValue = encodeExercise(encoder)(iouExerciseTransferCommand(contractId))
+        postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), exerciseJson)
+          .flatMap { case (status, output) =>
+            status shouldBe StatusCodes.InternalServerError
+            assertStatus(output, StatusCodes.InternalServerError)
+            expectedOneErrorMessage(output) should include(
+              "Contract could not be found with id ContractId(#NonExistentContractId)"
+            )
+          }: Future[Assertion]
+    }
 
-  private def testCreateCommandEncodingDecoding(
-      encoder: DomainJsonEncoder,
-      decoder: DomainJsonDecoder,
-  ): Assertion = {
-    import json.JsonProtocol._
-    import util.ErrorOps._
+    "exercise Archive" in withHttpService { (uri, encoder, _) =>
+      val create: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
+      postCreateCommand(create, encoder, uri)
+        .flatMap { case (createStatus, createOutput) =>
+          createStatus shouldBe StatusCodes.OK
+          assertStatus(createOutput, StatusCodes.OK)
 
-    val command0: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
+          val contractId = getContractId(getResult(createOutput))
+          val templateId = domain.TemplateId(None, "Iou", "Iou")
+          val reference = domain.EnrichedContractId(Some(templateId), contractId)
+          val exercise = archiveCommand(reference)
+          val exerciseJson: JsValue = encodeExercise(encoder)(exercise)
 
-    val x = for {
-      jsVal <- encoder.encodeCreateCommand(command0).liftErr(JsonError)
-      command1 <- decoder.decodeCreateCommand(jsVal)
-    } yield command1.bimap(removeRecordId, removePackageId) should ===(command0)
-
-    x.fold(e => fail(e.shows), identity)
-  }
-
-  private def testExerciseCommandEncodingDecoding(
-      encoder: DomainJsonEncoder,
-      decoder: DomainJsonDecoder,
-  ): Assertion = {
-    val command0 = iouExerciseTransferCommand(lar.ContractId("#a-contract-ID"))
-    val jsVal: JsValue = encodeExercise(encoder)(command0)
-    val command1 = decodeExercise(decoder)(jsVal)
-    command1.bimap(removeRecordId, identity) should ===(command0)
-  }
-
-  "request non-existent endpoint should return 404 with errors" in withHttpService {
-    (uri: Uri, _, _) =>
-      val badUri = uri.withPath(Uri.Path("/contracts/does-not-exist"))
-      getRequest(uri = badUri)
-        .flatMap { case (status, output) =>
-          status shouldBe StatusCodes.NotFound
-          assertStatus(output, StatusCodes.NotFound)
-          expectedOneErrorMessage(
-            output
-          ) shouldBe s"${HttpMethods.GET: HttpMethod}, uri: ${badUri: Uri}"
-        }: Future[Assertion]
-  }
-
-  "parties endpoint should return all known parties" in withHttpServiceAndClient {
-    (uri, _, _, client) =>
-      import scalaz.std.vector._
-      val partyIds = Vector("Alice", "Bob", "Charlie", "Dave")
-      val partyManagement = client.partyManagementClient
-
-      partyIds
-        .traverse { p =>
-          partyManagement.allocateParty(Some(p), Some(s"$p & Co. LLC"))
-        }
-        .flatMap { allocatedParties =>
-          getRequest(uri = uri.withPath(Uri.Path("/v1/parties"))).flatMap { case (status, output) =>
-            status shouldBe StatusCodes.OK
-            inside(
-              decode1[domain.OkResponse, List[domain.PartyDetails]](output)
-            ) { case \/-(response) =>
-              response.status shouldBe StatusCodes.OK
-              response.warnings shouldBe empty
-              val actualIds: Set[domain.Party] = response.result.view.map(_.identifier).toSet
-              actualIds shouldBe domain.Party.subst(partyIds.toSet)
-              response.result.toSet shouldBe
-                allocatedParties.toSet.map(domain.PartyDetails.fromLedgerApi)
+          postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), exerciseJson)
+            .flatMap { case (exerciseStatus, exerciseOutput) =>
+              exerciseStatus shouldBe StatusCodes.OK
+              assertStatus(exerciseOutput, StatusCodes.OK)
+              val exercisedResponse: JsObject = getResult(exerciseOutput).asJsObject
+              assertExerciseResponseArchivedContract(exercisedResponse, exercise)
             }
+        }: Future[Assertion]
+    }
+
+    "should support multi-party command submissions" in withHttpService { (uri, encoder, _) =>
+      val newDar = AbstractHttpServiceIntegrationTestFuns.dar3
+      for {
+        _ <- Http()
+          .singleRequest(
+            HttpRequest(
+              method = HttpMethods.POST,
+              uri = uri.withPath(Uri.Path("/v1/packages")),
+              headers = authorizationHeader(jwtAdminNoParty),
+              entity = HttpEntity.fromFile(ContentTypes.`application/octet-stream`, newDar),
+            )
+          )
+        // multi-party actAs on create
+        cid <- postCreateCommand(
+          multiPartyCreateCommand(List("Alice", "Bob"), ""),
+          encoder,
+          uri,
+          headersWithPartyAuth(List("Alice", "Bob")),
+        ).map { case (status, output) =>
+          status shouldBe StatusCodes.OK
+          getContractId(getResult(output))
+        }
+        // multi-party actAs on exercise
+        cidMulti <- postJsonRequest(
+          uri.withPath(Uri.Path("/v1/exercise")),
+          encodeExercise(encoder)(multiPartyAddSignatories(cid, List("Charlie", "David"))),
+          headersWithPartyAuth(List("Alice", "Bob", "Charlie", "David")),
+        ).map { case (status, output) =>
+          status shouldBe StatusCodes.OK
+          inside(getChild(getResult(output), "exerciseResult")) { case JsString(c) =>
+            lar.ContractId(c)
           }
-        }: Future[Assertion]
-  }
-
-  "parties endpoint should return only requested parties, unknown parties returned as warnings" in withHttpServiceAndClient {
-    (uri, _, _, client) =>
-      import scalaz.std.vector._
-
-      val charlie = domain.Party("Charlie")
-      val knownParties = domain.Party.subst(Vector("Alice", "Bob", "Dave")) :+ charlie
-      val erin = domain.Party("Erin")
-      val requestedPartyIds: Vector[domain.Party] = knownParties.filterNot(_ == charlie) :+ erin
-
-      val partyManagement = client.partyManagementClient
-
-      knownParties
-        .traverse { p =>
-          partyManagement.allocateParty(Some(p.unwrap), Some(s"${p.unwrap} & Co. LLC"))
         }
-        .flatMap { allocatedParties =>
-          postJsonRequest(
-            uri = uri.withPath(Uri.Path("/v1/parties")),
-            JsArray(requestedPartyIds.map(x => JsString(x.unwrap))),
-          ).flatMap { case (status, output) =>
-            status shouldBe StatusCodes.OK
-            inside(
-              decode1[domain.OkResponse, List[domain.PartyDetails]](output)
-            ) { case \/-(response) =>
-              response.status shouldBe StatusCodes.OK
-              response.warnings shouldBe Some(domain.UnknownParties(List(erin)))
-              val actualIds: Set[domain.Party] = response.result.view.map(_.identifier).toSet
-              actualIds shouldBe requestedPartyIds.toSet - erin // Erin is not known
-              val expected: Set[domain.PartyDetails] = allocatedParties.toSet
-                .map(domain.PartyDetails.fromLedgerApi)
-                .filterNot(_.identifier == charlie)
-              response.result.toSet shouldBe expected
+        // create a contract only visible to Alice
+        cid <- postCreateCommand(
+          multiPartyCreateCommand(List("Alice"), ""),
+          encoder,
+          uri,
+          headersWithPartyAuth(List("Alice")),
+        ).map { case (status, output) =>
+          status shouldBe StatusCodes.OK
+          getContractId(getResult(output))
+        }
+        _ <- postJsonRequest(
+          uri.withPath(Uri.Path("/v1/exercise")),
+          encodeExercise(encoder)(multiPartyFetchOther(cidMulti, cid, List("Charlie"))),
+          headersWithPartyAuth(List("Charlie"), readAs = List("Alice")),
+        ).map { case (status, _) =>
+          status shouldBe StatusCodes.OK
+        }
+      } yield succeed
+    }
+
+    def assertExerciseResponseArchivedContract(
+        exerciseResponse: JsValue,
+        exercise: domain.ExerciseCommand[v.Value, domain.EnrichedContractId],
+    ): Assertion = {
+      inside(exerciseResponse) { case result @ JsObject(_) =>
+        inside(SprayJson.decode[domain.ExerciseResponse[JsValue]](result)) {
+          case \/-(domain.ExerciseResponse(exerciseResult, List(contract1))) =>
+            exerciseResult shouldBe JsObject()
+            inside(contract1) { case domain.Contract(-\/(archivedContract)) =>
+              (archivedContract.contractId.unwrap: String) shouldBe (exercise.reference.contractId.unwrap: String)
             }
+        }
+      }
+    }
+
+    "should be able to serialize and deserialize domain commands" in withLedger { client =>
+      instanceUUIDLogCtx(implicit lc =>
+        jsonCodecs(client).map { case (encoder, decoder) =>
+          testCreateCommandEncodingDecoding(encoder, decoder)
+          testExerciseCommandEncodingDecoding(encoder, decoder)
+        }: Future[Assertion]
+      )
+    }
+
+    def testCreateCommandEncodingDecoding(
+        encoder: DomainJsonEncoder,
+        decoder: DomainJsonDecoder,
+    ): Assertion = {
+      import json.JsonProtocol._
+      import util.ErrorOps._
+
+      val command0: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
+
+      val x = for {
+        jsVal <- encoder.encodeCreateCommand(command0).liftErr(JsonError)
+        command1 <- decoder.decodeCreateCommand(jsVal)
+      } yield command1.bimap(removeRecordId, removePackageId) should ===(command0)
+
+      x.fold(e => fail(e.shows), identity)
+    }
+
+    def testExerciseCommandEncodingDecoding(
+        encoder: DomainJsonEncoder,
+        decoder: DomainJsonDecoder,
+    ): Assertion = {
+      val command0 = iouExerciseTransferCommand(lar.ContractId("#a-contract-ID"))
+      val jsVal: JsValue = encodeExercise(encoder)(command0)
+      val command1 = decodeExercise(decoder)(jsVal)
+      command1.bimap(removeRecordId, identity) should ===(command0)
+    }
+
+    "request non-existent endpoint should return 404 with errors" in withHttpService {
+      (uri: Uri, _, _) =>
+        val badUri = uri.withPath(Uri.Path("/contracts/does-not-exist"))
+        getRequest(uri = badUri)
+          .flatMap { case (status, output) =>
+            status shouldBe StatusCodes.NotFound
+            assertStatus(output, StatusCodes.NotFound)
+            expectedOneErrorMessage(
+              output
+            ) shouldBe s"${HttpMethods.GET: HttpMethod}, uri: ${badUri: Uri}"
+          }: Future[Assertion]
+    }
+
+    "parties endpoint should return all known parties" in withHttpServiceAndClient() {
+      (uri, _, _, client) =>
+        import scalaz.std.vector._
+        val partyIds = Vector("Alice", "Bob", "Charlie", "Dave")
+        val partyManagement = client.partyManagementClient
+
+        partyIds
+          .traverse { p =>
+            partyManagement.allocateParty(Some(p), Some(s"$p & Co. LLC"))
           }
-        }: Future[Assertion]
-  }
-
-  "parties endpoint should error if empty array passed as input" in withHttpServiceAndClient {
-    (uri, _, _, _) =>
-      postJsonRequest(
-        uri = uri.withPath(Uri.Path("/v1/parties")),
-        JsArray(Vector.empty),
-      ).flatMap { case (status, output) =>
-        status shouldBe StatusCodes.BadRequest
-        assertStatus(output, StatusCodes.BadRequest)
-        val errorMsg = expectedOneErrorMessage(output)
-        errorMsg should include("Cannot read JSON: <[]>")
-        errorMsg should include("must be a JSON array with at least 1 element")
-      }: Future[Assertion]
-  }
-
-  "parties endpoint returns error if empty party string passed" in withHttpServiceAndClient {
-    (uri, _, _, _) =>
-      val requestedPartyIds: Vector[domain.Party] = domain.Party.subst(Vector(""))
-
-      postJsonRequest(
-        uri = uri.withPath(Uri.Path("/v1/parties")),
-        JsArray(requestedPartyIds.map(x => JsString(x.unwrap))),
-      ).flatMap { case (status, output) =>
-        status shouldBe StatusCodes.BadRequest
-        inside(decode1[domain.SyncResponse, List[domain.PartyDetails]](output)) {
-          case \/-(domain.ErrorResponse(List(error), None, StatusCodes.BadRequest)) =>
-            error should include("Daml-LF Party is empty")
-        }
-      }: Future[Assertion]
-  }
-
-  "parties endpoint returns empty result with warnings and OK status if nothing found" in withHttpServiceAndClient {
-    (uri, _, _, _) =>
-      val requestedPartyIds: Vector[domain.Party] =
-        domain.Party.subst(Vector("Alice", "Bob", "Dave"))
-
-      postJsonRequest(
-        uri = uri.withPath(Uri.Path("/v1/parties")),
-        JsArray(requestedPartyIds.map(x => JsString(x.unwrap))),
-      ).flatMap { case (status, output) =>
-        status shouldBe StatusCodes.OK
-        inside(decode1[domain.SyncResponse, List[domain.PartyDetails]](output)) {
-          case \/-(domain.OkResponse(List(), Some(warnings), StatusCodes.OK)) =>
-            inside(warnings) { case domain.UnknownParties(unknownParties) =>
-              unknownParties.toSet shouldBe requestedPartyIds.toSet
+          .flatMap { allocatedParties =>
+            getRequest(uri = uri.withPath(Uri.Path("/v1/parties"))).flatMap {
+              case (status, output) =>
+                status shouldBe StatusCodes.OK
+                inside(
+                  decode1[domain.OkResponse, List[domain.PartyDetails]](output)
+                ) { case \/-(response) =>
+                  response.status shouldBe StatusCodes.OK
+                  response.warnings shouldBe empty
+                  val actualIds: Set[domain.Party] = response.result.view.map(_.identifier).toSet
+                  actualIds shouldBe domain.Party.subst(partyIds.toSet)
+                  response.result.toSet shouldBe
+                    allocatedParties.toSet.map(domain.PartyDetails.fromLedgerApi)
+                }
             }
-        }
-      }: Future[Assertion]
-  }
+          }: Future[Assertion]
+    }
 
-  "parties/allocate should allocate a new party" in withHttpServiceAndClient { (uri, _, _, _) =>
-    val request = domain.AllocatePartyRequest(
-      Some(domain.Party(s"Carol${uniqueId()}")),
-      Some("Carol & Co. LLC"),
-    )
-    val json = SprayJson.encode(request).valueOr(e => fail(e.shows))
+    "parties endpoint should return only requested parties, unknown parties returned as warnings" in withHttpServiceAndClient() {
+      (uri, _, _, client) =>
+        import scalaz.std.vector._
 
-    postJsonRequest(
-      uri = uri.withPath(Uri.Path("/v1/parties/allocate")),
-      json = json,
-      headers = authorizationHeader(jwtAdminNoParty),
-    )
-      .flatMap { case (status, output) =>
-        status shouldBe StatusCodes.OK
-        inside(decode1[domain.OkResponse, domain.PartyDetails](output)) { case \/-(response) =>
-          response.status shouldBe StatusCodes.OK
-          val newParty = response.result
-          Some(newParty.identifier) shouldBe request.identifierHint
-          newParty.displayName shouldBe request.displayName
-          newParty.isLocal shouldBe true
+        val charlie = domain.Party("Charlie")
+        val knownParties = domain.Party.subst(Vector("Alice", "Bob", "Dave")) :+ charlie
+        val erin = domain.Party("Erin")
+        val requestedPartyIds: Vector[domain.Party] = knownParties.filterNot(_ == charlie) :+ erin
 
-          getRequest(uri = uri.withPath(Uri.Path("/v1/parties"))).flatMap { case (status, output) =>
-            status shouldBe StatusCodes.OK
-            inside(decode1[domain.OkResponse, List[domain.PartyDetails]](output)) {
-              case \/-(response) =>
+        val partyManagement = client.partyManagementClient
+
+        knownParties
+          .traverse { p =>
+            partyManagement.allocateParty(Some(p.unwrap), Some(s"${p.unwrap} & Co. LLC"))
+          }
+          .flatMap { allocatedParties =>
+            postJsonRequest(
+              uri = uri.withPath(Uri.Path("/v1/parties")),
+              JsArray(requestedPartyIds.map(x => JsString(x.unwrap))),
+            ).flatMap { case (status, output) =>
+              status shouldBe StatusCodes.OK
+              inside(
+                decode1[domain.OkResponse, List[domain.PartyDetails]](output)
+              ) { case \/-(response) =>
                 response.status shouldBe StatusCodes.OK
-                response.result should contain(newParty)
+                response.warnings shouldBe Some(domain.UnknownParties(List(erin)))
+                val actualIds: Set[domain.Party] = response.result.view.map(_.identifier).toSet
+                actualIds shouldBe requestedPartyIds.toSet - erin // Erin is not known
+                val expected: Set[domain.PartyDetails] = allocatedParties.toSet
+                  .map(domain.PartyDetails.fromLedgerApi)
+                  .filterNot(_.identifier == charlie)
+                response.result.toSet shouldBe expected
+              }
             }
-          }
-        }
-      }: Future[Assertion]
-  }
+          }: Future[Assertion]
+    }
 
-  "parties/allocate should allocate a new party without any hints" in withHttpServiceAndClient {
-    (uri, _, _, _) =>
-      postJsonRequest(uri = uri.withPath(Uri.Path("/v1/parties/allocate")), json = JsObject())
+    "parties endpoint should error if empty array passed as input" in withHttpServiceAndClient() {
+      (uri, _, _, _) =>
+        postJsonRequest(
+          uri = uri.withPath(Uri.Path("/v1/parties")),
+          JsArray(Vector.empty),
+        ).flatMap { case (status, output) =>
+          status shouldBe StatusCodes.BadRequest
+          assertStatus(output, StatusCodes.BadRequest)
+          val errorMsg = expectedOneErrorMessage(output)
+          errorMsg should include("Cannot read JSON: <[]>")
+          errorMsg should include("must be a JSON array with at least 1 element")
+        }: Future[Assertion]
+    }
+
+    "parties endpoint returns error if empty party string passed" in withHttpServiceAndClient() {
+      (uri, _, _, _) =>
+        val requestedPartyIds: Vector[domain.Party] = domain.Party.subst(Vector(""))
+
+        postJsonRequest(
+          uri = uri.withPath(Uri.Path("/v1/parties")),
+          JsArray(requestedPartyIds.map(x => JsString(x.unwrap))),
+        ).flatMap { case (status, output) =>
+          status shouldBe StatusCodes.BadRequest
+          inside(decode1[domain.SyncResponse, List[domain.PartyDetails]](output)) {
+            case \/-(domain.ErrorResponse(List(error), None, StatusCodes.BadRequest)) =>
+              error should include("Daml-LF Party is empty")
+          }
+        }: Future[Assertion]
+    }
+
+    "parties endpoint returns empty result with warnings and OK status if nothing found" in withHttpServiceAndClient() {
+      (uri, _, _, _) =>
+        val requestedPartyIds: Vector[domain.Party] =
+          domain.Party.subst(Vector("Alice", "Bob", "Dave"))
+
+        postJsonRequest(
+          uri = uri.withPath(Uri.Path("/v1/parties")),
+          JsArray(requestedPartyIds.map(x => JsString(x.unwrap))),
+        ).flatMap { case (status, output) =>
+          status shouldBe StatusCodes.OK
+          inside(decode1[domain.SyncResponse, List[domain.PartyDetails]](output)) {
+            case \/-(domain.OkResponse(List(), Some(warnings), StatusCodes.OK)) =>
+              inside(warnings) { case domain.UnknownParties(unknownParties) =>
+                unknownParties.toSet shouldBe requestedPartyIds.toSet
+              }
+          }
+        }: Future[Assertion]
+    }
+
+    "parties/allocate should allocate a new party" in withHttpServiceAndClient() { (uri, _, _, _) =>
+      val request = domain.AllocatePartyRequest(
+        Some(domain.Party(s"Carol${uniqueId()}")),
+        Some("Carol & Co. LLC"),
+      )
+      val json = SprayJson.encode(request).valueOr(e => fail(e.shows))
+
+      postJsonRequest(
+        uri = uri.withPath(Uri.Path("/v1/parties/allocate")),
+        json = json,
+        headers = authorizationHeader(jwtAdminNoParty),
+      )
         .flatMap { case (status, output) =>
           status shouldBe StatusCodes.OK
           inside(decode1[domain.OkResponse, domain.PartyDetails](output)) { case \/-(response) =>
             response.status shouldBe StatusCodes.OK
             val newParty = response.result
-            newParty.identifier.unwrap.length should be > 0
-            newParty.displayName shouldBe None
+            Some(newParty.identifier) shouldBe request.identifierHint
+            newParty.displayName shouldBe request.displayName
             newParty.isLocal shouldBe true
 
             getRequest(uri = uri.withPath(Uri.Path("/v1/parties"))).flatMap {
@@ -1337,336 +1312,369 @@ abstract class AbstractHttpServiceIntegrationTest
             }
           }
         }: Future[Assertion]
-  }
+    }
 
-  "parties/allocate should return BadRequest error if party ID hint is invalid PartyIdString" in withHttpServiceAndClient {
-    (uri, _, _, _) =>
-      val request = domain.AllocatePartyRequest(
-        Some(domain.Party(s"Carol-!")),
-        Some("Carol & Co. LLC"),
-      )
-      val json = SprayJson.encode(request).valueOr(e => fail(e.shows))
+    "parties/allocate should allocate a new party without any hints" in withHttpServiceAndClient() {
+      (uri, _, _, _) =>
+        postJsonRequest(uri = uri.withPath(Uri.Path("/v1/parties/allocate")), json = JsObject())
+          .flatMap { case (status, output) =>
+            status shouldBe StatusCodes.OK
+            inside(decode1[domain.OkResponse, domain.PartyDetails](output)) { case \/-(response) =>
+              response.status shouldBe StatusCodes.OK
+              val newParty = response.result
+              newParty.identifier.unwrap.length should be > 0
+              newParty.displayName shouldBe None
+              newParty.isLocal shouldBe true
 
-      postJsonRequest(uri = uri.withPath(Uri.Path("/v1/parties/allocate")), json = json)
-        .flatMap { case (status, output) =>
-          status shouldBe StatusCodes.BadRequest
-          inside(decode[domain.ErrorResponse](output)) { case \/-(response) =>
-            response.status shouldBe StatusCodes.BadRequest
-            response.warnings shouldBe empty
-            response.errors.length shouldBe 1
+              getRequest(uri = uri.withPath(Uri.Path("/v1/parties"))).flatMap {
+                case (status, output) =>
+                  status shouldBe StatusCodes.OK
+                  inside(decode1[domain.OkResponse, List[domain.PartyDetails]](output)) {
+                    case \/-(response) =>
+                      response.status shouldBe StatusCodes.OK
+                      response.result should contain(newParty)
+                  }
+              }
+            }
+          }: Future[Assertion]
+    }
+
+    "parties/allocate should return BadRequest error if party ID hint is invalid PartyIdString" in withHttpServiceAndClient() {
+      (uri, _, _, _) =>
+        val request = domain.AllocatePartyRequest(
+          Some(domain.Party(s"Carol-!")),
+          Some("Carol & Co. LLC"),
+        )
+        val json = SprayJson.encode(request).valueOr(e => fail(e.shows))
+
+        postJsonRequest(uri = uri.withPath(Uri.Path("/v1/parties/allocate")), json = json)
+          .flatMap { case (status, output) =>
+            status shouldBe StatusCodes.BadRequest
+            inside(decode[domain.ErrorResponse](output)) { case \/-(response) =>
+              response.status shouldBe StatusCodes.BadRequest
+              response.warnings shouldBe empty
+              response.errors.length shouldBe 1
+            }
           }
-        }
-  }
+    }
 
-  "fetch by contractId" in withHttpService { (uri, encoder, _) =>
-    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
+    "fetch by contractId" in withHttpService { (uri, encoder, _) =>
+      val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand()
 
-    postCreateCommand(command, encoder, uri).flatMap { case (status, output) =>
-      status shouldBe StatusCodes.OK
-      assertStatus(output, StatusCodes.OK)
-      val contractId: ContractId = getContractId(getResult(output))
-      val locator = domain.EnrichedContractId(None, contractId)
-      lookupContractAndAssert(locator)(contractId, command, encoder, uri)
-    }: Future[Assertion]
-  }
+      postCreateCommand(command, encoder, uri).flatMap { case (status, output) =>
+        status shouldBe StatusCodes.OK
+        assertStatus(output, StatusCodes.OK)
+        val contractId: ContractId = getContractId(getResult(output))
+        val locator = domain.EnrichedContractId(None, contractId)
+        lookupContractAndAssert(locator)(contractId, command, encoder, uri)
+      }: Future[Assertion]
+    }
 
-  "fetch returns {status:200, result:null} when contract is not found" in withHttpService {
-    (uri, _, _) =>
+    "fetch returns {status:200, result:null} when contract is not found" in withHttpService {
+      (uri, _, _) =>
+        val owner = domain.Party("Alice")
+        val accountNumber = "abc123"
+        val locator = domain.EnrichedContractKey(
+          domain.TemplateId(None, "Account", "Account"),
+          JsArray(JsString(owner.unwrap), JsString(accountNumber)),
+        )
+        postContractsLookup(locator, uri.withPath(Uri.Path("/v1/fetch"))).flatMap {
+          case (status, output) =>
+            status shouldBe StatusCodes.OK
+            assertStatus(output, StatusCodes.OK)
+            output
+              .asJsObject(s"expected JsObject, got: $output")
+              .fields
+              .get("result") shouldBe Some(JsNull)
+        }: Future[Assertion]
+    }
+
+    "fetch by key" in withHttpService { (uri, encoder, _) =>
       val owner = domain.Party("Alice")
       val accountNumber = "abc123"
-      val locator = domain.EnrichedContractKey(
-        domain.TemplateId(None, "Account", "Account"),
-        JsArray(JsString(owner.unwrap), JsString(accountNumber)),
+      val command: domain.CreateCommand[v.Record, OptionalPkg] =
+        accountCreateCommand(owner, accountNumber)
+
+      postCreateCommand(command, encoder, uri).flatMap { case (status, output) =>
+        status shouldBe StatusCodes.OK
+        assertStatus(output, StatusCodes.OK)
+        val contractId: ContractId = getContractId(getResult(output))
+        val locator = domain.EnrichedContractKey(
+          domain.TemplateId(None, "Account", "Account"),
+          JsArray(JsString(owner.unwrap), JsString(accountNumber)),
+        )
+        lookupContractAndAssert(locator)(contractId, command, encoder, uri)
+      }: Future[Assertion]
+    }
+
+    "commands/exercise Archive by key" in withHttpService { (uri, encoder, _) =>
+      val owner = domain.Party("Alice")
+      val accountNumber = "abc123"
+      val create: domain.CreateCommand[v.Record, OptionalPkg] =
+        accountCreateCommand(owner, accountNumber)
+
+      val keyRecord = v.Record(
+        fields = Seq(
+          v.RecordField(value = Some(v.Value(v.Value.Sum.Party(owner.unwrap)))),
+          v.RecordField(value = Some(v.Value(v.Value.Sum.Text(accountNumber)))),
+        )
       )
-      postContractsLookup(locator, uri.withPath(Uri.Path("/v1/fetch"))).flatMap {
+      val locator = domain.EnrichedContractKey[v.Value](
+        domain.TemplateId(None, "Account", "Account"),
+        v.Value(v.Value.Sum.Record(keyRecord)),
+      )
+      val archive: domain.ExerciseCommand[v.Value, domain.EnrichedContractKey[v.Value]] =
+        archiveCommand(locator)
+      val archiveJson: JsValue = encodeExercise(encoder)(archive)
+
+      postCreateCommand(create, encoder, uri).flatMap { case (status, output) =>
+        status shouldBe StatusCodes.OK
+        assertStatus(output, StatusCodes.OK)
+
+        postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), archiveJson).flatMap {
+          case (exerciseStatus, exerciseOutput) =>
+            exerciseStatus shouldBe StatusCodes.OK
+            assertStatus(exerciseOutput, StatusCodes.OK)
+        }
+      }: Future[Assertion]
+    }
+
+    "fetch by key containing variant and record, encoded as array with number num" in withHttpService {
+      (uri, _, _) =>
+        testFetchByCompositeKey(
+          uri,
+          jsObject("""{
+              "templateId": "Account:KeyedByVariantAndRecord",
+              "key": [
+                "Alice",
+                {"tag": "Bar", "value": 42},
+                {"baz": "another baz value"}
+              ]
+            }"""),
+        )
+    }
+
+    "fetch by key containing variant and record, encoded as record with string num" in withHttpService {
+      (uri, _, _) =>
+        testFetchByCompositeKey(
+          uri,
+          jsObject("""{
+              "templateId": "Account:KeyedByVariantAndRecord",
+              "key": {
+                "_1": "Alice",
+                "_2": {"tag": "Bar", "value": "42"},
+                "_3": {"baz": "another baz value"}
+              }
+            }"""),
+        )
+    }
+
+    def testFetchByCompositeKey(uri: Uri, request: JsObject) = {
+      val createCommand = jsObject("""{
+          "templateId": "Account:KeyedByVariantAndRecord",
+          "payload": {
+            "name": "ABC DEF",
+            "party": "Alice",
+            "age": 123,
+            "fooVariant": {"tag": "Bar", "value": 42},
+            "bazRecord": {"baz": "another baz value"}
+          }
+        }""")
+
+      postJsonRequest(uri.withPath(Uri.Path("/v1/create")), createCommand).flatMap {
         case (status, output) =>
           status shouldBe StatusCodes.OK
           assertStatus(output, StatusCodes.OK)
-          output
-            .asJsObject(s"expected JsObject, got: $output")
-            .fields
-            .get("result") shouldBe Some(JsNull)
+          val contractId: ContractId = getContractId(getResult(output))
+
+          postJsonRequest(uri.withPath(Uri.Path("/v1/fetch")), request).flatMap {
+            case (status, output) =>
+              status shouldBe StatusCodes.OK
+              assertStatus(output, StatusCodes.OK)
+              activeContract(output).contractId shouldBe contractId
+          }
       }: Future[Assertion]
-  }
+    }
 
-  "fetch by key" in withHttpService { (uri, encoder, _) =>
-    val owner = domain.Party("Alice")
-    val accountNumber = "abc123"
-    val command: domain.CreateCommand[v.Record, OptionalPkg] =
-      accountCreateCommand(owner, accountNumber)
+    "query by a variant field" in withHttpService { (uri, encoder, _) =>
+      val owner = domain.Party("Alice")
+      val accountNumber = "abc123"
+      val now = TimestampConversion.instantToMicros(Instant.now)
+      val nowStr = TimestampConversion.microsToInstant(now).toString
+      val command: domain.CreateCommand[v.Record, OptionalPkg] =
+        accountCreateCommand(owner, accountNumber, now)
 
-    postCreateCommand(command, encoder, uri).flatMap { case (status, output) =>
-      status shouldBe StatusCodes.OK
-      assertStatus(output, StatusCodes.OK)
-      val contractId: ContractId = getContractId(getResult(output))
-      val locator = domain.EnrichedContractKey(
-        domain.TemplateId(None, "Account", "Account"),
-        JsArray(JsString(owner.unwrap), JsString(accountNumber)),
-      )
-      lookupContractAndAssert(locator)(contractId, command, encoder, uri)
-    }: Future[Assertion]
-  }
+      val packageId: Ref.PackageId = MetadataReader
+        .templateByName(metadata2)(Ref.QualifiedName.assertFromString("Account:Account"))
+        .headOption
+        .map(_._1)
+        .getOrElse(fail(s"Cannot retrieve packageId"))
 
-  "commands/exercise Archive by key" in withHttpService { (uri, encoder, _) =>
-    val owner = domain.Party("Alice")
-    val accountNumber = "abc123"
-    val create: domain.CreateCommand[v.Record, OptionalPkg] =
-      accountCreateCommand(owner, accountNumber)
-
-    val keyRecord = v.Record(
-      fields = Seq(
-        v.RecordField(value = Some(v.Value(v.Value.Sum.Party(owner.unwrap)))),
-        v.RecordField(value = Some(v.Value(v.Value.Sum.Text(accountNumber)))),
-      )
-    )
-    val locator = domain.EnrichedContractKey[v.Value](
-      domain.TemplateId(None, "Account", "Account"),
-      v.Value(v.Value.Sum.Record(keyRecord)),
-    )
-    val archive: domain.ExerciseCommand[v.Value, domain.EnrichedContractKey[v.Value]] =
-      archiveCommand(locator)
-    val archiveJson: JsValue = encodeExercise(encoder)(archive)
-
-    postCreateCommand(create, encoder, uri).flatMap { case (status, output) =>
-      status shouldBe StatusCodes.OK
-      assertStatus(output, StatusCodes.OK)
-
-      postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), archiveJson).flatMap {
-        case (exerciseStatus, exerciseOutput) =>
-          exerciseStatus shouldBe StatusCodes.OK
-          assertStatus(exerciseOutput, StatusCodes.OK)
-      }
-    }: Future[Assertion]
-  }
-
-  "fetch by key containing variant and record, encoded as array with number num" in withHttpService {
-    (uri, _, _) =>
-      testFetchByCompositeKey(
-        uri,
-        jsObject("""{
-            "templateId": "Account:KeyedByVariantAndRecord",
-            "key": [
-              "Alice",
-              {"tag": "Bar", "value": 42},
-              {"baz": "another baz value"}
-            ]
-          }"""),
-      )
-  }
-
-  "fetch by key containing variant and record, encoded as record with string num" in withHttpService {
-    (uri, _, _) =>
-      testFetchByCompositeKey(
-        uri,
-        jsObject("""{
-            "templateId": "Account:KeyedByVariantAndRecord",
-            "key": {
-              "_1": "Alice",
-              "_2": {"tag": "Bar", "value": "42"},
-              "_3": {"baz": "another baz value"}
-            }
-          }"""),
-      )
-  }
-
-  private def testFetchByCompositeKey(uri: Uri, request: JsObject) = {
-    val createCommand = jsObject("""{
-        "templateId": "Account:KeyedByVariantAndRecord",
-        "payload": {
-          "name": "ABC DEF",
-          "party": "Alice",
-          "age": 123,
-          "fooVariant": {"tag": "Bar", "value": 42},
-          "bazRecord": {"baz": "another baz value"}
-        }
-      }""")
-
-    postJsonRequest(uri.withPath(Uri.Path("/v1/create")), createCommand).flatMap {
-      case (status, output) =>
+      postCreateCommand(command, encoder, uri).flatMap { case (status, output) =>
         status shouldBe StatusCodes.OK
         assertStatus(output, StatusCodes.OK)
         val contractId: ContractId = getContractId(getResult(output))
 
-        postJsonRequest(uri.withPath(Uri.Path("/v1/fetch")), request).flatMap {
-          case (status, output) =>
-            status shouldBe StatusCodes.OK
-            assertStatus(output, StatusCodes.OK)
-            activeContract(output).contractId shouldBe contractId
-        }
-    }: Future[Assertion]
-  }
+        val query = jsObject(s"""{
+               "templateIds": ["$packageId:Account:Account"],
+               "query": {
+                   "number" : "abc123",
+                   "status" : {"tag": "Enabled", "value": "${nowStr: String}"}
+               }
+            }""")
 
-  "query by a variant field" in withHttpService { (uri, encoder, _) =>
-    val owner = domain.Party("Alice")
-    val accountNumber = "abc123"
-    val now = TimestampConversion.instantToMicros(Instant.now)
-    val nowStr = TimestampConversion.microsToInstant(now).toString
-    val command: domain.CreateCommand[v.Record, OptionalPkg] =
-      accountCreateCommand(owner, accountNumber, now)
-
-    val packageId: Ref.PackageId = MetadataReader
-      .templateByName(metadata2)(Ref.QualifiedName.assertFromString("Account:Account"))
-      .headOption
-      .map(_._1)
-      .getOrElse(fail(s"Cannot retrieve packageId"))
-
-    postCreateCommand(command, encoder, uri).flatMap { case (status, output) =>
-      status shouldBe StatusCodes.OK
-      assertStatus(output, StatusCodes.OK)
-      val contractId: ContractId = getContractId(getResult(output))
-
-      val query = jsObject(s"""{
-             "templateIds": ["$packageId:Account:Account"],
-             "query": {
-                 "number" : "abc123",
-                 "status" : {"tag": "Enabled", "value": "${nowStr: String}"}
-             }
-          }""")
-
-      postJsonRequest(uri.withPath(Uri.Path("/v1/query")), query).map {
-        case (searchStatus, searchOutput) =>
-          searchStatus shouldBe StatusCodes.OK
-          assertStatus(searchOutput, StatusCodes.OK)
-          inside(activeContractList(searchOutput)) { case List(ac) =>
-            ac.contractId shouldBe contractId
-          }
-      }
-    }: Future[Assertion]
-  }
-
-  "packages endpoint should return all known package IDs" in withHttpServiceAndClient {
-    (uri, _, _, _) =>
-      getAllPackageIds(uri).map { x =>
-        inside(x) {
-          case domain.OkResponse(ps, None, StatusCodes.OK) if ps.nonEmpty =>
-            Inspectors.forAll(ps)(_.length should be > 0)
-        }
-      }: Future[Assertion]
-  }
-
-  "packages/packageId should return a requested package" in withHttpServiceAndClient {
-    import AbstractHttpServiceIntegrationTestFuns.sha256
-
-    (uri, _, _, _) =>
-      getAllPackageIds(uri).flatMap { okResp =>
-        inside(okResp.result.headOption) { case Some(packageId) =>
-          Http()
-            .singleRequest(
-              HttpRequest(
-                method = HttpMethods.GET,
-                uri = uri.withPath(Uri.Path(s"/v1/packages/$packageId")),
-                headers = authorizationHeader(jwtAdminNoParty),
-              )
-            )
-            .map { resp =>
-              resp.status shouldBe StatusCodes.OK
-              resp.entity.getContentType() shouldBe ContentTypes.`application/octet-stream`
-              sha256(resp.entity.dataBytes) shouldBe Success(packageId)
+        postJsonRequest(uri.withPath(Uri.Path("/v1/query")), query).map {
+          case (searchStatus, searchOutput) =>
+            searchStatus shouldBe StatusCodes.OK
+            assertStatus(searchOutput, StatusCodes.OK)
+            inside(activeContractList(searchOutput)) { case List(ac) =>
+              ac.contractId shouldBe contractId
             }
         }
       }: Future[Assertion]
-  }
-
-  "packages upload endpoint" in withHttpServiceAndClient { (uri, _, _, _) =>
-    val newDar = AbstractHttpServiceIntegrationTestFuns.dar3
-
-    getAllPackageIds(uri).flatMap { okResp =>
-      val existingPackageIds: Set[String] = okResp.result.toSet
-      Http()
-        .singleRequest(
-          HttpRequest(
-            method = HttpMethods.POST,
-            uri = uri.withPath(Uri.Path("/v1/packages")),
-            headers = authorizationHeader(jwtAdminNoParty),
-            entity = HttpEntity.fromFile(ContentTypes.`application/octet-stream`, newDar),
-          )
-        )
-        .flatMap { resp =>
-          resp.status shouldBe StatusCodes.OK
-          getAllPackageIds(uri).map { okResp =>
-            val newPackageIds: Set[String] = okResp.result.toSet -- existingPackageIds
-            newPackageIds.size should be > 0
-          }
-        }
-    }: Future[Assertion]
-  }
-
-  "archiving a large number of contracts should succeed" in withHttpServiceAndClient(
-    StartSettings.DefaultMaxInboundMessageSize * 10
-  ) { (uri, encoder, _, _) =>
-    val numContracts: Long = 10000
-    val helperId = domain.TemplateId(None, "Account", "Helper")
-    val payload = v.Record(
-      fields = List(v.RecordField("owner", Some(v.Value(v.Value.Sum.Party("Alice")))))
-    )
-    val createCmd: domain.CreateAndExerciseCommand[v.Record, v.Value, OptionalPkg] =
-      domain.CreateAndExerciseCommand(
-        templateId = helperId,
-        payload = payload,
-        choice = lar.Choice("CreateN"),
-        argument = boxedRecord(
-          v.Record(fields =
-            List(v.RecordField("n", Some(v.Value(v.Value.Sum.Int64(numContracts)))))
-          )
-        ),
-        meta = None,
-      )
-    def encode(cmd: domain.CreateAndExerciseCommand[v.Record, v.Value, OptionalPkg]): JsValue =
-      encoder.encodeCreateAndExerciseCommand(cmd).valueOr(e => fail(e.shows))
-    def archiveCmd(cids: List[String]) =
-      domain.CreateAndExerciseCommand(
-        templateId = helperId,
-        payload = payload,
-        choice = lar.Choice("ArchiveAll"),
-        argument = boxedRecord(
-          v.Record(fields =
-            List(
-              v.RecordField(
-                "cids",
-                Some(
-                  v.Value(
-                    v.Value.Sum.List(v.List(cids.map(cid => v.Value(v.Value.Sum.ContractId(cid)))))
-                  )
-                ),
-              )
-            )
-          )
-        ),
-        meta = None,
-      )
-    def queryN(n: Long): Future[Assertion] = postJsonRequest(
-      uri.withPath(Uri.Path("/v1/query")),
-      jsObject("""{"templateIds": ["Account:Account"]}"""),
-    ).flatMap { case (status, output) =>
-      status shouldBe StatusCodes.OK
-      assertStatus(output, StatusCodes.OK)
-      inside(getResult(output)) { case JsArray(result) =>
-        result should have length n
-      }
     }
 
-    for {
-      resp <- postJsonRequest(uri.withPath(Uri.Path("/v1/create-and-exercise")), encode(createCmd))
-      (status, output) = resp
-      _ = {
+    "packages endpoint should return all known package IDs" in withHttpServiceAndClient() {
+      (uri, _, _, _) =>
+        getAllPackageIds(uri).map { x =>
+          inside(x) {
+            case domain.OkResponse(ps, None, StatusCodes.OK) if ps.nonEmpty =>
+              Inspectors.forAll(ps)(_.length should be > 0)
+          }
+        }: Future[Assertion]
+    }
+
+    "packages/packageId should return a requested package" in withHttpServiceAndClient() {
+      import AbstractHttpServiceIntegrationTestFuns.sha256
+
+      (uri, _, _, _) =>
+        getAllPackageIds(uri).flatMap { okResp =>
+          inside(okResp.result.headOption) { case Some(packageId) =>
+            Http()
+              .singleRequest(
+                HttpRequest(
+                  method = HttpMethods.GET,
+                  uri = uri.withPath(Uri.Path(s"/v1/packages/$packageId")),
+                  headers = authorizationHeader(jwtAdminNoParty),
+                )
+              )
+              .map { resp =>
+                resp.status shouldBe StatusCodes.OK
+                resp.entity.getContentType() shouldBe ContentTypes.`application/octet-stream`
+                sha256(resp.entity.dataBytes) shouldBe Success(packageId)
+              }
+          }
+        }: Future[Assertion]
+    }
+
+    "packages upload endpoint" in withHttpServiceAndClient() { (uri, _, _, _) =>
+      val newDar = AbstractHttpServiceIntegrationTestFuns.dar3
+
+      getAllPackageIds(uri).flatMap { okResp =>
+        val existingPackageIds: Set[String] = okResp.result.toSet
+        Http()
+          .singleRequest(
+            HttpRequest(
+              method = HttpMethods.POST,
+              uri = uri.withPath(Uri.Path("/v1/packages")),
+              headers = authorizationHeader(jwtAdminNoParty),
+              entity = HttpEntity.fromFile(ContentTypes.`application/octet-stream`, newDar),
+            )
+          )
+          .flatMap { resp =>
+            resp.status shouldBe StatusCodes.OK
+            getAllPackageIds(uri).map { okResp =>
+              val newPackageIds: Set[String] = okResp.result.toSet -- existingPackageIds
+              newPackageIds.size should be > 0
+            }
+          }
+      }: Future[Assertion]
+    }
+
+    "archiving a large number of contracts should succeed" in withHttpServiceAndClient(
+      StartSettings.DefaultMaxInboundMessageSize * 10
+    ) { (uri, encoder, _, _) =>
+      val numContracts: Long = 10000
+      val helperId = domain.TemplateId(None, "Account", "Helper")
+      val payload = v.Record(
+        fields = List(v.RecordField("owner", Some(v.Value(v.Value.Sum.Party("Alice")))))
+      )
+      val createCmd: domain.CreateAndExerciseCommand[v.Record, v.Value, OptionalPkg] =
+        domain.CreateAndExerciseCommand(
+          templateId = helperId,
+          payload = payload,
+          choice = lar.Choice("CreateN"),
+          argument = boxedRecord(
+            v.Record(fields =
+              List(v.RecordField("n", Some(v.Value(v.Value.Sum.Int64(numContracts)))))
+            )
+          ),
+          meta = None,
+        )
+
+      def encode(cmd: domain.CreateAndExerciseCommand[v.Record, v.Value, OptionalPkg]): JsValue =
+        encoder.encodeCreateAndExerciseCommand(cmd).valueOr(e => fail(e.shows))
+
+      def archiveCmd(cids: List[String]) =
+        domain.CreateAndExerciseCommand(
+          templateId = helperId,
+          payload = payload,
+          choice = lar.Choice("ArchiveAll"),
+          argument = boxedRecord(
+            v.Record(fields =
+              List(
+                v.RecordField(
+                  "cids",
+                  Some(
+                    v.Value(
+                      v.Value.Sum
+                        .List(v.List(cids.map(cid => v.Value(v.Value.Sum.ContractId(cid)))))
+                    )
+                  ),
+                )
+              )
+            )
+          ),
+          meta = None,
+        )
+
+      def queryN(n: Long): Future[Assertion] = postJsonRequest(
+        uri.withPath(Uri.Path("/v1/query")),
+        jsObject("""{"templateIds": ["Account:Account"]}"""),
+      ).flatMap { case (status, output) =>
         status shouldBe StatusCodes.OK
         assertStatus(output, StatusCodes.OK)
-      }
-      created = getChild(getResult(output), "exerciseResult").convertTo[List[String]]
-      _ = created should have length numContracts
-
-      _ <- queryN(numContracts)
-
-      status <- postJsonRequest(
-        uri.withPath(Uri.Path("/v1/create-and-exercise")),
-        encode(archiveCmd(created)),
-      ).map(_._1)
-      _ = {
-        status shouldBe StatusCodes.OK
-        assertStatus(output, StatusCodes.OK)
+        inside(getResult(output)) { case JsArray(result) =>
+          result should have length n
+        }
       }
 
-      _ <- queryN(0)
-    } yield succeed
+      for {
+        resp <- postJsonRequest(
+          uri.withPath(Uri.Path("/v1/create-and-exercise")),
+          encode(createCmd),
+        )
+        (status, output) = resp
+        _ = {
+          status shouldBe StatusCodes.OK
+          assertStatus(output, StatusCodes.OK)
+        }
+        created = getChild(getResult(output), "exerciseResult").convertTo[List[String]]
+        _ = created should have length numContracts
+
+        _ <- queryN(numContracts)
+
+        status <- postJsonRequest(
+          uri.withPath(Uri.Path("/v1/create-and-exercise")),
+          encode(archiveCmd(created)),
+        ).map(_._1)
+        _ = {
+          status shouldBe StatusCodes.OK
+          assertStatus(output, StatusCodes.OK)
+        }
+
+        _ <- queryN(0)
+      } yield succeed
+    }
   }
 }

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -59,281 +59,462 @@ abstract class AbstractWebsocketServiceIntegrationTest
     case _ => throw new IllegalArgumentException(s"Expected heartbeat but got $event")
   }
 
-  List(
-    SimpleScenario("query", Uri.Path("/v1/stream/query"), baseQueryInput),
-    SimpleScenario("fetch", Uri.Path("/v1/stream/fetch"), baseFetchInput),
-  ).foreach { scenario =>
-    s"${scenario.id} request with valid protocol token should allow client subscribe to stream" in withHttpService {
-      (uri, _, _) =>
-        wsConnectRequest(
-          uri.copy(scheme = "ws").withPath(scenario.path),
-          validSubprotocol(jwt),
-          scenario.input,
-        )._1 flatMap (x => x.response.status shouldBe StatusCodes.SwitchingProtocols)
-    }
+  protected def websocketServiceIntegrationTests(jdbcConfig: => Option[JdbcConfig]) = {
+    def withHttpService = this.withHttpService[Assertion](jdbcConfig)(_)
 
-    s"${scenario.id} request with invalid protocol token should be denied" in withHttpService {
-      (uri, _, _) =>
-        wsConnectRequest(
-          uri.copy(scheme = "ws").withPath(scenario.path),
-          Option("foo"),
-          scenario.input,
-        )._1 flatMap (x => x.response.status shouldBe StatusCodes.Unauthorized)
-    }
+    List(
+      SimpleScenario("query", Uri.Path("/v1/stream/query"), baseQueryInput),
+      SimpleScenario("fetch", Uri.Path("/v1/stream/fetch"), baseFetchInput),
+    ).foreach { scenario =>
+      s"${scenario.id} request with valid protocol token should allow client subscribe to stream" in withHttpService {
+        (uri, _, _) =>
+          wsConnectRequest(
+            uri.copy(scheme = "ws").withPath(scenario.path),
+            validSubprotocol(jwt),
+            scenario.input,
+          )._1 flatMap (x => x.response.status shouldBe StatusCodes.SwitchingProtocols)
+      }
 
-    s"${scenario.id} request without protocol token should be denied" in withHttpService {
-      (uri, _, _) =>
-        wsConnectRequest(
-          uri.copy(scheme = "ws").withPath(scenario.path),
-          None,
-          scenario.input,
-        )._1 flatMap (x => x.response.status shouldBe StatusCodes.Unauthorized)
-    }
+      s"${scenario.id} request with invalid protocol token should be denied" in withHttpService {
+        (uri, _, _) =>
+          wsConnectRequest(
+            uri.copy(scheme = "ws").withPath(scenario.path),
+            Option("foo"),
+            scenario.input,
+          )._1 flatMap (x => x.response.status shouldBe StatusCodes.Unauthorized)
+      }
 
-    s"two ${scenario.id} requests over the same WebSocket connection are NOT allowed" in withHttpService {
-      (uri, _, _) =>
-        val input = scenario.input.mapConcat(x => List(x, x))
-        val webSocketFlow =
-          Http().webSocketClientFlow(
-            WebSocketRequest(
-              uri = uri.copy(scheme = "ws").withPath(scenario.path),
-              subprotocol = validSubprotocol(jwt),
-            )
-          )
-        input
-          .via(webSocketFlow)
-          .runWith(collectResultsAsTextMessageSkipOffsetTicks)
-          .flatMap { msgs =>
-            inside(msgs) { case Seq(errorMsg) =>
-              val error = decodeErrorResponse(errorMsg)
-              error shouldBe domain.ErrorResponse(
-                List("Multiple requests over the same WebSocket connection are not allowed."),
-                None,
-                StatusCodes.BadRequest,
+      s"${scenario.id} request without protocol token should be denied" in withHttpService {
+        (uri, _, _) =>
+          wsConnectRequest(
+            uri.copy(scheme = "ws").withPath(scenario.path),
+            None,
+            scenario.input,
+          )._1 flatMap (x => x.response.status shouldBe StatusCodes.Unauthorized)
+      }
+
+      s"two ${scenario.id} requests over the same WebSocket connection are NOT allowed" in withHttpService {
+        (uri, _, _) =>
+          val input = scenario.input.mapConcat(x => List(x, x))
+          val webSocketFlow =
+            Http().webSocketClientFlow(
+              WebSocketRequest(
+                uri = uri.copy(scheme = "ws").withPath(scenario.path),
+                subprotocol = validSubprotocol(jwt),
               )
-            }
-          }
-    }
-  }
-
-  List(
-    SimpleScenario(
-      "query",
-      Uri.Path("/v1/stream/query"),
-      Source.single(TextMessage.Strict("""{"templateIds": ["AA:BB"]}""")),
-    ),
-    SimpleScenario(
-      "fetch",
-      Uri.Path("/v1/stream/fetch"),
-      Source.single(TextMessage.Strict("""[{"templateId": "AA:BB", "key": ["k", "v"]}]""")),
-    ),
-  ).foreach { scenario =>
-    s"${scenario.id} report UnknownTemplateIds and error when cannot resolve any template ID" in withHttpService {
-      (uri, _, _) =>
-        val webSocketFlow =
-          Http().webSocketClientFlow(
-            WebSocketRequest(
-              uri = uri.copy(scheme = "ws").withPath(scenario.path),
-              subprotocol = validSubprotocol(jwt),
             )
-          )
-        scenario.input
-          .via(webSocketFlow)
-          .runWith(collectResultsAsTextMessageSkipOffsetTicks)
-          .flatMap { msgs =>
-            inside(msgs) { case Seq(warningMsg, errorMsg) =>
-              val warning = decodeServiceWarning(warningMsg)
-              inside(warning) { case domain.UnknownTemplateIds(ids) =>
-                ids shouldBe List(domain.TemplateId(None, "AA", "BB"))
+          input
+            .via(webSocketFlow)
+            .runWith(collectResultsAsTextMessageSkipOffsetTicks)
+            .flatMap { msgs =>
+              inside(msgs) { case Seq(errorMsg) =>
+                val error = decodeErrorResponse(errorMsg)
+                error shouldBe domain.ErrorResponse(
+                  List("Multiple requests over the same WebSocket connection are not allowed."),
+                  None,
+                  StatusCodes.BadRequest,
+                )
               }
-              val error = decodeErrorResponse(errorMsg)
-              error shouldBe domain.ErrorResponse(
-                List(ErrorMessages.cannotResolveAnyTemplateId),
-                None,
-                StatusCodes.BadRequest,
-              )
             }
-          }
+      }
     }
-  }
 
-  "query endpoint should publish transactions when command create is completed" in withHttpService {
-    (uri, _, _) =>
+    List(
+      SimpleScenario(
+        "query",
+        Uri.Path("/v1/stream/query"),
+        Source.single(TextMessage.Strict("""{"templateIds": ["AA:BB"]}""")),
+      ),
+      SimpleScenario(
+        "fetch",
+        Uri.Path("/v1/stream/fetch"),
+        Source.single(TextMessage.Strict("""[{"templateId": "AA:BB", "key": ["k", "v"]}]""")),
+      ),
+    ).foreach { scenario =>
+      s"${scenario.id} report UnknownTemplateIds and error when cannot resolve any template ID" in withHttpService {
+        (uri, _, _) =>
+          val webSocketFlow =
+            Http().webSocketClientFlow(
+              WebSocketRequest(
+                uri = uri.copy(scheme = "ws").withPath(scenario.path),
+                subprotocol = validSubprotocol(jwt),
+              )
+            )
+          scenario.input
+            .via(webSocketFlow)
+            .runWith(collectResultsAsTextMessageSkipOffsetTicks)
+            .flatMap { msgs =>
+              inside(msgs) { case Seq(warningMsg, errorMsg) =>
+                val warning = decodeServiceWarning(warningMsg)
+                inside(warning) { case domain.UnknownTemplateIds(ids) =>
+                  ids shouldBe List(domain.TemplateId(None, "AA", "BB"))
+                }
+                val error = decodeErrorResponse(errorMsg)
+                error shouldBe domain.ErrorResponse(
+                  List(ErrorMessages.cannotResolveAnyTemplateId),
+                  None,
+                  StatusCodes.BadRequest,
+                )
+              }
+            }
+      }
+    }
+
+    "query endpoint should publish transactions when command create is completed" in withHttpService {
+      (uri, _, _) =>
+        for {
+          _ <- initialIouCreate(uri)
+
+          clientMsg <- singleClientQueryStream(
+            jwt,
+            uri,
+            """{"templateIds": ["Iou:Iou"]}""",
+          ).take(2)
+            .runWith(collectResultsAsTextMessage)
+        } yield inside(clientMsg) { case result +: heartbeats =>
+          result should include(""""issuer":"Alice"""")
+          result should include(""""amount":"999.99"""")
+          Inspectors.forAll(heartbeats)(assertHeartbeat)
+        }
+    }
+
+    "fetch endpoint should publish transactions when command create is completed" in withHttpService {
+      (uri, encoder, _) =>
+        for {
+          _ <- initialAccountCreate(uri, encoder)
+
+          clientMsg <- singleClientFetchStream(jwt, uri, fetchRequest)
+            .take(2)
+            .runWith(collectResultsAsTextMessage)
+        } yield inside(clientMsg) { case result +: heartbeats =>
+          result should include(""""owner":"Alice"""")
+          result should include(""""number":"abc123"""")
+          result should not include (""""offset":"""")
+          Inspectors.forAll(heartbeats)(assertHeartbeat)
+        }
+    }
+
+    "query endpoint should warn on unknown template IDs" in withHttpService { (uri, _, _) =>
       for {
         _ <- initialIouCreate(uri)
 
         clientMsg <- singleClientQueryStream(
           jwt,
           uri,
-          """{"templateIds": ["Iou:Iou"]}""",
-        ).take(2)
+          """{"templateIds": ["Iou:Iou", "Unknown:Template"]}""",
+        ).take(3)
           .runWith(collectResultsAsTextMessage)
-      } yield inside(clientMsg) { case result +: heartbeats =>
-        result should include(""""issuer":"Alice"""")
-        result should include(""""amount":"999.99"""")
+      } yield inside(clientMsg) { case warning +: result +: heartbeats =>
+        warning should include("\"warnings\":{\"unknownTemplateIds\":[\"Unk")
+        result should include("\"issuer\":\"Alice\"")
         Inspectors.forAll(heartbeats)(assertHeartbeat)
       }
-  }
+    }
 
-  "fetch endpoint should publish transactions when command create is completed" in withHttpService {
-    (uri, encoder, _) =>
+    "fetch endpoint should warn on unknown template IDs" in withHttpService { (uri, encoder, _) =>
       for {
         _ <- initialAccountCreate(uri, encoder)
 
-        clientMsg <- singleClientFetchStream(jwt, uri, fetchRequest)
-          .take(2)
+        clientMsg <- singleClientFetchStream(
+          jwt,
+          uri,
+          """[{"templateId": "Account:Account", "key": ["Alice", "abc123"]}, {"templateId": "Unknown:Template", "key": ["Alice", "abc123"]}]""",
+        ).take(3)
           .runWith(collectResultsAsTextMessage)
-      } yield inside(clientMsg) { case result +: heartbeats =>
+      } yield inside(clientMsg) { case warning +: result +: heartbeats =>
+        warning should include("""{"warnings":{"unknownTemplateIds":["Unk""")
         result should include(""""owner":"Alice"""")
         result should include(""""number":"abc123"""")
-        result should not include (""""offset":"""")
         Inspectors.forAll(heartbeats)(assertHeartbeat)
       }
-  }
-
-  "query endpoint should warn on unknown template IDs" in withHttpService { (uri, _, _) =>
-    for {
-      _ <- initialIouCreate(uri)
-
-      clientMsg <- singleClientQueryStream(
-        jwt,
-        uri,
-        """{"templateIds": ["Iou:Iou", "Unknown:Template"]}""",
-      ).take(3)
-        .runWith(collectResultsAsTextMessage)
-    } yield inside(clientMsg) { case warning +: result +: heartbeats =>
-      warning should include("\"warnings\":{\"unknownTemplateIds\":[\"Unk")
-      result should include("\"issuer\":\"Alice\"")
-      Inspectors.forAll(heartbeats)(assertHeartbeat)
     }
-  }
 
-  "fetch endpoint should warn on unknown template IDs" in withHttpService { (uri, encoder, _) =>
-    for {
-      _ <- initialAccountCreate(uri, encoder)
+    "query endpoint should send error msg when receiving malformed message" in withHttpService {
+      (uri, _, _) =>
+        val clientMsg = singleClientQueryStream(jwt, uri, "{}")
+          .runWith(collectResultsAsTextMessageSkipOffsetTicks)
 
-      clientMsg <- singleClientFetchStream(
-        jwt,
-        uri,
-        """[{"templateId": "Account:Account", "key": ["Alice", "abc123"]}, {"templateId": "Unknown:Template", "key": ["Alice", "abc123"]}]""",
-      ).take(3)
-        .runWith(collectResultsAsTextMessage)
-    } yield inside(clientMsg) { case warning +: result +: heartbeats =>
-      warning should include("""{"warnings":{"unknownTemplateIds":["Unk""")
-      result should include(""""owner":"Alice"""")
-      result should include(""""number":"abc123"""")
-      Inspectors.forAll(heartbeats)(assertHeartbeat)
+        val result = Await.result(clientMsg, 10.seconds)
+
+        result should have size 1
+        val errorResponse = decodeErrorResponse(result.head)
+        errorResponse.status shouldBe StatusCodes.BadRequest
+        errorResponse.errors should have size 1
     }
-  }
 
-  "query endpoint should send error msg when receiving malformed message" in withHttpService {
-    (uri, _, _) =>
-      val clientMsg = singleClientQueryStream(jwt, uri, "{}")
-        .runWith(collectResultsAsTextMessageSkipOffsetTicks)
+    "fetch endpoint should send error msg when receiving malformed message" in withHttpService {
+      (uri, _, _) =>
+        val clientMsg = singleClientFetchStream(jwt, uri, """[abcdefg!]""")
+          .runWith(collectResultsAsTextMessageSkipOffsetTicks)
 
-      val result = Await.result(clientMsg, 10.seconds)
+        val result = Await.result(clientMsg, 10.seconds)
 
-      result should have size 1
-      val errorResponse = decodeErrorResponse(result.head)
-      errorResponse.status shouldBe StatusCodes.BadRequest
-      errorResponse.errors should have size 1
-  }
+        result should have size 1
+        val errorResponse = decodeErrorResponse(result.head)
+        errorResponse.status shouldBe StatusCodes.BadRequest
+        errorResponse.errors should have size 1
+    }
 
-  "fetch endpoint should send error msg when receiving malformed message" in withHttpService {
-    (uri, _, _) =>
-      val clientMsg = singleClientFetchStream(jwt, uri, """[abcdefg!]""")
-        .runWith(collectResultsAsTextMessageSkipOffsetTicks)
+    "query should receive deltas as contracts are archived/created" in withHttpService {
+      (uri, _, _) =>
+        import spray.json._
 
-      val result = Await.result(clientMsg, 10.seconds)
+        val initialCreate = initialIouCreate(uri)
 
-      result should have size 1
-      val errorResponse = decodeErrorResponse(result.head)
-      errorResponse.status shouldBe StatusCodes.BadRequest
-      errorResponse.errors should have size 1
-  }
-
-  private def exercisePayload(cid: domain.ContractId, amount: BigDecimal = BigDecimal("42.42")) = {
-    import json.JsonProtocol._
-    import spray.json._
-    Map(
-      "templateId" -> "Iou:Iou".toJson,
-      "contractId" -> cid.toJson,
-      "choice" -> "Iou_Split".toJson,
-      "argument" -> Map("splitAmount" -> amount).toJson,
-    ).toJson
-  }
-
-  "query should receive deltas as contracts are archived/created" in withHttpService {
-    (uri, _, _) =>
-      import spray.json._
-
-      val initialCreate = initialIouCreate(uri)
-
-      val query =
-        """[
+        val query =
+          """[
           {"templateIds": ["Iou:Iou"], "query": {"amount": {"%lte": 50}}},
           {"templateIds": ["Iou:Iou"], "query": {"amount": {"%gt": 50}}},
           {"templateIds": ["Iou:Iou"]}
         ]"""
 
-      @nowarn("msg=pattern var evtsWrapper .* is never used")
-      def resp(
-          iouCid: domain.ContractId,
-          kill: UniqueKillSwitch,
-      ): Sink[JsValue, Future[ShouldHaveEnded]] = {
-        val dslSyntax = Consume.syntax[JsValue]
-        import dslSyntax._
-        Consume
-          .interpret(
-            for {
-              ContractDelta(Vector((ctid, _)), Vector(), None) <- readOne
-              _ = (ctid: String) shouldBe (iouCid.unwrap: String)
-              _ <- liftF(
-                postJsonRequest(
-                  uri.withPath(Uri.Path("/v1/exercise")),
-                  exercisePayload(domain.ContractId(ctid)),
-                  headersWithAuth,
-                ) map { case (statusCode, _) =>
-                  statusCode.isSuccess shouldBe true
+        @nowarn("msg=pattern var evtsWrapper .* is never used")
+        def resp(
+            iouCid: domain.ContractId,
+            kill: UniqueKillSwitch,
+        ): Sink[JsValue, Future[ShouldHaveEnded]] = {
+          val dslSyntax = Consume.syntax[JsValue]
+          import dslSyntax._
+          Consume
+            .interpret(
+              for {
+                ContractDelta(Vector((ctid, _)), Vector(), None) <- readOne
+                _ = (ctid: String) shouldBe (iouCid.unwrap: String)
+                _ <- liftF(
+                  postJsonRequest(
+                    uri.withPath(Uri.Path("/v1/exercise")),
+                    exercisePayload(domain.ContractId(ctid)),
+                    headersWithAuth,
+                  ) map { case (statusCode, _) =>
+                    statusCode.isSuccess shouldBe true
+                  }
+                )
+
+                ContractDelta(Vector(), _, Some(offset)) <- readOne
+
+                (preOffset, consumedCtid) = (offset, ctid)
+                evtsWrapper @ ContractDelta(
+                  Vector((fstId, fst), (sndId, snd)),
+                  Vector(observeConsumed),
+                  Some(lastSeenOffset),
+                ) <- readOne
+                (liveStartOffset, msgCount) = {
+                  observeConsumed.contractId should ===(consumedCtid)
+                  Set(fstId, sndId, consumedCtid) should have size 3
+                  inside(evtsWrapper) { case JsObject(obj) =>
+                    inside(obj get "events") {
+                      case Some(
+                            JsArray(
+                              Vector(
+                                Archived(_, _),
+                                Created(IouAmount(amt1), MatchedQueries(NumList(ixes1), _)),
+                                Created(IouAmount(amt2), MatchedQueries(NumList(ixes2), _)),
+                              )
+                            )
+                          ) =>
+                        Set((amt1, ixes1), (amt2, ixes2)) should ===(
+                          Set(
+                            (BigDecimal("42.42"), Vector(BigDecimal(0), BigDecimal(2))),
+                            (BigDecimal("957.57"), Vector(BigDecimal(1), BigDecimal(2))),
+                          )
+                        )
+                    }
+                  }
+                  (preOffset, 2)
                 }
+
+                _ = kill.shutdown()
+                heartbeats <- drain
+                hbCount = (heartbeats.iterator.map(heartbeatOffset).toSet + lastSeenOffset).size - 1
+              } yield
+              // don't count empty events block if lastSeenOffset does not change
+              ShouldHaveEnded(
+                liveStartOffset = liveStartOffset,
+                msgCount = msgCount + hbCount,
+                lastSeenOffset = lastSeenOffset,
               )
+            )
+        }
+
+        for {
+          creation <- initialCreate
+          _ = creation._1 shouldBe a[StatusCodes.Success]
+          iouCid = getContractId(getResult(creation._2))
+          (kill, source) = singleClientQueryStream(jwt, uri, query)
+            .viaMat(KillSwitches.single)(Keep.right)
+            .preMaterialize()
+          lastState <- source via parseResp runWith resp(iouCid, kill)
+          liveOffset = inside(lastState) { case ShouldHaveEnded(liveStart, 2, lastSeen) =>
+            lastSeen.unwrap should be > liveStart.unwrap
+            liveStart
+          }
+          rescan <- (singleClientQueryStream(jwt, uri, query, Some(liveOffset))
+            via parseResp).take(1) runWith remainingDeltas
+        } yield inside(rescan) {
+          case (Vector((fstId, fst @ _), (sndId, snd @ _)), Vector(observeConsumed), Some(_)) =>
+            Set(fstId, sndId, observeConsumed.contractId) should have size 3
+        }
+    }
+
+    "multi-party query should receive deltas as contracts are archived/created" in withHttpService {
+      (uri, encoder, _) =>
+        import spray.json._
+
+        val f1 =
+          postCreateCommand(
+            accountCreateCommand(domain.Party("Alice"), "abc123"),
+            encoder,
+            uri,
+            headers = headersWithPartyAuth(List("Alice")),
+          )
+        val f2 =
+          postCreateCommand(
+            accountCreateCommand(domain.Party("Bob"), "def456"),
+            encoder,
+            uri,
+            headers = headersWithPartyAuth(List("Bob")),
+          )
+
+        val query =
+          """[
+          {"templateIds": ["Account:Account"]}
+        ]"""
+
+        def resp(
+            cid1: domain.ContractId,
+            cid2: domain.ContractId,
+            kill: UniqueKillSwitch,
+        ): Sink[JsValue, Future[ShouldHaveEnded]] = {
+          val dslSyntax = Consume.syntax[JsValue]
+          import dslSyntax._
+          Consume.interpret(
+            for {
+              Vector((account1, _), (account2, _)) <- readAcsN(2)
+              _ = Seq(account1, account2) should contain theSameElementsAs Seq(cid1, cid2)
+              ContractDelta(Vector(), _, Some(liveStartOffset)) <- readOne
+              _ <- liftF(
+                postCreateCommand(
+                  accountCreateCommand(domain.Party("Alice"), "abc234"),
+                  encoder,
+                  uri,
+                  headers = headersWithPartyAuth(List("Alice")),
+                )
+              )
+              ContractDelta(Vector((_, aliceAccount)), _, Some(_)) <- readOne
+              _ = inside(aliceAccount) { case JsObject(obj) =>
+                inside((obj get "owner", obj get "number")) {
+                  case (Some(JsString(owner)), Some(JsString(number))) =>
+                    owner shouldBe "Alice"
+                    number shouldBe "abc234"
+                }
+              }
+              _ <- liftF(
+                postCreateCommand(
+                  accountCreateCommand(domain.Party("Bob"), "def567"),
+                  encoder,
+                  uri,
+                  headers = headersWithPartyAuth(List("Bob")),
+                )
+              )
+              ContractDelta(Vector((_, bobAccount)), _, Some(lastSeenOffset)) <- readOne
+              _ = inside(bobAccount) { case JsObject(obj) =>
+                inside((obj get "owner", obj get "number")) {
+                  case (Some(JsString(owner)), Some(JsString(number))) =>
+                    owner shouldBe "Bob"
+                    number shouldBe "def567"
+                }
+              }
+              _ = kill.shutdown()
+              heartbeats <- drain
+              hbCount = (heartbeats.iterator.map(heartbeatOffset).toSet + lastSeenOffset).size - 1
+            } yield (
+              // don't count empty events block if lastSeenOffset does not change
+              ShouldHaveEnded(
+                liveStartOffset = liveStartOffset,
+                msgCount = 5 + hbCount,
+                lastSeenOffset = lastSeenOffset,
+              ),
+            )
+          )
+        }
+
+        for {
+          r1 <- f1
+          _ = r1._1 shouldBe a[StatusCodes.Success]
+          cid1 = getContractId(getResult(r1._2))
+
+          r2 <- f2
+          _ = r2._1 shouldBe a[StatusCodes.Success]
+          cid2 = getContractId(getResult(r2._2))
+
+          (kill, source) = singleClientQueryStream(
+            jwtForParties(List("Alice", "Bob"), List(), testId),
+            uri,
+            query,
+          ).viaMat(KillSwitches.single)(Keep.right).preMaterialize()
+          lastState <- source via parseResp runWith resp(cid1, cid2, kill)
+          liveOffset = inside(lastState) { case ShouldHaveEnded(liveStart, 5, lastSeen) =>
+            lastSeen.unwrap should be > liveStart.unwrap
+            liveStart
+          }
+          rescan <- (singleClientQueryStream(jwt, uri, query, Some(liveOffset))
+            via parseResp).take(1) runWith remainingDeltas
+        } yield inside(rescan) { case (Vector(_), _, Some(_)) =>
+          succeed
+        }
+    }
+
+    "fetch should receive deltas as contracts are archived/created, filtering out phantom archives" in withHttpService {
+      (uri, encoder, _) =>
+        val templateId = domain.TemplateId(None, "Account", "Account")
+        def fetchRequest(contractIdAtOffset: Option[Option[domain.ContractId]] = None) = {
+          import spray.json._, json.JsonProtocol._
+          List(
+            Map("templateId" -> "Account:Account".toJson, "key" -> List("Alice", "abc123").toJson)
+              ++ contractIdAtOffset
+                .map(ocid => contractIdAtOffsetKey -> ocid.toJson)
+                .toList
+          ).toJson.compactPrint
+        }
+        val f1 =
+          postCreateCommand(accountCreateCommand(domain.Party("Alice"), "abc123"), encoder, uri)
+        val f2 =
+          postCreateCommand(accountCreateCommand(domain.Party("Alice"), "def456"), encoder, uri)
+
+        def resp(
+            cid1: domain.ContractId,
+            cid2: domain.ContractId,
+            kill: UniqueKillSwitch,
+        ): Sink[JsValue, Future[ShouldHaveEnded]] = {
+          val dslSyntax = Consume.syntax[JsValue]
+          import dslSyntax._
+          Consume.interpret(
+            for {
+              ContractDelta(Vector((cid, c)), Vector(), None) <- readOne
+              _ = (cid: String) shouldBe (cid1.unwrap: String)
+              ctid <- liftF(postArchiveCommand(templateId, cid2, encoder, uri).flatMap {
+                case (statusCode, _) =>
+                  statusCode.isSuccess shouldBe true
+                  postArchiveCommand(templateId, cid1, encoder, uri).map { case (statusCode, _) =>
+                    statusCode.isSuccess shouldBe true
+                    cid
+                  }
+              })
 
               ContractDelta(Vector(), _, Some(offset)) <- readOne
+              (off, archivedCid) = (offset, ctid)
 
-              (preOffset, consumedCtid) = (offset, ctid)
-              evtsWrapper @ ContractDelta(
-                Vector((fstId, fst), (sndId, snd)),
-                Vector(observeConsumed),
-                Some(lastSeenOffset),
-              ) <- readOne
+              ContractDelta(Vector(), Vector(observeArchivedCid), Some(lastSeenOffset)) <- readOne
               (liveStartOffset, msgCount) = {
-                observeConsumed.contractId should ===(consumedCtid)
-                Set(fstId, sndId, consumedCtid) should have size 3
-                inside(evtsWrapper) { case JsObject(obj) =>
-                  inside(obj get "events") {
-                    case Some(
-                          JsArray(
-                            Vector(
-                              Archived(_, _),
-                              Created(IouAmount(amt1), MatchedQueries(NumList(ixes1), _)),
-                              Created(IouAmount(amt2), MatchedQueries(NumList(ixes2), _)),
-                            )
-                          )
-                        ) =>
-                      Set((amt1, ixes1), (amt2, ixes2)) should ===(
-                        Set(
-                          (BigDecimal("42.42"), Vector(BigDecimal(0), BigDecimal(2))),
-                          (BigDecimal("957.57"), Vector(BigDecimal(1), BigDecimal(2))),
-                        )
-                      )
-                  }
-                }
-                (preOffset, 2)
+                (observeArchivedCid.contractId.unwrap: String) shouldBe (archivedCid: String)
+                (observeArchivedCid.contractId: domain.ContractId) shouldBe (cid1: domain.ContractId)
+                (off, 0)
               }
 
               _ = kill.shutdown()
               heartbeats <- drain
               hbCount = (heartbeats.iterator.map(heartbeatOffset).toSet + lastSeenOffset).size - 1
+
             } yield
             // don't count empty events block if lastSeenOffset does not change
             ShouldHaveEnded(
@@ -342,392 +523,510 @@ abstract class AbstractWebsocketServiceIntegrationTest
               lastSeenOffset = lastSeenOffset,
             )
           )
-      }
-
-      for {
-        creation <- initialCreate
-        _ = creation._1 shouldBe a[StatusCodes.Success]
-        iouCid = getContractId(getResult(creation._2))
-        (kill, source) = singleClientQueryStream(jwt, uri, query)
-          .viaMat(KillSwitches.single)(Keep.right)
-          .preMaterialize()
-        lastState <- source via parseResp runWith resp(iouCid, kill)
-        liveOffset = inside(lastState) { case ShouldHaveEnded(liveStart, 2, lastSeen) =>
-          lastSeen.unwrap should be > liveStart.unwrap
-          liveStart
-        }
-        rescan <- (singleClientQueryStream(jwt, uri, query, Some(liveOffset))
-          via parseResp).take(1) runWith remainingDeltas
-      } yield inside(rescan) {
-        case (Vector((fstId, fst @ _), (sndId, snd @ _)), Vector(observeConsumed), Some(_)) =>
-          Set(fstId, sndId, observeConsumed.contractId) should have size 3
-      }
-  }
-
-  "multi-party query should receive deltas as contracts are archived/created" in withHttpService {
-    (uri, encoder, _) =>
-      import spray.json._
-
-      val f1 =
-        postCreateCommand(
-          accountCreateCommand(domain.Party("Alice"), "abc123"),
-          encoder,
-          uri,
-          headers = headersWithPartyAuth(List("Alice")),
-        )
-      val f2 =
-        postCreateCommand(
-          accountCreateCommand(domain.Party("Bob"), "def456"),
-          encoder,
-          uri,
-          headers = headersWithPartyAuth(List("Bob")),
-        )
-
-      val query =
-        """[
-          {"templateIds": ["Account:Account"]}
-        ]"""
-
-      def resp(
-          cid1: domain.ContractId,
-          cid2: domain.ContractId,
-          kill: UniqueKillSwitch,
-      ): Sink[JsValue, Future[ShouldHaveEnded]] = {
-        val dslSyntax = Consume.syntax[JsValue]
-        import dslSyntax._
-        Consume.interpret(
-          for {
-            Vector((account1, _), (account2, _)) <- readAcsN(2)
-            _ = Seq(account1, account2) should contain theSameElementsAs Seq(cid1, cid2)
-            ContractDelta(Vector(), _, Some(liveStartOffset)) <- readOne
-            _ <- liftF(
-              postCreateCommand(
-                accountCreateCommand(domain.Party("Alice"), "abc234"),
-                encoder,
-                uri,
-                headers = headersWithPartyAuth(List("Alice")),
-              )
-            )
-            ContractDelta(Vector((_, aliceAccount)), _, Some(_)) <- readOne
-            _ = inside(aliceAccount) { case JsObject(obj) =>
-              inside((obj get "owner", obj get "number")) {
-                case (Some(JsString(owner)), Some(JsString(number))) =>
-                  owner shouldBe "Alice"
-                  number shouldBe "abc234"
-              }
-            }
-            _ <- liftF(
-              postCreateCommand(
-                accountCreateCommand(domain.Party("Bob"), "def567"),
-                encoder,
-                uri,
-                headers = headersWithPartyAuth(List("Bob")),
-              )
-            )
-            ContractDelta(Vector((_, bobAccount)), _, Some(lastSeenOffset)) <- readOne
-            _ = inside(bobAccount) { case JsObject(obj) =>
-              inside((obj get "owner", obj get "number")) {
-                case (Some(JsString(owner)), Some(JsString(number))) =>
-                  owner shouldBe "Bob"
-                  number shouldBe "def567"
-              }
-            }
-            _ = kill.shutdown()
-            heartbeats <- drain
-            hbCount = (heartbeats.iterator.map(heartbeatOffset).toSet + lastSeenOffset).size - 1
-          } yield (
-            // don't count empty events block if lastSeenOffset does not change
-            ShouldHaveEnded(
-              liveStartOffset = liveStartOffset,
-              msgCount = 5 + hbCount,
-              lastSeenOffset = lastSeenOffset,
-            ),
-          )
-        )
-      }
-
-      for {
-        r1 <- f1
-        _ = r1._1 shouldBe a[StatusCodes.Success]
-        cid1 = getContractId(getResult(r1._2))
-
-        r2 <- f2
-        _ = r2._1 shouldBe a[StatusCodes.Success]
-        cid2 = getContractId(getResult(r2._2))
-
-        (kill, source) = singleClientQueryStream(
-          jwtForParties(List("Alice", "Bob"), List(), testId),
-          uri,
-          query,
-        ).viaMat(KillSwitches.single)(Keep.right).preMaterialize()
-        lastState <- source via parseResp runWith resp(cid1, cid2, kill)
-        liveOffset = inside(lastState) { case ShouldHaveEnded(liveStart, 5, lastSeen) =>
-          lastSeen.unwrap should be > liveStart.unwrap
-          liveStart
-        }
-        rescan <- (singleClientQueryStream(jwt, uri, query, Some(liveOffset))
-          via parseResp).take(1) runWith remainingDeltas
-      } yield inside(rescan) { case (Vector(_), _, Some(_)) =>
-        succeed
-      }
-  }
-
-  "fetch should receive deltas as contracts are archived/created, filtering out phantom archives" in withHttpService {
-    (uri, encoder, _) =>
-      val templateId = domain.TemplateId(None, "Account", "Account")
-      def fetchRequest(contractIdAtOffset: Option[Option[domain.ContractId]] = None) = {
-        import spray.json._, json.JsonProtocol._
-        List(
-          Map("templateId" -> "Account:Account".toJson, "key" -> List("Alice", "abc123").toJson)
-            ++ contractIdAtOffset
-              .map(ocid => contractIdAtOffsetKey -> ocid.toJson)
-              .toList
-        ).toJson.compactPrint
-      }
-      val f1 =
-        postCreateCommand(accountCreateCommand(domain.Party("Alice"), "abc123"), encoder, uri)
-      val f2 =
-        postCreateCommand(accountCreateCommand(domain.Party("Alice"), "def456"), encoder, uri)
-
-      def resp(
-          cid1: domain.ContractId,
-          cid2: domain.ContractId,
-          kill: UniqueKillSwitch,
-      ): Sink[JsValue, Future[ShouldHaveEnded]] = {
-        val dslSyntax = Consume.syntax[JsValue]
-        import dslSyntax._
-        Consume.interpret(
-          for {
-            ContractDelta(Vector((cid, c)), Vector(), None) <- readOne
-            _ = (cid: String) shouldBe (cid1.unwrap: String)
-            ctid <- liftF(postArchiveCommand(templateId, cid2, encoder, uri).flatMap {
-              case (statusCode, _) =>
-                statusCode.isSuccess shouldBe true
-                postArchiveCommand(templateId, cid1, encoder, uri).map { case (statusCode, _) =>
-                  statusCode.isSuccess shouldBe true
-                  cid
-                }
-            })
-
-            ContractDelta(Vector(), _, Some(offset)) <- readOne
-            (off, archivedCid) = (offset, ctid)
-
-            ContractDelta(Vector(), Vector(observeArchivedCid), Some(lastSeenOffset)) <- readOne
-            (liveStartOffset, msgCount) = {
-              (observeArchivedCid.contractId.unwrap: String) shouldBe (archivedCid: String)
-              (observeArchivedCid.contractId: domain.ContractId) shouldBe (cid1: domain.ContractId)
-              (off, 0)
-            }
-
-            _ = kill.shutdown()
-            heartbeats <- drain
-            hbCount = (heartbeats.iterator.map(heartbeatOffset).toSet + lastSeenOffset).size - 1
-
-          } yield
-          // don't count empty events block if lastSeenOffset does not change
-          ShouldHaveEnded(
-            liveStartOffset = liveStartOffset,
-            msgCount = msgCount + hbCount,
-            lastSeenOffset = lastSeenOffset,
-          )
-        )
-      }
-
-      for {
-        r1 <- f1
-        _ = r1._1 shouldBe a[StatusCodes.Success]
-        cid1 = getContractId(getResult(r1._2))
-
-        r2 <- f2
-        _ = r2._1 shouldBe a[StatusCodes.Success]
-        cid2 = getContractId(getResult(r2._2))
-
-        (kill, source) = singleClientFetchStream(jwt, uri, fetchRequest())
-          .viaMat(KillSwitches.single)(Keep.right)
-          .preMaterialize()
-
-        lastState <- source
-          .via(parseResp) runWith resp(cid1, cid2, kill)
-
-        liveOffset = inside(lastState) { case ShouldHaveEnded(liveStart, 0, lastSeen) =>
-          lastSeen.unwrap should be > liveStart.unwrap
-          liveStart
         }
 
-        // check contractIdAtOffsets' effects on phantom filtering
-        resumes <- Future.traverse(Seq((None, 2L), (Some(None), 0L), (Some(Some(cid1)), 1L))) {
-          case (abcHint, expectArchives) =>
-            (singleClientFetchStream(
-              jwt,
-              uri,
-              fetchRequest(abcHint),
-              Some(liveOffset),
-            )
-              via parseResp)
-              .take(2)
-              .runWith(remainingDeltas)
-              .map { case (creates, archives, _) =>
-                creates shouldBe empty
-                archives should have size expectArchives
-              }
-        }
-
-      } yield resumes.foldLeft(1 shouldBe 1)((_, a) => a)
-  }
-
-  "fetch multiple keys should work" in withHttpService { (uri, encoder, _) =>
-    def create(account: String): Future[domain.ContractId] =
-      for {
-        r <- postCreateCommand(accountCreateCommand(domain.Party("Alice"), account), encoder, uri)
-      } yield {
-        assert(r._1.isSuccess)
-        getContractId(getResult(r._2))
-      }
-    def archive(id: domain.ContractId): Future[Assertion] =
-      for {
-        r <- postArchiveCommand(domain.TemplateId(None, "Account", "Account"), id, encoder, uri)
-      } yield {
-        assert(r._1.isSuccess)
-      }
-    def resp(kill: UniqueKillSwitch): Sink[JsValue, Future[Assertion]] = {
-      val dslSyntax = Consume.syntax[JsValue]
-      import dslSyntax._
-      Consume.interpret(
         for {
-          ContractDelta(Vector(), Vector(), Some(liveStartOffset)) <- readOne
-          cid1 <- liftF(create("abc123"))
-          ContractDelta(Vector((cid, _)), Vector(), Some(_)) <- readOne
-          _ = cid shouldBe cid1
-          _ <- liftF(create("abc124"))
-          _ <- liftF(create("abc125"))
-          cid2 <- liftF(create("def456"))
-          ContractDelta(Vector((cid, _)), Vector(), Some(_)) <- readOne
-          _ = cid shouldBe cid2
-          _ <- liftF(archive(cid2))
-          ContractDelta(Vector(), Vector(cid), Some(_)) <- readOne
-          _ = cid.contractId shouldBe cid2
-          _ <- liftF(archive(cid1))
-          ContractDelta(Vector(), Vector(cid), Some(_)) <- readOne
-          _ = cid.contractId shouldBe cid1
-          _ = kill.shutdown()
-          heartbeats <- drain
-          _ = heartbeats.foreach { d =>
-            inside(d) { case ContractDelta(Vector(), Vector(), Some(_)) =>
-              succeed
-            }
+          r1 <- f1
+          _ = r1._1 shouldBe a[StatusCodes.Success]
+          cid1 = getContractId(getResult(r1._2))
+
+          r2 <- f2
+          _ = r2._1 shouldBe a[StatusCodes.Success]
+          cid2 = getContractId(getResult(r2._2))
+
+          (kill, source) = singleClientFetchStream(jwt, uri, fetchRequest())
+            .viaMat(KillSwitches.single)(Keep.right)
+            .preMaterialize()
+
+          lastState <- source
+            .via(parseResp) runWith resp(cid1, cid2, kill)
+
+          liveOffset = inside(lastState) { case ShouldHaveEnded(liveStart, 0, lastSeen) =>
+            lastSeen.unwrap should be > liveStart.unwrap
+            liveStart
           }
-        } yield succeed
-      )
+
+          // check contractIdAtOffsets' effects on phantom filtering
+          resumes <- Future.traverse(Seq((None, 2L), (Some(None), 0L), (Some(Some(cid1)), 1L))) {
+            case (abcHint, expectArchives) =>
+              (singleClientFetchStream(
+                jwt,
+                uri,
+                fetchRequest(abcHint),
+                Some(liveOffset),
+              )
+                via parseResp)
+                .take(2)
+                .runWith(remainingDeltas)
+                .map { case (creates, archives, _) =>
+                  creates shouldBe empty
+                  archives should have size expectArchives
+                }
+          }
+
+        } yield resumes.foldLeft(1 shouldBe 1)((_, a) => a)
     }
-    val req =
-      """
+
+    "fetch multiple keys should work" in withHttpService { (uri, encoder, _) =>
+      def create(account: String): Future[domain.ContractId] =
+        for {
+          r <- postCreateCommand(accountCreateCommand(domain.Party("Alice"), account), encoder, uri)
+        } yield {
+          assert(r._1.isSuccess)
+          getContractId(getResult(r._2))
+        }
+      def archive(id: domain.ContractId): Future[Assertion] =
+        for {
+          r <- postArchiveCommand(domain.TemplateId(None, "Account", "Account"), id, encoder, uri)
+        } yield {
+          assert(r._1.isSuccess)
+        }
+      def resp(kill: UniqueKillSwitch): Sink[JsValue, Future[Assertion]] = {
+        val dslSyntax = Consume.syntax[JsValue]
+        import dslSyntax._
+        Consume.interpret(
+          for {
+            ContractDelta(Vector(), Vector(), Some(liveStartOffset)) <- readOne
+            cid1 <- liftF(create("abc123"))
+            ContractDelta(Vector((cid, _)), Vector(), Some(_)) <- readOne
+            _ = cid shouldBe cid1
+            _ <- liftF(create("abc124"))
+            _ <- liftF(create("abc125"))
+            cid2 <- liftF(create("def456"))
+            ContractDelta(Vector((cid, _)), Vector(), Some(_)) <- readOne
+            _ = cid shouldBe cid2
+            _ <- liftF(archive(cid2))
+            ContractDelta(Vector(), Vector(cid), Some(_)) <- readOne
+            _ = cid.contractId shouldBe cid2
+            _ <- liftF(archive(cid1))
+            ContractDelta(Vector(), Vector(cid), Some(_)) <- readOne
+            _ = cid.contractId shouldBe cid1
+            _ = kill.shutdown()
+            heartbeats <- drain
+            _ = heartbeats.foreach { d =>
+              inside(d) { case ContractDelta(Vector(), Vector(), Some(_)) =>
+                succeed
+              }
+            }
+          } yield succeed
+        )
+      }
+      val req =
+        """
           |[{"templateId": "Account:Account", "key": ["Alice", "abc123"]},
           | {"templateId": "Account:Account", "key": ["Alice", "def456"]}]
           |""".stripMargin
 
-    val (kill, source) = singleClientFetchStream(jwt, uri, req)
-      .viaMat(KillSwitches.single)(Keep.right)
-      .preMaterialize()
+      val (kill, source) = singleClientFetchStream(jwt, uri, req)
+        .viaMat(KillSwitches.single)(Keep.right)
+        .preMaterialize()
 
-    source.via(parseResp).runWith(resp(kill))
-  }
+      source.via(parseResp).runWith(resp(kill))
+    }
 
-  "multi-party fetch-by-key query should receive deltas as contracts are archived/created" in withHttpService {
-    (uri, encoder, _) =>
-      import spray.json._
+    "multi-party fetch-by-key query should receive deltas as contracts are archived/created" in withHttpService {
+      (uri, encoder, _) =>
+        import spray.json._
 
-      val templateId = domain.TemplateId(None, "Account", "Account")
+        val templateId = domain.TemplateId(None, "Account", "Account")
 
-      val f1 =
-        postCreateCommand(
-          accountCreateCommand(domain.Party("Alice"), "abc123"),
-          encoder,
-          uri,
-          headers = headersWithPartyAuth(List("Alice")),
-        )
-      val f2 =
-        postCreateCommand(
-          accountCreateCommand(domain.Party("Bob"), "def456"),
-          encoder,
-          uri,
-          headers = headersWithPartyAuth(List("Bob")),
-        )
+        val f1 =
+          postCreateCommand(
+            accountCreateCommand(domain.Party("Alice"), "abc123"),
+            encoder,
+            uri,
+            headers = headersWithPartyAuth(List("Alice")),
+          )
+        val f2 =
+          postCreateCommand(
+            accountCreateCommand(domain.Party("Bob"), "def456"),
+            encoder,
+            uri,
+            headers = headersWithPartyAuth(List("Bob")),
+          )
 
-      val query =
-        """[
+        val query =
+          """[
           {"templateId": "Account:Account", "key": ["Alice", "abc123"]},
           {"templateId": "Account:Account", "key": ["Bob", "def456"]}
         ]"""
 
-      def resp(
-          cid1: domain.ContractId,
-          cid2: domain.ContractId,
-          kill: UniqueKillSwitch,
-      ): Sink[JsValue, Future[ShouldHaveEnded]] = {
-        val dslSyntax = Consume.syntax[JsValue]
-        import dslSyntax._
-        Consume.interpret(
-          for {
-            Vector((account1, _), (account2, _)) <- readAcsN(2)
-            _ = Seq(account1, account2) should contain theSameElementsAs Seq(cid1, cid2)
-            ContractDelta(Vector(), _, Some(liveStartOffset)) <- readOne
-            _ <- liftF(postArchiveCommand(templateId, cid1, encoder, uri))
-            ContractDelta(Vector(), Vector(archivedCid1), Some(_)) <- readOne
-            _ = archivedCid1.contractId shouldBe cid1
-            _ <- liftF(
-              postArchiveCommand(
-                templateId,
-                cid2,
-                encoder,
-                uri,
-                headers = headersWithPartyAuth(List("Bob")),
+        def resp(
+            cid1: domain.ContractId,
+            cid2: domain.ContractId,
+            kill: UniqueKillSwitch,
+        ): Sink[JsValue, Future[ShouldHaveEnded]] = {
+          val dslSyntax = Consume.syntax[JsValue]
+          import dslSyntax._
+          Consume.interpret(
+            for {
+              Vector((account1, _), (account2, _)) <- readAcsN(2)
+              _ = Seq(account1, account2) should contain theSameElementsAs Seq(cid1, cid2)
+              ContractDelta(Vector(), _, Some(liveStartOffset)) <- readOne
+              _ <- liftF(postArchiveCommand(templateId, cid1, encoder, uri))
+              ContractDelta(Vector(), Vector(archivedCid1), Some(_)) <- readOne
+              _ = archivedCid1.contractId shouldBe cid1
+              _ <- liftF(
+                postArchiveCommand(
+                  templateId,
+                  cid2,
+                  encoder,
+                  uri,
+                  headers = headersWithPartyAuth(List("Bob")),
+                )
               )
+              ContractDelta(Vector(), Vector(archivedCid2), Some(lastSeenOffset)) <- readOne
+              _ = archivedCid2.contractId shouldBe cid2
+              _ = kill.shutdown()
+              heartbeats <- drain
+              hbCount = (heartbeats.iterator.map(heartbeatOffset).toSet + lastSeenOffset).size - 1
+            } yield (
+              // don't count empty events block if lastSeenOffset does not change
+              ShouldHaveEnded(
+                liveStartOffset = liveStartOffset,
+                msgCount = 5 + hbCount,
+                lastSeenOffset = lastSeenOffset,
+              ),
             )
-            ContractDelta(Vector(), Vector(archivedCid2), Some(lastSeenOffset)) <- readOne
-            _ = archivedCid2.contractId shouldBe cid2
-            _ = kill.shutdown()
-            heartbeats <- drain
-            hbCount = (heartbeats.iterator.map(heartbeatOffset).toSet + lastSeenOffset).size - 1
-          } yield (
+          )
+        }
+
+        for {
+          r1 <- f1
+          _ = r1._1 shouldBe a[StatusCodes.Success]
+          cid1 = getContractId(getResult(r1._2))
+
+          r2 <- f2
+          _ = r2._1 shouldBe a[StatusCodes.Success]
+          cid2 = getContractId(getResult(r2._2))
+
+          (kill, source) = singleClientFetchStream(
+            jwtForParties(List("Alice", "Bob"), List(), testId),
+            uri,
+            query,
+          ).viaMat(KillSwitches.single)(Keep.right).preMaterialize()
+          lastState <- source via parseResp runWith resp(cid1, cid2, kill)
+          liveOffset = inside(lastState) { case ShouldHaveEnded(liveStart, 5, lastSeen) =>
+            lastSeen.unwrap should be > liveStart.unwrap
+            liveStart
+          }
+          rescan <- (singleClientFetchStream(
+            jwtForParties(List("Alice", "Bob"), List(), testId),
+            uri,
+            query,
+            Some(liveOffset),
+          )
+            via parseResp).take(2) runWith remainingDeltas
+        } yield inside(rescan) { case (Vector(), Vector(_, _), Some(_)) =>
+          succeed
+        }
+    }
+
+    "fetch should should return an error if empty list of (templateId, key) pairs is passed" in withHttpService {
+      (uri, _, _) =>
+        singleClientFetchStream(jwt, uri, "[]")
+          .runWith(collectResultsAsTextMessageSkipOffsetTicks)
+          .map { clientMsgs =>
+            inside(clientMsgs) { case Seq(errorMsg) =>
+              val errorResponse = decodeErrorResponse(errorMsg)
+              errorResponse.status shouldBe StatusCodes.BadRequest
+              inside(errorResponse.errors) { case List(error) =>
+                error should include("must be a JSON array with at least 1 element")
+              }
+            }
+          }: Future[Assertion]
+    }
+
+    "query on a bunch of random splits should yield consistent results" in withHttpService {
+      (uri, _, _) =>
+        val splitSample = SplitSeq.gen.map(_ map (BigDecimal(_))).sample.get
+        val query =
+          """[
+          {"templateIds": ["Iou:Iou"]}
+        ]"""
+        val (kill, source) = singleClientQueryStream(jwt, uri, query)
+          .viaMat(KillSwitches.single)(Keep.right)
+          .preMaterialize()
+        source
+          .via(parseResp)
+          .map(iouSplitResult)
+          .filterNot(_ == \/-((Vector(), Vector()))) // liveness marker/heartbeat
+          .runWith(Consume.interpret(trialSplitSeq(uri, splitSample, kill)))
+    }
+
+    "no duplicates should be returned when retrieving contracts for multiple parties" in withHttpService {
+      (uri, encoder, _) =>
+        val aliceAndBob = List("Alice", "Bob")
+        val jwtForAliceAndBob = jwtForParties(actAs = aliceAndBob, readAs = Nil, ledgerId = testId)
+        import spray.json._
+
+        def test(
+            expectedContractId: String,
+            killSwitch: UniqueKillSwitch,
+        ): Sink[JsValue, Future[ShouldHaveEnded]] = {
+          val dslSyntax = Consume.syntax[JsValue]
+          import dslSyntax._
+          Consume.interpret(
+            for {
+              Vector((sharedAccountId, sharedAccount)) <- readAcsN(1)
+              _ = sharedAccountId shouldBe expectedContractId
+              ContractDelta(Vector(), _, Some(offset)) <- readOne
+              _ = inside(sharedAccount) { case JsObject(obj) =>
+                inside((obj get "owners", obj get "number")) {
+                  case (Some(JsArray(owners)), Some(JsString(number))) =>
+                    owners should contain theSameElementsAs Vector(
+                      JsString("Alice"),
+                      JsString("Bob"),
+                    )
+                    number shouldBe "4444"
+                }
+              }
+              ContractDelta(Vector(), _, Some(_)) <- readOne
+              _ = killSwitch.shutdown()
+              heartbeats <- drain
+              hbCount = (heartbeats.iterator.map(heartbeatOffset).toSet + offset).size - 1
+            } yield
             // don't count empty events block if lastSeenOffset does not change
             ShouldHaveEnded(
-              liveStartOffset = liveStartOffset,
-              msgCount = 5 + hbCount,
-              lastSeenOffset = lastSeenOffset,
-            ),
+              liveStartOffset = offset,
+              msgCount = 2 + hbCount,
+              lastSeenOffset = offset,
+            )
           )
-        )
+        }
+
+        for {
+          (status, value) <-
+            postCreateCommand(
+              cmd = sharedAccountCreateCommand(owners = aliceAndBob, "4444"),
+              encoder = encoder,
+              uri = uri,
+              headers = headersWithPartyAuth(aliceAndBob),
+            )
+          _ = status shouldBe a[StatusCodes.Success]
+          expectedContractId = getContractId(getResult(value))
+          (killSwitch, source) = singleClientQueryStream(
+            jwt = jwtForAliceAndBob,
+            serviceUri = uri,
+            query = """{"templateIds": ["Account:SharedAccount"]}""",
+          )
+            .viaMat(KillSwitches.single)(Keep.right)
+            .preMaterialize()
+          result <- source via parseResp runWith test(expectedContractId.unwrap, killSwitch)
+        } yield inside(result) { case ShouldHaveEnded(_, 2, _) =>
+          succeed
+        }
+    }
+
+    "Per-query offsets should work as expected" in withHttpService { (uri, _, _) =>
+      val dslSyntax = Consume.syntax[JsValue]
+      import dslSyntax._
+      import spray.json._
+      def createIouCommand(currency: String): String =
+        s"""{
+           |  "templateId": "Iou:Iou",
+           |  "payload": {
+           |    "observers": [],
+           |    "issuer": "Alice",
+           |    "amount": "999.99",
+           |    "currency": "$currency",
+           |    "owner": "Alice"
+           |  }
+           |}""".stripMargin
+      def createIou(currency: String): Future[Assertion] =
+        HttpServiceTestFixture
+          .postJsonStringRequest(
+            uri.withPath(Uri.Path("/v1/create")),
+            createIouCommand(currency),
+            headersWithAuth,
+          )
+          .map(_._1 shouldBe a[StatusCodes.Success])
+      def contractsQuery(currency: String): String =
+        s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}}"""
+      def contractsQueryWithOffset(offset: domain.Offset, currency: String): String =
+        s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}, "offset":"${offset.unwrap}"}"""
+      def contracts(currency: String, offset: Option[domain.Offset]): String =
+        offset.fold(contractsQuery(currency))(contractsQueryWithOffset(_, currency))
+      def acsEnd(expectedContracts: Int): Future[domain.Offset] = {
+        def go(killSwitch: UniqueKillSwitch): Sink[JsValue, Future[domain.Offset]] =
+          Consume.interpret(
+            for {
+              _ <- readAcsN(expectedContracts)
+              ContractDelta(Vector(), Vector(), Some(offset)) <- readOne
+              _ = killSwitch.shutdown()
+              _ <- drain
+            } yield offset
+          )
+        val (killSwitch, source) =
+          singleClientQueryStream(jwt, uri, """{"templateIds":["Iou:Iou"]}""")
+            .viaMat(KillSwitches.single)(Keep.right)
+            .preMaterialize()
+        source.via(parseResp).runWith(go(killSwitch))
+      }
+      def test(
+          clue: String,
+          expectedAcsSize: Int,
+          expectedEvents: Int,
+          queryFrom: Option[domain.Offset],
+          eurFrom: Option[domain.Offset],
+          usdFrom: Option[domain.Offset],
+          expected: Map[String, Int],
+      ): Future[Assertion] = {
+        def go(killSwitch: UniqueKillSwitch): Sink[JsValue, Future[Assertion]] = {
+          Consume.interpret(
+            for {
+              acs <- readAcsN(expectedAcsSize)
+              _ <- if (acs.nonEmpty) readOne else point(())
+              contracts <- updateAcs(Map.from(acs), expectedEvents)
+              result = contracts
+                .map(_._2.asJsObject.fields("currency").asInstanceOf[JsString].value)
+                .groupBy(identity)
+                .map { case (k, vs) => k -> vs.size }
+              _ = killSwitch.shutdown()
+            } yield withClue(clue) {
+              result shouldEqual expected
+            }
+          )
+        }
+        val (killSwitch, source) =
+          singleClientQueryStream(
+            jwt,
+            uri,
+            Seq(contracts("EUR", eurFrom), contracts("USD", usdFrom)).mkString("[", ",", "]"),
+            queryFrom,
+          )
+            .viaMat(KillSwitches.single)(Keep.right)
+            .preMaterialize()
+        source.via(parseResp).runWith(go(killSwitch))
       }
 
       for {
-        r1 <- f1
-        _ = r1._1 shouldBe a[StatusCodes.Success]
-        cid1 = getContractId(getResult(r1._2))
-
-        r2 <- f2
-        _ = r2._1 shouldBe a[StatusCodes.Success]
-        cid2 = getContractId(getResult(r2._2))
-
-        (kill, source) = singleClientFetchStream(
-          jwtForParties(List("Alice", "Bob"), List(), testId),
-          uri,
-          query,
-        ).viaMat(KillSwitches.single)(Keep.right).preMaterialize()
-        lastState <- source via parseResp runWith resp(cid1, cid2, kill)
-        liveOffset = inside(lastState) { case ShouldHaveEnded(liveStart, 5, lastSeen) =>
-          lastSeen.unwrap should be > liveStart.unwrap
-          liveStart
-        }
-        rescan <- (singleClientFetchStream(
-          jwtForParties(List("Alice", "Bob"), List(), testId),
-          uri,
-          query,
-          Some(liveOffset),
+        _ <- createIou("EUR")
+        _ <- createIou("USD")
+        offset1 <- acsEnd(2)
+        _ <- createIou("EUR")
+        _ <- createIou("USD")
+        offset2 <- acsEnd(4)
+        _ <- createIou("EUR")
+        _ <- createIou("USD")
+        _ <- test(
+          clue = "No offsets",
+          expectedAcsSize = 6,
+          expectedEvents = 0,
+          queryFrom = None,
+          eurFrom = None,
+          usdFrom = None,
+          expected = Map(
+            "EUR" -> 3,
+            "USD" -> 3,
+          ),
         )
-          via parseResp).take(2) runWith remainingDeltas
-      } yield inside(rescan) { case (Vector(), Vector(_, _), Some(_)) =>
-        succeed
+        _ <- test(
+          clue = "Offset message only",
+          expectedAcsSize = 0,
+          expectedEvents = 2,
+          queryFrom = Some(offset2),
+          eurFrom = None,
+          usdFrom = None,
+          expected = Map(
+            "EUR" -> 1,
+            "USD" -> 1,
+          ),
+        )
+        _ <- test(
+          clue = "Per-query offsets only",
+          expectedAcsSize = 0,
+          expectedEvents = 3,
+          queryFrom = None,
+          eurFrom = Some(offset1),
+          usdFrom = Some(offset2),
+          expected = Map(
+            "EUR" -> 2,
+            "USD" -> 1,
+          ),
+        )
+        _ <- test(
+          clue = "Absent per-query offset is overridden by offset message",
+          expectedAcsSize = 0,
+          expectedEvents = 3,
+          queryFrom = Some(offset2),
+          eurFrom = None,
+          usdFrom = Some(offset1),
+          expected = Map(
+            "EUR" -> 1,
+            "USD" -> 2,
+          ),
+        )
+        _ <- test(
+          clue = "Offset message does not override per-query offsets",
+          expectedAcsSize = 0,
+          expectedEvents = 4,
+          queryFrom = Some(offset2),
+          eurFrom = Some(offset1),
+          usdFrom = Some(offset1),
+          expected = Map(
+            "EUR" -> 2,
+            "USD" -> 2,
+          ),
+        )
+        _ <- test(
+          clue = "Per-query offset with ACS query",
+          expectedAcsSize = 3,
+          expectedEvents = 1,
+          queryFrom = None,
+          eurFrom = None,
+          usdFrom = Some(offset2),
+          expected = Map(
+            "EUR" -> 3,
+            "USD" -> 1,
+          ),
+        )
+      } yield succeed
+    }
+
+    "ContractKeyStreamRequest" - {
+      import spray.json._, json.JsonProtocol._
+      val baseVal =
+        domain.EnrichedContractKey(
+          domain.TemplateId(Some("ab"), "cd", "ef"),
+          JsString("42"): JsValue,
+        )
+      val baseMap = baseVal.toJson.asJsObject.fields
+      val withSome = JsObject(baseMap + (contractIdAtOffsetKey -> JsString("hi")))
+      val withNone = JsObject(baseMap + (contractIdAtOffsetKey -> JsNull))
+
+      "initial JSON reader" - {
+        type T = domain.ContractKeyStreamRequest[Unit, JsValue]
+
+        "shares EnrichedContractKey format" in {
+          JsObject(baseMap).convertTo[T] should ===(domain.ContractKeyStreamRequest((), baseVal))
+        }
+
+        "errors on contractIdAtOffset presence" in {
+          a[DeserializationException] shouldBe thrownBy {
+            withSome.convertTo[T]
+          }
+          a[DeserializationException] shouldBe thrownBy {
+            withNone.convertTo[T]
+          }
+        }
       }
+
+      "resuming JSON reader" - {
+        type T = domain.ContractKeyStreamRequest[Option[Option[domain.ContractId]], JsValue]
+
+        "shares EnrichedContractKey format" in {
+          JsObject(baseMap).convertTo[T] should ===(domain.ContractKeyStreamRequest(None, baseVal))
+        }
+
+        "distinguishes null and string" in {
+          withSome.convertTo[T] should ===(
+            domain.ContractKeyStreamRequest(Some(Some("hi")), baseVal)
+          )
+          withNone.convertTo[T] should ===(domain.ContractKeyStreamRequest(Some(None), baseVal))
+        }
+      }
+    }
   }
 
   /** Consume ACS blocks expecting `createCount` contracts.  Fail if there
@@ -745,6 +1044,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
           if found <= createCount
           tail <- if (found < createCount) go(createCount - found) else point(Vector.empty)
         } yield creates ++ tail
+
     go(createCount)
   }
 
@@ -771,39 +1071,19 @@ abstract class AbstractWebsocketServiceIntegrationTest
           next <- go(newAcs, missingEvents - events)
         } yield next
       }
+
     go(acs, events)
   }
 
-  "fetch should should return an error if empty list of (templateId, key) pairs is passed" in withHttpService {
-    (uri, _, _) =>
-      singleClientFetchStream(jwt, uri, "[]")
-        .runWith(collectResultsAsTextMessageSkipOffsetTicks)
-        .map { clientMsgs =>
-          inside(clientMsgs) { case Seq(errorMsg) =>
-            val errorResponse = decodeErrorResponse(errorMsg)
-            errorResponse.status shouldBe StatusCodes.BadRequest
-            inside(errorResponse.errors) { case List(error) =>
-              error should include("must be a JSON array with at least 1 element")
-            }
-          }
-        }: Future[Assertion]
-  }
-
-  "query on a bunch of random splits should yield consistent results" in withHttpService {
-    (uri, _, _) =>
-      val splitSample = SplitSeq.gen.map(_ map (BigDecimal(_))).sample.get
-      val query =
-        """[
-          {"templateIds": ["Iou:Iou"]}
-        ]"""
-      val (kill, source) = singleClientQueryStream(jwt, uri, query)
-        .viaMat(KillSwitches.single)(Keep.right)
-        .preMaterialize()
-      source
-        .via(parseResp)
-        .map(iouSplitResult)
-        .filterNot(_ == \/-((Vector(), Vector()))) // liveness marker/heartbeat
-        .runWith(Consume.interpret(trialSplitSeq(uri, splitSample, kill)))
+  private def exercisePayload(cid: domain.ContractId, amount: BigDecimal = BigDecimal("42.42")) = {
+    import json.JsonProtocol._
+    import spray.json._
+    Map(
+      "templateId" -> "Iou:Iou".toJson,
+      "contractId" -> cid.toJson,
+      "choice" -> "Iou_Split".toJson,
+      "argument" -> Map("splitAmount" -> amount).toJson,
+    ).toJson
   }
 
   private def trialSplitSeq(
@@ -880,270 +1160,6 @@ abstract class AbstractWebsocketServiceIntegrationTest
         case _ => None
       } map ((_, archives map (_.contractId))) toRightDisjunction jsv
     case _ => -\/(jsv)
-  }
-
-  "no duplicates should be returned when retrieving contracts for multiple parties" in withHttpService {
-    (uri, encoder, _) =>
-      val aliceAndBob = List("Alice", "Bob")
-      val jwtForAliceAndBob = jwtForParties(actAs = aliceAndBob, readAs = Nil, ledgerId = testId)
-      import spray.json._
-
-      def test(
-          expectedContractId: String,
-          killSwitch: UniqueKillSwitch,
-      ): Sink[JsValue, Future[ShouldHaveEnded]] = {
-        val dslSyntax = Consume.syntax[JsValue]
-        import dslSyntax._
-        Consume.interpret(
-          for {
-            Vector((sharedAccountId, sharedAccount)) <- readAcsN(1)
-            _ = sharedAccountId shouldBe expectedContractId
-            ContractDelta(Vector(), _, Some(offset)) <- readOne
-            _ = inside(sharedAccount) { case JsObject(obj) =>
-              inside((obj get "owners", obj get "number")) {
-                case (Some(JsArray(owners)), Some(JsString(number))) =>
-                  owners should contain theSameElementsAs Vector(JsString("Alice"), JsString("Bob"))
-                  number shouldBe "4444"
-              }
-            }
-            ContractDelta(Vector(), _, Some(_)) <- readOne
-            _ = killSwitch.shutdown()
-            heartbeats <- drain
-            hbCount = (heartbeats.iterator.map(heartbeatOffset).toSet + offset).size - 1
-          } yield
-          // don't count empty events block if lastSeenOffset does not change
-          ShouldHaveEnded(
-            liveStartOffset = offset,
-            msgCount = 2 + hbCount,
-            lastSeenOffset = offset,
-          )
-        )
-      }
-
-      for {
-        (status, value) <-
-          postCreateCommand(
-            cmd = sharedAccountCreateCommand(owners = aliceAndBob, "4444"),
-            encoder = encoder,
-            uri = uri,
-            headers = headersWithPartyAuth(aliceAndBob),
-          )
-        _ = status shouldBe a[StatusCodes.Success]
-        expectedContractId = getContractId(getResult(value))
-        (killSwitch, source) = singleClientQueryStream(
-          jwt = jwtForAliceAndBob,
-          serviceUri = uri,
-          query = """{"templateIds": ["Account:SharedAccount"]}""",
-        )
-          .viaMat(KillSwitches.single)(Keep.right)
-          .preMaterialize()
-        result <- source via parseResp runWith test(expectedContractId.unwrap, killSwitch)
-      } yield inside(result) { case ShouldHaveEnded(_, 2, _) =>
-        succeed
-      }
-  }
-
-  "Per-query offsets should work as expected" in withHttpService { (uri, _, _) =>
-    val dslSyntax = Consume.syntax[JsValue]
-    import dslSyntax._
-    import spray.json._
-    def createIouCommand(currency: String): String =
-      s"""{
-           |  "templateId": "Iou:Iou",
-           |  "payload": {
-           |    "observers": [],
-           |    "issuer": "Alice",
-           |    "amount": "999.99",
-           |    "currency": "$currency",
-           |    "owner": "Alice"
-           |  }
-           |}""".stripMargin
-    def createIou(currency: String): Future[Assertion] =
-      HttpServiceTestFixture
-        .postJsonStringRequest(
-          uri.withPath(Uri.Path("/v1/create")),
-          createIouCommand(currency),
-          headersWithAuth,
-        )
-        .map(_._1 shouldBe a[StatusCodes.Success])
-    def contractsQuery(currency: String): String =
-      s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}}"""
-    def contractsQueryWithOffset(offset: domain.Offset, currency: String): String =
-      s"""{"templateIds":["Iou:Iou"], "query":{"currency":"$currency"}, "offset":"${offset.unwrap}"}"""
-    def contracts(currency: String, offset: Option[domain.Offset]): String =
-      offset.fold(contractsQuery(currency))(contractsQueryWithOffset(_, currency))
-    def acsEnd(expectedContracts: Int): Future[domain.Offset] = {
-      def go(killSwitch: UniqueKillSwitch): Sink[JsValue, Future[domain.Offset]] =
-        Consume.interpret(
-          for {
-            _ <- readAcsN(expectedContracts)
-            ContractDelta(Vector(), Vector(), Some(offset)) <- readOne
-            _ = killSwitch.shutdown()
-            _ <- drain
-          } yield offset
-        )
-      val (killSwitch, source) =
-        singleClientQueryStream(jwt, uri, """{"templateIds":["Iou:Iou"]}""")
-          .viaMat(KillSwitches.single)(Keep.right)
-          .preMaterialize()
-      source.via(parseResp).runWith(go(killSwitch))
-    }
-    def test(
-        clue: String,
-        expectedAcsSize: Int,
-        expectedEvents: Int,
-        queryFrom: Option[domain.Offset],
-        eurFrom: Option[domain.Offset],
-        usdFrom: Option[domain.Offset],
-        expected: Map[String, Int],
-    ): Future[Assertion] = {
-      def go(killSwitch: UniqueKillSwitch): Sink[JsValue, Future[Assertion]] = {
-        Consume.interpret(
-          for {
-            acs <- readAcsN(expectedAcsSize)
-            _ <- if (acs.nonEmpty) readOne else point(())
-            contracts <- updateAcs(Map.from(acs), expectedEvents)
-            result = contracts
-              .map(_._2.asJsObject.fields("currency").asInstanceOf[JsString].value)
-              .groupBy(identity)
-              .map { case (k, vs) => k -> vs.size }
-            _ = killSwitch.shutdown()
-          } yield withClue(clue) { result shouldEqual expected }
-        )
-      }
-      val (killSwitch, source) =
-        singleClientQueryStream(
-          jwt,
-          uri,
-          Seq(contracts("EUR", eurFrom), contracts("USD", usdFrom)).mkString("[", ",", "]"),
-          queryFrom,
-        )
-          .viaMat(KillSwitches.single)(Keep.right)
-          .preMaterialize()
-      source.via(parseResp).runWith(go(killSwitch))
-    }
-
-    for {
-      _ <- createIou("EUR")
-      _ <- createIou("USD")
-      offset1 <- acsEnd(2)
-      _ <- createIou("EUR")
-      _ <- createIou("USD")
-      offset2 <- acsEnd(4)
-      _ <- createIou("EUR")
-      _ <- createIou("USD")
-      _ <- test(
-        clue = "No offsets",
-        expectedAcsSize = 6,
-        expectedEvents = 0,
-        queryFrom = None,
-        eurFrom = None,
-        usdFrom = None,
-        expected = Map(
-          "EUR" -> 3,
-          "USD" -> 3,
-        ),
-      )
-      _ <- test(
-        clue = "Offset message only",
-        expectedAcsSize = 0,
-        expectedEvents = 2,
-        queryFrom = Some(offset2),
-        eurFrom = None,
-        usdFrom = None,
-        expected = Map(
-          "EUR" -> 1,
-          "USD" -> 1,
-        ),
-      )
-      _ <- test(
-        clue = "Per-query offsets only",
-        expectedAcsSize = 0,
-        expectedEvents = 3,
-        queryFrom = None,
-        eurFrom = Some(offset1),
-        usdFrom = Some(offset2),
-        expected = Map(
-          "EUR" -> 2,
-          "USD" -> 1,
-        ),
-      )
-      _ <- test(
-        clue = "Absent per-query offset is overridden by offset message",
-        expectedAcsSize = 0,
-        expectedEvents = 3,
-        queryFrom = Some(offset2),
-        eurFrom = None,
-        usdFrom = Some(offset1),
-        expected = Map(
-          "EUR" -> 1,
-          "USD" -> 2,
-        ),
-      )
-      _ <- test(
-        clue = "Offset message does not override per-query offsets",
-        expectedAcsSize = 0,
-        expectedEvents = 4,
-        queryFrom = Some(offset2),
-        eurFrom = Some(offset1),
-        usdFrom = Some(offset1),
-        expected = Map(
-          "EUR" -> 2,
-          "USD" -> 2,
-        ),
-      )
-      _ <- test(
-        clue = "Per-query offset with ACS query",
-        expectedAcsSize = 3,
-        expectedEvents = 1,
-        queryFrom = None,
-        eurFrom = None,
-        usdFrom = Some(offset2),
-        expected = Map(
-          "EUR" -> 3,
-          "USD" -> 1,
-        ),
-      )
-    } yield succeed
-  }
-
-  "ContractKeyStreamRequest" - {
-    import spray.json._, json.JsonProtocol._
-    val baseVal =
-      domain.EnrichedContractKey(domain.TemplateId(Some("ab"), "cd", "ef"), JsString("42"): JsValue)
-    val baseMap = baseVal.toJson.asJsObject.fields
-    val withSome = JsObject(baseMap + (contractIdAtOffsetKey -> JsString("hi")))
-    val withNone = JsObject(baseMap + (contractIdAtOffsetKey -> JsNull))
-
-    "initial JSON reader" - {
-      type T = domain.ContractKeyStreamRequest[Unit, JsValue]
-
-      "shares EnrichedContractKey format" in {
-        JsObject(baseMap).convertTo[T] should ===(domain.ContractKeyStreamRequest((), baseVal))
-      }
-
-      "errors on contractIdAtOffset presence" in {
-        a[DeserializationException] shouldBe thrownBy {
-          withSome.convertTo[T]
-        }
-        a[DeserializationException] shouldBe thrownBy {
-          withNone.convertTo[T]
-        }
-      }
-    }
-
-    "resuming JSON reader" - {
-      type T = domain.ContractKeyStreamRequest[Option[Option[domain.ContractId]], JsValue]
-
-      "shares EnrichedContractKey format" in {
-        JsObject(baseMap).convertTo[T] should ===(domain.ContractKeyStreamRequest(None, baseVal))
-      }
-
-      "distinguishes null and string" in {
-        withSome.convertTo[T] should ===(domain.ContractKeyStreamRequest(Some(Some("hi")), baseVal))
-        withNone.convertTo[T] should ===(domain.ContractKeyStreamRequest(Some(None), baseVal))
-      }
-    }
   }
 
   private def wsConnectRequest[M](


### PR DESCRIPTION
 This catches more bugs than running e.g. the postgres integration tests
for each prefix while using a fresh db, because collisions cannot be
discovered with that approach.

I don't know yet whether the oracle tests will succeed but the CI will tell :smile: 

PS: This stuff here is full of lazy computations, simply because our jdbc config depends on the database url which isn't directly available at startup :face_with_head_bandage: 

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
