### PR TITLE
Construct ParsedModule directly in Daml Repl

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/Records.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/Records.hs
@@ -7,6 +7,7 @@ module DA.Daml.Preprocessor.Records
     , mkImport
     , recordDotPreprocessor
     , onExp
+    , onImports
     ) where
 
 

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -216,6 +216,7 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , matchOutput "^Source:.*$"
           , matchOutput "^Severity:.*$"
           , matchOutput "^Message:.*$"
+          , matchOutput "^.*Line0.daml.*$"
           , matchOutput "^.*Could not find module.*$"
           , matchOutput "^.*It is not a module.*$"
           , input "import DA.Time"
@@ -360,6 +361,13 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , input "let lookup1 k = Map.lookup k m"
           , input "lookup1 1"
           , matchOutput "^Some 2$"
+          ]
+    , testInteraction' "out of scope type"
+          [  -- import a function to build a map but not the type itself
+            input "import DA.Map (fromList)"
+          , input "let m = fromList [(0,0)]"
+          , input "m"
+          , matchOutput "Map \\[\\(0,0\\)\\]"
           ]
     ]
   where


### PR DESCRIPTION
This is a relatively large change unfortunately which unfortunately
requires reimplementing parts of the logic of the typechecker & core
compilation. I don’t think it is too bad but we might want to think
over time if we can factor this better.

This fixes #10073 and fixes #10664 by referencing the exact types
instead of going via the renamer.

There are some minor changes around error messages for "module not
found" errors. This is because these are now caught in the
typechecker instead of in our own code. We could keep the errors but
it requires duplicating even more logic and I don’t really see what it
buys us so I think I prefer the approach here.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
