### PR TITLE
Map shortened scala test suite names to long names on Windows

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -69,6 +69,9 @@ bazel build //... `
 bazel shutdown
 
 if ($env:SKIP_TESTS -ceq "False") {
+    # Generate mapping from shortened scala-test names on Windows to long names on Linux and MacOS.
+    ./ci/remap-scala-test-short-names.ps1 >scala-test-suite-name-map.json
+
     bazel test //... `
       `-`-profile test-profile.json `
       `-`-experimental_profile_include_target_label `

--- a/build.ps1
+++ b/build.ps1
@@ -70,7 +70,8 @@ bazel shutdown
 
 if ($env:SKIP_TESTS -ceq "False") {
     # Generate mapping from shortened scala-test names on Windows to long names on Linux and MacOS.
-    ./ci/remap-scala-test-short-names.ps1 >scala-test-suite-name-map.json
+    ./ci/remap-scala-test-short-names.ps1 `
+      | Out-File -Encoding UTF8 -NoNewline scala-test-suite-name-map.json
 
     bazel test //... `
       `-`-profile test-profile.json `

--- a/ci/remap-scala-test-short-names.ps1
+++ b/ci/remap-scala-test-short-names.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # $ErrorActionPreference = 'Stop' causes the script to fail because Bazel writes to stderr.
 $ErrorActionPreference = 'Continue'
 

--- a/ci/remap-scala-test-short-names.ps1
+++ b/ci/remap-scala-test-short-names.ps1
@@ -17,7 +17,7 @@ if ($scala_test_targets.count -gt 0) {
         @scala_test_targets `
         2>&1; $bazelexitcode=$lastexitcode)`
     | foreach { if ( $_ -match ">>>(?<filename>.*)" ) { Get-Content $Matches.filename } else { $errmsg += $_ } } `
-    | jq -s "map({key:.short_label,value:.long_label})|from_entries"
+    | jq -acsS "map({key:.short_label,value:.long_label})|from_entries"
 
   if ($lastexitcode -ne 0) {
     throw "jq returned non-zero exit code: $lastexitcode"

--- a/ci/remap-scala-test-short-names.ps1
+++ b/ci/remap-scala-test-short-names.ps1
@@ -8,23 +8,61 @@ if ($lastexitcode -ne 0) {
 
 if ($scala_test_targets.count -gt 0) {
 
-  [string]$errmsg = ""
+  try {
 
-  $(& bazel.exe build `
-        `-`-aspects=//bazel_tools:scala.bzl%da_scala_test_short_name_aspect `
-        `-`-output_groups=scala_test_info `
-        `-`-experimental_show_artifacts `
+    # Bazel writes the output of --experimental_show_artifacts to stderr
+    # instead of stdout. In Powershell this means that these outputs are not
+    # plain strings, but instead error objects. Simply redirecting these to
+    # stdout and piping them into further processing will lead to
+    # indeterministically missing items or indeterministically introduced
+    # additional newlines which may break paths.
+    #
+    # To work around this we extract the error message from error objects,
+    # introduce appropriate newlines, and write the output to a temporary file
+    # before further processing.
+    #
+    # This solution is taken and adapted from
+    # https://stackoverflow.com/a/48671797/841562
+    $bazelexitcode = 0
+    $tmp = New-TemporaryFile
+    try {
+      $append = $false
+      $out = [System.IO.StreamWriter]::new($tmp, $append)
+      bazel.exe build `
+        "--aspects=//bazel_tools:scala.bzl%da_scala_test_short_name_aspect" `
+        "--output_groups=scala_test_info" `
+        "--experimental_show_artifacts" `
         @scala_test_targets `
-        2>&1; $bazelexitcode=$lastexitcode)`
-    | foreach { if ( $_ -match ">>>(?<filename>.*)" ) { Get-Content $Matches.filename } else { $errmsg += $_ } } `
-    | jq -acsS "map({key:.short_label,value:.long_label})|from_entries"
+        2>&1 | % {
+          if ($_ -is [System.Management.Automation.ErrorRecord]) {
+            if ($_.TargetObject -ne $null) {
+              $out.WriteLine();
+            }
+            $out.Write($_.Exception.Message)
+          } else {
+            $out.WriteLine($_)
+          }
+        }
+      $bazelexitcode = $lastexitcode
+    } finally {
+      $out.Close()
+    }
 
-  if ($lastexitcode -ne 0) {
-    throw "jq returned non-zero exit code: $lastexitcode"
-  }
-  if ($bazelexitcode -ne 0) {
-    Write-Error -Message "$errmsg"
-    throw "bazel build returned non-zero exit code: $lastexitcode"
+    if ($bazelexitcode -ne 0) {
+      $errmsg = Get-Content $tmp
+      Write-Error -Message "$errmsg"
+      throw "bazel build returned non-zero exit code: $lastexitcode"
+    }
+
+    Get-Content $tmp |
+      % { if ( $_ -match ">>>(?<filename>.*)" ) { Get-Content $Matches.filename } } |
+      jq -acsS "map({key:.short_label,value:.long_label})|from_entries"
+
+    if ($lastexitcode -ne 0) {
+      throw "jq returned non-zero exit code: $lastexitcode"
+    }
+  } finally {
+    Remove-Item $tmp
   }
 
 }

--- a/ci/remap-scala-test-short-names.ps1
+++ b/ci/remap-scala-test-short-names.ps1
@@ -1,0 +1,30 @@
+# $ErrorActionPreference = 'Stop' causes the script to fail because Bazel writes to stderr.
+$ErrorActionPreference = 'Continue'
+
+[string[]]$scala_test_targets = bazel.exe query "kind(scala_test, deps(kind(test_suite, //...), 1))"
+if ($lastexitcode -ne 0) {
+  throw "bazel query returned non-zero exit code: $lastexitcode"
+}
+
+if ($scala_test_targets.count -gt 0) {
+
+  [string]$errmsg = ""
+
+  $(& bazel.exe build `
+        `-`-aspects=//bazel_tools:scala.bzl%da_scala_test_short_name_aspect `
+        `-`-output_groups=scala_test_info `
+        `-`-experimental_show_artifacts `
+        @scala_test_targets `
+        2>&1; $bazelexitcode=$lastexitcode)`
+    | foreach { if ( $_ -match ">>>(?<filename>.*)" ) { Get-Content $Matches.filename } else { $errmsg += $_ } } `
+    | jq -s "map({key:.short_label,value:.long_label})|from_entries"
+
+  if ($lastexitcode -ne 0) {
+    throw "jq returned non-zero exit code: $lastexitcode"
+  }
+  if ($bazelexitcode -ne 0) {
+    Write-Error -Message "$errmsg"
+    throw "bazel build returned non-zero exit code: $lastexitcode"
+  }
+
+}

--- a/ci/upload-bazel-metrics.yml
+++ b/ci/upload-bazel-metrics.yml
@@ -50,7 +50,7 @@ steps:
       target_dir="$(Build.StagingDirectory)/$(pipeline_id)"
       mkdir -p "$target_dir"
       cp "job-md.json" "$target_dir/job-md.json"
-      for log_file in 'build-profile.json' 'build-events.json' 'test-profile.json' 'test-events.json'; do
+      for log_file in 'build-profile.json' 'build-events.json' 'test-profile.json' 'test-events.json' 'scala-test-suite-name-map.json'; do
         [[ -f "$log_file" ]] && cp "$log_file" "$target_dir/$log_file" || echo "$log_file not found"
       done
       cd "$(Build.StagingDirectory)"


### PR DESCRIPTION
Generates a JSON file on Windows builds mapping shortened Scala test labels to their long counterparts. An example can be seen [here](https://gist.github.com/aherrmann/a674e4c39598eb4d16256ed882a0c88d). And patches the Windows Bazel metrics before uploading them to ElasticSearch.

`da_scala_test_suite` generates one `scala_test` target per Scala source file in `srcs`. The name of the generated test target is based on the path of the source file. On Linux and MacOS this target name has the form `//libs-scala/grpc-reverse-proxy:test_test_suite_src_test_scala_com_daml_grpc_ReverseProxySpec.scala` on Windows it [is shortened](https://github.com/bazelbuild/rules_scala/blob/c997c444a3a3bb8b6a3f8076a64ab9edb8c918b3/scala/private/rules/scala_test.bzl#L136) to the form `//libs-scala/grpc-reverse-proxy:test_1`. This differenence causes Windows tests to be reported separately from their Linux and MacOS counterparts in the Bazel Kibana dashboard. Using the mapping file generated with this PR we can replace the shortened names by longer names for reporting purposes.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
