### PR TITLE
fix macOS Bazel cache

### DIFF
--- a/infra/macos/2-common-box/init.sh
+++ b/infra/macos/2-common-box/init.sh
@@ -94,7 +94,7 @@ reset_cache() {
     fi
 
     rm -f "${file}.sparseimage"
-    hdiutil create -size 200g -fs 'Case-sensitive APFS' -volname "$file" -type SPARSE "$file"
+    hdiutil create -size 200g -fs APFS -volname "$file" -type SPARSE "$file"
     mkdir -p $mount_point
     hdiutil attach "${file}.sparseimage" -mountpoint "$mount_point"
     echo "Done."


### PR DESCRIPTION
macOS filesystems have been case-insensitive by default for years, and in particular our laptops are, so if we want the cache to work as expected, CI should be too.

Note: this does not apply to Nix, because the Nix partition is a case-sensitive image per @nycnewman's script on laptops too.

CHANGELOG_BEGIN
CHANGELOG_END