### PR TITLE
Simplify loading of logback file

### DIFF
--- a/ledger-service/cli-opts/BUILD.bazel
+++ b/ledger-service/cli-opts/BUILD.bazel
@@ -16,11 +16,6 @@ da_scala_library(
     ],
     scalacopts = lf_scalacopts,
     tags = ["maven_coordinates=com.daml:http-json-cli-opts:__VERSION__"],
-    versioned_scala_deps = {
-        "2.12": [
-            "@maven//:org_scala_lang_modules_scala_collection_compat",
-        ],
-    },
     visibility = ["//visibility:public"],
     runtime_deps = [
         "@maven//:org_codehaus_janino_janino",


### PR DESCRIPTION
doConfigure accepts a URL which slightly simplifies things.
Really the primary reason why I’m doing this is that it gets veracode
to shut up. I don’t fully understand what it’s worried about in the
first place but it looks like it gets angry about calling openStream
on the resource *shrug*

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
