### PR TITLE
[JSON-API/Docs] Fix the date bounds specification in the docs to be 9999-12-31

### DIFF
--- a/docs/source/json-api/lf-value-specification.rst
+++ b/docs/source/json-api/lf-value-specification.rst
@@ -240,7 +240,7 @@ Represented as an ISO 8601 date rendered using the format
     0001-01-01
 
 The dates must be between the bounds specified by Daml-LF and ISO 8601,
-[0001-01-01, 9999-99-99].
+[0001-01-01, 9999-12-31].
 
 Text
 ****


### PR DESCRIPTION
I think this should fix #10449

changelog_begin

- [JSON-API] The date bounds specification of the json api has been corrected, the upper limit is now 9999-12-31 instead of the invalid date 9999-99-99

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
