### PR TITLE
participant-integration-api: Simplify convertOffset.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
@@ -66,8 +66,7 @@ private[platform] final class LedgerBackedIndexService(
       filter: TransactionFilter,
       verbose: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetActiveContractsResponse, NotUsed] = {
-    val (acs, ledgerEnd) = ledger
-      .activeContracts(convertFilter(filter), verbose)
+    val (acs, ledgerEnd) = ledger.activeContracts(convertFilter(filter), verbose)
     acs.concat(Source.single(GetActiveContractsResponse(offset = ApiOffset.toApiString(ledgerEnd))))
   }
 
@@ -77,13 +76,13 @@ private[platform] final class LedgerBackedIndexService(
       filter: domain.TransactionFilter,
       verbose: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetTransactionTreesResponse, NotUsed] =
-    between(startExclusive, endInclusive)((from, to) => {
-      from.foreach(offset =>
+    between(startExclusive, endInclusive) { (from, to) =>
+      from.foreach { offset =>
         Spans.setCurrentSpanAttribute(SpanAttribute.OffsetFrom, offset.toHexString)
-      )
-      to.foreach(offset =>
+      }
+      to.foreach { offset =>
         Spans.setCurrentSpanAttribute(SpanAttribute.OffsetTo, offset.toHexString)
-      )
+      }
       ledger
         .transactionTrees(
           startExclusive = from,
@@ -92,7 +91,7 @@ private[platform] final class LedgerBackedIndexService(
           verbose = verbose,
         )
         .map(_._2)
-    })
+    }
 
   override def transactions(
       startExclusive: domain.LedgerOffset,
@@ -100,13 +99,13 @@ private[platform] final class LedgerBackedIndexService(
       filter: domain.TransactionFilter,
       verbose: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed] =
-    between(startExclusive, endInclusive)((from, to) => {
-      from.foreach(offset =>
+    between(startExclusive, endInclusive) { (from, to) =>
+      from.foreach { offset =>
         Spans.setCurrentSpanAttribute(SpanAttribute.OffsetFrom, offset.toHexString)
-      )
-      to.foreach(offset =>
+      }
+      to.foreach { offset =>
         Spans.setCurrentSpanAttribute(SpanAttribute.OffsetTo, offset.toHexString)
-      )
+      }
       ledger
         .flatTransactions(
           startExclusive = from,
@@ -115,7 +114,7 @@ private[platform] final class LedgerBackedIndexService(
           verbose = verbose,
         )
         .map(_._2)
-    })
+    }
 
   private def convertOffset(offset: LedgerOffset)(implicit
       loggingContext: LoggingContext


### PR DESCRIPTION
This function used to be memoized but I accidentally removed the behavior a year ago. As a reasonable client will never request the transactions from `LEDGER_END` to `LEDGER_END`, the behavior did not change.

This simplifies the function further.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
