### PR TITLE
DPP-368 unhide append-only CLI flags

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -549,7 +549,6 @@ object Config {
         // TODO append-only: remove after removing support for the current (mutating) schema
         opt[Unit]("index-append-only-schema")
           .optional()
-          .hidden()
           .text(
             s"Use the append-only index database with parallel ingestion."
           )

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -550,7 +550,10 @@ object Config {
         opt[Unit]("index-append-only-schema")
           .optional()
           .text(
-            s"Use the append-only index database with parallel ingestion."
+            "Use the append-only index database with parallel ingestion." +
+              " The first time this flag is enabled, the index database will migrate to a new schema that allows for significantly higher ingestion performance." +
+              " This migration is irreversible, subsequent starts will have to enable this flag as well." +
+              " In the future, this flag will be removed and this application will automatically migrate to the new schema."
           )
           .action((_, config) => config.copy(enableAppendOnlySchema = true))
 

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -322,7 +322,6 @@ class CommonCliBase(name: LedgerName) {
 
       // TODO append-only: cleanup
       opt[Unit]("enable-append-only-schema")
-        .hidden()
         .optional()
         .action((_, config) => config.copy(enableAppendOnlySchema = true))
         .text(

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -325,7 +325,10 @@ class CommonCliBase(name: LedgerName) {
         .optional()
         .action((_, config) => config.copy(enableAppendOnlySchema = true))
         .text(
-          s"Turns on append-only schema support."
+          s"Turns on append-only schema support." +
+            " The first time this flag is enabled, the database will migrate to a new schema that allows for significantly higher ingestion performance." +
+            " This migration is irreversible, subsequent starts will have to enable this flag as well." +
+            " In the future, this flag will be removed and this application will automatically migrate to the new schema."
         )
 
       // TODO append-only: cleanup


### PR DESCRIPTION
This PR unhides the CLI flags that enable the append-only schema. This effectively publicly releases the append-only schema, and should go together with a release note.

### Changelog entry:

```
- [Sandbox, participant] Added a flag to enable a new append-only database schema.
  This schema was designed to support significantly higher performance.
  In a future release, all applications will automatically migrate to the new schema.
```