### PR TITLE
Enable pruning in the sandbox-classic when the append-only schema is used [DPP-567]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -724,7 +724,7 @@ private[testtool] final class ParticipantTestContext private[participant] (
   def prune(
       pruneUpTo: LedgerOffset,
       attempts: Int = 10,
-      pruneAllDivulgedContracts: Boolean = true,
+      pruneAllDivulgedContracts: Boolean = false,
   ): Future[PruneResponse] =
     prune(pruneUpTo.getAbsolute, attempts, pruneAllDivulgedContracts)
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
@@ -703,7 +703,10 @@ class ParticipantPruningIT extends LedgerTestSuite {
         divulgence.exerciseCanFetch(_, contract),
       )
 
-      _ <- beta.prune(offsetAfterDivulgence_1)
+      _ <- beta.prune(
+        pruneUpTo = offsetAfterDivulgence_1,
+        pruneAllDivulgedContracts = true,
+      )
       // Check that Bob can still fetch the contract after pruning the first transaction
       _ <- beta.exerciseAndGetContract[Dummy](
         bob,

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -372,7 +372,7 @@ server_conformance_test(
         "default",
     ],
     server_args = [
-        "--static-time",
+        "--wall-clock-time",
         "--contract-id-seeding=testing-weak",
         "--enable-append-only-schema",
     ],

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -380,6 +380,8 @@ server_conformance_test(
     test_tool_args = [
         "--open-world",
         "--include=ParticipantPruningIT",
+        # Excluding tests that require using pruneAllDivulgedContracts option that is not supported by sandbox-classic
+        "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences,ParticipantPruningIT:PRDisclosureAndRetroactiveDivulgence",
     ],
 )
 

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -367,6 +367,23 @@ server_conformance_test(
 )
 
 server_conformance_test(
+    name = "conformance-test-pruning-append-only",
+    lf_versions = [
+        "default",
+    ],
+    server_args = [
+        "--static-time",
+        "--contract-id-seeding=testing-weak",
+        "--enable-append-only-schema",
+    ],
+    servers = ONLY_POSTGRES_SERVER,
+    test_tool_args = [
+        "--open-world",
+        "--include=ParticipantPruningIT",
+    ],
+)
+
+server_conformance_test(
     name = "conformance-test-wall-clock",
     server_args = [
         "--wall-clock-time",

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -102,6 +102,12 @@ private[stores] final class LedgerBackedWriteService(
       pruneAllDivulgedContracts: Boolean,
   ): CompletionStage[state.PruningResult] =
     CompletableFuture.completedFuture {
+      // The API pruning service performs pruning in two steps:
+      // 1. pruning the ledger using a write service
+      // 2. pruning the index db
+      // For the sandbox-classic the ledger and the index db are the same thing, so returning
+      // `state.PruningResult.ParticipantPruned` results in proceeding to the step 2. effectively pruning the db,
+      // while returning `state.PruningResult.NotPruned(Status.UNIMPLEMENTED)` prevents pruning at all.
       if (enablePruning) state.PruningResult.ParticipantPruned
       else state.PruningResult.NotPruned(Status.UNIMPLEMENTED)
     }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -96,6 +96,7 @@ private[stores] final class LedgerBackedWriteService(
       FutureConverters.toJava(ledger.publishConfiguration(maxRecordTime, submissionId, config))
     }
 
+  /** Pruning of all divulged contracts is not supported on sandbox-classic. */
   override def prune(
       pruneUpToInclusive: Offset,
       submissionId: Ref.SubmissionId,
@@ -108,7 +109,7 @@ private[stores] final class LedgerBackedWriteService(
       // For the sandbox-classic the ledger and the index db are the same thing, so returning
       // `state.PruningResult.ParticipantPruned` results in proceeding to the step 2. effectively pruning the db,
       // while returning `state.PruningResult.NotPruned(Status.UNIMPLEMENTED)` prevents pruning at all.
-      if (enablePruning) state.PruningResult.ParticipantPruned
+      if (enablePruning && !pruneAllDivulgedContracts) state.PruningResult.ParticipantPruned
       else state.PruningResult.NotPruned(Status.UNIMPLEMENTED)
     }
 


### PR DESCRIPTION
### Main change
- enabled participant pruning in the `sandbox-classic` when the append-only schema is used

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
