### PR TITLE
KV / integrity checker: conflate `Disputed`, `InvalidLedgerTime` and `Inconsistent` rejection reasons [KVL-1059]

### DIFF
--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
@@ -19,7 +19,7 @@ object UpdateNormalizer {
   private val MandatoryNormalizers = List(
     RecordTimeNormalizer,
     RejectionReasonDescriptionNormalizer,
-    RejectionReasonNormalizer,
+    CommandRejectionRedesignNormalizer,
     ConfigurationChangeRejectionNormalizer,
   )
 
@@ -76,7 +76,7 @@ object RejectionReasonDescriptionNormalizer extends UpdateNormalizer {
 /** Rejection reasons `Disputed`, `InvalidLedgerTime` and `Inconsistent` are being conflated
   *  as their usage has been re-designed in SDK 1.16.0-snapshot.20210727.7476.0.b5e9d861 [KVL-1015].
   */
-object RejectionReasonNormalizer extends UpdateNormalizer {
+object CommandRejectionRedesignNormalizer extends UpdateNormalizer {
   override def normalize(update: Update): Update = update match {
     case commandRejected @ Update.CommandRejected(_, _, reason) =>
       val newReason = reason match {

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
@@ -19,6 +19,7 @@ object UpdateNormalizer {
   private val MandatoryNormalizers = List(
     RecordTimeNormalizer,
     RejectionReasonDescriptionNormalizer,
+    RejectionReasonNormalizer,
     ConfigurationChangeRejectionNormalizer,
   )
 
@@ -72,7 +73,24 @@ object RejectionReasonDescriptionNormalizer extends UpdateNormalizer {
   }
 }
 
-/** Rejection reason strings should always be ignored as they can change arbitrarily. */
+/** Rejection reasons `Disputed`, `InvalidLedgerTime` and `Inconsistent` are being conflated
+  *  as their usage has been re-designed in SDK 1.16.0-snapshot.20210727.7476.0.b5e9d861 [KVL-1015].
+  */
+object RejectionReasonNormalizer extends UpdateNormalizer {
+  override def normalize(update: Update): Update = update match {
+    case commandRejected @ Update.CommandRejected(_, _, reason) =>
+      val newReason = reason match {
+        case RejectionReasonV0.Disputed(description) =>
+          RejectionReasonV0.Inconsistent(description)
+        case RejectionReasonV0.InvalidLedgerTime(description) =>
+          RejectionReasonV0.Inconsistent(description)
+        case _ => reason
+      }
+      commandRejected.copy(reason = newReason)
+    case _ => update
+  }
+}
+
 object ConfigurationChangeRejectionNormalizer extends UpdateNormalizer {
   override def normalize(update: Update): Update = update match {
     case u: Update.ConfigurationChangeRejected => u.copy(rejectionReason = "")


### PR DESCRIPTION
# Description:

Rejection in transaction validation has been re-designed in #10066 and the resulting KV write set is (intentionally and acceptedly) incompatible with the previous one, requiring a more relaxed checking.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
