### PR TITLE
Split the Daml ledger export integration tests

### DIFF
--- a/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
+++ b/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
@@ -3,12 +3,13 @@
 
 load(
     "//bazel_tools:scala.bzl",
-    "da_scala_test",
+    "da_scala_library",
+    "da_scala_test_suite",
 )
 
-da_scala_test(
-    name = "reproduces-transactions",
-    srcs = ["scala/com/daml/script/export/ReproducesTransactions.scala"],
+da_scala_library(
+    name = "test-lib",
+    srcs = ["test/scala/com/daml/script/export/ReproducesTransactions.scala"],
     data = [
         "//compiler/damlc",
         "//daml-script/daml:daml-script.dar",
@@ -18,11 +19,50 @@ da_scala_test(
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:io_spray_spray_json",
+        "@maven//:org_scalactic_scalactic",
         "@maven//:org_scalatest_scalatest",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    visibility = ["//visibility:public"],
     deps = [
+        "//:sdk-version-scala-lib",
+        "//bazel_tools/runfiles:scala_runfiles",
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
+        "//daml-script/export",
+        "//daml-script/export/transaction-eq",
+        "//daml-script/runner:script-runner-lib",
+        "//language-support/scala/bindings",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger/ledger-api-auth",
+        "//ledger/ledger-api-client",
+        "//ledger/ledger-api-common",
+        "//ledger/ledger-api-domain",
+        "//ledger/ledger-resources",
+        "//ledger/sandbox:sandbox-scala-tests-lib",
+        "//ledger/sandbox-common",
+        "//ledger/sandbox-common:sandbox-common-scala-tests-lib",
+        "//ledger/test-common",
+        "//libs-scala/fs-utils",
+        "//libs-scala/ports",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_netty_netty_handler",
+    ],
+)
+
+da_scala_test_suite(
+    name = "reproduces-transactions",
+    srcs = glob(["test-suite/scala/com/daml/script/export/*.scala"]),
+    scala_deps = [
+        "@maven//:com_typesafe_akka_akka_actor",
+        "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:io_spray_spray_json",
+        "@maven//:org_scalatest_scalatest",
+        "@maven//:org_scalaz_scalaz_core",
+    ],
+    deps = [
+        ":test-lib",
         "//:sdk-version-scala-lib",
         "//bazel_tools/runfiles:scala_runfiles",
         "//daml-lf/archive:daml_lf_archive_reader",

--- a/daml-script/export/integration-tests/reproduces-transactions/test-suite/scala/com/daml/script/export/EmptyACS.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/test-suite/scala/com/daml/script/export/EmptyACS.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.export
+
+final class EmptyACS extends ReproducesTransactions {
+  val numParties = 2
+  val skip = 0
+  val description = "empty ACS"
+}

--- a/daml-script/export/integration-tests/reproduces-transactions/test-suite/scala/com/daml/script/export/NoTrees.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/test-suite/scala/com/daml/script/export/NoTrees.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.export
+
+final class NoTrees extends ReproducesTransactions {
+  val numParties = 2
+  val skip = 4
+  val description = "no trees"
+}

--- a/daml-script/export/integration-tests/reproduces-transactions/test-suite/scala/com/daml/script/export/SkipSplit.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/test-suite/scala/com/daml/script/export/SkipSplit.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.export
+
+final class SkipSplit extends ReproducesTransactions {
+  val numParties = 2
+  val skip = 2
+  val description = "skip split"
+}

--- a/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
@@ -46,7 +46,7 @@ import org.scalatest._
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-final class ReproducesTransactions
+trait ReproducesTransactions
     extends AsyncFreeSpec
     with Matchers
     with AkkaBeforeAndAfterAll
@@ -290,10 +290,12 @@ final class ReproducesTransactions
       } yield ()
   }
 
+  def numParties: Int
+  def skip: Int
+  def description: String
+
   "Generated export for IOU transfer compiles" - {
-    "offset 0 - empty ACS" in { testOffset(2, 0)(testIou) }
-    "offset 2 - skip split" in { testOffset(2, 2)(testIou) }
-    "offset 4 - no trees" in { testOffset(2, 4)(testIou) }
+    s"offset $skip - $description" in { testOffset(numParties, skip)(testIou) }
   }
 
   private def transactionFilter(ps: Ref.Party*) =


### PR DESCRIPTION
Depends-On: #10492

This test suite performs the same test with different parameters three
times. These tests each setup some state on the ledger, then create a
Daml ledger export script, compile it, run it, and compare the new
ledger state to the previous state.

Running all this three times in the same target get exceed the default
timeout of 300s in some case. This splits these tests into three
separate targets to reduce the risk of timeouts.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
