### PR TITLE
Ledger API test tool: ensure that test identifiers are unique

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
@@ -187,7 +187,7 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "DuplicateSubmissionId",
+    "DuplicateConfigSubmissionId",
     "Duplicate submission ids are accepted when config changed twice",
     allocate(NoParties, NoParties),
     runConcurrently = false,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
@@ -187,7 +187,7 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "DuplicateConfigSubmissionId",
+    "CMDuplicateSubmissionId",
     "Duplicate submission ids are accepted when config changed twice",
     allocate(NoParties, NoParties),
     runConcurrently = false,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
@@ -30,7 +30,7 @@ final class PackageManagementServiceIT extends LedgerTestSuite {
   }
 
   test(
-    "PackageManagementEmptyUpload",
+    "PMEmptyUpload",
     "An attempt at uploading an empty payload should fail",
     allocate(NoParties),
   )(implicit ec => { case Participants(Participant(ledger)) =>
@@ -46,7 +46,7 @@ final class PackageManagementServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "DuplicatePackageSubmissionId",
+    "PMDuplicateSubmissionId",
     "Duplicate submission ids are accepted when package uploaded twice",
     allocate(NoParties, NoParties),
   )(implicit ec => { case Participants(Participant(alpha), Participant(beta)) =>
@@ -62,7 +62,7 @@ final class PackageManagementServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "PackageManagementLoad",
+    "PMLoad",
     "Concurrent uploads of the same package should be idempotent and result in the package being available for use",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, party)) =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
@@ -46,7 +46,7 @@ final class PackageManagementServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "DuplicateSubmissionId",
+    "DuplicatePackageSubmissionId",
     "Duplicate submission ids are accepted when package uploaded twice",
     allocate(NoParties, NoParties),
   )(implicit ec => { case Participants(Participant(alpha), Participant(beta)) =>

--- a/ledger/ledger-api-test-tool/src/test/suite/scala/com/daml/ledger/api/testtool/NamesSpec.scala
+++ b/ledger/ledger-api-test-tool/src/test/suite/scala/com/daml/ledger/api/testtool/NamesSpec.scala
@@ -26,7 +26,7 @@ class NamesSpec extends AnyWordSpec with Matchers {
       all(allTestIdentifiers) should fullyMatch regex """[A-Za-z][A-Za-z0-9]*""".r
     }
 
-    "not be a prefix of any other name, so that each test can be included independently" in {
+    "not be a prefix of or equal to any other name, so that each test can be included independently" in {
       allTestIdentifiers.zipWithIndex.foreach { case (testIdentifier, i) =>
         all(allTestIdentifiers.patch(i, Nil, 1)) should not startWith testIdentifier
       }

--- a/ledger/ledger-api-test-tool/src/test/suite/scala/com/daml/ledger/api/testtool/NamesSpec.scala
+++ b/ledger/ledger-api-test-tool/src/test/suite/scala/com/daml/ledger/api/testtool/NamesSpec.scala
@@ -27,8 +27,8 @@ class NamesSpec extends AnyWordSpec with Matchers {
     }
 
     "not be a prefix of any other name, so that each test can be included independently" in {
-      allTestIdentifiers.foreach { testIdentifier =>
-        all(allTestIdentifiers.toSet - testIdentifier) should not startWith testIdentifier
+      allTestIdentifiers.zipWithIndex.foreach { case (testIdentifier, i) =>
+        all(allTestIdentifiers.patch(i, Nil, 1)) should not startWith testIdentifier
       }
     }
   }

--- a/ledger/ledger-api-test-tool/src/test/suite/scala/com/daml/ledger/api/testtool/NamesSpec.scala
+++ b/ledger/ledger-api-test-tool/src/test/suite/scala/com/daml/ledger/api/testtool/NamesSpec.scala
@@ -28,7 +28,7 @@ class NamesSpec extends AnyWordSpec with Matchers {
 
     "not be a prefix of or equal to any other name, so that each test can be included independently" in {
       allTestIdentifiers.zipWithIndex.foreach { case (testIdentifier, i) =>
-        all(allTestIdentifiers.patch(i, Nil, 1)) should not startWith testIdentifier
+        all(allTestIdentifiers.drop(i + 1)) should not startWith testIdentifier
       }
     }
   }


### PR DESCRIPTION
## Description

Test identifiers should be unique because they are used to generate various IDs (e.g. party names, command IDs) that should not clash.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [X] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
