### PR TITLE
Support $ in daml-lf identifiers in the parser

### DIFF
--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -43,9 +43,9 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       eToTextTypeConName |
       eThrow |
       (id ^? builtinFunctions) ^^ EBuiltin |
+      experimental |
       caseOf |
       id ^^ EVar |
-      experimental |
       (`(` ~> expr <~ `)`)
 
   lazy val exprs: Parser[List[Expr]] = rep(expr0)
@@ -325,7 +325,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
   )
 
   private lazy val experimental: Parser[Expr] =
-    `$` ~> id ~ typeParser.typ ^^ { case id ~ typ => EExperimental(id, typ) }
+    Id("experimental") ~>! id ~ typeParser.typ ^^ { case id ~ typ => EExperimental(id, typ) }
 
   /* Scenarios */
 

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -67,7 +67,6 @@ private[parser] object Lexer extends RegexParsers {
       "=" ^^^ `=` |
       "_" ^^^ Token.`_` |
       "|" ^^^ `|` |
-      "$" ^^^ `$` |
       """[a-zA-Z_\$][\w\$]*""".r ^^ (s => keywords.getOrElse(s, Id(s))) |
       """#\w+""".r ^^ ContractId |
       """\'([^\\\']|\\\'|\\\\)+\'""".r >> toSimpleString |

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -99,6 +99,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
       val testCases = Table[String, Type](
         "string to parse" -> "expected type",
         "a" -> α,
+        "$alpha$" -> TVar(n"$$alpha$$"),
         "a b" -> TApp(α, β),
         "3" -> TNat(3),
         "a 3" -> TApp(α, TNat(3)),
@@ -360,7 +361,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
     }
 
     "parses properly experiment" in {
-      parseExpr("$ ANSWER (Unit -> Int64)") shouldBe Right(
+      parseExpr("experimental ANSWER (Unit -> Int64)") shouldBe Right(
         EExperimental("ANSWER", t"Unit -> Int64")
       )
     }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -248,7 +248,7 @@ class TypingSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matcher
         E"Λ (σ : ⋆). λ (e₁ : Update σ) (e₂: AnyException → Option (Update σ)) → (( try @σ e₁ catch x → e₂ x ))" ->
           T"∀ (σ : ⋆). Update σ → (AnyException → Option (Update σ)) → Update σ",
         // EExperimental
-        E"$$ ANSWER (Unit -> Int64)" ->
+        E"experimental ANSWER (Unit -> Int64)" ->
           T"Unit -> Int64",
       )
 


### PR DESCRIPTION
These are valid daml-lf identifiers and we use them e.g. in
https://github.com/digital-asset/daml/blob/f8a1820cc8a06bf8f8eb2b521189b7ee17c58dc2/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala#L49.

Arguably `experimental` is also just easier to understand than `$`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
