### PR TITLE
[DPP-578] Fix test flakiness related by adding byte-buddy-agent at jvm startup.

### DIFF
--- a/bazel-java-deps.bzl
+++ b/bazel-java-deps.bzl
@@ -160,6 +160,10 @@ def install_java_deps():
             "org.junit.platform:junit-platform-engine:1.0.0",
             "org.junit.platform:junit-platform-runner:1.0.0",
             "org.mockito:mockito-core:3.6.28",
+            # NOTE: Keep byte-buddy versions in sync with Mockito versions.
+            # We name it explicitly because wa want to sue byte-buddy-agent to work around https://github.com/mockito/mockito/issues/1879
+            "net.bytebuddy:byte-buddy:1.10.8",
+            "net.bytebuddy:byte-buddy-agent:1.10.8",
             "org.mockito:mockito-inline:3.6.28",
             "org.mockito:mockito-scala_{}:1.16.3".format(scala_major_version),
             "org.pcollections:pcollections:2.1.3",

--- a/bazel-java-deps.bzl
+++ b/bazel-java-deps.bzl
@@ -160,8 +160,9 @@ def install_java_deps():
             "org.junit.platform:junit-platform-engine:1.0.0",
             "org.junit.platform:junit-platform-runner:1.0.0",
             "org.mockito:mockito-core:3.6.28",
-            # NOTE: Keep byte-buddy versions in sync with Mockito versions.
-            # We name it explicitly because wa want to sue byte-buddy-agent to work around https://github.com/mockito/mockito/issues/1879
+            # NOTE: Keep byte-buddy in sync with Mockito versions.
+            # We list byte-buddy dependencies explicit because wa want to use byte-buddy-agent to work around
+            # https://github.com/mockito/mockito/issues/1879
             "net.bytebuddy:byte-buddy:1.10.8",
             "net.bytebuddy:byte-buddy-agent:1.10.8",
             "org.mockito:mockito-inline:3.6.28",

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -83,6 +83,10 @@ da_scala_library(
 da_scala_test_suite(
     name = "ledger-api-common-scala-tests",
     srcs = glob(["src/test/suite/**/*.scala"]),
+    jvm_flags = [
+        # NOTE: This is a work around for https://github.com/mockito/mockito/issues/1879
+        "-javaagent:$(rootpath @maven//:net_bytebuddy_byte_buddy_agent)",
+    ],
     plugins = [
         silencer_plugin,
     ],
@@ -141,6 +145,7 @@ da_scala_test_suite(
         "@maven//:io_opentelemetry_opentelemetry_context",
         "@maven//:io_opentelemetry_opentelemetry_sdk_testing",
         "@maven//:io_opentelemetry_opentelemetry_sdk_trace",
+        "@maven//:net_bytebuddy_byte_buddy_agent",
         "@maven//:org_awaitility_awaitility",
         "@maven//:org_mockito_mockito_core",
         "@maven//:org_reactivestreams_reactive_streams",

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -90,6 +90,9 @@ da_scala_test_suite(
     plugins = [
         silencer_plugin,
     ],
+    resources = [
+        "src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker",
+    ],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",

--- a/ledger/ledger-api-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/ledger/ledger-api-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/tls/TlsConfigurationTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/tls/TlsConfigurationTest.scala
@@ -91,8 +91,7 @@ class TlsConfigurationTest extends AnyWordSpec with Matchers with BeforeAndAfter
       e.getCause.getMessage shouldBe "Unable to convert TlsConfiguration(true,None,None,None,None,REQUIRE,false,List()) to SSL Context: cannot decrypt keyFile without secretsUrl."
     }
 
-    // TODO DPP-578: Enable this test once flakiness related to Mockito plugin is sorted
-    "attempt to decrypt private key using by fetching decryption params from an url" ignore {
+    "attempt to decrypt private key using by fetching decryption params from an url" in {
       // given
       val keyFilePath = Files.createTempFile("private-key", ".enc")
       Files.write(keyFilePath, "private-key-123".getBytes())


### PR DESCRIPTION
..as opposed to relying on dynamic agent attachment which could sometimes fail like this:

```
2021-08-31T09:46:28.7084817Z - should attempt to decrypt private key using by fetching decryption params from an url *** FAILED *** (5 seconds, 452 milliseconds)
2021-08-31T09:46:28.7086294Z   java.lang.IllegalStateException: Could not initialize plugin: interface org.mockito.plugins.MockMaker (alternate: null)
(...)
2021-08-31T09:46:28.8029094Z   Cause: org.mockito.exceptions.base.MockitoInitializationException: Could not initialize inline Byte Buddy mock maker.
2021-08-31T09:46:28.8029669Z 
2021-08-31T09:46:28.8030410Z It appears as if your JDK does not supply a working agent attachment mechanism.
2021-08-31T09:46:28.8031003Z Java               : 1.8
2021-08-31T09:46:28.8031538Z JVM vendor name    : Oracle Corporation
2021-08-31T09:46:28.8032800Z JVM vendor version : 25.272-b10
2021-08-31T09:46:28.8033588Z JVM name           : OpenJDK 64-Bit Server VM
2021-08-31T09:46:28.8034489Z JVM version        : 1.8.0_272-b10
2021-08-31T09:46:28.8035087Z JVM info           : mixed mode
2021-08-31T09:46:28.8035677Z OS name            : Linux
2021-08-31T09:46:28.8036452Z OS version         : 5.11.0-1017-gcp
```