### PR TITLE
Track command - use types for error handling instead of grpc statuses [KVL-1005]

### DIFF
--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
@@ -13,7 +13,10 @@ import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, LedgerId, Party}
 import com.daml.ledger.api.refinements.{CompositeCommand, CompositeCommandAdapter}
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
 import com.daml.ledger.api.v1.event.Event
-import com.daml.ledger.api.v1.ledger_identity_service.{GetLedgerIdentityRequest, LedgerIdentityServiceGrpc}
+import com.daml.ledger.api.v1.ledger_identity_service.{
+  GetLedgerIdentityRequest,
+  LedgerIdentityServiceGrpc,
+}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.transaction_filter.TransactionFilter
 import com.daml.ledger.client.LedgerClient

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
@@ -12,12 +12,8 @@ import com.daml.api.util.TimeProvider
 import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, LedgerId, Party}
 import com.daml.ledger.api.refinements.{CompositeCommand, CompositeCommandAdapter}
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
-import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.api.v1.event.Event
-import com.daml.ledger.api.v1.ledger_identity_service.{
-  GetLedgerIdentityRequest,
-  LedgerIdentityServiceGrpc,
-}
+import com.daml.ledger.api.v1.ledger_identity_service.{GetLedgerIdentityRequest, LedgerIdentityServiceGrpc}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.transaction_filter.TransactionFilter
 import com.daml.ledger.client.LedgerClient
@@ -25,6 +21,7 @@ import com.daml.ledger.client.binding.DomainTransactionMapper.DecoderType
 import com.daml.ledger.client.binding.retrying.{CommandRetryFlow, RetryInfo}
 import com.daml.ledger.client.binding.util.Slf4JLogger
 import com.daml.ledger.client.configuration.LedgerClientConfiguration
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.util.Ctx
 import io.grpc.ManagedChannel
 import io.grpc.netty.NegotiationType.TLS
@@ -84,7 +81,7 @@ class LedgerClientBinding(
       .via(DomainTransactionMapper(decoder))
   }
 
-  type CommandTrackingFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, Completion], NotUsed]
+  type CommandTrackingFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, CompletionResponse], NotUsed]
 
   private val compositeCommandAdapter = new CompositeCommandAdapter(
     LedgerId(ledgerClient.ledgerId.unwrap),
@@ -115,7 +112,7 @@ class LedgerClientBinding(
     retryInfo.request
   }
 
-  type CommandsFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, Completion], NotUsed]
+  type CommandsFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, CompletionResponse], NotUsed]
 
   def commands[C](party: Party)(implicit ec: ExecutionContext): Future[CommandsFlow[C]] = {
     for {

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
@@ -13,10 +13,7 @@ import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, LedgerId, Party}
 import com.daml.ledger.api.refinements.{CompositeCommand, CompositeCommandAdapter}
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
 import com.daml.ledger.api.v1.event.Event
-import com.daml.ledger.api.v1.ledger_identity_service.{
-  GetLedgerIdentityRequest,
-  LedgerIdentityServiceGrpc,
-}
+import com.daml.ledger.api.v1.ledger_identity_service.{GetLedgerIdentityRequest, LedgerIdentityServiceGrpc}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.transaction_filter.TransactionFilter
 import com.daml.ledger.client.LedgerClient
@@ -24,7 +21,7 @@ import com.daml.ledger.client.binding.DomainTransactionMapper.DecoderType
 import com.daml.ledger.client.binding.retrying.{CommandRetryFlow, RetryInfo}
 import com.daml.ledger.client.binding.util.Slf4JLogger
 import com.daml.ledger.client.configuration.LedgerClientConfiguration
-import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{CompletionFailure, CompletionSuccess}
 import com.daml.util.Ctx
 import io.grpc.ManagedChannel
 import io.grpc.netty.NegotiationType.TLS
@@ -84,7 +81,7 @@ class LedgerClientBinding(
       .via(DomainTransactionMapper(decoder))
   }
 
-  type CommandTrackingFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, CompletionResponse], NotUsed]
+  type CommandTrackingFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, Either[CompletionFailure, CompletionSuccess]], NotUsed]
 
   private val compositeCommandAdapter = new CompositeCommandAdapter(
     LedgerId(ledgerClient.ledgerId.unwrap),
@@ -115,7 +112,7 @@ class LedgerClientBinding(
     retryInfo.request
   }
 
-  type CommandsFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, CompletionResponse], NotUsed]
+  type CommandsFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, Either[CompletionFailure, CompletionSuccess]], NotUsed]
 
   def commands[C](party: Party)(implicit ec: ExecutionContext): Future[CommandsFlow[C]] = {
     for {

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/LedgerClientBinding.scala
@@ -13,7 +13,10 @@ import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, LedgerId, Party}
 import com.daml.ledger.api.refinements.{CompositeCommand, CompositeCommandAdapter}
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
 import com.daml.ledger.api.v1.event.Event
-import com.daml.ledger.api.v1.ledger_identity_service.{GetLedgerIdentityRequest, LedgerIdentityServiceGrpc}
+import com.daml.ledger.api.v1.ledger_identity_service.{
+  GetLedgerIdentityRequest,
+  LedgerIdentityServiceGrpc,
+}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.transaction_filter.TransactionFilter
 import com.daml.ledger.client.LedgerClient
@@ -21,7 +24,10 @@ import com.daml.ledger.client.binding.DomainTransactionMapper.DecoderType
 import com.daml.ledger.client.binding.retrying.{CommandRetryFlow, RetryInfo}
 import com.daml.ledger.client.binding.util.Slf4JLogger
 import com.daml.ledger.client.configuration.LedgerClientConfiguration
-import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{CompletionFailure, CompletionSuccess}
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionFailure,
+  CompletionSuccess,
+}
 import com.daml.util.Ctx
 import io.grpc.ManagedChannel
 import io.grpc.netty.NegotiationType.TLS
@@ -81,7 +87,8 @@ class LedgerClientBinding(
       .via(DomainTransactionMapper(decoder))
   }
 
-  type CommandTrackingFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, Either[CompletionFailure, CompletionSuccess]], NotUsed]
+  type CommandTrackingFlow[C] =
+    Flow[Ctx[C, CompositeCommand], Ctx[C, Either[CompletionFailure, CompletionSuccess]], NotUsed]
 
   private val compositeCommandAdapter = new CompositeCommandAdapter(
     LedgerId(ledgerClient.ledgerId.unwrap),
@@ -112,7 +119,8 @@ class LedgerClientBinding(
     retryInfo.request
   }
 
-  type CommandsFlow[C] = Flow[Ctx[C, CompositeCommand], Ctx[C, Either[CompletionFailure, CompletionSuccess]], NotUsed]
+  type CommandsFlow[C] =
+    Flow[Ctx[C, CompositeCommand], Ctx[C, Either[CompletionFailure, CompletionSuccess]], NotUsed]
 
   def commands[C](party: Party)(implicit ec: ExecutionContext): Future[CommandsFlow[C]] = {
     for {

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlow.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlow.scala
@@ -9,13 +9,13 @@ import akka.NotUsed
 import akka.stream.FlowShape
 import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition}
 import com.daml.api.util.TimeProvider
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
-import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.client.services.commands.CommandClient
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse
 import com.daml.util.Ctx
 import com.google.rpc.Code
-import com.google.rpc.status.Status
 import scalaz.syntax.tag._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -23,9 +23,9 @@ import scala.concurrent.{ExecutionContext, Future}
 object CommandRetryFlow {
 
   type In[C] = Ctx[C, SubmitRequest]
-  type Out[C] = Ctx[C, Completion]
+  type Out[C] = Ctx[C, CompletionResponse]
   type SubmissionFlowType[C] = Flow[In[C], Out[C], NotUsed]
-  type CreateRetryFn[C] = (RetryInfo[C], Completion) => SubmitRequest
+  type CreateRetryFn[C] = (RetryInfo[C], CompletionResponse) => SubmitRequest
 
   private val RETRY_PORT = 0
   private val PROPAGATE_PORT = 1
@@ -70,25 +70,38 @@ object CommandRetryFlow {
             {
               case Ctx(
                     RetryInfo(request, nrOfRetries, firstSubmissionTime, _),
-                    Completion(_, Some(status: Status), _),
+                    result,
                     _,
                   ) =>
-                if (status.code == Code.OK_VALUE) {
-                  PROPAGATE_PORT
-                } else if (
-                  (firstSubmissionTime plus maxRetryTime) isBefore timeProvider.getCurrentTime
-                ) {
-                  RetryLogger.logStopRetrying(request, status, nrOfRetries, firstSubmissionTime)
-                  PROPAGATE_PORT
-                } else if (RETRYABLE_ERROR_CODES.contains(status.code)) {
-                  RetryLogger.logNonFatal(request, status, nrOfRetries)
-                  RETRY_PORT
-                } else {
-                  RetryLogger.logFatal(request, status, nrOfRetries)
-                  PROPAGATE_PORT
+                result match {
+                  case Left(value) =>
+                    value match {
+                      case CompletionResponse.NotOkResponse(_, status) =>
+                        if (
+                          (firstSubmissionTime plus maxRetryTime) isBefore timeProvider.getCurrentTime
+                        ) {
+                          RetryLogger.logStopRetrying(
+                            request,
+                            status,
+                            nrOfRetries,
+                            firstSubmissionTime,
+                          )
+                          PROPAGATE_PORT
+                        } else if (RETRYABLE_ERROR_CODES.contains(status.code)) {
+                          RetryLogger.logNonFatal(request, status, nrOfRetries)
+                          RETRY_PORT
+                        } else {
+                          RetryLogger.logFatal(request, status, nrOfRetries)
+                          PROPAGATE_PORT
+                        }
+                      case CompletionResponse.TimeoutResponse(_) =>
+                        PROPAGATE_PORT
+                      case CompletionResponse.NoStatusInResponse(commandId) =>
+                        statusNotFoundError(commandId)
+                    }
+                  case Right(_) =>
+                    PROPAGATE_PORT
                 }
-              case Ctx(_, Completion(commandId, _, _), _) =>
-                statusNotFoundError(commandId)
             },
           )
         )

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlow.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlow.scala
@@ -9,11 +9,14 @@ import akka.NotUsed
 import akka.stream.FlowShape
 import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition}
 import com.daml.api.util.TimeProvider
-import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
 import com.daml.ledger.client.services.commands.CommandClient
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionFailure,
+  CompletionSuccess,
+}
 import com.daml.util.Ctx
 import com.google.rpc.Code
 import scalaz.syntax.tag._
@@ -23,9 +26,10 @@ import scala.concurrent.{ExecutionContext, Future}
 object CommandRetryFlow {
 
   type In[C] = Ctx[C, SubmitRequest]
-  type Out[C] = Ctx[C, CompletionResponse]
+  type Out[C] = Ctx[C, Either[CompletionFailure, CompletionSuccess]]
   type SubmissionFlowType[C] = Flow[In[C], Out[C], NotUsed]
-  type CreateRetryFn[C] = (RetryInfo[C], CompletionResponse) => SubmitRequest
+  type CreateRetryFn[C] =
+    (RetryInfo[C], Either[CompletionFailure, CompletionSuccess]) => SubmitRequest
 
   private val RETRY_PORT = 0
   private val PROPAGATE_PORT = 1

--- a/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
+++ b/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
@@ -43,7 +43,7 @@ class CommandRetryFlowUT extends AsyncWordSpec with Matchers with AkkaTest with 
           } else {
             Ctx(
               context,
-              Right(CompletionResponse.CompletionSuccess(commands.commandId, "")),
+              Right(CompletionResponse.CompletionSuccess(commands.commandId, "", status)),
             )
           }
         case x =>

--- a/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
+++ b/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
@@ -90,7 +90,7 @@ class CommandRetryFlowUT extends AsyncWordSpec with Matchers with AkkaTest with 
 
   CommandRetryFlow.getClass.getSimpleName should {
 
-    "propagete OK status" in {
+    "propagate OK status" in {
       submitRequest(Code.OK_VALUE, Instant.ofEpochSecond(45)) map { result =>
         inside(result) { case Seq(Ctx(context, Right(_), _)) =>
           context.nrOfRetries shouldBe 0

--- a/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
+++ b/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
@@ -13,7 +13,8 @@ import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.client.binding.retrying.CommandRetryFlow.{In, Out, SubmissionFlowType}
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
-  CompletionResponse,
+  CompletionFailure,
+  CompletionSuccess,
   NotOkResponse,
 }
 import com.daml.ledger.client.testing.AkkaTest
@@ -53,7 +54,10 @@ class CommandRetryFlowUT extends AsyncWordSpec with Matchers with AkkaTest with 
   private val maxRetryTime = Duration.ofSeconds(30)
 
   @nowarn("msg=parameter value response .* is never used") // matches createGraph signature
-  private def createRetry(retryInfo: RetryInfo[Status], response: CompletionResponse) = {
+  private def createRetry(
+      retryInfo: RetryInfo[Status],
+      response: Either[CompletionFailure, CompletionSuccess],
+  ) = {
     val commands = retryInfo.request.commands.get
     val dedupTime = commands.deduplicationTime.get
     val newDedupTime = dedupTime.copy(nanos = dedupTime.nanos + 1)

--- a/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
+++ b/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
@@ -104,7 +104,8 @@ class CommandRetryFlowUT extends AsyncWordSpec with Matchers with AkkaTest with 
           .values()
           .toList
           .filterNot(c =>
-            c == Code.UNRECOGNIZED || CommandRetryFlow.RETRYABLE_ERROR_CODES.contains(c.getNumber)
+            c == Code.UNRECOGNIZED || CommandRetryFlow.RETRYABLE_ERROR_CODES
+              .contains(c.getNumber) || c == Code.OK
           )
       val failedSubmissions = codesToFail.map { code =>
         submitRequest(code.getNumber, Instant.ofEpochSecond(45)) map { result =>

--- a/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
+++ b/language-support/scala/bindings-akka/src/test/scala/com/digitalasset/ledger/client/binding/retrying/CommandRetryFlowUT.scala
@@ -109,9 +109,8 @@ class CommandRetryFlowUT extends AsyncWordSpec with Matchers with AkkaTest with 
           )
       val failedSubmissions = codesToFail.map { code =>
         submitRequest(code.getNumber, Instant.ofEpochSecond(45)) map { result =>
-          result.size shouldBe 1
-          result.head.context.nrOfRetries shouldBe 0
-          inside(result.head.value) { case Left(NotOkResponse(_, grpcStatus)) =>
+          inside(result) { case Seq(Ctx(context, Left(NotOkResponse(_, grpcStatus)), _)) =>
+            context.nrOfRetries shouldBe 0
             grpcStatus.code shouldBe code.getNumber
           }
         }
@@ -137,9 +136,8 @@ class CommandRetryFlowUT extends AsyncWordSpec with Matchers with AkkaTest with 
 
     "stop retrying after maxRetryTime" in {
       submitRequest(Code.RESOURCE_EXHAUSTED_VALUE, Instant.ofEpochSecond(15)) map { result =>
-        result.size shouldBe 1
-        result.head.context.nrOfRetries shouldBe 0
-        inside(result.head.value) { case Left(NotOkResponse(_, grpcStatus)) =>
+        inside(result) { case Seq(Ctx(context, Left(NotOkResponse(_, grpcStatus)), _)) =>
+          context.nrOfRetries shouldBe 0
           grpcStatus.code shouldBe Code.RESOURCE_EXHAUSTED_VALUE.intValue
         }
       }

--- a/ledger/ledger-api-client/BUILD.bazel
+++ b/ledger/ledger-api-client/BUILD.bazel
@@ -38,6 +38,8 @@ da_scala_library(
         "//libs-scala/grpc-utils",
         "//libs-scala/ports",
         "//libs-scala/resources",
+        "@maven//:com_google_api_grpc_proto_google_common_protos",
+        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_netty_netty_handler",

--- a/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
+++ b/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
@@ -29,8 +29,9 @@ import com.daml.ledger.api.v1.testing.time_service.TimeServiceGrpc
 import com.daml.ledger.api.v1.value.{Record, RecordField}
 import com.daml.ledger.client.configuration.CommandClientConfiguration
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionFailure,
+  CompletionSuccess,
   NotOkResponse,
-  CompletionResponse,
 }
 import com.daml.ledger.client.services.commands.{CommandClient, CompletionStreamElement}
 import com.daml.ledger.client.services.testing.time.StaticTime
@@ -148,7 +149,9 @@ final class CommandClientIT
       .runWith(Sink.seq)
       .map(_.last) // one element is guaranteed
 
-  private def submitCommand(req: SubmitRequest): Future[CompletionResponse] =
+  private def submitCommand(
+      req: SubmitRequest
+  ): Future[Either[CompletionFailure, CompletionSuccess]] =
     commandClient().flatMap(_.trackSingleCommand(req))
 
   private def assertCommandFailsWithCode(

--- a/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
+++ b/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit
 import akka.NotUsed
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.api.util.TimeProvider
+import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.testing.utils.{
   IsStatusException,
@@ -21,27 +22,29 @@ import com.daml.ledger.api.v1.command_submission_service.{
   SubmitRequest,
 }
 import com.daml.ledger.api.v1.commands.{Command, CreateCommand, ExerciseCommand}
-import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.LedgerBoundary.LEDGER_BEGIN
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.Value.Boundary
 import com.daml.ledger.api.v1.testing.time_service.TimeServiceGrpc
 import com.daml.ledger.api.v1.value.{Record, RecordField}
 import com.daml.ledger.client.configuration.CommandClientConfiguration
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  NotOkResponse,
+  CompletionResponse,
+}
 import com.daml.ledger.client.services.commands.{CommandClient, CompletionStreamElement}
 import com.daml.ledger.client.services.testing.time.StaticTime
 import com.daml.platform.common.LedgerIdMode
-import com.daml.dec.DirectExecutionContext
 import com.daml.platform.participant.util.ValueConversions._
 import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.platform.sandbox.services.{SandboxFixture, TestCommands}
 import com.daml.util.Ctx
 import com.google.rpc.code.Code
 import io.grpc.{Status, StatusRuntimeException}
-import org.scalatest.time.Span
-import org.scalatest.time.SpanSugar._
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
 import org.scalatest.wordspec.AsyncWordSpec
 import scalaz.syntax.tag._
 
@@ -56,7 +59,8 @@ final class CommandClientIT
     with SandboxFixture
     with Matchers
     with SuiteResourceManagementAroundAll
-    with TryValues {
+    with TryValues
+    with Inside {
 
   private val defaultCommandClientConfiguration =
     CommandClientConfiguration(
@@ -144,7 +148,7 @@ final class CommandClientIT
       .runWith(Sink.seq)
       .map(_.last) // one element is guaranteed
 
-  private def submitCommand(req: SubmitRequest): Future[Completion] =
+  private def submitCommand(req: SubmitRequest): Future[CompletionResponse] =
     commandClient().flatMap(_.trackSingleCommand(req))
 
   private def assertCommandFailsWithCode(
@@ -152,9 +156,11 @@ final class CommandClientIT
       expectedErrorCode: Code,
       expectedMessageSubString: String,
   ): Future[Assertion] =
-    submitCommand(submitRequest).map { completion =>
-      completion.getStatus.code should be(expectedErrorCode.value)
-      completion.getStatus.message should include(expectedMessageSubString)
+    submitCommand(submitRequest).map { result =>
+      inside(result) { case Left(NotOkResponse(_, grpcStatus)) =>
+        grpcStatus.code should be(expectedErrorCode.value)
+        grpcStatus.message should include(expectedMessageSubString)
+      }
     }(DirectExecutionContext)
 
   /** Reads a set of command IDs expected in the given client after the given checkpoint.

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
@@ -8,7 +8,6 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.codahale.metrics.Counter
 import com.daml.grpc.adapter.ExecutionSequencerFactory
-import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc.CommandCompletionServiceStub
 import com.daml.ledger.api.v1.command_completion_service.{
@@ -23,15 +22,19 @@ import com.daml.ledger.api.validation.CommandsValidator
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.CommandClientConfiguration
 import com.daml.ledger.client.services.commands.CommandTrackerFlow.Materialized
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionFailure,
+  CompletionSuccess,
+}
 import com.daml.util.Ctx
 import com.daml.util.akkastreams.MaxInFlight
 import com.google.protobuf.duration.Duration
 import com.google.protobuf.empty.Empty
 import org.slf4j.{Logger, LoggerFactory}
+import scalaz.syntax.tag._
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.util.Try
-import scalaz.syntax.tag._
 
 /** Enables easy access to command services and high level operations on top of them.
   *
@@ -51,10 +54,14 @@ final class CommandClient(
 )(implicit esf: ExecutionSequencerFactory) {
 
   type TrackCommandFlow[Context] =
-    Flow[Ctx[Context, SubmitRequest], Ctx[Context, CompletionResponse], Materialized[
-      NotUsed,
-      Context,
-    ]]
+    Flow[
+      Ctx[Context, SubmitRequest],
+      Ctx[Context, Either[CompletionFailure, CompletionSuccess]],
+      Materialized[
+        NotUsed,
+        Context,
+      ],
+    ]
 
   /** Submit a single command. Successful result does not guarantee that the resulting transaction has been written to
     * the ledger. In order to get that semantic, use [[trackCommands]] or [[trackCommandsUnbounded]].
@@ -80,7 +87,7 @@ final class CommandClient(
     */
   def trackSingleCommand(submitRequest: SubmitRequest, token: Option[String] = None)(implicit
       mat: Materializer
-  ): Future[CompletionResponse] = {
+  ): Future[Either[CompletionFailure, CompletionSuccess]] = {
     implicit val executionContext: ExecutionContextExecutor = mat.executionContext
     val effectiveActAs = CommandsValidator.effectiveSubmitters(submitRequest.getCommands).actAs
     for {

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
@@ -95,7 +95,10 @@ final class CommandClient(
   def trackCommands[Context](parties: Seq[String], token: Option[String] = None)(implicit
       ec: ExecutionContext
   ): Future[
-    Flow[Ctx[Context, SubmitRequest], Ctx[Context, CompletionResponse], Materialized[NotUsed, Context]]
+    Flow[Ctx[Context, SubmitRequest], Ctx[Context, CompletionResponse], Materialized[
+      NotUsed,
+      Context,
+    ]]
   ] = {
     for {
       tracker <- trackCommandsUnbounded[Context](parties, token)
@@ -115,7 +118,10 @@ final class CommandClient(
   def trackCommandsUnbounded[Context](parties: Seq[String], token: Option[String] = None)(implicit
       ec: ExecutionContext
   ): Future[
-    Flow[Ctx[Context, SubmitRequest], Ctx[Context, CompletionResponse], Materialized[NotUsed, Context]]
+    Flow[Ctx[Context, SubmitRequest], Ctx[Context, CompletionResponse], Materialized[
+      NotUsed,
+      Context,
+    ]]
   ] =
     for {
       ledgerEnd <- getCompletionEnd(token)

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -8,8 +8,8 @@ import java.time.{Duration => JDuration}
 import akka.NotUsed
 import akka.stream.scaladsl.{Concat, Flow, GraphDSL, Merge, Source}
 import akka.stream.{DelayOverflowStrategy, FlowShape, OverflowStrategy}
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.ledger.api.v1.command_submission_service._
-import com.daml.ledger.api.v1.completion._
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.client.services.commands.tracker.CommandTracker
 import com.daml.util.Ctx
@@ -41,7 +41,7 @@ object CommandTrackerFlow {
       startingOffset: LedgerOffset,
       maxDeduplicationTime: () => JDuration,
       backOffDuration: FiniteDuration = 1.second,
-  ): Flow[Ctx[Context, SubmitRequest], Ctx[Context, Completion], Materialized[
+  ): Flow[Ctx[Context, SubmitRequest], Ctx[Context, CompletionResponse], Materialized[
     SubmissionMat,
     Context,
   ]] = {

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -8,10 +8,13 @@ import java.time.{Duration => JDuration}
 import akka.NotUsed
 import akka.stream.scaladsl.{Concat, Flow, GraphDSL, Merge, Source}
 import akka.stream.{DelayOverflowStrategy, FlowShape, OverflowStrategy}
-import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.ledger.api.v1.command_submission_service._
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.client.services.commands.tracker.CommandTracker
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionFailure,
+  CompletionSuccess,
+}
 import com.daml.util.Ctx
 import com.google.protobuf.empty.Empty
 import org.slf4j.LoggerFactory
@@ -41,7 +44,10 @@ object CommandTrackerFlow {
       startingOffset: LedgerOffset,
       maxDeduplicationTime: () => JDuration,
       backOffDuration: FiniteDuration = 1.second,
-  ): Flow[Ctx[Context, SubmitRequest], Ctx[Context, CompletionResponse], Materialized[
+  ): Flow[Ctx[Context, SubmitRequest], Ctx[
+    Context,
+    Either[CompletionFailure, CompletionSuccess],
+  ], Materialized[
     SubmissionMat,
     Context,
   ]] = {

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -8,10 +8,11 @@ import java.time.{Instant, Duration => JDuration}
 import akka.stream.stage._
 import akka.stream.{Attributes, Inlet, Outlet}
 import com.daml.grpc.{GrpcException, GrpcStatus}
+import CompletionResponse.CompletionResponse
 import com.daml.ledger.api.v1.command_submission_service._
 import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
-import com.daml.ledger.client.services.commands.CompletionStreamElement
+import com.daml.ledger.client.services.commands.{CompletionStreamElement, tracker}
 import com.daml.util.Ctx
 import com.google.protobuf.duration.{Duration => ProtoDuration}
 import com.google.protobuf.empty.Empty
@@ -58,8 +59,8 @@ private[commands] class CommandTracker[Context](maxDeduplicationTime: () => JDur
     Outlet[Ctx[(Context, String), SubmitRequest]]("submitRequestOut")
   val commandResultIn: Inlet[Either[Ctx[(Context, String), Try[Empty]], CompletionStreamElement]] =
     Inlet[Either[Ctx[(Context, String), Try[Empty]], CompletionStreamElement]]("commandResultIn")
-  val resultOut: Outlet[Ctx[Context, Completion]] =
-    Outlet[Ctx[Context, Completion]]("resultOut")
+  val resultOut: Outlet[Ctx[Context, CompletionResponse]] =
+    Outlet[Ctx[Context, CompletionResponse]]("resultOut")
   val offsetOut: Outlet[LedgerOffset] =
     Outlet[LedgerOffset]("offsetOut")
 
@@ -166,7 +167,9 @@ private[commands] class CommandTracker[Context](maxDeduplicationTime: () => JDur
         },
       )
 
-      private def pushResultOrPullCommandResultIn(compl: Option[Ctx[Context, Completion]]): Unit = {
+      private def pushResultOrPullCommandResultIn(
+          compl: Option[Ctx[Context, CompletionResponse]]
+      ): Unit = {
         // The command tracker detects timeouts outside the regular pull/push
         // mechanism of the input/output ports. Basically the timeout
         // detection jumps the line when emitting outputs on `resultOut`. If it
@@ -211,7 +214,7 @@ private[commands] class CommandTracker[Context](maxDeduplicationTime: () => JDur
           ) { commands =>
             val commandId = commands.commandId
             logger.trace("Begin tracking of command {}", commandId)
-            if (pendingCommands.get(commandId).nonEmpty) {
+            if (pendingCommands.contains(commandId)) {
               // TODO return an error identical to the server side duplicate command error once that's defined.
               throw new IllegalStateException(
                 s"A command with id $commandId is already being tracked. CommandIds submitted to the CommandTracker must be unique."
@@ -250,11 +253,10 @@ private[commands] class CommandTracker[Context](maxDeduplicationTime: () => JDur
               List(
                 Ctx(
                   trackingData.context,
-                  Completion(
-                    trackingData.commandId,
-                    Some(
-                      com.google.rpc.status.Status(RpcStatus.ABORTED.getCode.value(), "Timeout")
-                    ),
+                  Left(
+                    CompletionResponse.TimeoutResponse(
+                      commandId = trackingData.commandId
+                    )
                   ),
                 )
               )
@@ -277,19 +279,19 @@ private[commands] class CommandTracker[Context](maxDeduplicationTime: () => JDur
 
         logger.trace("Handling {} {}", errorText, completion.commandId: Any)
         pendingCommands.remove(commandId).map { t =>
-          Ctx(t.context, completion)
+          Ctx(t.context, tracker.CompletionResponse(completion))
         }
       }
 
       private def getOutputForTerminalStatusCode(
           commandId: String,
           status: Status,
-      ): Option[Ctx[Context, Completion]] = {
+      ): Option[Ctx[Context, CompletionResponse]] = {
         logger.trace("Handling failure of command {}", commandId)
         pendingCommands
           .remove(commandId)
           .map { t =>
-            Ctx(t.context, Completion(commandId, Some(status)))
+            Ctx(t.context, tracker.CompletionResponse(Completion(commandId, Some(status))))
           }
           .orElse {
             logger.trace("Platform signaled failure for unknown command {}", commandId)

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTrackerShape.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTrackerShape.scala
@@ -5,9 +5,9 @@ package com.daml.ledger.client.services.commands.tracker
 
 import akka.stream.{Inlet, Outlet, Shape}
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
-import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.client.services.commands.CompletionStreamElement
+import CompletionResponse.CompletionResponse
 import com.daml.util.Ctx
 import com.google.protobuf.empty.Empty
 
@@ -15,11 +15,11 @@ import scala.collection.immutable
 import scala.util.Try
 
 private[tracker] final case class CommandTrackerShape[Context](
-    submitRequestIn: Inlet[Ctx[Context, SubmitRequest]],
-    submitRequestOut: Outlet[Ctx[(Context, String), SubmitRequest]],
-    commandResultIn: Inlet[Either[Ctx[(Context, String), Try[Empty]], CompletionStreamElement]],
-    resultOut: Outlet[Ctx[Context, Completion]],
-    offsetOut: Outlet[LedgerOffset],
+                                                                submitRequestIn: Inlet[Ctx[Context, SubmitRequest]],
+                                                                submitRequestOut: Outlet[Ctx[(Context, String), SubmitRequest]],
+                                                                commandResultIn: Inlet[Either[Ctx[(Context, String), Try[Empty]], CompletionStreamElement]],
+                                                                resultOut: Outlet[Ctx[Context, CompletionResponse]],
+                                                                offsetOut: Outlet[LedgerOffset],
 ) extends Shape {
 
   override def inlets: immutable.Seq[Inlet[_]] = Vector(submitRequestIn, commandResultIn)

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTrackerShape.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTrackerShape.scala
@@ -15,11 +15,11 @@ import scala.collection.immutable
 import scala.util.Try
 
 private[tracker] final case class CommandTrackerShape[Context](
-                                                                submitRequestIn: Inlet[Ctx[Context, SubmitRequest]],
-                                                                submitRequestOut: Outlet[Ctx[(Context, String), SubmitRequest]],
-                                                                commandResultIn: Inlet[Either[Ctx[(Context, String), Try[Empty]], CompletionStreamElement]],
-                                                                resultOut: Outlet[Ctx[Context, CompletionResponse]],
-                                                                offsetOut: Outlet[LedgerOffset],
+    submitRequestIn: Inlet[Ctx[Context, SubmitRequest]],
+    submitRequestOut: Outlet[Ctx[(Context, String), SubmitRequest]],
+    commandResultIn: Inlet[Either[Ctx[(Context, String), Try[Empty]], CompletionStreamElement]],
+    resultOut: Outlet[Ctx[Context, CompletionResponse]],
+    offsetOut: Outlet[LedgerOffset],
 ) extends Shape {
 
   override def inlets: immutable.Seq[Inlet[_]] = Vector(submitRequestIn, commandResultIn)

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTrackerShape.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTrackerShape.scala
@@ -7,7 +7,10 @@ import akka.stream.{Inlet, Outlet, Shape}
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.client.services.commands.CompletionStreamElement
-import CompletionResponse.CompletionResponse
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionFailure,
+  CompletionSuccess,
+}
 import com.daml.util.Ctx
 import com.google.protobuf.empty.Empty
 
@@ -18,7 +21,7 @@ private[tracker] final case class CommandTrackerShape[Context](
     submitRequestIn: Inlet[Ctx[Context, SubmitRequest]],
     submitRequestOut: Outlet[Ctx[(Context, String), SubmitRequest]],
     commandResultIn: Inlet[Either[Ctx[(Context, String), Try[Empty]], CompletionStreamElement]],
-    resultOut: Outlet[Ctx[Context, CompletionResponse]],
+    resultOut: Outlet[Ctx[Context, Either[CompletionFailure, CompletionSuccess]]],
     offsetOut: Outlet[LedgerOffset],
 ) extends Shape {
 

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -13,7 +13,6 @@ import io.grpc.{StatusRuntimeException, protobuf}
 import scala.jdk.CollectionConverters._
 
 object CompletionResponse {
-  type CompletionResponse = Either[CompletionFailure, CompletionSuccess]
   sealed trait CompletionFailure {
     def metadata: Map[String, String] = Map.empty
   }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -21,7 +21,6 @@ object CompletionResponse {
       extends CompletionFailure
   final case class TimeoutResponse(commandId: String) extends CompletionFailure
   final case class NoStatusInResponse(commandId: String) extends CompletionFailure
-  final case class StartingExecutionFailure(status: Status) extends CompletionFailure
 
   final case class CompletionSuccess(commandId: String, transactionId: String)
 

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -32,7 +32,7 @@ object CompletionResponse {
     /** In most cases we're not interested in the original grpc status, as it's used only to keep backwards compatibility
       */
     def unapply(success: CompletionSuccess): Option[(String, String)] = {
-      Some(success.commandId, success.transactionId)
+      Some(success.commandId -> success.transactionId)
     }
   }
 

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -21,7 +21,20 @@ object CompletionResponse {
   final case class TimeoutResponse(commandId: String) extends CompletionFailure
   final case class NoStatusInResponse(commandId: String) extends CompletionFailure
 
-  final case class CompletionSuccess(commandId: String, transactionId: String)
+  final case class CompletionSuccess(
+      commandId: String,
+      transactionId: String,
+      originalStatus: StatusProto,
+  )
+
+  object CompletionSuccess {
+
+    /** In most cases we're not interested in the original grpc status, as it's used only to keep backwards compatibility
+      */
+    def unapply(success: CompletionSuccess): Option[(String, String)] = {
+      Some(success.commandId, success.transactionId)
+    }
+  }
 
   def apply(completion: Completion): Either[CompletionFailure, CompletionSuccess] =
     completion.status match {
@@ -30,6 +43,7 @@ object CompletionResponse {
           CompletionSuccess(
             commandId = completion.commandId,
             transactionId = completion.transactionId,
+            grpcStatus,
           )
         )
       case Some(grpcStatus) =>
@@ -37,6 +51,31 @@ object CompletionResponse {
       case None =>
         Left(NoStatusInResponse(completion.commandId))
     }
+
+  /** For backwards compatibility, clients that are too coupled to [[Completion]] as a type can convert back from [[Either[CompletionFailure, CompletionSuccess]]]
+    */
+  def toCompletion(response: Either[CompletionFailure, CompletionSuccess]): Completion = {
+    response match {
+      case Left(failure) =>
+        failure match {
+          case NotOkResponse(commandId, grpcStatus) =>
+            Completion(commandId = commandId, status = Some(grpcStatus))
+          case TimeoutResponse(commandId) =>
+            Completion(
+              commandId = commandId,
+              status = Some(StatusProto(Code.ABORTED.value(), "Timeout")),
+            )
+          case NoStatusInResponse(commandId) =>
+            Completion(commandId = commandId)
+        }
+      case Right(success) =>
+        Completion(
+          commandId = success.commandId,
+          transactionId = success.transactionId,
+          status = Some(success.originalStatus),
+        )
+    }
+  }
 
   def toException(response: CompletionResponse.CompletionFailure): StatusRuntimeException = {
     val errorInfo = rpc.ErrorInfo.newBuilder().putAllMetadata(response.metadata.asJava).build()

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -8,7 +8,7 @@ import com.google.protobuf.Any
 import com.google.rpc
 import com.google.rpc.status.{Status => StatusProto}
 import io.grpc.Status.Code
-import io.grpc.{StatusRuntimeException, protobuf}
+import io.grpc.{StatusException, protobuf}
 
 import scala.jdk.CollectionConverters._
 
@@ -77,7 +77,7 @@ object CompletionResponse {
     }
   }
 
-  def toException(response: CompletionResponse.CompletionFailure): StatusRuntimeException = {
+  def toException(response: CompletionResponse.CompletionFailure): StatusException = {
     val errorInfo = rpc.ErrorInfo.newBuilder().putAllMetadata(response.metadata.asJava).build()
     val details = Any.pack(errorInfo)
     val status = response match {
@@ -91,7 +91,7 @@ object CompletionResponse {
           .setCode(Code.INTERNAL.value())
           .setMessage("Missing status in completion response.")
     }
-    protobuf.StatusProto.toStatusRuntimeException(
+    protobuf.StatusProto.toStatusException(
       status
         .addDetails(details)
         .build()

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.ledger.client.services.commands.tracker
 
 import com.daml.ledger.api.v1.completion.Completion

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -1,0 +1,62 @@
+package com.daml.ledger.client.services.commands.tracker
+
+import com.daml.ledger.api.v1.completion.Completion
+import com.google.protobuf.Any
+import com.google.rpc
+import com.google.rpc.status.{Status => StatusProto}
+import io.grpc.Status.Code
+import io.grpc.{StatusRuntimeException, protobuf}
+
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+object CompletionResponse {
+  type CompletionResponse = Either[CompletionFailure, CompletionSuccess]
+  sealed trait CompletionFailure {
+    def metadata: Map[String, String] = Map.empty
+  }
+  final case class NotOkResponse(commandId: String, grpcStatus: StatusProto)
+      extends CompletionFailure
+  final case class TimeoutResponse(commandId: String) extends CompletionFailure
+  final case class NoStatusInResponse(commandId: String) extends CompletionFailure
+
+  final case class CompletionSuccess(commandId: String, transactionId: String)
+
+  def apply(completion: Completion): Either[CompletionFailure, CompletionSuccess] = {
+    completion.status match {
+      case Some(grpcStatus) =>
+        if (Code.OK.value() == grpcStatus.code) {
+          Right(
+            CompletionSuccess(
+              commandId = completion.commandId,
+              transactionId = completion.transactionId,
+            )
+          )
+        } else {
+          Left(NotOkResponse(completion.commandId, grpcStatus))
+        }
+      case None =>
+        Left(NoStatusInResponse(completion.commandId))
+    }
+  }
+
+  def toException(response: CompletionResponse.CompletionFailure): StatusRuntimeException = {
+    val errorInfo = rpc.ErrorInfo.newBuilder().putAllMetadata(response.metadata.asJava).build()
+    val details = Any.pack(errorInfo)
+    val status = response match {
+      case CompletionResponse.NotOkResponse(_, grpcStatus) =>
+        rpc.Status.newBuilder().setCode(grpcStatus.code).setMessage(grpcStatus.message)
+      case CompletionResponse.TimeoutResponse(_) =>
+        rpc.Status.newBuilder().setCode(Code.ABORTED.value()).setMessage("Timeout")
+      case CompletionResponse.NoStatusInResponse(_) =>
+        rpc.Status
+          .newBuilder()
+          .setCode(Code.INTERNAL.value())
+          .setMessage("Missing status in completion response.")
+    }
+    protobuf.StatusProto.toStatusRuntimeException(
+      status
+        .addDetails(details)
+        .build()
+    )
+  }
+}

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -10,7 +10,7 @@ import com.google.rpc.status.{Status => StatusProto}
 import io.grpc.Status.Code
 import io.grpc.{StatusRuntimeException, protobuf}
 
-import scala.jdk.CollectionConverters.MapHasAsJava
+import scala.jdk.CollectionConverters._
 
 object CompletionResponse {
   type CompletionResponse = Either[CompletionFailure, CompletionSuccess]

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -8,7 +8,7 @@ import com.google.protobuf.Any
 import com.google.rpc
 import com.google.rpc.status.{Status => StatusProto}
 import io.grpc.Status.Code
-import io.grpc.{Status, StatusRuntimeException, protobuf}
+import io.grpc.{StatusRuntimeException, protobuf}
 
 import scala.jdk.CollectionConverters.MapHasAsJava
 

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -24,7 +24,8 @@ import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.LedgerBoundary.LEDGER_B
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.Value.{Absolute, Boundary}
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
-  CompletionResponse,
+  CompletionFailure,
+  CompletionSuccess,
   NotOkResponse,
 }
 import com.daml.util.Ctx
@@ -60,7 +61,8 @@ class CommandTrackerFlowTest
   private val shortDuration = JDuration.ofSeconds(1L)
 
   private lazy val submissionSource = TestSource.probe[Ctx[Int, SubmitRequest]]
-  private lazy val resultSink = TestSink.probe[Ctx[Int, CompletionResponse]](system)
+  private lazy val resultSink =
+    TestSink.probe[Ctx[Int, Either[CompletionFailure, CompletionSuccess]]](system)
 
   private val mrt = Instant.EPOCH.plus(shortDuration)
   private val commandId = "commandId"
@@ -86,7 +88,7 @@ class CommandTrackerFlowTest
 
   private case class Handle(
       submissions: TestPublisher.Probe[Ctx[Int, SubmitRequest]],
-      completions: TestSubscriber.Probe[Ctx[Int, CompletionResponse]],
+      completions: TestSubscriber.Probe[Ctx[Int, Either[CompletionFailure, CompletionSuccess]]],
       whatever: Future[Map[String, Int]],
       completionsStreamMock: CompletionStreamMock,
   )

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -80,10 +80,10 @@ class CommandTrackerFlowTest
   )
 
   private case class Handle(
-                             submissions: TestPublisher.Probe[Ctx[Int, SubmitRequest]],
-                             completions: TestSubscriber.Probe[Ctx[Int, CompletionResponse]],
-                             whatever: Future[Map[String, Int]],
-                             completionsStreamMock: CompletionStreamMock,
+      submissions: TestPublisher.Probe[Ctx[Int, SubmitRequest]],
+      completions: TestSubscriber.Probe[Ctx[Int, CompletionResponse]],
+      whatever: Future[Map[String, Int]],
+      completionsStreamMock: CompletionStreamMock,
   )
 
   private class CompletionStreamMock() {

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponseTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponseTest.scala
@@ -1,0 +1,65 @@
+package com.daml.ledger.client.services.commands.tracker
+
+import com.daml.ledger.api.v1.completion.Completion
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  NoStatusInResponse,
+  NotOkResponse,
+  TimeoutResponse,
+}
+import com.google.protobuf.any.Any
+import com.google.rpc.status.Status
+import io.grpc.Status.Code
+import io.grpc.Status.Code.OK
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CompletionResponseTest extends AnyWordSpec with Matchers {
+
+  "Completion response" when {
+
+    val commandId = "commandId"
+    val completion = Completion(
+      commandId = commandId,
+      status = Some(Status(OK.value(), "message", Seq(Any()))),
+    )
+
+    "convert to/from completion" should {
+
+      "match successful completion" in {
+        val completionWithTransactionId = completion.update(_.transactionId := "transactionId")
+        val response = CompletionResponse(completionWithTransactionId)
+        response shouldBe a[Right[_, _]]
+        CompletionResponse.toCompletion(response) shouldEqual completionWithTransactionId
+      }
+
+      "match not ok status" in {
+        val failedCodeCompletion = completion.update(_.status.code := Code.INTERNAL.value())
+        val response =
+          CompletionResponse(failedCodeCompletion)
+        response should matchPattern { case Left(_: NotOkResponse) => }
+        CompletionResponse.toCompletion(response) shouldEqual failedCodeCompletion
+      }
+
+      "handle missing status" in {
+        val noStatusCodeCompletion = completion.update(_.optionalStatus := None)
+        val response =
+          CompletionResponse(noStatusCodeCompletion)
+        response should matchPattern { case Left(_: NoStatusInResponse) => }
+        CompletionResponse.toCompletion(response) shouldEqual noStatusCodeCompletion
+
+      }
+
+      "handle timeout" in {
+        CompletionResponse.toCompletion(Left(TimeoutResponse(commandId))) shouldEqual (Completion(
+          commandId = commandId,
+          status = Some(
+            Status(
+              code = Code.ABORTED.value(),
+              message = "Timeout",
+            )
+          ),
+        ))
+      }
+    }
+  }
+}

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponseTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponseTest.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.ledger.client.services.commands.tracker
 
 import com.daml.ledger.api.v1.completion.Completion

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponseTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponseTest.scala
@@ -50,7 +50,7 @@ class CompletionResponseTest extends AnyWordSpec with Matchers {
       }
 
       "handle timeout" in {
-        CompletionResponse.toCompletion(Left(TimeoutResponse(commandId))) shouldEqual (Completion(
+        CompletionResponse.toCompletion(Left(TimeoutResponse(commandId))) shouldEqual Completion(
           commandId = commandId,
           status = Some(
             Status(
@@ -58,7 +58,7 @@ class CompletionResponseTest extends AnyWordSpec with Matchers {
               message = "Timeout",
             )
           ),
-        ))
+        )
       }
     }
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -177,17 +177,15 @@ private[apiserver] final class ApiCommandService private (
       resp.fold(
         failure => Future.failed(CompletionResponse.toException(failure)),
         { resp =>
-          {
-            val effectiveActAs = CommandsValidator.effectiveSubmitters(request.getCommands).actAs
-            val txRequest = GetTransactionByIdRequest(
-              request.getCommands.ledgerId,
-              resp.transactionId,
-              effectiveActAs.toList,
-            )
-            services
-              .getFlatTransactionById(txRequest)
-              .map(resp => SubmitAndWaitForTransactionResponse(resp.transaction))
-          }
+          val effectiveActAs = CommandsValidator.effectiveSubmitters(request.getCommands).actAs
+          val txRequest = GetTransactionByIdRequest(
+            request.getCommands.ledgerId,
+            resp.transactionId,
+            effectiveActAs.toList,
+          )
+          services
+            .getFlatTransactionById(txRequest)
+            .map(resp => SubmitAndWaitForTransactionResponse(resp.transaction))
         },
       )
     }
@@ -199,17 +197,15 @@ private[apiserver] final class ApiCommandService private (
       resp.fold(
         failure => Future.failed(CompletionResponse.toException(failure)),
         { resp =>
-          {
-            val effectiveActAs = CommandsValidator.effectiveSubmitters(request.getCommands).actAs
-            val txRequest = GetTransactionByIdRequest(
-              request.getCommands.ledgerId,
-              resp.transactionId,
-              effectiveActAs.toList,
-            )
-            services
-              .getTransactionById(txRequest)
-              .map(resp => SubmitAndWaitForTransactionTreeResponse(resp.transaction))
-          }
+          val effectiveActAs = CommandsValidator.effectiveSubmitters(request.getCommands).actAs
+          val txRequest = GetTransactionByIdRequest(
+            request.getCommands.ledgerId,
+            resp.transactionId,
+            effectiveActAs.toList,
+          )
+          services
+            .getTransactionById(txRequest)
+            .map(resp => SubmitAndWaitForTransactionTreeResponse(resp.transaction))
         },
       )
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -11,6 +11,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Keep, Source}
 import com.daml.api.util.TimeProvider
 import com.daml.ledger.api.SubmissionIdGenerator
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.v1.command_completion_service.{
   CompletionEndResponse,
@@ -26,6 +27,7 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionResponse,
 }
 import com.daml.ledger.api.validation.CommandsValidator
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse
 import com.daml.ledger.client.services.commands.{CommandCompletionSource, CommandTrackerFlow}
 import com.daml.ledger.configuration.{Configuration => LedgerConfiguration}
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
@@ -79,7 +81,7 @@ private[apiserver] final class ApiCommandService private (
 
   private def submitAndWaitInternal(request: SubmitAndWaitRequest)(implicit
       loggingContext: LoggingContext
-  ): Future[Completion] =
+  ): Future[CompletionResponse] =
     withEnrichedLoggingContext(
       logging.commandId(request.getCommands.commandId),
       logging.partyString(request.getCommands.party),
@@ -89,7 +91,7 @@ private[apiserver] final class ApiCommandService private (
       if (running) {
         ledgerConfigurationSubscription
           .latestConfiguration()
-          .fold[Future[Completion]](
+          .fold[Future[CompletionResponse]](
             Future.failed(ErrorFactories.missingLedgerConfig())
           )(ledgerConfig => track(request, ledgerConfig))
       } else {
@@ -102,7 +104,7 @@ private[apiserver] final class ApiCommandService private (
   private def track(
       request: SubmitAndWaitRequest,
       ledgerConfig: LedgerConfiguration,
-  )(implicit loggingContext: LoggingContext): Future[Completion] = {
+  )(implicit loggingContext: LoggingContext): Future[CompletionResponse] = {
     val appId = request.getCommands.applicationId
     // Note: command completions are returned as long as at least one of the original submitters
     // is specified in the command completion request.
@@ -114,7 +116,7 @@ private[apiserver] final class ApiCommandService private (
       for {
         ledgerEnd <- services.getCompletionEnd().map(_.getOffset)
       } yield {
-        val tracker = CommandTrackerFlow[Promise[Completion], NotUsed](
+        val tracker = CommandTrackerFlow[Promise[CompletionResponse], NotUsed](
           services.submissionFlow,
           offset =>
             services
@@ -151,43 +153,65 @@ private[apiserver] final class ApiCommandService private (
   }
 
   override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] =
-    submitAndWaitInternal(request).map(_ => Empty.defaultInstance)
+    submitAndWaitInternal(request).map(
+      _.fold(
+        failure => throw CompletionResponse.toException(failure),
+        _ => Empty.defaultInstance,
+      )
+    )
 
   override def submitAndWaitForTransactionId(
       request: SubmitAndWaitRequest
   ): Future[SubmitAndWaitForTransactionIdResponse] =
-    submitAndWaitInternal(request).map { compl =>
-      SubmitAndWaitForTransactionIdResponse(compl.transactionId)
-    }
+    submitAndWaitInternal(request).map(
+      _.fold(
+        failure => throw CompletionResponse.toException(failure),
+        response => SubmitAndWaitForTransactionIdResponse(response.transactionId),
+      )
+    )
 
   override def submitAndWaitForTransaction(
       request: SubmitAndWaitRequest
   ): Future[SubmitAndWaitForTransactionResponse] =
     submitAndWaitInternal(request).flatMap { resp =>
-      val effectiveActAs = CommandsValidator.effectiveSubmitters(request.getCommands).actAs
-      val txRequest = GetTransactionByIdRequest(
-        request.getCommands.ledgerId,
-        resp.transactionId,
-        effectiveActAs.toList,
+      resp.fold(
+        failure => Future.failed(CompletionResponse.toException(failure)),
+        { resp =>
+          {
+            val effectiveActAs = CommandsValidator.effectiveSubmitters(request.getCommands).actAs
+            val txRequest = GetTransactionByIdRequest(
+              request.getCommands.ledgerId,
+              resp.transactionId,
+              effectiveActAs.toList,
+            )
+            services
+              .getFlatTransactionById(txRequest)
+              .map(resp => SubmitAndWaitForTransactionResponse(resp.transaction))
+          }
+        },
       )
-      services
-        .getFlatTransactionById(txRequest)
-        .map(resp => SubmitAndWaitForTransactionResponse(resp.transaction))
     }
 
   override def submitAndWaitForTransactionTree(
       request: SubmitAndWaitRequest
   ): Future[SubmitAndWaitForTransactionTreeResponse] =
     submitAndWaitInternal(request).flatMap { resp =>
-      val effectiveActAs = CommandsValidator.effectiveSubmitters(request.getCommands).actAs
-      val txRequest = GetTransactionByIdRequest(
-        request.getCommands.ledgerId,
-        resp.transactionId,
-        effectiveActAs.toList,
+      resp.fold(
+        failure => Future.failed(CompletionResponse.toException(failure)),
+        { resp =>
+          {
+            val effectiveActAs = CommandsValidator.effectiveSubmitters(request.getCommands).actAs
+            val txRequest = GetTransactionByIdRequest(
+              request.getCommands.ledgerId,
+              resp.transactionId,
+              effectiveActAs.toList,
+            )
+            services
+              .getTransactionById(txRequest)
+              .map(resp => SubmitAndWaitForTransactionTreeResponse(resp.transaction))
+          }
+        },
       )
-      services
-        .getTransactionById(txRequest)
-        .map(resp => SubmitAndWaitForTransactionTreeResponse(resp.transaction))
     }
 
   override def toString: String = ApiCommandService.getClass.getSimpleName
@@ -226,8 +250,8 @@ private[apiserver] object ApiCommandService {
 
   final case class LocalServices(
       submissionFlow: Flow[
-        Ctx[(Promise[Completion], String), SubmitRequest],
-        Ctx[(Promise[Completion], String), Try[Empty]],
+        Ctx[(Promise[CompletionResponse], String), SubmitRequest],
+        Ctx[(Promise[CompletionResponse], String), Try[Empty]],
         NotUsed,
       ],
       getCompletionSource: CompletionStreamRequest => Source[CompletionStreamResponse, NotUsed],

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/HandleOfferResult.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/HandleOfferResult.scala
@@ -5,7 +5,6 @@ package com.daml.platform.apiserver.services.tracking
 
 import akka.stream.QueueOfferResult
 import com.daml.platform.server.api.ApiException
-import com.google.rpc.status.Status
 import io.grpc.{Status => GrpcStatus}
 
 import scala.concurrent.Promise
@@ -44,9 +43,6 @@ private[tracking] object HandleOfferResult {
       Some(GrpcStatus.ABORTED.withDescription("Queue closed"))
     case Success(QueueOfferResult.Enqueued) => None // Promise will be completed downstream.
   }
-
-  def toStatusMessage: PartialFunction[Try[QueueOfferResult], Status] =
-    toGrpcStatus.andThen(_.fold(Status())(e => Status(e.getCode.value(), e.getDescription)))
 
   def completePromise(promise: Promise[_]): PartialFunction[Try[QueueOfferResult], Unit] =
     toGrpcStatus.andThen(_.foreach(s => promise.tryFailure(new ApiException(s))))

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
@@ -3,8 +3,8 @@
 
 package com.daml.platform.apiserver.services.tracking
 
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
-import com.daml.ledger.api.v1.completion.Completion
 import com.daml.logging.LoggingContext
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -14,7 +14,7 @@ private[tracking] trait Tracker extends AutoCloseable {
   def track(request: SubmitAndWaitRequest)(implicit
       ec: ExecutionContext,
       loggingContext: LoggingContext,
-  ): Future[Completion]
+  ): Future[CompletionResponse]
 
 }
 
@@ -31,7 +31,7 @@ private[tracking] object Tracker {
     override def track(request: SubmitAndWaitRequest)(implicit
         ec: ExecutionContext,
         loggingContext: LoggingContext,
-    ): Future[Completion] = {
+    ): Future[CompletionResponse] = {
       lastSubmission = System.nanoTime()
       delegate.track(request)
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
@@ -3,8 +3,11 @@
 
 package com.daml.platform.apiserver.services.tracking
 
-import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionFailure,
+  CompletionSuccess,
+}
 import com.daml.logging.LoggingContext
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -14,7 +17,7 @@ private[tracking] trait Tracker extends AutoCloseable {
   def track(request: SubmitAndWaitRequest)(implicit
       ec: ExecutionContext,
       loggingContext: LoggingContext,
-  ): Future[CompletionResponse]
+  ): Future[Either[CompletionFailure, CompletionSuccess]]
 
 }
 
@@ -31,7 +34,7 @@ private[tracking] object Tracker {
     override def track(request: SubmitAndWaitRequest)(implicit
         ec: ExecutionContext,
         loggingContext: LoggingContext,
-    ): Future[CompletionResponse] = {
+    ): Future[Either[CompletionFailure, CompletionSuccess]] = {
       lastSubmission = System.nanoTime()
       delegate.track(request)
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
@@ -93,10 +93,13 @@ private[services] object TrackerImpl {
       )
       .viaMat(tracker)(Keep.both)
       .toMat(Sink.foreach { case Ctx(promise, result, _) =>
-        logger.trace("Completing promise")
         val didCompletePromise = promise.trySuccess(result)
         if (!didCompletePromise) {
-          logger.trace("Failed to complete promise")
+          logger.trace(
+            "Promise was already completed, could not propagate the completion for the command."
+          )
+        } else {
+          logger.trace("Completed promise with the result of command.")
         }
         ()
       })(Keep.both)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
@@ -8,7 +8,10 @@ import akka.stream.{Materializer, OverflowStrategy}
 import akka.{Done, NotUsed}
 import com.codahale.metrics.{Counter, Timer}
 import com.daml.dec.DirectExecutionContext
-import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionFailure,
+  CompletionSuccess,
+}
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
 import com.daml.ledger.client.services.commands.CommandTrackerFlow.Materialized
@@ -37,15 +40,18 @@ private[services] final class TrackerImpl(
   override def track(request: SubmitAndWaitRequest)(implicit
       ec: ExecutionContext,
       loggingContext: LoggingContext,
-  ): Future[CompletionResponse] = {
+  ): Future[Either[CompletionFailure, CompletionSuccess]] = {
     logger.trace("Tracking command")
-    val promise = Promise[CompletionResponse]()
+    val promise = Promise[Either[CompletionFailure, CompletionSuccess]]()
     submitNewRequest(request, promise)
   }
 
-  private def submitNewRequest(request: SubmitAndWaitRequest, promise: Promise[CompletionResponse])(
-      implicit ec: ExecutionContext
-  ): Future[CompletionResponse] = {
+  private def submitNewRequest(
+      request: SubmitAndWaitRequest,
+      promise: Promise[Either[CompletionFailure, CompletionSuccess]],
+  )(implicit
+      ec: ExecutionContext
+  ): Future[Either[CompletionFailure, CompletionSuccess]] = {
     queue
       .offer(
         Ctx(
@@ -74,9 +80,12 @@ private[services] object TrackerImpl {
 
   def apply(
       tracker: Flow[
-        Ctx[Promise[CompletionResponse], SubmitRequest],
-        Ctx[Promise[CompletionResponse], CompletionResponse],
-        Materialized[NotUsed, Promise[CompletionResponse]],
+        Ctx[Promise[Either[CompletionFailure, CompletionSuccess]], SubmitRequest],
+        Ctx[
+          Promise[Either[CompletionFailure, CompletionSuccess]],
+          Either[CompletionFailure, CompletionSuccess],
+        ],
+        Materialized[NotUsed, Promise[Either[CompletionFailure, CompletionSuccess]]],
       ],
       inputBufferSize: Int,
       capacityCounter: Counter,
@@ -133,5 +142,5 @@ private[services] object TrackerImpl {
     new TrackerImpl(queue, done)
   }
 
-  type QueueInput = Ctx[Promise[CompletionResponse], SubmitRequest]
+  type QueueInput = Ctx[Promise[Either[CompletionFailure, CompletionSuccess]], SubmitRequest]
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
-import com.daml.ledger.api.v1.completion.Completion
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import org.slf4j.LoggerFactory
 
@@ -58,7 +58,7 @@ private[services] final class TrackerMap(retentionPeriod: FiniteDuration)(implic
 
   def track(submitter: TrackerMap.Key, request: SubmitAndWaitRequest)(
       newTracker: => Future[Tracker]
-  )(implicit ec: ExecutionContext): Future[Completion] =
+  )(implicit ec: ExecutionContext): Future[CompletionResponse] =
     // double-checked locking
     trackerBySubmitter
       .getOrElse(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
@@ -7,7 +7,10 @@ import java.util.concurrent.atomic.AtomicReference
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
-import com.daml.ledger.client.services.commands.tracker.CompletionResponse.CompletionResponse
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionFailure,
+  CompletionSuccess,
+}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import org.slf4j.LoggerFactory
 
@@ -58,7 +61,7 @@ private[services] final class TrackerMap(retentionPeriod: FiniteDuration)(implic
 
   def track(submitter: TrackerMap.Key, request: SubmitAndWaitRequest)(
       newTracker: => Future[Tracker]
-  )(implicit ec: ExecutionContext): Future[CompletionResponse] =
+  )(implicit ec: ExecutionContext): Future[Either[CompletionFailure, CompletionSuccess]] =
     // double-checked locking
     trackerBySubmitter
       .getOrElse(

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
@@ -16,14 +16,13 @@ import com.daml.ledger.api.testing.utils.{
 }
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands.Commands
-import com.daml.ledger.api.v1.completion.Completion
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse
 import com.daml.logging.LoggingContext
-import com.google.rpc.status.{Status => RpcStatus}
 import io.grpc.Status
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterEach, Succeeded}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterEach, Succeeded}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -49,7 +48,9 @@ class TrackerImplTest
     val (q, sink) = Source
       .queue[TrackerImpl.QueueInput](1, OverflowStrategy.dropNew)
       .map { in =>
-        in.context.success(Completion(in.value.getCommands.commandId, Some(RpcStatus())))
+        in.context.success(
+          Right(CompletionResponse.CompletionSuccess(in.value.getCommands.commandId, ""))
+        )
         NotUsed
       }
       .toMat(TestSink.probe[NotUsed])(Keep.both)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
@@ -18,6 +18,7 @@ import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands.Commands
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse
 import com.daml.logging.LoggingContext
+import com.google.rpc.status.{Status => StatusProto}
 import io.grpc.Status
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
@@ -49,7 +50,9 @@ class TrackerImplTest
       .queue[TrackerImpl.QueueInput](1, OverflowStrategy.dropNew)
       .map { in =>
         in.context.success(
-          Right(CompletionResponse.CompletionSuccess(in.value.getCommands.commandId, ""))
+          Right(
+            CompletionResponse.CompletionSuccess(in.value.getCommands.commandId, "", StatusProto())
+          )
         )
         NotUsed
       }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandStaticTimeIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandStaticTimeIT.scala
@@ -105,7 +105,8 @@ final class CommandStaticTimeIT
               )
             )
         } yield {
-          result shouldBe Symbol("right")
+          result should matchPattern { case Right(_) =>
+          }
         }
       }
 

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandStaticTimeIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandStaticTimeIT.scala
@@ -105,8 +105,7 @@ final class CommandStaticTimeIT
               )
             )
         } yield {
-          result should matchPattern { case Right(_) =>
-          }
+          result shouldBe a[Right[_, _]]
         }
       }
 

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandStaticTimeIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandStaticTimeIT.scala
@@ -6,6 +6,7 @@ package com.daml.platform.sandbox.services.command
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.daml.api.util.TimeProvider
+import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.testing.utils.{MockMessages, SuiteResourceManagementAroundAll}
 import com.daml.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc
 import com.daml.ledger.api.v1.command_submission_service.{
@@ -18,15 +19,12 @@ import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.client.configuration.CommandClientConfiguration
 import com.daml.ledger.client.services.commands.CommandClient
 import com.daml.ledger.client.services.testing.time.StaticTime
-import com.daml.dec.DirectExecutionContext
 import com.daml.platform.participant.util.ValueConversions._
 import com.daml.platform.sandbox.services.{SandboxFixture, TestCommands}
-import io.grpc.Status
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
-
 import scalaz.syntax.tag._
 
 import scala.concurrent.Future
@@ -96,7 +94,7 @@ final class CommandStaticTimeIT
       "commands should be accepted" in {
         for {
           commandClient <- createCommandClient()
-          completion <- commandClient
+          result <- commandClient
             .trackSingleCommand(
               SubmitRequest(
                 Some(
@@ -107,7 +105,7 @@ final class CommandStaticTimeIT
               )
             )
         } yield {
-          completion.status.value.code should be(Status.OK.getCode.value())
+          result shouldBe Symbol("right")
         }
       }
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
@@ -17,7 +17,6 @@ import com.daml.navigator.{model => Model}
 import com.daml.navigator.model.{IdentifierApiConversions, IdentifierDamlConversions}
 import com.daml.platform.participant.util.LfEngineToApi.{lfValueToApiRecord, lfValueToApiValue}
 
-import com.google.rpc.code.Code
 import scalaz.Tag
 import scalaz.syntax.bifunctor._
 import scalaz.syntax.traverse._

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
@@ -432,21 +432,6 @@ case object LedgerApiV1 {
       case v: Model.ApiVariant => fillInVariantTI(v, typ, ctx)
     }
 
-  def readCompletion(completion: V1.completion.Completion): Result[Option[Model.CommandStatus]] = {
-    for {
-      status <- Converter.checkExists("Completion.status", completion.status)
-    } yield {
-      val code = Code.fromValue(status.code)
-
-      if (code == Code.OK)
-        // The completion does not contain the new transaction created by this command.
-        // Do not report completion, the command result will be updated from the transaction stream.
-        None
-      else
-        Some(Model.CommandStatusError(code.toString(), status.message))
-    }
-  }
-
   // ------------------------------------------------------------------------------------------------------------------
   // Write methods (Model -> V1)
   // ------------------------------------------------------------------------------------------------------------------

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformSubscriber.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformSubscriber.scala
@@ -7,17 +7,19 @@ import akka.NotUsed
 import akka.actor.{Actor, ActorLogging, ActorRef, Props, Stash}
 import akka.stream._
 import akka.stream.scaladsl.{Sink, Source, SourceQueueWithComplete}
-import com.daml.lf.archive.ArchivePayloadParser
-import com.daml.lf.data.{Ref => DamlLfRef}
-import com.daml.lf.iface.reader.{Errors, InterfaceReader}
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
 import com.daml.ledger.api.v1.package_service.GetPackageResponse
 import com.daml.ledger.api.{v1 => V1}
 import com.daml.ledger.client.LedgerClient
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse
+import com.daml.lf.archive.ArchivePayloadParser
+import com.daml.lf.data.{Ref => DamlLfRef}
+import com.daml.lf.iface.reader.{Errors, InterfaceReader}
 import com.daml.navigator.model._
 import com.daml.navigator.model.converter.TypeNotFoundError
 import com.daml.navigator.store.Store.{StoreException, _}
 import com.daml.util.Ctx
+import com.google.rpc.code
 import scalaz.Tag
 import scalaz.syntax.tag._
 
@@ -237,25 +239,35 @@ class PlatformSubscriber(
       .queue[Ctx[Command, SubmitRequest]](1000, OverflowStrategy.dropNew)
       .via(commandTracker)
       .map(result => {
-        val completion = converter.LedgerApiV1.readCompletion(result.value)
         val commandId = result.context.id
-        completion match {
-          case Right(Some(status)) =>
-            // Command completed with an error
-            party.addCommandStatus(commandId, status)
-            log.info("Command '{}' completed with status '{}'.", commandId, status)
-          case Right(None) =>
+        result.value match {
+          case Right(_) =>
             // Command completed with success.
             // Don't update anything, state will be updated from the transaction stream instead.
             // This is because the completion stream does not contain information to correlate command id with transaction id.
             log.info("Command '{}' completed successfully.", commandId)
           case Left(error) =>
-            party.addCommandStatus(commandId, CommandStatusUnknown())
-            log.error(
-              "Command tracking failed. Status unknown for command '{}': {}.",
-              commandId,
-              error,
-            )
+            error match {
+              case CompletionResponse.NotOkResponse(_, grpcStatus) =>
+                // Command completed with an error
+                val status = CommandStatusError(
+                  code.Code.fromValue(grpcStatus.code).toString(),
+                  grpcStatus.message,
+                )
+                party.addCommandStatus(commandId, status)
+                log.info("Command '{}' completed with status '{}'.", commandId, status)
+              case CompletionResponse.TimeoutResponse(_) =>
+                val status = CommandStatusError(code.Code.ABORTED.toString(), "Timeout")
+                party.addCommandStatus(commandId, status)
+                log.info("Command '{}' completed with status '{}'.", commandId, status)
+              case CompletionResponse.NoStatusInResponse(_) =>
+                party.addCommandStatus(commandId, CommandStatusUnknown())
+                log.error(
+                  "Command tracking failed. Status unknown for command '{}': {}.",
+                  commandId,
+                  error,
+                )
+            }
         }
       })
       .to(Sink.ignore)


### PR DESCRIPTION
Use an Either as a response from the command tracking client. We convert the `Completion` into a typed response as soon as possible and no longer count on grpc `Status` to determine if it was an error or not later on in the code.

No changes as to the way we actually process the response.

- We have the ability to add metadata to the `ErrorInfo` returned as part of the grpc exception  but this is not used just yet. (Will be covered in another PR)
- The failure from adding to the command queue is still directly propagated as an exception but will update that in a new PR so that we're consistent in the way we handle errors in this flow

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
