### PR TITLE
Normalize transaction values within the engine

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
@@ -278,7 +278,7 @@ class ReplService(
               }
             case RunScriptRequest.Format.JSON =>
               try {
-                LfValueCodec.apiValueToJsValue(v.toValue).compactPrint
+                LfValueCodec.apiValueToJsValue(v.toUnnormalizedValue).compactPrint
               } catch {
                 case SError.SErrorCrash(_, _) => throw new ReplServiceMain.NonSerializableValue()
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -257,7 +257,7 @@ final class Conversions(
     def unserializable(what: String): proto.Value =
       proto.Value.newBuilder.setUnserializable(what).build
     try {
-      convertValue(svalue.toValue)
+      convertValue(svalue.toUnnormalizedValue)
     } catch {
       case _: SError.SErrorCrash => {
         // We cannot rely on serializability information since we do not have that available in the IDE.

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -310,6 +310,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
         readAs = readAs,
         validating = validating,
         contractKeyUniqueness = config.contractKeyUniqueness,
+        transactionNormalization = config.transactionNormalization,
       )
       interpretLoop(machine, ledgerTime)
     }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -17,6 +17,7 @@ import com.daml.lf.transaction.ContractKeyUniquenessMode
   * @param allowedLanguageVersions The range of language versions the
   *     engine is allowed to load.  The engine will crash if it asked
   *     to load a language version that is not included in this range.
+  * @param transactionNormalization Normalizes transaction nodes according to the LF version
   * @param stackTraceMode The flag enables the runtime support for
   *     stack trace.
   * @param profileDir The optional specifies the directory where to
@@ -29,6 +30,7 @@ import com.daml.lf.transaction.ContractKeyUniquenessMode
   */
 final case class EngineConfig(
     allowedLanguageVersions: VersionRange[language.LanguageVersion],
+    transactionNormalization: Boolean = true,
     packageValidation: Boolean = true,
     stackTraceMode: Boolean = false,
     profileDir: Option[Path] = None,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -17,7 +17,7 @@ import com.daml.lf.value.Value.ContractId
 final class ValueEnricher(engine: Engine) {
 
   def enrichValue(typ: Ast.Type, value: Value[ContractId]): Result[Value[ContractId]] =
-    engine.preprocessor.translateValue(typ, value).map(_.toValue)
+    engine.preprocessor.translateValue(typ, value).map(_.toUnnormalizedValue)
 
   def enrichContract(
       contract: Value.ContractInst[Value[ContractId]]

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -10,7 +10,7 @@ import com.daml.bazeltools.BazelRunfiles
 import com.daml.lf.archive.UniversalArchiveDecoder
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
-import com.daml.lf.language.Ast
+import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.lf.scenario.ScenarioLedger
 import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.lf.transaction.Transaction.Transaction
@@ -101,7 +101,8 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   private def report(name: String, quantity: Quantity[Double]): Unit =
     println(s"$name: $quantity")
 
-  private val engine: Engine = Engine.DevEngine()
+  private val engine: Engine =
+    new Engine(new EngineConfig(LanguageVersion.DevVersions, transactionNormalization = false))
 
   List(5000, 50000, 500000)
     .foreach { txSize =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -343,9 +343,9 @@ private[lf] object Anf {
           ).bounce
         Bounce(() => transform(depth, SETryCatch(body, handler), k))
 
-      case SEScopeExercise(body0) =>
+      case SEScopeExercise(templateId, body0) =>
         val body: SExpr = flattenExp(depth, env, body0)(anf => Land(anf.wrapped)).bounce
-        Bounce(() => transform(depth, SEScopeExercise(body), k))
+        Bounce(() => transform(depth, SEScopeExercise(templateId, body), k))
 
       case _: SEAbs | _: SEDamlException | _: SEAppAtomicFun | _: SEAppAtomicGeneral |
           _: SEAppAtomicSaturatedBuiltin | _: SELet1Builtin | _: SELet1BuiltinArithmetic |

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -995,7 +995,7 @@ private[lf] final class Compiler(
         )
       ) { _ =>
         addExprVar(choice.selfBinder, cidPos)
-        SEScopeExercise(app(compile(choice.update), svar(tokenPos)))
+        SEScopeExercise(tmplId, app(compile(choice.update), svar(tokenPos)))
       }
     }
   }
@@ -1163,8 +1163,8 @@ private[lf] final class Compiler(
           closureConvert(shift(remaps, 1), handler),
         )
 
-      case SEScopeExercise(body) =>
-        SEScopeExercise(closureConvert(remaps, body))
+      case SEScopeExercise(templateId, body) =>
+        SEScopeExercise(templateId, closureConvert(remaps, body))
 
       case SELabelClosure(label, expr) =>
         SELabelClosure(label, closureConvert(remaps, expr))
@@ -1235,7 +1235,7 @@ private[lf] final class Compiler(
           go(expr, bound, free)
         case SETryCatch(body, handler) =>
           go(body, bound, go(handler, 1 + bound, free))
-        case SEScopeExercise(body) =>
+        case SEScopeExercise(_, body) =>
           go(body, bound, free)
 
         case _: SELoc | _: SEMakeClo | _: SEDamlException | _: SEImportValue |
@@ -1326,7 +1326,7 @@ private[lf] final class Compiler(
         case SETryCatch(body, handler) =>
           go(body)
           goBody(maxS + 1, maxA, maxF)(handler)
-        case SEScopeExercise(body) =>
+        case SEScopeExercise(_, body) =>
           go(body)
 
         case _: SEVar | _: SEAbs | _: SEDamlException | _: SEImportValue =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -518,7 +518,7 @@ private[lf] object Pretty {
           text("try-catch") + char('(') + prettySExpr(index)(body) + text(", ") +
             prettySExpr(index)(handler) + char(')')
 
-        case SEScopeExercise(body) =>
+        case SEScopeExercise(_, body) =>
           text("exercise") + char('(') + prettySExpr(index)(body) + text(")")
 
         case x: SEBuiltinRecursiveDefinition => str(x)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -406,9 +406,9 @@ object SExpr {
   }
 
   /** Exercise scope (begin..end) */
-  final case class SEScopeExercise(body: SExpr) extends SExpr {
+  final case class SEScopeExercise(templateId: TypeConName, body: SExpr) extends SExpr {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KCloseExercise(machine))
+      machine.pushKont(KCloseExercise(templateId, machine))
       machine.ctrl = body
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -9,6 +9,7 @@ import java.util
 import com.daml.lf.data._
 import com.daml.lf.data.Ref._
 import com.daml.lf.language.Ast._
+import com.daml.lf.transaction.{TransactionVersion, Util}
 import com.daml.lf.value.Value.ValueArithmeticError
 import com.daml.lf.value.{Value => V}
 import com.daml.nameof.NameOf
@@ -26,7 +27,17 @@ sealed trait SValue {
 
   import SValue.{SValue => _, _}
 
-  def toValue: V[V.ContractId] = SValue.toValue(this)
+  /** Convert a speedy-value to a value which may not be correctly normalized.
+    * And so the resulting value should not be serialized.
+    */
+  def toUnnormalizedValue: V[V.ContractId] = SValue.toValue(this)
+
+  /** Convert a speedy-value to a value normalized according to the LF version.
+    */
+  def toNormalizedValue(version: TransactionVersion): V[V.ContractId] = {
+    val v = SValue.toValue(this)
+    Util.assertNormalizeValue(v, version) //TODO: avoid separate pass; inline norm into toValue
+  }
 
   def mapContractId(f: V.ContractId => V.ContractId): SValue =
     this match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -29,7 +29,7 @@ private[speedy] object SExprIterable {
     case SExpr.SEDamlException(_) => Iterator.empty
     case SExpr.SEImportValue(_, _) => Iterator.empty
     case SExpr.SETryCatch(body, handler) => Iterator(body, handler)
-    case SExpr.SEScopeExercise(body) => Iterator(body)
+    case SExpr.SEScopeExercise(_, body) => Iterator(body)
     case SExpr.SEBuiltin(_) => Iterator.empty
     case SExpr.SEBuiltinRecursiveDefinition(_) => Iterator.empty
     case SExpr.SELocA(_) => Iterator.empty

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -7,7 +7,7 @@ package speedy
 import com.daml.lf.data.ImmArray
 import com.daml.lf.ledger.Authorize
 import com.daml.lf.speedy.PartialTransaction._
-import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SValue.{SValue => _, _}
 import com.daml.lf.transaction.{ContractKeyUniquenessMode, Node, TransactionVersion}
 import com.daml.lf.value.Value
 import org.scalatest._
@@ -27,6 +27,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
     ContractKeyUniquenessMode.On,
     data.Time.Timestamp.Epoch,
     InitialSeeding.TransactionSeed(transactionSeed),
+    transactionNormalization = true,
   )
 
   private[this] def contractIdsInOrder(ptx: PartialTransaction): Seq[Value.ContractId] = {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -264,7 +264,7 @@ object ExceptionTest {
       tx.nodes(nid) match {
         case create: NodeCreate[_] =>
           create.arg match {
-            case ValueRecord(_, ImmArray(_, (Some("info"), ValueInt64(n)))) =>
+            case ValueRecord(_, ImmArray(_, (None, ValueInt64(n)))) =>
               List(C(n))
             case _ =>
               sys.error(s"unexpected create.arg: ${create.arg}")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
@@ -28,7 +28,7 @@ class SValueTest extends AnyWordSpec with Matchers {
     "rejects excessive nesting" in {
       // Because Z has a nesting of 1, toNat(Value.MAXIMUM_NESTING) has a nesting of
       // Value.MAXIMUM_NESTING + 1
-      Try(toNat(Value.MAXIMUM_NESTING).toValue) shouldBe
+      Try(toNat(Value.MAXIMUM_NESTING).toUnnormalizedValue) shouldBe
         Failure(SError.SErrorDamlException(interpretation.Error.ValueExceedsMaxNesting))
     }
 

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -486,7 +486,7 @@ object Repl {
             valueOpt match {
               case None => ()
               case Some(value) =>
-                val result = prettyValue(true)(value.toValue).render(128)
+                val result = prettyValue(true)(value.toUnnormalizedValue).render(128)
                 println("result:")
                 println(result)
             }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -404,6 +404,7 @@ object ScenarioRunner {
       traceLog = traceLog,
       warningLog = warningLog,
       commitLocation = location,
+      transactionNormalization = false,
     )
     val onLedger = ledgerMachine.withOnLedger(NameOf.qualifiedNameOfCurrentFunc)(identity)
     @tailrec

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
@@ -13,20 +13,20 @@ private final class Validation[Nid, Cid]() {
     *   the root nodes of [[recorded]].
     * @note This function is symmetric
     *
-    * 'isReplayedBy' normalizes its 2nd argument, and then determines structural equality.
+    * 'isReplayedBy' is simply structural equality.
     *
-    * The RIGHT `replayed` arg must be normalized because the engine currently does not.
+    * The RIGHT `replayed` arg requires *no* normalization since TXs coming from the
+    * engine are now normalized.
     */
 
   private def isReplayedBy(
       recorded: VersionedTransaction[Nid, Cid],
       replayed: VersionedTransaction[Nid, Cid],
   ): Either[ReplayMismatch[Nid, Cid], Unit] = {
-    val replayedN = Normalization.normalizeTx(replayed)
-    if (recorded == replayedN) {
+    if (recorded == replayed) {
       Right(())
     } else {
-      Left(ReplayMismatch(recorded, replayedN))
+      Left(ReplayMismatch(recorded, replayed))
     }
   }
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
@@ -27,13 +27,10 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   //
   // A 'Tweak[X]' is a family of (small) modifications to a value of type X.
   //
-  // This test file constructs tweaks for 'VersionedTransaction' (VTX) and classifies them
-  // as either SIGNIFICANT or INSIGNIFICANT (as reported by 'isReplayedBy').
+  // This test file constructs tweaks for 'VersionedTransaction' (VTX).
+  // All tweaks are SIGNIFICANT since 'isReplayedBy' is simply structual equality
   //
   // We aim to tweak every field of every ActionNode in a TX.
-  //
-  // Most fields are trivially significant; Some are trivially insignificant.  A few
-  // fields are more complicated, and have both significant and insignificant cases.
   //
   // The tweaks are tested by running over a hand constructed list of 'preTweakedVTXs'. We
   // are careful to limit the combinational explosion to just what is necessary to ensure
@@ -229,11 +226,6 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   //--[predicates]--
   // Some tweaks have version dependant significance.
 
-  private def versionBeforeMinByKey(v: TransactionVersion): Boolean = {
-    import scala.Ordering.Implicits.infixOrderingOps
-    v < TransactionVersion.minByKey
-  }
-
   private def versionSinceMinByKey(v: TransactionVersion): Boolean = {
     import scala.Ordering.Implicits.infixOrderingOps
     v >= TransactionVersion.minByKey
@@ -340,11 +332,6 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
       "tweakFetchVersion" -> tweakFetchVersion,
     )
 
-  private val insigFetchTweaks =
-    Map(
-      "tweakFetchByKey(Old Version)" -> tweakFetchByKey(versionBeforeMinByKey)
-    )
-
   //--[LookupByKey node tweaks]--
 
   private val tweakLookupTemplateId = Tweak.single[Node] { case nl: Node.NodeLookupByKey[_] =>
@@ -437,12 +424,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
       "tweakExerciseVersion" -> tweakExerciseVersion,
     )
 
-  private val insigExeTweaks =
-    Map(
-      "tweakExerciseByKey(Old Version)" -> tweakExerciseByKey(versionBeforeMinByKey)
-    )
-
-  //--[significant and insignificant tx tweaks]--
+  //--[significant tx tweaks]--
 
   private def tweakTxNodes(tweakNode: Tweak[Node]) = Tweak[VTX] { vtx =>
     // tweak any node in a transaction
@@ -463,11 +445,6 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
       .map { case (name, tw) => (name, tweakTxNodes(tw)) }
   }
 
-  private def insignificantTweaks: Map[String, Tweak[VTX]] = {
-    (insigFetchTweaks ++ insigExeTweaks)
-      .map { case (name, tw) => (name, tweakTxNodes(tw)) }
-  }
-
   //--[per tweak tests]--
 
   "Significant tweaks" - {
@@ -479,20 +456,6 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
         val testCases = Table[VTX, VTX](("txA", "txB"), pairs: _*)
         forEvery(testCases) { case (txA, txB) =>
           Validation.isReplayedBy(txA, txB) shouldBe a[Left[_, _]]
-        }
-      }
-    }
-  }
-
-  "Insignificant tweaks" - {
-    insignificantTweaks.foreach { case (name, tweak) =>
-      val pairs = runTweak(tweak)
-      val n = pairs.length
-      assert(n > 0) // ensure tweak actualy applies to something
-      s"[#$n] $name" in {
-        val testCases = Table[VTX, VTX](("txA", "txB"), pairs: _*)
-        forEvery(testCases) { case (txA, txB) =>
-          Validation.isReplayedBy(txA, txB) shouldBe a[Right[_, _]]
         }
       }
     }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -224,7 +224,7 @@ object Converter {
           anyTemplate <- toAnyTemplate(vals.get(0))
         } yield command.CreateCommand(
           templateId = anyTemplate.ty,
-          argument = anyTemplate.arg.toValue,
+          argument = anyTemplate.arg.toUnnormalizedValue,
         )
       }
       case _ => Left(s"Expected Create but got $v")
@@ -242,7 +242,7 @@ object Converter {
           templateId = tplId,
           contractId = cid,
           choiceId = anyChoice.name,
-          argument = anyChoice.arg.toValue,
+          argument = anyChoice.arg.toUnnormalizedValue,
         )
       }
       case _ => Left(s"Expected Exercise but got $v")
@@ -258,9 +258,9 @@ object Converter {
           anyChoice <- toAnyChoice(vals.get(2))
         } yield command.ExerciseByKeyCommand(
           templateId = tplId,
-          contractKey = anyKey.key.toValue,
+          contractKey = anyKey.key.toUnnormalizedValue,
           choiceId = anyChoice.name,
-          argument = anyChoice.arg.toValue,
+          argument = anyChoice.arg.toUnnormalizedValue,
         )
       }
       case _ => Left(s"Expected ExerciseByKey but got $v")
@@ -274,9 +274,9 @@ object Converter {
           anyChoice <- toAnyChoice(vals.get(1))
         } yield command.CreateAndExerciseCommand(
           templateId = anyTemplate.ty,
-          createArgument = anyTemplate.arg.toValue,
+          createArgument = anyTemplate.arg.toUnnormalizedValue,
           choiceId = anyChoice.name,
-          choiceArgument = anyChoice.arg.toValue,
+          choiceArgument = anyChoice.arg.toUnnormalizedValue,
         )
       }
       case _ => Left(s"Expected CreateAndExercise but got $v")

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -434,7 +434,8 @@ private[lf] class Runner(
                   case ScriptF.Throw(SAny(ty, value)) =>
                     Future.failed(
                       Runner.InterpretationError(
-                        SError.SErrorDamlException(IE.UnhandledException(ty, value.toValue))
+                        SError
+                          .SErrorDamlException(IE.UnhandledException(ty, value.toUnnormalizedValue))
                       )
                     )
                   case cmd: ScriptF.Cmd =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -108,7 +108,7 @@ object RunnerMain {
       result <- Runner.run(dar, scriptId, inputValue, clients, timeMode)
       _ <- Future {
         config.outputFile.foreach { outputFile =>
-          val jsVal = LfValueCodec.apiValueToJsValue(result.toValue)
+          val jsVal = LfValueCodec.apiValueToJsValue(result.toUnnormalizedValue)
           val outDir = outputFile.getParentFile()
           if (outDir != null) {
             val _ = Files.createDirectories(outDir.toPath())

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -108,7 +108,7 @@ class IdeLedgerClient(
       mat: Materializer,
   ): Future[Option[ScriptLedgerClient.ActiveContract]] = {
     GlobalKey
-      .build(templateId, key.toValue)
+      .build(templateId, key.toUnnormalizedValue)
       .fold(err => Future.failed(new ConverterException(err)), Future.successful(_))
       .flatMap { gkey =>
         ledger.ledgerData.activeKeys.get(gkey) match {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -180,7 +180,7 @@ class JsonLedgerClient(
       _ <- validateTokenParties(parties, "queryContractKey")
       fetchResponse <- requestSuccess[FetchKeyArgs, FetchResponse](
         uri.path./("v1")./("fetch"),
-        FetchKeyArgs(templateId, key.toValue),
+        FetchKeyArgs(templateId, key.toUnnormalizedValue),
       )
     } yield {
       val ctx = templateId.qualifiedName

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -468,7 +468,7 @@ final class JsonApiIt
           inputValue = Some(
             JsArray(
               JsArray(JsString(party0), JsString(party1)),
-              ApiCodecCompressed.apiValueToJsValue(cids.toValue.mapContractId(_.coid)),
+              ApiCodecCompressed.apiValueToJsValue(cids.toUnnormalizedValue.mapContractId(_.coid)),
             )
           ),
         )
@@ -486,14 +486,18 @@ final class JsonApiIt
           QualifiedName.assertFromString("ScriptTest:jsonMultiPartySubmissionCreateSingle"),
           inputValue = Some(JsString(party1)),
         )
-          .map(v => ApiCodecCompressed.apiValueToJsValue(v.toValue.mapContractId(_.coid)))
+          .map(v =>
+            ApiCodecCompressed.apiValueToJsValue(v.toUnnormalizedValue.mapContractId(_.coid))
+          )
         clientsBoth <- getMultiPartyClients(List(party1, party2))
         cidBoth <- run(
           clientsBoth,
           QualifiedName.assertFromString("ScriptTest:jsonMultiPartySubmissionCreate"),
           inputValue = Some(JsArray(JsString(party1), JsString(party2))),
         )
-          .map(v => ApiCodecCompressed.apiValueToJsValue(v.toValue.mapContractId(_.coid)))
+          .map(v =>
+            ApiCodecCompressed.apiValueToJsValue(v.toUnnormalizedValue.mapContractId(_.coid))
+          )
         clients2 <- getMultiPartyClients(List(party2), List(party1))
         r <- run(
           clients2,

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/SpeedyToValueBenchmark.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/SpeedyToValueBenchmark.scala
@@ -28,6 +28,6 @@ class SpeedyToValueBenchmark extends BenchmarkWithLedgerExport {
 
   @Benchmark
   def run(): Vector[Value[ContractId]] =
-    speedyValues.map(_.toValue)
+    speedyValues.map(_.toUnnormalizedValue)
 
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -172,6 +172,7 @@ final class SandboxServer(
         }
       EngineConfig(
         allowedLanguageVersions = allowedLanguageVersions,
+        transactionNormalization = false,
         profileDir = config.profileDir,
         stackTraceMode = config.stackTraces,
       )

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
@@ -78,10 +78,10 @@ object Converter {
   private case class AnyContractKey(key: SValue)
 
   private def toLedgerRecord(v: SValue): Either[String, value.Record] =
-    lfValueToApiRecord(true, v.toValue)
+    lfValueToApiRecord(true, v.toUnnormalizedValue)
 
   private def toLedgerValue(v: SValue): Either[String, value.Value] =
-    lfValueToApiValue(true, v.toValue)
+    lfValueToApiValue(true, v.toUnnormalizedValue)
 
   private def fromIdentifier(id: value.Identifier): SValue = {
     STypeRep(


### PR DESCRIPTION
Normalize transaction values in the engine as they are converted from speedy-values.
- Except in some limited cases! (scenario-runner, sandbox, some tests)
- `isReplayedBy` now finally becomes structural equality!
- Normalization controlled by a new `EngineConfig` flag (`transactionNormalization`)
- which is passed when a speedy `Machine` is constructed

This PR advances #6665
