### PR TITLE
Handle package dependencies without metadata in Daml export

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StablePackages.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/StablePackages.scala
@@ -116,5 +116,5 @@ object StablePackages {
       "99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235"
     ),
   )
-  private[lf] val Ids = nameToIdMap.values.toSet
+  val Ids = nameToIdMap.values.toSet
 }

--- a/daml-script/export/src/test/scala/com/daml/script/export/DependenciesSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/DependenciesSpec.scala
@@ -3,7 +3,11 @@
 
 package com.daml.script.export
 
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.PackageId
+import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.lf.language.LanguageVersion._
+import com.google.protobuf.ByteString
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -30,6 +34,80 @@ class DependenciesSpec extends AnyFreeSpec with Matchers {
     }
     "1.dev" in {
       targetFlag(v1_dev) shouldBe "--target=1.dev"
+    }
+  }
+  "toPackages" - {
+    "empty package set" in {
+      val pkgId: PackageId = PackageId.assertFromString(
+        "e7b2c7155f6dd6fc569c2325be821f1269186a540d0408b9a0c9e30406f6b64b"
+      )
+      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map.empty
+      toPackages(pkgId, pkgs) shouldBe None
+    }
+    "package with metadata" in {
+      val pkgId: PackageId = PackageId.assertFromString(
+        "e7b2c7155f6dd6fc569c2325be821f1269186a540d0408b9a0c9e30406f6b64b"
+      )
+      val pkg: Ast.Package = Ast.Package(
+        modules = Map.empty[Ref.ModuleName, Ast.GenModule[Ast.Expr]],
+        directDeps = Set.empty[PackageId],
+        languageVersion = LanguageVersion.v1_8,
+        metadata = Some(
+          Ast.PackageMetadata(
+            name = Ref.PackageName.assertFromString("example-pkg"),
+            version = Ref.PackageVersion.assertFromString("1.0.0"),
+          )
+        ),
+      )
+      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map(pkgId -> (ByteString.EMPTY, pkg))
+      toPackages(pkgId, pkgs) shouldBe Some("example-pkg-1.0.0")
+    }
+    "package without metadata" in {
+      val pkgId: PackageId = PackageId.assertFromString(
+        "e7b2c7155f6dd6fc569c2325be821f1269186a540d0408b9a0c9e30406f6b64b"
+      )
+      val pkg: Ast.Package = Ast.Package(
+        modules = Map.empty[Ref.ModuleName, Ast.GenModule[Ast.Expr]],
+        directDeps = Set.empty[PackageId],
+        languageVersion = LanguageVersion.v1_6,
+        metadata = None,
+      )
+      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map(pkgId -> (ByteString.EMPTY, pkg))
+      toPackages(pkgId, pkgs) shouldBe Some(
+        "e7b2c7155f6dd6fc569c2325be821f1269186a540d0408b9a0c9e30406f6b64b"
+      )
+    }
+    "stable-package with metadata" in {
+      val pkgId: PackageId = PackageId.assertFromString(
+        "4b36da183ec859061ca972c544c9ebb687e2ee6536d1edd15b04ae0696e607c7"
+      )
+      val pkg: Ast.Package = Ast.Package(
+        modules = Map.empty[Ref.ModuleName, Ast.GenModule[Ast.Expr]],
+        directDeps = Set.empty[PackageId],
+        languageVersion = LanguageVersion.v1_8,
+        metadata = Some(
+          Ast.PackageMetadata(
+            name = Ref.PackageName.assertFromString("daml-stdlib"),
+            version = Ref.PackageVersion.assertFromString("0.0.0"),
+          )
+        ),
+      )
+      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map(pkgId -> (ByteString.EMPTY, pkg))
+      toPackages(pkgId, pkgs) shouldBe None
+    }
+    "stable-package without metadata" in {
+      // daml-stdlib-DA-Internal-Template
+      val pkgId: PackageId = PackageId.assertFromString(
+        "d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662"
+      )
+      val pkg: Ast.Package = Ast.Package(
+        modules = Map.empty[Ref.ModuleName, Ast.GenModule[Ast.Expr]],
+        directDeps = Set.empty[PackageId],
+        languageVersion = LanguageVersion.v1_8,
+        metadata = None,
+      )
+      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map(pkgId -> (ByteString.EMPTY, pkg))
+      toPackages(pkgId, pkgs) shouldBe None
     }
   }
 }

--- a/daml-script/export/src/test/scala/com/daml/script/export/DependenciesSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/DependenciesSpec.scala
@@ -59,7 +59,7 @@ class DependenciesSpec extends AnyFreeSpec with Matchers {
           )
         ),
       )
-      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map(pkgId -> (ByteString.EMPTY, pkg))
+      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map((pkgId, (ByteString.EMPTY, pkg)))
       toPackages(pkgId, pkgs) shouldBe Some("example-pkg-1.0.0")
     }
     "package without metadata" in {
@@ -72,7 +72,7 @@ class DependenciesSpec extends AnyFreeSpec with Matchers {
         languageVersion = LanguageVersion.v1_6,
         metadata = None,
       )
-      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map(pkgId -> (ByteString.EMPTY, pkg))
+      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map((pkgId, (ByteString.EMPTY, pkg)))
       toPackages(pkgId, pkgs) shouldBe Some(
         "e7b2c7155f6dd6fc569c2325be821f1269186a540d0408b9a0c9e30406f6b64b"
       )
@@ -92,7 +92,7 @@ class DependenciesSpec extends AnyFreeSpec with Matchers {
           )
         ),
       )
-      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map(pkgId -> (ByteString.EMPTY, pkg))
+      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map((pkgId, (ByteString.EMPTY, pkg)))
       toPackages(pkgId, pkgs) shouldBe None
     }
     "stable-package without metadata" in {
@@ -106,7 +106,7 @@ class DependenciesSpec extends AnyFreeSpec with Matchers {
         languageVersion = LanguageVersion.v1_8,
         metadata = None,
       )
-      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map(pkgId -> (ByteString.EMPTY, pkg))
+      val pkgs: Map[PackageId, (ByteString, Ast.Package)] = Map((pkgId, (ByteString.EMPTY, pkg)))
       toPackages(pkgId, pkgs) shouldBe None
     }
   }


### PR DESCRIPTION
Depens-On: #10480

This addresses the immediate issue reported in #10435.

DALF packages before LF version 1.8 don't contain metadata such as the package name and version. However, Daml ledger export assumed that metadata was available to generate `--package` flags for data-dependencies.

This change generates `--package=<hash>` flags for such dependencies on packages that don't have metadata available.

This change requires additional care when checking if a package is a stable-package. As the package name is not available without metadata we cannot just check against names such as `daml-stdlib`. Instead this change uses the list of stable-package package-ids exposed by `com.daml.lf.language.StablePackages.Ids`, which was introduced in https://github.com/digital-asset/daml/commit/0da814d2501f87d45c525cb34454bf9fc4832f11.

Note that this does not fully resolve #10435. Building a generated Daml ledger export script will fail on missing instances of standard classes such as `HasTemplate` because packages prior to LF version 1.8 don't contain type-class instances. This will be addressed in a separate PR.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
