### PR TITLE
DPP-577 Check compatibility of timestamps

### DIFF
--- a/compatibility/sandbox-migration/runner/Migration/Types.hs
+++ b/compatibility/sandbox-migration/runner/Migration/Types.hs
@@ -18,6 +18,7 @@ module Migration.Types
 
 import qualified Data.Aeson as A
 import qualified Data.Text as T
+import qualified Data.Int as I
 import qualified Data.SemVer as SemVer
 import GHC.Generics (Generic)
 
@@ -91,6 +92,7 @@ instance A.FromJSON Event where
 data Transaction = Transaction
   { transactionId :: T.Text
   , events :: [Event]
+  , letMicros :: !I.Int64    -- :: Ledger effective time, in microseconds since unix epoch
   } deriving (Generic, Eq, Show)
 
 instance A.FromJSON Transaction

--- a/compatibility/sandbox-migration/src/com/daml/Application.scala
+++ b/compatibility/sandbox-migration/src/com/daml/Application.scala
@@ -55,11 +55,16 @@ object Application {
 
   object TransactionResult {
     def fromTransaction(transaction: Transaction): TransactionResult =
-      TransactionResult(transaction.transactionId, transaction.events.map(toEventResult))
+      TransactionResult(
+        transaction.transactionId,
+        transaction.events.map(toEventResult),
+        transaction.effectiveAt.map(t => t.seconds * 1000000L + t.nanos.toLong / 1000L).get,
+      )
   }
   final case class TransactionResult(
       transactionId: String,
       events: Seq[EventResult],
+      letMicros: Long,
   )
 
   sealed abstract class EventResult

--- a/compatibility/sandbox-migration/src/com/daml/JsonProtocol.scala
+++ b/compatibility/sandbox-migration/src/com/daml/JsonProtocol.scala
@@ -53,7 +53,7 @@ object JsonProtocol extends DefaultJsonProtocol {
   implicit val contractFormat: RootJsonFormat[ContractResult] =
     jsonFormat2(Application.ContractResult.apply)
   implicit val transactionFormat: RootJsonFormat[TransactionResult] =
-    jsonFormat2(Application.TransactionResult.apply)
+    jsonFormat3(Application.TransactionResult.apply)
 
   def saveAsJson[A: JsonWriter](outputFile: Path, a: A): Unit = {
     val _ = Files.write(outputFile, a.toJson.prettyPrint.getBytes())


### PR DESCRIPTION
This PR adds a check to the compatibility tests that verifies that the ledger effective time of existing transactions is not modified by an SDK upgrade.

Adding this test was motivated by the upcoming migration from TIMESTAMP to BIGINT columns to store timestamp values. 