### PR TITLE
LF: Comparisons fail at runtime if comparing local vs global CIDs

### DIFF
--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -73,6 +73,7 @@ da_scala_test_suite(
         "//daml-lf/transaction-test-lib",
         "//daml-lf/validation",
         "//libs-scala/logging-entries",
+        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_scalatest_scalatest_compatible",
         "@maven//:org_slf4j_slf4j_api",
     ],

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -96,8 +96,8 @@ private[lf] object Pretty {
         text("Update failed due to a unknown contract") & prettyContractId(cid)
       case NonComparableValues =>
         text("functions are not comparable")
-      case ContractIdFreshness(_) =>
-        text("Conflicting discriminators between a local and global contract id")
+      case ContractIdFreshness(globalCid) =>
+        text(s"The global contract ID $globalCid conflicts with a local contract ID")
       case ContractIdInContractKey(key) =>
         text(
           s"Contract IDs are not supported in contract keys: ${key.ensureNoCid.left.toOption.get}"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
@@ -5,6 +5,7 @@ package com.daml.lf
 package speedy
 package svalue
 
+import com.daml.lf.value.Value.ContractId
 import com.daml.nameof.NameOf
 
 import scala.jdk.CollectionConverters._
@@ -38,7 +39,24 @@ private[lf] object Equality {
     def step(tuple: (SValue, SValue)) =
       tuple match {
         case (x: SPrimLit, y: SPrimLit) =>
-          success = x == y
+          success =
+            if (x == y)
+              true
+            else
+              tuple match {
+                case (
+                      SContractId(cid1 @ ContractId.V1(discriminator1, suffix1)),
+                      SContractId(cid2 @ ContractId.V1(discriminator2, suffix2)),
+                    ) if discriminator1 == discriminator2 =>
+                  if (suffix1.isEmpty)
+                    throw SError.SErrorDamlException(interpretation.Error.ContractIdFreshness(cid2))
+                  else if (suffix2.isEmpty)
+                    throw SError.SErrorDamlException(interpretation.Error.ContractIdFreshness(cid1))
+                  else
+                    false
+                case _ =>
+                  false
+              }
         case (SEnum(_, _, xRank), SEnum(_, _, yRank)) =>
           success = xRank == yRank
         case (SRecord(_, _, xs), SRecord(_, _, ys)) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Ordering.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Ordering.scala
@@ -107,35 +107,32 @@ object Ordering extends scala.math.Ordering[SValue] {
   }
   @inline
   private[this] def compareCid(cid1: ContractId, cid2: ContractId): Int = {
-    cid1 match {
-      case ContractId.V0(s1) =>
-        cid2 match {
-          case ContractId.V0(s2) =>
-            s1 compareTo s2
-          case _: ContractId.V1 =>
-            -1
-        }
-      case cid1 @ ContractId.V1(discriminator1, suffix1) =>
-        cid2 match {
-          case _: ContractId.V0 =>
-            +1
-          case cid2 @ ContractId.V1(discriminator2, suffix2) =>
-            val c1 = crypto.Hash.ordering.compare(discriminator1, discriminator2)
-            if (c1 != 0) {
-              c1
-            } else if (suffix1.isEmpty) {
-              if (suffix2.isEmpty) {
-                0
-              } else {
-                throw SError.SErrorDamlException(interpretation.Error.ContractIdFreshness(cid2))
-              }
-            } else {
-              if (suffix2.isEmpty) {
-                throw SError.SErrorDamlException(interpretation.Error.ContractIdFreshness(cid1))
-              } else {
-                Bytes.ordering.compare(suffix1, suffix2)
-              }
-            }
+    (cid1, cid2) match {
+      case (ContractId.V0(s1), ContractId.V0(s2)) =>
+        s1 compareTo s2
+      case (_: ContractId.V0, _: ContractId.V1) =>
+        -1
+      case (_: ContractId.V1, _: ContractId.V0) =>
+        +1
+      case (
+            cid1 @ ContractId.V1(discriminator1, suffix1),
+            cid2 @ ContractId.V1(discriminator2, suffix2),
+          ) =>
+        val c1 = crypto.Hash.ordering.compare(discriminator1, discriminator2)
+        if (c1 != 0) {
+          c1
+        } else if (suffix1.isEmpty) {
+          if (suffix2.isEmpty) {
+            0
+          } else {
+            throw SError.SErrorDamlException(interpretation.Error.ContractIdFreshness(cid2))
+          }
+        } else {
+          if (suffix2.isEmpty) {
+            throw SError.SErrorDamlException(interpretation.Error.ContractIdFreshness(cid1))
+          } else {
+            Bytes.ordering.compare(suffix1, suffix2)
+          }
         }
     }
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
@@ -1,0 +1,66 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+package svalue
+
+import com.daml.lf.crypto
+import com.daml.lf.data.Bytes
+import com.daml.lf.interpretation.Error.ContractIdFreshness
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.value.Value
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.util.{Failure, Try}
+
+class EqualitySpec extends AnyWordSpec with Inside with Matchers with ScalaCheckPropertyChecks {
+
+  "Equality.areEquals" should {
+
+    "fail when trying to compare local contract ID with global contract ID with same discriminator" in {
+
+      val discriminator1 = crypto.Hash.hashPrivateKey("discriminator1")
+      val discriminator2 = crypto.Hash.hashPrivateKey("discriminator2")
+      val suffix1 = Bytes.assertFromString("00")
+      val suffix2 = Bytes.assertFromString("01")
+
+      val cid10 = Value.ContractId.V1(discriminator1, Bytes.Empty)
+      val cid11 = Value.ContractId.V1(discriminator1, suffix1)
+      val cid12 = Value.ContractId.V1(discriminator1, suffix2)
+      val cid21 = Value.ContractId.V1(discriminator2, suffix1)
+
+      val List(vCid10, vCid11, vCid12, vCid21) = List(cid10, cid11, cid12, cid21).map(SContractId)
+
+      val negativeTestCases =
+        Table(
+          "cid1" -> "cid2",
+          vCid10 -> vCid10,
+          vCid11 -> vCid11,
+          vCid11 -> vCid12,
+          vCid11 -> vCid21,
+        )
+
+      val positiveTestCases = Table(
+        "glovalCid2",
+        cid11,
+        cid12,
+      )
+
+      forEvery(negativeTestCases) { (cid1, cid2) =>
+        Equality.areEqual(cid1, cid2) shouldBe cid1 == cid2
+        Equality.areEqual(cid2, cid1) shouldBe cid1 == cid2
+      }
+
+      forEvery(positiveTestCases) { globalCid =>
+        Try(Equality.areEqual(vCid10, SContractId(globalCid))) shouldBe
+          Failure(SError.SErrorDamlException(ContractIdFreshness(globalCid)))
+        Try(Equality.areEqual(SContractId(globalCid), vCid10)) shouldBe
+          Failure(SError.SErrorDamlException(ContractIdFreshness(globalCid)))
+      }
+
+    }
+  }
+}

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -5,7 +5,7 @@ package com.daml.lf.speedy
 package svalue
 
 import com.daml.lf.crypto
-import com.daml.lf.data.{FrontStack, Ref}
+import com.daml.lf.data.{Bytes, FrontStack, Ref}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SExpr.{SEApp, SEImportValue, SELocA, SEMakeClo}
@@ -14,8 +14,10 @@ import com.daml.lf.value.test.TypedValueGenerators.genAddend
 import com.daml.lf.value.test.ValueGenerators.{cidV0Gen, comparableCoidsGen}
 import com.daml.lf.PureCompiledPackages
 import com.daml.lf.iface
+import com.daml.lf.interpretation.Error.ContractIdFreshness
 import com.daml.lf.language.{Ast, Util => AstUtil}
 import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.Inside
 import org.scalatest.prop.TableFor2
 import org.scalatestplus.scalacheck.{
   Checkers,
@@ -29,9 +31,11 @@ import scalaz.syntax.order._
 import scalaz.scalacheck.{ScalazProperties => SzP}
 
 import scala.language.implicitConversions
+import scala.util.{Failure, Try}
 
 class OrderingSpec
     extends AnyWordSpec
+    with Inside
     with Matchers
     with Checkers
     with ScalaCheckDrivenPropertyChecks
@@ -131,6 +135,49 @@ class OrderingSpec
         forAll(coidGen, coidGen, minSuccessful(50)) { (a, b) =>
           Cid.`Cid Order`.order(a, b) should ===(cidOrd.order(a, b))
         }
+    }
+
+    "fail when trying to compare local contract ID with global contract ID with same discriminator" in {
+
+      val discriminator1 = crypto.Hash.hashPrivateKey("discriminator1")
+      val discriminator2 = crypto.Hash.hashPrivateKey("discriminator2")
+      val suffix1 = Bytes.assertFromString("00")
+      val suffix2 = Bytes.assertFromString("01")
+
+      val cid10 = Value.ContractId.V1(discriminator1, Bytes.Empty)
+      val cid11 = Value.ContractId.V1(discriminator1, suffix1)
+      val cid12 = Value.ContractId.V1(discriminator1, suffix2)
+      val cid21 = Value.ContractId.V1(discriminator2, suffix1)
+
+      val List(vCid10, vCid11, vCid12, vCid21) = List(cid10, cid11, cid12, cid21).map(SContractId)
+
+      val negativeTestCases =
+        Table(
+          "cid1" -> "cid2",
+          vCid10 -> vCid10,
+          vCid11 -> vCid11,
+          vCid11 -> vCid12,
+          vCid11 -> vCid21,
+        )
+
+      val positiveTestCases = Table(
+        "glovalCid2",
+        cid11,
+        cid12,
+      )
+
+      forEvery(negativeTestCases) { (cid1, cid2) =>
+        Ordering.compare(cid1, cid2) == 0 shouldBe cid1 == cid2
+        Ordering.compare(cid2, cid1) == 0 shouldBe cid1 == cid2
+      }
+
+      forEvery(positiveTestCases) { globalCid =>
+        Try(Ordering.compare(vCid10, SContractId(globalCid))) shouldBe
+          Failure(SError.SErrorDamlException(ContractIdFreshness(globalCid)))
+        Try(Ordering.compare(SContractId(globalCid), vCid10)) shouldBe
+          Failure(SError.SErrorDamlException(ContractIdFreshness(globalCid)))
+      }
+
     }
   }
 

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -100,7 +100,7 @@ object Error {
   // as are not serializable.
   final case object NonComparableValues extends Error
 
-  final case class ContractIdFreshness(discriminator: crypto.Hash) extends Error
+  final case class ContractIdFreshness(globalCid: ContractId.V1) extends Error
 
   final case class ContractIdInContractKey(key: Value[ContractId]) extends Error
 


### PR DESCRIPTION
This PR enforces that LF Comparisons (both Ordering and Equality)
fails at runtime if comparing local vs global CID.

This corresponds to the second task of #10504.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
