### PR TITLE
Pruning offset comparisons should not log errors [DPP-557]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/DbDispatcher.scala
@@ -56,7 +56,7 @@ private[platform] final class DbDispatcher private (
           result
         } catch {
           case NonFatal(e) =>
-            logger.error("Exception while executing SQL query. Rolled back.", e)
+            logger.warn("Exception while executing SQL query. Rolled back.", e)
             throw e
           // fatal errors don't make it for some reason to the setUncaughtExceptionHandler
           case t: Throwable =>
@@ -71,7 +71,7 @@ private[platform] final class DbDispatcher private (
             overallExecutionTimer.update(execNanos, TimeUnit.NANOSECONDS)
           } catch {
             case NonFatal(e) =>
-              logger.error("Got an exception while updating timer metrics. Ignoring.", e)
+              logger.warn("Got an exception while updating timer metrics. Ignoring.", e)
           }
         }
       }(executionContext)
@@ -106,7 +106,7 @@ private[platform] object DbDispatcher {
             new ThreadFactoryBuilder()
               .setNameFormat(s"$threadPoolName-%d")
               .setUncaughtExceptionHandler((_, e) =>
-                logger.error("Uncaught exception in the SQL executor.", e)
+                logger.warn("Uncaught exception in the SQL executor.", e)
               )
               .build(),
           ),


### PR DESCRIPTION
Debatable, but the SQL query execution can lead to soft errors, hence the log level change. 
Far from ideal to log everything as WARNs, since query execution errors can be due to programming errors as well, which should definitely be ERROR.

Eager to learn about others' opinions

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
