### PR TITLE
participant-integration-api: Increase a test timeout.

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigurationSubscriptionFromIndexSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigurationSubscriptionFromIndexSpec.scala
@@ -37,6 +37,9 @@ final class LedgerConfigurationSubscriptionFromIndexSpec
   private implicit val resourceContext: ResourceContext = ResourceContext(executionContext)
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
+  override implicit def patienceConfig: PatienceConfig =
+    super.patienceConfig.copy(timeout = 1.second)
+
   "the current ledger configuration" should {
     "look up the latest configuration from the index on startup" in {
       val currentConfiguration =


### PR DESCRIPTION
The default patience timeout of 150ms is often too quick for CI. Let's increase it to 1s.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
