### PR TITLE
Include committers in PartialTransaction root context

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -343,7 +343,7 @@ private[lf] object Speedy {
 
     private[lf] def contextActors: Set[Party] =
       withOnLedger("ptx") { onLedger =>
-        onLedger.ptx.context.info.authorizers.getOrElse(onLedger.committers)
+        onLedger.ptx.context.info.authorizers
       }
 
     private[lf] def auth: Authorize = Authorize(this.contextActors)
@@ -787,6 +787,7 @@ private[lf] object Speedy {
               submissionTime,
               initialSeeding,
               transactionNormalization,
+              committers,
             ),
           committers = committers,
           readAs = readAs,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -21,6 +21,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   private[this] val choiceId = data.Ref.Name.assertFromString("choice")
   private[this] val cid = Value.ContractId.V1(crypto.Hash.hashPrivateKey("My contract"))
   private[this] val party = data.Ref.Party.assertFromString("Alice")
+  private[this] val committers: Set[data.Ref.Party] = Set.empty
 
   private[this] val initialState = PartialTransaction.initial(
     _ => TransactionVersion.maxVersion,
@@ -28,6 +29,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
     data.Time.Timestamp.Epoch,
     InitialSeeding.TransactionSeed(transactionSeed),
     transactionNormalization = true,
+    committers,
   )
 
   private[this] def contractIdsInOrder(ptx: PartialTransaction): Seq[Value.ContractId] = {


### PR DESCRIPTION
This gets us into a state where PartialTransaction always has the
authorization context which is much more sensible than having the
committers in speedy while the rest is in ptx.

The reason for having the split in the first place was the scenario
service but now that we create a new speedy machine per submission
that’s no longer a valid reason.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
