### PR TITLE
feature: remember checkboxes in script view

### DIFF
--- a/compiler/daml-extension/src/webview.js
+++ b/compiler/daml-extension/src/webview.js
@@ -3,17 +3,27 @@
 
 const vscode = acquireVsCodeApi();
 function show_archived_changed() {
-  document.body.classList.toggle('hide_archived', !document.getElementById('show_archived').checked);
+  const isChecked = document.getElementById('show_archived').checked;
+  document.body.classList.toggle('hide_archived', !isChecked);
+  vscode.postMessage({
+    'command': 'set_show_archived',
+    'value': isChecked
+  });
 }
 function toggle_detailed_disclosure() {
-  document.body.classList.toggle('hidden_disclosure', !document.getElementById('show_detailed_disclosure').checked);
+  const isChecked = document.getElementById('show_detailed_disclosure').checked;
+  document.body.classList.toggle('hidden_disclosure', !isChecked);
+  vscode.postMessage({
+    'command': 'set_show_detailed_disclosure',
+    'value': isChecked
+  });
 }
 function toggle_view() {
   document.body.classList.toggle('hide_transaction');
   document.body.classList.toggle('hide_table');
   vscode.postMessage({
-    'command': 'selected_view',
-    'value': document.body.classList.contains('hide_transaction') ? 'table' : 'transaction'
+    'command': 'set_selected_view',
+    'value': document.body.classList.contains('hide_transaction') ? 'table' : 'transaction',
   });
 }
 window.addEventListener('message', event => {
@@ -23,8 +33,8 @@ window.addEventListener('message', event => {
         document.body.classList.remove('hide_note');
         document.getElementById('note').innerHTML = message.value;
         break;
-    case 'select_view':
-      switch (message.value) {
+    case 'set_view':
+      switch (message.value.selected) {
         case 'transaction':
           document.body.classList.remove('hide_transaction');
           document.body.classList.add('hide_table');
@@ -34,9 +44,28 @@ window.addEventListener('message', event => {
           document.body.classList.remove('hide_table');
           break;
         default:
-          console.log('Unexpected value for select_view: ' + message.value);
+          console.log('Unexpected value for select_view: ' + message.value.selected);
           break;
       }
+      if (message.value.showArchived) {
+        document.body.classList.remove('hide_archived');
+        document.body.classList.add('show_archived');
+        document.getElementById('show_archived').checked = true;
+      } else {
+        document.body.classList.remove('show_archived');
+        document.body.classList.add('hide_archived');
+        document.getElementById('show_archived').checked = false;
+      }
+      if (message.value.showDetailedDisclosure) {
+        document.body.classList.remove('hidden_disclosure');
+        document.body.classList.add('show_disclosure');
+        document.getElementById('show_detailed_disclosure').checked = true;
+      } else {
+        document.body.classList.remove('show_disclosure');
+        document.body.classList.add('hidden_disclosure');
+        document.getElementById('show_detailed_disclosure').checked = false;
+      }
+
       break;
   }
 });

--- a/compiler/daml-extension/src/webview.js
+++ b/compiler/daml-extension/src/webview.js
@@ -28,6 +28,13 @@ function toggle_view() {
 }
 window.addEventListener('message', event => {
   const message = event.data;
+
+  function showOrHideClassWithName(show, showClass, hideClass, checkBoxId) {
+        document.body.classList.remove(show ? hideClass : showClass);
+        document.body.classList.add(show ? showClass : hideClass);
+        document.getElementById(checkBoxId).checked = show;
+  };
+
   switch (message.command) {
     case 'add_note':
         document.body.classList.remove('hide_note');
@@ -47,25 +54,8 @@ window.addEventListener('message', event => {
           console.log('Unexpected value for select_view: ' + message.value.selected);
           break;
       }
-      if (message.value.showArchived) {
-        document.body.classList.remove('hide_archived');
-        document.body.classList.add('show_archived');
-        document.getElementById('show_archived').checked = true;
-      } else {
-        document.body.classList.remove('show_archived');
-        document.body.classList.add('hide_archived');
-        document.getElementById('show_archived').checked = false;
-      }
-      if (message.value.showDetailedDisclosure) {
-        document.body.classList.remove('hidden_disclosure');
-        document.body.classList.add('show_disclosure');
-        document.getElementById('show_detailed_disclosure').checked = true;
-      } else {
-        document.body.classList.remove('show_disclosure');
-        document.body.classList.add('hidden_disclosure');
-        document.getElementById('show_detailed_disclosure').checked = false;
-      }
-
+      showOrHideClassWithName(message.value.showArchived, 'show_archived', 'hide_archived', 'show_archived')
+      showOrHideClassWithName(message.value.showDetailedDisclosure, 'show_disclosure', 'hidden_disclosure', 'show_detailed_disclosure')
       break;
   }
 });

--- a/compiler/daml-extension/src/webview.js
+++ b/compiler/daml-extension/src/webview.js
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const vscode = acquireVsCodeApi();
-function show_archived_changed() {
-  const isChecked = document.getElementById('show_archived').checked;
-  document.body.classList.toggle('hide_archived', !isChecked);
+
+function toggleCheckbox(checkboxId, classId, cmdId) {
+  const isChecked = document.getElementById(checkboxId).checked;
+  document.body.classList.toggle(classId, !isChecked);
   vscode.postMessage({
-    'command': 'set_show_archived',
+    'command': cmdId,
     'value': isChecked
   });
 }
+
+function show_archived_changed() {
+  toggleCheckbox('show_archived', 'hide_archived', 'set_show_archived')
+}
 function toggle_detailed_disclosure() {
-  const isChecked = document.getElementById('show_detailed_disclosure').checked;
-  document.body.classList.toggle('hidden_disclosure', !isChecked);
-  vscode.postMessage({
-    'command': 'set_show_detailed_disclosure',
-    'value': isChecked
-  });
+  toggleCheckbox('show_detailed_disclosure', 'hidden_disclosure', 'set_show_detailed_disclosure');
 }
 function toggle_view() {
   document.body.classList.toggle('hide_transaction');


### PR DESCRIPTION
Fixes #9177. This makes the script view remember the choices for
'show_archive', 'show detailed disclosure' and 'table/transaction' view
accross changes to the script.

Not sure if there is a test suite availabe for the extension where tests for
this could be added.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
