### PR TITLE
Move DeduplicationPeriod to ledger-api-domain [KVL-1047]

### DIFF
--- a/ledger/ledger-api-domain/BUILD.bazel
+++ b/ledger/ledger-api-domain/BUILD.bazel
@@ -20,6 +20,7 @@ da_scala_library(
         "//daml-lf/data",
         "//daml-lf/transaction",
         "//ledger/ledger-configuration",
+        "//ledger/ledger-offset",
         "//libs-scala/logging-entries",
     ],
 )

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/DeduplicationPeriod.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/DeduplicationPeriod.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api
 
-import java.time.{Duration, Instant}
+import java.time.Duration
 
 import com.daml.ledger.offset.Offset
 import com.daml.logging.entries.{LoggingValue, ToLoggingValue}
@@ -17,33 +17,6 @@ import com.daml.logging.entries.{LoggingValue, ToLoggingValue}
 sealed trait DeduplicationPeriod extends Product with Serializable
 
 object DeduplicationPeriod {
-
-  /** Backwards compatibility
-    * Transforms the [[period]] into an [[Instant]] to be used for deduplication into the future.
-    * Offset deduplication is not supported
-    * @param time The time to use for calculating the [[Instant]]. It can either be submission time or current time, based on usage
-    * @param period The deduplication period
-    * @param maxSkew Used when the deduplication period is computed from an [[Instant]].
-    */
-  def deduplicateUntil(
-      time: Instant,
-      period: DeduplicationPeriod,
-      maxSkew: Duration,
-  ): Instant = period match {
-    case DeduplicationDuration(duration) =>
-      time.plus(duration)
-    case DeduplicationOffset(_) =>
-      throw new NotImplementedError("Offset deduplication is not supported")
-    case DeduplicationFromTime(start) =>
-      /** deduplication_start: compute the duration as submissionTime + config.minSkew - deduplication_start
-        * We measure `deduplication_start` on the ledger’s clock, and thus need to add the minSkew to compensate for the maximal skew that the participant might be behind the ledger’s clock.
-        */
-      val duration = Duration.between(
-        time.plus(maxSkew),
-        start,
-      )
-      start.plus(duration)
-  }
 
   /** The length of the deduplication window, which ends when the [[WriteService]] or underlying Daml ledger processes
     * the command submission.
@@ -60,14 +33,10 @@ object DeduplicationPeriod {
   /** The `offset` defines the start of the deduplication period. */
   final case class DeduplicationOffset(offset: Offset) extends DeduplicationPeriod
 
-  final case class DeduplicationFromTime(start: Instant) extends DeduplicationPeriod
-
   implicit val `DeduplicationPeriod to LoggingValue`: ToLoggingValue[DeduplicationPeriod] = {
     case DeduplicationDuration(duration) =>
       LoggingValue.Nested.fromEntries("duration" -> duration)
     case DeduplicationOffset(offset) =>
       LoggingValue.Nested.fromEntries("offset" -> offset)
-    case DeduplicationFromTime(time) =>
-      LoggingValue.Nested.fromEntries("time" -> time)
   }
 }

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/DeduplicationPeriod.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/DeduplicationPeriod.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.participant.state.v2
+package com.daml.ledger.api
 
-import java.time.Duration
+import java.time.{Duration, Instant}
 
 import com.daml.ledger.offset.Offset
 import com.daml.logging.entries.{LoggingValue, ToLoggingValue}
@@ -17,6 +17,33 @@ import com.daml.logging.entries.{LoggingValue, ToLoggingValue}
 sealed trait DeduplicationPeriod extends Product with Serializable
 
 object DeduplicationPeriod {
+
+  /** Backwards compatibility
+    * Transforms the [[period]] into an [[Instant]] to be used for deduplication into the future.
+    * Offset deduplication is not supported
+    * @param time The time to use for calculating the [[Instant]]. It can either be submission time or current time, based on usage
+    * @param period The deduplication period
+    * @param maxSkew Used when the deduplication period is computed from an [[Instant]].
+    */
+  def deduplicateUntil(
+      time: Instant,
+      period: DeduplicationPeriod,
+      maxSkew: Duration,
+  ): Instant = period match {
+    case DeduplicationDuration(duration) =>
+      time.plus(duration)
+    case DeduplicationOffset(_) =>
+      throw new NotImplementedError("Offset deduplication is not supported")
+    case DeduplicationFromTime(start) =>
+      /** deduplication_start: compute the duration as submissionTime + config.minSkew - deduplication_start
+        * We measure `deduplication_start` on the ledger’s clock, and thus need to add the minSkew to compensate for the maximal skew that the participant might be behind the ledger’s clock.
+        */
+      val duration = Duration.between(
+        time.plus(maxSkew),
+        start,
+      )
+      start.plus(duration)
+  }
 
   /** The length of the deduplication window, which ends when the [[WriteService]] or underlying Daml ledger processes
     * the command submission.
@@ -33,10 +60,14 @@ object DeduplicationPeriod {
   /** The `offset` defines the start of the deduplication period. */
   final case class DeduplicationOffset(offset: Offset) extends DeduplicationPeriod
 
+  final case class DeduplicationFromTime(start: Instant) extends DeduplicationPeriod
+
   implicit val `DeduplicationPeriod to LoggingValue`: ToLoggingValue[DeduplicationPeriod] = {
     case DeduplicationDuration(duration) =>
       LoggingValue.Nested.fromEntries("duration" -> duration)
     case DeduplicationOffset(offset) =>
       LoggingValue.Nested.fromEntries("offset" -> offset)
+    case DeduplicationFromTime(time) =>
+      LoggingValue.Nested.fromEntries("time" -> time)
   }
 }

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api
 
-import java.time.{Duration, Instant}
+import java.time.Instant
 
 import com.daml.ledger.api.domain.Event.{CreateOrArchiveEvent, CreateOrExerciseEvent}
 import com.daml.ledger.configuration.Configuration
@@ -200,7 +200,7 @@ object domain {
       *
       * This means that the underlying ledger and its validation logic
       * considered the transaction potentially invalid. This can be due to a bug
-      * in the submission or validiation logic, or due to malicious behaviour.
+      * in the submission or validation logic, or due to malicious behaviour.
       */
     final case class Disputed(description: String) extends RejectionReason
 
@@ -283,11 +283,9 @@ object domain {
       actAs: Set[Ref.Party],
       readAs: Set[Ref.Party],
       submittedAt: Instant,
-      deduplicationDuration: Duration,
+      deduplication: DeduplicationPeriod,
       commands: LfCommands,
-  ) {
-    lazy val deduplicateUntil: Instant = submittedAt.plus(deduplicationDuration)
-  }
+  )
 
   object Commands {
 
@@ -302,7 +300,7 @@ object domain {
         "actAs" -> commands.actAs,
         "readAs" -> commands.readAs,
         "submittedAt" -> commands.submittedAt,
-        "deduplicationDuration" -> commands.deduplicationDuration,
+        "deduplication" -> commands.deduplication,
       )
   }
 

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 
 import com.daml.ledger.api.domain.Event.{CreateOrArchiveEvent, CreateOrExerciseEvent}
 import com.daml.ledger.configuration.Configuration
@@ -283,9 +283,11 @@ object domain {
       actAs: Set[Ref.Party],
       readAs: Set[Ref.Party],
       submittedAt: Instant,
-      deduplication: DeduplicationPeriod,
+      deduplicationDuration: Duration,
       commands: LfCommands,
-  )
+  ) {
+    lazy val deduplicateUntil: Instant = submittedAt.plus(deduplicationDuration)
+  }
 
   object Commands {
 
@@ -300,7 +302,7 @@ object domain {
         "actAs" -> commands.actAs,
         "readAs" -> commands.readAs,
         "submittedAt" -> commands.submittedAt,
-        "deduplication" -> commands.deduplication,
+        "deduplicationDuration" -> commands.deduplicationDuration,
       )
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -6,6 +6,7 @@ package com.daml.platform.apiserver.execution
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
+import com.daml.ledger.api.DeduplicationPeriod
 import com.daml.ledger.api.domain.{Commands => ApiCommands}
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.index.v2.{ContractStore, IndexPackagesService}
@@ -79,7 +80,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
               commands.actAs.toList,
               commands.applicationId.unwrap,
               commands.commandId.unwrap,
-              state.DeduplicationPeriod.DeduplicationDuration(commands.deduplicationDuration),
+              DeduplicationPeriod.DeduplicationDuration(commands.deduplicationDuration),
               commands.submissionId.unwrap,
               ledgerConfiguration,
             ),

--- a/ledger/participant-state/BUILD.bazel
+++ b/ledger/participant-state/BUILD.bazel
@@ -29,6 +29,7 @@ da_scala_library(
         "//daml-lf/transaction",
         "//language-support/scala/bindings",
         "//ledger-api/grpc-definitions:ledger_api_proto_scala",
+        "//ledger/ledger-api-domain",
         "//ledger/ledger-api-health",
         "//ledger/ledger-configuration",
         "//ledger/ledger-configuration/protobuf:ledger_configuration_proto_java",

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteService.scala
@@ -7,6 +7,7 @@ import java.time.Instant
 import java.util.concurrent.CompletionStage
 
 import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.api.DeduplicationPeriod
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/CompletionInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/CompletionInfo.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.participant.state.v2
 
+import com.daml.ledger.api.DeduplicationPeriod
 import com.daml.lf.data.Ref
 import com.daml.logging.entries.{LoggingValue, ToLoggingValue}
 

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.participant.state.v2
 
+import com.daml.ledger.api.DeduplicationPeriod
 import com.daml.ledger.configuration.Configuration
 import com.daml.lf.data.Ref
 import com.daml.logging.entries.{LoggingValue, ToLoggingValue}

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/Update.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.participant.state.v2
 import java.time.Duration
 
 import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.api.DeduplicationPeriod
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.grpc.GrpcStatuses
 import com.daml.lf.data.Ref

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -8,6 +8,7 @@ import java.util.UUID
 
 import akka.stream.scaladsl.Sink
 import com.daml.api.util.TimeProvider
+import com.daml.ledger.api.DeduplicationPeriod
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
@@ -96,7 +97,7 @@ class TransactionTimeModelComplianceIT
       actAs = List(Ref.Party.assertFromString("submitter")),
       applicationId = Ref.ApplicationId.assertFromString("appId"),
       commandId = Ref.CommandId.assertFromString(commandId + UUID.randomUUID().toString),
-      deduplicationPeriod = state.DeduplicationPeriod.DeduplicationDuration(JDuration.ZERO),
+      deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(JDuration.ZERO),
       submissionId = Ref.SubmissionId.assertFromString(submissionId),
       ledgerConfiguration = configuration,
     )


### PR DESCRIPTION
- To enable use the reuse of `DeduplicationPeriod`, so it can be passed down from the API to the submitter info
- I'm not at all convinced about this move, please feel free to propose another option

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
