### PR TITLE
participant-integration-api: Attempt to fix RecoveringIndexerSpec.

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -193,23 +193,23 @@ final class RecoveringIndexerSpec
       val healthStatusLogCapture = mutable.ArrayBuffer.empty[HealthStatus]
       val healthStatusRef = new AtomicReference[HealthStatus]()
 
-      val recoveringIndexer =
-        new RecoveringIndexer(
-          actorSystem.scheduler,
-          actorSystem.dispatcher,
-          someTimeout,
-          updateHealthStatus = healthStatus => {
-            logger.info(s"Updating the health status of the indexer to $healthStatus.")
-            healthStatusLogCapture += healthStatus
-            healthStatusRef.set(healthStatus)
-          },
-          () => healthStatusRef.get(),
-        )
+      val timeout = 100.millis
+      val recoveringIndexer = new RecoveringIndexer(
+        actorSystem.scheduler,
+        actorSystem.dispatcher,
+        timeout,
+        updateHealthStatus = healthStatus => {
+          logger.info(s"Updating the health status of the indexer to $healthStatus.")
+          healthStatusLogCapture += healthStatus
+          healthStatusRef.set(healthStatus)
+        },
+        () => healthStatusRef.get(),
+      )
       // Subscribe fails, then the stream fails, then the stream completes without errors.
       val testIndexer = new TestIndexer(
-        SubscribeResult("A", SubscriptionFails, someTimeout, someTimeout),
-        SubscribeResult("B", StreamFails, someTimeout, someTimeout),
-        SubscribeResult("C", SuccessfullyCompletes, someTimeout, someTimeout),
+        SubscribeResult("A", SubscriptionFails, timeout, timeout),
+        SubscribeResult("B", StreamFails, timeout, timeout),
+        SubscribeResult("C", SuccessfullyCompletes, timeout, timeout),
       )
 
       val resource = recoveringIndexer.start(() => testIndexer.subscribe())

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -33,8 +33,6 @@ final class RecoveringIndexerSpec
   private[this] implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
   private[this] var actorSystem: ActorSystem = _
 
-  private val someTimeout = 10.millis
-
   override def beforeEach(): Unit = {
     super.beforeEach()
     actorSystem = ActorSystem(getClass.getSimpleName)
@@ -50,10 +48,11 @@ final class RecoveringIndexerSpec
 
   "RecoveringIndexer" should {
     "work when the stream completes" in {
+      val timeout = 10.millis
       val recoveringIndexer =
-        RecoveringIndexer(actorSystem.scheduler, actorSystem.dispatcher, someTimeout)
+        RecoveringIndexer(actorSystem.scheduler, actorSystem.dispatcher, timeout)
       val testIndexer = new TestIndexer(
-        SubscribeResult("A", SuccessfullyCompletes, someTimeout, someTimeout)
+        SubscribeResult("A", SuccessfullyCompletes, timeout, timeout)
       )
 
       val resource = recoveringIndexer.start(() => testIndexer.subscribe())
@@ -81,11 +80,12 @@ final class RecoveringIndexerSpec
     }
 
     "work when the stream is stopped" in {
+      val timeout = 10.millis
       val recoveringIndexer =
-        RecoveringIndexer(actorSystem.scheduler, actorSystem.dispatcher, someTimeout)
+        RecoveringIndexer(actorSystem.scheduler, actorSystem.dispatcher, timeout)
       // Stream completes after 10s, but is released before that happens
       val testIndexer = new TestIndexer(
-        SubscribeResult("A", SuccessfullyCompletes, someTimeout, 10.seconds)
+        SubscribeResult("A", SuccessfullyCompletes, timeout, 10.seconds)
       )
 
       val resource = recoveringIndexer.start(() => testIndexer.subscribe())
@@ -115,10 +115,11 @@ final class RecoveringIndexerSpec
     }
 
     "wait until the subscription completes" in {
+      val timeout = 10.millis
       val recoveringIndexer =
-        RecoveringIndexer(actorSystem.scheduler, actorSystem.dispatcher, someTimeout)
+        RecoveringIndexer(actorSystem.scheduler, actorSystem.dispatcher, timeout)
       val testIndexer = new TestIndexer(
-        SubscribeResult("A", SuccessfullyCompletes, 100.millis, someTimeout)
+        SubscribeResult("A", SuccessfullyCompletes, 100.millis, timeout)
       )
 
       val resource = recoveringIndexer.start(() => testIndexer.subscribe())
@@ -145,13 +146,14 @@ final class RecoveringIndexerSpec
     }
 
     "recover from failure" in {
+      val timeout = 10.millis
       val recoveringIndexer =
-        RecoveringIndexer(actorSystem.scheduler, actorSystem.dispatcher, someTimeout)
+        RecoveringIndexer(actorSystem.scheduler, actorSystem.dispatcher, timeout)
       // Subscribe fails, then the stream fails, then the stream completes without errors.
       val testIndexer = new TestIndexer(
-        SubscribeResult("A", SubscriptionFails, someTimeout, someTimeout),
-        SubscribeResult("B", StreamFails, someTimeout, someTimeout),
-        SubscribeResult("C", SuccessfullyCompletes, someTimeout, someTimeout),
+        SubscribeResult("A", SubscriptionFails, timeout, timeout),
+        SubscribeResult("B", StreamFails, timeout, timeout),
+        SubscribeResult("C", SuccessfullyCompletes, timeout, timeout),
       )
 
       val resource = recoveringIndexer.start(() => testIndexer.subscribe())


### PR DESCRIPTION
The checks for the health status are racy. I'm hoping increasing the timeouts will help a little.

I have also added some extra logging and removed an annoying stack trace (so I could debug the tests, unfruitfully).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
