### PR TITLE
Handle dynamic port in auth middleware client (trigger service)

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -12,13 +12,6 @@ load(
     "da_scala_test_suite",
 )
 
-tsvc_main_scalacopts = [
-    "-P:wartremover:traverser:org.wartremover.warts.%s" % wart
-    for wart in [
-        "NonUnitStatements",
-    ]
-]
-
 triggerMain = "src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala"
 
 da_scala_library(
@@ -53,7 +46,6 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_slf4j",
         "@maven//:org_tpolecat_doobie_postgres",
     ],
-    scalacopts = tsvc_main_scalacopts,
     # Uncomment this if/when the target is published to maven.
     # tags = ["maven_coordinates=com.daml:trigger-service:__VERSION__"],
     visibility = ["//visibility:public"],

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -178,11 +178,15 @@ da_scala_test(
         "@maven//:com_typesafe_akka_akka_http",
         "@maven//:com_typesafe_akka_akka_http_core",
         "@maven//:com_typesafe_akka_akka_http_spray_json",
+        "@maven//:com_typesafe_akka_akka_http_testkit",
         "@maven//:com_typesafe_akka_akka_parsing",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:io_spray_spray_json",
         "@maven//:org_scalaz_scalaz_core",
+    ],
+    scala_runtime_deps = [
+        "@maven//:com_typesafe_akka_akka_stream_testkit",
     ],
     scalacopts = scalacopts,
     deps = [
@@ -202,5 +206,6 @@ da_scala_test(
         "//libs-scala/resources",
         "//libs-scala/scala-utils",
         "@maven//:com_auth0_java_jwt",
+        "@maven//:com_typesafe_config",
     ],
 )

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Client.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Client.scala
@@ -37,147 +37,191 @@ import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
 
+/** Client component for interaction with the auth middleware
+  *
+  * A client of the auth middleware is typically itself a web-application that serves HTTP requests.
+  * Note, a [[Client]] maintains state that needs to persist across such requests.
+  * In particular, you should not create the [[Client]] instance within a [[Route]].
+  *
+  * This may pose a challenge when the client application uses dynamic port binding,
+  * e.g. for testing purposes, as the login URI's redirect parameter may depend on the port.
+  * To that end the login and request handler components that may depend on the port
+  * are provided in a separate [[com.daml.auth.middleware.api.Client.Routes]] class
+  * that does not need to maintain state across requests and can safely be constructed
+  * within a [[Route]] using the [[routes]] family of methods.
+  */
 class Client(config: Client.Config) {
   private val callbacks: RequestStore[UUID, Response.Login => Route] = new RequestStore(
     config.maxAuthCallbacks,
     config.authCallbackTimeout,
   )
 
-  /** Handler for the callback in a login flow.
-    *
-    * Note, a GET request on the `callbackUri` must map to this route.
+  /** Create a [[Client.Routes]] based on an absolute login redirect URI.
     */
-  val callbackHandler: Route =
-    parameters(Symbol("state").as[UUID]) { requestId =>
-      callbacks.pop(requestId) match {
-        case None =>
-          complete(StatusCodes.NotFound)
-        case Some(callback) =>
-          Response.Login.callbackParameters { callback }
-      }
-    }
-
-  private val isHtmlRequest: Directive1[Boolean] = extractRequest.map { req =>
-    val negotiator = ContentNegotiator(req.headers)
-    val contentTypes = List(
-      ContentNegotiator.Alternative(MediaTypes.`application/json`),
-      ContentNegotiator.Alternative(MediaTypes.`text/html`),
+  def routes(callbackUri: Uri): Client.Routes = {
+    assert(
+      callbackUri.isAbsolute,
+      "The authorization middleware client callback URI must be absolute.",
     )
-    val preferred = negotiator.pickContentType(contentTypes)
-    preferred.map(_.mediaType) == Some(MediaTypes.`text/html`)
+    RoutesImpl(callbackUri)
   }
 
-  /** Pass control to the inner directive if we should redirect to login on auth failure, reject otherwise.
+  /** Create a [[Client.Routes]] based on a path to be appended to the requests URI scheme and authority.
+    *
+    * E.g. given `callbackPath = "cb"` and a request to `http://my.client/foo/bar`
+    * the redirect URI would take the form `http://my.client/cb`.
     */
-  private val onRedirectToLogin: Directive0 =
-    config.redirectToLogin match {
-      case RedirectToLogin.No => reject
-      case RedirectToLogin.Yes => pass
-      case RedirectToLogin.Auto =>
-        isHtmlRequest.flatMap {
-          case false => reject
-          case true => pass
-        }
+  def routesFromRequestAuthority(callbackPath: Uri.Path): Directive1[Client.Routes] =
+    extractUri.map { reqUri =>
+      RoutesImpl(
+        Uri()
+          .withScheme(reqUri.scheme)
+          .withAuthority(reqUri.authority)
+          .withPath(callbackPath)
+      ): Client.Routes
     }
 
-  /** This directive requires authorization for the given claims via the auth middleware.
-    *
-    * Authorization follows the steps defined in `triggers/service/authentication.md`.
-    * 1. Ask for a token on the `/auth` endpoint and return it if granted.
-    * 2a. Return 401 Unauthorized if denied and [[Client.Config.redirectToLogin]]
-    *     indicates not to redirect to the login endpoint.
-    * 2b. Redirect to the login endpoint if denied and [[Client.Config.redirectToLogin]]
-    *     indicates to redirect to the login endpoint.
-    *     In this case this will store the current continuation to proceed
-    *     once the login flow completed and authentication succeeded.
-    *     A route for the [[callbackHandler]] must be configured.
+  /** Equivalent to [[routes]] if [[callbackUri]] is an absolute URI,
+    * otherwise equivalent to [[routesFromRequestAuthority]].
     */
-  def authorize(claims: Request.Claims): Directive1[Client.AuthorizeResult] = {
-    auth(claims).flatMap {
-      // Authorization successful - pass token to continuation
-      case Some(authorization) => provide(Client.Authorized(authorization))
-      // Authorization failed - login and retry on callback request.
-      case None =>
-        onRedirectToLogin
-          .tflatMap { _ =>
-            // Ensure that the request is fully uploaded.
-            val timeout = config.httpEntityUploadTimeout
-            val maxBytes = config.maxHttpEntityUploadSize
-            toStrictEntity(timeout, maxBytes).tflatMap { _ =>
-              extractRequestContext.flatMap { ctx =>
-                Directive { (inner: Tuple1[Client.AuthorizeResult] => Route) =>
-                  def continue(result: Client.AuthorizeResult): Route =
-                    mapRequestContext(_ => ctx) {
-                      inner(Tuple1(result))
-                    }
-                  val callback: Response.Login => Route = {
-                    case Response.LoginSuccess =>
-                      auth(claims) {
-                        case None => continue(Client.Unauthorized)
-                        case Some(authorization) => continue(Client.Authorized(authorization))
+  def routesAuto(callbackUri: Uri): Directive1[Client.Routes] = {
+    if (callbackUri.isAbsolute) {
+      provide(routes(callbackUri))
+    } else {
+      routesFromRequestAuthority(callbackUri.path)
+    }
+  }
+
+  private case class RoutesImpl(callbackUri: Uri) extends Client.Routes {
+    val callbackHandler: Route =
+      parameters(Symbol("state").as[UUID]) { requestId =>
+        callbacks.pop(requestId) match {
+          case None =>
+            complete(StatusCodes.NotFound)
+          case Some(callback) =>
+            Response.Login.callbackParameters { callback }
+        }
+      }
+
+    private val isHtmlRequest: Directive1[Boolean] = extractRequest.map { req =>
+      val negotiator = ContentNegotiator(req.headers)
+      val contentTypes = List(
+        ContentNegotiator.Alternative(MediaTypes.`application/json`),
+        ContentNegotiator.Alternative(MediaTypes.`text/html`),
+      )
+      val preferred = negotiator.pickContentType(contentTypes)
+      preferred.map(_.mediaType) == Some(MediaTypes.`text/html`)
+    }
+
+    /** Pass control to the inner directive if we should redirect to login on auth failure, reject otherwise.
+      */
+    private val onRedirectToLogin: Directive0 =
+      config.redirectToLogin match {
+        case RedirectToLogin.No => reject
+        case RedirectToLogin.Yes => pass
+        case RedirectToLogin.Auto =>
+          isHtmlRequest.flatMap {
+            case false => reject
+            case true => pass
+          }
+      }
+
+    def authorize(claims: Request.Claims): Directive1[Client.AuthorizeResult] = {
+      auth(claims).flatMap {
+        // Authorization successful - pass token to continuation
+        case Some(authorization) => provide(Client.Authorized(authorization))
+        // Authorization failed - login and retry on callback request.
+        case None =>
+          onRedirectToLogin
+            .tflatMap { _ =>
+              // Ensure that the request is fully uploaded.
+              val timeout = config.httpEntityUploadTimeout
+              val maxBytes = config.maxHttpEntityUploadSize
+              toStrictEntity(timeout, maxBytes).tflatMap { _ =>
+                extractRequestContext.flatMap { ctx =>
+                  Directive { (inner: Tuple1[Client.AuthorizeResult] => Route) =>
+                    def continue(result: Client.AuthorizeResult): Route =
+                      mapRequestContext(_ => ctx) {
+                        inner(Tuple1(result))
                       }
-                    case loginError: Response.LoginError =>
-                      continue(Client.LoginFailed(loginError))
+                    val callback: Response.Login => Route = {
+                      case Response.LoginSuccess =>
+                        auth(claims) {
+                          case None => continue(Client.Unauthorized)
+                          case Some(authorization) => continue(Client.Authorized(authorization))
+                        }
+                      case loginError: Response.LoginError =>
+                        continue(Client.LoginFailed(loginError))
+                    }
+                    login(claims, callback)
                   }
-                  login(claims, callback)
                 }
               }
             }
-          }
-          .or(unauthorized(claims))
-    }
-  }
-
-  /** This directive attempts to obtain an access token from the middleware's auth endpoint for the given claims.
-    *
-    * Forwards the current request's cookies. Completes with 500 on an unexpected response from the auth middleware.
-    *
-    * @return `None` if the request was denied otherwise `Some` access and optionally refresh token.
-    */
-  def auth(claims: Request.Claims): Directive1[Option[Response.Authorize]] =
-    extractExecutionContext.flatMap { implicit ec =>
-      extractActorSystem.flatMap { implicit system =>
-        extract(_.request.headers[headers.Cookie]).flatMap { cookies =>
-          onSuccess(requestAuth(claims, cookies))
-        }
+            .or(unauthorized(claims))
       }
     }
 
-  /** Return a 401 Unauthorized response.
-    *
-    * Includes a `WWW-Authenticate` header with a custom challenge to login at the auth middleware.
-    * Lists the required claims in the `realm` and the login URI in the `login` parameter
-    * and the auth URI in the `auth` parameter.
-    *
-    * The challenge is also included in the response body
-    * as some browsers make it difficult to access the `WWW-Authenticate` header.
-    */
-  def unauthorized(claims: Request.Claims): StandardRoute = {
-    import com.daml.auth.middleware.api.JsonProtocol.responseAuthenticateChallengeFormat
-    val challenge = Response.AuthenticateChallenge(
-      claims,
-      loginUri(claims, None, false),
-      authUri(claims),
-    )
-    complete(
-      status = StatusCodes.Unauthorized,
-      headers = immutable.Seq(challenge.toHeader),
-      challenge,
-    )
-  }
+    /** This directive attempts to obtain an access token from the middleware's auth endpoint for the given claims.
+      *
+      * Forwards the current request's cookies. Completes with 500 on an unexpected response from the auth middleware.
+      *
+      * @return `None` if the request was denied otherwise `Some` access and optionally refresh token.
+      */
+    private def auth(claims: Request.Claims): Directive1[Option[Response.Authorize]] =
+      extractExecutionContext.flatMap { implicit ec =>
+        extractActorSystem.flatMap { implicit system =>
+          extract(_.request.headers[headers.Cookie]).flatMap { cookies =>
+            onSuccess(requestAuth(claims, cookies))
+          }
+        }
+      }
 
-  /** Redirect the client to login with the auth middleware.
-    *
-    * Will respond with 503 if the callback store is full ([[Client.Config.maxAuthCallbacks]]).
-    *
-    * @param callback Will be stored and executed once the login flow completed.
-    */
-  def login(claims: Request.Claims, callback: Response.Login => Route): Route = {
-    val requestId = UUID.randomUUID()
-    if (callbacks.put(requestId, callback)) {
-      redirect(loginUri(claims, Some(requestId)), StatusCodes.Found)
-    } else {
-      complete(StatusCodes.ServiceUnavailable)
+    /** Return a 401 Unauthorized response.
+      *
+      * Includes a `WWW-Authenticate` header with a custom challenge to login at the auth middleware.
+      * Lists the required claims in the `realm` and the login URI in the `login` parameter
+      * and the auth URI in the `auth` parameter.
+      *
+      * The challenge is also included in the response body
+      * as some browsers make it difficult to access the `WWW-Authenticate` header.
+      */
+    private def unauthorized(claims: Request.Claims): StandardRoute = {
+      import com.daml.auth.middleware.api.JsonProtocol.responseAuthenticateChallengeFormat
+      val challenge = Response.AuthenticateChallenge(
+        claims,
+        loginUri(claims, None, false),
+        authUri(claims),
+      )
+      complete(
+        status = StatusCodes.Unauthorized,
+        headers = immutable.Seq(challenge.toHeader),
+        challenge,
+      )
+    }
+
+    def login(claims: Request.Claims, callback: Response.Login => Route): Route = {
+      val requestId = UUID.randomUUID()
+      if (callbacks.put(requestId, callback)) {
+        redirect(loginUri(claims, Some(requestId)), StatusCodes.Found)
+      } else {
+        complete(StatusCodes.ServiceUnavailable)
+      }
+    }
+
+    def loginUri(
+        claims: Request.Claims,
+        requestId: Option[UUID] = None,
+        redirect: Boolean = true,
+    ): Uri = {
+      val redirectUri =
+        if (redirect) { Some(callbackUri) }
+        else { None }
+      appendToUri(
+        config.authMiddlewareUri,
+        Path./("login"),
+        Request.Login(redirectUri, claims, requestId.map(_.toString)).toQuery,
+      )
     }
   }
 
@@ -253,21 +297,6 @@ class Client(config: Client.Config) {
       Request.Auth(claims).toQuery,
     )
 
-  def loginUri(
-      claims: Request.Claims,
-      requestId: Option[UUID] = None,
-      redirect: Boolean = true,
-  ): Uri = {
-    val redirectUri =
-      if (redirect) { Some(config.callbackUri) }
-      else { None }
-    appendToUri(
-      config.authMiddlewareUri,
-      Path./("login"),
-      Request.Login(redirectUri, claims, requestId.map(_.toString)).toQuery,
-    )
-  }
-
   val refreshUri: Uri =
     appendToUri(config.authMiddlewareUri, Path./("refresh"))
 }
@@ -299,12 +328,48 @@ object Client {
   case class Config(
       authMiddlewareUri: Uri,
       redirectToLogin: RedirectToLogin,
-      callbackUri: Uri,
       maxAuthCallbacks: Int,
       authCallbackTimeout: FiniteDuration,
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
   )
+
+  trait Routes {
+
+    /** Handler for the callback in a login flow.
+      *
+      * Note, a GET request on the `callbackUri` must map to this route.
+      */
+    def callbackHandler: Route
+
+    /** This directive requires authorization for the given claims via the auth middleware.
+      *
+      * Authorization follows the steps defined in `triggers/service/authentication.md`.
+      * 1. Ask for a token on the `/auth` endpoint and return it if granted.
+      * 2a. Return 401 Unauthorized if denied and [[Client.Config.redirectToLogin]]
+      *     indicates not to redirect to the login endpoint.
+      * 2b. Redirect to the login endpoint if denied and [[Client.Config.redirectToLogin]]
+      *     indicates to redirect to the login endpoint.
+      *     In this case this will store the current continuation to proceed
+      *     once the login flow completed and authentication succeeded.
+      *     A route for the [[callbackHandler]] must be configured.
+      */
+    def authorize(claims: Request.Claims): Directive1[Client.AuthorizeResult]
+
+    /** Redirect the client to login with the auth middleware.
+      *
+      * Will respond with 503 if the callback store is full ([[Client.Config.maxAuthCallbacks]]).
+      *
+      * @param callback Will be stored and executed once the login flow completed.
+      */
+    def login(claims: Request.Claims, callback: Response.Login => Route): Route
+
+    def loginUri(
+        claims: Request.Claims,
+        requestId: Option[UUID] = None,
+        redirect: Boolean = true,
+    ): Uri
+  }
 
   def apply(config: Config): Client = new Client(config)
 }

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Resources.scala
@@ -10,14 +10,13 @@ import java.time.{Clock, Duration, Instant, ZoneId}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives._
 import com.daml.auth.middleware.api.Client
 import com.daml.auth.middleware.api.Request.Claims
 import com.daml.clock.AdjustableClock
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.auth.oauth2.test.server.{Server => OAuthServer}
-import com.daml.ports.{LockedFreePort, Port}
 import com.daml.scalautil.Statement.discard
 
 import scala.concurrent.Future
@@ -52,56 +51,55 @@ object Resources {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
         Resource(Server.start(config))(_.unbind().map(_ => ()))
     }
-  def port(): ResourceOwner[Port] =
-    new ResourceOwner[Port] {
-      override def acquire()(implicit context: ResourceContext): Resource[Port] =
-        Resource(Future(LockedFreePort.find()))(lock => Future(lock.unlock())).map(_.port)
-    }
-  def authMiddlewareClientBinding(config: Client.Config, client: Client)(implicit
+  def authMiddlewareClientBinding(client: Client, callbackPath: Uri.Path)(implicit
       sys: ActorSystem
   ): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
         Resource {
           Http()
-            .newServerAt(
-              config.callbackUri.authority.host.toString(),
-              config.callbackUri.authority.port,
-            )
+            .newServerAt("localhost", 0)
             .bind {
-              concat(
-                path("authorize") {
-                  get {
-                    parameters(Symbol("claims").as[Claims]) { claims =>
-                      client.authorize(claims) {
-                        case Client.Authorized(authorization) =>
-                          import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-                          import com.daml.auth.middleware.api.JsonProtocol.responseAuthorizeFormat
-                          complete(StatusCodes.OK, authorization)
-                        case Client.Unauthorized =>
-                          complete(StatusCodes.Unauthorized)
-                        case Client.LoginFailed(loginError) =>
-                          import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-                          import com.daml.auth.middleware.api.JsonProtocol.ResponseLoginFormat
-                          complete(
-                            StatusCodes.Forbidden,
-                            loginError: com.daml.auth.middleware.api.Response.Login,
-                          )
+              extractUri { reqUri =>
+                val callbackUri = Uri()
+                  .withScheme(reqUri.scheme)
+                  .withAuthority(reqUri.authority)
+                  .withPath(callbackPath)
+                val clientRoutes = client.routes(callbackUri)
+                concat(
+                  path("authorize") {
+                    get {
+                      parameters(Symbol("claims").as[Claims]) { claims =>
+                        clientRoutes.authorize(claims) {
+                          case Client.Authorized(authorization) =>
+                            import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+                            import com.daml.auth.middleware.api.JsonProtocol.responseAuthorizeFormat
+                            complete(StatusCodes.OK, authorization)
+                          case Client.Unauthorized =>
+                            complete(StatusCodes.Unauthorized)
+                          case Client.LoginFailed(loginError) =>
+                            import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+                            import com.daml.auth.middleware.api.JsonProtocol.ResponseLoginFormat
+                            complete(
+                              StatusCodes.Forbidden,
+                              loginError: com.daml.auth.middleware.api.Response.Login,
+                            )
+                        }
                       }
                     }
-                  }
-                },
-                path("login") {
-                  get {
-                    parameters(Symbol("claims").as[Claims]) { claims =>
-                      import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-                      import com.daml.auth.middleware.api.JsonProtocol.ResponseLoginFormat
-                      client.login(claims, login => complete(StatusCodes.OK, login))
+                  },
+                  path("login") {
+                    get {
+                      parameters(Symbol("claims").as[Claims]) { claims =>
+                        import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+                        import com.daml.auth.middleware.api.JsonProtocol.ResponseLoginFormat
+                        clientRoutes.login(claims, login => complete(StatusCodes.OK, login))
+                      }
                     }
-                  }
-                },
-                path("cb") { get { client.callbackHandler } },
-              )
+                  },
+                  path("cb") { get { clientRoutes.callbackHandler } },
+                )
+              }
             }
         } {
           _.unbind().map(_ => ())

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -50,6 +50,7 @@ trait TestFixture
   protected val maxMiddlewareLogins: Int = Config.DefaultMaxLoginRequests
   protected val maxClientAuthCallbacks: Int = 1000
   protected val middlewareCallbackUri: Option[Uri] = None
+  protected val middlewareClientCallbackPath: Uri.Path = Uri.Path./("cb")
   protected val redirectToLogin: Client.RedirectToLogin = Client.RedirectToLogin.Yes
   lazy protected val clock: AdjustableClock = suiteResource.value.clock
   lazy protected val server: OAuthServer = suiteResource.value.authServer
@@ -65,8 +66,10 @@ trait TestFixture
     Uri()
       .withScheme("http")
       .withAuthority("localhost", host.getPort)
-      .withPath(Uri.Path./("cb"))
+      .withPath(middlewareClientCallbackPath)
   }
+  lazy protected val middlewareClientRoutes: Client.Routes =
+    middlewareClient.routes(middlewareClientCallbackUri)
   override protected lazy val suiteResource: Resource[TestResources] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
     new OwnedResource[ResourceContext, TestResources](
@@ -115,7 +118,6 @@ trait TestFixture
             ),
           )
         )
-        middlewareClientPort <- Resources.port()
         middlewareClientConfig = Client.Config(
           authMiddlewareUri = Uri()
             .withScheme("http")
@@ -124,10 +126,6 @@ trait TestFixture
               middlewareBinding.localAddress.getPort,
             ),
           redirectToLogin = redirectToLogin,
-          callbackUri = Uri()
-            .withScheme("http")
-            .withAuthority("localhost", middlewareClientPort.value)
-            .withPath(Uri.Path./("cb")),
           maxAuthCallbacks = maxClientAuthCallbacks,
           authCallbackTimeout = FiniteDuration(1, duration.MINUTES),
           maxHttpEntityUploadSize = 4194304,
@@ -135,7 +133,7 @@ trait TestFixture
         )
         middlewareClient = Client(middlewareClientConfig)
         middlewareClientBinding <- Resources
-          .authMiddlewareClientBinding(middlewareClientConfig, middlewareClient)
+          .authMiddlewareClientBinding(middlewareClient, middlewareClientCallbackPath)
       } yield TestResources(
         clock = clock,
         authServer = server,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -57,7 +57,7 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
 class Server(
-    authClient: Option[AuthClient],
+    authRoutes: Option[Directive1[AuthClient.Routes]],
     triggerDao: RunningTriggerDao,
     val logTriggerStatus: (UUID, String) => Unit,
 )(implicit ctx: ActorContext[Server.Message])
@@ -230,9 +230,9 @@ class Server(
   // This directive requires authorization for the given claims via the auth middleware, if configured.
   // If no auth middleware is configured, then the request will proceed without attempting authorization.
   private def authorize(claims: AuthRequest.Claims): Directive1[Option[AuthResponse.Authorize]] =
-    authClient match {
+    authRoutes match {
       case None => provide(None)
-      case Some(client) =>
+      case Some(extractRoutes) =>
         handleExceptions(ExceptionHandler { case ex: AuthClient.ClientException =>
           logger.error(ex.getLocalizedMessage)
           complete(
@@ -242,19 +242,21 @@ class Server(
             )
           )
         }).tflatMap { _ =>
-          client.authorize(claims).flatMap {
-            case AuthClient.Authorized(authorization) => provide(Some(authorization))
-            case AuthClient.Unauthorized =>
-              // Authorization failed after login - respond with 401
-              // TODO[AH] Add WWW-Authenticate header
-              complete(errorResponse(StatusCodes.Unauthorized))
-            case AuthClient.LoginFailed(AuthResponse.LoginError(error, errorDescription)) =>
-              complete(
-                errorResponse(
-                  StatusCodes.Forbidden,
-                  s"Failed to authenticate: $error${errorDescription.fold("")(": " + _)}",
+          extractRoutes.flatMap { routes =>
+            routes.authorize(claims).flatMap {
+              case AuthClient.Authorized(authorization) => provide(Some(authorization))
+              case AuthClient.Unauthorized =>
+                // Authorization failed after login - respond with 401
+                // TODO[AH] Add WWW-Authenticate header
+                complete(errorResponse(StatusCodes.Unauthorized))
+              case AuthClient.LoginFailed(AuthResponse.LoginError(error, errorDescription)) =>
+                complete(
+                  errorResponse(
+                    StatusCodes.Forbidden,
+                    s"Failed to authenticate: $error${errorDescription.fold("")(": " + _)}",
+                  )
                 )
-              )
+            }
           }
         }
     }
@@ -266,7 +268,7 @@ class Server(
       uuid: UUID,
       readOnly: Boolean = false,
   ): Directive1[Option[AuthResponse.Authorize]] =
-    authClient match {
+    authRoutes match {
       case None => provide(None)
       case Some(_) =>
         extractExecutionContext.flatMap { implicit ec =>
@@ -423,7 +425,9 @@ class Server(
       complete((StatusCodes.OK, JsObject(("status", "pass".toJson))))
     },
     // Authorization callback endpoint
-    authClient.fold(reject: Route)(client => path("cb") { get { client.callbackHandler } }),
+    authRoutes.fold(reject: Route) { case extractRoutes =>
+      path("cb") { get { extractRoutes { _.callbackHandler } } }
+    },
   )
 }
 
@@ -511,34 +515,34 @@ object Server {
     implicit val esf: ExecutionSequencerFactory =
       new AkkaExecutionSequencerPool("TriggerService")(untypedSystem)
 
-    val authClient = authConfig match {
+    val authClientRoutes = authConfig match {
       case NoAuth => None
       case AuthMiddleware(uri) =>
-        Some(
+        val client =
           AuthClient(
             AuthClient.Config(
               authMiddlewareUri = uri,
               redirectToLogin = authRedirectToLogin,
-              callbackUri = authCallback.getOrElse {
-                Uri().withScheme("http").withAuthority(host, port).withPath(Path./("cb"))
-              },
               maxAuthCallbacks = maxAuthCallbacks,
               authCallbackTimeout = authCallbackTimeout,
               maxHttpEntityUploadSize = maxHttpEntityUploadSize,
               httpEntityUploadTimeout = httpEntityUploadTimeout,
             )
           )
-        )
+        val routes = client.routesAuto(authCallback.getOrElse(Uri().withPath(Path./("cb"))))
+        Some((client, routes))
     }
+    val authClient = authClientRoutes.map(_._1)
+    val authRoutes = authClientRoutes.map(_._2)
 
     val (dao, server, initializeF): (RunningTriggerDao, Server, Future[Unit]) = jdbcConfig match {
       case None =>
         val dao = InMemoryTriggerDao()
-        val server = new Server(authClient, dao, logTriggerStatus)
+        val server = new Server(authRoutes, dao, logTriggerStatus)
         (dao, server, Future.successful(()))
       case Some(c) =>
         val dao = DbTriggerDao(c)
-        val server = new Server(authClient, dao, logTriggerStatus)
+        val server = new Server(authRoutes, dao, logTriggerStatus)
         val initialize = for {
           _ <- dao.initialize
           packages <- dao.readPackages

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -504,11 +504,10 @@ trait TriggerServiceFixture
               minRestartInterval,
               ServiceConfig.DefaultMaxRestartInterval,
             )
-            val lock = LockedFreePort.find()
             for {
               r <- ServiceMain.startServer(
                 host.getHostName,
-                lock.port.value,
+                Port.Dynamic.value,
                 ServiceConfig.DefaultMaxAuthCallbacks,
                 ServiceConfig.DefaultAuthCallbackTimeout,
                 ServiceConfig.DefaultMaxHttpEntityUploadSize,
@@ -522,7 +521,6 @@ trait TriggerServiceFixture
                 jdbcConfig,
                 logTriggerStatus,
               )
-              _ = lock.unlock()
             } yield r
           } { case (_, system) =>
             system ! Server.Stop


### PR DESCRIPTION
The auth middleware client, which is used in the trigger service when authentication is enabled, did not handle dynamic port selection (port 0) correctly. The client needs to know the external URI to itself to construct the callback URI for the login flow. If not specified it was previously constructed from the host and port parameters. The port parameter may be 0 leading to an incorrect callback URI.

This PR changes the trigger service to fall back to a URI constructed based on the request URI if the user did not explicitly specify a callback URI.

To this end the auth middleware client is split into two parts. One part that is independent of the callback URI and holds state that needs to persist across requests to the client (e.g. the trigger service). Another part that takes the callback URI as a parameter and does not need to persist across requests.

This change allows us to remove the use of `LockedFreePort` in the trigger service tests and the auth middleware client tests and use port 0 instead.

This moves some code, so is probably easiest reviewed with
```
git diff -w --color-moved --color-moved-ws=allow-indentation-change
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
