### PR TITLE
participant-integration-api: Move `TrackerMap` code around. [KVL-1009]

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -49,15 +49,6 @@ object CompletionResponse {
       originalStatus: StatusProto,
   )
 
-  object CompletionSuccess {
-
-    /** In most cases we're not interested in the original grpc status, as it's used only to keep backwards compatibility
-      */
-    def unapply(success: CompletionSuccess): Option[(String, String)] = Some(
-      success.commandId -> success.transactionId
-    )
-  }
-
   def apply(completion: Completion): Either[CompletionFailure, CompletionSuccess] =
     completion.status match {
       case Some(grpcStatus) if Code.OK.value() == grpcStatus.code =>

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -203,13 +203,16 @@ object CommandsValidator {
   }
 
   def effectiveSubmitters(commands: ProtoCommands): Submitters[String] = {
-    val effectiveActAs =
-      if (commands.party.isEmpty)
-        commands.actAs.toSet
-      else
-        commands.actAs.toSet + commands.party
-    val effectiveReadAs = commands.readAs.toSet -- effectiveActAs
-    Submitters(effectiveActAs, effectiveReadAs)
+    val actAs = effectiveActAs(commands)
+    val readAs = commands.readAs.toSet -- actAs
+    Submitters(actAs, readAs)
+  }
+
+  def effectiveActAs(commands: ProtoCommands): Set[String] = {
+    if (commands.party.isEmpty)
+      commands.actAs.toSet
+    else
+      commands.actAs.toSet + commands.party
   }
 
   val noSubmitters: Submitters[String] = Submitters(Set.empty, Set.empty)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -208,12 +208,11 @@ object CommandsValidator {
     Submitters(actAs, readAs)
   }
 
-  def effectiveActAs(commands: ProtoCommands): Set[String] = {
+  def effectiveActAs(commands: ProtoCommands): Set[String] =
     if (commands.party.isEmpty)
       commands.actAs.toSet
     else
       commands.actAs.toSet + commands.party
-  }
 
   val noSubmitters: Submitters[String] = Submitters(Set.empty, Set.empty)
 

--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -232,6 +232,9 @@ da_scala_test_suite(
     jvm_flags = [
         "-Djava.security.debug=\"certpath ocsp\"",  # This facilitates debugging of the OCSP checks mechanism
     ],
+    plugins = [
+        silencer_plugin,
+    ],
     resources = glob(["src/test/resources/**/*"]),
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
@@ -241,6 +244,7 @@ da_scala_test_suite(
         "@maven//:org_mockito_mockito_scala",
         "@maven//:org_playframework_anorm_anorm",
         "@maven//:org_playframework_anorm_anorm_tokenizer",
+        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalactic_scalactic",
         "@maven//:org_scalatest_scalatest_core",

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -163,7 +163,7 @@ private[apiserver] object ApiCommandService {
       executionContext: ExecutionContext,
       loggingContext: LoggingContext,
   ): CommandServiceGrpc.CommandService with GrpcApiService = {
-    val submissionTracker = TrackerMap.selfCleaning(
+    val submissionTracker = new TrackerMap.SelfCleaning(
       configuration.retentionPeriod,
       Tracking.getTrackerKey,
       Tracking.newTracker(configuration, services, ledgerConfigurationSubscription, metrics),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
@@ -12,10 +12,10 @@ import com.daml.logging.LoggingContext
 
 import scala.concurrent.{ExecutionContext, Future}
 
-private[tracking] trait Tracker extends AutoCloseable {
+trait Tracker extends AutoCloseable {
 
   def track(request: SubmitAndWaitRequest)(implicit
-      ec: ExecutionContext,
+      executionContext: ExecutionContext,
       loggingContext: LoggingContext,
   ): Future[Either[TrackedCompletionFailure, CompletionSuccess]]
 
@@ -32,7 +32,7 @@ private[tracking] object Tracker {
     def getLastSubmission: Long = lastSubmission
 
     override def track(request: SubmitAndWaitRequest)(implicit
-        ec: ExecutionContext,
+        executionContext: ExecutionContext,
         loggingContext: LoggingContext,
     ): Future[Either[TrackedCompletionFailure, CompletionSuccess]] = {
       lastSubmission = System.nanoTime()

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
@@ -20,27 +20,3 @@ trait Tracker extends AutoCloseable {
   ): Future[Either[TrackedCompletionFailure, CompletionSuccess]]
 
 }
-
-private[tracking] object Tracker {
-
-  class WithLastSubmission(delegate: Tracker) extends Tracker {
-
-    override def close(): Unit = delegate.close()
-
-    @volatile private var lastSubmission = System.nanoTime()
-
-    def getLastSubmission: Long = lastSubmission
-
-    override def track(request: SubmitAndWaitRequest)(implicit
-        executionContext: ExecutionContext,
-        loggingContext: LoggingContext,
-    ): Future[Either[TrackedCompletionFailure, CompletionSuccess]] = {
-      lastSubmission = System.nanoTime()
-      delegate.track(request)
-    }
-  }
-
-  object WithLastSubmission {
-    def apply(delegate: Tracker): WithLastSubmission = new WithLastSubmission(delegate)
-  }
-}

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
@@ -35,7 +35,7 @@ private[services] final class TrackerImpl(
   import TrackerImpl.logger
 
   override def track(request: SubmitAndWaitRequest)(implicit
-      ec: ExecutionContext,
+      executionContext: ExecutionContext,
       loggingContext: LoggingContext,
   ): Future[Either[TrackedCompletionFailure, CompletionSuccess]] = {
     logger.trace("Tracking command")

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
@@ -37,31 +37,28 @@ private[services] final class TrackerMap(
   @volatile private var trackerBySubmitter =
     HashMap.empty[TrackerMap.Key, TrackerMap.AsyncResource[Tracker.WithLastSubmission]]
 
-  val cleanup: Runnable = {
-    require(
-      retentionPeriod < Long.MaxValue.nanoseconds,
-      s"Retention period$retentionPeriod is too long. Must be below ${Long.MaxValue} nanoseconds.",
-    )
+  require(
+    retentionPeriod < Long.MaxValue.nanoseconds,
+    s"Retention period$retentionPeriod is too long. Must be below ${Long.MaxValue} nanoseconds.",
+  )
 
-    val retentionNanos = retentionPeriod.toNanos
+  private val retentionNanos = retentionPeriod.toNanos
 
-    { () =>
-      lock.synchronized {
-        val nanoTime = System.nanoTime()
-        trackerBySubmitter foreach { case (submitter, trackerResource) =>
-          trackerResource.ifPresent(tracker =>
-            if (nanoTime - tracker.getLastSubmission > retentionNanos) {
-              logger.info(
-                s"Shutting down tracker for $submitter after inactivity of $retentionPeriod"
-              )(trackerResource.loggingContext)
-              remove(submitter)
-              tracker.close()
-            }
-          )
+  val cleanup: Runnable = () =>
+    lock.synchronized {
+      val nanoTime = System.nanoTime()
+      trackerBySubmitter foreach { case (submitter, trackerResource) =>
+        trackerResource.ifPresent { tracker =>
+          if (nanoTime - tracker.getLastSubmission > retentionNanos) {
+            logger.info(
+              s"Shutting down tracker for $submitter after inactivity of $retentionPeriod"
+            )(trackerResource.loggingContext)
+            trackerBySubmitter -= submitter
+            tracker.close()
+          }
         }
       }
     }
-  }
 
   def track(
       request: SubmitAndWaitRequest
@@ -83,9 +80,7 @@ private[services] final class TrackerMap(
                 logger.info(s"Registered tracker for submitter $submitter")
                 Tracker.WithLastSubmission(t)
               })
-
               trackerBySubmitter += submitter -> r
-
               r
             },
           )
@@ -94,16 +89,10 @@ private[services] final class TrackerMap(
       .flatMap(_.track(request))
   }
 
-  private def remove(submitter: TrackerMap.Key): Unit = lock.synchronized {
-    trackerBySubmitter -= submitter
-  }
-
-  def close(): Unit = {
-    lock.synchronized {
-      logger.info(s"Shutting down ${trackerBySubmitter.size} trackers")
-      trackerBySubmitter.values.foreach(_.close())
-      trackerBySubmitter = HashMap.empty
-    }
+  def close(): Unit = lock.synchronized {
+    logger.info(s"Shutting down ${trackerBySubmitter.size} trackers")
+    trackerBySubmitter.values.foreach(_.close())
+    trackerBySubmitter = HashMap.empty
   }
 }
 
@@ -143,16 +132,12 @@ private[services] object TrackerMap {
         state.set(Closed)
     }(DirectExecutionContext)
 
-    def flatMap[U](f: T => Future[U])(implicit ex: ExecutionContext): Future[U] = {
+    def flatMap[U](f: T => Future[U])(implicit ex: ExecutionContext): Future[U] =
       state.get() match {
         case Waiting => future.flatMap(f)
         case Closed => throw new IllegalStateException()
         case Ready(t) => f(t)
       }
-    }
-
-    def map[U](f: T => U)(implicit ex: ExecutionContext): Future[U] =
-      flatMap(t => Future.successful(f(t)))
 
     def ifPresent[U](f: T => U): Option[U] = state.get() match {
       case Ready(t) => Some(f(t))

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
@@ -109,7 +109,7 @@ private[services] object TrackerMap {
   ) extends Tracker {
     private val delegate = new TrackerMap(retentionPeriod, getKey, newTracker)
     private val trackerCleanupJob = materializer.system.scheduler
-      .scheduleAtFixedRate(cleanupInterval, cleanupInterval)(delegate.cleanup _)
+      .scheduleAtFixedRate(cleanupInterval, cleanupInterval)(() => delegate.cleanup())
 
     override def track(
         request: SubmitAndWaitRequest

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
@@ -26,7 +26,7 @@ import scala.util.{Failure, Success}
 private[services] final class TrackerMap[Key](
     retentionPeriod: FiniteDuration,
     getKey: Commands => Key,
-    newTracker: Commands => Future[Tracker],
+    newTracker: Key => Future[Tracker],
 )(implicit loggingContext: LoggingContext)
     extends Tracker
     with AutoCloseable {
@@ -76,7 +76,7 @@ private[services] final class TrackerMap[Key](
         lock.synchronized {
           trackerBySubmitter.getOrElse(
             key, {
-              val r = new TrackerMap.AsyncResource(newTracker(commands).map { t =>
+              val r = new TrackerMap.AsyncResource(newTracker(key).map { t =>
                 logger.info(s"Registered tracker for submitter $key")
                 new TrackerWithLastSubmission(t)
               })

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
@@ -1,0 +1,156 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.apiserver.services.tracking
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
+import com.daml.ledger.api.v1.commands.Commands
+import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
+  CompletionSuccess,
+  TrackedCompletionFailure,
+}
+import com.daml.logging.LoggingContext
+import com.daml.platform.apiserver.services.tracking.TrackerMapSpec._
+import com.google.rpc.status.Status
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.{ExecutionContext, Future}
+
+class TrackerMapSpec extends AsyncWordSpec with Matchers {
+  private implicit val ec: ExecutionContext = ExecutionContext.global
+  private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
+
+  "the tracker map" should {
+    "delegate submissions to the constructed trackers" in {
+      val transactionIds = Seq("transaction A", "transaction B").iterator
+      val tracker = new TrackerMap[String](
+        retentionPeriod = 1.minute,
+        getKey = commands => commands.commandId,
+        newTracker = _ => Future.successful(new FakeTracker(transactionIds)),
+      )
+
+      for {
+        completion1 <- tracker.track(
+          SubmitAndWaitRequest.of(commands = Some(Commands(commandId = "1", actAs = Seq("Alice"))))
+        )
+        completion2 <- tracker.track(
+          SubmitAndWaitRequest.of(commands = Some(Commands(commandId = "2", actAs = Seq("Bob"))))
+        )
+      } yield {
+        completion1 should matchPattern { case Right(CompletionSuccess("1", "transaction A")) => }
+        completion2 should matchPattern { case Right(CompletionSuccess("2", "transaction B")) => }
+      }
+    }
+
+    "only construct one tracker per key" in {
+      val trackerCount = new AtomicInteger(0)
+      val tracker = new TrackerMap[Set[String]](
+        retentionPeriod = 1.minute,
+        getKey = commands => commands.actAs.toSet,
+        newTracker = actAs => {
+          trackerCount.incrementAndGet()
+          val transactionIds =
+            (0 until Int.MaxValue).iterator.map(i => s"${actAs.mkString(", ")}: $i")
+          Future.successful(new FakeTracker(transactionIds))
+        },
+      )
+
+      for {
+        completion1 <- tracker.track(
+          SubmitAndWaitRequest.of(
+            commands = Some(Commands(commandId = "X", actAs = Seq("Alice", "Bob")))
+          )
+        )
+        completion2 <- tracker.track(
+          SubmitAndWaitRequest.of(
+            commands = Some(Commands(commandId = "Y", actAs = Seq("Bob", "Alice")))
+          )
+        )
+      } yield {
+        trackerCount.get() should be(1)
+        completion1 should matchPattern { case Right(CompletionSuccess("X", "Alice, Bob: 0")) => }
+        completion2 should matchPattern { case Right(CompletionSuccess("Y", "Alice, Bob: 1")) => }
+      }
+    }
+
+    "only construct one tracker per key, even under heavy contention" in {
+      val requestCount = 1000
+      val expectedTrackerCount = 10
+      val actualTrackerCount = new AtomicInteger(0)
+      val tracker = new TrackerMap[String](
+        retentionPeriod = 1.minute,
+        getKey = commands => commands.applicationId,
+        newTracker = _ => {
+          actualTrackerCount.incrementAndGet()
+          Future.successful(new FakeTracker(transactionIds = Iterator.continually("")))
+        },
+      )
+
+      val requests = (0 until requestCount).map { i =>
+        val key = (i % expectedTrackerCount).toString
+        SubmitAndWaitRequest.of(
+          commands = Some(Commands(commandId = i.toString, applicationId = key))
+        )
+      }
+      Future.sequence(requests.map(tracker.track)).map { completions =>
+        actualTrackerCount.get() should be(expectedTrackerCount)
+        all(completions) should matchPattern { case Right(_) => }
+      }
+    }
+
+    "clean up old trackers" in {
+      val trackerCounts = TrieMap.empty[Set[String], AtomicInteger]
+      val tracker = new TrackerMap[Set[String]](
+        retentionPeriod = Duration.Zero,
+        getKey = commands => commands.actAs.toSet,
+        newTracker = actAs => {
+          trackerCounts.getOrElseUpdate(actAs, new AtomicInteger(0)).incrementAndGet()
+          Future.successful(new FakeTracker(transactionIds = Iterator.continually("")))
+        },
+      )
+
+      for {
+        _ <- tracker.track(
+          SubmitAndWaitRequest.of(commands = Some(Commands(commandId = "1", actAs = Seq("Alice"))))
+        )
+        _ <- tracker.track(
+          SubmitAndWaitRequest.of(commands = Some(Commands(commandId = "2", actAs = Seq("Bob"))))
+        )
+        _ = tracker.cleanup()
+        _ <- tracker.track(
+          SubmitAndWaitRequest.of(commands = Some(Commands(commandId = "3", actAs = Seq("Bob"))))
+        )
+      } yield {
+        val finalTrackerCounts = trackerCounts.view.mapValues(_.get()).toMap
+        finalTrackerCounts should be(Map(Set("Alice") -> 1, Set("Bob") -> 2))
+      }
+    }
+  }
+}
+
+object TrackerMapSpec {
+  final class FakeTracker(transactionIds: Iterator[String]) extends Tracker {
+    override def track(
+        request: SubmitAndWaitRequest
+    )(implicit
+        executionContext: ExecutionContext,
+        loggingContext: LoggingContext,
+    ): Future[Either[TrackedCompletionFailure, CompletionSuccess]] =
+      Future.successful(
+        Right(
+          CompletionSuccess(
+            commandId = request.getCommands.commandId,
+            transactionId = transactionIds.next(),
+            originalStatus = Status.defaultInstance,
+          )
+        )
+      )
+
+    override def close(): Unit = ()
+  }
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
@@ -17,6 +17,7 @@ import com.google.rpc.status.Status
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
+import scala.collection.compat._
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, Future}
@@ -42,8 +43,10 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
           SubmitAndWaitRequest.of(commands = Some(Commands(commandId = "2", actAs = Seq("Bob"))))
         )
       } yield {
-        completion1 should matchPattern { case Right(CompletionSuccess("1", "transaction A")) => }
-        completion2 should matchPattern { case Right(CompletionSuccess("2", "transaction B")) => }
+        completion1 should matchPattern { case Right(CompletionSuccess("1", "transaction A", _)) =>
+        }
+        completion2 should matchPattern { case Right(CompletionSuccess("2", "transaction B", _)) =>
+        }
       }
     }
 
@@ -73,8 +76,10 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
         )
       } yield {
         trackerCount.get() should be(1)
-        completion1 should matchPattern { case Right(CompletionSuccess("X", "Alice, Bob: 0")) => }
-        completion2 should matchPattern { case Right(CompletionSuccess("Y", "Alice, Bob: 1")) => }
+        completion1 should matchPattern { case Right(CompletionSuccess("X", "Alice, Bob: 0", _)) =>
+        }
+        completion2 should matchPattern { case Right(CompletionSuccess("Y", "Alice, Bob: 1", _)) =>
+        }
       }
     }
 


### PR DESCRIPTION
This is pure refactoring to:

- make `TrackerMap` a subtype of `Tracker`, by passing the tracker creation code into the constructor,
- make `TrackerMap` generic over the key, because it doesn't need to know the contents,
- move `Tracker.WithLastSubmission` to `TrackerMap.TrackerWithLastSubmission`, because it's only used by `TrackerMap`,
- move the `TrackerMap` scheduler into `TrackerMap.selfCleaning`,
- move `TrackerMap` construction into `ApiCommandService.create`, and
- move a bunch of other code around for convenience.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
