### PR TITLE
DPP-368 enable append-only flag in sandbox

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -23,7 +23,7 @@ case class IndexerConfig(
     updatePreparationParallelism: Int = DefaultUpdatePreparationParallelism,
     allowExistingSchema: Boolean = false,
     // TODO append-only: remove after removing support for the current (mutating) schema
-    enableAppendOnlySchema: Boolean = false,
+    enableAppendOnlySchema: Boolean,
     asyncCommitMode: DbType.AsyncCommitMode = DefaultAsyncCommitMode,
     maxInputBufferSize: Int = DefaultMaxInputBufferSize,
     inputMappingParallelism: Int = DefaultInputMappingParallelism,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
@@ -179,6 +179,7 @@ final class JdbcIndexerSpec
       jdbcUrl = postgresDatabase.url,
       startupMode = IndexerStartupMode.MigrateAndStart,
       asyncCommitMode = jdbcAsyncCommitMode,
+      enableAppendOnlySchema = false,
     )
     val metrics = new Metrics(new MetricRegistry)
     new indexer.JdbcIndexer.Factory(

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -319,6 +319,7 @@ object IntegrityChecker {
       participantId = Ref.ParticipantId.assertFromString("IntegrityCheckerParticipant"),
       jdbcUrl = jdbcUrl(config),
       startupMode = IndexerStartupMode.MigrateAndStart,
+      enableAppendOnlySchema = false,
     )
 
   private[integritycheck] def jdbcUrl(config: Config): String =

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -213,6 +213,7 @@ class RecoveringIndexerIntegrationSpec
           jdbcUrl = jdbcUrl,
           startupMode = IndexerStartupMode.MigrateAndStart,
           restartDelay = restartDelay,
+          enableAppendOnlySchema = false,
         ),
         servicesExecutionContext = servicesExecutionContext,
         metrics = new Metrics(new MetricRegistry),

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -333,12 +333,20 @@ class CommonCliBase(name: LedgerName) {
 
       // TODO append-only: cleanup
       opt[Unit]("enable-compression")
-        .hidden()
         .optional()
         .action((_, config) => config.copy(enableCompression = true))
         .text(
-          s"By default compression is off, this switch enables it. This has only effect for append-only ingestion." // TODO append-only: fix description
+          s"Enables application-side compression of Daml-LF values stored in the database using the append-only schema." +
+            " By default, compression is disabled."
         )
+
+      checkConfig(c => {
+        if (c.enableCompression && !c.enableAppendOnlySchema)
+          failure(
+            "Compression (`--enable-compression`) can only be used together with the append-only schema (`--enable-append-only-schema`)."
+          )
+        else success
+      })
 
       com.daml.cliopts.Metrics.metricsReporterParse(this)(
         (setter, config) => config.copy(metricsReporter = setter(config.metricsReporter)),

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -322,3 +322,16 @@ server_conformance_test(
         "--include=ContractIdIT:Accept",
     ],
 )
+
+# TODO append-only: cleanup
+server_conformance_test(
+    name = "next-conformance-test-append-only",
+    server_args = [
+        "--enable-append-only-schema",
+    ],
+    servers = {"postgresql": NEXT_SERVERS["postgresql"]},
+    test_tool_args = [
+        "--open-world",
+        "--exclude=ClosedWorldIT",
+    ],
+)

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -206,6 +206,8 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     else IndexerStartupMode.MigrateAndStart,
                   eventsPageSize = config.eventsPageSize,
                   allowExistingSchema = true,
+                  enableAppendOnlySchema = config.enableAppendOnlySchema,
+                  enableCompression = config.enableCompression,
                 ),
                 servicesExecutionContext = servicesExecutionContext,
                 metrics = metrics,
@@ -255,7 +257,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   // TODO append-only: augment the following defaults for enabling the features for sandbox next
                   seeding = config.seeding.get,
                   managementServiceTimeout = config.managementServiceTimeout,
-                  enableAppendOnlySchema = false,
+                  enableAppendOnlySchema = config.enableAppendOnlySchema,
                   maxContractStateCacheSize = 0L,
                   maxContractKeyStateCacheSize = 0L,
                   enableMutableContractStateCache = false,


### PR DESCRIPTION
This PR makes sure the `--enable-append-only-schema` flag is respected in sandbox. Sandbox classic and daml-on-sql already respected the flag.
