### PR TITLE
Use the tracker retention period as the maximum expiry time. [KVL-1009]

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
@@ -138,10 +138,13 @@ final class CommandClient(
         .via(commandUpdaterFlow[Context])
         .viaMat(
           CommandTrackerFlow[Context, NotUsed](
-            CommandSubmissionFlow[(Context, String)](submit(token), config.maxParallelSubmissions),
-            offset => completionSource(parties, offset, token),
-            ledgerEnd.getOffset,
-            () => Some(config.defaultDeduplicationTime),
+            commandSubmissionFlow = CommandSubmissionFlow[(Context, String)](
+              submit(token),
+              config.maxParallelSubmissions,
+            ),
+            createCommandCompletionSource = offset => completionSource(parties, offset, token),
+            startingOffset = ledgerEnd.getOffset,
+            maximumExpiryTime = config.defaultDeduplicationTime,
           )
         )(Keep.right)
     }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
@@ -144,7 +144,7 @@ final class CommandClient(
             ),
             createCommandCompletionSource = offset => completionSource(parties, offset, token),
             startingOffset = ledgerEnd.getOffset,
-            maximumExpiryTime = config.defaultDeduplicationTime,
+            maximumCommandTimeout = config.defaultDeduplicationTime,
           )
         )(Keep.right)
     }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -45,7 +45,7 @@ object CommandTrackerFlow {
       ],
       createCommandCompletionSource: LedgerOffset => Source[CompletionStreamElement, NotUsed],
       startingOffset: LedgerOffset,
-      maximumExpiryTime: Duration,
+      maximumCommandTimeout: Duration,
       backOffDuration: FiniteDuration = 1.second,
   ): Flow[Ctx[Context, CommandSubmission], Ctx[
     Context,
@@ -55,7 +55,7 @@ object CommandTrackerFlow {
     Context,
   ]] = {
 
-    val trackerExternal = new CommandTracker[Context](maximumExpiryTime)
+    val trackerExternal = new CommandTracker[Context](maximumCommandTimeout)
 
     Flow.fromGraph(GraphDSL.create(commandSubmissionFlow, trackerExternal)(Materialized.apply) {
       implicit builder => (submissionFlow, tracker) =>

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -47,6 +47,7 @@ object CommandTrackerFlow {
       startingOffset: LedgerOffset,
       maximumCommandTimeout: Duration,
       backOffDuration: FiniteDuration = 1.second,
+      timeoutDetectionPeriod: FiniteDuration = 1.second,
   ): Flow[Ctx[Context, CommandSubmission], Ctx[
     Context,
     Either[CompletionFailure, CompletionSuccess],
@@ -55,7 +56,7 @@ object CommandTrackerFlow {
     Context,
   ]] = {
 
-    val trackerExternal = new CommandTracker[Context](maximumCommandTimeout)
+    val trackerExternal = new CommandTracker[Context](maximumCommandTimeout, timeoutDetectionPeriod)
 
     Flow.fromGraph(GraphDSL.create(commandSubmissionFlow, trackerExternal)(Materialized.apply) {
       implicit builder => (submissionFlow, tracker) =>

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.client.services.commands
 
-import java.time.{Duration => JDuration}
+import java.time.Duration
 
 import akka.NotUsed
 import akka.stream.scaladsl.{Concat, Flow, GraphDSL, Merge, Source}
@@ -45,7 +45,7 @@ object CommandTrackerFlow {
       ],
       createCommandCompletionSource: LedgerOffset => Source[CompletionStreamElement, NotUsed],
       startingOffset: LedgerOffset,
-      maximumExpiryTime: () => Option[JDuration],
+      maximumExpiryTime: () => Option[Duration],
       backOffDuration: FiniteDuration = 1.second,
   ): Flow[Ctx[Context, CommandSubmission], Ctx[
     Context,

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -45,7 +45,7 @@ object CommandTrackerFlow {
       ],
       createCommandCompletionSource: LedgerOffset => Source[CompletionStreamElement, NotUsed],
       startingOffset: LedgerOffset,
-      maximumExpiryTime: () => Option[Duration],
+      maximumExpiryTime: Duration,
       backOffDuration: FiniteDuration = 1.second,
   ): Flow[Ctx[Context, CommandSubmission], Ctx[
     Context,

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlow.scala
@@ -45,7 +45,7 @@ object CommandTrackerFlow {
       ],
       createCommandCompletionSource: LedgerOffset => Source[CompletionStreamElement, NotUsed],
       startingOffset: LedgerOffset,
-      maxDeduplicationTime: () => Option[JDuration],
+      maximumExpiryTime: () => Option[JDuration],
       backOffDuration: FiniteDuration = 1.second,
   ): Flow[Ctx[Context, CommandSubmission], Ctx[
     Context,
@@ -55,7 +55,7 @@ object CommandTrackerFlow {
     Context,
   ]] = {
 
-    val trackerExternal = new CommandTracker[Context](maxDeduplicationTime)
+    val trackerExternal = new CommandTracker[Context](maximumExpiryTime)
 
     Flow.fromGraph(GraphDSL.create(commandSubmissionFlow, trackerExternal)(Materialized.apply) {
       implicit builder => (submissionFlow, tracker) =>

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -82,9 +82,9 @@ private[commands] class CommandTracker[Context](
     val logic: TimerGraphStageLogic = new TimerGraphStageLogic(shape) {
 
       val timeout_detection = "timeout-detection"
+
       override def preStart(): Unit = {
         scheduleWithFixedDelay(timeout_detection, 1.second, 1.second)
-
       }
 
       override protected def onTimer(timerKey: Any): Unit = {

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.client.services.commands.tracker
 
-import java.time.{Instant, Duration => JDuration}
+import java.time.{Duration, Instant}
 
 import akka.stream.stage._
 import akka.stream.{Attributes, Inlet, Outlet}
@@ -54,7 +54,7 @@ import scala.util.{Failure, Success, Try}
   */
 // TODO(mthvedt): This should have unit tests.
 private[commands] class CommandTracker[Context](
-    maximumExpiryTime: () => Option[JDuration]
+    maximumExpiryTime: () => Option[Duration]
 ) extends GraphStageWithMaterializedValue[
       CommandTrackerShape[Context],
       Future[Map[String, Context]],
@@ -320,22 +320,22 @@ private[commands] class CommandTracker[Context](
 
   private def timeoutFromDeduplicationPeriod(
       deduplicationPeriod: DeduplicationPeriod,
-      maximumExpiryTime: JDuration,
+      maximumExpiryTime: Duration,
   ) = {
     val deduplicationDuration = deduplicationPeriod match {
       case DeduplicationPeriod.Empty =>
         None
       case DeduplicationPeriod.DeduplicationTime(duration) =>
-        Some(JDuration.ofSeconds(duration.seconds, duration.nanos.toLong))
+        Some(Duration.ofSeconds(duration.seconds, duration.nanos.toLong))
       case DeduplicationPeriod.DeduplicationDuration(duration) =>
-        Some(JDuration.ofSeconds(duration.seconds, duration.nanos.toLong))
+        Some(Duration.ofSeconds(duration.seconds, duration.nanos.toLong))
       case DeduplicationPeriod.DeduplicationOffset(_) =>
         // no way of extracting the duration from here, will be removed soon
         None
     }
     val timeout = deduplicationDuration match {
       case None => maximumExpiryTime
-      case Some(duration) => implicitly[Ordering[JDuration]].min(maximumExpiryTime, duration)
+      case Some(duration) => implicitly[Ordering[Duration]].min(maximumExpiryTime, duration)
     }
     Instant.now().plus(timeout)
   }

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.client.services.commands
 
-import java.time.{Instant, Duration => JDuration}
+import java.time.{Duration, Instant}
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.NotUsed
@@ -59,7 +59,7 @@ class CommandTrackerFlowTest
       _.map(_ => Success(Empty.defaultInstance))
     }
 
-  private val shortDuration = JDuration.ofSeconds(1L)
+  private val shortDuration = Duration.ofSeconds(1L)
 
   private lazy val submissionSource = TestSource.probe[Ctx[Int, CommandSubmission]]
   private lazy val resultSink =
@@ -75,7 +75,7 @@ class CommandTrackerFlowTest
   private val successStatus = Status(Code.OK.value)
   private val context = 1
   private val submission = newSubmission(commandId)
-  private def newSubmission(commandId: String, dedupTime: Option[JDuration] = None) = Ctx(
+  private def newSubmission(commandId: String, dedupTime: Option[Duration] = None) = Ctx(
     context,
     CommandSubmission(
       Commands(
@@ -302,7 +302,7 @@ class CommandTrackerFlowTest
       "timeout the command when the MRT passes" in {
         val Handle(submissions, results, _, _) = runCommandTrackingFlow(allSubmissionsSuccessful)
 
-        submissions.sendNext(newSubmission(commandId, dedupTime = Some(JDuration.ofMillis(500))))
+        submissions.sendNext(newSubmission(commandId, dedupTime = Some(Duration.ofMillis(500))))
 
         results.expectNext(
           2.seconds,
@@ -314,7 +314,7 @@ class CommandTrackerFlowTest
       "use the maximum expiry time, if provided" in {
         val Handle(submissions, results, _, _) = runCommandTrackingFlow(
           allSubmissionsSuccessful,
-          maximumExpiryTime = Some(JDuration.ofSeconds(1)),
+          maximumExpiryTime = Some(Duration.ofSeconds(1)),
         )
 
         submissions.sendNext(submission)
@@ -329,10 +329,10 @@ class CommandTrackerFlowTest
       "cap the timeout at the maximum expiry time" in {
         val Handle(submissions, results, _, _) = runCommandTrackingFlow(
           allSubmissionsSuccessful,
-          maximumExpiryTime = Some(JDuration.ofSeconds(1)),
+          maximumExpiryTime = Some(Duration.ofSeconds(1)),
         )
 
-        submissions.sendNext(newSubmission(commandId, dedupTime = Some(JDuration.ofSeconds(10))))
+        submissions.sendNext(newSubmission(commandId, dedupTime = Some(Duration.ofSeconds(10))))
 
         results.expectNext(
           2.seconds,
@@ -577,7 +577,7 @@ class CommandTrackerFlowTest
         Ctx[(Int, String), Try[Empty]],
         NotUsed,
       ],
-      maximumExpiryTime: Option[JDuration] = Some(JDuration.ofSeconds(10)),
+      maximumExpiryTime: Option[Duration] = Some(Duration.ofSeconds(10)),
   ): Handle = {
 
     val completionsMock = new CompletionStreamMock()

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -291,10 +291,10 @@ class CommandTrackerFlowTest
         succeed
       }
 
-      "use the maximum expiry time, if provided" in {
+      "use the maximum command timeout, if provided" in {
         val Handle(submissions, results, _, _) = runCommandTrackingFlow(
           allSubmissionsSuccessful,
-          maximumExpiryTime = Duration.ofSeconds(1),
+          maximumCommandTimeout = Duration.ofSeconds(1),
         )
 
         submissions.sendNext(submission)
@@ -306,10 +306,10 @@ class CommandTrackerFlowTest
         succeed
       }
 
-      "cap the timeout at the maximum expiry time" in {
+      "cap the timeout at the maximum command timeout" in {
         val Handle(submissions, results, _, _) = runCommandTrackingFlow(
           allSubmissionsSuccessful,
-          maximumExpiryTime = Duration.ofSeconds(1),
+          maximumCommandTimeout = Duration.ofSeconds(1),
         )
 
         submissions.sendNext(newSubmission(commandId, dedupTime = Some(Duration.ofSeconds(10))))
@@ -557,17 +557,17 @@ class CommandTrackerFlowTest
         Ctx[(Int, String), Try[Empty]],
         NotUsed,
       ],
-      maximumExpiryTime: Duration = Duration.ofSeconds(10),
+      maximumCommandTimeout: Duration = Duration.ofSeconds(10),
   ): Handle = {
 
     val completionsMock = new CompletionStreamMock()
 
     val trackingFlow =
       CommandTrackerFlow[Int, NotUsed](
-        submissionFlow,
-        completionsMock.createCompletionsSource,
-        LedgerOffset(Boundary(LEDGER_BEGIN)),
-        maximumExpiryTime,
+        commandSubmissionFlow = submissionFlow,
+        createCommandCompletionSource = completionsMock.createCompletionsSource,
+        startingOffset = LedgerOffset(Boundary(LEDGER_BEGIN)),
+        maximumCommandTimeout = maximumCommandTimeout,
       )
 
     val handle = submissionSource

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -325,6 +325,21 @@ class CommandTrackerFlowTest
         )
         succeed
       }
+
+      "cap the timeout at the maximum expiry time" in {
+        val Handle(submissions, results, _, _) = runCommandTrackingFlow(
+          allSubmissionsSuccessful,
+          maximumExpiryTime = Some(JDuration.ofSeconds(1)),
+        )
+
+        submissions.sendNext(newSubmission(commandId, dedupTime = Some(JDuration.ofSeconds(10))))
+
+        results.expectNext(
+          2.seconds,
+          Ctx(context, Left(CompletionResponse.TimeoutResponse(commandId))),
+        )
+        succeed
+      }
     }
 
     "successful completion arrives" should {

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -136,7 +136,7 @@ class CommandTrackerFlowTest
     "no configuration is available" should {
       "fail immediately" in {
         val Handle(submissions, results, _, _) =
-          runCommandTrackingFlow(allSubmissionsSuccessful, maxDeduplicationTime = None)
+          runCommandTrackingFlow(allSubmissionsSuccessful, maximumExpiryTime = None)
 
         submissions.sendNext(submission)
 
@@ -542,7 +542,7 @@ class CommandTrackerFlowTest
         Ctx[(Int, String), Try[Empty]],
         NotUsed,
       ],
-      maxDeduplicationTime: Option[JDuration] = Some(JDuration.ofSeconds(10)),
+      maximumExpiryTime: Option[JDuration] = Some(JDuration.ofSeconds(10)),
   ) = {
 
     val completionsMock = new CompletionStreamMock()
@@ -552,7 +552,7 @@ class CommandTrackerFlowTest
         submissionFlow,
         completionsMock.createCompletionsSource,
         LedgerOffset(Boundary(LEDGER_BEGIN)),
-        () => maxDeduplicationTime,
+        () => maximumExpiryTime,
       )
 
     val handle = submissionSource

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.apiserver.services
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 
 import akka.NotUsed
 import akka.stream.Materializer
@@ -51,7 +51,7 @@ import com.google.protobuf.empty.Empty
 import io.grpc.Status
 import scalaz.syntax.tag._
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try
 
@@ -203,7 +203,7 @@ private[apiserver] object ApiCommandService {
       ledgerId: LedgerId,
       inputBufferSize: Int,
       maxCommandsInFlight: Int,
-      trackerRetentionPeriod: FiniteDuration,
+      trackerRetentionPeriod: Duration,
   )
 
   final class CompletionServices(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -252,7 +252,13 @@ private[apiserver] object ApiCommandService {
                 )
                 .mapConcat(CommandCompletionSource.toStreamElements),
             startingOffset = ledgerEnd,
-            maximumExpiryTime = configuration.trackerRetentionPeriod,
+            // We use the tracker retention period as the maximum command timeout, because the is
+            // the maximum length of time we can guarantee that the tracker stays alive (assuming
+            // the server stays up). If we set it any longer, the tracker might be shut down while
+            // we wait.
+            // In the future, we may want to configure this separately, but for now, we use re-use
+            // the tracker retention period for convenience.
+            maximumCommandTimeout = configuration.trackerRetentionPeriod,
           )
         val trackingFlow = MaxInFlight(
           configuration.maxCommandsInFlight,

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/CommandConfiguration.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/CommandConfiguration.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.configuration
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import java.time.Duration
 
 /** Reaching either [[inputBufferSize]] or [[maxCommandsInFlight]] will trigger
   * back-pressure by [[com.daml.ledger.client.services.commands.CommandClient]].
@@ -28,11 +28,11 @@ final case class CommandConfiguration(
     inputBufferSize: Int,
     maxParallelSubmissions: Int,
     maxCommandsInFlight: Int,
-    trackerRetentionPeriod: FiniteDuration,
+    trackerRetentionPeriod: Duration,
 )
 
 object CommandConfiguration {
-  val DefaultTrackerRetentionPeriod: FiniteDuration = 5.minutes
+  val DefaultTrackerRetentionPeriod: Duration = Duration.ofMinutes(5)
 
   lazy val default: CommandConfiguration =
     CommandConfiguration(

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
@@ -3,6 +3,7 @@
 
 package com.daml.platform.apiserver.services.tracking
 
+import java.time.Duration
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import com.daml.ledger.api.v1.commands.Commands
@@ -20,7 +21,7 @@ import org.scalatest.wordspec.AsyncWordSpec
 
 import scala.collection.compat._
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
 class TrackerMapSpec extends AsyncWordSpec with Matchers {
@@ -31,7 +32,7 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
     "delegate submissions to the constructed trackers" in {
       val transactionIds = Seq("transaction A", "transaction B").iterator
       val tracker = new TrackerMap[String](
-        retentionPeriod = 1.minute,
+        retentionPeriod = Duration.ofMinutes(1),
         getKey = commands => commands.commandId,
         newTracker = _ => Future.successful(new FakeTracker(transactionIds)),
       )
@@ -54,7 +55,7 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
     "only construct one tracker per key" in {
       val trackerCount = new AtomicInteger(0)
       val tracker = new TrackerMap[Set[String]](
-        retentionPeriod = 1.minute,
+        retentionPeriod = Duration.ofMinutes(1),
         getKey = commands => commands.actAs.toSet,
         newTracker = actAs => {
           trackerCount.incrementAndGet()
@@ -85,7 +86,7 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
       val expectedTrackerCount = 10
       val actualTrackerCount = new AtomicInteger(0)
       val tracker = new TrackerMap[String](
-        retentionPeriod = 1.minute,
+        retentionPeriod = Duration.ofMinutes(1),
         getKey = commands => commands.applicationId,
         newTracker = _ => {
           actualTrackerCount.incrementAndGet()
@@ -106,7 +107,7 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
     "clean up old trackers" in {
       val trackerCounts = TrieMap.empty[Set[String], AtomicInteger]
       val tracker = new TrackerMap[Set[String]](
-        retentionPeriod = Duration.Zero,
+        retentionPeriod = Duration.ZERO,
         getKey = commands => commands.actAs.toSet,
         newTracker = actAs => {
           trackerCounts.getOrElseUpdate(actAs, new AtomicInteger(0)).incrementAndGet()
@@ -128,7 +129,7 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
     "clean up failed trackers" in {
       val trackerCounts = TrieMap.empty[String, AtomicInteger]
       val tracker = new TrackerMap[String](
-        retentionPeriod = 1.minute,
+        retentionPeriod = Duration.ofMinutes(1),
         getKey = commands => commands.applicationId,
         newTracker = applicationId => {
           trackerCounts.getOrElseUpdate(applicationId, new AtomicInteger(0)).incrementAndGet()
@@ -162,7 +163,7 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
       val openTrackerCount = new AtomicInteger(0)
       val closedTrackerCount = new AtomicInteger(0)
       val tracker = new TrackerMap[String](
-        retentionPeriod = 1.minute,
+        retentionPeriod = Duration.ofMinutes(1),
         getKey = commands => commands.applicationId,
         newTracker = _ =>
           Future.successful {
@@ -209,7 +210,7 @@ class TrackerMapSpec extends AsyncWordSpec with Matchers {
       val openTracker = new AtomicBoolean(false)
       val closedTracker = new AtomicBoolean(false)
       val tracker = new TrackerMap[Unit](
-        retentionPeriod = 1.minute,
+        retentionPeriod = Duration.ofMinutes(1),
         getKey = _ => (),
         newTracker = _ =>
           Delayed.by(1.second) {

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -400,11 +400,7 @@ object Config {
         opt[Duration]("tracker-retention-period")
           .optional()
           .action((value, config) =>
-            config.copy(
-              commandConfig = config.commandConfig.copy(
-                trackerRetentionPeriod = FiniteDuration(value.getSeconds, TimeUnit.SECONDS)
-              )
-            )
+            config.copy(commandConfig = config.commandConfig.copy(trackerRetentionPeriod = value))
           )
           .text(
             "The duration that the command service will keep an active command tracker for a given set of parties." +

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
@@ -3,6 +3,10 @@
 
 package com.daml.ledger.participant.state.kvutils.app
 
+import java.io.File
+import java.net.URL
+import java.time.Duration
+
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.lf.data.Ref
 import io.netty.handler.ssl.ClientAuth
@@ -11,11 +15,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import scopt.OptionParser
-
-import java.io.File
-import java.net.URL
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.FiniteDuration
 
 final class ConfigSpec
     extends AnyFlatSpec
@@ -175,10 +174,7 @@ final class ConfigSpec
 
   it should "get the tracker retention period when provided" in {
     val periodStringRepresentation = "P0DT1H2M3S"
-    val expectedPeriod =
-      FiniteDuration(1, TimeUnit.HOURS) +
-        FiniteDuration(2, TimeUnit.MINUTES) +
-        FiniteDuration(3, TimeUnit.SECONDS)
+    val expectedPeriod = Duration.ofHours(1).plusMinutes(2).plusSeconds(3)
     val config =
       configParser(parameters =
         minimalValidOptions ++ List(trackerRetentionPeriod, periodStringRepresentation)


### PR DESCRIPTION
### Changelog

- **[Ledger API Server]** The command service now uses the tracker retention period (typically specified with the `--tracker-retention-period` command-line argument) as the maximum time to wait for a command to arrive on the completion stream. After this time, the command will time out, though it may still complete in the future. Previously, the deduplication period was used, but it was likely the tracker would be terminated before that anyway.

  The default tracker retention period is 5 minutes, unless otherwise specified.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
