### PR TITLE
Follow-up to h2 storage backend user/password in url: Review feedback switch to regex and move to pure function

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
@@ -33,8 +33,6 @@ import com.daml.platform.store.backend.{
 }
 import javax.sql.DataSource
 
-import scala.util.matching.Regex
-
 private[backend] object H2StorageBackend
     extends StorageBackend[AppendOnlySchema.Batch]
     with CommonStorageBackend[AppendOnlySchema.Batch]
@@ -206,7 +204,7 @@ private[backend] object H2StorageBackend
       jdbcUrl: String
   ): (String, Option[String], Option[String]) = {
     def setKeyValueAndRemoveFromUrl(url: String, key: String): (String, Option[String]) = {
-      val regex = new Regex(s".*(;${key}=([^;]*)).*")
+      val regex = s".*(;(?i)${key}=([^;]*)).*".r
       url match {
         case regex(keyAndValue, value) =>
           (url.replace(keyAndValue, ""), Some(value))

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
@@ -33,6 +33,8 @@ import com.daml.platform.store.backend.{
 }
 import javax.sql.DataSource
 
+import scala.util.matching.Regex
+
 private[backend] object H2StorageBackend
     extends StorageBackend[AppendOnlySchema.Batch]
     with CommonStorageBackend[AppendOnlySchema.Batch]
@@ -192,31 +194,29 @@ private[backend] object H2StorageBackend
     // user/password in the URLs, so we don't bother exposing user/password configs separately from the url just for h2
     // which is anyway not supported for production. (This also helps run canton h2 participants that set user and
     // password.)
-    val urlNoUser = setKeyValueAndRemoveFromUrl(jdbcUrl, "user", h2DataSource.setUser)
-    val urlNoUserNoPassword =
-      setKeyValueAndRemoveFromUrl(urlNoUser, "password", h2DataSource.setPassword)
+    val (urlNoUserNoPassword, user, password) = extractUserPasswordAndRemoveFromUrl(jdbcUrl)
+    user.foreach(h2DataSource.setUser)
+    password.foreach(h2DataSource.setPassword)
     h2DataSource.setUrl(urlNoUserNoPassword)
 
     InitHookDataSourceProxy(h2DataSource, connectionInitHook.toList)
   }
 
-  def setKeyValueAndRemoveFromUrl(url: String, key: String, setter: String => Unit): String = {
-    val separator = ";"
-    url.toLowerCase.indexOf(separator + key + "=") match {
-      case -1 => url // leave url intact if key is not found
-      case indexKeyValueBegin =>
-        val valueBegin = indexKeyValueBegin + 1 + key.length + 1 // separator, key, "="
-        val (value, shortenedUrl) = url.indexOf(separator, indexKeyValueBegin + 1) match {
-          case -1 => (url.substring(valueBegin), url.take(indexKeyValueBegin))
-          case indexKeyValueEnd =>
-            (
-              url.substring(valueBegin, indexKeyValueEnd),
-              url.take(indexKeyValueBegin) + url.takeRight(url.length - indexKeyValueEnd),
-            )
-        }
-        setter(value)
-        shortenedUrl
+  def extractUserPasswordAndRemoveFromUrl(
+      jdbcUrl: String
+  ): (String, Option[String], Option[String]) = {
+    def setKeyValueAndRemoveFromUrl(url: String, key: String): (String, Option[String]) = {
+      val regex = new Regex(s".*(;${key}=([^;]*)).*")
+      url match {
+        case regex(keyAndValue, value) =>
+          (url.replace(keyAndValue, ""), Some(value))
+        case _ => (url, None)
+      }
     }
+
+    val (urlNoUser, user) = setKeyValueAndRemoveFromUrl(jdbcUrl, "user")
+    val (urlNoUserNoPassword, password) = setKeyValueAndRemoveFromUrl(urlNoUser, "password")
+    (urlNoUserNoPassword, user, password)
   }
 
   override def tryAcquire(

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/h2/H2StorageBackendSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/h2/H2StorageBackendSpec.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.backend.h2
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class H2StorageBackendSpec extends AnyWordSpec with Matchers {
+
+  "H2StorageBackend" should {
+    "extractUserPasswordAndRemoveFromUrl" should {
+
+      "strip user from url with user" in {
+        H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
+          "url;user=harry"
+        ) shouldBe ("url", Some("harry"), None)
+      }
+
+      "strip user from url with user in the middle" in {
+        H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
+          "url;user=harry;password=weak"
+        ) shouldBe ("url", Some("harry"), Some("weak"))
+      }
+
+      "only strip password if user absent" in {
+        H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
+          "url;password=weak"
+        ) shouldBe ("url", None, Some("weak"))
+      }
+
+      "not touch other properties" in {
+        H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
+          "url;alpha=1;beta=2;gamma=3"
+        ) shouldBe ("url;alpha=1;beta=2;gamma=3", None, None)
+      }
+    }
+  }
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/h2/H2StorageBackendSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/h2/H2StorageBackendSpec.scala
@@ -34,6 +34,18 @@ class H2StorageBackendSpec extends AnyWordSpec with Matchers {
           "url;alpha=1;beta=2;gamma=3"
         ) shouldBe ("url;alpha=1;beta=2;gamma=3", None, None)
       }
+
+      "match upper-case user and password keys" in {
+        H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
+          "url;USER=sally;PASSWORD=supersafe"
+        ) shouldBe ("url", Some("sally"), Some("supersafe"))
+      }
+
+      "match mixed-case user and password keys" in {
+        H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
+          "url;User=sally;Password=supersafe"
+        ) shouldBe ("url", Some("sally"), Some("supersafe"))
+      }
     }
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/h2/H2StorageBackendSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/h2/H2StorageBackendSpec.scala
@@ -14,37 +14,37 @@ class H2StorageBackendSpec extends AnyWordSpec with Matchers {
       "strip user from url with user" in {
         H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
           "url;user=harry"
-        ) shouldBe ("url", Some("harry"), None)
+        ) shouldBe (("url", Some("harry"), None))
       }
 
       "strip user from url with user in the middle" in {
         H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
           "url;user=harry;password=weak"
-        ) shouldBe ("url", Some("harry"), Some("weak"))
+        ) shouldBe (("url", Some("harry"), Some("weak")))
       }
 
       "only strip password if user absent" in {
         H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
           "url;password=weak"
-        ) shouldBe ("url", None, Some("weak"))
+        ) shouldBe (("url", None, Some("weak")))
       }
 
       "not touch other properties" in {
         H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
           "url;alpha=1;beta=2;gamma=3"
-        ) shouldBe ("url;alpha=1;beta=2;gamma=3", None, None)
+        ) shouldBe (("url;alpha=1;beta=2;gamma=3", None, None))
       }
 
       "match upper-case user and password keys" in {
         H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
           "url;USER=sally;PASSWORD=supersafe"
-        ) shouldBe ("url", Some("sally"), Some("supersafe"))
+        ) shouldBe (("url", Some("sally"), Some("supersafe")))
       }
 
       "match mixed-case user and password keys" in {
         H2StorageBackend.extractUserPasswordAndRemoveFromUrl(
           "url;User=sally;Password=supersafe"
-        ) shouldBe ("url", Some("sally"), Some("supersafe"))
+        ) shouldBe (("url", Some("sally"), Some("supersafe")))
       }
     }
   }


### PR DESCRIPTION
Follow-up from review feedback of https://github.com/digital-asset/daml/pull/10523

- [x] Switch to using regex
- [x] Unit tests for `extractUserPasswordAndRemoveFromUrl` pure function

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
