### PR TITLE
bump cleanup threshold

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -38,7 +38,7 @@ steps:
     ## END temp debug
 
     df -h .
-    if [ $(df -m . | sed 1d | awk '{print $4}') -lt 50000 ]; then
+    if [ $(df -m . | sed 1d | awk '{print $4}') -lt 80000 ]; then
         echo "Disk full, cleaning up..."
         $HOME/reset_caches.sh
         echo "Done."


### PR DESCRIPTION
I've witnessed a build ([link], though that will likely expire soon) that failed with a "No space left on device" error after skipping the cleanup step because the machine still had 68GB free.

[link]: https://dev.azure.com/digitalasset/daml/_build/results?buildId=87591&view=logs&j=870bb40c-6da0-5bff-67ed-547f10fa97f2&t=deecee86-545a-596e-8b0d-fb7d606fe9f2

With the machines only having 200GB disk size total, cleaning up at 80 is probably going to start hampering the overall efficiency of the finding ways to reduce the size requirements of our builds). Important note, though: we can't actually increase the macOS disk size very much.

The failure happened on the `compatibility_linux` job.

CHANGELOG_BEGIN
CHANGELOG_END