### PR TITLE
participant-state: Generate correct gRPC error codes by v2 `WriteService` [KVL-1081]

### DIFF
--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteService.scala
@@ -141,10 +141,13 @@ private[v2] object AdaptedV1WriteService {
         SubmissionResult.SynchronousError(rpcStatus)
     }
 
-  private def errorDetailsForFailure(failure: StatusRuntimeException): Seq[com.google.protobuf.any.Any] = {
+  private def errorDetailsForFailure(
+      failure: StatusRuntimeException
+  ): Seq[com.google.protobuf.any.Any] = {
     val metadata = Option(failure.getTrailers)
       .map { trailers =>
-        trailers.keys()
+        trailers
+          .keys()
           .asScala
           .map { key =>
             key -> trailers.get[String](Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER))

--- a/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteServiceSpec.scala
+++ b/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteServiceSpec.scala
@@ -33,7 +33,7 @@ class AdaptedV1WriteServiceSpec extends AnyWordSpec with Matchers with TableDriv
       }
     }
 
-    "transform synchronous rejections' details into an ErrorInfo" in {
+    "transform details of synchronous rejection into an ErrorInfo" in {
       val expectedMetadata = new Metadata()
       expectedMetadata.put(Metadata.Key.of("key", Metadata.ASCII_STRING_MARSHALLER), "value")
       val expectedStatus = Status.UNIMPLEMENTED.withDescription("not yet")

--- a/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteServiceSpec.scala
+++ b/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteServiceSpec.scala
@@ -18,11 +18,17 @@ class AdaptedV1WriteServiceSpec extends AnyWordSpec with Matchers with TableDriv
         (v1.SubmissionResult.Overloaded, Status.RESOURCE_EXHAUSTED),
         (v1.SubmissionResult.NotSupported, Status.UNIMPLEMENTED),
         (v1.SubmissionResult.InternalError("some reason"), Status.INTERNAL),
-        (v1.SubmissionResult.SynchronousReject(Status.UNAVAILABLE.asRuntimeException(new Metadata())), Status.UNAVAILABLE),
+        (
+          v1.SubmissionResult.SynchronousReject(
+            Status.UNAVAILABLE.asRuntimeException(new Metadata())
+          ),
+          Status.UNAVAILABLE,
+        ),
       )
 
       forAll(cases) { case (input, expectedGrpcStatus) =>
-        val SubmissionResult.SynchronousError(actual) = AdaptedV1WriteService.adaptSubmissionResult(input)
+        val SubmissionResult.SynchronousError(actual) =
+          AdaptedV1WriteService.adaptSubmissionResult(input)
         actual.code should be(expectedGrpcStatus.getCode.value())
       }
     }
@@ -34,7 +40,8 @@ class AdaptedV1WriteServiceSpec extends AnyWordSpec with Matchers with TableDriv
       val expectedStatusRuntimeException = expectedStatus.asRuntimeException(expectedMetadata)
       val input = v1.SubmissionResult.SynchronousReject(expectedStatusRuntimeException)
 
-      val SubmissionResult.SynchronousError(actual) = AdaptedV1WriteService.adaptSubmissionResult(input)
+      val SubmissionResult.SynchronousError(actual) =
+        AdaptedV1WriteService.adaptSubmissionResult(input)
 
       actual.code should be(expectedStatus.getCode.value())
       actual.details should have size 1
@@ -46,9 +53,11 @@ class AdaptedV1WriteServiceSpec extends AnyWordSpec with Matchers with TableDriv
     }
 
     "handle null metadata for synchronous rejection" in {
-      val input = v1.SubmissionResult.SynchronousReject(Status.UNIMPLEMENTED.asRuntimeException(null))
+      val input =
+        v1.SubmissionResult.SynchronousReject(Status.UNIMPLEMENTED.asRuntimeException(null))
 
-      val SubmissionResult.SynchronousError(actual) = AdaptedV1WriteService.adaptSubmissionResult(input)
+      val SubmissionResult.SynchronousError(actual) =
+        AdaptedV1WriteService.adaptSubmissionResult(input)
 
       actual.code should be(Status.UNIMPLEMENTED.getCode.value())
       actual.details should have size 1

--- a/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteServiceSpec.scala
+++ b/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteServiceSpec.scala
@@ -53,11 +53,11 @@ class AdaptedV1WriteServiceSpec extends AnyWordSpec with Matchers with TableDriv
     }
 
     "handle null metadata for synchronous rejection" in {
-      val input =
+      val inputWithNullMetadata =
         v1.SubmissionResult.SynchronousReject(Status.UNIMPLEMENTED.asRuntimeException(null))
 
       val SubmissionResult.SynchronousError(actual) =
-        AdaptedV1WriteService.adaptSubmissionResult(input)
+        AdaptedV1WriteService.adaptSubmissionResult(inputWithNullMetadata)
 
       actual.code should be(Status.UNIMPLEMENTED.getCode.value())
       actual.details should have size 1

--- a/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteServiceSpec.scala
+++ b/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/v2/AdaptedV1WriteServiceSpec.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v2
+
+import com.daml.ledger.participant.state.v1
+import com.google.rpc.error_details.ErrorInfo
+import io.grpc.{Metadata, Status}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+
+class AdaptedV1WriteServiceSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+  "adaptSubmissionResult" should {
+    "produce correct gRPC error codes for synchronous errors" in {
+      val cases = Table(
+        ("Submission Result", "Expected gRPC Error Code"),
+        (v1.SubmissionResult.Overloaded, Status.RESOURCE_EXHAUSTED),
+        (v1.SubmissionResult.NotSupported, Status.UNIMPLEMENTED),
+        (v1.SubmissionResult.InternalError("some reason"), Status.INTERNAL),
+        (v1.SubmissionResult.SynchronousReject(Status.UNAVAILABLE.asRuntimeException(new Metadata())), Status.UNAVAILABLE),
+      )
+
+      forAll(cases) { case (input, expectedGrpcStatus) =>
+        val SubmissionResult.SynchronousError(actual) = AdaptedV1WriteService.adaptSubmissionResult(input)
+        actual.code should be(expectedGrpcStatus.getCode.value())
+      }
+    }
+
+    "transform synchronous rejections' details into an ErrorInfo" in {
+      val expectedMetadata = new Metadata()
+      expectedMetadata.put(Metadata.Key.of("key", Metadata.ASCII_STRING_MARSHALLER), "value")
+      val expectedStatus = Status.UNIMPLEMENTED.withDescription("not yet")
+      val expectedStatusRuntimeException = expectedStatus.asRuntimeException(expectedMetadata)
+      val input = v1.SubmissionResult.SynchronousReject(expectedStatusRuntimeException)
+
+      val SubmissionResult.SynchronousError(actual) = AdaptedV1WriteService.adaptSubmissionResult(input)
+
+      actual.code should be(expectedStatus.getCode.value())
+      actual.details should have size 1
+      val com.google.protobuf.any.Any(_, actualSerializedErrorInfo, _) = actual.details.head
+      val actualErrorInfo = ErrorInfo.parseFrom(actualSerializedErrorInfo.newCodedInput())
+      actualErrorInfo.reason should be(expectedStatusRuntimeException.getLocalizedMessage)
+      actualErrorInfo.domain should be("Synchronous rejection")
+      actualErrorInfo.metadata should be(Map("key" -> "value"))
+    }
+
+    "handle null metadata for synchronous rejection" in {
+      val input = v1.SubmissionResult.SynchronousReject(Status.UNIMPLEMENTED.asRuntimeException(null))
+
+      val SubmissionResult.SynchronousError(actual) = AdaptedV1WriteService.adaptSubmissionResult(input)
+
+      actual.code should be(Status.UNIMPLEMENTED.getCode.value())
+      actual.details should have size 1
+      val com.google.protobuf.any.Any(_, actualSerializedErrorInfo, _) = actual.details.head
+      val actualErrorInfo = ErrorInfo.parseFrom(actualSerializedErrorInfo.newCodedInput())
+      actualErrorInfo.metadata should be(Map.empty)
+    }
+  }
+}


### PR DESCRIPTION
Summary of changes:
* Correctly set status code (`status.value` instead of enum index) for synchronous errors.
* Handle null metadata when translating a `StatusRuntimeException` for synchronous rejections.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
