### PR TITLE
Factor out Daml export integration tests

### DIFF
--- a/daml-script/export/BUILD.bazel
+++ b/daml-script/export/BUILD.bazel
@@ -83,52 +83,6 @@ da_scala_test(
     ],
 )
 
-da_scala_test(
-    name = "integration-tests",
-    srcs = glob(["src/it/scala/**/*.scala"]),
-    data = [
-        "//compiler/damlc",
-        "//daml-script/daml:daml-script.dar",
-        "//ledger/test-common:dar-files",
-    ],
-    resources = glob(["src/test/resources/**/*"]),
-    scala_deps = [
-        "@maven//:com_typesafe_akka_akka_actor",
-        "@maven//:com_typesafe_akka_akka_stream",
-        "@maven//:io_spray_spray_json",
-        "@maven//:org_scalatest_scalatest",
-        "@maven//:org_scalaz_scalaz_core",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":export",
-        "//:sdk-version-scala-lib",
-        "//bazel_tools/runfiles:scala_runfiles",
-        "//daml-lf/archive:daml_lf_archive_reader",
-        "//daml-lf/interpreter",
-        "//daml-lf/language",
-        "//daml-script/export/transaction-eq",
-        "//daml-script/runner:script-runner-lib",
-        "//language-support/scala/bindings",
-        "//ledger-api/rs-grpc-bridge",
-        "//ledger-api/testing-utils",
-        "//ledger/ledger-api-auth",
-        "//ledger/ledger-api-client",
-        "//ledger/ledger-api-common",
-        "//ledger/ledger-api-domain",
-        "//ledger/ledger-resources",
-        "//ledger/sandbox:sandbox-scala-tests-lib",
-        "//ledger/sandbox-common",
-        "//ledger/sandbox-common:sandbox-common-scala-tests-lib",
-        "//ledger/test-common",
-        "//libs-scala/fs-utils",
-        "//libs-scala/ports",
-        "//libs-scala/resources",
-        "@maven//:io_grpc_grpc_api",
-        "@maven//:io_netty_netty_handler",
-    ],
-)
-
 da_scala_binary(
     name = "example-export-client",
     srcs = ["src/example-export/scala/com/daml/script/export/ExampleClient.scala"],

--- a/daml-script/export/BUILD.bazel
+++ b/daml-script/export/BUILD.bazel
@@ -13,7 +13,6 @@ load(
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
-    "da_scala_library",
     "da_scala_test",
     "silencer_plugin",
 )
@@ -81,91 +80,4 @@ da_scala_test(
         "//ledger/ledger-api-common",
         "//libs-scala/auth-utils",
     ],
-)
-
-da_scala_binary(
-    name = "example-export-client",
-    srcs = ["src/example-export/scala/com/daml/script/export/ExampleClient.scala"],
-    main_class = "com.daml.script.export.ExampleClient",
-    scala_deps = [
-        "@maven//:com_github_scopt_scopt",
-    ],
-    deps = [
-        ":export",
-        "//daml-lf/data",
-        "//daml-script/runner:script-runner-lib",
-        "//language-support/scala/bindings",
-        "//language-support/scala/bindings-akka",
-        "//ledger/ledger-api-common",
-        "//libs-scala/auth-utils",
-        "//libs-scala/fs-utils",
-    ],
-)
-
-client_server_build(
-    name = "example-export",
-    outs = [
-        "example-export/Export.daml",
-        "example-export/args.json",
-        "example-export/daml.yaml",
-    ],
-    client = ":example-export-client",
-    client_files = ["//daml-script/test:script-test.dar"],
-    data = ["//daml-script/test:script-test.dar"],
-    output_env = "EXPORT_OUT",
-    server = "//ledger/sandbox:sandbox-binary",
-    server_args = [
-        "--port",
-        "0",
-    ],
-    server_files = ["//daml-script/test:script-test.dar"],
-)
-
-# Compare the generated Daml ledger export to the example export used in the
-# documentation. This functions as both a golden test on ledger exports and to
-# make sure that the documentation stays up-to-date.
-#
-# Normalizes the expected output by removing the copyright header and any
-# documentation import markers and normalizes the actual output by adding a
-# newline to the last line if missing.
-#
-# Normalizes the data-dependencies by replacing the SDK version, package-id
-# hashes with a placeholder, and Windows path separators by Unix separators.
-sh_inline_test(
-    name = "example-export-compare",
-    cmd = """\
-EXPECTED_EXPORT=$$(canonicalize_rlocation $(rootpath //docs:source/tools/export/output-root/Export.daml))
-EXPECTED_ARGS=$$(canonicalize_rlocation $(rootpath //docs:source/tools/export/output-root/args.json))
-EXPECTED_YAML=$$(canonicalize_rlocation $(rootpath //docs:source/tools/export/output-root/daml.yaml))
-ACTUAL_EXPORT=$$(canonicalize_rlocation $(rootpath :example-export/Export.daml))
-ACTUAL_ARGS=$$(canonicalize_rlocation $(rootpath :example-export/args.json))
-ACTUAL_YAML=$$(canonicalize_rlocation $(rootpath :example-export/daml.yaml))
-# Normalize the expected file by removing the copyright header and any documentation import markers.
-# Normalize the actual output by adding a newline to the last line if missing.
-$(POSIX_DIFF) -Naur --strip-trailing-cr <($(POSIX_SED) '1,3d;/^-- EXPORT/d' $$EXPECTED_EXPORT) <($(POSIX_SED) '$$a\\' $$ACTUAL_EXPORT) || {{
-  echo "$$EXPECTED_EXPORT did not match $$ACTUAL_EXPORT"
-  exit 1
-}}
-$(POSIX_DIFF) -Naur --strip-trailing-cr $$EXPECTED_ARGS <($(POSIX_SED) '$$a\\' $$ACTUAL_ARGS) || {{
-  echo "$$EXPECTED_ARGS did not match $$ACTUAL_ARGS"
-  exit 1
-}}
-# Normalize the expected file by removing the copyright header and any documentation import markers.
-# Normalize the data-dependencies by replacing the SDK version, package-id hashes with a placeholder, and Windows path separators by Unix separators.
-$(POSIX_DIFF) -Naur --strip-trailing-cr <($(POSIX_SED) '1,3d;s/[0-9a-f]\\{{64\\}}/HASH/;s/daml-\\(script\\|stdlib\\)-0\\.0\\.0/daml-\\1-{ghc_version}/' $$EXPECTED_YAML) <($(POSIX_SED) 's/[0-9a-f]\\{{64\\}}/HASH/;s,\\\\,/,g;$$a\\' $$ACTUAL_YAML) || {{
-  echo "$$EXPECTED_YAML did not match $$ACTUAL_YAML"
-  exit 1
-}}
-""".format(
-        ghc_version = ghc_version,
-    ),
-    data = [
-        ":example-export/Export.daml",
-        ":example-export/args.json",
-        ":example-export/daml.yaml",
-        "//docs:source/tools/export/output-root/Export.daml",
-        "//docs:source/tools/export/output-root/args.json",
-        "//docs:source/tools/export/output-root/daml.yaml",
-    ],
-    toolchains = ["@rules_sh//sh/posix:make_variables"],
 )

--- a/daml-script/export/integration-tests/matches-docs/BUILD.bazel
+++ b/daml-script/export/integration-tests/matches-docs/BUILD.bazel
@@ -1,0 +1,103 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@build_environment//:configuration.bzl", "ghc_version")
+load(
+    "//bazel_tools/client_server:client_server_build.bzl",
+    "client_server_build",
+)
+load(
+    "//bazel_tools/sh:sh.bzl",
+    "sh_inline_test",
+)
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+)
+
+da_scala_binary(
+    name = "example-export-client",
+    srcs = ["scala/com/daml/script/export/ExampleExportClient.scala"],
+    main_class = "com.daml.script.export.ExampleExportClient",
+    scala_deps = [
+        "@maven//:com_github_scopt_scopt",
+    ],
+    deps = [
+        "//daml-lf/data",
+        "//daml-script/export",
+        "//daml-script/runner:script-runner-lib",
+        "//language-support/scala/bindings",
+        "//language-support/scala/bindings-akka",
+        "//ledger/ledger-api-common",
+        "//libs-scala/auth-utils",
+        "//libs-scala/fs-utils",
+    ],
+)
+
+client_server_build(
+    name = "example-export",
+    outs = [
+        "example-export/Export.daml",
+        "example-export/args.json",
+        "example-export/daml.yaml",
+    ],
+    client = ":example-export-client",
+    client_files = ["//daml-script/test:script-test.dar"],
+    data = ["//daml-script/test:script-test.dar"],
+    output_env = "EXPORT_OUT",
+    server = "//ledger/sandbox:sandbox-binary",
+    server_args = [
+        "--port",
+        "0",
+    ],
+    server_files = ["//daml-script/test:script-test.dar"],
+)
+
+# Compare the generated Daml ledger export to the example export used in the
+# documentation. This functions as both a golden test on ledger exports and to
+# make sure that the documentation stays up-to-date.
+#
+# Normalizes the expected output by removing the copyright header and any
+# documentation import markers and normalizes the actual output by adding a
+# newline to the last line if missing.
+#
+# Normalizes the data-dependencies by replacing the SDK version, package-id
+# hashes with a placeholder, and Windows path separators by Unix separators.
+sh_inline_test(
+    name = "example-export-compare",
+    cmd = """\
+EXPECTED_EXPORT=$$(canonicalize_rlocation $(rootpath //docs:source/tools/export/output-root/Export.daml))
+EXPECTED_ARGS=$$(canonicalize_rlocation $(rootpath //docs:source/tools/export/output-root/args.json))
+EXPECTED_YAML=$$(canonicalize_rlocation $(rootpath //docs:source/tools/export/output-root/daml.yaml))
+ACTUAL_EXPORT=$$(canonicalize_rlocation $(rootpath :example-export/Export.daml))
+ACTUAL_ARGS=$$(canonicalize_rlocation $(rootpath :example-export/args.json))
+ACTUAL_YAML=$$(canonicalize_rlocation $(rootpath :example-export/daml.yaml))
+# Normalize the expected file by removing the copyright header and any documentation import markers.
+# Normalize the actual output by adding a newline to the last line if missing.
+$(POSIX_DIFF) -Naur --strip-trailing-cr <($(POSIX_SED) '1,3d;/^-- EXPORT/d' $$EXPECTED_EXPORT) <($(POSIX_SED) '$$a\\' $$ACTUAL_EXPORT) || {{
+  echo "$$EXPECTED_EXPORT did not match $$ACTUAL_EXPORT"
+  exit 1
+}}
+$(POSIX_DIFF) -Naur --strip-trailing-cr $$EXPECTED_ARGS <($(POSIX_SED) '$$a\\' $$ACTUAL_ARGS) || {{
+  echo "$$EXPECTED_ARGS did not match $$ACTUAL_ARGS"
+  exit 1
+}}
+# Normalize the expected file by removing the copyright header and any documentation import markers.
+# Normalize the data-dependencies by replacing the SDK version, package-id hashes with a placeholder, and Windows path separators by Unix separators.
+$(POSIX_DIFF) -Naur --strip-trailing-cr <($(POSIX_SED) '1,3d;s/[0-9a-f]\\{{64\\}}/HASH/;s/daml-\\(script\\|stdlib\\)-0\\.0\\.0/daml-\\1-{ghc_version}/' $$EXPECTED_YAML) <($(POSIX_SED) 's/[0-9a-f]\\{{64\\}}/HASH/;s,\\\\,/,g;$$a\\' $$ACTUAL_YAML) || {{
+  echo "$$EXPECTED_YAML did not match $$ACTUAL_YAML"
+  exit 1
+}}
+""".format(
+        ghc_version = ghc_version,
+    ),
+    data = [
+        ":example-export/Export.daml",
+        ":example-export/args.json",
+        ":example-export/daml.yaml",
+        "//docs:source/tools/export/output-root/Export.daml",
+        "//docs:source/tools/export/output-root/args.json",
+        "//docs:source/tools/export/output-root/daml.yaml",
+    ],
+    toolchains = ["@rules_sh//sh/posix:make_variables"],
+)

--- a/daml-script/export/integration-tests/matches-docs/scala/com/daml/script/export/ExampleExportClient.scala
+++ b/daml-script/export/integration-tests/matches-docs/scala/com/daml/script/export/ExampleExportClient.scala
@@ -11,7 +11,7 @@ import com.daml.fs.Utils.deleteRecursively
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.lf.engine.script.{RunnerConfig, RunnerMain}
 
-case class ExampleClientConfig(
+case class ExampleExportClientConfig(
     darPath: File,
     targetPort: Int,
     outputExportDaml: Path,
@@ -19,11 +19,11 @@ case class ExampleClientConfig(
     outputDamlYaml: Path,
 )
 
-object ExampleClientConfig {
-  def parse(args: Array[String]): Option[ExampleClientConfig] =
+object ExampleExportClientConfig {
+  def parse(args: Array[String]): Option[ExampleExportClientConfig] =
     parser.parse(
       args,
-      ExampleClientConfig(
+      ExampleExportClientConfig(
         darPath = null,
         targetPort = -1,
         outputExportDaml = null,
@@ -34,7 +34,7 @@ object ExampleClientConfig {
 
   private def parseExportOut(
       envVar: String
-  ): Either[String, ExampleClientConfig => ExampleClientConfig] = {
+  ): Either[String, ExampleExportClientConfig => ExampleExportClientConfig] = {
     envVar.split(" ").map(s => Paths.get(s)) match {
       case Array(export_daml, args_json, daml_yaml) =>
         Right(c =>
@@ -48,7 +48,7 @@ object ExampleClientConfig {
     }
   }
 
-  private val parser = new scopt.OptionParser[ExampleClientConfig]("script-export") {
+  private val parser = new scopt.OptionParser[ExampleExportClientConfig]("script-export") {
     help("help")
       .text("Show this help message.")
     opt[Int]("target-port")
@@ -73,14 +73,14 @@ object ExampleClientConfig {
   }
 }
 
-object ExampleClient {
+object ExampleExportClient {
   def main(args: Array[String]): Unit = {
-    ExampleClientConfig.parse(args) match {
+    ExampleExportClientConfig.parse(args) match {
       case Some(clientConfig) => main(clientConfig)
       case None => sys.exit(1)
     }
   }
-  def main(clientConfig: ExampleClientConfig): Unit = {
+  def main(clientConfig: ExampleExportClientConfig): Unit = {
     RunnerMain.main(
       RunnerConfig(
         darPath = clientConfig.darPath,

--- a/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
+++ b/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
@@ -1,0 +1,52 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_test",
+)
+
+da_scala_test(
+    name = "reproduces-transactions",
+    srcs = ["scala/com/daml/script/export/ReproducesTransactions.scala"],
+    data = [
+        "//compiler/damlc",
+        "//daml-script/daml:daml-script.dar",
+        "//ledger/test-common:dar-files",
+    ],
+    scala_deps = [
+        "@maven//:com_typesafe_akka_akka_actor",
+        "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:io_spray_spray_json",
+        "@maven//:org_scalatest_scalatest",
+        "@maven//:org_scalaz_scalaz_core",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:sdk-version-scala-lib",
+        "//bazel_tools/runfiles:scala_runfiles",
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
+        "//daml-script/export",
+        "//daml-script/export/transaction-eq",
+        "//daml-script/runner:script-runner-lib",
+        "//language-support/scala/bindings",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger/ledger-api-auth",
+        "//ledger/ledger-api-client",
+        "//ledger/ledger-api-common",
+        "//ledger/ledger-api-domain",
+        "//ledger/ledger-resources",
+        "//ledger/sandbox:sandbox-scala-tests-lib",
+        "//ledger/sandbox-common",
+        "//ledger/sandbox-common:sandbox-common-scala-tests-lib",
+        "//ledger/test-common",
+        "//libs-scala/fs-utils",
+        "//libs-scala/ports",
+        "//libs-scala/resources",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_netty_netty_handler",
+    ],
+)

--- a/daml-script/export/integration-tests/reproduces-transactions/scala/com/daml/script/export/ReproducesTransactions.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/scala/com/daml/script/export/ReproducesTransactions.scala
@@ -46,7 +46,7 @@ import org.scalatest._
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-final class IT
+final class ReproducesTransactions
     extends AsyncFreeSpec
     with Matchers
     with AkkaBeforeAndAfterAll


### PR DESCRIPTION
This only moves files and build definitions around and renames some test-classes. It separates the integration tests defined in `daml-script/export/BUILD.bazel` into dedicated BUILD files underneath `daml-script/export/integration-tests`. The motivation is to make it easier to create new integration tests that involve multiple Bazel targets. 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
