### PR TITLE
Use at least LF version 1.7 for Daml ledger export

### DIFF
--- a/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
@@ -40,9 +40,14 @@ object Dependencies {
     go(references, Map.empty)
   }
 
+  /** The Daml-LF version to target based on the DALF dependencies.
+    *
+    * Chooses the latest LF version among the DALFs but at least 1.7 as that is the minimum required for Daml Script.
+    * Returns None if no DALFs are given.
+    */
   def targetLfVersion(dalfs: Iterable[LanguageVersion]): Option[LanguageVersion] = {
     if (dalfs.isEmpty) { None }
-    else { Some(dalfs.max) }
+    else { Some((List(LanguageVersion.v1_7) ++ dalfs).max) }
   }
 
   def targetFlag(v: LanguageVersion): String =

--- a/daml-script/export/src/test/scala/com/daml/script/export/DependenciesSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/DependenciesSpec.scala
@@ -4,7 +4,6 @@
 package com.daml.script.export
 
 import com.daml.lf.language.LanguageVersion._
-
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -20,6 +19,9 @@ class DependenciesSpec extends AnyFreeSpec with Matchers {
     }
     "multiple DALFs" in {
       targetLfVersion(Seq(v1_8, v1_11, v1_12)) shouldBe Some(v1_12)
+    }
+    "should be at least 1.7" in {
+      targetLfVersion(Seq(v1_6)) shouldBe Some(v1_7)
     }
   }
   "targetFlag" - {


### PR DESCRIPTION
That is the earliest LF version at which Daml Script is available, according to https://github.com/digital-asset/daml/blob/50c7b79f83bd905f88df5201722c47c6a1f58327/daml-lf/language/daml-lf.bzl#L71

Discovered while debugging https://github.com/digital-asset/daml/issues/10435

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
