### PR TITLE
Enable --incompatible_remote_results_ignore_disk

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,10 @@
 # flag: --noremote_accept_cached
 build:darwin --remote_http_cache=https://bazel-cache.da-ext.net
 build:linux --remote_http_cache=https://bazel-cache.da-ext.net/ubuntu_20_04
+# Don't push local build results to the remote cache.
 build --remote_upload_local_results=false
+# Do still push local build results to the local disk cache.
+build --incompatible_remote_results_ignore_disk=true
 # Enable the disk cache in addition to the http cache.
 build:linux --disk_cache=.bazel-cache/disk
 build:darwin --disk_cache=.bazel-cache/disk

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -2,7 +2,10 @@
 # flag: --noremote_accept_cached
 build:darwin --remote_http_cache=https://bazel-cache.da-ext.net
 build:linux --remote_http_cache=https://bazel-cache.da-ext.net/ubuntu_20_04
+# Don't push local build results to the remote cache.
 build --remote_upload_local_results=false
+# Do still push local build results to the local disk cache.
+build --incompatible_remote_results_ignore_disk=true
 # Enable the disk cache in addition to the http cache.
 build:linux --disk_cache=.bazel-cache/disk
 build:darwin --disk_cache=.bazel-cache/disk


### PR DESCRIPTION
> If set to true, --noremote_upload_local_results and --noremote_accept_cached will not apply to the disk cache. If a combined cache is used: --noremote_upload_local_results will cause results to be written to the disk cache, but not uploaded to the remote cache. --noremote_accept_cached will result in Bazel checking for results in the disk cache, but not in the remote cache. See #8216 for details.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
