### PR TITLE
Support TLS in Daml Helper --json-api requests

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -594,9 +594,12 @@ httpBsRequest args method path modify = do
 
 makeRequest :: LedgerArgs -> Method -> Path -> (Request -> Request) -> IO Request
 makeRequest LedgerArgs {sslConfigM, tokM, port, host} method path modify = do
-  when (isJust sslConfigM) $
-    fail "The HTTP JSON API doesn't support TLS requests, but a TLS flag was set."
+  secure <- case sslConfigM of
+    Nothing -> pure False
+    Just (L.ClientSSLConfig Nothing Nothing Nothing) -> pure True
+    Just _ -> fail "The HTTP JSON API does not support --pem, --crt and --cacrt flags."
   pure $
+    setRequestSecure secure $
     setRequestPort port $
     setRequestHost (BSC.pack host) $
     setRequestMethod (unMethod method) $


### PR DESCRIPTION
This PR accepts the --tls flag but rejects the flags to set certs
because those don’t really make sense here (or are at least not easily
settable).

Unfortunately no great way to test this without a huge amount of test
infrastructure to setup a custom TLS reverse proxy for tests.

If someone has an idea to add a reasonable test, I’m all ears. I did test it manually against daml hub which worked fine.

We should probably also add an option to specify a URL because this is bit of a crappy UX for an http API but one step at a time.

changelog_begin

- [Daml Assistant] The `daml ledger` commands now accepts `--tls` in
  combination with `--json-api` to access a JSON API behind a TLS
  reverse proxy.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
