### PR TITLE
Use soft references for values in the caches [DPP-561]

### DIFF
--- a/ledger/caching/src/main/scala/com/daml/caching/SizedCache.scala
+++ b/ledger/caching/src/main/scala/com/daml/caching/SizedCache.scala
@@ -29,6 +29,7 @@ object SizedCache {
       case Configuration(maximumSize) =>
         val builder = caffeine.Caffeine
           .newBuilder()
+          .softValues()
           .maximumSize(maximumSize)
         CaffeineCache[Key, Value](builder, metrics)
     }

--- a/ledger/caching/src/main/scala/com/daml/caching/WeightedCache.scala
+++ b/ledger/caching/src/main/scala/com/daml/caching/WeightedCache.scala
@@ -30,6 +30,7 @@ object WeightedCache {
         val builder =
           caffeine.Caffeine
             .newBuilder()
+            .softValues()
             .maximumWeight(maximumWeight)
             .weigher(Weight.weigher[Key, Value])
         CaffeineCache(builder, metrics)


### PR DESCRIPTION
Soft references allow the garbage collector to collect the values referenced
by soft references in case of memory pressure. Since these caches are not the
source of truth for the data, it's better to remove values from the cache
instead of having the process die due to OOM (not enough heap or excessive GC).

Fixes DPP-561.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
