### PR TITLE
LF: Contract ID suffix check in Preprocessor

### DIFF
--- a/daml-lf/engine/BUILD.bazel
+++ b/daml-lf/engine/BUILD.bazel
@@ -29,6 +29,7 @@ da_scala_library(
         "//daml-lf/transaction",
         "//daml-lf/validation",
         "//libs-scala/nameof",
+        "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -34,7 +34,7 @@ final case class EngineConfig(
     profileDir: Option[Path] = None,
     contractKeyUniqueness: ContractKeyUniquenessMode = ContractKeyUniquenessMode.On,
     // TODO: https://github.com/digital-asset/daml/issues/10504
-    //  swicth the default to true
+    //  switch the default to true
     requireSuffixedGlobalCids: Boolean = false,
 ) {
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -22,6 +22,10 @@ import com.daml.lf.transaction.ContractKeyUniquenessMode
   * @param profileDir The optional specifies the directory where to
   *     save the output of the Daml scenario profiler. The profiler is
   *     disabled if the option is empty.
+  * @param requireSuffixedGlobalCids Since August 2018 we expect new
+  *     ledgers to suffix CIDs before committing a transaction.
+  *     This option should be disable for backward compatibility in ledger
+  *     that do not (i.e. Sandboxes, KV, Corda).
   */
 final case class EngineConfig(
     allowedLanguageVersions: VersionRange[language.LanguageVersion],
@@ -29,6 +33,9 @@ final case class EngineConfig(
     stackTraceMode: Boolean = false,
     profileDir: Option[Path] = None,
     contractKeyUniqueness: ContractKeyUniquenessMode = ContractKeyUniquenessMode.On,
+    // TODO: https://github.com/digital-asset/daml/issues/10504
+    //  swicth the default to true
+    requireSuffixedGlobalCids: Boolean = false,
 ) {
 
   private[lf] def getCompilerConfig: speedy.Compiler.Config =

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -105,7 +105,7 @@ object Error {
         s"Provided value exceeds maximum nesting level of ${Value.MAXIMUM_NESTING}"
     }
 
-    final case class NonSuffixCid(cid: Value.ContractId.V1) extends Error {
+    final case class NonSuffixedCid(cid: Value.ContractId.V1) extends Error {
       override def message: String =
         s"Provided Contract ID $cid is not suffixed"
     }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -105,6 +105,11 @@ object Error {
         s"Provided value exceeds maximum nesting level of ${Value.MAXIMUM_NESTING}"
     }
 
+    final case class NonSuffixCid(cid: Value.ContractId.V1) extends Error {
+      override def message: String =
+        s"Provided Contract ID $cid is not suffixed"
+    }
+
     final case class RootNode(nodeId: NodeId, override val message: String) extends Error
 
   }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -17,7 +17,7 @@ import com.daml.lf.value.Value.ContractId
 final class ValueEnricher(engine: Engine) {
 
   def enrichValue(typ: Ast.Type, value: Value[ContractId]): Result[Value[ContractId]] =
-    engine.enrich(typ, value)
+    engine.preprocessor.translateValue(typ, value).map(_.toValue)
 
   def enrichContract(
       contract: Value.ContractInst[Value[ContractId]]

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -15,6 +15,26 @@ import com.daml.nameof.NameOf
 
 import scala.annotation.tailrec
 
+/** The Command Preprocessor is responsible of the following tasks:
+  *  - normalizes value representation (e.g. resolves missing type
+  *    reference in record/variant/enumeration, infers missing labeled
+  *    record fields, orders labeled record fields, ...);
+  *  - checks value nesting does not overpass 100;
+  *  - checks a LF command/value is properly typed according the
+  *    Daml-LF package definitions;
+  *  - checks for Contract ID suffix (see [[requiredCidSuffix]]);
+  *  - translates a LF command/value into speedy command/value; and
+  *  - translates a complete transaction into a list of speedy
+  *    commands.
+  *
+  * @param compiledPackages a [[MutableCompiledPackages]] contains the
+  *   Daml-LF package definitions against the command should
+  *   resolved/typechecked. It is updated dynamically each time the
+  *   [[ResultNeedPackage]] continuation is called.
+  * @param requiredCidSuffix when `true` the preprocessor will reject
+  *   any value/command/transaction that contains V1 Contract IDs
+  *   without suffixed.
+  */
 private[engine] final class Preprocessor(
     compiledPackages: MutableCompiledPackages,
     requiredCidSuffix: Boolean = true,
@@ -148,6 +168,7 @@ private[engine] final class Preprocessor(
       commandPreprocessor.unsafePreprocessCommands(cmds)
     }
 
+  /** Translates a complete transaction. Assumes no contract ID suffixes are used */
   def translateTransactionRoots(
       tx: SubmittedTransaction
   ): Result[ImmArray[speedy.Command]] =

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -16,6 +16,7 @@ import scala.annotation.tailrec
 
 private[engine] final class ValueTranslator(
     interface: language.Interface,
+    // See Preprocessor.requiredCidSuffix for more details about the following flag.
     requiredCidSuffix: Boolean,
 ) {
 
@@ -43,10 +44,13 @@ private[engine] final class ValueTranslator(
 
   private[preprocessing] val unsafeTranslateCid: ContractId => SValue.SContractId =
     if (requiredCidSuffix) {
-      case cid1: ContractId.V1 if cid1.suffix.isEmpty =>
-        throw Error.Preprocessing.NonSuffixCid(cid1)
-      case cid =>
-        SValue.SContractId(cid)
+      case cid1: ContractId.V1 =>
+        if (cid1.suffix.isEmpty)
+          throw Error.Preprocessing.NonSuffixedCid(cid1)
+        else
+          SValue.SContractId(cid1)
+      case cid0: ContractId.V0 =>
+        SValue.SContractId(cid0)
     }
     else
       SValue.SContractId

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -39,8 +39,6 @@ import org.scalatest.EitherValues
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.Inside._
-import scalaz.std.either._
-import scalaz.syntax.apply._
 
 import scala.collection.immutable.HashMap
 import scala.language.implicitConversions
@@ -158,10 +156,12 @@ class EngineTest
         None
     }
 
-  // TODO make these two per-test, so that we make sure not to pollute the package cache and other possibly mutable stuff
-  val engine = Engine.DevEngine()
+  val suffixLenientEngine = newEngine()
+  val suffixStrictEngine = newEngine(requireCidSuffixes = true)
   val preprocessor =
-    new preprocessing.Preprocessor(ConcurrentCompiledPackages(engine.config.getCompilerConfig))
+    new preprocessing.Preprocessor(
+      ConcurrentCompiledPackages(suffixLenientEngine.config.getCompilerConfig)
+    )
 
   "valid data variant identifier" should {
     "found and return the argument types" in {
@@ -437,7 +437,9 @@ class EngineTest
         loadPackage("daml-lf/tests/Optional.dar")
 
       val translator =
-        new preprocessing.Preprocessor(ConcurrentCompiledPackages(engine.config.getCompilerConfig))
+        new preprocessing.Preprocessor(
+          ConcurrentCompiledPackages(suffixLenientEngine.config.getCompilerConfig)
+        )
 
       val id = Identifier(optionalPkgId, "Optional:Rec")
       val someValue =
@@ -463,7 +465,9 @@ class EngineTest
 
     "returns correct error when resuming" in {
       val translator =
-        new preprocessing.Preprocessor(ConcurrentCompiledPackages(engine.config.getCompilerConfig))
+        new preprocessing.Preprocessor(
+          ConcurrentCompiledPackages(suffixLenientEngine.config.getCompilerConfig)
+        )
       val id = Identifier(basicTestsPkgId, "BasicTests:MyRec")
       val wrongRecord =
         ValueRecord(Some(id), ImmArray(Some[Name]("wrongLbl") -> ValueText("foo")))
@@ -491,7 +495,7 @@ class EngineTest
       .preprocessCommands(ImmArray(command))
       .consume(lookupContract, lookupPackage, lookupKey)
     res shouldBe a[Right[_, _]]
-    val interpretResult = engine
+    val interpretResult = suffixLenientEngine
       .submit(
         submitters,
         readAs,
@@ -507,18 +511,19 @@ class EngineTest
 
     "reinterpret to the same result" in {
       val Right((tx, txMeta)) = interpretResult
+      val stx = suffix(tx)
 
       val Right((rtx, newMeta)) =
         reinterpret(
-          engine,
+          suffixStrictEngine,
           Set(party),
-          tx.roots,
-          tx,
+          stx.roots,
+          stx,
           txMeta,
           let,
           lookupPackage,
         )
-      isReplayedBy(tx, rtx) shouldBe Right(())
+      isReplayedBy(stx, rtx) shouldBe Right(())
       txMeta.nodeSeeds shouldBe newMeta.nodeSeeds
     }
 
@@ -527,7 +532,7 @@ class EngineTest
       val Right(submitter) = tx.guessSubmitter
       val submitters = Set(submitter)
       val ntx = SubmittedTransaction(Normalization.normalizeTx(tx))
-      val validated = engine
+      val validated = suffixLenientEngine
         .validate(submitters, ntx, let, participant, meta.submissionTime, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey)
       validated match {
@@ -581,7 +586,7 @@ class EngineTest
         .consume(lookupContract, lookupPackage, lookupKey)
       withClue("Preprocessing result: ")(res shouldBe a[Right[_, _]])
 
-      engine
+      suffixLenientEngine
         .submit(actAs, readAs, Commands(ImmArray(cmd), let, "test"), participant, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey)
     }
@@ -595,18 +600,19 @@ class EngineTest
     "reinterpret to the same result" in {
       forAll(cases) { case (templateId, signatories, submitters) =>
         val Right((tx, txMeta)) = interpretResult(templateId, signatories, submitters)
+        val stx = suffix(tx)
 
         val Right((rtx, _)) =
           reinterpret(
-            engine,
+            suffixStrictEngine,
             signatories.map(_._2),
-            tx.roots,
-            tx,
+            stx.roots,
+            stx,
             txMeta,
             let,
             lookupPackage,
           )
-        isReplayedBy(tx, rtx) shouldBe Right(())
+        isReplayedBy(stx, rtx) shouldBe Right(())
       }
     }
 
@@ -614,7 +620,7 @@ class EngineTest
       forAll(cases) { case (templateId, signatories, submitters) =>
         val Right((tx, meta)) = interpretResult(templateId, signatories, submitters)
         val ntx = SubmittedTransaction(Normalization.normalizeTx(tx))
-        val validated = engine
+        val validated = suffixLenientEngine
           .validate(submitters, ntx, let, participant, meta.submissionTime, submissionSeed)
           .consume(
             lookupContract,
@@ -634,7 +640,7 @@ class EngineTest
         val Right((tx, _)) = interpretResult(templateId, signatories, submitters)
 
         val replaySubmitters = submitters + party
-        val replayResult = engine.replay(
+        val replayResult = suffixLenientEngine.replay(
           submitters = replaySubmitters,
           tx = tx,
           ledgerEffectiveTime = let,
@@ -652,7 +658,7 @@ class EngineTest
         val Right((tx, _)) = interpretResult(templateId, signatories, submitters)
 
         val replaySubmitters = submitters.drop(1)
-        val replayResult = engine.replay(
+        val replayResult = suffixLenientEngine.replay(
           submitters = replaySubmitters,
           tx = tx,
           ledgerEffectiveTime = let,
@@ -685,7 +691,7 @@ class EngineTest
     val interpretResult =
       res
         .flatMap { cmds =>
-          engine
+          suffixLenientEngine
             .interpretCommands(
               validating = false,
               submitters = submitters,
@@ -705,7 +711,7 @@ class EngineTest
     val Right(submitter) = tx.guessSubmitter
 
     "be translated" in {
-      val Right((rtx, _)) = engine
+      val Right((rtx, _)) = suffixLenientEngine
         .submit(
           Set(party),
           readAs,
@@ -722,23 +728,25 @@ class EngineTest
     }
 
     "reinterpret to the same result" in {
+      val stx = suffix(tx)
+
       val Right((rtx, _)) =
         reinterpret(
-          engine,
+          suffixStrictEngine,
           Set(party),
-          tx.roots,
-          tx,
+          stx.roots,
+          stx,
           txMeta,
           let,
           lookupPackage,
           defaultContracts,
         )
-      isReplayedBy(tx, rtx) shouldBe Right(())
+      isReplayedBy(stx, rtx) shouldBe Right(())
     }
 
     "be validated" in {
       val ntx = SubmittedTransaction(Normalization.normalizeTx(tx))
-      val validated = engine
+      val validated = suffixLenientEngine
         .validate(Set(submitter), ntx, let, participant, let, submissionSeed)
         .consume(
           lookupContract,
@@ -772,7 +780,7 @@ class EngineTest
     res shouldBe a[Right[_, _]]
 
     "fail at submission" in {
-      val submitResult = engine
+      val submitResult = suffixLenientEngine
         .submit(
           submitters,
           readAs,
@@ -821,7 +829,7 @@ class EngineTest
     val result =
       res
         .flatMap { cmds =>
-          engine
+          suffixLenientEngine
             .interpretCommands(
               validating = false,
               submitters = submitters,
@@ -840,7 +848,7 @@ class EngineTest
     val Right((tx, txMeta)) = result
 
     "be translated" in {
-      val submitResult = engine
+      val Right((rtx, _)) = suffixLenientEngine
         .submit(
           submitters,
           readAs,
@@ -848,40 +856,33 @@ class EngineTest
           participant,
           submissionSeed,
         )
-        .consume(
-          lookupContract,
-          lookupPackage,
-          lookupKey,
-        )
-        .map(_._1)
-      (result.map(_._1) |@| submitResult)((tx, rtx) => isReplayedBy(tx, rtx)) shouldBe Right(
-        Right(())
-      )
+        .consume(lookupContract, lookupPackage, lookupKey)
+
+      isReplayedBy(tx, rtx) shouldBe Right(())
     }
 
     "reinterpret to the same result" in {
+      val stx = suffix(tx)
 
-      val reinterpretResult =
+      val Right((rtx, _)) =
         reinterpret(
-          engine,
+          suffixStrictEngine,
           Set(alice),
-          tx.roots,
-          tx,
+          stx.roots,
+          stx,
           txMeta,
           let,
           lookupPackage,
           defaultContracts,
           defaultKey,
         )
-          .map(_._1)
-      (result.map(_._1) |@| reinterpretResult)((tx, rtx) => isReplayedBy(tx, rtx)) shouldBe Right(
-        Right(())
-      )
+
+      isReplayedBy(stx, rtx) shouldBe Right(())
     }
 
     "be validated" in {
       val ntx = SubmittedTransaction(Normalization.normalizeTx(tx))
-      val validated = engine
+      val validated = suffixLenientEngine
         .validate(submitters, ntx, let, participant, let, submissionSeed)
         .consume(
           lookupContract,
@@ -924,7 +925,7 @@ class EngineTest
       )
       val submitters = Set(alice)
 
-      val result = engine
+      val result = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -962,7 +963,7 @@ class EngineTest
 
       val submitters = Set(alice)
 
-      val result = engine
+      val result = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -997,7 +998,7 @@ class EngineTest
 
       val submitters = Set(alice)
 
-      val result = engine
+      val result = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -1043,7 +1044,7 @@ class EngineTest
 
       val submitters = Set(alice)
 
-      val result = engine
+      val result = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -1098,7 +1099,7 @@ class EngineTest
     val interpretResult =
       res
         .flatMap { cmds =>
-          engine
+          suffixLenientEngine
             .interpretCommands(
               validating = false,
               submitters = submitters,
@@ -1127,18 +1128,17 @@ class EngineTest
     }
 
     "reinterpret to the same result" in {
+      val stx = suffix(tx)
 
-      val reinterpretResult =
-        reinterpret(engine, Set(party), tx.roots, tx, txMeta, let, lookupPackage)
-          .map(_._1)
-      (interpretResult.map(_._1) |@| reinterpretResult)((tx, rtx) =>
-        isReplayedBy(tx, rtx)
-      ) shouldBe Right(Right(()))
+      val Right((rtx, _)) =
+        reinterpret(suffixStrictEngine, Set(party), stx.roots, stx, txMeta, let, lookupPackage)
+
+      isReplayedBy(stx, rtx) shouldBe Right(())
     }
 
     "be validated" in {
       val ntx = SubmittedTransaction(Normalization.normalizeTx(tx))
-      val validated = engine
+      val validated = suffixLenientEngine
         .validate(Set(submitter), ntx, let, participant, let, submissionSeed)
         .consume(
           lookupContract,
@@ -1363,7 +1363,7 @@ class EngineTest
     val submitters = Set(bob)
     val readAs = (Set.empty: Set[Party])
 
-    val Right((tx, txMeta)) = engine
+    val Right((tx, txMeta)) = suffixLenientEngine
       .submit(
         submitters,
         readAs,
@@ -1380,7 +1380,7 @@ class EngineTest
     val Right(cmds) = preprocessor
       .preprocessCommands(ImmArray(command))
       .consume(lookupContract, lookupPackage, lookupKey)
-    val Right((rtx, _)) = engine
+    val Right((rtx, _)) = suffixLenientEngine
       .interpretCommands(
         validating = false,
         submitters = submitters,
@@ -1399,19 +1399,21 @@ class EngineTest
     val blindingInfo = Blinding.blind(tx)
 
     "reinterpret to the same result" in {
+      val stx = suffix(tx)
 
       val Right((rtx, _)) =
         reinterpret(
-          engine,
+          suffixStrictEngine,
           Set(bob),
-          tx.transaction.roots,
-          tx,
+          stx.transaction.roots,
+          stx,
           txMeta,
           let,
           lookupPackage,
           defaultContracts,
         )
-      isReplayedBy(rtx, tx) shouldBe Right(())
+
+      isReplayedBy(rtx, stx) shouldBe Right(())
     }
 
     "blinded correctly" in {
@@ -1545,7 +1547,7 @@ class EngineTest
 
       res
         .flatMap { cmds =>
-          engine
+          suffixLenientEngine
             .interpretCommands(
               validating = false,
               submitters = submitters,
@@ -1586,7 +1588,7 @@ class EngineTest
         val nid = NodeId(0) //we must use node-0 so the constructed tx is normalized
         val fetchTx = VersionedTransaction(n.version, Map(nid -> n), ImmArray(nid))
         val Right((reinterpreted, _)) =
-          engine
+          suffixLenientEngine
             .reinterpret(
               n.requiredAuthorizers,
               FetchCommand(n.templateId, n.coid),
@@ -1637,7 +1639,7 @@ class EngineTest
     }
 
     "succeed with a fresh engine, correctly compiling packages" in {
-      val engine = Engine.DevEngine()
+      val engine = newEngine()
 
       val fetchNode = FetchCommand(
         templateId = fetchedTid,
@@ -1713,7 +1715,7 @@ class EngineTest
       )
       val submitters = Set(alice)
       val readAs = (Set.empty: Set[Party])
-      val Right((tx, _)) = engine
+      val Right((tx, _)) = newEngine()
         .submit(submitters, readAs, Commands(ImmArray(exerciseCmd), now, "test"), participant, seed)
         .consume(
           lookupContractMap.get,
@@ -1739,7 +1741,7 @@ class EngineTest
       val submitters = Set(alice)
       val readAs = (Set.empty: Set[Party])
 
-      val Right((tx, txMeta)) = engine
+      val Right((tx, txMeta)) = suffixLenientEngine
         .submit(submitters, readAs, Commands(ImmArray(exerciseCmd), now, "test"), participant, seed)
         .consume(
           lookupContractMap.get,
@@ -1752,8 +1754,7 @@ class EngineTest
       lookupNode.result shouldBe Some(lookedUpCid)
 
       val Right((reinterpreted, _)) =
-        Engine
-          .DevEngine()
+        newEngine()
           .reinterpret(
             submitters,
             LookupByKeyCommand(lookupNode.templateId, lookupNode.key.key),
@@ -1780,7 +1781,7 @@ class EngineTest
       val submitters = Set(alice)
       val readAs = (Set.empty: Set[Party])
 
-      val Right((tx, txMeta)) = engine
+      val Right((tx, txMeta)) = suffixLenientEngine
         .submit(submitters, readAs, Commands(ImmArray(exerciseCmd), now, "test"), participant, seed)
         .consume(
           lookupContractMap.get,
@@ -1794,8 +1795,7 @@ class EngineTest
       lookupNode.result shouldBe None
 
       val Right((reinterpreted, _)) =
-        Engine
-          .DevEngine()
+        newEngine()
           .reinterpret(
             submitters,
             LookupByKeyCommand(lookupNode.templateId, lookupNode.key.key),
@@ -1822,7 +1822,7 @@ class EngineTest
 
       val submitters = Set(alice)
 
-      val result = engine
+      val result = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -1855,7 +1855,7 @@ class EngineTest
         )
       val submitters = Set(party)
       val readAs = (Set.empty: Set[Party])
-      engine
+      suffixLenientEngine
         .submit(
           submitters,
           readAs,
@@ -1888,7 +1888,7 @@ class EngineTest
 
       val submitters = Set(alice)
 
-      val Right((tx, _)) = engine
+      val Right((tx, _)) = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -1961,7 +1961,7 @@ class EngineTest
           lookupKey,
         )
 
-      val Right((tx, _)) = engine
+      val Right((tx, _)) = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -2026,7 +2026,7 @@ class EngineTest
     val submitters = Set(alice)
     val readAs = (Set.empty: Set[Party])
     def run(cmds: ImmArray[ApiCommand]) =
-      engine
+      suffixLenientEngine
         .submit(submitters, readAs, Commands(cmds, now, ""), participant, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey)
 
@@ -2075,7 +2075,7 @@ class EngineTest
       )
       val submitters = Set(party)
       val readAs = (Set.empty: Set[Party])
-      engine
+      suffixLenientEngine
         .submit(
           submitters,
           readAs,
@@ -2098,7 +2098,7 @@ class EngineTest
         for {
           submitter <- tx.guessSubmitter
           ntx = SubmittedTransaction(Normalization.normalizeTx(tx))
-          res <- engine
+          res <- suffixLenientEngine
             .validate(
               Set(submitter),
               ntx,
@@ -2122,16 +2122,18 @@ class EngineTest
 
     "be partially reinterpretable" in {
       val Right((tx, txMeta)) = run(3)
+      val stx = suffix(tx)
+
       val ImmArray(_, exeNode1) = tx.transaction.roots
       val Node.NodeExercises(_, _, _, _, _, _, _, _, _, children, _, _, _, _) =
         tx.transaction.nodes(exeNode1)
       val nids = children.toSeq.take(2).toImmArray
 
       reinterpret(
-        engine,
+        suffixStrictEngine,
         Set(party),
         nids,
-        tx,
+        stx,
         txMeta,
         let,
         lookupPackage,
@@ -2169,7 +2171,7 @@ class EngineTest
         )
         .consume(_ => None, lookupPackage, lookupKey)
 
-      val result = engine
+      val result = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -2198,7 +2200,7 @@ class EngineTest
         .preprocessCommands(ImmArray(CreateCommand(templateId, createArg)))
         .consume(_ => None, lookupPackage, lookupKey)
 
-      val result = engine
+      val result = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -2229,7 +2231,7 @@ class EngineTest
       val Right(cmds) = preprocessor
         .preprocessCommands(ImmArray(CreateCommand(templateId, createArg)))
         .consume(_ => None, lookupPackage, lookupKey)
-      val result = engine
+      val result = suffixLenientEngine
         .interpretCommands(
           validating = false,
           submitters = submitters,
@@ -2257,12 +2259,14 @@ class EngineTest
         EngineConfig(
           allowedLanguageVersions = LV.DevVersions,
           contractKeyUniqueness = ContractKeyUniquenessMode.Off,
+          requireSuffixedGlobalCids = true,
         )
       )
       val uckEngine = new Engine(
         EngineConfig(
           allowedLanguageVersions = LV.DevVersions,
           contractKeyUniqueness = ContractKeyUniquenessMode.On,
+          requireSuffixedGlobalCids = true,
         )
       )
       val (multiKeysPkgId, _, allMultiKeysPkgs) = loadPackage("daml-lf/tests/MultiKeys.dar")
@@ -2427,7 +2431,7 @@ class EngineTest
             lookupPackage,
             lookupKey,
           )
-        engine
+        suffixLenientEngine
           .interpretCommands(
             validating = false,
             submitters = submitters,
@@ -2537,7 +2541,7 @@ class EngineTest
             lookupPackage,
             lookupKey,
           )
-        engine
+        suffixLenientEngine
           .interpretCommands(
             validating = false,
             submitters = submitters,
@@ -2619,7 +2623,7 @@ class EngineTest
             lookupPackage,
             mockedKeyLookup,
           )
-        val result = engine
+        val result = suffixLenientEngine
           .interpretCommands(
             validating = false,
             submitters = submitters,
@@ -2672,7 +2676,8 @@ class EngineTest
     def engine(min: LV, max: LV) =
       new Engine(
         EngineConfig(
-          allowedLanguageVersions = VersionRange(min, max)
+          allowedLanguageVersions = VersionRange(min, max),
+          requireSuffixedGlobalCids = true,
         )
       )
 
@@ -2718,6 +2723,14 @@ class EngineTest
 
 object EngineTest {
 
+  private def engineConfig(requireCidSuffixes: Boolean) = EngineConfig(
+    allowedLanguageVersions = language.LanguageVersion.DevVersions,
+    requireSuffixedGlobalCids = requireCidSuffixes,
+  )
+
+  private def newEngine(requireCidSuffixes: Boolean = false) =
+    new Engine(engineConfig(requireCidSuffixes))
+
   private implicit def qualifiedNameStr(s: String): QualifiedName =
     QualifiedName.assertFromString(s)
 
@@ -2751,6 +2764,13 @@ object EngineTest {
     Validation.isReplayedBy(Normalization.normalizeTx(recorded), replayed)
   }
 
+  private val dummySuffix = Bytes.assertFromString("00")
+
+  private def suffix(tx: Tx.Transaction) =
+    data.assertRight(tx.suffixCid(_ => dummySuffix))
+
+  // Mimics Canton reinterpreation
+  // requires a suffixed transaction.
   private def reinterpret(
       engine: Engine,
       submitters: Set[Party],
@@ -2811,7 +2831,8 @@ object EngineTest {
               lookupPackages,
               k => keys0.get(k.globalKey),
             )
-          (tr1, meta1) = currentStep
+          (tr0, meta1) = currentStep
+          tr1 = suffix(tr0)
           (contracts1, keys1) = tr1.transaction.fold((contracts0, keys0)) {
             case (
                   (contracts, keys),

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -101,11 +101,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   private def report(name: String, quantity: Quantity[Double]): Unit =
     println(s"$name: $quantity")
 
-  private val engine: Engine = new Engine(
-    EngineConfig(
-      allowedLanguageVersions = language.LanguageVersion.DevVersions
-    )
-  )
+  private val engine: Engine = Engine.DevEngine()
 
   List(5000, 50000, 500000)
     .foreach { txSize =>

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -101,7 +101,11 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   private def report(name: String, quantity: Quantity[Double]): Unit =
     println(s"$name: $quantity")
 
-  private val engine: Engine = Engine.DevEngine()
+  private val engine: Engine = new Engine(
+    EngineConfig(
+      allowedLanguageVersions = language.LanguageVersion.DevVersions
+    )
+  )
 
   List(5000, 50000, 500000)
     .foreach { txSize =>

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ReinterpretTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ReinterpretTest.scala
@@ -69,7 +69,12 @@ class ReinterpretTest
   val lookupPackage = allPackages.get(_)
   val lookupKey = { _: GlobalKeyWithMaintainers => None }
 
-  private val engine = Engine.DevEngine()
+  private val engine = new Engine(
+    EngineConfig(
+      allowedLanguageVersions = language.LanguageVersion.DevVersions,
+      requireSuffixedGlobalCids = true,
+    )
+  )
 
   def Top(xs: Shape*) = Shape.Top(xs.toList)
   def Exercise(xs: Shape*) = Shape.Exercise(xs.toList)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -675,7 +675,8 @@ object Converter {
         } catch {
           case e: Exception => Left(s"LF conversion failed: ${e.toString}")
         }
-      valueTranslator = new preprocessing.ValueTranslator(compiledPackages.interface)
+      valueTranslator =
+        new preprocessing.ValueTranslator(compiledPackages.interface, requiredCidSuffix = false)
       sValue <- valueTranslator
         .translateValue(ty, lfValue)
         .left

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -64,7 +64,8 @@ object ScriptF {
   ) {
     def clients = _clients
     def compiledPackages = machine.compiledPackages
-    val valueTranslator = new ValueTranslator(compiledPackages.interface)
+    val valueTranslator =
+      new ValueTranslator(interface = compiledPackages.interface, requiredCidSuffix = false)
     val utcClock = Clock.systemUTC()
     def addPartyParticipantMapping(party: Party, participant: Participant) = {
       _clients =

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -47,8 +47,6 @@ class IdeLedgerClient(
   def currentSubmission: Option[ScenarioRunner.CurrentSubmission] = _currentSubmission
 
   private[this] val preprocessor =
-    // TODO: https://github.com/digital-asset/daml/pull/10504
-    //  See if we can require CID Suffixes
     new preprocessing.CommandPreprocessor(compiledPackages.interface, requiredCidSuffix = false)
 
   private var _ledger: ScenarioLedger = ScenarioLedger.initialLedger(Time.Timestamp.Epoch)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -46,7 +46,10 @@ class IdeLedgerClient(
 
   def currentSubmission: Option[ScenarioRunner.CurrentSubmission] = _currentSubmission
 
-  private[this] val preprocessor = new engine.preprocessing.CommandPreprocessor(compiledPackages)
+  private[this] val preprocessor =
+    // TODO: https://github.com/digital-asset/daml/pull/10504
+    //  See if we can require CID Suffixes
+    new preprocessing.CommandPreprocessor(compiledPackages.interface, requiredCidSuffix = false)
 
   private var _ledger: ScenarioLedger = ScenarioLedger.initialLedger(Time.Timestamp.Epoch)
   def ledger: ScenarioLedger = _ledger

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/SpeedyToValueBenchmark.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/SpeedyToValueBenchmark.scala
@@ -18,7 +18,11 @@ class SpeedyToValueBenchmark extends BenchmarkWithLedgerExport {
   override def setup(): Unit = {
     super.setup()
     val decodedValues = submissions.values.map(_.mapValue(assertDecode)).toVector
-    val translator = new ValueTranslator(submissions.compiledPackages.interface)
+    val translator =
+      new ValueTranslator(
+        interface = submissions.compiledPackages.interface,
+        requiredCidSuffix = false,
+      )
     speedyValues = decodedValues.map(x => assertTranslate(translator)(x.mapValue(_.value)))
   }
 

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/ValueTranslatorBenchmark.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/ValueTranslatorBenchmark.scala
@@ -19,7 +19,8 @@ class ValueTranslatorBenchmark extends BenchmarkWithLedgerExport {
   override def setup(): Unit = {
     super.setup()
     decodedValues = submissions.values.map(_.mapValue(assertDecode).mapValue(_.value)).toVector
-    translator = new ValueTranslator(submissions.compiledPackages.interface)
+    translator =
+      new ValueTranslator(submissions.compiledPackages.interface, requiredCidSuffix = false)
   }
 
   @Benchmark

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
@@ -498,7 +498,8 @@ object Converter {
   }
 
   def apply(compiledPackages: CompiledPackages, triggerIds: TriggerIds): Converter = {
-    val valueTranslator = new preprocessing.ValueTranslator(compiledPackages.interface)
+    val valueTranslator =
+      new preprocessing.ValueTranslator(compiledPackages.interface, requiredCidSuffix = false)
     Converter(
       fromTransaction(valueTranslator, triggerIds, _),
       fromCompletion(triggerIds, _),


### PR DESCRIPTION
This PR makes possible to check for contract IDs suffix during
preprocessing.

This is the first part of the task 3 described in #10504.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
