### PR TITLE
daml ledger export: export all parties

### DIFF
--- a/daml-script/export/integration-tests/export-lf-1.6/scala/com/daml/script/export/LF16ExportClient.scala
+++ b/daml-script/export/integration-tests/export-lf-1.6/scala/com/daml/script/export/LF16ExportClient.scala
@@ -23,6 +23,7 @@ import com.daml.ledger.api.v1.value
 import com.daml.ledger.api.domain
 import com.daml.lf.archive.DarDecoder
 import com.daml.SdkVersion
+import com.daml.ledger.api.refinements.ApiTypes.Party
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
@@ -196,7 +197,10 @@ object LF16ExportClient {
         Config.Empty.copy(
           ledgerHost = "localhost",
           ledgerPort = ledgerPort,
-          parties = Seq("Alice"),
+          partyConfig = PartyConfig(
+            parties = Seq.empty[Party],
+            allParties = true,
+          ),
           exportType = Some(
             Config.EmptyExportScript.copy(
               sdkVersion = SdkVersion.sdkVersion,

--- a/daml-script/export/integration-tests/matches-docs/scala/com/daml/script/export/ExampleExportClient.scala
+++ b/daml-script/export/integration-tests/matches-docs/scala/com/daml/script/export/ExampleExportClient.scala
@@ -9,6 +9,7 @@ import java.time.Duration
 
 import com.daml.SdkVersion
 import com.daml.fs.Utils.deleteRecursively
+import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.lf.engine.script.{RunnerConfig, RunnerMain}
 
@@ -105,7 +106,10 @@ object ExampleExportClient {
         Config.Empty.copy(
           ledgerHost = "localhost",
           ledgerPort = clientConfig.targetPort,
-          parties = Seq("Alice", "Bob"),
+          partyConfig = PartyConfig(
+            allParties = false,
+            parties = Party.subst(Seq("Alice", "Bob")),
+          ),
           exportType = Some(
             Config.EmptyExportScript.copy(
               sdkVersion = SdkVersion.sdkVersion,

--- a/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
@@ -13,7 +13,7 @@ import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.script.{Participants, Runner}
 import com.daml.ledger.api.domain
-import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
+import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, Party}
 import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundAll}
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands._
@@ -129,7 +129,10 @@ trait ReproducesTransactions
         ledgerPort = serverPort.value,
         tlsConfig = TlsConfiguration(false, None, None, None),
         accessToken = None,
-        parties = parties,
+        partyConfig = PartyConfig(
+          parties = Party.subst(parties),
+          allParties = false,
+        ),
         start = offset,
         end = ledgerEnd,
         exportType = Some(

--- a/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
@@ -54,8 +54,9 @@ object Main {
             config.ledgerPort,
             clientConfig(config),
           )
-          acs <- LedgerUtils.getACS(client, config.parties, config.start)
-          trees <- LedgerUtils.getTransactionTrees(client, config.parties, config.start, config.end)
+          parties <- LedgerUtils.getAllParties(client, config.accessToken, config.partyConfig)
+          acs <- LedgerUtils.getACS(client, parties, config.start)
+          trees <- LedgerUtils.getTransactionTrees(client, parties, config.start, config.end)
           acsPkgRefs = TreeUtils.contractsReferences(acs.values)
           treePkgRefs = TreeUtils.treesReferences(trees)
           pkgRefs = acsPkgRefs ++ treePkgRefs

--- a/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
@@ -118,5 +118,17 @@ class ConfigSpec extends AnyFreeSpec with Matchers with OptionValues {
         optConfig.value.accessToken.value.token.value shouldBe token
       }
     }
+    "Output type" - {
+      "missing" in {
+        val args = ledgerArgs ++ partyArgs
+        val optConfig = Config.parse(args)
+        optConfig shouldBe empty
+      }
+      "script" in {
+        val args = outputTypeArgs ++ outputArgs ++ sdkVersionArgs ++ ledgerArgs ++ partyArgs
+        val optConfig = Config.parse(args)
+        optConfig.value.exportType.value shouldBe an[ExportScript]
+      }
+    }
   }
 }

--- a/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
@@ -63,22 +63,41 @@ class ConfigSpec extends AnyFreeSpec with Matchers with OptionValues {
         optConfig.value.end shouldBe LedgerOffset().withAbsolute("00100")
       }
     }
-    "--party" - {
+    "--party or --all-parties" - {
       val defaultRequiredArgs = outputTypeArgs ++ outputArgs ++ sdkVersionArgs ++ ledgerArgs
       "--party Alice" in {
         val args = defaultRequiredArgs ++ Array("--party", "Alice")
         val optConfig = Config.parse(args)
-        optConfig.value.parties should contain only ("Alice")
+        optConfig.value.partyConfig.parties should contain only ("Alice")
+        optConfig.value.partyConfig.allParties shouldBe false
       }
       "--party Alice --party Bob" in {
         val args = defaultRequiredArgs ++ Array("--party", "Alice", "--party", "Bob")
         val optConfig = Config.parse(args)
-        optConfig.value.parties should contain only ("Alice", "Bob")
+        optConfig.value.partyConfig.parties should contain only ("Alice", "Bob")
+        optConfig.value.partyConfig.allParties shouldBe false
       }
       "--party Alice,Bob" in {
         val args = defaultRequiredArgs ++ Array("--party", "Alice,Bob")
         val optConfig = Config.parse(args)
-        optConfig.value.parties should contain only ("Alice", "Bob")
+        optConfig.value.partyConfig.parties should contain only ("Alice", "Bob")
+        optConfig.value.partyConfig.allParties shouldBe false
+      }
+      "--all-parties" in {
+        val args = defaultRequiredArgs ++ Array("--all-parties")
+        val optConfig = Config.parse(args)
+        optConfig.value.partyConfig.parties shouldBe empty
+        optConfig.value.partyConfig.allParties shouldBe true
+      }
+      "missing" in {
+        val args = defaultRequiredArgs
+        val optConfig = Config.parse(args)
+        optConfig shouldBe empty
+      }
+      "--party and --all-parties" in {
+        val args = defaultRequiredArgs ++ Array("--party", "Alice", "--all-parties")
+        val optConfig = Config.parse(args)
+        optConfig shouldBe empty
       }
     }
     "TLS" - {

--- a/docs/source/tools/export/index.rst
+++ b/docs/source/tools/export/index.rst
@@ -39,8 +39,9 @@ with a running ledger, e.g. with a running ``daml start``.
 
 The ``--party`` flags define which contracts will be included in the export. In
 the above example only contracts visible to the parties Alice and Bob will be
-included in the export. Lack of visibility of certain events may cause
-references to :ref:`unknown contract ids <export-unknown-cids>`.
+included in the export. Alternatively, you can set ``--all-parties`` to export
+contracts seen by all known parties. Lack of visibility of certain events may
+cause references to :ref:`unknown contract ids <export-unknown-cids>`.
 
 The ``--output`` flag defines the directory prefix under which to generate the
 Daml project that contains the Daml script that represents the ledger export.


### PR DESCRIPTION
Closes #10436

Adds an `--all-parties` flag to the Daml ledger export command. If set the tool will query all known parties from the ledger and generated an export of the ledger state as seen by these parties.


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
