### PR TITLE
Fix link to the gRPC health checks in the driver for PostgreSQL docs

### DIFF
--- a/ledger/daml-on-sql/README.rst
+++ b/ledger/daml-on-sql/README.rst
@@ -135,7 +135,7 @@ or orchestration system taking care of evaluating its health of the core
 components and ensuring its availability. The Ledger API exposes the standard
 gRPC health checkpoint that can be used to evaluate the health status of the
 Ledger API component. More information on the endpoint can be found at the
-`documentation for gRPC <https://github.com/grpc/grpc/blob/1.29.0/doc/health-checking.md>`__.
+`documentation for gRPC <https://github.com/grpc/grpc/blob/v1.35.0/doc/health-checking.md>`__.
 
 When overloaded, the ledger will attempt to refuse additional requests, instead
 responding with a ``RESOURCE_EXHAUSTED`` error. This error represents


### PR DESCRIPTION
Fixes #10776

changelog_begin
[Docs] Fixed link to the gRPC health checks in the driver for PostgreSQL docs
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
