### PR TITLE
Upgrade Nixpkgs [KVL-1045]

### DIFF
--- a/Upgrading.md
+++ b/Upgrading.md
@@ -22,7 +22,7 @@ bazel run @stackage-unpinned//:pin
 ## Nixpkgs
 
 To update the nixpkgs revision, find a commit in nixkgs-unstable from
-https://github.com/NixOS/nixpkgs-channels/commits/nixpkgs-unstable and
+https://github.com/NixOS/nixpkgs/commits/nixpkgs-unstable and
 use it in the `rev` field in `nix/nixpkgs/default.src.json`.  Set the
 `sha256` to a dummy hash, e.g., 64 zeros and run `nix-build -A tools
 -A cached nix` and nix will tell you the correct hash.

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
@@ -29,7 +29,7 @@ handle
     :: IdeState
     -> CodeLensParams
     -> LSP.LspM c (Either e (List CodeLens))
-handle ide (CodeLensParams{_textDocument=TextDocumentIdentifier uri}) = liftIO $ Right <$> do
+handle ide CodeLensParams{_textDocument=TextDocumentIdentifier uri} = liftIO $ Right <$> do
     mbResult <- case uriToFilePath' uri of
         Just (toNormalizedFilePath' -> filePath) -> do
           logInfo (ideLogger ide) $ "CodeLens request for file: " <> T.pack (fromNormalizedFilePath filePath)

--- a/nix/nixpkgs/default.src.json
+++ b/nix/nixpkgs/default.src.json
@@ -1,6 +1,6 @@
 {
   "owner": "NixOS",
   "repo": "nixpkgs",
-  "rev": "7e567a3d092b7de69cdf5deaeb8d9526de230916",
-  "sha256": "0gnbxg435pnp727gbakifqkjnf2pm7qsq2b6767rj4si4w60v96v"
+  "rev": "253aecf69ed7595aaefabde779aa6449195bebb7",
+  "sha256": "14szn1k345jfm47k6vcgbxprmw1v16n7mvyhcdl7jbjmcggjh4z7"
 }


### PR DESCRIPTION
This upgrade Nixpkgs so that we can use more recent tooling (specifically, `buf`).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
