### PR TITLE
participant-integration-api: Make the initial ledger config optional. [KVL-1046]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
@@ -25,7 +25,7 @@ case class ApiServerConfig(
     databaseConnectionTimeout: FiniteDuration,
     tlsConfig: Option[TlsConfiguration],
     maxInboundMessageSize: Int,
-    initialLedgerConfiguration: InitialLedgerConfiguration,
+    initialLedgerConfiguration: Option[InitialLedgerConfiguration],
     configurationLoadTimeout: Duration,
     eventsPageSize: Int = IndexConfiguration.DefaultEventsPageSize,
     eventsProcessingParallelism: Int = IndexConfiguration.DefaultEventsProcessingParallelism,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -83,7 +83,7 @@ private[daml] object ApiServices {
       timeProvider: TimeProvider,
       timeProviderType: TimeProviderType,
       configurationLoadTimeout: Duration,
-      initialLedgerConfiguration: InitialLedgerConfiguration,
+      initialLedgerConfiguration: Option[InitialLedgerConfiguration],
       commandConfig: CommandConfiguration,
       partyConfig: PartyConfiguration,
       optTimeServiceBackend: Option[TimeServiceBackend],

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigurationInitializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigurationInitializer.scala
@@ -41,9 +41,9 @@ final class LedgerConfigurationInitializer(
       // First, we acquire the mechanism for looking up the current ledger configuration.
       ledgerConfigurationSubscription <- subscriptionBuilder.subscription(configurationLoadTimeout)
       // Next, we provision the configuration if one does not already exist on the ledger.
-      _ <- optWriteService.zip(initialLedgerConfiguration) match {
-        case None => ResourceOwner.unit
-        case Some((writeService, initialConfiguration)) =>
+      _ <- (optWriteService, initialLedgerConfiguration) match {
+        case (None, _) | (_, None) => ResourceOwner.unit
+        case (Some(writeService), Some(initialConfiguration)) =>
           val submissionIdGenerator = SubmissionIdGenerator.Random
           new LedgerConfigurationProvisioner(
             ledgerConfigurationSubscription,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigurationInitializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigurationInitializer.scala
@@ -31,7 +31,7 @@ final class LedgerConfigurationInitializer(
   )
 
   def initialize(
-      initialLedgerConfiguration: InitialLedgerConfiguration,
+      initialLedgerConfiguration: Option[InitialLedgerConfiguration],
       configurationLoadTimeout: Duration,
   )(implicit
       resourceContext: ResourceContext,
@@ -41,9 +41,9 @@ final class LedgerConfigurationInitializer(
       // First, we acquire the mechanism for looking up the current ledger configuration.
       ledgerConfigurationSubscription <- subscriptionBuilder.subscription(configurationLoadTimeout)
       // Next, we provision the configuration if one does not already exist on the ledger.
-      _ <- optWriteService match {
+      _ <- optWriteService.zip(initialLedgerConfiguration) match {
         case None => ResourceOwner.unit
-        case Some(writeService) =>
+        case Some((writeService, initialConfiguration)) =>
           val submissionIdGenerator = SubmissionIdGenerator.Random
           new LedgerConfigurationProvisioner(
             ledgerConfigurationSubscription,
@@ -51,7 +51,7 @@ final class LedgerConfigurationInitializer(
             timeProvider,
             submissionIdGenerator,
             scheduler,
-          ).submit(initialLedgerConfiguration)(servicesExecutionContext, loggingContext)
+          ).submit(initialConfiguration)(servicesExecutionContext, loggingContext)
       }
       // Finally, we wait until either an existing configuration or the provisioned configuration
       // appears on the index.

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -73,7 +73,7 @@ trait ConfigProvider[ExtraConfig] {
       ),
       tlsConfig = config.tlsConfig,
       maxInboundMessageSize = config.maxInboundMessageSize,
-      initialLedgerConfiguration = initialLedgerConfig(config),
+      initialLedgerConfiguration = Some(initialLedgerConfig(config)),
       configurationLoadTimeout = config.configurationLoadTimeout,
       eventsPageSize = config.eventsPageSize,
       eventsProcessingParallelism = config.eventsProcessingParallelism,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -374,7 +374,7 @@ final class SandboxServer(
         timeProvider = timeProvider,
         timeProviderType = timeProviderType,
         configurationLoadTimeout = config.configurationLoadTimeout,
-        initialLedgerConfiguration = config.initialLedgerConfiguration,
+        initialLedgerConfiguration = Some(config.initialLedgerConfiguration),
         commandConfig = config.commandConfig,
         partyConfig = PartyConfiguration.default.copy(
           implicitPartyAllocation = config.implicitPartyAllocation

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -236,7 +236,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   databaseConnectionTimeout = config.databaseConnectionTimeout,
                   tlsConfig = config.tlsConfig,
                   maxInboundMessageSize = config.maxInboundMessageSize,
-                  initialLedgerConfiguration = config.initialLedgerConfiguration,
+                  initialLedgerConfiguration = Some(config.initialLedgerConfiguration),
                   configurationLoadTimeout = config.configurationLoadTimeout,
                   eventsPageSize = config.eventsPageSize,
                   portFile = config.portFile,


### PR DESCRIPTION
### Changelog

- **[Integration Kit]** The initial ledger configuration is now optional; if it is not specified, the participant will not attempt to submit a configuration, but instead wait for something else to provision the ledger with a configuration.

  This behavior is intended to be used by ledger drivers that have alternative means of setting up the initial ledger configuration. If no configuration is provisioned, the participant server will not be able to submit commands to the ledger.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
