### PR TITLE
sandbox-classic: Add ErrorInfo metadata for rejections. [KVL-1048]

### DIFF
--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -162,6 +162,7 @@ da_scala_library(
         "//ledger/metrics",
         "//ledger/participant-integration-api",
         "//ledger/participant-integration-api:participant-integration-api-tests-lib",
+        "//ledger/participant-state",
         "//ledger/sandbox-common",
         "//ledger/sandbox-common:sandbox-common-scala-tests-lib",
         "//ledger/test-common",

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Rejection.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Rejection.scala
@@ -5,75 +5,69 @@ package com.daml.platform.sandbox.stores.ledger
 
 import com.daml.ledger.api.domain
 import com.daml.ledger.configuration.LedgerTimeModel
-import com.daml.ledger.participant.state.{v1, v2}
-import com.daml.platform.sandbox.stores.ledger.Rejection._
+import com.daml.ledger.participant.state.{v2 => state}
 import com.google.protobuf.any.{Any => AnyProto}
 import com.google.rpc.error_details.ErrorInfo
 import com.google.rpc.status.{Status => RpcStatus}
 import io.grpc.Status
 
 sealed trait Rejection {
-  val reason: String
-
-  val code: Status.Code
-
-  def description: String
-
-  def metadata: Map[String, String]
-
   def toDomainRejectionReason: domain.RejectionReason
 
-  def toStateV1RejectionReason: v1.RejectionReason
-
-  def toStateV2RejectionReason: v2.Update.CommandRejected.RejectionReasonTemplate =
-    v2.Update.CommandRejected.FinalReason(
-      RpcStatus.of(
-        code.value(),
-        description,
-        Seq(
-          AnyProto.pack(ErrorInfo.of(reason = reason, domain = errorDomain, metadata = metadata))
-        ),
-      )
-    )
+  def toStateRejectionReason: state.Update.CommandRejected.RejectionReasonTemplate
 }
 
 object Rejection {
-  val errorDomain = "com.daml.on.sql"
+  val ErrorDomain = "com.daml.on.sql"
 
   object NoLedgerConfiguration extends Rejection {
-    override val reason: String = "NO_LEDGER_CONFIGURATION"
-
-    override val description: String =
+    private val description: String =
       "No ledger configuration available, cannot validate ledger time"
-
-    override val code: Status.Code = Status.Code.ABORTED
-
-    override lazy val metadata: Map[String, String] = Map.empty
 
     override lazy val toDomainRejectionReason: domain.RejectionReason =
       domain.RejectionReason.InvalidLedgerTime(description)
 
-    override lazy val toStateV1RejectionReason: v1.RejectionReason =
-      v1.RejectionReasonV0.InvalidLedgerTime(description)
+    override lazy val toStateRejectionReason: state.Update.CommandRejected.RejectionReasonTemplate =
+      state.Update.CommandRejected.FinalReason(
+        RpcStatus.of(
+          code = Status.Code.ABORTED.value(),
+          message = description,
+          details = Seq(
+            AnyProto.pack(
+              ErrorInfo.of(
+                reason = "NO_LEDGER_CONFIGURATION",
+                domain = ErrorDomain,
+                metadata = Map.empty,
+              )
+            )
+          ),
+        )
+      )
   }
 
   final case class InvalidLedgerTime(outOfRange: LedgerTimeModel.OutOfRange) extends Rejection {
-    override val reason: String = "INVALID_LEDGER_TIME"
-
-    override val code: Status.Code = Status.Code.ABORTED
-
-    override lazy val description: String = outOfRange.message
-
-    override lazy val metadata: Map[String, String] = Map(
-      "ledgerTime" -> outOfRange.ledgerTime.toString,
-      "lowerBound" -> outOfRange.lowerBound.toString,
-      "upperBound" -> outOfRange.upperBound.toString,
-    )
-
     override lazy val toDomainRejectionReason: domain.RejectionReason =
-      domain.RejectionReason.InvalidLedgerTime(description)
+      domain.RejectionReason.InvalidLedgerTime(outOfRange.message)
 
-    override lazy val toStateV1RejectionReason: v1.RejectionReason =
-      v1.RejectionReasonV0.InvalidLedgerTime(description)
+    override lazy val toStateRejectionReason: state.Update.CommandRejected.RejectionReasonTemplate =
+      state.Update.CommandRejected.FinalReason(
+        RpcStatus.of(
+          code = Status.Code.ABORTED.value(),
+          message = outOfRange.message,
+          details = Seq(
+            AnyProto.pack(
+              ErrorInfo.of(
+                reason = "INVALID_LEDGER_TIME",
+                domain = ErrorDomain,
+                metadata = Map(
+                  "ledgerTime" -> outOfRange.ledgerTime.toString,
+                  "lowerBound" -> outOfRange.lowerBound.toString,
+                  "upperBound" -> outOfRange.upperBound.toString,
+                ),
+              )
+            )
+          ),
+        )
+      )
   }
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Rejection.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Rejection.scala
@@ -21,7 +21,7 @@ sealed trait Rejection {
   def toStateV1RejectionReason: v1.RejectionReason
 
   def toStateV2RejectionReason: v2.Update.CommandRejected.RejectionReasonTemplate =
-    new v2.Update.CommandRejected.FinalReason(
+    v2.Update.CommandRejected.FinalReason(
       RpcStatus.of(code.value(), description, Seq.empty)
     )
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Rejection.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Rejection.scala
@@ -6,8 +6,11 @@ package com.daml.platform.sandbox.stores.ledger
 import com.daml.ledger.api.domain
 import com.daml.ledger.configuration.LedgerTimeModel
 import com.daml.ledger.participant.state.{v1, v2}
-import io.grpc.Status
+import com.daml.platform.sandbox.stores.ledger.Rejection._
+import com.google.protobuf.any.{Any => AnyProto}
+import com.google.rpc.error_details.ErrorInfo
 import com.google.rpc.status.{Status => RpcStatus}
+import io.grpc.Status
 
 sealed trait Rejection {
   val reason: String
@@ -16,17 +19,27 @@ sealed trait Rejection {
 
   def description: String
 
+  def metadata: Map[String, String]
+
   def toDomainRejectionReason: domain.RejectionReason
 
   def toStateV1RejectionReason: v1.RejectionReason
 
   def toStateV2RejectionReason: v2.Update.CommandRejected.RejectionReasonTemplate =
     v2.Update.CommandRejected.FinalReason(
-      RpcStatus.of(code.value(), description, Seq.empty)
+      RpcStatus.of(
+        code.value(),
+        description,
+        Seq(
+          AnyProto.pack(ErrorInfo.of(reason = reason, domain = errorDomain, metadata = metadata))
+        ),
+      )
     )
 }
 
 object Rejection {
+  val errorDomain = "com.daml.on.sql"
+
   object NoLedgerConfiguration extends Rejection {
     override val reason: String = "NO_LEDGER_CONFIGURATION"
 
@@ -34,6 +47,8 @@ object Rejection {
       "No ledger configuration available, cannot validate ledger time"
 
     override val code: Status.Code = Status.Code.ABORTED
+
+    override lazy val metadata: Map[String, String] = Map.empty
 
     override lazy val toDomainRejectionReason: domain.RejectionReason =
       domain.RejectionReason.InvalidLedgerTime(description)
@@ -48,6 +63,12 @@ object Rejection {
     override val code: Status.Code = Status.Code.ABORTED
 
     override lazy val description: String = outOfRange.message
+
+    override lazy val metadata: Map[String, String] = Map(
+      "ledgerTime" -> outOfRange.ledgerTime.toString,
+      "lowerBound" -> outOfRange.lowerBound.toString,
+      "upperBound" -> outOfRange.upperBound.toString,
+    )
 
     override lazy val toDomainRejectionReason: domain.RejectionReason =
       domain.RejectionReason.InvalidLedgerTime(description)

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -426,7 +426,7 @@ private final class SqlLedger(
               completionInfo = Some(submitterInfo.toCompletionInfo),
               recordTime = recordTime,
               offsetStep = CurrentOffset(offset),
-              reason = reason.toStateV2RejectionReason,
+              reason = reason.toStateRejectionReason,
             ),
           _ => {
             val divulgedContracts = Nil

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/stores/ledger/RejectionSpec.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/stores/ledger/RejectionSpec.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.stores.ledger
+
+import java.time.Instant
+
+import com.daml.ledger.configuration.LedgerTimeModel
+import com.daml.ledger.participant.state.{v2 => state}
+import com.google.protobuf.any.{Any => AnyProto}
+import com.google.rpc.error_details.ErrorInfo
+import com.google.rpc.status.{Status => StatusProto}
+import io.grpc.Status
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class RejectionSpec extends AnyWordSpec with Matchers {
+  "Rejection.NoLedgerConfiguration" should {
+    "convert to a state rejection reason" in {
+      Rejection.NoLedgerConfiguration.toStateV2RejectionReason should be(
+        state.Update.CommandRejected.FinalReason(
+          StatusProto.of(
+            code = Status.Code.ABORTED.value,
+            message = "No ledger configuration available, cannot validate ledger time",
+            details = Seq(
+              AnyProto.pack(
+                ErrorInfo.of(
+                  reason = "NO_LEDGER_CONFIGURATION",
+                  domain = "com.daml.on.sql",
+                  metadata = Map.empty,
+                )
+              )
+            ),
+          )
+        )
+      )
+    }
+  }
+
+  "Rejection.InvalidLedgerTime" should {
+    "convert to a state rejection reason" in {
+      val ledgerTime = Instant.parse("2021-07-20T09:30:00Z")
+      val lowerBound = Instant.parse("2021-07-20T09:00:00Z")
+      val upperBound = Instant.parse("2021-07-20T09:10:00Z")
+      val outOfRange = LedgerTimeModel.OutOfRange(ledgerTime, lowerBound, upperBound)
+
+      Rejection.InvalidLedgerTime(outOfRange).toStateV2RejectionReason should be(
+        state.Update.CommandRejected.FinalReason(
+          StatusProto.of(
+            code = Status.Code.ABORTED.value,
+            message = outOfRange.message,
+            details = Seq(
+              AnyProto.pack(
+                ErrorInfo.of(
+                  reason = "INVALID_LEDGER_TIME",
+                  domain = "com.daml.on.sql",
+                  metadata = Map(
+                    "ledgerTime" -> ledgerTime.toString,
+                    "lowerBound" -> lowerBound.toString,
+                    "upperBound" -> upperBound.toString,
+                  ),
+                )
+              )
+            ),
+          )
+        )
+      )
+    }
+  }
+}

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/stores/ledger/RejectionSpec.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/stores/ledger/RejectionSpec.scala
@@ -17,7 +17,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class RejectionSpec extends AnyWordSpec with Matchers {
   "Rejection.NoLedgerConfiguration" should {
     "convert to a state rejection reason" in {
-      Rejection.NoLedgerConfiguration.toStateV2RejectionReason should be(
+      Rejection.NoLedgerConfiguration.toStateRejectionReason should be(
         state.Update.CommandRejected.FinalReason(
           StatusProto.of(
             code = Status.Code.ABORTED.value,
@@ -44,7 +44,7 @@ class RejectionSpec extends AnyWordSpec with Matchers {
       val upperBound = Instant.parse("2021-07-20T09:10:00Z")
       val outOfRange = LedgerTimeModel.OutOfRange(ledgerTime, lowerBound, upperBound)
 
-      Rejection.InvalidLedgerTime(outOfRange).toStateV2RejectionReason should be(
+      Rejection.InvalidLedgerTime(outOfRange).toStateRejectionReason should be(
         state.Update.CommandRejected.FinalReason(
           StatusProto.of(
             code = Status.Code.ABORTED.value,

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -213,7 +213,12 @@ final class SqlLedgerSpec
       */
     "does not use async commit when building JdbcLedgerDao" in {
       for {
-        _ <- createSqlLedger()
+        _ <- createSqlLedger(
+          ledgerId = None,
+          participantId = None,
+          packages = List.empty,
+          enableAppendOnlySchema = false,
+        )
       } yield {
         val hikariDataSourceLogs =
           LogCollector.read[this.type]("com.daml.platform.store.dao.HikariConnection")
@@ -450,6 +455,7 @@ final class SqlLedgerSpec
       participantId: Option[ParticipantId],
       packages: List[DamlLf.Archive],
       timeProvider: TimeProvider = TimeProvider.UTC,
+      enableAppendOnlySchema: Boolean = true,
   ): Future[Ledger] = {
     metrics.getNames.forEach(name => { val _ = metrics.remove(name) })
     val ledger =
@@ -476,6 +482,8 @@ final class SqlLedgerSpec
         lfValueTranslationCache = LfValueTranslationCache.Cache.none,
         engine = new Engine(),
         validatePartyAllocation = false,
+        enableAppendOnlySchema = enableAppendOnlySchema,
+        enableCompression = false,
       ).acquire()(ResourceContext(system.dispatcher))
     createdLedgers += ledger
     ledger.asFuture


### PR DESCRIPTION
This includes a bunch of extra tests for `SqlLedger`. I enabled the append-only index for these tests as the rejection reason details are not included if we use the mutable index.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
