### PR TITLE
Disable DeeplyNestedValueIT suite against canton in Daml repo

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -86,7 +86,7 @@ conformance_test(
         ",RaceConditionIT:WWDoubleNonTransientCreate,RaceConditionIT:WWArchiveVsNonTransientCreate,RaceConditionIT:RWTransientCreateVsNonTransientCreate,RaceConditionIT:RWArchiveVsFailedLookupByKey" +
         ",RaceConditionIT:RWArchiveVsLookupByKey,RaceConditionIT:RWArchiveVsNonConsumingChoice,RaceConditionIT:RWArchiveVsFetch,RaceConditionIT:WWDoubleArchive" +
         ",ExceptionsIT,ExceptionRaceConditionIT" +  # need UCK mode - added below
-        ",DeeplyNestedValueIT:Reject,DeeplyNestedValueIT:AcceptFailingLookupByKey100" +  # FIXME: Too deeply nested values flake with a time out (half of the time)
+        ",DeeplyNestedValueIT" +  # FIXME: Too deeply nested values flake with a time out (half of the time)
         ",CommandServiceIT:CSReturnStackTrace",  # FIXME: Ensure canton returns stack trace
     ],
 ) if not is_windows else None


### PR DESCRIPTION
Due to flakes. The same DeeplyNestedValueIT suite runs apparently
without flakes in the canton repo.

changelog_begin
changelog_end

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
