### PR TITLE
[Divulgence pruning] Prune all divulged contracts only after migration offset [DPP-483]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -641,6 +641,12 @@ private class JdbcLedgerDao(
 
     dbDispatcher
       .executeSql(metrics.daml.index.db.pruneDbMetrics) { conn =>
+        storageBackend.validatePruningOffsetAgainstMigration(
+          pruneUpToInclusive,
+          pruneAllDivulgedContracts,
+          conn,
+        )
+
         storageBackend.pruneEvents(pruneUpToInclusive, pruneAllDivulgedContracts)(
           conn,
           loggingContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
@@ -241,6 +241,11 @@ trait EventStorageBackend {
       connection: Connection,
       loggingContext: LoggingContext,
   ): Unit
+  def validatePruningOffsetAgainstMigration(
+      pruneUpToInclusive: Offset,
+      pruneAllDivulgedContracts: Boolean,
+      connection: Connection,
+  ): Unit
   def transactionEvents(
       rangeParams: RangeParams,
       filterParams: FilterParams,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
@@ -491,6 +491,7 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
           -- Retroactive divulgence events
           delete from participant_events_divulgence delete_events
           where delete_events.event_offset <= $pruneUpToInclusive
+            or delete_events.event_offset is null
           """
       }(connection, loggingContext)
     } else {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
@@ -31,6 +31,7 @@ import com.daml.platform.store.backend.{
   StorageBackend,
   common,
 }
+import com.daml.scalautil.Statement.discard
 import javax.sql.DataSource
 
 private[backend] object H2StorageBackend
@@ -228,4 +229,15 @@ private[backend] object H2StorageBackend
     throw new UnsupportedOperationException("db level locks are not supported for H2")
 
   override def dbLockSupported: Boolean = false
+
+  // Migration from mutable schema is not supported for H2
+  override def validatePruningOffsetAgainstMigration(
+      pruneUpToInclusive: Offset,
+      pruneAllDivulgedContracts: Boolean,
+      connection: Connection,
+  ): Unit = {
+    discard(pruneUpToInclusive)
+    discard(pruneAllDivulgedContracts)
+    discard(connection)
+  }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
@@ -31,7 +31,6 @@ import com.daml.platform.store.backend.{
   StorageBackend,
   common,
 }
-import com.daml.scalautil.Statement.discard
 import javax.sql.DataSource
 
 private[backend] object H2StorageBackend
@@ -235,9 +234,5 @@ private[backend] object H2StorageBackend
       pruneUpToInclusive: Offset,
       pruneAllDivulgedContracts: Boolean,
       connection: Connection,
-  ): Unit = {
-    discard(pruneUpToInclusive)
-    discard(pruneAllDivulgedContracts)
-    discard(connection)
-  }
+  ): Unit = ()
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
@@ -31,7 +31,6 @@ import com.daml.ledger.offset.Offset
 import com.daml.platform.store.backend.EventStorageBackend.FilterParams
 import com.daml.logging.LoggingContext
 import com.daml.platform.store.backend.common.ComposableQuery.{CompositeSql, SqlStringInterpolation}
-import com.daml.scalautil.Statement.discard
 import javax.sql.DataSource
 
 private[backend] object OracleStorageBackend
@@ -251,9 +250,5 @@ private[backend] object OracleStorageBackend
       pruneUpToInclusive: Offset,
       pruneAllDivulgedContracts: Boolean,
       connection: Connection,
-  ): Unit = {
-    discard(pruneUpToInclusive)
-    discard(pruneAllDivulgedContracts)
-    discard(connection)
-  }
+  ): Unit = ()
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
@@ -31,6 +31,7 @@ import com.daml.ledger.offset.Offset
 import com.daml.platform.store.backend.EventStorageBackend.FilterParams
 import com.daml.logging.LoggingContext
 import com.daml.platform.store.backend.common.ComposableQuery.{CompositeSql, SqlStringInterpolation}
+import com.daml.scalautil.Statement.discard
 import javax.sql.DataSource
 
 private[backend] object OracleStorageBackend
@@ -244,4 +245,15 @@ private[backend] object OracleStorageBackend
   override def lock(id: Int): DBLockStorageBackend.LockId = OracleLockId(id)
 
   override def dbLockSupported: Boolean = true
+
+  // Migration from mutable schema is not supported for Oracle
+  override def validatePruningOffsetAgainstMigration(
+      pruneUpToInclusive: Offset,
+      pruneAllDivulgedContracts: Boolean,
+      connection: Connection,
+  ): Unit = {
+    discard(pruneUpToInclusive)
+    discard(pruneAllDivulgedContracts)
+    discard(connection)
+  }
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
@@ -183,7 +183,7 @@ private[backend] object StorageBackendTestValues {
   /** A single divulgence event
     */
   def dtoDivulgence(
-      offset: Offset,
+      offset: Option[Offset],
       eventSequentialId: Long,
       contractId: String,
       submitter: String = "signatory",
@@ -191,7 +191,7 @@ private[backend] object StorageBackendTestValues {
       commandId: String = UUID.randomUUID().toString,
   ): DbDto.EventDivulgence = {
     DbDto.EventDivulgence(
-      event_offset = Some(offset.toHexString),
+      event_offset = offset.map(_.toHexString),
       command_id = Some(commandId),
       workflow_id = Some("workflow_id"),
       application_id = Some(someApplicationId),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsInitializeIngestion.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsInitializeIngestion.scala
@@ -46,7 +46,7 @@ private[backend] trait StorageBackendTestsInitializeIngestion
       dtoCompletion(offset(4)),
       // 5: transaction with exercise node and retroactive divulgence
       dtoExercise(offset(5), 2L, false, "#4"),
-      dtoDivulgence(offset(5), 3L, "#4"),
+      dtoDivulgence(Some(offset(5)), 3L, "#4"),
       dtoCompletion(offset(5)),
     )
 
@@ -63,7 +63,7 @@ private[backend] trait StorageBackendTestsInitializeIngestion
       dtoCompletion(offset(9)),
       // 10: transaction with exercise node and retroactive divulgence
       dtoExercise(offset(10), 5L, false, "#9"),
-      dtoDivulgence(offset(10), 6L, "#9"),
+      dtoDivulgence(Some(offset(10)), 6L, "#9"),
       dtoCompletion(offset(10)),
     )
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsMigrationPruning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsMigrationPruning.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.backend
+
+import java.sql.Connection
+
+import com.daml.lf.data.Ref
+import com.daml.platform.server.api.ApiException
+import com.daml.platform.store.appendonlydao.events.ContractId
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.Future
+
+private[backend] trait StorageBackendTestsMigrationPruning
+    extends Matchers
+    with StorageBackendSpec {
+  this: AsyncFlatSpec =>
+
+  import StorageBackendTestValues._
+
+  it should "prune all divulgence events if pruning offset is after migration offset" in {
+    val divulgee = Ref.Party.assertFromString("divulgee")
+    val submitter = Ref.Party.assertFromString("submitter")
+
+    val create = dtoCreate(offset(1), 1L, "#1", submitter)
+    val divulgence = dtoDivulgence(None, 2L, "#1", submitter, divulgee)
+    val archive = dtoExercise(offset(2), 3L, consuming = true, "#1", submitter)
+
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+      _ <- executeSql(ingest(Vector(create, divulgence, archive), _))
+      _ <- executeSql(backend.updateLedgerEnd(ParameterStorageBackend.LedgerEnd(offset(2), 3L)))
+      // Simulate that the archive happened after the migration to append-only schema
+      _ <- executeSql(updateMigrationHistoryTable(ledgerSequentialIdBefore = 2))
+      beforePruning <- executeSql(
+        backend.activeContractWithoutArgument(Set(divulgee), ContractId.assertFromString("#1"))
+      )
+      // Check that the divulgee can fetch the divulged event
+      _ <- Future.successful(beforePruning should not be empty)
+      // Trying to prune all divulged contracts before the migration should fail
+      _ <-
+        recoverToSucceededIf[ApiException](
+          executeSql(
+            backend.validatePruningOffsetAgainstMigration(
+              offset(1),
+              pruneAllDivulgedContracts = true,
+              _,
+            )
+          )
+        )
+      // Validation passes the pruning offset for all divulged contracts is after the migration
+      _ <- executeSql(
+        backend.validatePruningOffsetAgainstMigration(
+          offset(2),
+          pruneAllDivulgedContracts = true,
+          _,
+        )
+      )
+      _ <- executeSql(
+        backend.pruneEvents(offset(2), pruneAllDivulgedContracts = true)(_, loggingContext)
+      )
+      // Ensure the divulged contract is not visible anymore
+      afterPruning <- executeSql(
+        backend.activeContractWithoutArgument(Set(divulgee), ContractId.assertFromString("#1"))
+      )
+    } yield {
+      // Pruning succeeded
+      afterPruning shouldBe empty
+    }
+  }
+
+  private def updateMigrationHistoryTable(ledgerSequentialIdBefore: Long) = { conn: Connection =>
+    val statement = conn.prepareStatement(
+      "UPDATE participant_migration_history_v100 SET ledger_end_sequential_id_before = ?"
+    )
+    statement.setLong(1, ledgerSequentialIdBefore)
+    statement.executeUpdate()
+    statement.close()
+  }
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsReset.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsReset.scala
@@ -60,7 +60,7 @@ private[backend] trait StorageBackendTestsReset extends Matchers with StorageBac
       dtoCompletion(offset(4)),
       // 5: transaction with exercise node and retroactive divulgence
       dtoExercise(offset(5), 2L, true, "#4"),
-      dtoDivulgence(offset(5), 3L, "#4"),
+      dtoDivulgence(Some(offset(5)), 3L, "#4"),
       dtoCompletion(offset(5)),
     )
 
@@ -107,7 +107,7 @@ private[backend] trait StorageBackendTestsReset extends Matchers with StorageBac
       dtoCompletion(offset(4)),
       // 5: transaction with exercise node and retroactive divulgence
       dtoExercise(offset(5), 2L, true, "#4"),
-      dtoDivulgence(offset(5), 3L, "#4"),
+      dtoDivulgence(Some(offset(5)), 3L, "#4"),
       dtoCompletion(offset(5)),
     )
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/StorageBackendPostgresSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/StorageBackendPostgresSpec.scala
@@ -9,7 +9,8 @@ import org.scalatest.flatspec.AsyncFlatSpec
 final class StorageBackendPostgresSpec
     extends AsyncFlatSpec
     with StorageBackendProviderPostgres
-    with StorageBackendSuite {
+    with StorageBackendSuite
+    with StorageBackendTestsMigrationPruning {
 
   behavior of "StorageBackend (Postgres)"
 


### PR DESCRIPTION
Prune all divulged contracts only after migration offset
 * Prune all divulgence events with NULL offset
 * Check pruning request against migration offset
 * Added unit test in `StorageBackendTestsPruning`

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
