### PR TITLE
Disable pushing Bazel metrics on PRs from forks

### DIFF
--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -57,7 +57,7 @@ steps:
       GZIP=-9 tar --force-local -c -z -f "build-event-logs.tar.gz" "$(pipeline_id)"
       date="$(echo $(pipeline_id) | cut -c1-7)/$(echo $(pipeline_id) | cut -c9-10)"
       gcs "$GCRED" cp "build-event-logs.tar.gz" "gs://daml-data/bazel-metrics/$date/$(pipeline_id).tar.gz"
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['System.PullRequest.IsFork'], 'False'))
     displayName: 'Upload Bazel metrics'
     env:
       GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)


### PR DESCRIPTION
We don’t have credentials there so the job just fails.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
