### PR TITLE
Handle missing template instances in Daml ledger export

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
@@ -28,6 +28,21 @@ object Util {
     }
   }
 
+  object TTVarApp {
+    def apply(name: Ast.TypeVarName, args: ImmArray[Type]): Type =
+      args.foldLeft[Type](TVar(name))((typ, arg) => TApp(typ, arg))
+    def unapply(typ: Type): Option[(Ast.TypeVarName, ImmArray[Type])] = {
+      @tailrec
+      def go(typ: Type, targs: List[Type]): Option[(Ast.TypeVarName, ImmArray[Type])] =
+        typ match {
+          case TApp(tfun, targ) => go(tfun, targ :: targs)
+          case TVar(name) => Some((name, ImmArray(targs)))
+          case _ => None
+        }
+      go(typ, Nil)
+    }
+  }
+
   object TFun extends ((Type, Type) => Type) {
     def apply(targ: Type, tres: Type) =
       TApp(TApp(TBuiltin(BTArrow), targ), tres)

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -30,6 +30,10 @@ module Daml.Script
   , exerciseByKeyCmd
   , createAndExerciseCmd
   , archiveCmd
+  , internalCreateCmd
+  , internalExerciseCmd
+  , internalExerciseByKeyCmd
+  , internalCreateAndExerciseCmd
   , getTime
   , setTime
   , passTime
@@ -478,21 +482,45 @@ data LedgerValue = LedgerValue {}
 fromLedgerValue : LedgerValue -> a
 fromLedgerValue = error "foobar"
 
+-- | HIDE A version of 'createCmd' without constraints.
+--
+-- This is used for Daml ledger exports involving contracts defined in Daml-LF 1.6 or 1.7.
+internalCreateCmd : AnyTemplate -> Commands (ContractId t)
+internalCreateCmd arg = Commands $ Ap (\f -> f (Create arg identity) (pure coerceContractId))
+
+-- | HIDE A version of 'exerciseCmd' without constraints.
+--
+-- This is used for Daml ledger exports involving contracts defined in Daml-LF 1.6 or 1.7.
+internalExerciseCmd : TemplateTypeRep -> ContractId () -> AnyChoice -> Commands r
+internalExerciseCmd tplTypeRep cId arg = Commands $ Ap (\f -> f (Exercise tplTypeRep cId arg identity) (pure fromLedgerValue))
+
+-- | HIDE A version of 'exerciseByKeyCmd' without constraints.
+--
+-- This is used for Daml ledger exports involving contracts defined in Daml-LF 1.6 or 1.7.
+internalExerciseByKeyCmd : TemplateTypeRep -> AnyContractKey -> AnyChoice -> Commands r
+internalExerciseByKeyCmd tplTypeRep key arg = Commands $ Ap (\f -> f (ExerciseByKey tplTypeRep key arg identity) (pure fromLedgerValue))
+
+-- | HIDE A version of 'createAndExerciseCmd' without constraints.
+--
+-- This is used for Daml ledger exports involving contracts defined in Daml-LF 1.6 or 1.7.
+internalCreateAndExerciseCmd : AnyTemplate -> AnyChoice -> Commands r
+internalCreateAndExerciseCmd tplArg choiceArg = Commands $ Ap (\f -> f (CreateAndExercise tplArg choiceArg identity) (pure fromLedgerValue))
+
 -- | Create a contract of the given template.
 createCmd : Template t => t -> Commands (ContractId t)
-createCmd arg = Commands $ Ap (\f -> f (Create (toAnyTemplate arg) identity) (pure coerceContractId))
+createCmd arg = internalCreateCmd (toAnyTemplate arg)
 
 -- | Exercise a choice on the given contract.
 exerciseCmd : forall t c r. Choice t c r => ContractId t -> c -> Commands r
-exerciseCmd cId arg = Commands $ Ap (\f -> f (Exercise (templateTypeRep @t) (coerceContractId cId) (toAnyChoice @t arg) identity) (pure fromLedgerValue))
+exerciseCmd cId arg = internalExerciseCmd (templateTypeRep @t) (coerceContractId cId) (toAnyChoice @t arg)
 
 -- | Exercise a choice on the contract with the given key.
 exerciseByKeyCmd : forall t k c r. (TemplateKey t k, Choice t c r) => k -> c -> Commands r
-exerciseByKeyCmd key arg = Commands $ Ap (\f -> f (ExerciseByKey (templateTypeRep @t) (toAnyContractKey @t key) (toAnyChoice @t arg) identity) (pure fromLedgerValue))
+exerciseByKeyCmd key arg = internalExerciseByKeyCmd (templateTypeRep @t) (toAnyContractKey @t key) (toAnyChoice @t arg)
 
 -- | Create a contract and exercise a choice on it in the same transaction.
 createAndExerciseCmd : forall t c r. Choice t c r => t -> c -> Commands r
-createAndExerciseCmd tplArg choiceArg = Commands $ Ap (\f -> f (CreateAndExercise (toAnyTemplate tplArg) (toAnyChoice @t choiceArg) identity) (pure fromLedgerValue))
+createAndExerciseCmd tplArg choiceArg = internalCreateAndExerciseCmd (toAnyTemplate tplArg) (toAnyChoice @t choiceArg)
 
 -- | Archive the given contract.
 --

--- a/daml-script/export/integration-tests/export-lf-1.6/BUILD.bazel
+++ b/daml-script/export/integration-tests/export-lf-1.6/BUILD.bazel
@@ -1,0 +1,89 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools/client_server:client_server_build.bzl",
+    "client_server_build",
+)
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+)
+load(
+    "//bazel_tools/sh:sh.bzl",
+    "sh_inline_test",
+)
+load(
+    "//rules_daml:daml.bzl",
+    "daml_compile",
+)
+
+daml_compile(
+    name = "lf16",
+    srcs = ["daml/LF16.daml"],
+    target = "1.6",
+    version = "1.0.0",
+)
+
+da_scala_binary(
+    name = "lf16-export-client",
+    srcs = ["scala/com/daml/script/export/LF16ExportClient.scala"],
+    main_class = "com.daml.script.export.LF16ExportClient",
+    scala_deps = [
+        "@maven//:com_github_scopt_scopt",
+    ],
+    deps = [
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/data",
+        "//daml-lf/language",
+        "//daml-script/export",
+        "//language-support/scala/bindings",
+        "//language-support/scala/bindings-akka",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger/ledger-api-common",
+        "//libs-scala/auth-utils",
+        "//libs-scala/fs-utils",
+    ],
+)
+
+client_server_build(
+    name = "lf16-export",
+    outs = [
+        "lf16-export.zip",
+    ],
+    client = ":lf16-export-client",
+    client_args = [
+        "--ledgerid",
+        "lf16-export-ledger",
+    ],
+    client_files = ["lf16.build"],
+    data = ["lf16.build"],
+    output_env = "EXPORT_OUT",
+    server = "//ledger/sandbox:sandbox-binary",
+    server_args = [
+        "--port",
+        "0",
+        "--ledgerid",
+        "lf16-export-ledger",
+    ],
+    server_files = ["lf16.build"],
+)
+
+sh_inline_test(
+    name = "lf16-export-build",
+    cmd = """\
+set -eoux pipefail
+tmpdir=$$(mktemp -d)
+trap "rm -rf $$tmpdir" EXIT
+DAMLC=$$(canonicalize_rlocation $(rootpath //compiler/damlc))
+unzip $$(canonicalize_rlocation $(rootpath :lf16-export.zip)) -d $$tmpdir
+cp -L $$(canonicalize_rlocation $(rootpath //daml-script/daml:daml-script-1.7.dar)) $$tmpdir/
+sed -i.bak 's/daml-script/daml-script-1.7.dar/' $$tmpdir/daml.yaml
+DAML_PROJECT=$$tmpdir $$DAMLC build
+""",
+    data = [
+        ":lf16-export.zip",
+        "//compiler/damlc",
+        "//daml-script/daml:daml-script-1.7.dar",
+    ],
+)

--- a/daml-script/export/integration-tests/export-lf-1.6/daml/LF16.daml
+++ b/daml-script/export/integration-tests/export-lf-1.6/daml/LF16.daml
@@ -1,0 +1,18 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module LF16 where
+
+template LF16
+  with
+    issuer : Party
+    count : Int
+  where
+    signatory issuer
+
+    key (issuer, count) : (Party, Int)
+    maintainer key._1
+
+    choice Increment : ContractId LF16
+      controller issuer
+      do create this with count = count + 1

--- a/daml-script/export/integration-tests/export-lf-1.6/scala/com/daml/script/export/LF16ExportClient.scala
+++ b/daml-script/export/integration-tests/export-lf-1.6/scala/com/daml/script/export/LF16ExportClient.scala
@@ -1,0 +1,387 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.export
+
+import java.io.{File, FileOutputStream}
+import java.nio.file.{Files, Path, Paths}
+import java.util.zip.{ZipEntry, ZipOutputStream}
+
+import akka.actor.ActorSystem
+import com.daml.ledger.client.LedgerClient
+import com.daml.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement,
+}
+import com.daml.fs.Utils.deleteRecursively
+import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
+import com.daml.ledger.api.v1.command_service
+import com.daml.ledger.api.v1.commands
+import com.daml.ledger.api.v1.transaction
+import com.daml.ledger.api.v1.value
+import com.daml.ledger.api.domain
+import com.daml.lf.archive.DarDecoder
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+
+case class LF16ExportClientConfig(
+    darPath: File,
+    targetPort: Int,
+    ledgerId: String,
+    outputZip: Path,
+)
+
+object LF16ExportClientConfig {
+  def parse(args: Array[String]): Option[LF16ExportClientConfig] =
+    parser.parse(
+      args,
+      LF16ExportClientConfig(
+        darPath = null,
+        targetPort = -1,
+        ledgerId = null,
+        outputZip = null,
+      ),
+    )
+
+  private def parseExportOut(
+      envVar: String
+  ): Either[String, LF16ExportClientConfig => LF16ExportClientConfig] = {
+    envVar.split(" ").map(s => Paths.get(s)) match {
+      case Array(output_zip) =>
+        Right(c =>
+          c.copy(
+            outputZip = output_zip
+          )
+        )
+      case _ => Left("Environment variable EXPORT_OUT must contain one path")
+    }
+  }
+
+  private val parser = new scopt.OptionParser[LF16ExportClientConfig]("lf16-export-client") {
+    help("help")
+      .text("Show this help message.")
+    opt[Int]("target-port")
+      .required()
+      .action((x, c) => c.copy(targetPort = x))
+      .text("Daml ledger port to connect to.")
+    opt[String]("ledgerid")
+      .required()
+      .action((x, c) => c.copy(ledgerId = x))
+      .text("Daml ledger identifier.")
+    opt[String]("output")
+      .hidden()
+      .withFallback(() => sys.env.getOrElse("EXPORT_OUT", ""))
+      .validate(x => parseExportOut(x).map(_ => ()))
+      .action { (x, c) =>
+        parseExportOut(x) match {
+          case Left(msg) =>
+            throw new RuntimeException(s"Failed to validate EXPORT_OUT environment variable: $msg")
+          case Right(f) => f(c)
+        }
+      }
+    arg[File]("dar")
+      .required()
+      .action((f, c) => c.copy(darPath = f))
+      .text("Path to the dar file containing the initialization script")
+  }
+}
+
+object LF16ExportClient {
+  def main(args: Array[String]): Unit = {
+    LF16ExportClientConfig.parse(args) match {
+      case Some(clientConfig) => main(clientConfig)
+      case None => sys.exit(1)
+    }
+  }
+  def main(clientConfig: LF16ExportClientConfig): Unit = {
+    setupLedger(clientConfig.targetPort, clientConfig.ledgerId, clientConfig.darPath)
+    generateExport(
+      clientConfig.targetPort,
+      clientConfig.outputZip.toFile,
+    )
+  }
+
+  private def setupLedger(ledgerPort: Int, ledgerId: String, darPath: File): Unit = {
+    implicit val sys: ActorSystem = ActorSystem("lf16-export-client")
+    implicit val ec: ExecutionContext = sys.dispatcher
+    implicit val seq: ExecutionSequencerFactory = new AkkaExecutionSequencerPool(
+      "lf16-export-client"
+    )
+    val run: Future[Unit] = for {
+      dar <- Future.fromTry(DarDecoder.readArchiveFromFile(darPath).toTry)
+      mainPackageId = dar.main._1
+      lf16TemplateId = value
+        .Identifier()
+        .withPackageId(mainPackageId)
+        .withModuleName("LF16")
+        .withEntityName("LF16")
+      lf16IncrementId = value
+        .Identifier()
+        .withPackageId(mainPackageId)
+        .withModuleName("LF16")
+        .withEntityName("Increment")
+      client <- ApiClient(
+        applicationId = "lf16-export-client",
+        ledgerId = ledgerId,
+        host = "localhost",
+        port = ledgerPort,
+      )
+      alice <- client.allocateParty("Alice", "Alice")
+      // To generate an internalCreateCmd.
+      tx <- client.submit(
+        "create-LF16",
+        Seq(alice.party),
+        ApiCommand.create(
+          lf16TemplateId,
+          ApiValue.recordRec(
+            lf16TemplateId,
+            "issuer" -> ApiValue.party(alice.party),
+            "count" -> ApiValue.int(0),
+          ),
+        ),
+      )
+      cid = tx.events(0).event.created.get.contractId
+      // To generate an internalExerciseCmd on the Increment choice.
+      tx <- client.submit(
+        "exercise-Lf16-Increment",
+        Seq(alice.party),
+        ApiCommand.exercise(lf16TemplateId, cid, "Increment", ApiValue.record(lf16IncrementId)),
+      )
+      cid = tx.events.find(_.event.isCreated).get.event.created.get.contractId
+      // To generate an internalExerciseCmd on the Archive choice.
+      _ <- client.submit(
+        "archive-Lf16",
+        Seq(alice.party),
+        ApiCommand.archive(lf16TemplateId, cid),
+      )
+      // To generate an internalCreateAndExerciseCmd followed by an internalExerciseByKeyCmd.
+      // Note the exerciseByKey should not directly follow a create command,
+      // otherwise the exporter will generate a createAndExerciseCmd instead of an exerciseByKeyCmd.
+      _ <- client.submit(
+        "createAndExercise-exerciseByKey-Lf16-Increment",
+        Seq(alice.party),
+        ApiCommand.createAndExercise(
+          lf16TemplateId,
+          ApiValue.recordRec(
+            lf16TemplateId,
+            "issuer" -> ApiValue.party(alice.party),
+            "count" -> ApiValue.int(0),
+          ),
+          "Increment",
+          ApiValue.record(lf16IncrementId),
+        ),
+        ApiCommand.exerciseByKey(
+          lf16TemplateId,
+          ApiValue.tuple(ApiValue.party(alice.party), ApiValue.int(1)),
+          "Increment",
+          ApiValue.record(lf16IncrementId),
+        ),
+      )
+    } yield ()
+    run.onComplete { _ => sys.terminate() }
+    val _ = Await.result(sys.whenTerminated, Duration.Inf)
+    Await.result(run, Duration.Inf)
+  }
+
+  private def generateExport(
+      ledgerPort: Int,
+      outputZip: File,
+  ): Unit = {
+    withTemporaryDirectory { outputPath =>
+      Main.main(
+        Config.Empty.copy(
+          ledgerHost = "localhost",
+          ledgerPort = ledgerPort,
+          parties = Seq("Alice"),
+          exportType = Some(
+            Config.EmptyExportScript.copy(
+              sdkVersion = "0.0.0",
+              outputPath = outputPath,
+            )
+          ),
+        )
+      )
+      createZipArchive(outputPath.toFile, outputZip)
+    }
+  }
+
+  /** Recursively archives all files contained in a directory.
+    *
+    * The generated zip archive is reproducible in that the order of entries and their timestamps are deterministic.
+    *
+    * @param src Archive all files underneath this directory. The paths of the entries will be relative to this directory.
+    * @param dst Write the zip archive to this file.
+    */
+  private def createZipArchive(src: File, dst: File): Unit = {
+    val out = new FileOutputStream(dst)
+    val zipOut = new ZipOutputStream(out)
+    def addFile(file: File): Unit = {
+      val path = src.toPath.relativize(file.toPath)
+      val entry = new ZipEntry(path.toString)
+      entry.setTime(0)
+      zipOut.putNextEntry(entry)
+      Files.copy(file.toPath, zipOut)
+      zipOut.closeEntry()
+    }
+    def addDirectory(dir: File): Unit = {
+      dir
+        .listFiles()
+        .sorted
+        .foreach(f =>
+          if (f.isDirectory) { addDirectory(f) }
+          else { addFile(f) }
+        )
+    }
+    addDirectory(src)
+    zipOut.close
+  }
+
+  private def withTemporaryDirectory(f: Path => Unit): Unit = {
+    val tmpDir = Files.createTempDirectory("daml-ledger-export")
+    try {
+      f(tmpDir)
+    } finally {
+      deleteRecursively(tmpDir)
+    }
+  }
+}
+
+object ApiValue {
+  def tupleId(n: Int): value.Identifier =
+    value
+      .Identifier()
+      .withPackageId("40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7")
+      .withModuleName("DA.Types")
+      .withEntityName(s"Tuple$n")
+  def recordRec(id: value.Identifier, fields: (String, value.Value)*): value.Record =
+    value
+      .Record()
+      .withRecordId(id)
+      .withFields(fields.map { case (lbl, v) =>
+        value
+          .RecordField()
+          .withLabel(lbl)
+          .withValue(v)
+      })
+  def record(id: value.Identifier, fields: (String, value.Value)*): value.Value =
+    value.Value().withRecord(recordRec(id, fields: _*))
+  def tuple(vals: value.Value*): value.Value = {
+    record(tupleId(vals.size), vals.zipWithIndex.map { case (v, ix) => (s"_${ix + 1}", v) }: _*)
+  }
+  def party(p: String): value.Value = value.Value().withParty(p)
+  def int(i: Long): value.Value = value.Value().withInt64(i)
+}
+
+object ApiCommand {
+  val archiveId = value
+    .Identifier()
+    .withPackageId("d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662")
+    .withModuleName("DA.Internal.Template")
+    .withEntityName("Archive")
+  def create(tplId: value.Identifier, args: value.Record): commands.Command =
+    commands
+      .Command()
+      .withCreate(
+        commands
+          .CreateCommand()
+          .withTemplateId(tplId)
+          .withCreateArguments(args)
+      )
+  def exercise(
+      tplId: value.Identifier,
+      cid: String,
+      choice: String,
+      arg: value.Value,
+  ): commands.Command =
+    commands
+      .Command()
+      .withExercise(
+        commands
+          .ExerciseCommand()
+          .withTemplateId(tplId)
+          .withContractId(cid)
+          .withChoice(choice)
+          .withChoiceArgument(arg)
+      )
+  def archive(tplId: value.Identifier, cid: String): commands.Command =
+    exercise(tplId, cid, "Archive", ApiValue.record(archiveId))
+  def createAndExercise(
+      tplId: value.Identifier,
+      tplArgs: value.Record,
+      choice: String,
+      choiceArg: value.Value,
+  ): commands.Command =
+    commands
+      .Command()
+      .withCreateAndExercise(
+        commands
+          .CreateAndExerciseCommand()
+          .withTemplateId(tplId)
+          .withCreateArguments(tplArgs)
+          .withChoice(choice)
+          .withChoiceArgument(choiceArg)
+      )
+  def exerciseByKey(
+      tplId: value.Identifier,
+      key: value.Value,
+      choice: String,
+      arg: value.Value,
+  ): commands.Command =
+    commands
+      .Command()
+      .withExerciseByKey(
+        commands
+          .ExerciseByKeyCommand()
+          .withTemplateId(tplId)
+          .withContractKey(key)
+          .withChoice(choice)
+          .withChoiceArgument(arg)
+      )
+}
+
+case class ApiClient(applicationId: String, ledgerId: String, ledgerClient: LedgerClient) {
+  def allocateParty(hint: String, displayName: String): Future[domain.PartyDetails] = {
+    ledgerClient.partyManagementClient.allocateParty(Some(hint), Some(displayName))
+  }
+  def submit(commandId: String, actAs: Seq[String], cmds: commands.Command*)(implicit
+      ec: ExecutionContext
+  ): Future[transaction.Transaction] = {
+    ledgerClient.commandServiceClient
+      .submitAndWaitForTransaction(
+        command_service
+          .SubmitAndWaitRequest()
+          .withCommands(
+            commands
+              .Commands()
+              .withLedgerId(ledgerId)
+              .withApplicationId(applicationId)
+              .withCommandId(commandId)
+              .withActAs(actAs)
+              .withCommands(cmds)
+          )
+      )
+      .map(_.getTransaction)
+  }
+}
+
+object ApiClient {
+  def apply(
+      applicationId: String,
+      ledgerId: String,
+      host: String,
+      port: Int,
+  )(implicit ec: ExecutionContext, esf: ExecutionSequencerFactory): Future[ApiClient] = {
+    val ledgerConfig = LedgerClientConfiguration(
+      applicationId = applicationId,
+      ledgerIdRequirement = LedgerIdRequirement.none,
+      commandClient = CommandClientConfiguration.default,
+      sslContext = None,
+    )
+    LedgerClient
+      .singleHost(host, port, ledgerConfig)
+      .map(ledgerClient => new ApiClient(applicationId, ledgerId, ledgerClient))
+
+  }
+}

--- a/daml-script/export/integration-tests/export-lf-1.6/scala/com/daml/script/export/LF16ExportClient.scala
+++ b/daml-script/export/integration-tests/export-lf-1.6/scala/com/daml/script/export/LF16ExportClient.scala
@@ -25,6 +25,7 @@ import com.daml.lf.archive.DarDecoder
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
+import scala.jdk.CollectionConverters._
 
 case class LF16ExportClientConfig(
     darPath: File,
@@ -219,7 +220,9 @@ object LF16ExportClient {
     val zipOut = new ZipOutputStream(out)
     def addFile(file: File): Unit = {
       val path = src.toPath.relativize(file.toPath)
-      val entry = new ZipEntry(path.toString)
+      // Section "4.4.17 file name" in ZIP specification https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.9.TXT
+      // > All slashes MUST be forward slashes '/' as opposed to backwards slashes '\' [...]
+      val entry = new ZipEntry(path.iterator.asScala.mkString("/"))
       entry.setTime(0)
       zipOut.putNextEntry(entry)
       Files.copy(file.toPath, zipOut)

--- a/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
@@ -50,9 +50,13 @@ object Dependencies {
   def lfMissingInstances(version: LanguageVersion): Boolean =
     LanguageVersion.Ordering.lt(version, LanguageVersion.v1_8)
 
+  final case class ChoiceInstanceSpec(
+      arg: Ast.Type,
+      ret: Ast.Type,
+  )
   final case class TemplateInstanceSpec(
       key: Option[Ast.Type],
-      choices: Map[ApiTypes.Choice, Ast.Type],
+      choices: Map[ApiTypes.Choice, ChoiceInstanceSpec],
   )
 
   /** Extract all templates that are missing instances due to their package's LF version.
@@ -78,7 +82,10 @@ object Dependencies {
             map += tplId -> TemplateInstanceSpec(
               key = tpl.key.map(_.typ),
               choices = tpl.choices.map { case (name, choice) =>
-                ApiTypes.Choice(name: String) -> choice.returnType
+                ApiTypes.Choice(name: String) -> ChoiceInstanceSpec(
+                  choice.argBinder._2,
+                  choice.returnType,
+                )
               },
             )
           }

--- a/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Dependencies.scala
@@ -7,6 +7,8 @@ import java.io.FileOutputStream
 import java.nio.file.Path
 
 import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.api.refinements.ApiTypes
+import com.daml.ledger.api.v1.value
 import com.daml.ledger.client.LedgerClient
 import com.daml.lf.archive
 import com.daml.lf.data.Ref
@@ -14,6 +16,7 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.language.{Ast, LanguageVersion}
 import com.google.protobuf.ByteString
 
+import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 
 object Dependencies {
@@ -38,6 +41,51 @@ object Dependencies {
           }
       }
     go(references, Map.empty)
+  }
+
+  /** Whether the given LF version is missing type-class instances.
+    *
+    * If so then we need to generate replacement instances for standard template and choice instances.
+    */
+  def lfMissingInstances(version: LanguageVersion): Boolean =
+    LanguageVersion.Ordering.lt(version, LanguageVersion.v1_8)
+
+  final case class TemplateInstanceSpec(
+      key: Option[Ast.Type],
+      choices: Map[ApiTypes.Choice, Ast.Type],
+  )
+
+  /** Extract all templates that are missing instances due to their package's LF version.
+    *
+    * The exporter will need to create replacement type class instances
+    * for the standard template and choice instances for these templates.
+    */
+  def templatesMissingInstances(
+      pkgs: Map[PackageId, (ByteString, Ast.Package)]
+  ): Map[ApiTypes.TemplateId, TemplateInstanceSpec] = {
+    val map = mutable.HashMap.empty[ApiTypes.TemplateId, TemplateInstanceSpec]
+    pkgs.foreach {
+      case (pkgId, (_, pkg)) if lfMissingInstances(pkg.languageVersion) =>
+        pkg.modules.foreach { case (modName, mod) =>
+          mod.templates.foreach { case (tplName, tpl) =>
+            val tplId = ApiTypes.TemplateId(
+              value
+                .Identifier()
+                .withPackageId(pkgId)
+                .withModuleName(modName.dottedName)
+                .withEntityName(tplName.dottedName)
+            )
+            map += tplId -> TemplateInstanceSpec(
+              key = tpl.key.map(_.typ),
+              choices = tpl.choices.map { case (name, choice) =>
+                ApiTypes.Choice(name: String) -> choice.returnType
+              },
+            )
+          }
+        }
+      case _ => ()
+    }
+    map.toMap
   }
 
   /** The Daml-LF version to target based on the DALF dependencies.

--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -281,7 +281,9 @@ private[export] object Encode {
           case Ast.BTContractId => "ContractId"
           case Ast.BTArrow => "(->)"
           case Ast.BTAny =>
-            "Any" // TODO[AH] DA.Internal.LF.Any is not importable. How to handle this?
+            // We only need to encode types in type-class instances of serializable types.
+            // DA.Internal.LF.Any is not serializable and also cannot be imported.
+            throw new NotImplementedError("Encoding of Any is not implemented")
           case Ast.BTTypeRep => "TypeRep"
           case Ast.BTAnyException => "AnyException"
           case Ast.BTRoundingMode => "RoundingMode"

--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -32,23 +32,20 @@ private[export] object Encode {
   }
 
   def encodeExport(export: Export): Doc = {
-    encodeModuleHeader(export.moduleRefs) /
-      Doc.hardLine +
-      encodePartyType() /
-      Doc.hardLine +
-      encodeLookupParty() /
-      Doc.hardLine +
-      encodeAllocateParties(export.partyMap) /
-      Doc.hardLine +
-      encodeContractsType() /
-      Doc.hardLine +
-      encodeLookupContract() /
-      Doc.hardLine +
-      encodeArgsType() /
-      Doc.hardLine +
-      encodeTestExport() /
-      Doc.hardLine +
-      encodeExportActions(export)
+    Doc.intercalate(
+      Doc.line + Doc.hardLine,
+      Seq(
+        encodeModuleHeader(export.moduleRefs),
+        encodePartyType(),
+        encodeLookupParty(),
+        encodeAllocateParties(export.partyMap),
+        encodeContractsType(),
+        encodeLookupContract(),
+        encodeArgsType(),
+        encodeTestExport(),
+        encodeExportActions(export),
+      ),
+    )
   }
 
   private def encodeExportActions(export: Export): Doc = {

--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.{Date, Timestamp}
 import com.daml.lf.language.Ast
-import com.daml.script.export.Dependencies.TemplateInstanceSpec
+import com.daml.script.export.Dependencies.{ChoiceInstanceSpec, TemplateInstanceSpec}
 import com.daml.script.export.TreeUtils._
 import org.apache.commons.text.StringEscapeUtils
 import org.typelevel.paiges.Doc
@@ -71,9 +71,8 @@ private[export] object Encode {
     )
     val keyInstances =
       spec.key.toList.map(key => primInstance("toAnyContractKey", tplIdDoc & encodeType(key, 11)))
-    val choiceInstances = spec.choices.map { case (choice, ret) =>
-      val choiceDoc = if (choice == "Archive") { Doc.text("Archive") }
-      else { qualifyId(TemplateId.unwrap(tplId).copy().withEntityName(Choice.unwrap(choice))) }
+    val choiceInstances = spec.choices.values.map { case ChoiceInstanceSpec(arg, ret) =>
+      val choiceDoc = encodeType(arg, 11)
       val retDoc = encodeType(ret, 11)
       primInstance("toAnyChoice", tplIdDoc & choiceDoc & retDoc)
     }

--- a/daml-script/export/src/test/scala/com/daml/script/export/AstSyntax.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/AstSyntax.scala
@@ -5,40 +5,22 @@ package com.daml.script.export
 
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.language.Ast
+import com.daml.lf.language.Util._
 
 private[export] object AstSyntax {
-  implicit class AstApp(private val lhs: Ast.Type) extends AnyVal {
-    def :@(rhs: Ast.Type): Ast.Type = {
-      Ast.TApp(lhs, rhs)
-    }
-  }
   implicit class AstArrow(private val rhs: Ast.Type) extends AnyVal {
     def =>:(lhs: Ast.Type): Ast.Type = {
-      val arrowTy: Ast.Type = Ast.TBuiltin(Ast.BTArrow)
-      Ast.TApp(Ast.TApp(arrowTy, lhs), rhs)
+      TFun(lhs, rhs)
     }
   }
-  def synApp(syn: Ref.TypeSynName, args: Ast.Type*): Ast.Type = {
-    Ast.TSynApp(syn, ImmArray(args))
-  }
   def tuple(tys: Ast.Type*): Ast.Type = {
-    val tupleTyCon: Ast.Type = Ast.TTyCon(
-      Ref.TypeConName.assertFromString(
-        "40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7:DA.Types:Tuple"
-      )
+    val tupleName = Ref.TypeConName.assertFromString(
+      "40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7:DA.Types:Tuple"
     )
-    tys.foldLeft(tupleTyCon) { case (acc, ty) => acc :@ ty }
+    TTyConApp(tupleName, ImmArray(tys))
   }
-  def list(ty: Ast.Type): Ast.Type = {
-    Ast.TBuiltin(Ast.BTList) :@ ty
-  }
-  val unit: Ast.Type = Ast.TBuiltin(Ast.BTUnit)
-  val int: Ast.Type = Ast.TBuiltin(Ast.BTInt64)
-  val text: Ast.Type = Ast.TBuiltin(Ast.BTText)
-  val party: Ast.Type = Ast.TBuiltin(Ast.BTParty)
-  val contractId: Ast.Type = Ast.TBuiltin(Ast.BTContractId)
-  val vFoo: Ast.Type = Ast.TVar(Ref.Name.assertFromString("foo"))
-  val vBar: Ast.Type = Ast.TVar(Ref.Name.assertFromString("bar"))
+  val vFoo: Ref.Name = Ref.Name.assertFromString("foo")
+  val vBar: Ref.Name = Ref.Name.assertFromString("bar")
   val tArchive: Ast.Type = Ast.TTyCon(
     Ref.TypeConName.assertFromString(
       "d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662:DA.Internal.Template:Archive"

--- a/daml-script/export/src/test/scala/com/daml/script/export/AstSyntax.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/AstSyntax.scala
@@ -39,6 +39,11 @@ private[export] object AstSyntax {
   val contractId: Ast.Type = Ast.TBuiltin(Ast.BTContractId)
   val vFoo: Ast.Type = Ast.TVar(Ref.Name.assertFromString("foo"))
   val vBar: Ast.Type = Ast.TVar(Ref.Name.assertFromString("bar"))
+  val tArchive: Ast.Type = Ast.TTyCon(
+    Ref.TypeConName.assertFromString(
+      "d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662:DA.Internal.Template:Archive"
+    )
+  )
   val nFoo: Ref.Identifier = Ref.TypeSynName.assertFromString(
     "e7b2c7155f6dd6fc569c2325be821f1269186a540d0408b9a0c9e30406f6b64b:Module:Foo"
   )

--- a/daml-script/export/src/test/scala/com/daml/script/export/AstSyntax.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/AstSyntax.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.export
+
+import com.daml.lf.data.{ImmArray, Ref}
+import com.daml.lf.language.Ast
+
+private[export] object AstSyntax {
+  implicit class AstApp(private val lhs: Ast.Type) extends AnyVal {
+    def :@(rhs: Ast.Type): Ast.Type = {
+      Ast.TApp(lhs, rhs)
+    }
+  }
+  implicit class AstArrow(private val rhs: Ast.Type) extends AnyVal {
+    def =>:(lhs: Ast.Type): Ast.Type = {
+      val arrowTy: Ast.Type = Ast.TBuiltin(Ast.BTArrow)
+      Ast.TApp(Ast.TApp(arrowTy, lhs), rhs)
+    }
+  }
+  def synApp(syn: Ref.TypeSynName, args: Ast.Type*): Ast.Type = {
+    Ast.TSynApp(syn, ImmArray(args))
+  }
+  def tuple(tys: Ast.Type*): Ast.Type = {
+    val tupleTyCon: Ast.Type = Ast.TTyCon(
+      Ref.TypeConName.assertFromString(
+        "40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7:DA.Types:Tuple"
+      )
+    )
+    tys.foldLeft(tupleTyCon) { case (acc, ty) => acc :@ ty }
+  }
+  def list(ty: Ast.Type): Ast.Type = {
+    Ast.TBuiltin(Ast.BTList) :@ ty
+  }
+  val unit: Ast.Type = Ast.TBuiltin(Ast.BTUnit)
+  val int: Ast.Type = Ast.TBuiltin(Ast.BTInt64)
+  val text: Ast.Type = Ast.TBuiltin(Ast.BTText)
+  val party: Ast.Type = Ast.TBuiltin(Ast.BTParty)
+  val contractId: Ast.Type = Ast.TBuiltin(Ast.BTContractId)
+  val vFoo: Ast.Type = Ast.TVar(Ref.Name.assertFromString("foo"))
+  val vBar: Ast.Type = Ast.TVar(Ref.Name.assertFromString("bar"))
+  val nFoo: Ref.Identifier = Ref.TypeSynName.assertFromString(
+    "e7b2c7155f6dd6fc569c2325be821f1269186a540d0408b9a0c9e30406f6b64b:Module:Foo"
+  )
+  val nBar: Ref.Identifier = Ref.TypeSynName.assertFromString(
+    "e7b2c7155f6dd6fc569c2325be821f1269186a540d0408b9a0c9e30406f6b64b:Module:Bar"
+  )
+}

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeInstancesSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeInstancesSpec.scala
@@ -17,6 +17,14 @@ class EncodeInstancesSpec extends AnyFreeSpec with Matchers {
   import Encode._
   import AstSyntax._
 
+  private val headerComment =
+    """{- Module.Template is defined in a package using LF version 1.7 or earlier.
+       |   These packages don't provide the required type class instances to generate
+       |   ledger commands. The following defines replacement instances. -}""".stripMargin.replace(
+      "\r\n",
+      "\n",
+    )
+
   "encodeMissingInstances" - {
     "template only" in {
       val tplId = ApiTypes.TemplateId(
@@ -27,13 +35,11 @@ class EncodeInstancesSpec extends AnyFreeSpec with Matchers {
         choices = Map.empty,
       )
       encodeMissingInstances(tplId, spec).render(80) shouldBe
-        """{- Module.Template is defined in a package using LF version 1.7 or earlier.
-          |   These packages don't provide the required type class instances to generate
-          |   ledger commands. The following defines replacement instances. -}
-          |instance HasTemplateTypeRep Module.Template where
-          |  _templateTypeRep = GHC.Types.primitive @"ETemplateTypeRep"
-          |instance HasToAnyTemplate Module.Template where
-          |  _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"""".stripMargin.replace(
+        s"""$headerComment
+           |instance HasTemplateTypeRep Module.Template where
+           |  _templateTypeRep = GHC.Types.primitive @"ETemplateTypeRep"
+           |instance HasToAnyTemplate Module.Template where
+           |  _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"""".stripMargin.replace(
           "\r\n",
           "\n",
         )
@@ -58,39 +64,36 @@ class EncodeInstancesSpec extends AnyFreeSpec with Matchers {
         ),
       )
       encodeMissingInstances(tplId, spec).render(80) shouldBe
-        """{- Module.Template is defined in a package using LF version 1.7 or earlier.
-          |   These packages don't provide the required type class instances to generate
-          |   ledger commands. The following defines replacement instances. -}
-          |instance HasTemplateTypeRep Module.Template where
-          |  _templateTypeRep = GHC.Types.primitive @"ETemplateTypeRep"
-          |instance HasToAnyTemplate Module.Template where
-          |  _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"
-          |instance HasToAnyChoice Module.Template DA.Internal.Template.Archive () where
-          |  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
-          |instance HasToAnyChoice Module.Template Module.Choice (ContractId Module.Foo) where
-          |  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"""".stripMargin.replace("\r\n", "\n")
+        s"""$headerComment
+           |instance HasTemplateTypeRep Module.Template where
+           |  _templateTypeRep = GHC.Types.primitive @"ETemplateTypeRep"
+           |instance HasToAnyTemplate Module.Template where
+           |  _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"
+           |instance HasToAnyChoice Module.Template DA.Internal.Template.Archive () where
+           |  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"
+           |instance HasToAnyChoice Module.Template Module.Choice (ContractId Module.Foo) where
+           |  _toAnyChoice = GHC.Types.primitive @"EToAnyChoice"""".stripMargin
+          .replace("\r\n", "\n")
     }
-  }
-  "template with contract key" in {
-    val tplId = ApiTypes.TemplateId(
-      V.Identifier().withPackageId("pkg-id").withModuleName("Module").withEntityName("Template")
-    )
-    val spec = TemplateInstanceSpec(
-      key = Some(tuple(TParty, TInt64)),
-      choices = Map.empty,
-    )
-    encodeMissingInstances(tplId, spec).render(80) shouldBe
-      """{- Module.Template is defined in a package using LF version 1.7 or earlier.
-        |   These packages don't provide the required type class instances to generate
-        |   ledger commands. The following defines replacement instances. -}
-        |instance HasTemplateTypeRep Module.Template where
-        |  _templateTypeRep = GHC.Types.primitive @"ETemplateTypeRep"
-        |instance HasToAnyTemplate Module.Template where
-        |  _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"
-        |instance HasToAnyContractKey Module.Template (Party, Int) where
-        |  _toAnyContractKey = GHC.Types.primitive @"EToAnyContractKey"""".stripMargin.replace(
-        "\r\n",
-        "\n",
+    "template with contract key" in {
+      val tplId = ApiTypes.TemplateId(
+        V.Identifier().withPackageId("pkg-id").withModuleName("Module").withEntityName("Template")
       )
+      val spec = TemplateInstanceSpec(
+        key = Some(tuple(TParty, TInt64)),
+        choices = Map.empty,
+      )
+      encodeMissingInstances(tplId, spec).render(80) shouldBe
+        s"""$headerComment
+           |instance HasTemplateTypeRep Module.Template where
+           |  _templateTypeRep = GHC.Types.primitive @"ETemplateTypeRep"
+           |instance HasToAnyTemplate Module.Template where
+           |  _toAnyTemplate = GHC.Types.primitive @"EToAnyTemplate"
+           |instance HasToAnyContractKey Module.Template (Party, Int) where
+           |  _toAnyContractKey = GHC.Types.primitive @"EToAnyContractKey"""".stripMargin.replace(
+          "\r\n",
+          "\n",
+        )
+    }
   }
 }

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeInstancesSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeInstancesSpec.scala
@@ -7,6 +7,7 @@ import com.daml.ledger.api.refinements.ApiTypes
 import com.daml.ledger.api.v1.{value => V}
 import com.daml.lf.data.Ref
 import com.daml.lf.language.Ast
+import com.daml.lf.language.Util._
 import com.daml.script.`export`.Dependencies.ChoiceInstanceSpec
 import com.daml.script.export.Dependencies.TemplateInstanceSpec
 import org.scalatest.freespec.AnyFreeSpec
@@ -52,8 +53,8 @@ class EncodeInstancesSpec extends AnyFreeSpec with Matchers {
       val spec = TemplateInstanceSpec(
         key = None,
         choices = Map(
-          ApiTypes.Choice("Archive") -> ChoiceInstanceSpec(tArchive, unit),
-          ApiTypes.Choice("Choice") -> ChoiceInstanceSpec(choiceArg, contractId :@ Ast.TTyCon(nFoo)),
+          ApiTypes.Choice("Archive") -> ChoiceInstanceSpec(tArchive, TUnit),
+          ApiTypes.Choice("Choice") -> ChoiceInstanceSpec(choiceArg, TContractId(Ast.TTyCon(nFoo))),
         ),
       )
       encodeMissingInstances(tplId, spec).render(80) shouldBe
@@ -75,7 +76,7 @@ class EncodeInstancesSpec extends AnyFreeSpec with Matchers {
       V.Identifier().withPackageId("pkg-id").withModuleName("Module").withEntityName("Template")
     )
     val spec = TemplateInstanceSpec(
-      key = Some(tuple(party, int)),
+      key = Some(tuple(TParty, TInt64)),
       choices = Map.empty,
     )
     encodeMissingInstances(tplId, spec).render(80) shouldBe

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeTypeSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeTypeSpec.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.export
+
+import com.daml.lf.language.Ast
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class EncodeTypeSpec extends AnyFreeSpec with Matchers {
+  import Encode._
+  import AstSyntax._
+
+  "encodeType" - {
+    "builtin types" - {
+      val builtins: Seq[(Ast.BuiltinType, String)] = Seq(
+        Ast.BTInt64 -> "Int",
+        Ast.BTNumeric -> "Numeric",
+        Ast.BTText -> "Text",
+        Ast.BTTimestamp -> "Time",
+        Ast.BTParty -> "Party",
+        Ast.BTUnit -> "()",
+        Ast.BTBool -> "Bool",
+        Ast.BTList -> "[]",
+        Ast.BTOptional -> "Optional",
+        Ast.BTTextMap -> "DA.TextMap.TextMap",
+        Ast.BTGenMap -> "DA.Map.Map",
+        Ast.BTUpdate -> "Update",
+        Ast.BTScenario -> "Scenario",
+        Ast.BTDate -> "Date",
+        Ast.BTContractId -> "ContractId",
+        Ast.BTArrow -> "(->)",
+        Ast.BTAny -> "Any",
+        Ast.BTTypeRep -> "TypeRep",
+        Ast.BTAnyException -> "AnyException",
+        Ast.BTRoundingMode -> "RoundingMode",
+        Ast.BTBigNumeric -> "BigNumeric",
+      )
+      builtins foreach { case (ty, repr) =>
+        s"$ty" in {
+          encodeType(Ast.TBuiltin(ty)).render(80) shouldBe repr
+        }
+      }
+    }
+    "simple types" - {
+      "type variable" in {
+        encodeType(vFoo).render(80) shouldBe "foo"
+      }
+      "natural number" in {
+        encodeType(Ast.TNat.values(2)).render(80) shouldBe "2"
+      }
+      "type constructor" in {
+        encodeType(Ast.TTyCon(nFoo)).render(80) shouldBe "Module.Foo"
+      }
+    }
+    "composed types" - {
+      "type synonym application" in {
+        val ty = synApp(nFoo, int, synApp(nBar, text))
+        encodeType(ty).render(80) shouldBe "Module.Foo Int (Module.Bar Text)"
+      }
+      "type application" in {
+        val ty = vFoo :@ int :@ (vBar :@ text)
+        encodeType(ty).render(80) shouldBe "foo Int (bar Text)"
+      }
+      "tuple type" in {
+        val ty = tuple(int, text, vFoo :@ int)
+        encodeType(ty).render(80) shouldBe "(Int, Text, foo Int)"
+      }
+      "list type" in {
+        val ty = list(int)
+        encodeType(ty).render(80) shouldBe "[Int]"
+      }
+      "arrow type" in {
+        val ty = (vFoo :@ int =>: text) =>: int =>: text
+        encodeType(ty).render(80) shouldBe "(foo Int -> Text) -> Int -> Text"
+      }
+    }
+  }
+}

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeTypeSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeTypeSpec.scala
@@ -30,7 +30,6 @@ class EncodeTypeSpec extends AnyFreeSpec with Matchers {
         Ast.BTDate -> "Date",
         Ast.BTContractId -> "ContractId",
         Ast.BTArrow -> "(->)",
-        Ast.BTAny -> "Any",
         Ast.BTTypeRep -> "TypeRep",
         Ast.BTAnyException -> "AnyException",
         Ast.BTRoundingMode -> "RoundingMode",

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeTypeSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeTypeSpec.scala
@@ -3,7 +3,10 @@
 
 package com.daml.script.export
 
+import com.daml.lf.data.ImmArray
 import com.daml.lf.language.Ast
+import com.daml.lf.language.Ast.TSynApp
+import com.daml.lf.language.Util._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -43,7 +46,7 @@ class EncodeTypeSpec extends AnyFreeSpec with Matchers {
     }
     "simple types" - {
       "type variable" in {
-        encodeType(vFoo).render(80) shouldBe "foo"
+        encodeType(Ast.TVar(vFoo)).render(80) shouldBe "foo"
       }
       "natural number" in {
         encodeType(Ast.TNat.values(2)).render(80) shouldBe "2"
@@ -54,23 +57,23 @@ class EncodeTypeSpec extends AnyFreeSpec with Matchers {
     }
     "composed types" - {
       "type synonym application" in {
-        val ty = synApp(nFoo, int, synApp(nBar, text))
+        val ty = TSynApp(nFoo, ImmArray(TInt64, TSynApp(nBar, ImmArray(TText))))
         encodeType(ty).render(80) shouldBe "Module.Foo Int (Module.Bar Text)"
       }
       "type application" in {
-        val ty = vFoo :@ int :@ (vBar :@ text)
+        val ty = TTVarApp(vFoo, ImmArray(TInt64, TTVarApp(vBar, ImmArray(TText))))
         encodeType(ty).render(80) shouldBe "foo Int (bar Text)"
       }
       "tuple type" in {
-        val ty = tuple(int, text, vFoo :@ int)
+        val ty = tuple(TInt64, TText, TTVarApp(vFoo, ImmArray(TInt64)))
         encodeType(ty).render(80) shouldBe "(Int, Text, foo Int)"
       }
       "list type" in {
-        val ty = list(int)
+        val ty = TList(TInt64)
         encodeType(ty).render(80) shouldBe "[Int]"
       }
       "arrow type" in {
-        val ty = (vFoo :@ int =>: text) =>: int =>: text
+        val ty = (TTVarApp(vFoo, ImmArray(TInt64)) =>: TText) =>: TInt64 =>: TText
         encodeType(ty).render(80) shouldBe "(foo Int -> Text) -> Int -> Text"
       }
     }

--- a/daml-script/export/src/test/scala/com/daml/script/export/ExportCidRefsSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ExportCidRefsSpec.scala
@@ -33,7 +33,8 @@ class ExportCidRefsSpec extends AnyFreeSpec with Matchers {
             )
           ),
       ).map(_.toTransactionTree)
-      val export = Export.fromTransactionTrees(acs, trees, acsBatchSize = 10, setTime = false)
+      val export =
+        Export.fromTransactionTrees(acs, trees, Map.empty, acsBatchSize = 10, setTime = false)
       export.cidRefs shouldBe empty
       export.cidMap shouldBe empty
       export.unknownCids shouldBe empty
@@ -71,7 +72,8 @@ class ExportCidRefsSpec extends AnyFreeSpec with Matchers {
             )
           ),
       ).map(_.toTransactionTree)
-      val export = Export.fromTransactionTrees(acs, trees, acsBatchSize = 10, setTime = false)
+      val export =
+        Export.fromTransactionTrees(acs, trees, Map.empty, acsBatchSize = 10, setTime = false)
       export.cidRefs should contain only (
         ContractId("acs1"),
         ContractId("acs2"),
@@ -111,7 +113,8 @@ class ExportCidRefsSpec extends AnyFreeSpec with Matchers {
           )
         )
     ).map(_.toTransactionTree)
-    val export = Export.fromTransactionTrees(acs, trees, acsBatchSize = 10, setTime = false)
+    val export =
+      Export.fromTransactionTrees(acs, trees, Map.empty, acsBatchSize = 10, setTime = false)
     export.cidRefs should contain only (ContractId("un1"), ContractId("un2"))
     export.cidMap shouldBe empty
     export.unknownCids should contain only (ContractId("un1"), ContractId("un2"))


### PR DESCRIPTION
Closes #10435 

This is the second part to #10481.

Templates that are defined in packages using LF versions 1.7 or older don't have the required type class instances to submit ledger commands operating on these templates using Daml script, as these LF versions don't include instances.

This PR adds support for templates from packages with these LF versions to Daml ledger export.
- `Daml.Script` now exports unconstrained versions of the `createCmd` family of functions called `internal*Cmd`. These directly take `TemplateTypeRep`, `AnyTemplate`, etc. parameters.
- The exporter now identifies all templates defined with old LF versions and emits `internal*Cmd` functions for commands involving these templates.
- The generated Daml script includes the necessary type class instances for these templates `HasTemplateTypeRep`, `HasToAnyTemplate`, etc.

This PR adds an integration test for this feature. It builds DAR a with `--target=1.6`, constructs a ledger state using the templates from this DAR and generates a Daml export script for it, and it finally tests that the generated export script compiles.

This PR is best reviewed commit by commit.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
