### PR TITLE
Deprecate kvutils rejections generated only by participant state v1 [KVL-1090]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_kvutils.proto
@@ -197,9 +197,9 @@ message DamlTransactionRejectionEntry {
   oneof reason {
 
     // Rejections used by both participant.state v1 and v2 API.
-    InvalidLedgerTime invalid_ledger_time = 9;
-    SubmitterCannotActViaParticipant submitter_cannot_act_via_participant = 8;
     Duplicate duplicate_command = 6;
+    SubmitterCannotActViaParticipant submitter_cannot_act_via_participant = 8;
+    InvalidLedgerTime invalid_ledger_time = 9;
 
     //
     // Rejections used by participant.state.v1 API.

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_kvutils.proto
@@ -199,16 +199,16 @@ message DamlTransactionRejectionEntry {
     // Rejections used by both participant.state v1 and v2 API.
     InvalidLedgerTime invalid_ledger_time = 9;
     SubmitterCannotActViaParticipant submitter_cannot_act_via_participant = 8;
+    Duplicate duplicate_command = 6;
 
     //
     // Rejections used by participant.state.v1 API.
     // Note that these are deprecated.
     //
-    Inconsistent inconsistent = 2;
-    Disputed disputed = 3;
-    ResourcesExhausted resources_exhausted = 4;
-    Duplicate duplicate_command = 6;
-    PartyNotKnownOnLedger party_not_known_on_ledger = 7;
+    Inconsistent inconsistent = 2 [deprecated = true];
+    Disputed disputed = 3 [deprecated = true];
+    ResourcesExhausted resources_exhausted = 4 [deprecated = true];
+    PartyNotKnownOnLedger party_not_known_on_ledger = 7 [deprecated = true];
 
     //
     // Rejections used by participant.state.v2 API.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -441,6 +441,7 @@ private[state] object Conversions {
     builder
   }
 
+  @nowarn("msg=deprecated")
   def decodeTransactionRejectionEntry(
       entry: DamlTransactionRejectionEntry
   ): Option[FinalReason] = {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/ConflictDetection.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/ConflictDetection.scala
@@ -13,6 +13,8 @@ import com.daml.lf.value.ValueCoder
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 
+import scala.annotation.nowarn
+
 class ConflictDetection(val damlMetrics: Metrics) {
   private val logger = ContextualizedLogger.get(getClass)
   private val metrics = damlMetrics.daml.kvutils.conflictdetection
@@ -123,6 +125,7 @@ class ConflictDetection(val damlMetrics: Metrics) {
       }
       .getOrElse("Unspecified conflict")
 
+  @nowarn("msg=deprecated")
   private def transactionRejectionEntryFrom(
       logEntry: DamlLogEntry,
       reason: String,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/ConflictDetectionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/ConflictDetectionSpec.scala
@@ -14,6 +14,9 @@ import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
+import scala.annotation.nowarn
+
+@nowarn("msg=deprecated")
 class ConflictDetectionSpec extends AsyncWordSpec with Matchers with Inside with MockitoSugar {
   "detectConflictsAndRecover" should {
     "return output keys as invalidated and unchanged input in case of no conflicts" in {


### PR DESCRIPTION
CHANGELOG_BEGIN
kvutils - protobuf rejections generated by the participant state v1 API are deprecated (Inconsistent, Disputed, ResourcesExhausted, PartyNotKnownOnLedger)
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
