### PR TITLE
IndexerBenchmark: an option for defining minimum update rate [DPP-541]

### DIFF
--- a/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/Config.scala
+++ b/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/Config.scala
@@ -30,7 +30,7 @@ object Config {
     updateCount = None,
     updateSource = "",
     metricsReporter = None,
-    metricsReportingInterval = Duration.ofSeconds(10),
+    metricsReportingInterval = Duration.ofSeconds(1),
     indexerConfig = IndexerConfig(
       participantId = Ref.ParticipantId.assertFromString("IndexerBenchmarkParticipant"),
       jdbcUrl = "",

--- a/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/Config.scala
+++ b/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/Config.scala
@@ -23,6 +23,7 @@ case class Config(
     metricsReportingInterval: Duration,
     indexerConfig: IndexerConfig,
     waitForUserInput: Boolean,
+    minUpdateRate: Option[Long],
 )
 
 object Config {
@@ -38,6 +39,7 @@ object Config {
       enableAppendOnlySchema = true,
     ),
     waitForUserInput = false,
+    minUpdateRate = None,
   )
 
   private[this] val Parser: OptionParser[Config] =
@@ -106,6 +108,12 @@ object Config {
           "If enabled, the app will wait for user input after the benchmark has finished, but before cleaning up resources. Use to inspect the contents of an ephemeral index database."
         )
         .action((value, config) => config.copy(waitForUserInput = value))
+
+      opt[Long]("min-update-rate")
+        .text(
+          "Minimum value of the processed updates per second. If not satisfied the application will report an error."
+        )
+        .action((value, config) => config.copy(minUpdateRate = Some(value)))
 
       opt[MetricsReporter]("metrics-reporter")
         .optional()

--- a/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/IndexerBenchmark.scala
+++ b/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/IndexerBenchmark.scala
@@ -105,11 +105,15 @@ class IndexerBenchmark() {
         val duration: Double = (stopTime - startTime).toDouble / 1000000000.0
         val updates: Long = metrics.daml.parallelIndexer.updates.getCount
         val updateRate: Double = updates / duration
-        val minimumUpdateRateFailureInfo: String = config.minUpdateRate match {
-          case Some(requiredMinUpdateRate) if (requiredMinUpdateRate > updateRate) =>
-            s"[failure][UpdateRate] Minimum number of updates per second: required: $requiredMinUpdateRate, metered: $updateRate"
-          case _ => ""
-        }
+        val (failure, minimumUpdateRateFailureInfo): (Boolean, String) =
+          config.minUpdateRate match {
+            case Some(requiredMinUpdateRate) if (requiredMinUpdateRate > updateRate) =>
+              (
+                true,
+                s"[failure][UpdateRate] Minimum number of updates per second: required: $requiredMinUpdateRate, metered: $updateRate",
+              )
+            case _ => (false, "")
+          }
         println(
           s"""
              |--------------------------------------------------------------------------------
@@ -136,7 +140,7 @@ class IndexerBenchmark() {
              |  duration:    $duration
              |  updates:     $updates
              |  updates/sec: $updateRate
-             |$minimumUpdateRateFailureInfo
+             |  $minimumUpdateRateFailureInfo
              |
              |Other metrics:
              |  inputMapping.batchSize:     ${histogramToString(
@@ -165,6 +169,8 @@ class IndexerBenchmark() {
           println(s"Index database is still running at ${config.indexerConfig.jdbcUrl}.")
           StdIn.readLine("Press <enter> to terminate this process.")
         }
+
+        if (failure) throw new RuntimeException("Indexer Benchmark failure.")
         ()
       }
       resource.asFuture
@@ -207,25 +213,29 @@ object IndexerBenchmark {
   def runAndExit(
       args: Array[String],
       updates: Config => Future[Iterator[(Offset, Update)]],
-  ): Unit = {
-    val config: Config = Config.parse(args).getOrElse {
-      sys.exit(1)
+  ): Unit =
+    Config.parse(args) match {
+      case Some(config) => IndexerBenchmark.runAndExit(config, updates)
+      case None => sys.exit(1)
     }
-    IndexerBenchmark.runAndExit(config, updates)
-  }
 
   def runAndExit(
       config: Config,
       updates: Config => Future[Iterator[(Offset, Update)]],
   ): Unit = {
-    val result = if (config.indexerConfig.jdbcUrl.isEmpty) {
-      new IndexerBenchmark().runWithEphemeralPostgres(updates, config)
-    } else {
-      new IndexerBenchmark().run(updates, config)
-    }
+    val result: Future[Unit] =
+      (if (config.indexerConfig.jdbcUrl.isEmpty) {
+         new IndexerBenchmark().runWithEphemeralPostgres(updates, config)
+       } else {
+         new IndexerBenchmark().run(updates, config)
+       }).recover { case ex =>
+        println(s"Error: ${ex.getMessage}")
+        sys.exit(1)
+      }(scala.concurrent.ExecutionContext.Implicits.global)
+
     Await.result(result, Duration(100, "hour"))
     println("Done.")
     // TODO: some actor system or thread pool is still running, preventing a shutdown
-    System.exit(0)
+    sys.exit(0)
   }
 }


### PR DESCRIPTION
### Changes
- new command line argument `--min-update-rate` for defining minimum update rate
- returning exit code `1` when the SLO defined with the new argument is violated

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
