### PR TITLE
Introduce a new `Offset` format [KVL-1063]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilder.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilder.scala
@@ -38,14 +38,14 @@ object OffsetBuilder {
   def fromLong(first: Long, second: Int = 0, third: Int = 0): Offset =
     delegate.of(first, second, third)
 
-  def highestIndex(offset: Offset): Long = VersionedOffsetBuilder.highestIndex(offset)
+  def highestIndex(offset: Offset): Long = delegate.highestIndex(offset)
 
-  def middleIndex(offset: Offset): Int = VersionedOffsetBuilder.middleIndex(offset)
+  def middleIndex(offset: Offset): Int = delegate.middleIndex(offset)
 
-  def lowestIndex(offset: Offset): Int = VersionedOffsetBuilder.lowestIndex(offset)
+  def lowestIndex(offset: Offset): Int = delegate.lowestIndex(offset)
 
   private[kvutils] def split(offset: Offset): (Long, Int, Int) = {
-    val (highest, middle, lowest) = VersionedOffsetBuilder.split(offset)
+    val (highest, middle, lowest) = delegate.split(offset)
     (highest, middle, lowest)
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilder.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilder.scala
@@ -43,16 +43,16 @@ class VersionedOffsetBuilder(version: Byte) {
     of(highest, middle, lowest)
   }
 
-  def of(first: Long, second: Int = 0, third: Int = 0): Offset = {
-    if (first < 0 || first > MaxHighest)
-      throw new IllegalArgumentException(s"Highest: $first is out of range [0, $MaxHighest]")
+  def of(highest: Long, middle: Int = 0, lowest: Int = 0): Offset = {
+    if (highest < 0 || highest > MaxHighest)
+      throw new IllegalArgumentException(s"Highest: $highest is out of range [0, $MaxHighest]")
 
     val bytes = new ByteArrayOutputStream
     val stream = new DataOutputStream(bytes)
     stream.writeByte(version.toInt)
-    writeHighest(first, stream)
-    stream.writeInt(second)
-    stream.writeInt(third)
+    writeHighest(highest, stream)
+    stream.writeInt(middle)
+    stream.writeInt(lowest)
     Offset.fromByteArray(bytes.toByteArray)
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilder.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilder.scala
@@ -1,0 +1,107 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import com.daml.ledger.offset.Offset
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
+import java.nio.ByteBuffer
+
+/** Helper functions for generating versioned 16 byte [[Offset]]s from integers.
+  * The created offset will look as follows:
+  * | version (8 bits) | highest index (56 bits) | middle index (32 bits) | lowest index (32 bits) |
+  * Leading zeros will be retained when generating the resulting offset bytes.
+  *
+  * Example usage:
+  *
+  *   - If you have one record per block then use [[of]] with the block ID as the second and last argument.
+  *   - If you may have multiple records per block then use [[of]] with the index within the block as the third argument.
+  *
+  * @see com.daml.ledger.offset.Offset
+  */
+class VersionedOffsetBuilder(version: Byte) {
+  import VersionedOffsetBuilder._
+
+  def onlyKeepHighestIndex(offset: Offset): Offset = {
+    val highest = highestIndex(offset)
+    of(highest)
+  }
+
+  def dropLowestIndex(offset: Offset): Offset = {
+    val (highest, middle, _) = split(offset)
+    of(highest, middle)
+  }
+
+  def setMiddleIndex(offset: Offset, middle: Int): Offset = {
+    val (highest, _, lowest) = split(offset)
+    of(highest, middle, lowest)
+  }
+
+  def setLowestIndex(offset: Offset, lowest: Int): Offset = {
+    val (highest, middle, _) = split(offset)
+    of(highest, middle, lowest)
+  }
+
+  def of(first: Long, second: Int = 0, third: Int = 0): Offset = {
+    if (first < 0 || first > MaxHighest)
+      throw new IllegalArgumentException(s"Highest: $first is out of range [0, $MaxHighest]")
+
+    val bytes = new ByteArrayOutputStream
+    val stream = new DataOutputStream(bytes)
+    stream.writeByte(version.toInt)
+    writeHighest(first, stream)
+    stream.writeInt(second)
+    stream.writeInt(third)
+    Offset.fromByteArray(bytes.toByteArray)
+  }
+}
+
+object VersionedOffsetBuilder {
+
+  val MaxHighest: Long = (1L << 56) - 1
+
+  private val highestStartByte = 1
+  private val highestSizeBytes = 7
+  private val highestMask = 0x00ffffffffffffffL
+
+  def apply(version: Byte): VersionedOffsetBuilder = new VersionedOffsetBuilder(version)
+
+  def version(offset: Offset): Byte = {
+    val stream = toDataInputStream(offset)
+    stream.readByte()
+  }
+
+  // `highestIndex` is used a lot, so it's worth optimizing a little rather than reusing `split`.
+  def highestIndex(offset: Offset): Long = {
+    val stream = toDataInputStream(offset)
+    readHighest(stream)
+  }
+
+  def middleIndex(offset: Offset): Int = split(offset)._2
+
+  def lowestIndex(offset: Offset): Int = split(offset)._3
+
+  private[kvutils] def split(offset: Offset): (Long, Int, Int) = {
+    val stream = toDataInputStream(offset)
+    val highest = readHighest(stream)
+    val middle = stream.readInt()
+    val lowest = stream.readInt()
+    (highest, middle, lowest)
+  }
+
+  private def toDataInputStream(offset: Offset) = new DataInputStream(
+    new ByteArrayInputStream(offset.toByteArray)
+  )
+
+  private def readHighest(stream: DataInputStream) = {
+    val versionAndHighest = stream.readLong()
+    versionAndHighest & highestMask
+  }
+
+  private def writeHighest(highest: Long, stream: DataOutputStream): Unit = {
+    val buffer = ByteBuffer.allocate(8)
+    buffer.putLong(highest)
+    stream.write(buffer.array(), highestStartByte, highestSizeBytes)
+  }
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilder.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilder.scala
@@ -44,8 +44,9 @@ class VersionedOffsetBuilder(version: Byte) {
   }
 
   def of(highest: Long, middle: Int = 0, lowest: Int = 0): Offset = {
-    if (highest < 0 || highest > MaxHighest)
-      throw new IllegalArgumentException(s"Highest: $highest is out of range [0, $MaxHighest]")
+    require(highest >= 0 && highest <= MaxHighest, s"highest ($highest) is out of range [0, $MaxHighest]")
+    require(middle >= 0, s"middle ($middle) is lower than 0")
+    require(lowest >= 0, s"lowest ($lowest) is lower than 0")
 
     val bytes = new ByteArrayOutputStream
     val stream = new DataOutputStream(bytes)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilder.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilder.scala
@@ -44,7 +44,10 @@ class VersionedOffsetBuilder(version: Byte) {
   }
 
   def of(highest: Long, middle: Int = 0, lowest: Int = 0): Offset = {
-    require(highest >= 0 && highest <= MaxHighest, s"highest ($highest) is out of range [0, $MaxHighest]")
+    require(
+      highest >= 0 && highest <= MaxHighest,
+      s"highest ($highest) is out of range [0, $MaxHighest]",
+    )
     require(middle >= 0, s"middle ($middle) is lower than 0")
     require(lowest >= 0, s"lowest ($lowest) is lower than 0")
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilderSpec.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state.kvutils
 
 import com.daml.ledger.offset.Offset
 import com.daml.lf.data.Bytes
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -22,14 +21,14 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
     }
 
     "always return an offset of the same length" in {
-      forAll(genHighest, arbitrary[Int], arbitrary[Int]) { (highest, middle, lowest) =>
+      forAll(genHighest, Gen.posNum[Int], Gen.posNum[Int]) { (highest, middle, lowest) =>
         val offset = OffsetBuilder.fromLong(highest, middle, lowest)
         offset.bytes.length should be(OffsetBuilder.end)
       }
     }
 
     "construct and extract" in {
-      forAll(genHighest, arbitrary[Int], arbitrary[Int]) { (highest, middle, lowest) =>
+      forAll(genHighest, Gen.posNum[Int], Gen.posNum[Int]) { (highest, middle, lowest) =>
         val offset = OffsetBuilder.fromLong(highest, middle, lowest)
 
         OffsetBuilder.highestIndex(offset) should be(highest)
@@ -40,7 +39,7 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
     }
 
     "set the middle index" in {
-      forAll(genHighest, arbitrary[Int], arbitrary[Int], arbitrary[Int]) {
+      forAll(genHighest, Gen.posNum[Int], Gen.posNum[Int], Gen.posNum[Int]) {
         (highest, middle, lowest, newMiddle) =>
           val offset = OffsetBuilder.fromLong(highest, middle, lowest)
           val modifiedOffset = OffsetBuilder.setMiddleIndex(offset, newMiddle)
@@ -50,7 +49,7 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
     }
 
     "only change individual indexes" in {
-      forAll(genHighest, arbitrary[Int], arbitrary[Int], arbitrary[Int]) {
+      forAll(genHighest, Gen.posNum[Int], Gen.posNum[Int], Gen.posNum[Int]) {
         (highest, middle, lowest, newLowest) =>
           val offset = OffsetBuilder.fromLong(highest, middle, lowest)
           val modifiedOffset = OffsetBuilder.setLowestIndex(offset, newLowest)
@@ -60,7 +59,7 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
     }
 
     "zero out the middle and lowest index" in {
-      forAll(genHighest, arbitrary[Int], arbitrary[Int]) { (highest, middle, lowest) =>
+      forAll(genHighest, Gen.posNum[Int], Gen.posNum[Int]) { (highest, middle, lowest) =>
         val offset = OffsetBuilder.fromLong(highest, middle, lowest)
         val modifiedOffset = OffsetBuilder.onlyKeepHighestIndex(offset)
 
@@ -69,7 +68,7 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
     }
 
     "zero out the lowest index" in {
-      forAll(genHighest, arbitrary[Int], arbitrary[Int]) { (highest, middle, lowest) =>
+      forAll(genHighest, Gen.posNum[Int], Gen.posNum[Int]) { (highest, middle, lowest) =>
         val offset = OffsetBuilder.fromLong(highest, middle, lowest)
         val modifiedOffset = OffsetBuilder.dropLowestIndex(offset)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/OffsetBuilderSpec.scala
@@ -5,12 +5,14 @@ package com.daml.ledger.participant.state.kvutils
 
 import com.daml.ledger.offset.Offset
 import com.daml.lf.data.Bytes
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
-  private val zeroOffset = Offset(Bytes.fromByteArray(Array.fill(16)(0: Byte)))
+  import OffsetBuilderSpec._
 
   "OffsetBuilder" should {
     "return all zeroes for the zeroth offset" in {
@@ -20,14 +22,14 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
     }
 
     "always return an offset of the same length" in {
-      forAll { (highest: Long, middle: Int, lowest: Int) =>
+      forAll(genHighest, arbitrary[Int], arbitrary[Int]) { (highest, middle, lowest) =>
         val offset = OffsetBuilder.fromLong(highest, middle, lowest)
         offset.bytes.length should be(OffsetBuilder.end)
       }
     }
 
     "construct and extract" in {
-      forAll { (highest: Long, middle: Int, lowest: Int) =>
+      forAll(genHighest, arbitrary[Int], arbitrary[Int]) { (highest, middle, lowest) =>
         val offset = OffsetBuilder.fromLong(highest, middle, lowest)
 
         OffsetBuilder.highestIndex(offset) should be(highest)
@@ -38,25 +40,27 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
     }
 
     "set the middle index" in {
-      forAll { (highest: Long, middle: Int, lowest: Int, newMiddle: Int) =>
-        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
-        val modifiedOffset = OffsetBuilder.setMiddleIndex(offset, newMiddle)
+      forAll(genHighest, arbitrary[Int], arbitrary[Int], arbitrary[Int]) {
+        (highest, middle, lowest, newMiddle) =>
+          val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+          val modifiedOffset = OffsetBuilder.setMiddleIndex(offset, newMiddle)
 
-        OffsetBuilder.split(modifiedOffset) should be((highest, newMiddle, lowest))
+          OffsetBuilder.split(modifiedOffset) should be((highest, newMiddle, lowest))
       }
     }
 
     "only change individual indexes" in {
-      forAll { (highest: Long, middle: Int, lowest: Int, newLowest: Int) =>
-        val offset = OffsetBuilder.fromLong(highest, middle, lowest)
-        val modifiedOffset = OffsetBuilder.setLowestIndex(offset, newLowest)
+      forAll(genHighest, arbitrary[Int], arbitrary[Int], arbitrary[Int]) {
+        (highest, middle, lowest, newLowest) =>
+          val offset = OffsetBuilder.fromLong(highest, middle, lowest)
+          val modifiedOffset = OffsetBuilder.setLowestIndex(offset, newLowest)
 
-        OffsetBuilder.split(modifiedOffset) should be((highest, middle, newLowest))
+          OffsetBuilder.split(modifiedOffset) should be((highest, middle, newLowest))
       }
     }
 
     "zero out the middle and lowest index" in {
-      forAll { (highest: Long, middle: Int, lowest: Int) =>
+      forAll(genHighest, arbitrary[Int], arbitrary[Int]) { (highest, middle, lowest) =>
         val offset = OffsetBuilder.fromLong(highest, middle, lowest)
         val modifiedOffset = OffsetBuilder.onlyKeepHighestIndex(offset)
 
@@ -65,7 +69,7 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
     }
 
     "zero out the lowest index" in {
-      forAll { (highest: Long, middle: Int, lowest: Int) =>
+      forAll(genHighest, arbitrary[Int], arbitrary[Int]) { (highest, middle, lowest) =>
         val offset = OffsetBuilder.fromLong(highest, middle, lowest)
         val modifiedOffset = OffsetBuilder.dropLowestIndex(offset)
 
@@ -92,4 +96,10 @@ class OffsetBuilderSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
       lowest.takeRight(1) should be(Array[Byte](3))
     }
   }
+}
+
+object OffsetBuilderSpec {
+  private val zeroOffset = Offset(Bytes.fromByteArray(Array.fill(16)(0: Byte)))
+
+  private val genHighest = Gen.chooseNum(0L, VersionedOffsetBuilder.MaxHighest)
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilderSpec.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+/** Other test cases are covered by [[OffsetBuilder]] */
+class VersionedOffsetBuilderSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckDrivenPropertyChecks {
+  import VersionedOffsetBuilderSpec._
+
+  "VersionedOffsetBuilder" should {
+    "construct and extract" in {
+      forAll(arbitrary[Byte], genHighest, arbitrary[Int], arbitrary[Int]) {
+        (version, highest, middle, lowest) =>
+          val offset = VersionedOffsetBuilder(version).of(highest, middle, lowest)
+
+          VersionedOffsetBuilder.version(offset) should be(version)
+          VersionedOffsetBuilder.highestIndex(offset) should be(highest)
+          VersionedOffsetBuilder.middleIndex(offset) should be(middle)
+          VersionedOffsetBuilder.lowestIndex(offset) should be(lowest)
+          VersionedOffsetBuilder.split(offset) should be((highest, middle, lowest))
+      }
+    }
+
+    "fail on a highest that is out of range" in {
+      forAll(arbitrary[Byte], genOutOfRangeHighest, arbitrary[Int], arbitrary[Int]) {
+        (version, highest, middle, lowest) =>
+          the[IllegalArgumentException] thrownBy VersionedOffsetBuilder(version).of(
+            highest,
+            middle,
+            lowest,
+          ) should have message s"Highest: $highest is out of range [0, ${VersionedOffsetBuilder.MaxHighest}]"
+      }
+    }
+  }
+}
+
+object VersionedOffsetBuilderSpec {
+  private val genHighest = Gen.chooseNum(0L, VersionedOffsetBuilder.MaxHighest)
+  private val genOutOfRangeHighest =
+    Gen.oneOf(Gen.negNum[Long], Gen.chooseNum(VersionedOffsetBuilder.MaxHighest + 1, Long.MaxValue))
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilderSpec.scala
@@ -18,7 +18,7 @@ class VersionedOffsetBuilderSpec
 
   "VersionedOffsetBuilder" should {
     "construct and extract" in {
-      forAll(arbitrary[Byte], genHighest, arbitrary[Int], arbitrary[Int]) {
+      forAll(arbitrary[Byte], genHighest, Gen.posNum[Int], Gen.posNum[Int]) {
         (version, highest, middle, lowest) =>
           val offset = VersionedOffsetBuilder(version).of(highest, middle, lowest)
 
@@ -31,13 +31,35 @@ class VersionedOffsetBuilderSpec
     }
 
     "fail on a highest that is out of range" in {
-      forAll(arbitrary[Byte], genOutOfRangeHighest, arbitrary[Int], arbitrary[Int]) {
+      forAll(arbitrary[Byte], genOutOfRangeHighest, Gen.posNum[Int], Gen.posNum[Int]) {
         (version, highest, middle, lowest) =>
           the[IllegalArgumentException] thrownBy VersionedOffsetBuilder(version).of(
             highest,
             middle,
             lowest,
-          ) should have message s"Highest: $highest is out of range [0, ${VersionedOffsetBuilder.MaxHighest}]"
+          ) should have message s"requirement failed: highest ($highest) is out of range [0, ${VersionedOffsetBuilder.MaxHighest}]"
+      }
+    }
+
+    "fail on a negative middle index" in {
+      forAll(arbitrary[Byte], genHighest, Gen.negNum[Int], Gen.posNum[Int]) {
+        (version, highest, middle, lowest) =>
+          the[IllegalArgumentException] thrownBy VersionedOffsetBuilder(version).of(
+            highest,
+            middle,
+            lowest,
+          ) should have message s"requirement failed: middle ($middle) is lower than 0"
+      }
+    }
+
+    "fail on a negative lowest index" in {
+      forAll(arbitrary[Byte], genHighest, Gen.posNum[Int], Gen.negNum[Int]) {
+        (version, highest, middle, lowest) =>
+          the[IllegalArgumentException] thrownBy VersionedOffsetBuilder(version).of(
+            highest,
+            middle,
+            lowest,
+          ) should have message s"requirement failed: lowest ($lowest) is lower than 0"
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilderSpec.scala
@@ -68,9 +68,15 @@ class VersionedOffsetBuilderSpec
       forAll(genHighest, Gen.posNum[Int], Gen.posNum[Int], genDifferentVersions) {
         (highest, middle, lowest, versions) =>
           val offset = VersionedOffsetBuilder(versions._1).of(highest, middle, lowest)
-          the[IllegalArgumentException] thrownBy VersionedOffsetBuilder(versions._2).highestIndex(
-            offset
-          ) should have message s"requirement failed: wrong version ${versions._1}, should be ${versions._2}"
+          val offsetBuilder = VersionedOffsetBuilder(versions._2)
+          val testedMethods =
+            List(offsetBuilder.version(_), offsetBuilder.highestIndex(_), offsetBuilder.split(_))
+
+          testedMethods.foreach { method =>
+            the[IllegalArgumentException] thrownBy method(
+              offset
+            ) should have message s"requirement failed: wrong version ${versions._1}, should be ${versions._2}"
+          }
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/VersionedOffsetBuilderSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-/** Other test cases are covered by [[OffsetBuilder]] */
+/** Other test cases are covered by [[OffsetBuilderSpec]] */
 class VersionedOffsetBuilderSpec
     extends AnyWordSpec
     with Matchers


### PR DESCRIPTION
CHANGELOG_BEGIN

- [Integration Kit] Changes the Offset format to contain a version and therefore reduces the highest index size by one byte

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
