### PR TITLE
Fix badly versioned empty tx

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -222,7 +222,7 @@ class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableV
       (rtx, _) = result
       validationResult <-
         transaction.Validation
-          .isReplayedBy(transaction.Normalization.normalizeTx(tx), rtx)
+          .isReplayedBy(tx, rtx)
           .fold(
             e => ResultError(Error.Validation.ReplayMismatch(e)),
             _ => ResultDone.Unit,

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -274,7 +274,7 @@ object TransactionBuilder {
   // not valid transactions.
   val Empty: Tx.Transaction =
     VersionedTransaction(
-      TransactionVersion.minNodeVersion,
+      TransactionVersion.minVersion, // A normalized empty tx is V10
       HashMap.empty,
       ImmArray.empty,
     )

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
@@ -45,17 +45,9 @@ class Normalization[Nid, Cid] {
 
   def normalizeTx(vtx: VTX): VTX = {
     vtx match {
-      case VersionedTransaction(_, nodes, roots) =>
-        // TODO: Normalized version calc should be shared with code in asVersionedTransaction
-        val version = roots.iterator.foldLeft(TransactionVersion.minVersion) { (acc, nodeId) =>
-          import scala.Ordering.Implicits.infixOrderingOps
-          nodes(nodeId).optVersion match {
-            case Some(version) => acc max version
-            case None => acc max TransactionVersion.minExceptions
-          }
-        }
+      case VersionedTransaction(_, nodes, _) =>
         VersionedTransaction(
-          version,
+          vtx.version,
           nodes.map { case (k, v) =>
             (k, normNode(v))
           },


### PR DESCRIPTION
Fix badly versioned empty tx
- and so avoid need to call `normalizeTx` from `Engine.validate`
- (and also remove code to recalc the tx-version in `normalizeTx`; we can assume it is correct)

This change fixes the issue discussed here:
https://github.com/digital-asset/daml/pull/10524#discussion_r689270599

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
