### PR TITLE
Support running daml navigator without a config file

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -56,7 +56,6 @@ import Network.GRPC.Unsafe.ChannelArgs (Arg(..))
 import Network.HTTP.Simple
 import Network.HTTP.Types (statusCode)
 import Numeric.Natural
-import System.Directory
 import System.Exit
 import System.FilePath
 import System.IO.Extra
@@ -535,10 +534,6 @@ runLedgerNavigator flags remainingArguments = do
             , ["--ignore-project-parties"]
             , remainingArguments
             ]
-    -- We write an empty ui-backend.conf file for backward compatibility. Otherwise navigator will
-    -- not start outside a project file.
-    let dummyNavigatorConf = "ui-backend.conf"
-    unlessM (doesFileExist dummyNavigatorConf) $ writeFile dummyNavigatorConf ""
     withJar
       damlSdkJar
       [logbackArg]

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Config.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Config.scala
@@ -59,8 +59,13 @@ object Config {
         loadSdkConfig(useDatabase).left
           .flatMap {
             case ConfigNotFound(_) =>
-              logger.warn("SDK config does not exist. Falling back to Navigator config file.")
-              loadNavigatorConfig(configFile, useDatabase)
+              logger.info("SDK config does not exist. Falling back to Navigator config file.")
+              loadNavigatorConfig(configFile, useDatabase) match {
+                case Left(ConfigNotFound(_)) =>
+                  logger.info("No config file found. Using default config")
+                  Right(Config())
+                case r => r
+              }
             case e: ConfigReadError =>
               logger.warn(s"SDK config exists, but is not usable: ${e.reason}")
               Left(e)

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/config/ConfigSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/config/ConfigSpec.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.navigator.config
+
+import com.daml.ledger.api.refinements.ApiTypes.Party
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.freespec.AnyFreeSpec
+
+class RowSpec extends AnyFreeSpec with Matchers {
+  private val defaultConfigText = "users { Alice { party = alice }, Bob { party = bob } }"
+  private val defaultConfig = Config(
+    Map(
+      "Alice" -> UserConfig(Party("alice"), None, false),
+      "Bob" -> UserConfig(Party("bob"), None, false),
+    )
+  )
+
+  private def withConfig[A](f: Path => A): A = {
+    val path = Files.createTempFile("navigator", ".conf")
+    try {
+      Files.write(path, defaultConfigText.getBytes(StandardCharsets.UTF_8))
+      f(path)
+    } finally {
+      Files.delete(path)
+    }
+  }
+  "Config" - {
+    "load" - {
+      "loads explicit config" in {
+        withConfig { conf =>
+          Config.load(ExplicitConfig(conf), false) shouldBe Right(defaultConfig)
+        }
+      }
+      "fails if explicit config does not exist" in {
+        Config.load(ExplicitConfig(Paths.get("nonexistentgarbage")), false) shouldBe Left(
+          ConfigNotFound("File nonexistentgarbage not found")
+        )
+      }
+      "loads default config if none is specified" in {
+        withConfig { conf =>
+          Config.load(DefaultConfig(conf), false) shouldBe Right(defaultConfig)
+        }
+      }
+      "loads an empty config if default config does not exist" in {
+        Config.load(DefaultConfig(Paths.get("nonexistentgarbage")), false) shouldBe Right(Config())
+      }
+    }
+  }
+}


### PR DESCRIPTION
No reason to force the existence of a config file if you can start
without one.

fixes #10516

changelog_begin

- [Navigator] Navigator will now start with an empty config if no
config file exists and it is run outside of a project.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
