### PR TITLE
Enhance InMemoryLedger to use the ValueEnricher

### DIFF
--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -172,7 +172,6 @@ final class SandboxServer(
         }
       EngineConfig(
         allowedLanguageVersions = allowedLanguageVersions,
-        transactionNormalization = false,
         profileDir = config.profileDir,
         stackTraceMode = config.stackTraces,
       )
@@ -347,6 +346,7 @@ final class SandboxServer(
             transactionCommitter,
             packageStore,
             metrics,
+            engine,
           )
       }).acquire()
       ledgerId <- Resource.fromFuture(indexAndWriteService.indexService.getLedgerId())

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -104,6 +104,7 @@ private[sandbox] object SandboxIndexAndWriteService {
       transactionCommitter: TransactionCommitter,
       templateStore: InMemoryPackageStore,
       metrics: Metrics,
+      engine: Engine,
   )(implicit
       mat: Materializer,
       loggingContext: LoggingContext,
@@ -116,6 +117,7 @@ private[sandbox] object SandboxIndexAndWriteService {
         transactionCommitter,
         templateStore,
         ledgerEntries,
+        engine,
       )
     owner(MeteredLedger(ledger, metrics), participantId, timeProvider)
   }

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
@@ -49,6 +49,7 @@ private[sandbox] object LedgerResource {
           transactionCommitter = StandardTransactionCommitter,
           packageStoreInit = packages,
           ledgerEntries = entries,
+          engine = new Engine(),
         )
       )
     )


### PR DESCRIPTION
Enhance `InMemoryLedger` to use the `ValueEnricher`.
- Allowing `SandboxServer` to run Engine with the default `transactionNormalization=false`.
- Enrichment is *not* done when transactions are published; the ACS stores un-enriched contracts and txs.
- Enrichment is done only when responding to verbose API queries.

This change advances the state of #6665
