### PR TITLE
Dpp-558 Fix startexclusive queries on oracle

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
@@ -312,7 +312,7 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
 
   private val SQL_GET_PARTY_ENTRIES = SQL(
     """select * from party_entries
-      |where ({startExclusive} is null or ledger_offset>{startExclusive}) and ledger_offset<={endInclusive}
+      |where ({startExclusive} is null or ledger_offset > {startExclusive}) and ledger_offset <= {endInclusive}
       |order by ledger_offset asc
       |offset {queryOffset} rows
       |fetch next {pageSize} rows only""".stripMargin
@@ -484,8 +484,8 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
 
   private val SQL_GET_PACKAGE_ENTRIES = SQL(
     """select * from package_entries
-      |where ({startExclusive} is null or ledger_offset>{startExclusive})
-      |and ledger_offset<={endInclusive}
+      |where ({startExclusive} is null or ledger_offset > {startExclusive})
+      |and ledger_offset <= {endInclusive}
       |order by ledger_offset asc
       |offset {queryOffset} rows
       |fetch next {pageSize} rows only""".stripMargin

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CompletionStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CompletionStorageBackendTemplate.scala
@@ -69,7 +69,7 @@ trait CompletionStorageBackendTemplate extends CompletionStorageBackend {
         FROM
           participant_command_completions
         WHERE
-          completion_offset > $startExclusive AND
+          ($startExclusive is null or completion_offset > $startExclusive) AND
           completion_offset <= $endInclusive AND
           application_id = $applicationId AND
           ${queryStrategy.arrayIntersectionNonEmptyClause("submitters", parties)}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -1212,17 +1212,17 @@ private[platform] object JdbcLedgerDao {
 
     protected[JdbcLedgerDao] def SQL_GET_PACKAGE_ENTRIES: String =
       """select * from package_entries
-        |where ledger_offset>{startExclusive} and ledger_offset<={endInclusive}
+        |where ({startExclusive} is null or ledger_offset > {startExclusive}) and ledger_offset <= {endInclusive}
         |order by ledger_offset asc limit {pageSize} offset {queryOffset}""".stripMargin
 
     protected[JdbcLedgerDao] def SQL_GET_PARTY_ENTRIES: String =
       """select * from party_entries
-        |where ledger_offset>{startExclusive} and ledger_offset<={endInclusive}
+        |where ({startExclusive} is null or ledger_offset > {startExclusive}) and ledger_offset <= {endInclusive}
         |order by ledger_offset asc limit {pageSize} offset {queryOffset}""".stripMargin
 
     protected[JdbcLedgerDao] def SQL_GET_CONFIGURATION_ENTRIES: String =
       """select * from configuration_entries where
-        |ledger_offset > {startExclusive} and ledger_offset <= {endInclusive}
+        |({startExclusive} is null or ledger_offset > {startExclusive}) and ledger_offset <= {endInclusive}
         |order by ledger_offset asc limit {pageSize} offset {queryOffset}""".stripMargin
 
     // TODO: Avoid brittleness of error message checks

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -1394,19 +1394,19 @@ private[platform] object JdbcLedgerDao {
 
     override protected[JdbcLedgerDao] val SQL_GET_PACKAGE_ENTRIES: String =
       """select * from package_entries where
-        |({startExclusive} is null or ledger_offset>{startExclusive}) and ledger_offset<={endInclusive}
+        |({startExclusive} is null or ledger_offset > {startExclusive}) and ledger_offset <= {endInclusive}
         |order by ledger_offset asc
         |offset {queryOffset} rows fetch next {pageSize} rows only""".stripMargin
 
     override protected[JdbcLedgerDao] val SQL_GET_PARTY_ENTRIES: String =
       """select * from party_entries where
-        |({startExclusive} is null or ledger_offset>{startExclusive}) and ledger_offset<={endInclusive}
+        |({startExclusive} is null or ledger_offset > {startExclusive}) and ledger_offset <= {endInclusive}
         |order by ledger_offset asc
         |offset {queryOffset} rows fetch next {pageSize} rows only""".stripMargin
 
     override protected[JdbcLedgerDao] val SQL_GET_CONFIGURATION_ENTRIES: String =
       """select * from configuration_entries where
-        |({startExclusive} is null or ledger_offset>{startExclusive}) and ledger_offset<={endInclusive}
+        |({startExclusive} is null or ledger_offset > {startExclusive}) and ledger_offset <= {endInclusive}
         |order by ledger_offset asc
         |offset {queryOffset} rows fetch next {pageSize} rows only""".stripMargin
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableTreeEvents.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableTreeEvents.scala
@@ -123,8 +123,8 @@ private[events] object EventsTableTreeEvents {
     )} then command_id else '' end as command_id
           from participant_events
           join parameters on
-            (participant_pruned_up_to_inclusive is null OR
-            event_offset > participant_pruned_up_to_inclusive) and event_offset <= ledger_end
+            (participant_pruned_up_to_inclusive is null or event_offset > participant_pruned_up_to_inclusive)
+            and event_offset <= ledger_end
           where transaction_id = $transactionId and #$witnessesWhereClause
           order by node_index asc"""
   }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
@@ -10,6 +10,7 @@ trait StorageBackendSuite
     with StorageBackendTestsInitialization
     with StorageBackendTestsInitializeIngestion
     with StorageBackendTestsIngestion
+    with StorageBackendTestsCompletions
     with StorageBackendTestsReset
     with StorageBackendTestsPruning {
   this: AsyncFlatSpec =>

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
@@ -40,6 +40,7 @@ private[backend] object StorageBackendTestValues {
   val someIdentityParams: ParameterStorageBackend.IdentityParams =
     ParameterStorageBackend.IdentityParams(someLedgerId, someParticipantId)
   val someParty: Ref.Party = Ref.Party.assertFromString("party")
+  val someApplicationId: Ref.ApplicationId = Ref.ApplicationId.assertFromString("application_id")
 
   val someArchive: DamlLf.Archive = DamlLf.Archive.newBuilder
     .setHash("00001")
@@ -126,7 +127,7 @@ private[backend] object StorageBackendTestValues {
       ledger_effective_time = Some(someTime),
       command_id = Some(commandId),
       workflow_id = Some("workflow_id"),
-      application_id = Some("application_id"),
+      application_id = Some(someApplicationId),
       submitters = None,
       node_index = Some(0),
       event_id = Some(EventId(transactionId, NodeId(0)).toLedgerString),
@@ -169,7 +170,7 @@ private[backend] object StorageBackendTestValues {
       ledger_effective_time = Some(someTime),
       command_id = Some(commandId),
       workflow_id = Some("workflow_id"),
-      application_id = Some("application_id"),
+      application_id = Some(someApplicationId),
       submitters = Some(Set(actor)),
       node_index = Some(0),
       event_id = Some(EventId(transactionId, NodeId(0)).toLedgerString),
@@ -204,7 +205,7 @@ private[backend] object StorageBackendTestValues {
       event_offset = Some(offset.toHexString),
       command_id = Some(commandId),
       workflow_id = Some("workflow_id"),
-      application_id = Some("application_id"),
+      application_id = Some(someApplicationId),
       submitters = Some(Set(submitter)),
       contract_id = contractId,
       template_id = Some(someTemplateId.toString),
@@ -219,12 +220,13 @@ private[backend] object StorageBackendTestValues {
       offset: Offset,
       submitter: String = "signatory",
       commandId: String = UUID.randomUUID().toString,
+      applicationId: String = someApplicationId,
   ): DbDto.CommandCompletion = {
     val transactionId = transactionIdFromOffset(offset)
     DbDto.CommandCompletion(
       completion_offset = offset.toHexString,
       record_time = someTime,
-      application_id = "application_id",
+      application_id = applicationId,
       submitters = Set(submitter),
       command_id = commandId,
       transaction_id = Some(transactionId),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsCompletions.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsCompletions.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.backend
+
+import com.daml.ledger.offset.Offset
+import org.scalatest.Inside
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+private[backend] trait StorageBackendTestsCompletions
+    extends Matchers
+    with Inside
+    with StorageBackendSpec {
+  this: AsyncFlatSpec =>
+
+  behavior of "StorageBackend (completions)"
+
+  import StorageBackendTestValues._
+
+  it should "correctly find completions by offset range" in {
+    val party = someParty
+    val applicationId = someApplicationId
+
+    val dtos = Vector(
+      dtoConfiguration(offset(1)),
+      dtoCompletion(offset(2), submitter = party),
+      dtoCompletion(offset(3), submitter = party),
+      dtoCompletion(offset(4), submitter = party),
+    )
+
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+      _ <- executeSql(ingest(dtos, _))
+      _ <- executeSql(backend.updateLedgerEnd(ParameterStorageBackend.LedgerEnd(offset(4), 3L)))
+      completions0to3 <- executeSql(
+        backend.commandCompletions(Offset.beforeBegin, offset(3), applicationId, Set(party))
+      )
+      completions1to3 <- executeSql(
+        backend.commandCompletions(offset(1), offset(3), applicationId, Set(party))
+      )
+      completions2to3 <- executeSql(
+        backend.commandCompletions(offset(2), offset(3), applicationId, Set(party))
+      )
+      completions1to9 <- executeSql(
+        backend.commandCompletions(offset(1), offset(9), applicationId, Set(party))
+      )
+    } yield {
+      completions0to3 should have length 2
+      completions1to3 should have length 2
+      completions2to3 should have length 1
+      completions1to9 should have length 3
+    }
+  }
+
+}


### PR DESCRIPTION
# Issue

Oracle treats empty byte arrays as null. We handled this in some places, but not everywhere.

# Why wasn't this caught

JdbcLedgerDao tests are not isolated. They look up the ledger end at the start of the test, and query from there. The tests never query from ledger begin.

# Fix

The following columns store offsets and are potentially affected. I have searched for all comparisons on these columns and fixed two places where the comparison was not guarded against null.

- parameters.ledger_end
- parameters.participant_pruned_up_to_inclusive
- configuration_entries.ledger_offset
- packages.ledger_offset
- package_entries.ledger_offset
- parties.ledger_offset
- party_entries.ledger_offset
- participant_command_completions.completion_offset
- participant_events_*.event_offset