### PR TITLE
feature: persist script view config in worspace

### DIFF
--- a/compiler/daml-extension/src/extension.ts
+++ b/compiler/daml-extension/src/extension.ts
@@ -8,16 +8,13 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import * as cp from 'child_process';
-import * as tmp from 'tmp';
-import { LanguageClient, LanguageClientOptions, RequestType, NotificationType, TextDocumentIdentifier, TextDocument, ExecuteCommandRequest } from 'vscode-languageclient';
-import { Uri, Event, TextDocumentContentProvider, ViewColumn, EventEmitter, window, QuickPickOptions, ExtensionContext, env, WorkspaceConfiguration } from 'vscode';
+import { LanguageClient, LanguageClientOptions, RequestType, NotificationType, ExecuteCommandRequest } from 'vscode-languageclient';
+import { Uri, ViewColumn, window, QuickPickOptions, ExtensionContext, WorkspaceConfiguration } from 'vscode';
 import * as which from 'which';
 import * as util from 'util';
 import fetch from 'node-fetch';
 import { getOrd } from 'fp-ts/lib/Array';
 import { ordNumber } from 'fp-ts/lib/Ord';
-import {Key} from 'readline';
 
 let damlRoot: string = path.join(os.homedir(), '.daml');
 


### PR DESCRIPTION
This fixes #9188. We remember the config for the script view in the
workspace state. This way script results can be closed and reopened with
the same view config. This also works across restarts of Daml studio.

CHANGELOG_BEGIN
[Daml studio] The script view configuration is remembered for each
script in a workspace and does not need to be reconfigured upon
closing/reopening or restarting of Daml studio.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
