### PR TITLE
kvutils: Improve the test coverage of OffsetBuilder, and support negative numbers.

### DIFF
--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -84,11 +84,11 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_mockito_mockito_scala",
+        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scala_lang_modules_scala_java8_compat",
         "@maven//:org_scalactic_scalactic",
         "@maven//:org_scalatest_scalatest",
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     tags = ["maven_coordinates=com.daml:kvutils-tests-lib:__VERSION__"],
     visibility = [
@@ -142,12 +142,14 @@ da_scala_test_suite(
     ],
     resources = glob(["src/test/resources/*"]),
     scala_deps = [
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_mockito_mockito_scala",
+        "@maven//:org_scala_lang_modules_scala_collection_compat",
+        "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalactic_scalactic",
         "@maven//:org_scalatest_scalatest",
+        "@maven//:org_scalatestplus_scalacheck_1_14",
         "@maven//:org_scalaz_scalaz_core",
     ],
     deps = [

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilder.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilder.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
+
 import com.daml.ledger.offset.Offset
 
 /** Helper functions for generating 16 byte [[Offset]]s from integers.
@@ -11,9 +13,9 @@ import com.daml.ledger.offset.Offset
   * Leading zeros will be retained when generating the resulting offset bytes.
   *
   * Example usage:
-  * * If you have one record per block then just use [[OffsetBuilder.fromLong(<block-ID>)]]
-  * * If you may have multiple records per block then use [[OffsetBuilder.fromLong(<block-ID>, <index>)]],
-  * where <index> denotes the position or index of a given log entry in the block.
+  *
+  *   - If you have one record per block then use [[OffsetBuilder.fromLong]] with a single argument, the block ID.
+  *   - If you may have multiple records per block then use [[OffsetBuilder.fromLong]] with the index within the block as the second argument.
   *
   * @see com.daml.ledger.offset.Offset
   * @see com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateReader
@@ -24,44 +26,50 @@ object OffsetBuilder {
   private[kvutils] val lowestStart = 12
   private[kvutils] val end = 16
 
-  private val maxValuePlusOne = BigInt(1) << (end * 8)
-
   def onlyKeepHighestIndex(offset: Offset): Offset = {
     val highest = highestIndex(offset)
     fromLong(highest)
   }
 
   def dropLowestIndex(offset: Offset): Offset = {
-    val highest = highestIndex(offset)
-    val middle = middleIndex(offset)
-    fromLong(highest, middle.toInt)
+    val (highest, middle, _) = split(offset)
+    fromLong(highest, middle)
   }
 
   def setMiddleIndex(offset: Offset, middle: Int): Offset = {
-    val highest = highestIndex(offset)
-    val lowest = lowestIndex(offset)
-    fromLong(highest.toLong, middle, lowest.toInt)
+    val (highest, _, lowest) = split(offset)
+    fromLong(highest, middle, lowest)
   }
 
   def setLowestIndex(offset: Offset, lowest: Int): Offset = {
-    val highest = highestIndex(offset)
-    val middle = middleIndex(offset)
-    fromLong(highest.toLong, middle.toInt, lowest)
+    val (highest, middle, _) = split(offset)
+    fromLong(highest, middle, lowest)
   }
 
   def fromLong(first: Long, second: Int = 0, third: Int = 0): Offset = {
-    val highest = BigInt(first) << ((end - middleStart) * 8)
-    val middle = BigInt(second) << ((end - lowestStart) * 8)
-    val lowest = BigInt(third)
-    val bytes = (maxValuePlusOne | highest | middle | lowest).toByteArray
-      .drop(1) // this retains leading zeros
-    Offset.fromByteArray(bytes)
+    val bytes = new ByteArrayOutputStream
+    val stream = new DataOutputStream(bytes)
+    stream.writeLong(first)
+    stream.writeInt(second)
+    stream.writeInt(third)
+    Offset.fromByteArray(bytes.toByteArray)
   }
 
-  def highestIndex(offset: Offset): Long =
-    BigInt(offset.toByteArray.slice(highestStart, middleStart)).toLong
-  def middleIndex(offset: Offset): Long =
-    BigInt(offset.toByteArray.slice(middleStart, lowestStart)).toLong
-  def lowestIndex(offset: Offset): Long = BigInt(offset.toByteArray.slice(lowestStart, end)).toLong
+  // Doesn't call `split` because it's used a lot, so it's worth optimizing a little.
+  def highestIndex(offset: Offset): Long = {
+    val stream = new DataInputStream(new ByteArrayInputStream(offset.toByteArray))
+    stream.readLong()
+  }
 
+  def middleIndex(offset: Offset): Int = split(offset)._2
+
+  def lowestIndex(offset: Offset): Int = split(offset)._3
+
+  def split(offset: Offset): (Long, Int, Int) = {
+    val stream = new DataInputStream(new ByteArrayInputStream(offset.toByteArray))
+    val highest = stream.readLong()
+    val middle = stream.readInt()
+    val lowest = stream.readInt()
+    (highest, middle, lowest)
+  }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilder.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilder.scala
@@ -55,7 +55,7 @@ object OffsetBuilder {
     Offset.fromByteArray(bytes.toByteArray)
   }
 
-  // Doesn't call `split` because it's used a lot, so it's worth optimizing a little.
+  // `highestIndex` is used a lot, so it's worth optimizing a little rather than reusing `split`.
   def highestIndex(offset: Offset): Long = {
     val stream = new DataInputStream(new ByteArrayInputStream(offset.toByteArray))
     stream.readLong()

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilderSpec.scala
@@ -68,21 +68,17 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
 
     "convert back and forth" in {
       forAll { (highest: Long, middle: Int, lowest: Int) =>
-        whenever(highest >= 0 && middle >= 0 && lowest >= 0) {
-          val offset = OffsetBuilder.fromLong(highest, middle, lowest)
-          OffsetBuilder.highestIndex(offset) should be(highest)
-          OffsetBuilder.middleIndex(offset) should be(middle)
-          OffsetBuilder.lowestIndex(offset) should be(lowest)
-        }
+        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+        OffsetBuilder.highestIndex(offset) should be(highest)
+        OffsetBuilder.middleIndex(offset) should be(middle)
+        OffsetBuilder.lowestIndex(offset) should be(lowest)
       }
     }
 
     "always has the same length" in {
       forAll { (highest: Long, middle: Int, lowest: Int) =>
-        whenever(highest >= 0 && middle >= 0 && lowest >= 0) {
-          val offset = OffsetBuilder.fromLong(highest, middle, lowest)
-          offset.bytes.length should be(OffsetBuilder.end)
-        }
+        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+        offset.bytes.length should be(OffsetBuilder.end)
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilderSpec.scala
@@ -4,47 +4,73 @@
 package com.daml.ledger.participant.state.kvutils
 
 import com.daml.ledger.offset.Offset
-import com.daml.lf.data
+import com.daml.lf.data.Bytes
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+  private val zeroOffset = Offset(Bytes.fromByteArray(Array.fill(16)(0: Byte)))
 
   "OffsetBuilder" should {
-    val zeroBytes = data.Bytes.fromByteArray(Array.fill(16)(0: Byte))
+    "return all zeroes for the zeroth offset" in {
+      val offset = OffsetBuilder.fromLong(0)
 
-    def triple(offset: Offset): (Long, Long, Long) =
-      (
-        OffsetBuilder.highestIndex(offset),
-        OffsetBuilder.middleIndex(offset),
-        OffsetBuilder.lowestIndex(offset),
-      )
-
-    "set 0 bytes" in {
-      OffsetBuilder.fromLong(0).bytes shouldEqual zeroBytes
+      offset should be(zeroOffset)
     }
 
-    "extract the correct indexes" in {
-      val offset = OffsetBuilder.fromLong(1, 2, 3)
-      triple(offset) shouldBe ((1, 2, 3))
+    "always return an offset of the same length" in {
+      forAll { (highest: Long, middle: Int, lowest: Int) =>
+        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+        offset.bytes.length should be(OffsetBuilder.end)
+      }
+    }
+
+    "construct and extract" in {
+      forAll { (highest: Long, middle: Int, lowest: Int) =>
+        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+
+        OffsetBuilder.highestIndex(offset) should be(highest)
+        OffsetBuilder.middleIndex(offset) should be(middle)
+        OffsetBuilder.lowestIndex(offset) should be(lowest)
+        OffsetBuilder.split(offset) should be((highest, middle, lowest))
+      }
+    }
+
+    "set the middle index" in {
+      forAll { (highest: Long, middle: Int, lowest: Int, newMiddle: Int) =>
+        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+        val modifiedOffset = OffsetBuilder.setMiddleIndex(offset, newMiddle)
+
+        OffsetBuilder.split(modifiedOffset) should be((highest, newMiddle, lowest))
+      }
     }
 
     "only change individual indexes" in {
-      val offset = OffsetBuilder.fromLong(1, 2, 3)
+      forAll { (highest: Long, middle: Int, lowest: Int, newLowest: Int) =>
+        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+        val modifiedOffset = OffsetBuilder.setLowestIndex(offset, newLowest)
 
-      triple(OffsetBuilder.setLowestIndex(offset, 17)) shouldBe ((1, 2, 17))
-      triple(OffsetBuilder.setMiddleIndex(offset, 17)) shouldBe ((1, 17, 3))
+        OffsetBuilder.split(modifiedOffset) should be((highest, middle, newLowest))
+      }
     }
 
     "zero out the middle and lowest index" in {
-      val offset = OffsetBuilder.fromLong(1, 2, 3)
-      triple(OffsetBuilder.onlyKeepHighestIndex(offset)) shouldBe ((1, 0, 0))
+      forAll { (highest: Long, middle: Int, lowest: Int) =>
+        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+        val modifiedOffset = OffsetBuilder.onlyKeepHighestIndex(offset)
+
+        OffsetBuilder.split(modifiedOffset) should be((highest, 0, 0))
+      }
     }
 
     "zero out the lowest index" in {
-      val offset = OffsetBuilder.fromLong(1, 2, 3)
-      triple(OffsetBuilder.dropLowestIndex(offset)) shouldBe ((1, 2, 0))
+      forAll { (highest: Long, middle: Int, lowest: Int) =>
+        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+        val modifiedOffset = OffsetBuilder.dropLowestIndex(offset)
+
+        OffsetBuilder.split(modifiedOffset) should be((highest, middle, 0))
+      }
     }
 
     "retain leading zeros" in {
@@ -53,33 +79,17 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
       val middle = offset.toByteArray.slice(OffsetBuilder.middleStart, OffsetBuilder.lowestStart)
       val lowest = offset.toByteArray.slice(OffsetBuilder.lowestStart, OffsetBuilder.end)
 
-      val highestZeros = highest.dropRight(1)
-      highestZeros.forall(_ == 0) shouldBe true
-      highest.takeRight(1)(0) shouldBe 1
+      val highestZeros = highest.dropRight(1).toSeq
+      all(highestZeros) should be(0)
+      highest.takeRight(1) should be(Array[Byte](1))
 
-      val middleZeros = middle.dropRight(1)
-      middleZeros.forall(_ == 0) shouldBe true
-      middle.takeRight(1)(0) shouldBe 2
+      val middleZeros = middle.dropRight(1).toSeq
+      all(middleZeros) should be(0)
+      middle.takeRight(1) should be(Array[Byte](2))
 
-      val lowestZeros = lowest.dropRight(1)
-      lowestZeros.forall(_ == 0) shouldBe true
-      lowest.takeRight(1)(0) shouldBe 3
-    }
-
-    "convert back and forth" in {
-      forAll { (highest: Long, middle: Int, lowest: Int) =>
-        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
-        OffsetBuilder.highestIndex(offset) should be(highest)
-        OffsetBuilder.middleIndex(offset) should be(middle)
-        OffsetBuilder.lowestIndex(offset) should be(lowest)
-      }
-    }
-
-    "always has the same length" in {
-      forAll { (highest: Long, middle: Int, lowest: Int) =>
-        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
-        offset.bytes.length should be(OffsetBuilder.end)
-      }
+      val lowestZeros = lowest.dropRight(1).toSeq
+      all(lowestZeros) should be(0)
+      lowest.takeRight(1) should be(Array[Byte](3))
     }
   }
 }


### PR DESCRIPTION
I noticed the test coverage of `OffsetBuilder` was lacking so I added some.

In practice, there's no reason to support negative numbers (and it's probably a bad idea), but we should at least return a valid offset. Prior to these changes, a negative value passed to `OffsetBuilder.fromLong` would result in strange behavior.

I think `DataOutputStream` is probably also safer than clever bit arithmetic and `BigInt`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
