### PR TITLE
Command dedup: In the committer set the deduplicate until context value based on the given deduplication period [KVL-1049]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -490,7 +490,12 @@ private[state] object Conversions {
           )
         )
       case DamlTransactionRejectionEntry.ReasonCase.DUPLICATE_COMMAND =>
-        None // No rejection for duplicate commands.
+        Some(
+          buildStatus(
+            Code.ALREADY_EXISTS,
+            "Duplicate commands",
+          )
+        )
       case DamlTransactionRejectionEntry.ReasonCase.PARTY_NOT_KNOWN_ON_LEDGER =>
         val rejection = entry.getPartyNotKnownOnLedger
         Some(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -1,5 +1,4 @@
 // Copyright
-// (Conversions.parseDuration(transactionEntry.submitterInfo.getDeduplicationDuration)
 // SPDX-License-Identifier: Apache-2.0
 
 package com.daml.ledger.participant.state.kvutils.committer.transaction

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -212,6 +212,12 @@ class ConversionsSpec extends AnyWordSpec with Matchers with OptionValues {
                     .setPartyNotKnownOnLedger(PartyNotKnownOnLedger.newBuilder()),
                 Code.INVALID_ARGUMENT,
               ),
+              (
+                (builder: DamlTransactionRejectionEntry.Builder) =>
+                  builder
+                    .setDuplicateCommand(Duplicate.newBuilder()),
+                Code.ALREADY_EXISTS,
+              ),
             )
           ) { (rejectionBuilder, code) =>
             {
@@ -225,17 +231,6 @@ class ConversionsSpec extends AnyWordSpec with Matchers with OptionValues {
             }
           }
         }
-
-        "handle duplicate" in {
-          Conversions
-            .decodeTransactionRejectionEntry(
-              DamlTransactionRejectionEntry
-                .newBuilder()
-                .setDuplicateCommand(Duplicate.newBuilder())
-                .build()
-            ) shouldBe None
-        }
-
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -3,12 +3,15 @@
 
 package com.daml.ledger.participant.state.kvutils.committer.transaction
 
+import java.time
+
 import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
-import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepStop}
+import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepStop}
 import com.daml.ledger.participant.state.kvutils.{Conversions, committer}
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Time.Timestamp
@@ -20,13 +23,20 @@ import com.daml.lf.value.Value.{ValueRecord, ValueText}
 import com.daml.lf.value.{Value, ValueOuterClass}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
+import com.google.protobuf
 import org.mockito.MockitoSugar
+import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
-
-class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSugar {
+@nowarn("msg=deprecated")
+class TransactionCommitterSpec
+    extends AnyWordSpec
+    with Matchers
+    with MockitoSugar
+    with OptionValues {
   import TransactionCommitterSpec._
 
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
@@ -207,6 +217,91 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         }
       }
     }
+
+    "setting dedup context" should {
+      val deduplicateUntil = protobuf.Timestamp.newBuilder().setSeconds(30).build()
+      val submissionTime = protobuf.Timestamp.newBuilder().setSeconds(60)
+
+      def buildContextAndTransaction(
+          submitterInfoAugmenter: DamlSubmitterInfo.Builder => DamlSubmitterInfo.Builder
+      ) = {
+
+        val context = createCommitContext(None)
+        context.set(Conversions.configurationStateKey, aDamlConfigurationStateValue)
+        val transactionEntrySummary = DamlTransactionEntrySummary(
+          aDamlTransactionEntry.toBuilder
+            .setSubmitterInfo(
+              submitterInfoAugmenter(
+                DamlSubmitterInfo
+                  .newBuilder()
+              )
+            )
+            .setSubmissionTime(submissionTime)
+            .build()
+        )
+        context -> transactionEntrySummary
+      }
+
+      def contextSetDeduplicateUntil(
+          context: CommitContext,
+          transactionEntrySummary: DamlTransactionEntrySummary,
+      ) = {
+        context
+          .get(Conversions.commandDedupKey(transactionEntrySummary.submitterInfo))
+          .value
+          .getCommandDedup
+          .getDeduplicatedUntil
+      }
+
+      "set deduplicate until based on submitter info deduplicate until" in {
+        val (context, transactionEntrySummary) =
+          buildContextAndTransaction(_.setDeduplicateUntil(deduplicateUntil))
+        transactionCommitter.setDedupEntry(context, transactionEntrySummary)
+        contextSetDeduplicateUntil(context, transactionEntrySummary) shouldBe deduplicateUntil
+      }
+
+      "set deduplicate until based on submitter info deduplicate duration" in {
+        val deduplicationDuration = time.Duration.ofSeconds(3)
+        val (context, transactionEntrySummary) =
+          buildContextAndTransaction(
+            _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration))
+          )
+        transactionCommitter.setDedupEntry(context, transactionEntrySummary)
+        contextSetDeduplicateUntil(context, transactionEntrySummary) shouldBe protobuf.Timestamp
+          .newBuilder()
+          .setSeconds(
+            submissionTime.getSeconds + deduplicationDuration.getSeconds + theDefaultConfig.timeModel.minSkew.getSeconds
+          )
+          .build()
+      }
+
+      "set deduplicate until based on submitter info deduplication offset" in {
+        val (context, transactionEntrySummary) =
+          buildContextAndTransaction(
+            _.setDeduplicationOffset("offset")
+          )
+        transactionCommitter.setDedupEntry(context, transactionEntrySummary)
+        contextSetDeduplicateUntil(context, transactionEntrySummary) shouldBe protobuf.Timestamp
+          .newBuilder()
+          .setSeconds(
+            submissionTime.getSeconds + theDefaultConfig.maxDeduplicationTime.getSeconds + theDefaultConfig.timeModel.minSkew.getSeconds
+          )
+          .build()
+      }
+
+      "do not set deduplicate until when no submitter info deduplication is set" in {
+        val (context, transactionEntrySummary) =
+          buildContextAndTransaction(
+            identity
+          )
+        transactionCommitter.setDedupEntry(context, transactionEntrySummary)
+        context
+          .get(Conversions.commandDedupKey(transactionEntrySummary.submitterInfo))
+          .value
+          .getCommandDedup
+          .hasDeduplicatedUntil shouldBe false
+      }
+    }
   }
 
   "buildLogEntry" should {
@@ -259,6 +354,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
   "blind" should {
     "always set blindingInfo" in {
       val context = createCommitContext(recordTime = None)
+      context.set(Conversions.configurationStateKey, aDamlConfigurationStateValue)
 
       val builder = TransactionBuilder(TransactionVersion.VDev)
       val cid = builder.newCid
@@ -361,6 +457,12 @@ object TransactionCommitterSpec {
   private val aDummyValue = TransactionBuilder.record("field" -> "value")
   private val aKey = "key"
   private val aKeyMaintainer = "maintainer"
+  private val aDamlConfigurationStateValue = DamlStateValue.newBuilder
+    .setConfigurationEntry(
+      DamlConfigurationEntry.newBuilder
+        .setConfiguration(Configuration.encode(theDefaultConfig))
+    )
+    .build
   private val aRichTransactionTreeSummary = {
     val roots = Seq("Exercise-1", "Fetch-1", "LookupByKey-1", "Create-1")
     val nodes: Seq[TransactionOuterClass.Node] = Seq(


### PR DESCRIPTION
### Pull Request Checklist

Calculate deduplicate until for committer side deduplication based on the submitter given deduplication period
- if using the deprecated `deduplicateUntil` then just set the given timestamp
- if using duration then calculate the new `deduplicateUntil` by using the formula (`submissionTime` + `deduplicationDuration` + `minSkew`)
- if using offset deduplication then calculate `deduplicateUntil` by using the formula (`submissionTime` + `maxDeduplicationDuration` + `minSkew`)
- if the deduplication period is not set then we don't set `deduplicateUntil`

Update the conformance tests to so that they update the time model before running to account for the usage of `minSkew` when calculating `deduplicateUntil`

Emit completions for `DuplicateCommand` rejections, if not then we would never get a completion for the submitter command.

Tried to disable participant deduplication but there are still 2 failures on the conformance tests:

```
CommandDeduplicationIT
- [CommandDeduplicationIT:CDDeduplicateSubmitterBasic] Commands with identical submitter and command identifier should be deduplicated by the submission client ... Unexpected failure (ExpectedFailureException)
  Expected a failure when submitting a request as Alice for the second time, but got a successful result of: ()
- [CommandDeduplicationIT:CDSimpleDeduplicationBasic] Deduplicate commands within the deduplication time window ... Unexpected failure (ExpectedFailureException)
  Expected a failure when submitting the first request for the second time, but got a successful result of: ()
```


- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
