### PR TITLE
participant-integration-api: Accommodate changes to max dedup time.

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
@@ -136,7 +136,7 @@ final class CommandClient(
             CommandSubmissionFlow[(Context, String)](submit(token), config.maxParallelSubmissions),
             offset => completionSource(parties, offset, token),
             ledgerEnd.getOffset,
-            () => config.defaultDeduplicationTime,
+            () => Some(config.defaultDeduplicationTime),
           )
         )(Keep.right)
     }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -42,7 +42,7 @@ object CommandTrackerFlow {
       ]], SubmissionMat],
       createCommandCompletionSource: LedgerOffset => Source[CompletionStreamElement, NotUsed],
       startingOffset: LedgerOffset,
-      maxDeduplicationTime: () => JDuration,
+      maxDeduplicationTime: () => Option[JDuration],
       backOffDuration: FiniteDuration = 1.second,
   ): Flow[Ctx[Context, SubmitRequest], Ctx[
     Context,


### PR DESCRIPTION
Previously, if the max deduplication time was extended, the participant _might_ retain the old time for certain submissions.

@fabiotudone-da explains it better than I could:

- Previously, the max deduplication time was read from the ledger configuration only upon a tracker's creation.
- This meant that alive trackers would not take into account updates to it (via ledger configuration updates) during their lifetime.
- Now, the max deduplication time is checked every time it is needed.
- This also means that the failure when the ledger configuration is missing happens later.

### Changelog

- **[Ledger API Server]** The API server manages a single command tracker per (application ID × submitters) pair. This tracker would read the current ledger configuration's maximum deduplication time on creation, but never updated it, leading to trackers that might inadvertently reject a submission when it should have been accepted. The tracker now reads the latest ledger configuration.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
