### PR TITLE
[Divulgence pruning] Added `prune_all_divulged_contracts` to PruneRequest [DPP-534]

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
@@ -50,7 +50,7 @@ message PruneRequest {
   // Optional, defaults to a random identifier, used for logging.
   string submission_id = 2;
 
-  // Prune all immediate and retroactive divulged contracts created before `prune_up_to`
+  // Prune all immediately and retroactively divulged contracts created before `prune_up_to`
   // independent of whether they were archived before `prune_up_to`. Useful to avoid leaking
   // storage on participant nodes that can see a divulged contract but not its archival.
   //

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
@@ -39,12 +39,29 @@ service ParticipantPruningService {
 }
 
 message PruneRequest {
-  // Inclusive offset up to and at which the ledger is to be pruned.
+  // Inclusive offset up to which the ledger is to be pruned.
+  // By default the following data is pruned:
+  //   1. All normal and divulged contracts that have been archived before
+  //   `prune_up_to`.
+  //   2. All transaction events and completions before `prune_up_to`
   string prune_up_to = 1;
 
   // Unique submission identifier.
   // Optional, defaults to a random identifier, used for logging.
   string submission_id = 2;
+
+  // Prune all immediate and retroactive divulged contracts created before `prune_up_to`
+  // independent of whether they were archived before `prune_up_to`. Useful to avoid leaking
+  // storage on participant nodes that can see a divulged contract but not its archival.
+  //
+  // Application developers SHOULD write their Daml applications
+  // such that they do not rely on divulged contracts; i.e., no warnings from
+  // using divulged contracts as inputs to transactions are emitted.
+  //
+  // Participant node operators SHOULD set this flag to avoid leaking
+  // storage due to accumulating unarchived divulged contracts PROVIDED no
+  // application using this participant node relies on divulgence.
+  bool prune_all_divulged_contracts = 3;
 }
 
 message PruneResponse {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -724,7 +724,8 @@ private[testtool] final class ParticipantTestContext private[participant] (
   def prune(
       pruneUpTo: LedgerOffset,
       attempts: Int = 10,
-      pruneAllDivulgedContracts: Boolean = true,
+      // TODO Divulgence pruning: Change default to `true` once all divulgence pruning is implemented
+      pruneAllDivulgedContracts: Boolean = false,
   ): Future[PruneResponse] =
     prune(pruneUpTo.getAbsolute, attempts, pruneAllDivulgedContracts)
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -706,17 +706,27 @@ private[testtool] final class ParticipantTestContext private[participant] (
   ): Future[SetTimeModelResponse] =
     services.configManagement.setTimeModel(request)
 
-  def prune(pruneUpTo: String, attempts: Int): Future[PruneResponse] =
+  def prune(
+      pruneUpTo: String,
+      attempts: Int,
+      pruneAllDivulgedContracts: Boolean,
+  ): Future[PruneResponse] =
     // Distributed ledger participants need to reach global consensus prior to pruning. Hence the "eventually" here:
     eventually(
       attempts = attempts,
       runAssertion = {
-        services.participantPruning.prune(PruneRequest(pruneUpTo, nextSubmissionId()))
+        services.participantPruning.prune(
+          PruneRequest(pruneUpTo, nextSubmissionId(), pruneAllDivulgedContracts)
+        )
       },
     )
 
-  def prune(pruneUpTo: LedgerOffset, attempts: Int = 10): Future[PruneResponse] =
-    prune(pruneUpTo.getAbsolute, attempts)
+  def prune(
+      pruneUpTo: LedgerOffset,
+      attempts: Int = 10,
+      pruneAllDivulgedContracts: Boolean = true,
+  ): Future[PruneResponse] =
+    prune(pruneUpTo.getAbsolute, attempts, pruneAllDivulgedContracts)
 
   private[infrastructure] def preallocateParties(
       n: Int,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
@@ -32,7 +32,8 @@ class ParticipantPruningIT extends LedgerTestSuite {
   )(implicit ec => { case Participants(Participant(participant)) =>
     for {
       failure <- participant
-        .prune("", attempts = 1, pruneAllDivulgedContracts = true)
+        // TODO Divulgence pruning: Change to `true` once all divulgence pruning is implemented
+        .prune("", attempts = 1, pruneAllDivulgedContracts = false)
         .mustFail("pruning without specifying an offset")
     } yield {
       assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "prune_up_to not specified")
@@ -46,7 +47,8 @@ class ParticipantPruningIT extends LedgerTestSuite {
   )(implicit ec => { case Participants(Participant(participant)) =>
     for {
       cannotPruneNonHexOffset <- participant
-        .prune("cofefe", attempts = 1, pruneAllDivulgedContracts = true)
+        // TODO Divulgence pruning: Change to `true` once all divulgence pruning is implemented
+        .prune("covfefe", attempts = 1, pruneAllDivulgedContracts = false)
         .mustFail("pruning, specifiying a non-hexadecimal offset")
     } yield {
       assertGrpcError(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
@@ -32,7 +32,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
   )(implicit ec => { case Participants(Participant(participant)) =>
     for {
       failure <- participant
-        .prune("", attempts = 1)
+        .prune("", attempts = 1, pruneAllDivulgedContracts = true)
         .mustFail("pruning without specifying an offset")
     } yield {
       assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "prune_up_to not specified")
@@ -46,7 +46,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
   )(implicit ec => { case Participants(Participant(participant)) =>
     for {
       cannotPruneNonHexOffset <- participant
-        .prune("cofefe", attempts = 1)
+        .prune("cofefe", attempts = 1, pruneAllDivulgedContracts = true)
         .mustFail("pruning, specifiying a non-hexadecimal offset")
     } yield {
       assertGrpcError(

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
@@ -73,10 +73,11 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
   override def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
+      pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[PruningResult] =
     Timed.completionStage(
       metrics.daml.services.write.prune,
-      delegate.prune(pruneUpToInclusive, submissionId),
+      delegate.prune(pruneUpToInclusive, submissionId, pruneAllDivulgedContracts),
     )
 
   override def currentHealth(): HealthStatus =

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
@@ -73,10 +73,11 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
   override def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
+      pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[PruningResult] =
     Timed.completionStage(
       metrics.daml.services.write.prune,
-      delegate.prune(pruneUpToInclusive, submissionId),
+      delegate.prune(pruneUpToInclusive, submissionId, pruneAllDivulgedContracts),
     )
 
   override def currentHealth(): HealthStatus =

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -67,6 +67,8 @@ da_scala_library(
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_dropwizard_metrics_metrics_core",
+        # TODO Divulgence pruning: Remove once KeyValueParticipantStateWriter doesn't need to return UNIMPLEMENTED for prune
+        "@maven//:io_grpc_grpc_api",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
@@ -90,8 +90,9 @@ class KeyValueParticipantState(
   override def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
+      pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[PruningResult] =
-    writerAdapter.prune(pruneUpToInclusive, submissionId)
+    writerAdapter.prune(pruneUpToInclusive, submissionId, pruneAllDivulgedContracts)
 
   override def currentHealth(): HealthStatus =
     reader.currentHealth() and writer.currentHealth()

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -23,6 +23,7 @@ import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.metrics.Metrics
 import com.daml.telemetry.TelemetryContext
+import io.grpc.Status
 
 import scala.compat.java8.FutureConverters
 
@@ -115,6 +116,13 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
       submissionId: Ref.SubmissionId,
       pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[PruningResult] =
-    // kvutils has no participant local state to prune, so return success to let participant pruning proceed elsewhere.
-    CompletableFuture.completedFuture(PruningResult.ParticipantPruned)
+    if (pruneAllDivulgedContracts) {
+      // Pruning of all divulged contracts is not yet implemented
+      // TODO Divulgence pruning: Remove `UNIMPLEMENTED` branch
+      //                          after all divulgence pruning is implemented.
+      CompletableFuture.completedFuture(PruningResult.NotPruned(Status.UNIMPLEMENTED))
+    } else {
+      // kvutils has no participant local state to prune, so return success to let participant pruning proceed elsewhere.
+      CompletableFuture.completedFuture(PruningResult.ParticipantPruned)
+    }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -113,6 +113,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
   override def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
+      pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[PruningResult] =
     // kvutils has no participant local state to prune, so return success to let participant pruning proceed elsewhere.
     CompletableFuture.completedFuture(PruningResult.ParticipantPruned)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteParticipantPruningService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteParticipantPruningService.scala
@@ -38,7 +38,7 @@ trait WriteParticipantPruningService {
     *
     * @param pruneUpToInclusive The offset up to which contracts should be pruned.
     * @param submissionId The submission id.
-    * @param pruneAllDivulgedContracts If set, instruct the ledger to prune all immediate and retroactive divulged contracts
+    * @param pruneAllDivulgedContracts If set, instruct the ledger to prune all immediately and retroactively divulged contracts
     *                                  created before `pruneUpToInclusive` independent of whether they were archived before
     *                                  `pruneUpToInclusive`.
     * @return The pruning result.

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteParticipantPruningService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteParticipantPruningService.scala
@@ -35,10 +35,17 @@ trait WriteParticipantPruningService {
     * step upon successful completion of each prune call. To reach eventual consistency upon failures, be sure
     * to return ParticipantPruned even if the specified offset has already been pruned to allow ledger api server
     * index pruning to proceed in case of an earlier failure.
+    *
+    * @param pruneUpToInclusive The offset up to which contracts should be pruned.
+    * @param submissionId The submission id.
+    * @param pruneAllDivulgedContracts If set, instruct the ledger to prune all immediate and retroactive divulged contracts
+    *                                  created before `pruneUpToInclusive` independent of whether they were archived before
+    *                                  `pruneUpToInclusive`.
+    * @return The pruning result.
     */
   def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
+      pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[PruningResult]
-
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteService.scala
@@ -65,9 +65,10 @@ class AdaptedV1WriteService(delegate: v1.WriteService) extends WriteService {
   override def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
+      pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[PruningResult] =
     delegate
-      .prune(pruneUpToInclusive, submissionId)
+      .prune(pruneUpToInclusive, submissionId, pruneAllDivulgedContracts)
       .thenApply(adaptPruningResult)
 
   override def uploadPackages(

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteParticipantPruningService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteParticipantPruningService.scala
@@ -38,7 +38,7 @@ trait WriteParticipantPruningService {
     *
     * @param pruneUpToInclusive The offset up to which contracts should be pruned.
     * @param submissionId The submission id.
-    * @param pruneAllDivulgedContracts If set, instruct the ledger to prune all immediate and retroactive divulged contracts
+    * @param pruneAllDivulgedContracts If set, instruct the ledger to prune all immediately and retroactively divulged contracts
     *                                  created before `pruneUpToInclusive` independent of whether they were archived before
     *                                  `pruneUpToInclusive`.
     * @return The pruning result.

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteParticipantPruningService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteParticipantPruningService.scala
@@ -35,10 +35,18 @@ trait WriteParticipantPruningService {
     * step upon successful completion of each prune call. To reach eventual consistency upon failures, be sure
     * to return ParticipantPruned even if the specified offset has already been pruned to allow ledger api server
     * index pruning to proceed in case of an earlier failure.
+    *
+    * @param pruneUpToInclusive The offset up to which contracts should be pruned.
+    * @param submissionId The submission id.
+    * @param pruneAllDivulgedContracts If set, instruct the ledger to prune all immediate and retroactive divulged contracts
+    *                                  created before `pruneUpToInclusive` independent of whether they were archived before
+    *                                  `pruneUpToInclusive`.
+    * @return The pruning result.
     */
   def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
+      pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[PruningResult]
 
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -96,6 +96,7 @@ private[stores] final class LedgerBackedWriteService(ledger: Ledger, timeProvide
   override def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
+      pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[state.PruningResult] =
     CompletableFuture.completedFuture(state.PruningResult.NotPruned(Status.UNIMPLEMENTED))
 

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
@@ -106,6 +106,7 @@ case class ReadWriteServiceBridge(
   override def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
+      pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[PruningResult] =
     CompletableFuture.completedFuture(
       PruningResult.ParticipantPruned


### PR DESCRIPTION
This PR enriches the `PruningRequest` with an additional flag `prune_all_divulged_contracts`. 
* The flag is passed to the `WriteParticipantPruningService` (v1 and v2)

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
