### PR TITLE
Handle imports for builtin types correctly in Daml export

### DIFF
--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -312,20 +312,6 @@ private[export] object Encode {
     }
   }
 
-  private def isTupleId(id: Identifier): Boolean = {
-    val daTypesId = "40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7"
-    id.packageId == daTypesId && id.moduleName == "DA.Types" && id.entityName.startsWith("Tuple")
-  }
-
-  private def isTupleRefId(name: Ref.Identifier): Boolean = {
-    isTupleId(
-      Identifier()
-        .withPackageId(name.packageId)
-        .withModuleName(name.qualifiedName.module.dottedName)
-        .withEntityName(name.qualifiedName.name.dottedName)
-    )
-  }
-
   private def quotes(v: Doc) =
     "\"" +: v :+ "\""
 

--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -223,7 +223,7 @@ private[export] object Encode {
           qualifyId(value.getEnumId.copy(entityName = value.constructor))
         case Sum.GenMap(m) =>
           parens(
-            Doc.text("Map.fromList ") + list(
+            Doc.text("DA.Map.fromList ") + list(
               m.entries.map(e => pair(go(e.getKey.sum), go(e.getValue.sum)))
             )
           )

--- a/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Encode.scala
@@ -216,7 +216,7 @@ private[export] object Encode {
           }
         case Sum.Map(m) =>
           parens(
-            Doc.text("TextMap.fromList ") +
+            Doc.text("DA.TextMap.fromList ") +
               list(m.entries.map(e => pair(go(Value.Sum.Text(e.key)), go(e.getValue.sum))))
           )
         case Sum.Enum(value) =>

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -11,6 +11,7 @@ import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
 import com.daml.ledger.api.v1.transaction.TreeEvent.Kind
 import com.daml.ledger.api.v1.value.{Identifier, Value}
 import com.daml.ledger.api.v1.value.Value.Sum
+import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.language.Graphs
@@ -485,6 +486,20 @@ object TreeUtils {
     case Sum.Enum(value) => Set(value.getEnumId)
     case Sum.GenMap(value) =>
       value.entries.foldMap(e => valueRefs(e.getKey.sum).union(valueRefs(e.getValue.sum)))
+  }
+
+  def isTupleId(id: Identifier): Boolean = {
+    val daTypesId = "40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7"
+    id.packageId == daTypesId && id.moduleName == "DA.Types" && id.entityName.startsWith("Tuple")
+  }
+
+  def isTupleRefId(name: Ref.Identifier): Boolean = {
+    isTupleId(
+      Identifier()
+        .withPackageId(name.packageId)
+        .withModuleName(name.qualifiedName.module.dottedName)
+        .withEntityName(name.qualifiedName.name.dottedName)
+    )
   }
 
   def valueCids(v: Value.Sum): Set[ContractId] = v match {

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -471,7 +471,7 @@ object TreeUtils {
   /** All identifiers referenced by the given value that require a module import.
     *
     * Note, the package-id component of the identifier may be empty for stable packages
-       as those are imported via daml-stdlib/daml-prim. E.g. DA.Time.Time incurred by Timestamp values.
+    * as those are imported via daml-stdlib/daml-prim. E.g. DA.Time.Time incurred by Timestamp values.
     */
   def valueRefs(v: Value.Sum): Set[Identifier] = v match {
     case Sum.Empty => Set()

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -469,7 +469,12 @@ object TreeUtils {
   def valueRefs(v: Value.Sum): Set[Identifier] = v match {
     case Sum.Empty => Set()
     case Sum.Record(value) =>
-      Set(value.getRecordId).union(value.fields.foldMap(f => valueRefs(f.getValue.sum)))
+      val fieldRefs = value.fields.foldMap(f => valueRefs(f.getValue.sum))
+      if (isTupleId(value.getRecordId)) {
+        fieldRefs
+      } else {
+        Set(value.getRecordId).union(fieldRefs)
+      }
     case Sum.Variant(value) => Set(value.getVariantId).union(valueRefs(value.getValue.sum))
     case Sum.ContractId(_) => Set()
     case Sum.List(value) => value.elements.foldMap(v => valueRefs(v.sum))

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -470,8 +470,8 @@ object TreeUtils {
 
   /** All identifiers referenced by the given value that require a module import.
     *
-    * Note, the package-id component of the identifier may be empty if there is no
-    * corresponding package-id available. E.g. DA.Time.Time incurred by Timestamp values.
+    * Note, the package-id component of the identifier may be empty for stable packages
+       as those are imported via daml-stdlib/daml-prim. E.g. DA.Time.Time incurred by Timestamp values.
     */
   def valueRefs(v: Value.Sum): Set[Identifier] = v match {
     case Sum.Empty => Set()

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -504,7 +504,9 @@ object TreeUtils {
       )
     case Sum.Enum(value) => Set(value.getEnumId)
     case Sum.GenMap(value) =>
-      value.entries.foldMap(e => valueRefs(e.getKey.sum).union(valueRefs(e.getValue.sum)))
+      Set(Identifier().withModuleName("DA.Map").withEntityName("Map")).union(
+        value.entries.foldMap(e => valueRefs(e.getKey.sum).union(valueRefs(e.getValue.sum)))
+      )
   }
 
   def isTupleId(id: Identifier): Boolean = {

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -480,7 +480,7 @@ object TreeUtils {
       if (isTupleId(value.getRecordId)) {
         fieldRefs
       } else {
-        Set(value.getRecordId).union(fieldRefs)
+        fieldRefs + value.getRecordId
       }
     case Sum.Variant(value) => Set(value.getVariantId).union(valueRefs(value.getValue.sum))
     case Sum.ContractId(_) => Set()

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -498,7 +498,10 @@ object TreeUtils {
     case Sum.Unit(_) => Set()
     case Sum.Date(_) => Set(Identifier().withModuleName("DA.Date").withEntityName("Date"))
     case Sum.Optional(value) => value.value.foldMap(v => valueRefs(v.sum))
-    case Sum.Map(value) => value.entries.foldMap(e => valueRefs(e.getValue.sum))
+    case Sum.Map(value) =>
+      Set(Identifier().withModuleName("DA.TextMap").withEntityName("TextMap")).union(
+        value.entries.foldMap(e => valueRefs(e.getValue.sum))
+      )
     case Sum.Enum(value) => Set(value.getEnumId)
     case Sum.GenMap(value) =>
       value.entries.foldMap(e => valueRefs(e.getKey.sum).union(valueRefs(e.getValue.sum)))

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -482,7 +482,7 @@ object TreeUtils {
       } else {
         fieldRefs + value.getRecordId
       }
-    case Sum.Variant(value) => Set(value.getVariantId).union(valueRefs(value.getValue.sum))
+    case Sum.Variant(value) => valueRefs(value.getValue.sum) + value.getVariantId
     case Sum.ContractId(_) => Set()
     case Sum.List(value) => value.elements.foldMap(v => valueRefs(v.sum))
     case Sum.Int64(_) => Set()
@@ -499,14 +499,14 @@ object TreeUtils {
     case Sum.Date(_) => Set(Identifier().withModuleName("DA.Date").withEntityName("Date"))
     case Sum.Optional(value) => value.value.foldMap(v => valueRefs(v.sum))
     case Sum.Map(value) =>
-      Set(Identifier().withModuleName("DA.TextMap").withEntityName("TextMap")).union(
-        value.entries.foldMap(e => valueRefs(e.getValue.sum))
-      )
+      value.entries.foldMap(e => valueRefs(e.getValue.sum)) + Identifier()
+        .withModuleName("DA.TextMap")
+        .withEntityName("TextMap")
     case Sum.Enum(value) => Set(value.getEnumId)
     case Sum.GenMap(value) =>
-      Set(Identifier().withModuleName("DA.Map").withEntityName("Map")).union(
-        value.entries.foldMap(e => valueRefs(e.getKey.sum).union(valueRefs(e.getValue.sum)))
-      )
+      value.entries.foldMap(e =>
+        valueRefs(e.getKey.sum).union(valueRefs(e.getValue.sum))
+      ) + Identifier().withModuleName("DA.Map").withEntityName("Map")
   }
 
   def isTupleId(id: Identifier): Boolean = {

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
@@ -140,7 +140,7 @@ class EncodeValueSpec extends AnyFreeSpec with Matchers {
         Map.empty,
         v.Value.Sum.Map(v.Map(Seq(v.Map.Entry("key", Some(v.Value().withText("value")))))),
       ).render(80) shouldBe
-        "(TextMap.fromList [(\"key\", \"value\")])"
+        "(DA.TextMap.fromList [(\"key\", \"value\")])"
     }
     "enum" in {
       val id = v.Identifier("pkg-id", "M", "E")

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
@@ -153,7 +153,7 @@ class EncodeValueSpec extends AnyFreeSpec with Matchers {
           Seq(v.GenMap.Entry(Some(v.Value().withInt64(42)), Some(v.Value().withText("value"))))
         )
       )
-      encodeValue(Map.empty, Map.empty, m).render(80) shouldBe "(Map.fromList [(42, \"value\")])"
+      encodeValue(Map.empty, Map.empty, m).render(80) shouldBe "(DA.Map.fromList [(42, \"value\")])"
     }
   }
 }

--- a/daml-script/export/src/test/scala/com/daml/script/export/ReferencesSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ReferencesSpec.scala
@@ -1,0 +1,226 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.export
+
+import com.daml.ledger.api.v1.{value => v}
+import java.time.{Instant, LocalDate, OffsetDateTime, ZoneOffset}
+import java.util.concurrent.TimeUnit
+
+import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
+import com.daml.script.export.TreeUtils.{contractsReferences, treesReferences, valueRefs}
+import com.google.protobuf.empty.Empty
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ReferencesSpec extends AnyFreeSpec with Matchers {
+  private def assertMicrosFromInstant(i: Instant): Long =
+    TimeUnit.SECONDS.toMicros(i.getEpochSecond) + TimeUnit.NANOSECONDS.toMicros(i.getNano.toLong)
+
+  "valueRefs" - {
+    val nestedId = v.Identifier("pkg-id", "M", "Nested")
+    val nestedVal = v.Value().withRecord(v.Record().withRecordId(nestedId))
+    "record" in {
+      val idR = v.Identifier("pkg-id", "M", "R1")
+      val r = v
+        .Value()
+        .withRecord(
+          v.Record()
+            .withRecordId(idR)
+            .withFields(Seq(v.RecordField().withLabel("a").withValue(nestedVal)))
+        )
+      valueRefs(r.sum) should contain only (idR, nestedId)
+    }
+    "tuple" in {
+      def tupleId(n: Int): v.Identifier = v
+        .Identifier()
+        .withPackageId("40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7")
+        .withModuleName("DA.Types")
+        .withEntityName(s"Tuple$n")
+      def tuple(vals: v.Value*): v.Value = {
+        v.Value()
+          .withRecord(
+            v.Record()
+              .withRecordId(tupleId(vals.size))
+              .withFields(vals.zipWithIndex.map { case (value, ix) =>
+                v.RecordField().withLabel(s"_$ix").withValue(value)
+              })
+          )
+      }
+      val int1 = v.Value().withInt64(1)
+      val int2 = v.Value().withInt64(2)
+      val tuple1 = tuple(int1, int2)
+      val tuple2 = tuple(int1, int2, nestedVal)
+      val tuple3 = tuple(int1, tuple1, tuple2)
+      valueRefs(tuple3.sum) should contain only (nestedId)
+    }
+    "variant" in {
+      val variantId = v.Identifier("pkg-id", "M", "V")
+      val variant =
+        v.Value()
+          .withVariant(
+            v.Variant()
+              .withVariantId(variantId)
+              .withConstructor("Constr")
+              .withValue(nestedVal)
+          )
+      valueRefs(variant.sum) should contain only (variantId, nestedId)
+    }
+    "either" in {
+      val leftId: v.Identifier = v
+        .Identifier()
+        .withPackageId("40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7")
+        .withModuleName("DA.Types")
+        .withEntityName("Left")
+      val rightId: v.Identifier = v
+        .Identifier()
+        .withPackageId("40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7")
+        .withModuleName("DA.Types")
+        .withEntityName("Right")
+      val variant =
+        v.Value()
+          .withVariant(
+            v.Variant()
+              .withVariantId(leftId)
+              .withConstructor("Left")
+              .withValue(
+                v.Value()
+                  .withVariant(
+                    v.Variant()
+                      .withVariantId(rightId)
+                      .withConstructor("Right")
+                      .withValue(nestedVal)
+                  )
+              )
+          )
+      valueRefs(variant.sum) should contain only (leftId, rightId, nestedId)
+    }
+    "contract id" in {
+      val cid = v.Value().withContractId("my-contract-id")
+      valueRefs(cid.sum) shouldBe empty
+    }
+    "list" in {
+      val l = v.Value().withList(v.List(Seq(nestedVal)))
+      valueRefs(l.sum) should contain only (nestedId)
+    }
+    "int64" in {
+      valueRefs(v.Value().withInt64(42).sum) shouldBe empty
+    }
+    "numeric" in {
+      valueRefs(v.Value().withNumeric("1.3000").sum) shouldBe empty
+    }
+    "text" in {
+      valueRefs(v.Value.Sum.Text("abc\"def")) shouldBe empty
+    }
+    "party" in {
+      valueRefs(v.Value.Sum.Party("unmapped")) shouldBe empty
+    }
+    "bool" in {
+      valueRefs(v.Value.Sum.Bool(true)) shouldBe empty
+      valueRefs(v.Value.Sum.Bool(false)) shouldBe empty
+    }
+    "unit" in {
+      valueRefs(v.Value.Sum.Unit(Empty())) shouldBe empty
+    }
+    "timestamp" in {
+      val dateId: v.Identifier = v
+        .Identifier()
+        .withModuleName("DA.Date")
+        .withEntityName("Date")
+      val timeId: v.Identifier = v
+        .Identifier()
+        .withModuleName("DA.Time")
+        .withEntityName("Time")
+      val date = OffsetDateTime.of(1999, 11, 16, 13, 37, 42, 0, ZoneOffset.UTC)
+      valueRefs(
+        v.Value.Sum.Timestamp(assertMicrosFromInstant(date.toInstant()))
+      ) should contain only (dateId, timeId)
+    }
+    "date" in {
+      val dateId: v.Identifier = v
+        .Identifier()
+        .withModuleName("DA.Date")
+        .withEntityName("Date")
+      val date = LocalDate.of(1999, 11, 16)
+      valueRefs(v.Value.Sum.Date(date.toEpochDay().toInt)) should contain only (dateId)
+    }
+    "optional" in {
+      val none = v.Value().withOptional(v.Optional())
+      valueRefs(none.sum) shouldBe empty
+      val some = v.Value().withOptional(v.Optional().withValue(nestedVal))
+      valueRefs(some.sum) should contain only (nestedId)
+    }
+    "textmap" in {
+      val textmapId: v.Identifier = v
+        .Identifier()
+        .withModuleName("DA.TextMap")
+        .withEntityName("TextMap")
+      val textmap = v
+        .Value()
+        .withMap(v.Map().withEntries(Seq(v.Map.Entry().withKey("key").withValue(nestedVal))))
+      valueRefs(textmap.sum) should contain only (textmapId, nestedId)
+    }
+    "enum" in {
+      val id = v.Identifier("pkg-id", "M", "E")
+      valueRefs(
+        v.Value().withEnum(v.Enum().withEnumId(id).withConstructor("Constr")).sum
+      ) should contain only (id)
+    }
+    "map" in {
+      val genmapId: v.Identifier = v
+        .Identifier()
+        .withModuleName("DA.Map")
+        .withEntityName("Map")
+      val anotherId = v.Identifier("pkg-id", "M", "Another")
+      val anotherVal = v.Value().withRecord(v.Record().withRecordId(anotherId))
+      val genmap = v
+        .Value()
+        .withGenMap(
+          v.GenMap().withEntries(Seq(v.GenMap.Entry().withKey(anotherVal).withValue(nestedVal)))
+        )
+      valueRefs(genmap.sum) should contain only (anotherId, nestedId, genmapId)
+    }
+  }
+  "package references" - {
+    "missing package id" - {
+      val noId = v.Identifier().withModuleName("Module").withEntityName("EntityA")
+      val noIdVal = v.Value().withRecord(v.Record().withRecordId(noId))
+      val someId =
+        v.Identifier().withPackageId("package").withModuleName("Module").withEntityName("EntityB")
+      val someIdVal = v.Value().withRecord(v.Record().withRecordId(someId))
+      "contractsReferences" in {
+        val acs = TestData
+          .ACS(
+            Seq(
+              TestData.Created(
+                contractId = ContractId("cid1"),
+                createArguments = Seq(
+                  v.RecordField().withLabel("field1").withValue(noIdVal),
+                  v.RecordField().withLabel("field2").withValue(someIdVal),
+                ),
+                submitters = Seq(Party("Alice")),
+              )
+            )
+          )
+          .toCreatedEvents
+        contractsReferences(acs) should contain only ("package")
+      }
+      "treesReferences" in {
+        val tree = TestData
+          .Tree(
+            Seq(
+              TestData.Created(
+                contractId = ContractId("cid1"),
+                createArguments = Seq(
+                  v.RecordField().withLabel("field1").withValue(noIdVal),
+                  v.RecordField().withLabel("field2").withValue(someIdVal),
+                ),
+              )
+            )
+          )
+          .toTransactionTree
+        treesReferences(Seq(tree)) should contain only ("package")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #10438

Changes the encoding so that values of builtin types that require imports consistently use fully qualified names, e.g. `DA.Map.fromList`.

Tracks references to such modules that require imports, e.g. `DA.Map`. (The package-id is left empty in this case, as no corresponding `--package` flag is required).

Avoids imports of `DA.Types` due to tuples as these would be unused imports.

Adds unit tests.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
