### PR TITLE
Wrap missing label names in quotes

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -318,6 +318,17 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        "end": "1.17.0-snapshot.20210831.7702.0.f058c2f1",
+        "platform_ranges": [
+            {
+                "start": "1.17.0-snapshot.20210831.7702.1.f058c2f1",
+                "exclusions": [
+                    "CommandServiceIT:CSRefuseBadParameter",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -210,7 +210,7 @@ private[engine] final class ValueTranslator(
                       mbLbl.foreach(lbl_ =>
                         if (lbl_ != lbl)
                           typeError(
-                            s"Mismatching record field label $lbl_ (expecting $lbl) for record $tyCon"
+                            s"Mismatching record field label '$lbl_' (expecting '$lbl') for record $tyCon"
                           )
                       )
                       val replacedTyp = AstUtil.substitute(typ, subst)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -210,7 +210,7 @@ private[engine] final class ValueTranslator(
                       mbLbl.foreach(lbl_ =>
                         if (lbl_ != lbl)
                           typeError(
-                            s"Mismatching record label $lbl_ (expecting $lbl) for record $tyCon"
+                            s"Mismatching record field label $lbl_ (expecting $lbl) for record $tyCon"
                           )
                       )
                       val replacedTyp = AstUtil.substitute(typ, subst)
@@ -220,7 +220,7 @@ private[engine] final class ValueTranslator(
                     recordFlds.map { case (lbl, typ) =>
                       labeledRecords
                         .get(lbl)
-                        .fold(typeError(s"Missing record label $lbl for record $tyCon")) { v =>
+                        .fold(typeError(s"Missing record field '$lbl' for record $tyCon")) { v =>
                           val replacedTyp = AstUtil.substitute(typ, subst)
                           lbl -> go(replacedTyp, v, newNesting)
                         }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -295,7 +295,7 @@ class EngineTest
         .consume(lookupContract, lookupPackage, lookupKey)
       inside(res) { case Left(Error.Preprocessing(error)) =>
         error shouldBe a[Error.Preprocessing.TypeMismatch]
-        error.message should startWith("Missing record label n for record")
+        error.message should startWith("Missing record field 'n' for record")
       }
     }
 

--- a/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
+++ b/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
@@ -425,7 +425,7 @@ final class CommandClientIT
 
       "not accept commands with unknown args, return INVALID_ARGUMENT" in {
         val expectedMessageSubstring =
-          "Missing record label"
+          "Missing record field"
         val command =
           submitRequest(
             "Param_with_wrong_name",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -280,7 +280,11 @@ final class CommandServiceIT extends LedgerTestSuite {
         .submitAndWait(badRequest)
         .mustFail("submitting a request with a bad parameter label")
     } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, s"Missing record label")
+      assertGrpcError(
+        failure,
+        Status.Code.INVALID_ARGUMENT,
+        Some(Pattern.compile(s"Missing record (label|field)")),
+      )
     }
   })
 


### PR DESCRIPTION
See
https://discuss.daml.com/t/why-might-i-be-getting-missing-record-label-identity-from-the-ledger-api-when-submitting-a-command/3059/5
this has caused some confusion for users since it’s not obvious that
it is the label name if you have a very generic label name like
`identity`.

I have no strong feelings on whether this should be single or double
quotes so happy to change it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
