### PR TITLE
[Integrity Checker] Implemented pairwise Update normalizer

### DIFF
--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/Config.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/Config.scala
@@ -19,6 +19,7 @@ case class Config(
     actualUpdatesPath: Option[Path] = None,
     expectedUpdateNormalizers: Iterable[UpdateNormalizer] = Iterable.empty,
     actualUpdateNormalizers: Iterable[UpdateNormalizer] = Iterable.empty,
+    pairwiseUpdateNormalizers: Iterable[PairwiseUpdateNormalizer] = Iterable.empty,
 ) {
   def exportFileName: String = exportFilePath.getFileName.toString
 }

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -61,6 +61,7 @@ class IntegrityChecker[LogResult](
       actualReadServiceFactory.createReadService,
       config.expectedUpdateNormalizers,
       config.actualUpdateNormalizers,
+      config.pairwiseUpdateNormalizers,
     )
 
     checkIntegrity(

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparison.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparison.scala
@@ -21,6 +21,7 @@ final class ReadServiceStateUpdateComparison(
     actualReadService: ReplayingReadService,
     expectedUpdateNormalizers: Iterable[UpdateNormalizer],
     actualUpdateNormalizers: Iterable[UpdateNormalizer],
+    pairwiseUpdateNormalizers: Iterable[PairwiseUpdateNormalizer],
 )(implicit
     materializer: Materializer,
     executionContext: ExecutionContext,
@@ -50,6 +51,7 @@ final class ReadServiceStateUpdateComparison(
                 actualUpdate,
                 expectedUpdateNormalizers,
                 actualUpdateNormalizers,
+                pairwiseUpdateNormalizers,
               ),
             )
           )
@@ -77,9 +79,15 @@ object ReadServiceStateUpdateComparison {
       actualUpdate: Update,
       expectedUpdateNormalizers: Iterable[UpdateNormalizer],
       actualUpdateNormalizers: Iterable[UpdateNormalizer],
+      pairwiseUpdateNormalizers: Iterable[PairwiseUpdateNormalizer],
   ): Future[Unit] = {
-    val expectedNormalizedUpdate = normalize(expectedUpdate, expectedUpdateNormalizers)
-    val actualNormalizedUpdate = normalize(actualUpdate, actualUpdateNormalizers)
+
+    val (expectedNormalizedUpdate, actualNormalizedUpdate) = PairwiseUpdateNormalizer.normalize(
+      normalize(expectedUpdate, expectedUpdateNormalizers),
+      normalize(actualUpdate, actualUpdateNormalizers),
+      pairwiseUpdateNormalizers,
+    )
+
     if (expectedNormalizedUpdate != actualNormalizedUpdate) {
       Future.failed(
         new ComparisonFailureException(

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
@@ -30,6 +30,26 @@ object UpdateNormalizer {
   }
 }
 
+/** Normalizes the expected and/or actual updates based on their counterparts.
+  * Useful when scalar update normalization is not possible.
+  * (e.g. ensure contents of one update are a superset of the ones in the other update)
+  */
+trait PairwiseUpdateNormalizer {
+  def normalize(expectedUpdate: Update, actualUpdate: Update): (Update, Update)
+}
+
+object PairwiseUpdateNormalizer {
+  def normalize(
+      expectedUpdate: Update,
+      actualUpdate: Update,
+      normalizers: Iterable[PairwiseUpdateNormalizer],
+  ): (Update, Update) = {
+    normalizers.foldLeft(expectedUpdate -> actualUpdate) { case ((expected, actual), normalizer) =>
+      normalizer.normalize(expected, actual)
+    }
+  }
+}
+
 /** Ignores the record time set later by post-execution because it's unimportant.
   * We only care about the update type and content.
   */

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
@@ -43,11 +43,10 @@ object PairwiseUpdateNormalizer {
       expectedUpdate: Update,
       actualUpdate: Update,
       normalizers: Iterable[PairwiseUpdateNormalizer],
-  ): (Update, Update) = {
+  ): (Update, Update) =
     normalizers.foldLeft(expectedUpdate -> actualUpdate) { case ((expected, actual), normalizer) =>
       normalizer.normalize(expected, actual)
     }
-  }
 }
 
 /** Ignores the record time set later by post-execution because it's unimportant.

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
@@ -31,8 +31,8 @@ object UpdateNormalizer {
 }
 
 /** Normalizes the expected and/or actual updates based on their counterparts.
-  * Useful when scalar update normalization is not possible.
-  * (e.g. ensure contents of one update are a superset of the ones in the other update)
+  * Useful when independent update normalization is not possible
+  * (e.g. ensuring that the content of the actual update is a super-set of the content of the expected update).
   */
 trait PairwiseUpdateNormalizer {
   def normalize(expectedUpdate: Update, actualUpdate: Update): (Update, Update)

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparisonSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparisonSpec.scala
@@ -34,7 +34,7 @@ final class StateUpdateComparisonSpec
       val right = aConfigurationChangeRejected.copy(rejectionReason = "another reason")
 
       ReadServiceStateUpdateComparison
-        .compareUpdates(left, right, List.empty, List.empty, List.empty)
+        .compareUpdates(left, right, Iterable.empty, Iterable.empty, Iterable.empty)
         .map(_ => succeed)
     }
 

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparisonSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparisonSpec.scala
@@ -34,7 +34,7 @@ final class StateUpdateComparisonSpec
       val right = aConfigurationChangeRejected.copy(rejectionReason = "another reason")
 
       ReadServiceStateUpdateComparison
-        .compareUpdates(left, right, List.empty, List.empty)
+        .compareUpdates(left, right, List.empty, List.empty, List.empty)
         .map(_ => succeed)
     }
 
@@ -74,7 +74,7 @@ final class StateUpdateComparisonSpec
       val normalizers = List(BlindingInfoNormalizer)
 
       ReadServiceStateUpdateComparison
-        .compareUpdates(left, right, normalizers, normalizers)
+        .compareUpdates(left, right, normalizers, normalizers, Iterable.empty)
         .map(_ => succeed)
     }
 
@@ -93,6 +93,7 @@ final class StateUpdateComparisonSpec
           right,
           expectedUpdateNormalizers = normalizers,
           actualUpdateNormalizers = normalizers,
+          pairwiseUpdateNormalizers = Iterable.empty,
         )
         .map(_ => succeed)
     }
@@ -191,6 +192,7 @@ final class StateUpdateComparisonSpec
         aCommandRejectedUpdate.copy(reason = right),
         expectedUpdateNormalizers = Iterable.empty,
         actualUpdateNormalizers = Iterable.empty,
+        pairwiseUpdateNormalizers = Iterable.empty,
       )
       .map(_ => succeed)
 }


### PR DESCRIPTION
This PR enriches the state update comparison in the `IntegrityChecker` with a pairwise update normalizer, meant to adapt the actual/expected updates in relation with their counterpart
  
CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
