### PR TITLE
[DPP-438] Change open-ended metric names into static ones (by removing partyName part)

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/util/Ctx.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/util/Ctx.scala
@@ -25,10 +25,6 @@ final case class Ctx[+Context, +Value](
 
 object Ctx {
 
-  def fromPair[Context, Value](pair: (Context, Value)) = Ctx(pair._1, pair._2)
-
   def unit[T](item: T): Ctx[Unit, T] = Ctx((), item)
-
-  def derive[T, U](transform: T => U)(item: T) = Ctx(transform(item), item)
 
 }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/util/Ctx.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/util/Ctx.scala
@@ -6,19 +6,19 @@ package com.daml.util
 import com.daml.telemetry.{NoOpTelemetryContext, TelemetryContext}
 
 /** Ctx wraps a value with some contextual information.
- */
+  */
 final case class Ctx[+Context, +Value](
-                                        context: Context,
-                                        value: Value,
-                                        telemetryContext: TelemetryContext = NoOpTelemetryContext,
-                                      ) {
+    context: Context,
+    value: Value,
+    telemetryContext: TelemetryContext = NoOpTelemetryContext,
+) {
 
   def map[T](transform: Value => T): Ctx[Context, T] =
     Ctx(context, transform(value), telemetryContext)
 
   def enrich[NewContext](
-                          enrichingFunction: (Context, Value) => NewContext
-                        ): Ctx[NewContext, Value] =
+      enrichingFunction: (Context, Value) => NewContext
+  ): Ctx[NewContext, Value] =
     Ctx(enrichingFunction(context, value), value, telemetryContext)
 
 }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/util/Ctx.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/util/Ctx.scala
@@ -6,25 +6,29 @@ package com.daml.util
 import com.daml.telemetry.{NoOpTelemetryContext, TelemetryContext}
 
 /** Ctx wraps a value with some contextual information.
-  */
+ */
 final case class Ctx[+Context, +Value](
-    context: Context,
-    value: Value,
-    telemetryContext: TelemetryContext = NoOpTelemetryContext,
-) {
+                                        context: Context,
+                                        value: Value,
+                                        telemetryContext: TelemetryContext = NoOpTelemetryContext,
+                                      ) {
 
   def map[T](transform: Value => T): Ctx[Context, T] =
     Ctx(context, transform(value), telemetryContext)
 
   def enrich[NewContext](
-      enrichingFunction: (Context, Value) => NewContext
-  ): Ctx[NewContext, Value] =
+                          enrichingFunction: (Context, Value) => NewContext
+                        ): Ctx[NewContext, Value] =
     Ctx(enrichingFunction(context, value), value, telemetryContext)
 
 }
 
 object Ctx {
 
+  def fromPair[Context, Value](pair: (Context, Value)) = Ctx(pair._1, pair._2)
+
   def unit[T](item: T): Ctx[Unit, T] = Ctx((), item)
+
+  def derive[T, U](transform: T => U)(item: T) = Ctx(transform(item), item)
 
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -38,16 +38,11 @@ final class Metrics(val registry: MetricRegistry) {
       val validSubmissions: Meter =
         registry.meter(Prefix :+ "valid_submissions")
 
-      def inputBufferLength(firstParty: String): Counter =
-        registry.counter(Prefix :+ firstParty :+ "input_buffer_length")
-      def inputBufferCapacity(firstParty: String): Counter =
-        registry.counter(Prefix :+ firstParty :+ "input_buffer_capacity")
-      def inputBufferDelay(firstParty: String): Timer =
-        registry.timer(Prefix :+ firstParty :+ "input_buffer_delay")
-      def maxInFlightLength(firstParty: String): Counter =
-        registry.counter(Prefix :+ firstParty :+ "max_in_flight_length")
-      def maxInFlightCapacity(firstParty: String): Counter =
-        registry.counter(Prefix :+ firstParty :+ "max_in_flight_capacity")
+      val inputBufferLength: Counter = registry.counter(Prefix :+ "input_buffer_length")
+      val inputBufferCapacity: Counter = registry.counter(Prefix :+ "input_buffer_capacity")
+      val inputBufferDelay: Timer = registry.timer(Prefix :+ "input_buffer_delay")
+      val maxInFlightLength: Counter = registry.counter(Prefix :+ "max_in_flight_length")
+      val maxInFlightCapacity: Counter = registry.counter(Prefix :+ "max_in_flight_capacity")
     }
 
     object execution {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -232,8 +232,6 @@ private[apiserver] object ApiCommandService {
     ): Future[Tracker] = {
       // Note: command completions are returned as long as at least one of the original submitters
       // is specified in the command completion request.
-      // Use just name of first party for open-ended metrics to avoid unbounded metrics name for multiple parties
-      val metricsPrefixFirstParty = key.parties.min
       for {
         ledgerEnd <- completionServices.getCompletionEnd().map(_.getOffset)
       } yield {
@@ -262,16 +260,16 @@ private[apiserver] object ApiCommandService {
           )
         val trackingFlow = MaxInFlight(
           configuration.maxCommandsInFlight,
-          capacityCounter = metrics.daml.commands.maxInFlightCapacity(metricsPrefixFirstParty),
-          lengthCounter = metrics.daml.commands.maxInFlightLength(metricsPrefixFirstParty),
+          capacityCounter = metrics.daml.commands.maxInFlightCapacity,
+          lengthCounter = metrics.daml.commands.maxInFlightLength,
         ).joinMat(commandTrackerFlow)(Keep.right)
 
         QueueBackedTracker(
           trackingFlow,
           configuration.inputBufferSize,
-          capacityCounter = metrics.daml.commands.inputBufferCapacity(metricsPrefixFirstParty),
-          lengthCounter = metrics.daml.commands.inputBufferLength(metricsPrefixFirstParty),
-          delayTimer = metrics.daml.commands.inputBufferDelay(metricsPrefixFirstParty),
+          capacityCounter = metrics.daml.commands.inputBufferCapacity,
+          lengthCounter = metrics.daml.commands.inputBufferLength,
+          delayTimer = metrics.daml.commands.inputBufferDelay,
         )
       }
     }


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END


### Details

Sample metric name before and after this change (obtained by running conformance test tool against ledger-on-memory locally)

BEFORE:
```
daml_commands_AcceptChoiceArgumentInCreateAndExerciseCommand100_alpha_1352983bce9f_party_0_input_buffer_delay
```

AFTER:
```
daml_commands_input_buffer_delay
```

Testing setup details:
```
Build ledger-on-memory
bazel build //ledger/ledger-on-memory:app_deploy.jar

Run ledger-on-memory with Prometheus server built-in:
java -Xmx4g -jar bazel-bin/ledger/ledger-on-memory/app_deploy.jar --participant participant-id=dummy-participant,port=6865 --daml-lf-dev-mode-unsafe --metrics-reporter prometheus://localhost:9494

Configure Prometheus UI (prometheus.yml)
scrape_configs:
  - job_name: "participant-server-local"
    static_configs:
      - targets: ["localhost:9494"]

Run Prometheus UI
./prometheus --config.file=prometheus.yml

Build conformance test tool:
bazel build //ledger/ledger-api-test-tool:ledger-api-test-tool_deploy.jar

Run conformance test tool:
java -jar bazel-bin/ledger/ledger-api-test-tool/ledger-api-test-tool_deploy.jar localhost:6865
```


### Notes from investigating potentially open-ended named metrics:


1. Party names' metrics
```
com.daml.metrics.Metrics.daml.commands#inputBufferLength
def inputBufferLength(firstParty: String): Counter =
  registry.counter(Prefix :+ firstParty :+ "input_buffer_length")
def inputBufferCapacity(firstParty: String): Counter =
  registry.counter(Prefix :+ firstParty :+ "input_buffer_capacity")
def inputBufferDelay(firstParty: String): Timer =
  registry.timer(Prefix :+ firstParty :+ "input_buffer_delay")
def maxInFlightLength(firstParty: String): Counter =
  registry.counter(Prefix :+ firstParty :+ "max_in_flight_length")
def maxInFlightCapacity(firstParty: String): Counter =
  registry.counter(Prefix :+ firstParty :+ "max_in_flight_capacity")
```


2. Committer names' metrics
```
com.daml.metrics.Metrics.daml.kvutils.committer#runTimer
def runTimer(committerName: String): Timer =
  registry.timer(Prefix :+ committerName :+ "run_timer")
def preExecutionRunTimer(committerName: String): Timer =
  registry.timer(Prefix :+ committerName :+ "preexecution_run_timer")
def stepTimer(committerName: String, stepName: String): Timer =
  registry.timer(Prefix :+ committerName :+ "step_timers" :+ stepName)
```
Committer name is a val like this: ` override protected val committerName = "party_allocation"`
There are for classes that define it: 
```
- PartyAllocationCommitter (com.daml.ledger.participant.state.kvutils.committer)
- ConfigCommitter (com.daml.ledger.participant.state.kvutils.committer)
- TransactionCommitter (com.daml.ledger.participant.state.kvutils.committer.transaction)
- PackageCommitter (com.daml.ledger.participant.state.kvutils.committer)
 
```

3. Rejection reason name's metrics
```
 com.daml.metrics.Metrics.daml.kvutils.committer.transaction#rejection
def rejection(name: String): Counter =
  registry.counter(Prefix :+ s"rejections_$name")
```
 There is a metric instance per reasonCase. 
Reasons are listed in `com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlTransactionRejectionEntry.ReasonCase`
from `libdaml_kvutils_proto-speed-hjar.jar`
```
metrics.daml.kvutils.committer.transaction
  .rejection(reasonCase.name()) 
```
```
public enum ReasonCase
    implements com.google.protobuf.Internal.EnumLite,
        com.google.protobuf.AbstractMessage.InternalOneOfEnum {
  INCONSISTENT(2),
  DISPUTED(3),
  RESOURCES_EXHAUSTED(4),
  DUPLICATE_COMMAND(6),
  PARTY_NOT_KNOWN_ON_LEDGER(7),
  SUBMITTER_CANNOT_ACT_VIA_PARTICIPANT(8),
  INVALID_LEDGER_TIME(9),
  REASON_NOT_SET(0);
... 
```

4. Metrics per gRPC method call 
```
 com.daml.metrics.Metrics.daml.lapi#forMethod
def forMethod(name: String): Timer = registry.timer(Prefix :+ name)
```
 com.daml.platform.apiserver.MetricsInterceptor
io.grpc.ServerInterceptor
```
private[apiserver] final class MetricsInterceptor(metrics: Metrics) extends ServerInterceptor {

  // Cache the result of calling MetricsInterceptor.nameFor, which practically has a
  // limited co-domain and whose cost we don't want to pay every time an endpoint is hit
  private val fullServiceToMetricNameCache = TrieMap.empty[String, Timer]

  override def interceptCall[ReqT, RespT](
      call: ServerCall[ReqT, RespT],
      headers: Metadata,
      next: ServerCallHandler[ReqT, RespT],
  ): ServerCall.Listener[ReqT] = {
    val fullMethodName = call.getMethodDescriptor.getFullMethodName
    val timer = fullServiceToMetricNameCache.getOrElseUpdate(
      fullMethodName,
      metrics.daml.lapi.forMethod(MetricsNaming.nameFor(fullMethodName)),
    )
    val timerCtx = timer.time
    next.startCall(new TimedServerCall(call, timerCtx), headers)
  }
```

 5. Connections' metrics
```
com.daml.metrics.Metrics.daml.ledger.database.transactions#acquireConnection
def acquireConnection(name: String): Timer =
  registry.timer(Prefix :+ name :+ "acquire_connection")
def run(name: String): Timer =
  registry.timer(Prefix :+ name :+ "run")
```

"name" is a transaction name. There is only a few fixed transaction names: "commit"
"retrieve_ledger_id"
"read_log"
"read_head"
"ledger_reset"
 


6. Event's buffers' metrics
```
com.daml.metrics.Metrics.daml.services.index.streamsBuffer#push
def push(qualifier: String): Timer = registry.timer(Prefix :+ qualifier :+ "push")
def slice(qualifier: String): Timer = registry.timer(Prefix :+ qualifier :+ "slice")
def prune(qualifier: String): Timer = registry.timer(Prefix :+ qualifier :+ "prune")
```
```
com.daml.platform.store.cache.EventsBuffer private[platform] final class EventsBuffer[O: Ordering, E](
    maxBufferSize: Long,
    metrics: Metrics,
    bufferQualifier: String,
    isRangeEndMarker: E => Boolean,
) {
  @volatile private var _bufferStateRef = BufferStateRef[O, E]()

  private val pushTimer = metrics.daml.services.index.streamsBuffer.push(bufferQualifier)
  private val sliceTimer = metrics.daml.services.index.streamsBuffer.slice(bufferQualifier)
  private val pruneTimer = metrics.daml.services.index.streamsBuffer.prune(bufferQualifier)
```
 There is only one `bufferQualifier` distinct value used in the main sources:
"transactions"  in platform/index/ReadOnlySqlLedgerWithMutableCache.scala:158

Usages In tests:
"integers"
"test"
