### PR TITLE
Add a test to show that postgres timestamps are broken

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
@@ -12,6 +12,7 @@ trait StorageBackendSuite
     with StorageBackendTestsIngestion
     with StorageBackendTestsCompletions
     with StorageBackendTestsReset
-    with StorageBackendTestsPruning {
+    with StorageBackendTestsPruning
+    with StorageBackendTestsTimestamps {
   this: AsyncFlatSpec =>
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
@@ -108,12 +108,13 @@ private[backend] object StorageBackendTestValues {
       signatory: String = "signatory",
       observer: String = "observer",
       commandId: String = UUID.randomUUID().toString,
+      ledgerEffectiveTime: Option[Instant] = Some(someTime),
   ): DbDto.EventCreate = {
     val transactionId = transactionIdFromOffset(offset)
     DbDto.EventCreate(
       event_offset = Some(offset.toHexString),
       transaction_id = Some(transactionId),
-      ledger_effective_time = Some(someTime),
+      ledger_effective_time = ledgerEffectiveTime,
       command_id = Some(commandId),
       workflow_id = Some("workflow_id"),
       application_id = Some(someApplicationId),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsTimestamps.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsTimestamps.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.backend
+
+import java.sql.Connection
+import java.time.Instant
+import java.util.TimeZone
+
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Success
+
+private[backend] trait StorageBackendTestsTimestamps extends Matchers with StorageBackendSpec {
+  this: AsyncFlatSpec =>
+
+  behavior of "StorageBackend (timestamps)"
+
+  import StorageBackendTestValues._
+
+  it should "correctly read ledger effective time using maximumLedgerTime" in {
+    val let = Instant.now
+    val cid = com.daml.lf.value.Value.ContractId.V0.assertFromString("#1")
+    val create = dtoCreate(
+      offset = offset(1),
+      eventSequentialId = 1L,
+      contractId = cid.coid,
+      ledgerEffectiveTime = Some(let),
+    )
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+
+      _ <- executeSql(ingest(Vector(create), _))
+      _ <- executeSql(backend.updateLedgerEnd(ParameterStorageBackend.LedgerEnd(offset(1), 1L)))
+
+      let1 <- executeSql(backend.maximumLedgerTime(Set(cid)))
+      let2 <- executeSql(withDefaultTimeZone("GMT-1")(backend.maximumLedgerTime(Set(cid))))
+      let3 <- executeSql(withDefaultTimeZone("GMT+1")(backend.maximumLedgerTime(Set(cid))))
+    } yield {
+      withClue("UTC") { let1 shouldBe Success(Some(let)) }
+      withClue("GMT-1") { let2 shouldBe Success(Some(let)) }
+      withClue("GMT+1") { let3 shouldBe Success(Some(let)) }
+    }
+  }
+
+  it should "correctly read ledger effective time using rawEvents" in {
+    val let = Instant.now
+    val cid = com.daml.lf.value.Value.ContractId.V0.assertFromString("#1")
+    val create = dtoCreate(
+      offset = offset(1),
+      eventSequentialId = 1L,
+      contractId = cid.coid,
+      ledgerEffectiveTime = Some(let),
+    )
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+
+      _ <- executeSql(ingest(Vector(create), _))
+      _ <- executeSql(backend.updateLedgerEnd(ParameterStorageBackend.LedgerEnd(offset(1), 1L)))
+
+      events1 <- executeSql(backend.rawEvents(0L, 1L))
+      events2 <- executeSql(withDefaultTimeZone("GMT-1")(backend.rawEvents(0L, 1L)))
+      events3 <- executeSql(withDefaultTimeZone("GMT+1")(backend.rawEvents(0L, 1L)))
+    } yield {
+      withClue("UTC") { events1.head.ledgerEffectiveTime shouldBe Some(let) }
+      withClue("GMT-1") { events2.head.ledgerEffectiveTime shouldBe Some(let) }
+      withClue("GMT+1") { events3.head.ledgerEffectiveTime shouldBe Some(let) }
+    }
+  }
+
+  // Some JDBC operations depend on the JVM default time zone
+  private def withDefaultTimeZone[T](tz: String)(f: Connection => T)(connection: Connection): T = {
+    val previousDefaultTimeZone = TimeZone.getDefault
+    TimeZone.setDefault(TimeZone.getTimeZone(tz))
+    val result = f(connection)
+    TimeZone.setDefault(previousDefaultTimeZone)
+    result
+  }
+}


### PR DESCRIPTION
This PR shows that the append-only index database has an issue if the default time zone is not UTC.