### PR TITLE
[JSON-API] key_hash field to speed up fetchByKey queries

### DIFF
--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -41,6 +41,7 @@ da_scala_library(
     ],
     deps = [
         "//daml-lf/data",
+        "//daml-lf/transaction",
         "//libs-scala/scala-utils",
     ],
 )

--- a/ledger-service/http-json-perf/README.md
+++ b/ledger-service/http-json-perf/README.md
@@ -16,7 +16,7 @@ Gatling scenarios extend from `io.gatling.core.scenario.Simulation`:
 - `com.daml.http.perf.scenario.SyncQueryConstantAcs`
 - `com.daml.http.perf.scenario.SyncQueryNewAcs`
 - `com.daml.http.perf.scenario.SyncQueryVariableAcs`
-- `com.daml.http.perf.scenario.MultiUserQueryScenario`
+- `com.daml.http.perf.scenario.OracleMultiUserQueryScenario`
 
 # 2. Running Gatling Scenarios from Bazel
 
@@ -34,9 +34,9 @@ $ bazel run //ledger-service/http-json-perf:http-json-perf-binary -- \
 --jwt="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU"
 ```
 
-## 2.3 Running MultiUserQueryScenario
+## 2.3 Running OracleMultiUserQueryScenario
 
-Preferably retain the data between runs to specifically focus on testing query performance.
+We use an external docker oracle vm, so we want to retain the data between runs to specifically focus on testing query performance.
 use `RETAIN_DATA` and `USE_DEFAULT_USER` env vars to use a static user(`ORACLE_USER`) and preserve data.
 This scenario uses a single template `KeyedIou` defined in `LargeAcs.daml`.
 
@@ -48,7 +48,7 @@ We can control a few scenario parameters i.e `NUM_RECORDS` `NUM_QUERIES` `NUM_RE
 
 ```
 
-USE_DEFAULT_USER=true RETAIN_DATA=true RUN_MODE="populateCache" bazel run //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.MultiUserQueryScenario --jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU --dars=$PWD/bazel-bin/ledger-service/http-json-perf/LargeAcs.dar --query-store-index oracle
+USE_DEFAULT_USER=true RETAIN_DATA=true RUN_MODE="populateCache" bazel run //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.OracleMultiUserQueryScenario --jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU --dars=$PWD/bazel-bin/ledger-service/http-json-perf/LargeAcs.dar --query-store-index oracle
 
 ```
 
@@ -58,7 +58,7 @@ Query contracts by the defined key field.
 
 ```
 
-USE_DEFAULT_USER=true RETAIN_DATA=true RUN_MODE="fetchByKey" NUM_QUERIES=100 bazel run //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.MultiUserQueryScenario --jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU --dars=$PWD/bazel-bin/ledger-service/http-json-perf/LargeAcs.dar --query-store-index oracle
+USE_DEFAULT_USER=true RETAIN_DATA=true RUN_MODE="fetchByKey" NUM_QUERIES=100 bazel run //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.OracleMultiUserQueryScenario --jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU --dars=$PWD/bazel-bin/ledger-service/http-json-perf/LargeAcs.dar --query-store-index oracle
 
 ```
 
@@ -68,7 +68,7 @@ Query contracts by a field on the payload which is the `id` in this case.
 
 ```
 
-USE_DEFAULT_USER=true RETAIN_DATA=true RUN_MODE="fetchByQuery" bazel run //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.MultiUserQueryScenario --jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU --dars=$PWD/bazel-bin/ledger-service/http-json-perf/LargeAcs.dar --query-store-index oracle
+USE_DEFAULT_USER=true RETAIN_DATA=true RUN_MODE="fetchByQuery" bazel run //ledger-service/http-json-perf:http-json-perf-binary-ee -- --scenario=com.daml.http.perf.scenario.OracleMultiUserQueryScenario --jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU --dars=$PWD/bazel-bin/ledger-service/http-json-perf/LargeAcs.dar --query-store-index oracle
 
 ```
 

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
@@ -219,7 +219,6 @@ object Main extends StrictLogging {
           user.name,
           user.pwd,
           dbStartupMode = startupMode,
-          connectionTimeout = 15000, // increase value for performance tests
         )
       }
 

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/OracleMultiUserQueryScenario.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/OracleMultiUserQueryScenario.scala
@@ -3,7 +3,7 @@
 
 package com.daml.http.perf.scenario
 
-import com.daml.http.perf.scenario.MultiUserQueryScenario._
+import com.daml.http.perf.scenario.OracleMultiUserQueryScenario._
 import io.gatling.core.Predef._
 import io.gatling.core.structure.PopulationBuilder
 import io.gatling.http.Predef._
@@ -19,7 +19,7 @@ private[scenario] trait HasRandomCurrency {
   }
 }
 
-object MultiUserQueryScenario {
+object OracleMultiUserQueryScenario {
   sealed trait RunMode { def name: String }
   case object PopulateCache extends RunMode { val name = "populateCache" }
   case object FetchByKey extends RunMode { val name = "fetchByKey" }
@@ -27,7 +27,7 @@ object MultiUserQueryScenario {
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-class MultiUserQueryScenario
+class OracleMultiUserQueryScenario
     extends Simulation
     with SimulationConfig
     with HasRandomAmount
@@ -142,11 +142,10 @@ class MultiUserQueryScenario
   def getPopulationBuilder(runMode: RunMode): PopulationBuilder = {
     runMode match {
       case PopulateCache =>
-        val currIter = currencies.iterator
         writeScn
           .inject(atOnceUsers(numWriters))
           .andThen(
-            currQueryScn(numIterations = currencies.size, () => currIter.next())
+            currQueryScn(numIterations = 1, () => currencies.head)
               .inject(
                 nothingFor(2.seconds),
                 atOnceUsers(1),

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
@@ -56,7 +56,7 @@ abstract class ContractDaoBenchmark extends OracleAround {
     contractId = s"#$id",
     templateId = tpid,
     key = JsNull,
-    keyHash = "",
+    keyHash = None,
     payload = payload,
     signatories = Seq(signatory),
     observers = Seq.empty,

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
@@ -56,6 +56,7 @@ abstract class ContractDaoBenchmark extends OracleAround {
     contractId = s"#$id",
     templateId = tpid,
     key = JsNull,
+    keyHash = "",
     payload = payload,
     signatories = Seq(signatory),
     observers = Seq.empty,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -189,12 +189,10 @@ private class ContractsFetch(
       contractId = ac.contractId.unwrap,
       templateId = ac.templateId,
       key = lfKey.cata(lfValueToDbJsValue, JsNull),
-      keyHash = lfKey.cata(
+      keyHash = lfKey.map(
         Hash
           .assertHashContractKey(TemplateId.toLedgerApiValue(ac.templateId), _)
           .toHexString
-          .toString,
-        "",
       ),
       payload = lfValueToDbJsValue(lfArg),
       signatories = ac.signatories,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -178,6 +178,7 @@ private class ContractsFetch(
   ): Exception \/ PreInsertContract = {
     import scalaz.syntax.traverse._
     import scalaz.std.option._
+    import com.daml.lf.crypto.Hash
     for {
       ac <- domain.ActiveContract fromLedgerApi ce leftMap (de =>
         new IllegalArgumentException(s"contract ${ce.contractId}: ${de.shows}"): Exception,
@@ -188,6 +189,13 @@ private class ContractsFetch(
       contractId = ac.contractId.unwrap,
       templateId = ac.templateId,
       key = lfKey.cata(lfValueToDbJsValue, JsNull),
+      keyHash = lfKey.cata(
+        Hash
+          .assertHashContractKey(TemplateId.toLedgerApiValue(ac.templateId), _)
+          .toHexString
+          .toString,
+        "",
+      ),
       payload = lfValueToDbJsValue(lfArg),
       signatories = ac.signatories,
       observers = ac.observers,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -8,6 +8,7 @@ import cats.syntax.apply._
 import com.daml.doobie.logging.Slf4jLogHandler
 import com.daml.http.domain
 import com.daml.http.json.JsonProtocol.LfValueDatabaseCodec
+import com.daml.lf.crypto.Hash
 import com.daml.scalautil.nonempty.+-:
 import doobie.LogHandler
 import doobie.free.connection.ConnectionIO
@@ -233,7 +234,7 @@ object ContractDao {
   private[http] def fetchByKey(
       parties: OneAnd[Set, domain.Party],
       templateId: domain.TemplateId.RequiredPkg,
-      key: JsValue,
+      key: Hash,
   )(implicit
       log: LogHandler,
       sjd: SupportedJdbcDriver,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -268,6 +268,13 @@ object domain {
         Ref.DottedName.assertFromString(a.moduleName),
         Ref.DottedName.assertFromString(a.entityName),
       )
+
+    def toLedgerApiValue(a: RequiredPkg): Ref.Identifier = {
+      val qfName = qualifiedName(a)
+      val packageId = Ref.PackageId.assertFromString(a.packageId)
+      Ref.Identifier(packageId, qfName)
+    }
+
   }
 
   object Contract {


### PR DESCRIPTION
Addition of a key_hash field to speed up fetchByKey queries

Based on gatling perf tests

baseline
```
> Number of requests                                  1000 (OK=1000   KO=-     )
> Min. response time                                   487 (OK=487    KO=-     )
> Max. response time                                  4631 (OK=4631   KO=-     )
> Mean response time                                  2462 (OK=2462   KO=-     )
> Std. deviation                                       787 (OK=787    KO=-     )
> response time 90th percentile                       2507 (OK=2507   KO=-     )
> response time 95th percentile                       3002 (OK=3002   KO=-     )
> response time 99th percentile                       3637 (OK=3637   KO=-     )
> response time 99.9th percentile                     4126 (OK=4126   KO=-     )
> Mean requests/second                               3.906 (OK=3.906  KO=-     )
---- Response time distribution ------------------------------------------------
> t < 800 ms                                             7 (  1%)
> 800 ms < t < 1200 ms                                  67 (  7%)
> t > 1200 ms                                          926 ( 93%)
> failed                                                 0 (  -%)
```

query using hashed key field
```
> Number of requests                                  1000 (OK=1000   KO=-     )
> Min. response time                                   206 (OK=206    KO=-     )
> Max. response time                                  2893 (OK=2893   KO=-     )
> Mean response time                                  1074 (OK=1074   KO=-     )
> Std. deviation                                       348 (OK=348    KO=-     )
> response time 90th percentile                       1100 (OK=1100   KO=-     )
> response time 95th percentile                       1330 (OK=1330   KO=-     )
> response time 99th percentile                       1577 (OK=1577   KO=-     )
> response time 99.9th percentile                     1832 (OK=1832   KO=-     )
> Mean requests/second                                8.85 (OK=8.85   KO=-     )
---- Response time distribution ------------------------------------------------
> t < 800 ms                                           217 ( 22%)
> 800 ms < t < 1200 ms                                 422 ( 42%)
> t > 1200 ms                                          361 ( 36%)
> failed                                                 0 (  -%)
```

changelog_begin
- Update schema version for http-json-api query store with new key_hash field
- Improved performance for fetchByKey query which now uses key_hash field
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
