### PR TITLE
LF: revisit how contract IDs are handed in commands

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -105,7 +105,6 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
           ledgerTime = cmds.ledgerEffectiveTime,
           submissionTime = submissionTime,
           seeding = Engine.initialSeeding(submissionSeed, participantId, submissionTime),
-          globalCids = Set.empty,
         ) map { case (tx, meta) =>
           // Annotate the transaction with the package dependencies. Since
           // all commands are actions on a contract template, with a fully typed
@@ -180,7 +179,6 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
         ledgerTime = ledgerEffectiveTime,
         submissionTime = submissionTime,
         seeding = Engine.initialSeeding(submissionSeed, participantId, submissionTime),
-        globalCids = Set.empty,
       )
 
     } yield result
@@ -271,7 +269,7 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
       ledgerTime: Time.Timestamp,
       submissionTime: Time.Timestamp,
       seeding: speedy.InitialSeeding,
-      globalCids: Set[Value.ContractId],
+      globalCids: Set[Value.ContractId] = Set.empty,
   ): Result[(SubmittedTransaction, Tx.Metadata)] = {
     val sexpr = compiledPackages.compiler.unsafeCompile(commands)
     interpretExpression(

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -132,7 +132,7 @@ private[engine] final class Preprocessor(compiledPackages: MutableCompiledPackag
 
   private[engine] def preprocessCommand(
       cmd: command.Command
-  ): Result[(speedy.Command, Set[Value.ContractId])] =
+  ): Result[speedy.Command] =
     safelyRun(getDependencies(List.empty, List(cmd.templateId))) {
       unsafePreprocessCommand(cmd)
     }
@@ -141,14 +141,14 @@ private[engine] final class Preprocessor(compiledPackages: MutableCompiledPackag
     */
   def preprocessCommands(
       cmds: data.ImmArray[command.ApiCommand]
-  ): Result[(ImmArray[speedy.Command], Set[Value.ContractId])] =
+  ): Result[ImmArray[speedy.Command]] =
     safelyRun(getDependencies(List.empty, cmds.map(_.templateId).toList)) {
-      unsafePreprocessCommands(cmds)
+      cmds.map(unsafePreprocessCommand)
     }
 
   def translateTransactionRoots[Cid <: Value.ContractId](
       tx: GenTransaction[NodeId, Cid]
-  ): Result[(ImmArray[speedy.Command], Set[Value.ContractId])] =
+  ): Result[ImmArray[speedy.Command]] =
     safelyRun(
       getDependencies(List.empty, tx.rootNodes.toList.map(_.templateId))
     ) {

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -44,9 +44,9 @@ private[engine] final class ValueTranslator(interface: language.Interface) {
   private[preprocessing] def unsafeTranslateValue(
       ty: Type,
       value: Value[ContractId],
-  ): (SValue, Set[Value.ContractId]) = {
+  ): (SValue, Set[Value.ContractId.V1]) = {
 
-    val cids = Set.newBuilder[Value.ContractId]
+    val cids = Set.newBuilder[Value.ContractId.V1]
 
     def go(ty0: Type, value0: Value[ContractId], nesting: Int = 0): SValue =
       if (nesting > Value.MAXIMUM_NESTING) {
@@ -91,7 +91,12 @@ private[engine] final class ValueTranslator(interface: language.Interface) {
                         typeError()
                     }
                   case (BTContractId, ValueContractId(c)) =>
-                    cids += c
+                    c match {
+                      case cV1: ContractId.V1 =>
+                        cids += cV1
+                      case _: ContractId.V0 =>
+                    }
+
                     SValue.SContractId(c)
                   case (BTOptional, ValueOptional(mbValue)) =>
                     mbValue match {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -682,7 +682,7 @@ class EngineTest
     res shouldBe a[Right[_, _]]
     val interpretResult =
       res
-        .flatMap { case (cmds, globalCids) =>
+        .flatMap(cmds =>
           engine
             .interpretCommands(
               validating = false,
@@ -692,14 +692,14 @@ class EngineTest
               ledgerTime = let,
               submissionTime = let,
               seeding = seeding,
-              globalCids = globalCids,
+              globalCids = Set.empty,
             )
             .consume(
               lookupContract,
               lookupPackage,
               lookupKey,
             )
-        }
+        )
     val Right((tx, txMeta)) = interpretResult
     val Right(submitter) = tx.guessSubmitter
 
@@ -818,7 +818,7 @@ class EngineTest
     res shouldBe a[Right[_, _]]
     val result =
       res
-        .flatMap { case (cmds, globalCids) =>
+        .flatMap(cmds =>
           engine
             .interpretCommands(
               validating = false,
@@ -828,14 +828,14 @@ class EngineTest
               ledgerTime = let,
               submissionTime = let,
               seeding = seeding,
-              globalCids = globalCids,
+              globalCids = Set.empty,
             )
             .consume(
               lookupContract,
               lookupPackage,
               lookupKey,
             )
-        }
+        )
     val Right((tx, txMeta)) = result
 
     "be translated" in {
@@ -918,6 +918,7 @@ class EngineTest
           contractKey = SParty(alice),
           choiceId = ChoiceName.assertFromString("Noop"),
           argument = SValue.SUnit,
+          coids = Set.empty,
         )
       )
       val submitters = Set(alice)
@@ -1039,6 +1040,7 @@ class EngineTest
           SRecord(templateId, ImmArray.empty, ArrayList(SParty(alice))),
           "FetchAfterLookup",
           SRecord(templateId, ImmArray.empty, ArrayList(SInt64(43))),
+          Set.empty,
         )
       )
 
@@ -1099,7 +1101,7 @@ class EngineTest
     res shouldBe a[Right[_, _]]
     val interpretResult =
       res
-        .flatMap { case (cmds, globalCids) =>
+        .flatMap(cmds =>
           engine
             .interpretCommands(
               validating = false,
@@ -1109,14 +1111,14 @@ class EngineTest
               ledgerTime = let,
               submissionTime = let,
               seeding = InitialSeeding.TransactionSeed(txSeed),
-              globalCids = globalCids,
+              globalCids = Set.empty,
             )
             .consume(
               lookupContract,
               lookupPackage,
               lookupKey,
             )
-        }
+        )
 
     val Right((tx, txMeta)) = interpretResult
     val Right(submitter) = tx.guessSubmitter
@@ -1379,7 +1381,7 @@ class EngineTest
 
     val txSeed =
       crypto.Hash.deriveTransactionSeed(submissionSeed, participant, submissionTime)
-    val Right((cmds, globalCids)) = preprocessor
+    val Right(cmds) = preprocessor
       .preprocessCommands(ImmArray(command))
       .consume(lookupContract, lookupPackage, lookupKey)
     val Right((rtx, _)) = engine
@@ -1391,7 +1393,7 @@ class EngineTest
         ledgerTime = let,
         submissionTime = submissionTime,
         seeding = InitialSeeding.TransactionSeed(txSeed),
-        globalCids = globalCids,
+        globalCids = Set.empty,
       )
       .consume(lookupContract, lookupPackage, lookupKey)
 
@@ -1547,7 +1549,7 @@ class EngineTest
         .consume(lookupContract, lookupPackage, lookupKey)
 
       res
-        .flatMap { case (cmds, globalCids) =>
+        .flatMap(cmds =>
           engine
             .interpretCommands(
               validating = false,
@@ -1557,14 +1559,14 @@ class EngineTest
               ledgerTime = let,
               submissionTime = let,
               seeding = seeding,
-              globalCids = globalCids,
+              globalCids = Set.empty,
             )
             .consume(
               lookupContract,
               lookupPackage,
               lookupKey,
             )
-        }
+        )
 
     }
 
@@ -1949,7 +1951,7 @@ class EngineTest
 
       val submitters = Set(alice)
 
-      val Right((cmds, globalCids)) = preprocessor
+      val Right(cmds) = preprocessor
         .preprocessCommands(
           ImmArray(
             ExerciseCommand(
@@ -1975,7 +1977,7 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
-          globalCids = globalCids,
+          globalCids = Set.empty,
         )
         .consume(
           lookupContractMap.get,
@@ -2159,7 +2161,7 @@ class EngineTest
 
       val submitters = Set(alice)
 
-      val Right((cmds, globalCids)) = preprocessor
+      val Right(cmds) = preprocessor
         .preprocessCommands(
           ImmArray(
             CreateAndExerciseCommand(templateId, createArg, "DontExecuteCreate", exerciseArg)
@@ -2176,7 +2178,7 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
-          globalCids = globalCids,
+          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
       result shouldBe a[Right[_, _]]
@@ -2193,7 +2195,7 @@ class EngineTest
 
       val submitters = Set(alice)
 
-      val Right((cmds, globalCids)) = preprocessor
+      val Right(cmds) = preprocessor
         .preprocessCommands(ImmArray(CreateCommand(templateId, createArg)))
         .consume(_ => None, lookupPackage, lookupKey)
 
@@ -2206,7 +2208,7 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
-          globalCids = globalCids,
+          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
       result shouldBe a[Left[_, _]]
@@ -2226,7 +2228,7 @@ class EngineTest
 
       val submitters = Set(alice)
 
-      val Right((cmds, globalCids)) = preprocessor
+      val Right(cmds) = preprocessor
         .preprocessCommands(ImmArray(CreateCommand(templateId, createArg)))
         .consume(_ => None, lookupPackage, lookupKey)
       val result = engine
@@ -2238,7 +2240,7 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
-          globalCids = globalCids,
+          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
 
@@ -2300,7 +2302,7 @@ class EngineTest
           choice,
           argument,
         )
-        val Right((cmds, globalCids)) = preprocessor
+        val Right(cmds) = preprocessor
           .preprocessCommands(ImmArray(cmd))
           .consume(lookupContract, lookupPackage, lookupKey)
         engine
@@ -2312,7 +2314,7 @@ class EngineTest
             ledgerTime = let,
             submissionTime = let,
             seeding = seeding,
-            globalCids = globalCids,
+            globalCids = Set.empty,
           )
           .consume(lookupContract, lookupPackage, lookupKey)
       }
@@ -2422,7 +2424,7 @@ class EngineTest
         }
       def run(cmd: ApiCommand) = {
         val submitters = Set(party)
-        val Right((cmds, globalCids)) = preprocessor
+        val Right(cmds) = preprocessor
           .preprocessCommands(ImmArray(cmd))
           .consume(
             lookupContract,
@@ -2438,7 +2440,7 @@ class EngineTest
             ledgerTime = let,
             submissionTime = let,
             seeding = seeding,
-            globalCids = globalCids,
+            globalCids = Set.empty,
           )
           .consume(
             lookupContract,
@@ -2533,7 +2535,7 @@ class EngineTest
         }
       def run(cmd: ApiCommand) = {
         val submitters = Set(party)
-        val Right((cmds, globalCids)) = preprocessor
+        val Right(cmds) = preprocessor
           .preprocessCommands(ImmArray(cmd))
           .consume(
             lookupContract,
@@ -2549,7 +2551,7 @@ class EngineTest
             ledgerTime = let,
             submissionTime = let,
             seeding = seeding,
-            globalCids = globalCids,
+            globalCids = Set.empty,
           )
           .consume(
             lookupContract,
@@ -2616,7 +2618,7 @@ class EngineTest
           keyLookups += 1
           lookupKey(key)
         }
-        val Right((cmds, globalCids)) = preprocessor
+        val Right(cmds) = preprocessor
           .preprocessCommands(ImmArray(cmd))
           .consume(
             lookupContract,
@@ -2632,7 +2634,7 @@ class EngineTest
             ledgerTime = let,
             submissionTime = let,
             seeding = seeding,
-            globalCids = globalCids,
+            globalCids = Set.empty,
           )
           .consume(
             lookupContract,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -692,7 +692,6 @@ class EngineTest
               ledgerTime = let,
               submissionTime = let,
               seeding = seeding,
-              globalCids = Set.empty,
             )
             .consume(
               lookupContract,
@@ -828,7 +827,6 @@ class EngineTest
               ledgerTime = let,
               submissionTime = let,
               seeding = seeding,
-              globalCids = Set.empty,
             )
             .consume(
               lookupContract,
@@ -932,7 +930,6 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(seed),
-          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
 
@@ -971,7 +968,6 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(seed),
-          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
 
@@ -1007,7 +1003,6 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(seed),
-          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
 
@@ -1055,7 +1050,6 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(seed),
-          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
 
@@ -1111,7 +1105,6 @@ class EngineTest
               ledgerTime = let,
               submissionTime = let,
               seeding = InitialSeeding.TransactionSeed(txSeed),
-              globalCids = Set.empty,
             )
             .consume(
               lookupContract,
@@ -1393,7 +1386,6 @@ class EngineTest
         ledgerTime = let,
         submissionTime = submissionTime,
         seeding = InitialSeeding.TransactionSeed(txSeed),
-        globalCids = Set.empty,
       )
       .consume(lookupContract, lookupPackage, lookupKey)
 
@@ -1559,7 +1551,6 @@ class EngineTest
               ledgerTime = let,
               submissionTime = let,
               seeding = seeding,
-              globalCids = Set.empty,
             )
             .consume(
               lookupContract,
@@ -1836,7 +1827,6 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(seed),
-          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
 
@@ -1977,7 +1967,6 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
-          globalCids = Set.empty,
         )
         .consume(
           lookupContractMap.get,
@@ -2178,7 +2167,6 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
-          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
       result shouldBe a[Right[_, _]]
@@ -2208,7 +2196,6 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
-          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
       result shouldBe a[Left[_, _]]
@@ -2240,7 +2227,6 @@ class EngineTest
           ledgerTime = now,
           submissionTime = now,
           seeding = InitialSeeding.TransactionSeed(txSeed),
-          globalCids = Set.empty,
         )
         .consume(_ => None, lookupPackage, lookupKey)
 
@@ -2314,7 +2300,6 @@ class EngineTest
             ledgerTime = let,
             submissionTime = let,
             seeding = seeding,
-            globalCids = Set.empty,
           )
           .consume(lookupContract, lookupPackage, lookupKey)
       }
@@ -2440,7 +2425,6 @@ class EngineTest
             ledgerTime = let,
             submissionTime = let,
             seeding = seeding,
-            globalCids = Set.empty,
           )
           .consume(
             lookupContract,
@@ -2551,7 +2535,6 @@ class EngineTest
             ledgerTime = let,
             submissionTime = let,
             seeding = seeding,
-            globalCids = Set.empty,
           )
           .consume(
             lookupContract,
@@ -2634,7 +2617,6 @@ class EngineTest
             ledgerTime = let,
             submissionTime = let,
             seeding = seeding,
-            globalCids = Set.empty,
           )
           .consume(
             lookupContract,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
@@ -5,6 +5,7 @@ package com.daml.lf.speedy
 
 import com.daml.lf.data.Ref.{ChoiceName, Identifier}
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.value.Value.ContractId
 
 // ---------------------
 // Preprocessed commands
@@ -18,6 +19,7 @@ object Command {
   final case class Create(
       templateId: Identifier,
       argument: SValue,
+      coids: Set[ContractId.V1],
   ) extends Command
 
   final case class Exercise(
@@ -25,6 +27,7 @@ object Command {
       contractId: SContractId,
       choiceId: ChoiceName,
       argument: SValue,
+      coids: Set[ContractId.V1],
   ) extends Command
 
   final case class ExerciseByKey(
@@ -32,6 +35,7 @@ object Command {
       contractKey: SValue,
       choiceId: ChoiceName,
       argument: SValue,
+      coids: Set[ContractId.V1],
   ) extends Command
 
   final case class Fetch(
@@ -49,6 +53,7 @@ object Command {
       createArgument: SValue,
       choiceId: ChoiceName,
       choiceArgument: SValue,
+      coid: Set[ContractId.V1],
   ) extends Command
 
   final case class LookupByKey(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -521,10 +521,9 @@ private[lf] object Pretty {
         case SEScopeExercise(body) =>
           text("exercise") + char('(') + prettySExpr(index)(body) + text(")")
 
-        case x: SEBuiltinRecursiveDefinition => str(x)
-        case x: SEImportValue => str(x)
-        case x: SELabelClosure => str(x)
-        case x: SEDamlException => str(x)
+        case _: SEBuiltinRecursiveDefinition | _: SEImportValue | _: SELabelClosure |
+            _: SEDamlException =>
+          str(e)
       }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -944,6 +944,17 @@ private[lf] object SBuiltin {
     }
   }
 
+  final case class SBUImportCids(cids: Set[V.ContractId.V1]) extends SBuiltin(1) {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Unit = {
+      checkToken(args, 0)
+      cids.foreach(machine.addGlobalCid)
+      machine.returnValue = SUnit
+    }
+  }
+
   /** $beginExercise
     *    :: arg                                           0 (choice argument)
     *    -> ContractId arg                                1 (contract to exercise)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
@@ -45,6 +45,7 @@ class CompilerTest extends AnyWordSpec with Matchers {
           Command.Create(
             recordCon,
             SValue.SRecord(recordCon, ImmArray.empty, new util.ArrayList()),
+            Set.empty,
           )
         )
         .toImmArray

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -127,7 +127,7 @@ class IdeLedgerClient(
     ScenarioRunner.SubmissionResult[ScenarioLedger.CommitResult]
   ] =
     Future {
-      val speedyCommands = preprocessor.unsafePreprocessCommands(commands.to(ImmArray))._1
+      val speedyCommands = commands.map(preprocessor.unsafePreprocessCommand).to(ImmArray)
       val translated = compiledPackages.compiler.unsafeCompile(speedyCommands)
 
       val ledgerApi = ScenarioRunner.ScenarioLedgerApi(ledger)


### PR DESCRIPTION
Instead of the complicate (and probably buggy) logic in the command preprocessor that tries to detect contract ID freshness conflict statically, we  
- collect input contract IDs during the command preprocessing (without conflict detection) and store those in the Speedy command
- add a builtin to import dynamically those IDs and check freshness conflict at run time
- run the dynamic import before each command
- process a create follow by an exercise on the same cid as one `CreateAndExercise` command, when translation transaction.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
