### PR TITLE
Skip subject in changelog check

### DIFF
--- a/ci/check-changelog.sh
+++ b/ci/check-changelog.sh
@@ -13,7 +13,7 @@ contains_changelog () {
 
         END { print flag }
     "
-    [[ 2 == $(git show -s --format=%B $1 | awk "$awk_script") ]]
+    [[ 2 == $(git show -s --format=%b $1 | awk "$awk_script") ]]
 }
 
 is_dependabot_pr() {

--- a/ci/check-changelog.sh
+++ b/ci/check-changelog.sh
@@ -56,7 +56,9 @@ has_a_changelog() {
         fi
     done
     echo "
-No changelog entry found; please add one. If your PR does not need a
+No changelog entry found; please add one. Note that the
+changelog entry must be in the commit message body excluding the subject in the first line.
+If your PR does not need a
 changelog entry, please add an explicit, empty one, i.e. add
 
 CHANGELOG_BEGIN


### PR DESCRIPTION
This matches what unreleased.sh does.

Ideally we’d probably share the code but this is bash and I do not
like bash so I cannot be bothered to do this right now.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
