### PR TITLE
add minimumOn & maximumOn

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/List.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/List.daml
@@ -32,6 +32,8 @@ module DA.List
   , sort
   , sortBy
   , sortOn
+  , minimumOn
+  , maximumOn
   , stripPrefix
   , stripSuffix
   , stripInfix
@@ -124,6 +126,28 @@ sortOn : Ord k => (a -> k) -> [a] -> [a]
 sortOn f = map snd . sortBy (compare `on` fst) . map (\x -> (f x, x))
   where
     on op f x y = f x `op` f y
+
+-- | `minimumOn f xs` returns the first element `x` of `xs` for which `f x`
+-- is smaller than or equal to any other `f y` for `y` in `xs`. `xs` must be
+-- non-empty.
+minimumOn : Ord k => (a -> k) -> [a] -> a
+minimumOn _ [] = error "minimumOn: empty list"
+minimumOn f (x::xs) = fst $ foldl keep_min (x, f x) xs
+  where keep_min (m, km) e = let ke = f e
+                             in if ke < km
+                                then (e, ke)
+                                else (m, km)
+
+-- | `maximumOn f xs` returns the first element `x` of `xs` for which `f x`
+-- is greater than or equal to any other `f y` for `y` in `xs`. `xs` must be
+-- non-empty.
+maximumOn : Ord k => (a -> k) -> [a] -> a
+maximumOn _ [] = error "maximumOn: empty list"
+maximumOn f (x::xs) = fst $ foldl keep_max (x, f x) xs
+  where keep_max (m, km) e = let ke = f e
+                             in if ke > km
+                                then (e, ke)
+                                else (m, km)
 
 -- | Merge two sorted lists using into a single, sorted whole, allowing
 -- the programmer to specify the comparison function.

--- a/compiler/damlc/daml-stdlib-src/DA/List/Total.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/List/Total.daml
@@ -11,10 +11,12 @@ module DA.List.Total
   , foldr1
   , foldBalanced1
   , (!!)
+  , maximumOn
+  , minimumOn
   )
 where
 
-import DA.List hiding (foldBalanced1, head, tail, init, last, foldl1, foldr1, (!!))
+import DA.List hiding (foldBalanced1, head, tail, init, last, foldl1, foldr1, (!!), minimumOn, maximumOn)
 
 head : ActionFail m => [a] -> m a
 head (x::_) = pure x
@@ -50,3 +52,25 @@ foldBalanced1 : ActionFail m => (a -> a -> a) -> [a] -> m a
 foldBalanced1 _ [] = fail "foldBalanced1: empty list"
 foldBalanced1 _ [x] = pure x
 foldBalanced1 f xs = foldBalanced1 f (combinePairs f xs)
+
+-- | `minimumOn f xs` returns the first element `x` of `xs` for which `f x`
+-- is smaller than or equal to any other `f y` for `y` in `xs`. The result is
+-- wrapped in a monadic context, with a failure if `xs` is empty.
+minimumOn : (ActionFail m, Ord k) => (a -> k) -> [a] -> m a
+minimumOn _ [] = fail "minimumOn: empty list"
+minimumOn f (x::xs) = pure $ fst $ foldl keep_min (x, f x) xs
+  where keep_min (m, km) e = let ke = f e
+                             in if ke < km
+                                then (e, ke)
+                                else (m, km)
+
+-- | `maximumOn f xs` returns the first element `x` of `xs` for which `f x`
+-- is greater than or equal to any other `f y` for `y` in `xs`. The result is
+-- wrapped in a monadic context, with a failure if `xs` is empty.
+maximumOn : (ActionFail m, Ord k) => (a -> k) -> [a] -> m a
+maximumOn _ [] = fail "maximumOn: empty list"
+maximumOn f (x::xs) = pure $ fst $ foldl keep_max (x, f x) xs
+  where keep_max (m, km) e = let ke = f e
+                             in if ke > km
+                                then (e, ke)
+                                else (m, km)

--- a/compiler/damlc/tests/daml-test-files/List.daml
+++ b/compiler/damlc/tests/daml-test-files/List.daml
@@ -1,13 +1,13 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=115:17-115:32; Use dedup
--- @INFO range=301:10-301:24; Evaluate
--- @INFO range=316:38-316:48; Use sum
--- @INFO range=317:43-317:53; Use sum
--- @INFO range=318:29-318:39; Use sum
--- @INFO range=321:3-321:23; Use head
--- @INFO range=326:29-326:36; Use head
+-- @INFO range=118:17-118:32; Use dedup
+-- @INFO range=304:10-304:24; Evaluate
+-- @INFO range=319:38-319:48; Use sum
+-- @INFO range=320:43-320:53; Use sum
+-- @INFO range=321:29-321:39; Use sum
+-- @INFO range=324:3-324:23; Use head
+-- @INFO range=329:29-329:36; Use head
 
 module List where
 
@@ -23,9 +23,12 @@ testSort6 = scenario do
           , Foo 10 "c"
           , Foo 15 "c"
           , Foo 5 "b" ]
-  let m = sortOn (\t -> (Down t.y, Down t.x)) l
+  let sortFn = \t -> (Down t.y, Down t.x)
+  let m = sortOn sortFn l
   head m === Foo 15 "c"
   last m === Foo 42 "a"
+  Foo 15 "c" === minimumOn sortFn l
+  Foo 42 "a" === maximumOn sortFn l
 
 -- Utility called on by 'testSort4' and 'testSort5'
 check45 n m = do

--- a/compiler/damlc/tests/daml-test-files/List_Total.daml
+++ b/compiler/damlc/tests/daml-test-files/List_Total.daml
@@ -1,0 +1,43 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+module List_Total where
+
+import DA.List.Total
+import DA.Assert
+
+testHead = scenario do
+  None === head @Optional @Int []
+  Some 1 === head [1, 2, 3]
+
+testTail = scenario do
+  None === tail @Optional @Int []
+  Some [2, 3] === tail [1, 2, 3]
+
+testInit = scenario do
+  None === init @Optional @Int []
+  Some [1, 2] === init [1, 2, 3]
+
+testDoubleBang = scenario do
+  None === [1, 2, 3] !! 4
+  Some 2 === [1, 2, 3] !! 1
+
+testFoldl1 = scenario do
+  None === foldl1 @Optional @Int (-) []
+  Some (-4) === foldl1 (-) [1, 2, 3]
+
+testFoldr1 = scenario do
+  None === foldr1 @Optional @Int (-) []
+  Some 2 === foldr1 (-) [1, 2, 3]
+
+testFoldBalanced1 = scenario do
+  None === foldBalanced1 @Optional @Int (+) []
+  Some 6 === foldBalanced1 (+) [1, 2, 3]
+
+testMinimumOn = scenario do
+  None === minimumOn @Optional @Int @Int negate []
+  Some 3 === minimumOn negate [1, 2, 3]
+
+testMaximumOn = scenario do
+  None === maximumOn @Optional @Int @Int negate []
+  Some 1 === maximumOn negate [1, 2, 3]


### PR DESCRIPTION
Requested in #10509. Should we also add `minimumBy` and `maximumBy` for consistency with `sortBy`?

```
CHANGELOG_BEGIN
- The DA.List and DA.List.Total modules now export minimumOn and
  maximumOn, respectively behaving similarly to (head . sortOn f) and
  (last . sortOn f).
CHANGELOG_END
```