### PR TITLE
add cryptographic hash method to ChangeId and base equality on hash

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -232,6 +232,7 @@ object Hash {
     val MaintainerContractKeyUUID = Purpose(4)
     val PrivateKey = Purpose(3)
     val ContractInstance = Purpose(5)
+    val ChangeId = Purpose(6)
   }
 
   // package private for testing purpose.
@@ -332,6 +333,17 @@ object Hash {
       arg: Value[Value.ContractId],
   ): Either[String, Hash] =
     handleError(assertHashContractInstance(templateId, arg))
+
+  def hashChangeId(
+      applicationId: Ref.ApplicationId,
+      commandId: Ref.CommandId,
+      actAs: Set[Ref.Party],
+  ): Hash =
+    builder(Purpose.ChangeId, noCid2String)
+      .add(applicationId)
+      .add(commandId)
+      .addStringSet(actAs)
+      .build
 
   def deriveSubmissionSeed(
       nonce: Hash,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -223,7 +223,7 @@ object Hash {
   }
 
   // The purpose of a hash serves to avoid hash collisions due to equal encodings for different objects.
-  // Each purpose should be used at most one.
+  // Each purpose should be used at most once.
   private[crypto] case class Purpose(id: Byte)
 
   private[crypto] object Purpose {

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ChangeId.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ChangeId.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.participant.state.v2
 import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref
 
-/** Identifier for ledger changes used by command deduplication
+/** Identifier for ledger changes used by command deduplication.
   * Equality is defined in terms of the cryptographic hash.
   *
   * @see ReadService.stateUpdates for the command deduplication guarantee
@@ -20,7 +20,7 @@ final case class ChangeId(
   /** A stable hash of the change id.
     * Suitable for storing in persistent storage.
     */
-  val hash: Hash = Hash.hashChangeId(applicationId, commandId, actAs)
+  lazy val hash: Hash = Hash.hashChangeId(applicationId, commandId, actAs)
 
   override def equals(that: Any): Boolean = that match {
     case other: ChangeId =>

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ChangeId.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ChangeId.scala
@@ -3,14 +3,45 @@
 
 package com.daml.ledger.participant.state.v2
 
+import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref
 
 /** Identifier for ledger changes used by command deduplication
   *
   * @see ReadService.stateUpdates for the command deduplication guarantee
   */
-final case class ChangeId(
-    private val applicationId: Ref.ApplicationId,
-    private val commandId: Ref.CommandId,
-    private val actAs: Set[Ref.Party],
-)
+final class ChangeId(
+    applicationId: Ref.ApplicationId,
+    commandId: Ref.CommandId,
+    actAs: Set[Ref.Party],
+) extends scala.Equals {
+
+  /** A stable hash of the change id.
+    * Suitable for storing in persistent storage.
+    */
+  val hash: Hash = Hash.hashChangeId(applicationId, commandId, actAs)
+
+  @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
+  override def canEqual(that: Any): Boolean = that.isInstanceOf[ChangeId]
+
+  override def equals(that: Any): Boolean = that match {
+    case other: ChangeId =>
+      if (this eq other) true
+      else other.canEqual(this) && this.hash == other.hash
+    case _ => false
+  }
+
+  override def hashCode(): Int = hash.hashCode()
+
+  override def toString: String =
+    s"ChangeId(applicationId=$applicationId, command ID=$commandId, actAs={${actAs.mkString(", ")}})"
+}
+
+object ChangeId {
+  def apply(
+      applicationId: Ref.ApplicationId,
+      commandId: Ref.CommandId,
+      actAs: Set[Ref.Party],
+  ): ChangeId =
+    new ChangeId(applicationId, commandId, actAs)
+}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ChangeId.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/ChangeId.scala
@@ -7,22 +7,20 @@ import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref
 
 /** Identifier for ledger changes used by command deduplication
+  * Equality is defined in terms of the cryptographic hash.
   *
   * @see ReadService.stateUpdates for the command deduplication guarantee
   */
-final class ChangeId(
+final case class ChangeId(
     applicationId: Ref.ApplicationId,
     commandId: Ref.CommandId,
     actAs: Set[Ref.Party],
-) extends scala.Equals {
+) {
 
   /** A stable hash of the change id.
     * Suitable for storing in persistent storage.
     */
   val hash: Hash = Hash.hashChangeId(applicationId, commandId, actAs)
-
-  @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
-  override def canEqual(that: Any): Boolean = that.isInstanceOf[ChangeId]
 
   override def equals(that: Any): Boolean = that match {
     case other: ChangeId =>
@@ -32,16 +30,4 @@ final class ChangeId(
   }
 
   override def hashCode(): Int = hash.hashCode()
-
-  override def toString: String =
-    s"ChangeId(applicationId=$applicationId, command ID=$commandId, actAs={${actAs.mkString(", ")}})"
-}
-
-object ChangeId {
-  def apply(
-      applicationId: Ref.ApplicationId,
-      commandId: Ref.CommandId,
-      actAs: Set[Ref.Party],
-  ): ChangeId =
-    new ChangeId(applicationId, commandId, actAs)
 }


### PR DESCRIPTION
Add a cryptographic hash method to `ChangeId`.

* Equality of `ChangeId` is based on the hash so that we don't have to worry about hash collisions when specifying the deduplication guarantee.
* Made the fields public so that other code can do something with a `ChangeId`.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
