### PR TITLE
participant-integration-api: Always wait for the first config lookup.

### DIFF
--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
@@ -13,7 +13,6 @@ import com.daml.ledger.validator.DefaultStateKeySerializationStrategy
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
-import com.daml.platform.configuration.InitialLedgerConfiguration
 import scopt.OptionParser
 
 private[memory] class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state: InMemoryState)
@@ -49,11 +48,6 @@ private[memory] class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state
       createMetrics(participantConfig, config),
     )
   }
-
-  override def initialLedgerConfig(config: Config[Unit]): InitialLedgerConfiguration =
-    super
-      .initialLedgerConfig(config)
-      .copy(delayBeforeSubmitting = Config.LocalInitialConfigurationSubmissionDelay)
 
   override def extraConfigParser(parser: OptionParser[Config[Unit]]): Unit = ()
 

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -16,18 +16,12 @@ import com.daml.ledger.participant.state.kvutils.caching._
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
-import com.daml.platform.configuration.InitialLedgerConfiguration
 import scopt.OptionParser
 
 object SqlLedgerFactory extends LedgerFactory[ReadWriteService, ExtraConfig] {
   override val defaultExtraConfig: ExtraConfig = ExtraConfig(
     jdbcUrl = None
   )
-
-  override def initialLedgerConfig(config: Config[ExtraConfig]): InitialLedgerConfiguration =
-    super
-      .initialLedgerConfig(config)
-      .copy(delayBeforeSubmitting = Config.LocalInitialConfigurationSubmissionDelay)
 
   override def extraConfigParser(parser: OptionParser[Config[ExtraConfig]]): Unit = {
     parser

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -58,18 +58,6 @@ object Config {
 
   val DefaultMaxInboundMessageSize: Int = 64 * 1024 * 1024
 
-  /** The default delay before submitting an initial configuration.
-    * 5 seconds is typically enough for the participant to look up the current configuration from a
-    * remote ledger.
-    */
-  val DefaultInitialConfigurationSubmissionDelay: Duration = Duration.ofSeconds(5)
-
-  /** The delay before submitting an initial configuration to a local ledger.
-    * 500 milliseconds is typically enough for the participant to look up the current configuration
-    * from a local ledger.
-    */
-  val LocalInitialConfigurationSubmissionDelay: Duration = Duration.ofMillis(500)
-
   def createDefault[Extra](extra: Extra): Config[Extra] =
     Config(
       mode = Mode.Run,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.app
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 import akka.stream.Materializer
@@ -95,7 +96,7 @@ trait ConfigProvider[ExtraConfig] {
   def initialLedgerConfig(config: Config[ExtraConfig]): InitialLedgerConfiguration =
     InitialLedgerConfiguration(
       configuration = Configuration.reasonableInitialConfiguration,
-      delayBeforeSubmitting = Config.DefaultInitialConfigurationSubmissionDelay,
+      delayBeforeSubmitting = Duration.ZERO,
     )
 
   def timeServiceBackend(@unused config: Config[ExtraConfig]): Option[TimeServiceBackend] = None

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -96,6 +96,10 @@ trait ConfigProvider[ExtraConfig] {
   def initialLedgerConfig(config: Config[ExtraConfig]): InitialLedgerConfiguration =
     InitialLedgerConfiguration(
       configuration = Configuration.reasonableInitialConfiguration,
+      // If a new index database is added to an already existing ledger,
+      // a zero delay will likely produce a "configuration rejected" ledger entry,
+      // because at startup the indexer hasn't ingested any configuration change yet.
+      // Override this setting for distributed ledgers where you want to avoid these superfluous entries.
       delayBeforeSubmitting = Duration.ZERO,
     )
 

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeLedgerFactory.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeLedgerFactory.scala
@@ -8,7 +8,6 @@ import com.daml.ledger.participant.state.kvutils.app.{Config, LedgerFactory, Par
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
-import com.daml.platform.configuration.InitialLedgerConfiguration
 import scopt.OptionParser
 
 case class BridgeConfig(maxDedupSeconds: Int, submissionBufferSize: Int)
@@ -30,11 +29,6 @@ object BridgeLedgerFactory extends LedgerFactory[ReadWriteServiceBridge, BridgeC
         submissionBufferSize = config.extra.submissionBufferSize,
       )
     )
-
-  override def initialLedgerConfig(config: Config[BridgeConfig]): InitialLedgerConfiguration =
-    super
-      .initialLedgerConfig(config)
-      .copy(delayBeforeSubmitting = Config.LocalInitialConfigurationSubmissionDelay)
 
   override def extraConfigParser(parser: OptionParser[Config[BridgeConfig]]): Unit = {
     parser


### PR DESCRIPTION
This means we don't have to guess how long a `lookupConfiguration()` round trip will take. Instead we can just submit the initial configuration if one is not found.

Some drivers may still need to wait a while for other reasons.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
