### PR TITLE
Adding Ord instance for NonEmpty

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/NonEmpty.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/NonEmpty.daml
@@ -39,6 +39,7 @@ import DA.Action qualified as M
 
 deriving instance Eq a => Eq (NonEmpty a)
 deriving instance Show a => Show (NonEmpty a)
+deriving instance Ord a => Ord (NonEmpty a)
 
 -- NonEmpty is defined in a stable LF package so we need to handwrite the HasField instances here.
 

--- a/compiler/damlc/tests/daml-test-files/NonEmpty.daml
+++ b/compiler/damlc/tests/daml-test-files/NonEmpty.daml
@@ -13,3 +13,12 @@ testApplicative = scenario do
   (fs <*> l) === NonEmpty 2 [4, 6, 8, 3, 6, 9, 12]
   hd l === 1
   tl l === [2, 3, 4]
+
+testOrd = scenario do
+  compare (NonEmpty 1 []) (NonEmpty 1 []) === EQ
+  compare (NonEmpty 2 []) (NonEmpty 1 []) === GT
+  compare (NonEmpty 1 []) (NonEmpty 2 []) === LT
+  compare (NonEmpty 1 [0]) (NonEmpty 1 []) === GT
+  compare (NonEmpty 1 []) (NonEmpty 1 [0]) === LT
+  compare (NonEmpty 1 [0]) (NonEmpty 1 [0]) === EQ
+  compare (NonEmpty 1 [0]) (NonEmpty 1 [1]) === LT


### PR DESCRIPTION
As discussed in https://discuss.daml.com/t/no-ord-instance-for-nonempty/2964

CHANGELOG_BEGIN

- [Daml Standard Library] Instance of the Ord typeclass added for the NonEmpty data type.

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
