### PR TITLE
 [Divulgence pruning] Prune immediate divulgence [DPP-513]

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -188,7 +188,5 @@ conformance_test(
         "--verbose",
         "--concurrent-test-runs=1",  # lowered from default #procs to reduce flakes - details in https://github.com/digital-asset/daml/issues/7316
         "--include=ParticipantPruningIT",
-        # Disable tests targeting only multi-participant setups
-        "--exclude=ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
     ],
 ) if not is_windows else None

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -188,5 +188,7 @@ conformance_test(
         "--verbose",
         "--concurrent-test-runs=1",  # lowered from default #procs to reduce flakes - details in https://github.com/digital-asset/daml/issues/7316
         "--include=ParticipantPruningIT",
+        # Disable tests targeting only multi-participant setups
+        "--exclude=ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
     ],
 ) if not is_windows else None

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
@@ -595,15 +595,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         divulgence.exerciseDivulge(_, contract),
       )
 
-      _ <- divulgencePruneAndCheck(
-        alice,
-        bob,
-        alpha,
-        beta,
-        contract,
-        divulgence,
-        disclosureVisibility = false,
-      )
+      _ <- divulgencePruneAndCheck(alice, bob, alpha, beta, contract, divulgence)
     } yield ()
   })
 
@@ -624,15 +616,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         divulgeNotDiscloseTemplate.exerciseDivulgeNoDisclose(_, divulgence),
       )
 
-      _ <- divulgencePruneAndCheck(
-        alice,
-        bob,
-        alpha,
-        beta,
-        contract,
-        divulgence,
-        disclosureVisibility = false,
-      )
+      _ <- divulgencePruneAndCheck(alice, bob, alpha, beta, contract, divulgence)
     } yield ()
   })
 
@@ -649,15 +633,8 @@ class ParticipantPruningIT extends LedgerTestSuite {
         alice,
         divulgence.exerciseCreateAndDisclose,
       )
-      _ <- divulgencePruneAndCheck(
-        alice,
-        bob,
-        alpha,
-        beta,
-        contract,
-        divulgence,
-        disclosureVisibility = true,
-      )
+
+      _ <- divulgencePruneAndCheck(alice, bob, alpha, beta, contract, divulgence)
     } yield ()
   })
 
@@ -679,8 +656,6 @@ class ParticipantPruningIT extends LedgerTestSuite {
       beta: ParticipantTestContext,
       contract: Primitive.ContractId[Contract],
       divulgence: binding.Primitive.ContractId[Divulgence],
-      // TODO Divulgence pruning: Remove when immediate divulgence pruning is implemented
-      disclosureVisibility: Boolean,
   )(implicit ec: ExecutionContext) =
     for {
       // Check that Bob can fetch the contract
@@ -716,23 +691,12 @@ class ParticipantPruningIT extends LedgerTestSuite {
       _ <- pruneAtCurrentOffset(beta, bob, pruneAllDivulgedContracts = true)
 
       // TODO Divulgence pruning: Check ACS equality before and after pruning
-      // TODO Divulgence pruning: Remove the true-clause of the if-statement below
-      //                          when disclosure pruning is implemented.
-      _ <-
-        if (disclosureVisibility) {
-          beta
-            .exerciseAndGetContract[Dummy](
-              bob,
-              divulgence.exerciseCanFetch(_, contract),
-            )
-        } else {
-          beta
-            .exerciseAndGetContract[Dummy](
-              bob,
-              divulgence.exerciseCanFetch(_, contract),
-            )
-            .mustFail("Bob cannot access the divulged contract after the second pruning")
-        }
+      _ <- beta
+        .exerciseAndGetContract[Dummy](
+          bob,
+          divulgence.exerciseCanFetch(_, contract),
+        )
+        .mustFail("Bob cannot access the divulged contract after the second pruning")
     } yield ()
 
   private def populateLedgerAndGetOffsets(participant: ParticipantTestContext, submitter: Party)(

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -226,7 +226,7 @@ conformance_test(
         "--verbose",
         "--include=ParticipantPruningIT",
         # Disable tests targeting only append-only schema functionality
-        "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences",
+        "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences,ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
     ],
 )
 

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -280,7 +280,7 @@ da_scala_test_suite(
                 "--verbose",
                 "--include=ParticipantPruningIT",
                 # Disable tests targeting only append-only schema functionality
-                "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences",
+                "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences,ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
             ],
         ),
         conformance_test(
@@ -441,6 +441,8 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--include=ParticipantPruningIT",
+        # Disable tests targeting only multi-participant setups
+        "--exclude=ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
     ],
 )
 
@@ -459,6 +461,8 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--include=ParticipantPruningIT",
+        # Disable tests targeting only multi-participant setups
+        "--exclude=ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
     ],
 )
 
@@ -477,6 +481,8 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--include=ParticipantPruningIT",
+        # Disable tests targeting only multi-participant setups
+        "--exclude=ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
     ],
 )
 
@@ -493,7 +499,7 @@ conformance_test(
         "--verbose",
         "--include=ParticipantPruningIT",
         # Disable tests targeting only append-only schema functionality
-        "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences",
+        "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences,ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
     ],
 )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
@@ -480,6 +480,7 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
 
   // Events
 
+  // TODO Cleanup: Extract to [[EventStorageBackendTemplate]]
   def pruneEvents(
       pruneUpToInclusive: Offset,
       pruneAllDivulgedContracts: Boolean,
@@ -526,11 +527,14 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
     }(connection, loggingContext)
 
     if (pruneAllDivulgedContracts) {
-      val pruneAfterClause =
+      val pruneAfterClause = {
+        // We need to distinguish between the two cases since lexicographical comparison
+        // in Oracle doesn't work with '' (empty strings are treated as NULLs) as one of the operands
         participantAllDivulgedContractsPrunedUpToInclusive(connection) match {
           case Some(pruneAfter) => cSQL"and event_offset > $pruneAfter"
           case None => cSQL""
         }
+      }
 
       pruneWithLogging(queryDescription = "Immediate divulgence events pruning") {
         SQL"""

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
@@ -525,22 +525,6 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
             )"""
     }(connection, loggingContext)
 
-    pruneWithLogging(queryDescription = "Exercise (consuming) events pruning") {
-      SQL"""
-          -- Exercise events (consuming)
-          delete from participant_events_consuming_exercise delete_events
-          where
-            delete_events.event_offset <= $pruneUpToInclusive"""
-    }(connection, loggingContext)
-
-    pruneWithLogging(queryDescription = "Exercise (non-consuming) events pruning") {
-      SQL"""
-          -- Exercise events (non-consuming)
-          delete from participant_events_non_consuming_exercise delete_events
-          where
-            delete_events.event_offset <= $pruneUpToInclusive"""
-    }(connection, loggingContext)
-
     if (pruneAllDivulgedContracts) {
       val pruneAfterClause =
         participantAllDivulgedContractsPrunedUpToInclusive(connection) match {
@@ -566,6 +550,22 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
          """
       }(connection, loggingContext)
     }
+
+    pruneWithLogging(queryDescription = "Exercise (consuming) events pruning") {
+      SQL"""
+          -- Exercise events (consuming)
+          delete from participant_events_consuming_exercise delete_events
+          where
+            delete_events.event_offset <= $pruneUpToInclusive"""
+    }(connection, loggingContext)
+
+    pruneWithLogging(queryDescription = "Exercise (non-consuming) events pruning") {
+      SQL"""
+          -- Exercise events (non-consuming)
+          delete from participant_events_non_consuming_exercise delete_events
+          where
+            delete_events.event_offset <= $pruneUpToInclusive"""
+    }(connection, loggingContext)
   }
 
   private def participantAllDivulgedContractsPrunedUpToInclusive(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackend.scala
@@ -557,8 +557,7 @@ private[backend] trait CommonStorageBackend[DB_BATCH] extends StorageBackend[DB_
       pruneWithLogging(queryDescription = "Immediate divulgence events pruning") {
         SQL"""
             -- Immediate divulgence pruning
-            delete
-            from participant_events_create c
+            delete from participant_events_create c
             where event_offset > $prunedAllDivulgedContractsUpToInclusive
             and event_offset <= $pruneUpToInclusive
             and not exists (

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
@@ -47,4 +47,12 @@ trait QueryStrategy {
     * @return the function name
     */
   def booleanOrAggregationFunction: String = "bool_or"
+
+  /** Predicate which tests if the element referenced by the `elementColumnName`
+    * is in the array from column `arrayColumnName`
+    */
+  def arrayContains(arrayColumnName: String, elementColumnName: String): String
+
+  /** Boolean predicate */
+  def isTrue(booleanColumnName: String): String
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
@@ -127,6 +127,10 @@ private[backend] object H2StorageBackend
           .map(p => cSQL"array_contains(#$columnName, '#${p.toString}')")
           .mkComposite("(", " or ", ")")
 
+    override def arrayContains(arrayColumnName: String, elementColumnName: String): String =
+      s"array_contains($arrayColumnName, $elementColumnName)"
+
+    override def isTrue(booleanColumnName: String): String = booleanColumnName
   }
 
   override def queryStrategy: QueryStrategy = H2QueryStrategy

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
@@ -113,6 +113,11 @@ private[backend] object OracleStorageBackend
       s"""case when ($column = $value) then 1 else 0 end"""
 
     override def booleanOrAggregationFunction: String = "max"
+
+    override def arrayContains(arrayColumnName: String, elementColumnName: String): String =
+      s"EXISTS (SELECT 1 FROM JSON_TABLE($arrayColumnName, '$$[*]' columns (value PATH '$$')) WHERE value = $elementColumnName)"
+
+    override def isTrue(booleanColumnName: String): String = s"$booleanColumnName = 1"
   }
 
   override def queryStrategy: QueryStrategy = OracleQueryStrategy

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackend.scala
@@ -188,6 +188,10 @@ private[backend] object PostgresStorageBackend
       cSQL"#$columnName::text[] && $partiesArray::text[]"
     }
 
+    override def arrayContains(arrayColumnName: String, elementColumnName: String): String =
+      s"$elementColumnName = any($arrayColumnName)"
+
+    override def isTrue(booleanColumnName: String): String = booleanColumnName
   }
 
   override def queryStrategy: QueryStrategy = PostgresQueryStrategy

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
@@ -70,6 +70,7 @@ private[backend] object StorageBackendTestValues {
   def dtoPartyEntry(
       offset: Offset,
       party: String = someParty,
+      isLocal: Boolean = true,
   ): DbDto.PartyEntry = DbDto.PartyEntry(
     ledger_offset = offset.toHexString,
     recorded_at = someTime,
@@ -78,7 +79,7 @@ private[backend] object StorageBackendTestValues {
     display_name = Some(party),
     typ = JdbcLedgerDao.acceptType,
     rejection_reason = None,
-    is_local = Some(true),
+    is_local = Some(isLocal),
   )
 
   def dtoPackage(offset: Offset): DbDto.Package = DbDto.Package(

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsPruning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsPruning.scala
@@ -164,7 +164,7 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
     )
     val contract1_retroactiveDivulgence =
       dtoDivulgence(
-        offset = offset(3),
+        offset = Some(offset(3)),
         eventSequentialId = 3L,
         contractId = contract1_id,
         divulgee = partyName,
@@ -236,7 +236,7 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
       signatory = signatory,
     )
     val contract1_divulgence = dtoDivulgence(
-      offset = offset(2),
+      offset = Some(offset(2)),
       eventSequentialId = 2L,
       contractId = contract1_id,
       divulgee = "party",
@@ -248,7 +248,7 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
       contractId = contract1_id,
     )
     val contract2_divulgence = dtoDivulgence(
-      offset = offset(4),
+      offset = Some(offset(4)),
       eventSequentialId = 4L,
       contractId = contract2_id,
       divulgee = divulgee,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsPruning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsPruning.scala
@@ -4,6 +4,7 @@
 package com.daml.platform.store.backend
 
 import com.daml.lf.data.Ref
+import com.daml.platform.store.appendonlydao.events.ContractId
 import com.daml.platform.store.backend.EventStorageBackend.{FilterParams, RangeParams}
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -61,7 +62,7 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
       // Prune
       // TODO Divulgence pruning: Adapt the tests for all divulged contracts pruning and set the flag to `true`
       _ <- executeSql(
-        backend.pruneEvents(offset(2), pruneAllDivulgedContracts = false)(_, loggingContext)
+        backend.pruneEvents(offset(2), pruneAllDivulgedContracts = true)(_, loggingContext)
       )
       _ <- executeSql(backend.updatePrunedUptoInclusive(offset(2)))
       // Make sure the events are not visible anymore
@@ -89,9 +90,11 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
   }
 
   it should "not prune an active contract" in {
-    val someParty = Ref.Party.assertFromString("party")
+    val partyName = "party"
+    val someParty = Ref.Party.assertFromString(partyName)
+    val partyEntry = dtoPartyEntry(offset(1), "party")
     val create = dtoCreate(
-      offset = offset(1),
+      offset = offset(2),
       eventSequentialId = 1L,
       contractId = "#1",
       signatory = someParty,
@@ -102,11 +105,11 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
     for {
       _ <- executeSql(backend.initializeParameters(someIdentityParams))
       // Ingest a create and archive event
-      _ <- executeSql(ingest(Vector(create), _))
-      _ <- executeSql(backend.updateLedgerEnd(ParameterStorageBackend.LedgerEnd(offset(1), 1L)))
+      _ <- executeSql(ingest(Vector(partyEntry, create), _))
+      _ <- executeSql(backend.updateLedgerEnd(ParameterStorageBackend.LedgerEnd(offset(2), 1L)))
       // Make sure the events are visible
       before1 <- executeSql(backend.transactionEvents(range, filter))
-      before2 <- executeSql(backend.activeContractEvents(range, filter, offset(1)))
+      before2 <- executeSql(backend.activeContractEvents(range, filter, offset(2)))
       before3 <- executeSql(backend.flatTransaction(createTransactionId, filter))
       before4 <- executeSql(backend.transactionTreeEvents(range, filter))
       before5 <- executeSql(backend.transactionTree(createTransactionId, filter))
@@ -114,12 +117,12 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
       // Prune
       // TODO Divulgence pruning: Adapt the tests for all divulged contracts pruning and set the flag to `true`
       _ <- executeSql(
-        backend.pruneEvents(offset(1), pruneAllDivulgedContracts = false)(_, loggingContext)
+        backend.pruneEvents(offset(2), pruneAllDivulgedContracts = true)(_, loggingContext)
       )
-      _ <- executeSql(backend.updatePrunedUptoInclusive(offset(1)))
+      _ <- executeSql(backend.updatePrunedUptoInclusive(offset(2)))
       // Make sure the events are still visible - active contracts should not be pruned
       after1 <- executeSql(backend.transactionEvents(range, filter))
-      after2 <- executeSql(backend.activeContractEvents(range, filter, offset(1)))
+      after2 <- executeSql(backend.activeContractEvents(range, filter, offset(2)))
       after3 <- executeSql(backend.flatTransaction(createTransactionId, filter))
       after4 <- executeSql(backend.transactionTreeEvents(range, filter))
       after5 <- executeSql(backend.transactionTree(createTransactionId, filter))
@@ -139,6 +142,246 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
       after4 should not be empty
       after5 shouldBe empty // should not be empty
       after6 should not be empty
+    }
+  }
+
+  it should "prune all retroactively and immediately divulged contracts (if pruneAllDivulgedContracts is set)" in {
+    val partyName = "party"
+    val divulgee = Ref.Party.assertFromString(partyName)
+    val contract1_id = "#1"
+    val contract2_id = "#2"
+
+    val contract1_immediateDivulgence = dtoCreate(
+      offset = offset(1),
+      eventSequentialId = 1L,
+      contractId = contract1_id,
+      signatory = divulgee,
+    )
+    val partyEntry = dtoPartyEntry(offset(2), partyName)
+    val contract2_createWithLocalStakeholders = dtoCreate(
+      offset = offset(3),
+      eventSequentialId = 2L,
+      contractId = contract2_id,
+      signatory = divulgee,
+    )
+    val contract1_retroactiveDivulgence =
+      dtoDivulgence(
+        offset = offset(3),
+        eventSequentialId = 3L,
+        contractId = contract1_id,
+        divulgee = partyName,
+      )
+
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+      // Ingest
+      _ <- executeSql(
+        ingest(
+          Vector(
+            contract1_immediateDivulgence,
+            partyEntry,
+            contract1_retroactiveDivulgence,
+            contract2_createWithLocalStakeholders,
+          ),
+          _,
+        )
+      )
+      _ <- executeSql(backend.updateLedgerEnd(ParameterStorageBackend.LedgerEnd(offset(4), 4L)))
+      contract1_beforePruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract1_id),
+        )
+      )
+      contract2_beforePruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract2_id),
+        )
+      )
+      _ <- executeSql(
+        backend.pruneEvents(offset(3), pruneAllDivulgedContracts = true)(_, loggingContext)
+      )
+      contract1_afterPruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract1_id),
+        )
+      )
+      contract2_afterPruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract2_id),
+        )
+      )
+    } yield {
+      contract1_beforePruning should not be empty
+      contract2_beforePruning should not be empty
+
+      contract1_afterPruning shouldBe empty
+      // Immediate divulgence for contract 2 occurred after the associated party became locally hosted
+      // It is not pruned
+      contract2_afterPruning should not be empty
+    }
+  }
+
+  it should "only prune retroactively divulged contracts if there exists an associated consuming exercise (if pruneAllDivulgedContracts is not set)" in {
+    val signatory = "signatory"
+    val divulgee = Ref.Party.assertFromString("party")
+    val contract1_id = "#1"
+    val contract2_id = "#2"
+
+    val contract1_create = dtoCreate(
+      offset = offset(1),
+      eventSequentialId = 1L,
+      contractId = contract1_id,
+      signatory = signatory,
+    )
+    val contract1_divulgence = dtoDivulgence(
+      offset = offset(2),
+      eventSequentialId = 2L,
+      contractId = contract1_id,
+      divulgee = "party",
+    )
+    val contract1_consumingExercise = dtoExercise(
+      offset = offset(3),
+      eventSequentialId = 3L,
+      consuming = true,
+      contractId = contract1_id,
+    )
+    val contract2_divulgence = dtoDivulgence(
+      offset = offset(4),
+      eventSequentialId = 4L,
+      contractId = contract2_id,
+      divulgee = divulgee,
+    )
+
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+      // Ingest
+      _ <- executeSql(
+        ingest(
+          Vector(
+            contract1_create,
+            contract1_divulgence,
+            contract1_consumingExercise,
+            contract2_divulgence,
+          ),
+          _,
+        )
+      )
+      _ <- executeSql(backend.updateLedgerEnd(ParameterStorageBackend.LedgerEnd(offset(5), 5L)))
+      contract1_beforePruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract1_id),
+        )
+      )
+      contract2_beforePruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract2_id),
+        )
+      )
+      _ <- executeSql(
+        backend.pruneEvents(offset(4), pruneAllDivulgedContracts = false)(_, loggingContext)
+      )
+      contract1_afterPruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract1_id),
+        )
+      )
+      contract2_afterPruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract2_id),
+        )
+      )
+    } yield {
+      contract1_beforePruning should not be empty
+      contract2_beforePruning should not be empty
+
+      contract1_afterPruning shouldBe empty
+      contract2_afterPruning should not be empty
+    }
+  }
+
+  it should "prune all retroactively and immediately divulged contracts if pruneAllDivulgedContracts is set" in {
+    val partyName = "party"
+    val divulgee = Ref.Party.assertFromString(partyName)
+    val contract1_id = "#1"
+    val contract2_id = "#2"
+
+    val contract1_immediateDivulgence = dtoCreate(
+      offset = offset(1),
+      eventSequentialId = 1L,
+      contractId = contract1_id,
+      signatory = divulgee,
+    )
+    val partyEntry = dtoPartyEntry(offset(2), partyName)
+    val contract2_createWithLocalStakeholders = dtoCreate(
+      offset = offset(3),
+      eventSequentialId = 2L,
+      contractId = contract2_id,
+      signatory = divulgee,
+    )
+    val contract1_retroactiveDivulgence =
+      dtoDivulgence(
+        offset = offset(3),
+        eventSequentialId = 3L,
+        contractId = contract1_id,
+        divulgee = partyName,
+      )
+
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+      // Ingest
+      _ <- executeSql(
+        ingest(
+          Vector(
+            contract1_immediateDivulgence,
+            partyEntry,
+            contract1_retroactiveDivulgence,
+            contract2_createWithLocalStakeholders,
+          ),
+          _,
+        )
+      )
+      _ <- executeSql(backend.updateLedgerEnd(ParameterStorageBackend.LedgerEnd(offset(4), 4L)))
+      contract1_beforePruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract1_id),
+        )
+      )
+      contract2_beforePruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract2_id),
+        )
+      )
+      _ <- executeSql(
+        backend.pruneEvents(offset(3), pruneAllDivulgedContracts = true)(_, loggingContext)
+      )
+      contract1_afterPruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract1_id),
+        )
+      )
+      contract2_afterPruning <- executeSql(
+        backend.activeContractWithoutArgument(
+          Set(divulgee),
+          ContractId.assertFromString(contract2_id),
+        )
+      )
+    } yield {
+      contract1_beforePruning should not be empty
+      contract2_beforePruning should not be empty
+
+      contract1_afterPruning shouldBe empty
+      contract2_afterPruning should not be empty
     }
   }
 

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -164,7 +164,7 @@ conformance_test(
         "--verbose",
         "--include=ParticipantPruningIT",
         # Disable tests targeting only append-only schema functionality
-        "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences",
+        "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences,ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
     ],
 )
 


### PR DESCRIPTION
 [Divulgence pruning] Prune immediate divulgence
* Adapt `CommonStorageBackend.pruneEvents` to prune all immediately divulged events
* Adapt ParticipantPruningIT to assert immediate divulgence pruning
* Adapt ParticipantPruningIT tests for divulgence pruning to assert the ACS before and after pruning

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
