### PR TITLE
rotate release duty after 1.17.0-snapshot.20210811.7560.0.4f9de4ba

### DIFF
--- a/release/rotation
+++ b/release/rotation
@@ -1,5 +1,4 @@
 UHHMLCNGM nickchapman-da
-U021DSF26BS victormueller-da
 UPBBGF5MZ SamirTalwar-DA
 UTUPD35SR aherrmann-da
 UEHLS0JUB cocreature
@@ -10,3 +9,4 @@ U011H6KFYPN sofiafaro-da
 U026PEZLTPX akshayshirahatti-da
 U0PNNPY05 robin-da
 UEGT3JT0Q remyhaemmerle-da
+U021DSF26BS victormueller-da


### PR DESCRIPTION
@realvictorprm is taking care of 1.17.0-snapshot.20210811.7560.0.4f9de4ba (#10544), so they get pushed back to the end of the line (doing this instead of @nickchapman-da).

Please do not merge this before #10544.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
