### PR TITLE
DPP-460 Extract constant for event sequential IDs

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
@@ -19,7 +19,7 @@ import com.daml.platform.{PruneBuffers, PruneBuffersNoOp}
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.akkastreams.dispatcher.SubSource.RangeSource
 import com.daml.platform.index.ReadOnlySqlLedgerWithMutableCache.DispatcherLagMeter
-import com.daml.platform.store.LfValueTranslationCache
+import com.daml.platform.store.{EventSequentialId, LfValueTranslationCache}
 import com.daml.platform.store.appendonlydao.events.{BufferedTransactionsReader, LfValueTranslation}
 import com.daml.platform.store.cache.MutableCacheBackedContractStore.SignalNewLedgerHead
 import com.daml.platform.store.cache.{EventsBuffer, MutableCacheBackedContractStore}
@@ -74,8 +74,7 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
     private def dispatcherOffsetSeqIdOwner(ledgerEnd: Offset, evtSeqId: Long) = {
       Dispatcher.owner(
         name = "transaction-log-updates",
-        zeroIndex =
-          (Offset.beforeBegin, 0L), // TODO: append-only: FIXME consolidating parameters table
+        zeroIndex = (Offset.beforeBegin, EventSequentialId.zero),
         headAtInitialization = (ledgerEnd, evtSeqId),
       )
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedgerWithMutableCache.scala
@@ -74,7 +74,7 @@ private[index] object ReadOnlySqlLedgerWithMutableCache {
     private def dispatcherOffsetSeqIdOwner(ledgerEnd: Offset, evtSeqId: Long) = {
       Dispatcher.owner(
         name = "transaction-log-updates",
-        zeroIndex = (Offset.beforeBegin, EventSequentialId.zero),
+        zeroIndex = (Offset.beforeBegin, EventSequentialId.beforeBegin),
         headAtInitialization = (ledgerEnd, evtSeqId),
       )
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -175,7 +175,10 @@ object ParallelIndexerFactory {
                 )
                 .flatMap { initialized =>
                   val (killSwitch, completionFuture) =
-                    ingest(initialized.map(_.lastEventSeqId).getOrElse(EventSequentialId.zero), dbDispatcher)(
+                    ingest(
+                      initialized.map(_.lastEventSeqId).getOrElse(EventSequentialId.beforeBegin),
+                      dbDispatcher,
+                    )(
                       readService.stateUpdates(beginAfter = initialized.map(_.lastOffset))
                     )
                       .viaMat(KillSwitches.single)(Keep.right[NotUsed, UniqueKillSwitch])

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -23,7 +23,7 @@ import com.daml.platform.indexer.parallel.AsyncSupport._
 import com.daml.platform.indexer.{IndexFeedHandle, Indexer}
 import com.daml.platform.store.appendonlydao.DbDispatcher
 import com.daml.platform.store.appendonlydao.events.{CompressionStrategy, LfValueTranslation}
-import com.daml.platform.store.backend
+import com.daml.platform.store.{EventSequentialId, backend}
 import com.daml.platform.store.backend.DataSourceStorageBackend.DataSourceConfig
 import com.daml.platform.store.backend.ParameterStorageBackend.LedgerEnd
 import com.daml.platform.store.backend.{DbDto, StorageBackend}
@@ -175,7 +175,7 @@ object ParallelIndexerFactory {
                 )
                 .flatMap { initialized =>
                   val (killSwitch, completionFuture) =
-                    ingest(initialized.map(_.lastEventSeqId).getOrElse(0L), dbDispatcher)(
+                    ingest(initialized.map(_.lastEventSeqId).getOrElse(EventSequentialId.zero), dbDispatcher)(
                       readService.stateUpdates(beginAfter = initialized.map(_.lastOffset))
                     )
                       .viaMat(KillSwitches.single)(Keep.right[NotUsed, UniqueKillSwitch])

--- a/ledger/participant-integration-api/src/main/scala/platform/store/EventSequentialId.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/EventSequentialId.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store
+
+object EventSequentialId {
+  /** The sequential id to use if there are no events in the index database. */
+  val zero: Long = 0L
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/EventSequentialId.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/EventSequentialId.scala
@@ -4,6 +4,7 @@
 package com.daml.platform.store
 
 object EventSequentialId {
+
   /** The sequential id to use if there are no events in the index database. */
-  val zero: Long = 0L
+  val beforeBegin: Long = 0L
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsRange.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsRange.scala
@@ -5,6 +5,7 @@ package com.daml.platform.store.appendonlydao.events
 import java.sql.Connection
 
 import com.daml.ledger.offset.Offset
+import com.daml.platform.store.EventSequentialId
 
 // (startExclusive, endInclusive]
 private[events] final case class EventsRange[A](startExclusive: A, endInclusive: A) {
@@ -13,10 +14,8 @@ private[events] final case class EventsRange[A](startExclusive: A, endInclusive:
 }
 
 private[events] object EventsRange {
-  private val EmptyLedgerEventSeqId = 0L
-
   // (0, 0] -- non-existent range
-  private val EmptyEventSeqIdRange = EventsRange(EmptyLedgerEventSeqId, EmptyLedgerEventSeqId)
+  private val EmptyEventSeqIdRange = EventsRange(EventSequentialId.zero, EventSequentialId.zero)
 
   def isEmpty[A: Ordering](range: EventsRange[A]): Boolean = {
     val A = implicitly[Ordering[A]]
@@ -57,7 +56,7 @@ private[events] object EventsRange {
 
     private def readEventSeqId(offset: Offset)(connection: java.sql.Connection): Long =
       lookupEventSeqId(offset)(connection)
-        .getOrElse(EmptyLedgerEventSeqId)
+        .getOrElse(EventSequentialId.zero)
   }
 
   private[events] def readPage[A](

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsRange.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/EventsRange.scala
@@ -15,7 +15,8 @@ private[events] final case class EventsRange[A](startExclusive: A, endInclusive:
 
 private[events] object EventsRange {
   // (0, 0] -- non-existent range
-  private val EmptyEventSeqIdRange = EventsRange(EventSequentialId.zero, EventSequentialId.zero)
+  private val EmptyEventSeqIdRange =
+    EventsRange(EventSequentialId.beforeBegin, EventSequentialId.beforeBegin)
 
   def isEmpty[A: Ordering](range: EventsRange[A]): Boolean = {
     val A = implicitly[Ordering[A]]
@@ -56,7 +57,7 @@ private[events] object EventsRange {
 
     private def readEventSeqId(offset: Offset)(connection: java.sql.Connection): Long =
       lookupEventSeqId(offset)(connection)
-        .getOrElse(EventSequentialId.zero)
+        .getOrElse(EventSequentialId.beforeBegin)
   }
 
   private[events] def readPage[A](

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
@@ -16,7 +16,7 @@ import com.daml.lf.data.Ref
 import com.daml.lf.ledger.EventId
 import com.daml.logging.LoggingContext
 import com.daml.platform
-import com.daml.platform.store.DbType
+import com.daml.platform.store.{DbType, EventSequentialId}
 import com.daml.platform.store.appendonlydao.events.{ContractId, EventsTable, Key, Raw}
 import com.daml.platform.store.backend.EventStorageBackend.{FilterParams, RangeParams}
 import com.daml.platform.store.backend.StorageBackend.RawTransactionEvent
@@ -106,7 +106,9 @@ trait ParameterStorageBackend {
     * @return the current LedgerEnd, or a LedgerEnd that points to before the ledger begin if no ledger end exists
     */
   final def ledgerEndOrBeforeBegin(connection: Connection): ParameterStorageBackend.LedgerEnd =
-    ledgerEnd(connection).getOrElse(ParameterStorageBackend.LedgerEnd(Offset.beforeBegin, 0L))
+    ledgerEnd(connection).getOrElse(
+      ParameterStorageBackend.LedgerEnd(Offset.beforeBegin, EventSequentialId.beforeBegin)
+    )
 
   /** Part of pruning process, this needs to be in the same transaction as the other pruning related database operations
     */

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -15,6 +15,7 @@ import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.transaction.GlobalKey
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
+import com.daml.platform.store.EventSequentialId
 import com.daml.platform.store.cache.ContractKeyStateValue._
 import com.daml.platform.store.cache.ContractStateValue._
 import com.daml.platform.store.cache.MutableCacheBackedContractStore._
@@ -399,6 +400,6 @@ private[platform] object MutableCacheBackedContractStore {
 
     def get: Option[(Offset, EventSequentialId)] = offsetRef.get()
 
-    def getSequentialId: EventSequentialId = get.map(_._2).getOrElse(0L)
+    def getSequentialId: EventSequentialId = get.map(_._2).getOrElse(EventSequentialId.zero)
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -400,6 +400,6 @@ private[platform] object MutableCacheBackedContractStore {
 
     def get: Option[(Offset, EventSequentialId)] = offsetRef.get()
 
-    def getSequentialId: EventSequentialId = get.map(_._2).getOrElse(EventSequentialId.zero)
+    def getSequentialId: EventSequentialId = get.map(_._2).getOrElse(EventSequentialId.beforeBegin)
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsRange.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsRange.scala
@@ -16,7 +16,8 @@ private[events] final case class EventsRange[A](startExclusive: A, endInclusive:
 private[events] object EventsRange {
 
   // (0, 0] -- non-existent range
-  private val EmptyEventSeqIdRange = EventsRange(EventSequentialId.zero, EventSequentialId.zero)
+  private val EmptyEventSeqIdRange =
+    EventsRange(EventSequentialId.beforeBegin, EventSequentialId.beforeBegin)
 
   def isEmpty[A: Ordering](range: EventsRange[A]): Boolean = {
     val A = implicitly[Ordering[A]]
@@ -64,7 +65,7 @@ private[events] object EventsRange {
     SQL"select max(event_sequential_id) from participant_events where event_offset <= ${offset} group by event_offset order by event_offset desc #${SqlFunctions(dbType)
       .limitClause(1)}"
       .as(get[Long](1).singleOpt)(connection)
-      .getOrElse(EventSequentialId.zero)
+      .getOrElse(EventSequentialId.beforeBegin)
   }
 
   private[events] def readPage[A](

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsRange.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsRange.scala
@@ -5,7 +5,7 @@ package com.daml.platform.store.dao.events
 import anorm.SqlParser.get
 import anorm.{Row, RowParser, SimpleSql, SqlStringInterpolation}
 import com.daml.ledger.offset.Offset
-import com.daml.platform.store.DbType
+import com.daml.platform.store.{DbType, EventSequentialId}
 
 // (startExclusive, endInclusive]
 private[events] final case class EventsRange[A](startExclusive: A, endInclusive: A) {
@@ -15,10 +15,8 @@ private[events] final case class EventsRange[A](startExclusive: A, endInclusive:
 
 private[events] object EventsRange {
 
-  private val EmptyLedgerEventSeqId = 0L
-
   // (0, 0] -- non-existent range
-  private val EmptyEventSeqIdRange = EventsRange(EmptyLedgerEventSeqId, EmptyLedgerEventSeqId)
+  private val EmptyEventSeqIdRange = EventsRange(EventSequentialId.zero, EventSequentialId.zero)
 
   def isEmpty[A: Ordering](range: EventsRange[A]): Boolean = {
     val A = implicitly[Ordering[A]]
@@ -66,7 +64,7 @@ private[events] object EventsRange {
     SQL"select max(event_sequential_id) from participant_events where event_offset <= ${offset} group by event_offset order by event_offset desc #${SqlFunctions(dbType)
       .limitClause(1)}"
       .as(get[Long](1).singleOpt)(connection)
-      .getOrElse(EmptyLedgerEventSeqId)
+      .getOrElse(EventSequentialId.zero)
   }
 
   private[events] def readPage[A](

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
@@ -17,6 +17,7 @@ import com.daml.lf.transaction.TransactionVersion
 import com.daml.lf.value.Value.{ContractId, ValueInt64, ValueText, VersionedValue}
 import com.daml.logging.LoggingContext
 import com.daml.platform.index.BuffersUpdaterSpec.{contractStateEventMock, transactionLogUpdateMock}
+import com.daml.platform.store.EventSequentialId
 import com.daml.platform.store.appendonlydao.events.{Contract, Key, Party}
 import com.daml.platform.store.cache.MutableCacheBackedContractStore.EventSequentialId
 import com.daml.platform.store.dao.events.ContractStateEvent
@@ -307,7 +308,7 @@ final class BuffersUpdaterSpec
 }
 
 private object BuffersUpdaterSpec {
-  val mockSeed = new AtomicLong(0L)
+  val mockSeed = new AtomicLong(EventSequentialId.beforeBegin)
   /* We use the simplest embodiments of the interfaces as mocks and pick the eventSequentialId as discriminator */
   private def transactionLogUpdateMock() =
     TransactionLogUpdate.LedgerEndMarker(Offset.beforeBegin, mockSeed.getAndIncrement())


### PR DESCRIPTION
This PR creates a constant for the (arbitrary) ID used when the index doesn't contain any events.