### PR TITLE
fix claims check in auth middleware

### DIFF
--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
@@ -66,8 +66,8 @@ class Server(config: Config) extends StrictLogging {
       tokenPayload <- AuthServiceJWTCodec.readFromString(decodedJwt.payload).toOption
     } yield {
       (tokenPayload.admin || !claims.admin) &&
-      tokenPayload.actAs.toSet.subsetOf(claims.actAs.map(_.toString).toSet) &&
-      tokenPayload.readAs.toSet.subsetOf(claims.readAs.map(_.toString).toSet) &&
+      claims.actAs.map(_.toString).toSet.subsetOf(tokenPayload.actAs.toSet) &&
+      claims.readAs.map(_.toString).toSet.subsetOf(tokenPayload.readAs.toSet) &&
       ((claims.applicationId, tokenPayload.applicationId) match {
         // No requirement on app id
         case (None, _) => true

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
@@ -30,7 +30,11 @@ import scala.concurrent.duration.FiniteDuration
 import scala.io.Source
 import scala.util.{Failure, Success}
 
-class TestMiddleware extends AsyncWordSpec with TestFixture with SuiteResourceManagementAroundAll {
+class TestMiddleware
+    extends AsyncWordSpec
+    with TestFixture
+    with SuiteResourceManagementAroundAll
+    with Matchers {
   private def makeToken(
       claims: Request.Claims,
       secret: String = "secret",
@@ -114,7 +118,7 @@ class TestMiddleware extends AsyncWordSpec with TestFixture with SuiteResourceMa
           )
       for {
         aliceA <- r("Alice")()
-        empty <- r()()
+        nothing <- r()()
         aliceA_bobA <- r("Alice", "Bob")()
         aliceA_bobR <- r("Alice")("Bob")
         aliceR_bobA <- r("Bob")("Alice")
@@ -123,15 +127,15 @@ class TestMiddleware extends AsyncWordSpec with TestFixture with SuiteResourceMa
         bobR <- r()("Bob")
         bobAR <- r("Bob")("Bob")
       } yield {
-        assert(aliceA.isEmpty)
-        assert(empty.isEmpty)
-        assert(aliceA_bobA.isDefined)
-        assert(aliceA_bobR.isEmpty)
-        assert(aliceR_bobA.isDefined)
-        assert(aliceR_bobR.isEmpty)
-        assert(bobA.isDefined)
-        assert(bobR.isEmpty)
-        assert(bobAR.isDefined)
+        aliceA shouldBe empty
+        nothing shouldBe empty
+        aliceA_bobA should not be empty
+        aliceA_bobR shouldBe empty
+        aliceR_bobA should not be empty
+        aliceR_bobR shouldBe empty
+        bobA should not be empty
+        bobR shouldBe empty
+        bobAR should not be empty
       }
     }
     "return unauthorized on insufficient app id claims" in {

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
@@ -25,6 +25,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.{AnyWordSpec, AsyncWordSpec}
 
 import scala.collection.immutable
+import scala.collection.immutable.Seq
 import scala.concurrent.duration
 import scala.concurrent.duration.FiniteDuration
 import scala.io.Source


### PR DESCRIPTION
The claims check in the auth middleware was switched around: in effect,
it checked that we did not receive _more_ than we asked for, rather than
checking we receive _at least_ what we asked for.

Of course this would still not let anyone run any trigger without the
proper access token, but it would let people list running triggers and
request (or stop) trigger executions.

CHANGELOG_BEGIN
- Fix a bug in the auth middleware where insufficient credentials could
  still give access to list of running triggers.
CHANGELOG_END