### PR TITLE
H2 Storage backend support for canton jdbc urls with user/password

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
@@ -199,31 +199,35 @@ private[backend] object H2StorageBackend
     val h2DataSource = new org.h2.jdbcx.JdbcDataSource()
 
     // H2 (org.h2.jdbcx.JdbcDataSource) does not support setting the user/password within the jdbcUrl, so remove
-    // those properties from the url if present and set them separately. This helps run canton tests which set
-    // user/password. Note that Postgres and Oracle support user/password in the URLs, so we don't bother exposing
-    // user/password configs separately from the url just for h2 which is anyway not supported for production.
-    def setKeyValueAndRemoveFromUrl(url: String, key: String, setter: String => Unit): String = {
-      val separator = ";"
-      url.toLowerCase.indexOf(separator + key + "=") match {
-        case -1 => url
-        case i =>
-          val valueBegin = i + 1 + key.length + 1 // separator, key, "="
-          val (value, shortenedUrl) = url.indexOf(separator, i + 1) match {
-            case -1 => (url.substring(valueBegin), url.take(i))
-            case next =>
-              (url.substring(valueBegin, next), url.take(i) + url.takeRight(url.length - next))
-          }
-          setter(value)
-          shortenedUrl
-      }
-    }
-
+    // those properties from the url if present and set them separately. Note that Postgres and Oracle support
+    // user/password in the URLs, so we don't bother exposing user/password configs separately from the url just for h2
+    // which is anyway not supported for production. (This also helps run canton h2 participants that set user and
+    // password.)
     val urlNoUser = setKeyValueAndRemoveFromUrl(jdbcUrl, "user", h2DataSource.setUser)
     val urlNoUserNoPassword =
       setKeyValueAndRemoveFromUrl(urlNoUser, "password", h2DataSource.setPassword)
     h2DataSource.setUrl(urlNoUserNoPassword)
 
     InitHookDataSourceProxy(h2DataSource, connectionInitHook.toList)
+  }
+
+  def setKeyValueAndRemoveFromUrl(url: String, key: String, setter: String => Unit): String = {
+    val separator = ";"
+    url.toLowerCase.indexOf(separator + key + "=") match {
+      case -1 => url // leave url intact if key is not found
+      case indexKeyValueBegin =>
+        val valueBegin = indexKeyValueBegin + 1 + key.length + 1 // separator, key, "="
+        val (value, shortenedUrl) = url.indexOf(separator, indexKeyValueBegin + 1) match {
+          case -1 => (url.substring(valueBegin), url.take(indexKeyValueBegin))
+          case indexKeyValueEnd =>
+            (
+              url.substring(valueBegin, indexKeyValueEnd),
+              url.take(indexKeyValueBegin) + url.takeRight(url.length - indexKeyValueEnd),
+            )
+        }
+        setter(value)
+        shortenedUrl
+    }
   }
 
   override def tryAcquire(


### PR DESCRIPTION
The H2 database's JdbcDataSource does not like seeing user/password
properties in the jdbc url raising errors upon hikari connection pool
initialization:

`org.h2.jdbc.JdbcSQLNonTransientConnectionException: Duplicate property "USER"`

expecting to be able to set user and password separately from passing on
the jdbc url.

As h2 is not supported in production and to get canton integration tests past this
resorting to parsing the jdbc url looking for user/password properties, removing
them from the url and instead setting them explicitly on the data source object.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
