### PR TITLE
Fix exclusions for command dedup in compat tests

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -307,6 +307,37 @@ excluded_test_tool_tests = [
         ],
     },
     {
+        # Tests got renamed in
+        # https://github.com/digital-asset/daml/commit/f2707cc54f5b7da339bc565bc322be1e57db5edb
+        "end": last_nongranular_test_tool,
+        "platform_ranges": [
+            {
+                "start": "1.17.0-snapshot.20210831.7702.1.f058c2f1",
+                "exclusions": [
+                    "CommandDeduplicationIT",
+                ],
+            },
+        ],
+    },
+    {
+        # Tests got renamed in
+        # https://github.com/digital-asset/daml/commit/f2707cc54f5b7da339bc565bc322be1e57db5edb
+        "start": first_granular_test_tool,
+        "end": "1.5.0-snapshot.20200907.5151.0.eb68e680",
+        "platform_ranges": [
+            {
+                "start": "1.17.0-snapshot.20210831.7702.1.f058c2f1",
+                "exclusions": [
+                    "CommandDeduplicationIT:CDSimpleDeduplication",
+                    "CommandDeduplicationIT:CDSimpleDeduplicationCommandClient",
+                ],
+            },
+        ],
+    },
+    {
+        # Tests got renamed in
+        # https://github.com/digital-asset/daml/commit/f2707cc54f5b7da339bc565bc322be1e57db5edb
+        "start": "1.5.0-snapshot.20200907.5151.0.eb68e680",
         "end": "1.17.0-snapshot.20210831.7702.0.f058c2f1",
         "platform_ranges": [
             {


### PR DESCRIPTION
We need to differentiate between 3 cases:

1. Ledger API test tool versions that only support exclusion of whole
suites.
2. Ledger API test tool versions where the tests had different names.
3. and the current state

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
