### PR TITLE
ledger-on-memory: If the index provided already exists, fail.

### DIFF
--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
@@ -13,6 +13,7 @@ import com.daml.ledger.validator.DefaultStateKeySerializationStrategy
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
+import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode}
 import scopt.OptionParser
 
 private[memory] class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state: InMemoryState)
@@ -50,6 +51,13 @@ private[memory] class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state
   }
 
   override def extraConfigParser(parser: OptionParser[Config[Unit]]): Unit = ()
+
+  override def indexerConfig(
+      participantConfig: ParticipantConfig,
+      config: Config[Unit],
+  ): IndexerConfig = super
+    .indexerConfig(participantConfig, config)
+    .copy(startupMode = IndexerStartupMode.EnforceEmptySchemaAndMigrate)
 
   override val defaultExtraConfig: Unit = ()
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerStartupMode.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerStartupMode.scala
@@ -17,4 +17,6 @@ object IndexerStartupMode {
 
   case object MigrateOnEmptySchemaAndStart extends IndexerStartupMode
 
+  case object EnforceEmptySchemaAndMigrate extends IndexerStartupMode
+
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -98,6 +98,13 @@ object JdbcIndexer {
         .migrateOnEmptySchema(config.enableAppendOnlySchema)
         .flatMap(_ => initialized(resetSchema = false))(resourceContext.executionContext)
 
+    def enforceEmptySchemaAndMigrate()(implicit
+        resourceContext: ResourceContext
+    ): Future[ResourceOwner[Indexer]] =
+      flywayMigrations
+        .enforceEmptySchemaAndMigrate(config.enableAppendOnlySchema)
+        .flatMap(_ => initialized(resetSchema = false))(resourceContext.executionContext)
+
     private[this] def initializedMutatingSchema(
         resetSchema: Boolean
     )(implicit resourceContext: ResourceContext): Future[ResourceOwner[Indexer]] =

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -84,6 +84,14 @@ final class StandaloneIndexerServer(
             logger.debug("Waiting for the indexer to initialize the empty or up-to-date database.")
             healthReporter
           }
+      case IndexerStartupMode.EnforceEmptySchemaAndMigrate =>
+        Resource
+          .fromFuture(indexerFactory.enforceEmptySchemaAndMigrate())
+          .flatMap(startIndexer(indexer, _))
+          .map { healthReporter =>
+            logger.debug("Waiting for the indexer to initialize the database.")
+            healthReporter
+          }
     }
   }
 


### PR DESCRIPTION
Pointing ledger-on-memory at an existing index is a recipe for disaster, as the ledger will have no entries but the index might have some.

This enforces an empty index by failing if any migrations have been applied.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
