### PR TITLE
Report some oracle_json_perf numbers on slack 

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -216,7 +216,7 @@ jobs:
           }
 
           # dont want to wait forever to test connection , 15m is more than sufficient here.
-          declare -x testConnection
+          declare -xf testConnection
           timeout 15m bash -c 'until testConnection; do echo "Could not connect to Oracle, trying again..." ; sleep 1 ; done'
 
           # Actually run some tests
@@ -270,7 +270,7 @@ jobs:
           RES=""
           for KEY in $READ_PERF_KEYS; do
             # capture the avg, stddev, p90, p99, requests_per_second numbers from gatling summary csv
-            perf=$(cat ${OUT}/${KEY}/*/summary.csv | awk -F"," '{print $11,$12,$6,$8,$13}' | tail -n 1)
+            perf=$(cat ${OUT}/${KEY}/*/summary.csv | awk -F, '{print $11,$12,$6,$8,$13}' | tail -n 1)
             RES="${RES}json_oracle/${KEY}: $perf)\n"
           done
 

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -269,11 +269,12 @@ jobs:
           "
           RES=""
           for KEY in $READ_PERF_KEYS; do
-            perf=$(cat ${OUT}/${KEY}/*/summary.csv | cut -d, -f8 | tail -n 1)
-            RES="${RES}(${KEY} p99 = $perf) "
+            # capture the avg, stddev, p90, p99, requests_per_second numbers from gatling summary csv
+            perf=$(cat ${OUT}/${KEY}/*/summary.csv | awk -F"," '{print $11,$12,$6,$8,$13}' | tail -n 1)
+            RES="${RES}json_oracle/${KEY}: $perf)\n"
           done
 
-          setvar oracle_perf_results "http_json_oracle_latency: $RES"
+          setvar oracle_perf_results "$RES"
 
           GZIP=-9 tar -zcf ${OUT}.tgz ${OUT}
 

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -263,6 +263,18 @@ jobs:
               --query-store-index=oracle
           done
 
+          READ_PERF_KEYS="\
+           fetchByKey \
+           fetchByQuery\
+          "
+          RES=""
+          for KEY in $READ_PERF_KEYS; do
+            perf=$(cat ${OUT}/${KEY}/*/summary.csv | cut -d, -f8 | tail -n 1)
+            RES="${RES}(${KEY} p99 = $perf) "
+          done
+
+          setvar oracle_perf_results "http_json_oracle_latency: $RES"
+
           GZIP=-9 tar -zcf ${OUT}.tgz ${OUT}
 
           gcs "$GCRED" cp "$OUT.tgz" "gs://daml-data/perf/http-json-oracle/${REPORT_ID}.tgz"
@@ -429,6 +441,7 @@ jobs:
       speedy_perf: $[ dependencies.perf_speedy.outputs['out.speedy_perf'] ]
       perf_http_json: $[ dependencies.perf_http_json.result ]
       perf_http_json_oracle: $[ dependencies.perf_http_json_oracle.result ]
+      oracle_perf_results: $[ dependencies.perf_http_json_oracle.outputs['out.oracle_perf_results'] ]
       check_releases: $[ dependencies.check_releases.result ]
       blackduck_scan: $[ dependencies.blackduck_scan.result ]
       run_notices_pr_build: $[ dependencies.run_notices_pr_build.result ]
@@ -457,6 +470,7 @@ jobs:
             MSG="Daily tests passed: $COMMIT_LINK"
             REPORT='```
         speedy_perf: $(speedy_perf)
+        $(oracle_perf_results)
         ```
         '
             tell_slack "$(echo -e "$MSG\n$REPORT")" "$(Slack.ci-failures-daml)"


### PR DESCRIPTION
Add `avg, stddev, p90, p99, requests_per_second` numbers to be reported on slack similar to speedy_perf
```
json_oracle/fetchByKey: 208.0 106.0 185.0 470.0 33.333333333333336
json_oracle/fetchByQuery: 442.0 262.0 370.0 950.0 20.0
```
changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
