### PR TITLE
Stop using `controller _ can` syntax in daml-lf tests

### DIFF
--- a/daml-lf/archive/src/test/daml/DarReaderTest.daml
+++ b/daml-lf/archive/src/test/daml/DarReaderTest.daml
@@ -21,11 +21,13 @@ template CallablePayout
     receiver: Party
   where
     signatory giver
-    controller receiver can
-      Call2 : ContractId PayOut
-        do create PayOut with receiver; giver
-      Transfer : ContractId CallablePayout
-        with newReceiver: Party
-        do create this with receiver = newReceiver
+    observer receiver
+    choice Call2 : ContractId PayOut
+      controller receiver
+      do create PayOut with receiver; giver
+    choice Transfer : ContractId CallablePayout
+      with newReceiver: Party
+      controller receiver
+      do create this with receiver = newReceiver
 
 reverseCopy = reverse

--- a/daml-lf/tests/AuthorizedDivulgence.daml
+++ b/daml-lf/tests/AuthorizedDivulgence.daml
@@ -43,9 +43,9 @@ template Iou with
     signatory obligor
     observer owner
 
-    controller owner can
-      Sell : ContractId Iou
+    choice Sell : ContractId Iou
         with newOwner : Party
+        controller owner
         do create this with owner = newOwner
 
 template Swap1 with
@@ -55,13 +55,14 @@ template Swap1 with
     signatory p1
     observer p2
 
-    controller p1 can
-      GoSwap1 : ContractId Swap2
+    choice GoSwap1 : ContractId Swap2
         with cid1 : ContractId Iou
+        controller p1
         do create Swap2 with p1; p2; cid1
 
-      GoSwap1WithFetch : ContractId Swap2
+    choice GoSwap1WithFetch : ContractId Swap2
         with cid1 : ContractId Iou
+        controller p1
         do
           fetch cid1
           create Swap2 with p1; p2; cid1
@@ -74,9 +75,9 @@ template Swap2 with
     signatory p1
     observer p2
 
-    controller p2 can
-      GoSwap2 : ()
+    choice GoSwap2 : ()
         with cid2 : ContractId Iou
+        controller p2
         do
           exercise cid1 Sell with newOwner = p2
           exercise cid2 Sell with newOwner = p1
@@ -115,10 +116,11 @@ template C
     p2: Party
   where
     signatory p1
+    observer p2
 
-    controller p2 can
-      Delegate : ContractId D do
-        create $ D p1 p2
+    choice Delegate : ContractId D
+      controller p2
+      do create $ D p1 p2
 
 
 template D
@@ -127,8 +129,9 @@ template D
     p2: Party
   where
     signatory p1, p2
-    controller p1 can
-      GoD : ContractId E do
+    choice GoD : ContractId E
+      controller p1
+      do
         -- We create a contract right before exercising. p2 can't know about it and will only learn of
         -- it when he exercises the choice in the validation.
         cid <- create $ E p1 p2
@@ -141,10 +144,11 @@ template E
     p2: Party
   where
     signatory p1
+    observer p2
 
-    controller p2 can
-      nonconsuming DoSomething : () do
-        pure ()
+    nonconsuming choice DoSomething : ()
+      controller p2
+      do pure ()
 
 -- We test that target contract id's of choices are divulged to parties. This will only pass if the
 -- DontDivulgeContractIdsInCreateArguments flag is turned on.

--- a/daml-lf/tests/BasicTests.daml
+++ b/daml-lf/tests/BasicTests.daml
@@ -132,9 +132,9 @@ template Simple
     agreement show p
     signatory p
 
-    controller p can
-      Hello : Text
-        do pure "hello"
+    choice Hello : Text
+      controller p
+      do pure "hello"
 
 template SimpleMultiParty
   with
@@ -144,9 +144,9 @@ template SimpleMultiParty
     agreement show p1 <> show p2
     signatory p1, p2
 
-    controller p1, p2 can
-      HelloMultiParty : Text
-        do pure "Hello multi-party"
+    choice HelloMultiParty : Text
+      controller p1, p2
+      do pure "Hello multi-party"
     
 
 template Composite
@@ -155,12 +155,11 @@ template Composite
      agreement show p1
      signatory p1
 
-     controller p1 can
-       First : Text
-         do
-           cid <- create Simple with p = p1
-           cid2 <- exercise cid Hello
-           pure "hello"
+     choice First : Text
+       controller p1
+       do cid <- create Simple with p = p1
+          cid2 <- exercise cid Hello
+          pure "hello"
 
 
 ucreate : Party -> Update (ContractId Simple)
@@ -240,9 +239,9 @@ template TypeWithParameters
   where
     signatory p
 
-    controller p can
-      Hello2 : Text
-        do pure "hello"
+    choice Hello2 : Text
+      controller p
+      do pure "hello"
 
 test_typeWithParameters = scenario do
   alice <- getParty "Alice"
@@ -285,12 +284,14 @@ template CallablePayout
     receiver: Party
   where
     signatory giver
-    controller receiver can
-      Call : ContractId PayOut
-        do create PayOut with receiver; giver
-      Transfer : ContractId CallablePayout
-        with newReceiver: Party
-        do create this with receiver = newReceiver
+    observer receiver
+    choice Call : ContractId PayOut
+      controller receiver
+      do create PayOut with receiver; giver
+    choice Transfer : ContractId CallablePayout
+      with newReceiver: Party
+      controller receiver
+      do create this with receiver = newReceiver
 
 
 
@@ -317,13 +318,13 @@ template TwoParties
     signatory p
     signatory p2
 
-    controller p can
-      Hello3 : Text
-        do pure "hello"
+    choice Hello3 : Text
+      controller p
+      do pure "hello"
 
-    controller p2 can
-      World : Text
-        do pure "world"
+    choice World : Text
+      controller p2
+      do pure "world"
 
 template WithKey
   with p: Party
@@ -334,11 +335,10 @@ template WithKey
     key (p, k): (Party, Int)
     maintainer key._1
 
-    controller p can
-      nonconsuming SumToK : Int
-        with
-          n : Int
-        do pure (n + k)
+    nonconsuming choice SumToK : Int
+      with n : Int
+      controller p
+      do pure (n + k)
 
 template FetcherByKey
   with p: Party
@@ -346,10 +346,10 @@ template FetcherByKey
   where
     signatory p
 
-    controller p can
-      nonconsuming Fetch : WithKey
+    nonconsuming choice Fetch : WithKey
         with
           n : Int
+        controller p
         do
           (_, c) <- fetchByKey @WithKey (p, n)
           pure c
@@ -359,10 +359,10 @@ template LookerUpByKey
   where
     signatory p
 
-    controller p can
-      nonconsuming Lookup : Optional (ContractId WithKey)
+    nonconsuming choice Lookup : Optional (ContractId WithKey)
         with
           n : Int
+        controller p
         do
           lookupByKey @WithKey (p, n)
 
@@ -406,10 +406,11 @@ template Fetcher
     fetcher : Party
   where
     signatory sig
-    controller fetcher can
-      DoFetch : Fetched
-        with cid : ContractId Fetched
-        do fetch cid
+    observer fetcher
+    choice DoFetch : Fetched
+      with cid : ContractId Fetched
+      controller fetcher
+      do fetch cid
 
 
 template Forkable
@@ -419,14 +420,13 @@ template Forkable
   where
     signatory party
 
-    controller party can
-      Fork: [ContractId Forkable]
-        with n: Int
-          do
-            if (n == 0) then
-               pure [self]
-            else
-              do
+    choice Fork : [ContractId Forkable]
+      with n: Int
+      controller party
+      do if (n == 0)
+           then
+             pure [self]
+            else do
                 c1 <- create Forkable with party = party, parent = Some self
                 l1 <- exercise c1 Fork with n = n-1
                 c2 <- create Forkable with party = party, parent = Some self
@@ -589,14 +589,14 @@ template TimeGetter with
     p : Party
   where
     signatory p
-    controller p can
-      GetTime : Time
-        do
-         t <- getTime
+    choice GetTime : Time
+      controller p
+      do t <- getTime
          pure t
-      FactorialOfThree: Int
-        do
-          pure $ product [1, 2, 3]
+
+    choice FactorialOfThree: Int
+      controller p
+      do pure $ product [1, 2, 3]
 
 template ComputeContractKeyAfterEnsureClause with
     owner: Party

--- a/daml-lf/tests/ConjunctionChoices.daml
+++ b/daml-lf/tests/ConjunctionChoices.daml
@@ -36,10 +36,11 @@ template PaintHouseProposal
     price   : Decimal
   where
     signatory owner
+    observer [painter, cleaner]
 
-    controller [painter, cleaner] can
-      PaintHouseProposal_Accept : ContractId PaintHouse
-        do create PaintHouse with owner; painter; cleaner; price
+    choice PaintHouseProposal_Accept : ContractId PaintHouse
+      controller [painter, cleaner]
+      do create PaintHouse with owner; painter; cleaner; price
 
 
 template PainterCleanerRelationship
@@ -51,15 +52,14 @@ template PainterCleanerRelationship
     signatory painter
     signatory cleaner
 
-    controller painter can
-      nonconsuming AcceptPaintHouse : ContractId PaintHouse
-        with cid : ContractId PaintHouseProposal
-        do
-          paintHouseProposal <- fetch cid
-          assert (paintHouseProposal.painter == painter)
-          assert (paintHouseProposal.cleaner == cleaner)
-          assert (paintHouseProposal.price >= threshold)
-          exercise cid PaintHouseProposal_Accept
+    nonconsuming choice AcceptPaintHouse : ContractId PaintHouse
+      with cid : ContractId PaintHouseProposal
+      controller painter
+      do paintHouseProposal <- fetch cid
+         assert (paintHouseProposal.painter == painter)
+         assert (paintHouseProposal.cleaner == cleaner)
+         assert (paintHouseProposal.price >= threshold)
+         exercise cid PaintHouseProposal_Accept
 
 
 template PainterCleanerProposal
@@ -69,10 +69,11 @@ template PainterCleanerProposal
     threshold : Decimal
   where
     signatory painter
+    observer cleaner
 
-    controller cleaner can
-      PainterCleanerProposal_Accept : ContractId PainterCleanerRelationship
-        do create PainterCleanerRelationship with painter; cleaner; threshold
+    choice PainterCleanerProposal_Accept : ContractId PainterCleanerRelationship
+      controller cleaner
+      do create PainterCleanerRelationship with painter; cleaner; threshold
 
 
 demo = scenario do

--- a/daml-lf/tests/ContractKeys.daml
+++ b/daml-lf/tests/ContractKeys.daml
@@ -22,12 +22,12 @@ template Divulger
     sig : Party
   where
     signatory divulgee
+    observer sig
 
-    controller sig can
-      nonconsuming DivulgeKeyed
-        : Keyed
+    nonconsuming choice DivulgeKeyed : Keyed
         with
           keyedCid : ContractId Keyed
+        controller sig
         do
           fetch keyedCid
 

--- a/daml-lf/tests/DontDiscloseNonConsumingExercisesToObservers.daml
+++ b/daml-lf/tests/DontDiscloseNonConsumingExercisesToObservers.daml
@@ -12,9 +12,9 @@ template NonObservable with
     signatory p
     observer obs
 
-    controller p can
-      nonconsuming CreateEvent : ContractId Event
-        do create $ Event p
+    nonconsuming choice CreateEvent : ContractId Event
+      controller p
+      do create $ Event p
 
 template Event with
     p : Party

--- a/daml-lf/tests/LargeTransaction.daml
+++ b/daml-lf/tests/LargeTransaction.daml
@@ -54,25 +54,26 @@ template RangeOfInts
     size: Int
   where
     signatory party
-    controller party can
-      ToList: [Int]
-        do return (range start (\x -> x + step) size)
-      ToListContainer: ContractId ListContainer
-        do create ListContainer with party = party, list = (range start (\x -> x + step) size)
-      ToListOfIntContainers: [ContractId IntContainer]
-        do
-          let xs: [Int] = (range start (\x -> x + step) size)
-          mapA (\x -> create IntContainer with party = party, value = x) xs
+    choice ToList: [Int]
+      controller party
+      do return (range start (\x -> x + step) size)
+    choice ToListContainer: ContractId ListContainer
+      controller party
+      do create ListContainer with party = party, list = (range start (\x -> x + step) size)
+    choice ToListOfIntContainers: [ContractId IntContainer]
+      controller party
+      do let xs: [Int] = (range start (\x -> x + step) size)
+         mapA (\x -> create IntContainer with party = party, value = x) xs
 
 template ListUtil
   with
     party: Party
   where
     signatory party
-    controller party can
-      Size: ContractId IntContainer
-        with list: [Int]
-        do create IntContainer with party = party, value = (length list)
+    choice Size: ContractId IntContainer
+      with list: [Int]
+      controller party
+      do create IntContainer with party = party, value = (length list)
         
 rangeOfIntsToListTest = scenario do
     p <- getParty "Dummy"

--- a/daml-lf/tests/reinterpret/daml/ReinterpretTests.daml
+++ b/daml-lf/tests/reinterpret/daml/ReinterpretTests.daml
@@ -20,36 +20,31 @@ template MySimple
     agreement show p
     signatory p
 
-    controller p can
-      MyHello : Text
-        do pure "hello"
+    choice MyHello : Text
+      controller p
+      do pure "hello"
 
-    controller p can
-      MyThrow : Text
-        do throw MyError
+    choice MyThrow : Text
+      controller p
+      do throw MyError
 
-    controller p can
-      ProvokeBadOrd : Text
-        do
-          let x = Thing (\x -> x+1)
-          let zs = dedup [x,x]
-          pure "wont reach here"
+    choice ProvokeBadOrd : Text
+      controller p
+      do let x = Thing (\x -> x+1)
+         let zs = dedup [x,x]
+         pure "wont reach here"
 
-    controller p can
-      Contract14ThenThrow : Text
-        do
-          x <- create (Contract14 with p) -- will be rolled back
-          throw MyError
-          pure "wont reach here"
+    choice Contract14ThenThrow : Text
+      controller p
+      do x <- create (Contract14 with p) -- will be rolled back
+         throw MyError
+         pure "wont reach here"
 
-    controller p can
-      Contract13ThenThrow : Text
-        do
-          x <- create (Contract13 with p) -- will *not* be rolled back; version check will prevent it
-          throw MyError
-          pure "wont reach here"
-
-
+    choice Contract13ThenThrow : Text
+      controller p
+      do x <- create (Contract13 with p) -- will *not* be rolled back; version check will prevent it
+         throw MyError
+         pure "wont reach here"
 
 data Thing = Thing (Int -> Int)
 instance Eq Thing where

--- a/daml-lf/tests/scenario/stable/contract-key-through-exercises/Test.daml
+++ b/daml-lf/tests/scenario/stable/contract-key-through-exercises/Test.daml
@@ -21,11 +21,11 @@ template KeyOps
 
   where
     signatory signatories
+    observer counterParty
 
-    controller counterParty can
-      Accept: ContractId (KeyOps)
-        do
-          create this with signatories = S.insert counterParty signatories
+    choice Accept: ContractId (KeyOps)
+      controller counterParty
+      do create this with signatories = S.insert counterParty signatories
 
     nonconsuming choice
       LookupGivenKey: Optional (ContractId BasicKey)

--- a/daml-lf/tests/scenario/stable/contract-keys/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/stable/contract-keys/EXPECTED.ledger
@@ -1,5 +1,5 @@
 transactions:
-TX #0 1970-01-01T00:00:00Z [Test:77] version: 14
+TX #0 1970-01-01T00:00:00Z [Test:74] version: 14
 #0:0 version: 14
 │   archived by #8:0
 │   referenced by #4:0, #5:0, #8:0
@@ -8,53 +8,53 @@ TX #0 1970-01-01T00:00:00Z [Test:77] version: 14
     with: { p = 'Alice', k = "some-key", disclosedTo = ['Bob'] }
 key { _1 = 'Alice', _2 = "some-key" }
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:84]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:81]
 
-mustFailAt actAs: {'Bob'} readAs: {} [Test:91]
+mustFailAt actAs: {'Bob'} readAs: {} [Test:88]
 
-mustFailAt actAs: {'Bob'} readAs: {} [Test:93]
+mustFailAt actAs: {'Bob'} readAs: {} [Test:90]
 
-TX #4 1970-01-01T00:00:00Z [Test:96] version: 14
+TX #4 1970-01-01T00:00:00Z [Test:93] version: 14
 #4:0 version: 14
 │   known to (since): Alice (#4)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "some-key" }
 found 0066d7eab72b04d1ab3c24f2f3cb2a2d9266c2c2dc769c8b4699b6db3a4f56ec46
 
-TX #5 1970-01-01T00:00:00Z [Test:100] version: 14
+TX #5 1970-01-01T00:00:00Z [Test:97] version: 14
 #5:0 version: 14
 │   known to (since): Alice (#5)
 └─> ensure active 0066d7eab72b04d1ab3c24f2f3cb2a2d9266c2c2dc769c8b4699b6db3a4f56ec46
 
-TX #6 1970-01-01T00:00:00Z [Test:104] version: 14
+TX #6 1970-01-01T00:00:00Z [Test:101] version: 14
 #6:0 version: 14
 │   known to (since): Alice (#6)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "blah" }
 not found
 
-TX #7 1970-01-01T00:00:00Z [Test:108] version: 14
+TX #7 1970-01-01T00:00:00Z [Test:105] version: 14
 #7:0 version: 14
 │   known to (since): Bob (#7)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Bob', _2 = "some-key" }
 not found
 
-TX #8 1970-01-01T00:00:00Z [Test:112] version: 14
+TX #8 1970-01-01T00:00:00Z [Test:109] version: 14
 #8:0 version: 14
 │   known to (since): Alice (#8), Bob (#8)
 └─> Alice exercises TextKeyChoice:Test:TextKey@XXXXXXXX on 0066d7eab72b04d1ab3c24f2f3cb2a2d9266c2c2dc769c8b4699b6db3a4f56ec46
     with {  }
     
 
-TX #9 1970-01-01T00:00:00Z [Test:115] version: 14
+TX #9 1970-01-01T00:00:00Z [Test:112] version: 14
 #9:0 version: 14
 │   known to (since): Alice (#9)
 └─> lookup by key Test:TextKey@XXXXXXXX
 key { _1 = 'Alice', _2 = "some-key" }
 not found
 
-TX #10 1970-01-01T00:00:00Z [Test:121] version: 14
+TX #10 1970-01-01T00:00:00Z [Test:118] version: 14
 #10:0 version: 14
 │   archived by #11:0
 │   referenced by #11:0
@@ -63,7 +63,7 @@ TX #10 1970-01-01T00:00:00Z [Test:121] version: 14
     with: { p = 'Alice', k = "some-key-2", disclosedTo = ['Bob'] }
 key { _1 = 'Alice', _2 = "some-key-2" }
 
-TX #11 1970-01-01T00:00:00Z [Test:126] version: 14
+TX #11 1970-01-01T00:00:00Z [Test:123] version: 14
 #11:0 version: 14
 │   known to (since): Alice (#11), Bob (#11)
 └─> Alice exercises TextKeyChoice:Test:TextKey@XXXXXXXX on 004f56105c00ca4026b905ed27b104471dffcaf2de15832139b93ef46b87000232
@@ -76,7 +76,7 @@ TX #11 1970-01-01T00:00:00Z [Test:126] version: 14
 key { _1 = 'Alice', _2 = "some-key-2" }
 not found
 
-TX #12 1970-01-01T00:00:00Z [Test:132] version: 14
+TX #12 1970-01-01T00:00:00Z [Test:129] version: 14
 #12:0 version: 14
 │   referenced by #12:1
 │   known to (since): Alice (#12)
@@ -90,14 +90,14 @@ key { _1 = 'Alice', _2 = "same-submit-key" }
 key { _1 = 'Alice', _2 = "same-submit-key" }
 found 00a95ea3bb21422ab003f15dc95de204110b3f7f2682b407a2ba75d36b0be9053b
 
-TX #13 1970-01-01T00:00:00Z [Test:140] version: 14
+TX #13 1970-01-01T00:00:00Z [Test:137] version: 14
 #13:0 version: 14
 │   referenced by #14:0
 │   known to (since): Alice (#13)
 └─> create Test:CreateAndLookup@XXXXXXXX
     with: { p = 'Alice', k = "same-choice-key" }
 
-TX #14 1970-01-01T00:00:00Z [Test:144] version: 14
+TX #14 1970-01-01T00:00:00Z [Test:141] version: 14
 #14:0 version: 14
 │   known to (since): Alice (#14)
 └─> Alice exercises Good:Test:CreateAndLookup@XXXXXXXX on 00528ef7ca096fcc1cfb640394394117e237d21236faef81c544770ec5962c462c
@@ -118,9 +118,9 @@ TX #14 1970-01-01T00:00:00Z [Test:144] version: 14
     │   known to (since): Alice (#14)
     └─> ensure active 00ce68df68a7e42ecadca4ff1e4d35ffff75f009d1f01ae130d36116e1332ff773
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:147]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:144]
 
-TX #16 1970-01-01T00:00:00Z [Test:151] version: 14
+TX #16 1970-01-01T00:00:00Z [Test:148] version: 14
 #16:0 version: 14
 │   referenced by #16:1, #16:2
 │   known to (since): Alice (#16)
@@ -140,7 +140,7 @@ key { _1 = 'Alice', _2 = "non-consuming-choice" }
 key { _1 = 'Alice', _2 = "non-consuming-choice" }
 found 00bcf23c0f4133f226e7051a79ab289277e1a3941dcf08c545ff477593c9b22651
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:161]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:158]
 
 active contracts:
    00528ef7ca096fcc1cfb640394394117e237d21236faef81c544770ec5962c462c, 00a95ea3bb21422ab003f15dc95de204110b3f7f2682b407a2ba75d36b0be9053b, 00bcf23c0f4133f226e7051a79ab289277e1a3941dcf08c545ff477593c9b22651, 00ce68df68a7e42ecadca4ff1e4d35ffff75f009d1f01ae130d36116e1332ff773

--- a/daml-lf/tests/scenario/stable/contract-keys/Test.daml
+++ b/daml-lf/tests/scenario/stable/contract-keys/Test.daml
@@ -17,15 +17,13 @@ template TextKey
     key (p, k): (Party, Text)
     maintainer key._1
 
-    controller p can
-      TextKeyChoice : ()
-        do
-          return ()
+    choice TextKeyChoice : ()
+      controller p
+      do return ()
 
-    controller p can
-      nonconsuming TextKeyNonconsumingChoice : ()
-        do
-          return ()
+    nonconsuming choice TextKeyNonconsumingChoice : ()
+      controller p
+      do return ()
 
 template CreateAndLookup
   with
@@ -34,31 +32,30 @@ template CreateAndLookup
   where
     signatory p
 
-    controller p can
-      nonconsuming Good : ()
-        do
-          cid <- create TextKey with
-            p = p
-            k = k
-            disclosedTo = []
-          mbCid <- lookupByKey @TextKey (p, k)
-          assertMsg ("Some cid == mbCid") (Some cid == mbCid)
-          (fCid, c) <- fetchByKey @TextKey (p, k)
-          assertMsg ("fCid == cid") (fCid == cid)
-          assertMsg ("contract fetched by key has correct values") (c.p == p && c.k == k && c.disclosedTo == [])
+    nonconsuming choice Good : ()
+      controller p
+      do cid <- create TextKey with
+           p = p
+           k = k
+           disclosedTo = []
+         mbCid <- lookupByKey @TextKey (p, k)
+         assertMsg ("Some cid == mbCid") (Some cid == mbCid)
+         (fCid, c) <- fetchByKey @TextKey (p, k)
+         assertMsg ("fCid == cid") (fCid == cid)
+         assertMsg ("contract fetched by key has correct values") (c.p == p && c.k == k && c.disclosedTo == [])
 
-    controller p can
-      nonconsuming Dupe : ()
-        do
-          _ <- create TextKey with
-            p = p
-            k = k
-            disclosedTo = []
-          _ <- create TextKey with
-            p = p
-            k = k
-            disclosedTo = []
-          return ()
+    nonconsuming choice Dupe : ()
+      controller p
+      do
+        _ <- create TextKey with
+          p = p
+          k = k
+          disclosedTo = []
+        _ <- create TextKey with
+          p = p
+          k = k
+          disclosedTo = []
+        return ()
 
 template MaintainerNotSignatory
   with

--- a/daml-lf/tests/scenario/stable/divulge-iou/Test.daml
+++ b/daml-lf/tests/scenario/stable/divulge-iou/Test.daml
@@ -41,11 +41,14 @@ template Iou
    amount: Amount
  where
    signatory payer
-   controller owner can
-     Call: ContractId GetCash
-       do create GetCash with payer; owner; amount
-     Transfer: ContractId Iou with newOwner: Party
-       do create Iou with payer; owner = newOwner; amount
+   observer owner
+   choice Call: ContractId GetCash
+     controller owner
+     do create GetCash with payer; owner; amount
+
+   choice Transfer: ContractId Iou with newOwner: Party
+     controller owner
+     do create Iou with payer; owner = newOwner; amount
 
 template DivulgeIouByExercise
  with
@@ -53,9 +56,9 @@ template DivulgeIouByExercise
    divulgee: Party
  where
    signatory divulgee
-   controller payer can
-     nonconsuming Divulge: ()
-       with ref : ContractId Iou
-       do
-         iou <- fetch ref
-         pure ()
+   observer payer
+   nonconsuming choice Divulge: ()
+     with ref : ContractId Iou
+     controller payer
+     do iou <- fetch ref
+        pure ()

--- a/daml-lf/tests/scenario/stable/mustfails/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/stable/mustfails/EXPECTED.ledger
@@ -1,13 +1,13 @@
 transactions:
-mustFailAt actAs: {'Alice'} readAs: {} [Test:88]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:91]
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:92]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:95]
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:96]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:99]
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:100]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:103]
 
-TX #4 1970-01-01T00:00:00Z [Test:108] version: 14
+TX #4 1970-01-01T00:00:00Z [Test:111] version: 14
 #4:0 version: 14
 │   known to (since): Alice (#4), Bob (#4)
 └─> create Test:X@XXXXXXXX
@@ -15,19 +15,19 @@ TX #4 1970-01-01T00:00:00Z [Test:108] version: 14
 
 pass -100000000
 
-mustFailAt actAs: {'Bob'} readAs: {} [Test:110]
+mustFailAt actAs: {'Bob'} readAs: {} [Test:113]
 
-TX #7 1969-12-31T23:58:20Z [Test:115] version: 14
+TX #7 1969-12-31T23:58:20Z [Test:118] version: 14
 #7:0 version: 14
 │   known to (since): Alice (#7)
 └─> create Test:TwoParties@XXXXXXXX
     with: { p = 'Alice', p2 = 'Alice' }
 
-mustFailAt actAs: {'Bob'} readAs: {} [Test:116]
+mustFailAt actAs: {'Bob'} readAs: {} [Test:119]
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:123]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:126]
 
-TX #10 1969-12-31T23:58:20Z [Test:128] version: 14
+TX #10 1969-12-31T23:58:20Z [Test:131] version: 14
 #10:0 version: 14
 │   archived by #11:0
 │   referenced by #11:0
@@ -35,7 +35,7 @@ TX #10 1969-12-31T23:58:20Z [Test:128] version: 14
 └─> create Test:ToTwoParties@XXXXXXXX
     with: { p = 'Alice', p2 = 'Bob' }
 
-TX #11 1969-12-31T23:58:20Z [Test:129] version: 14
+TX #11 1969-12-31T23:58:20Z [Test:132] version: 14
 #11:0 version: 14
 │   known to (since): Alice (#11), Bob (#11)
 └─> Bob exercises Convert:Test:ToTwoParties@XXXXXXXX on 00059653cdb8e866d69fac4d5bd0f62bbdaba4c36b01c438b86351fbdbf2cab8b0
@@ -46,43 +46,43 @@ TX #11 1969-12-31T23:58:20Z [Test:129] version: 14
     └─> create Test:TwoParties@XXXXXXXX
         with: { p = 'Alice', p2 = 'Bob' }
 
-mustFailAt actAs: {'Bob'} readAs: {} [Test:130]
+mustFailAt actAs: {'Bob'} readAs: {} [Test:133]
 
-TX #13 1969-12-31T23:58:20Z [Test:134] version: 14
+TX #13 1969-12-31T23:58:20Z [Test:137] version: 14
 #13:0 version: 14
 │   known to (since): Alice (#13)
 └─> create Test:NoCtrls@XXXXXXXX
     with: { p = 'Alice', xs = [] }
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:135]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:138]
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:139]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:142]
 
-TX #16 1969-12-31T23:58:20Z [Test:144] version: 14
+TX #16 1969-12-31T23:58:20Z [Test:147] version: 14
 #16:0 version: 14
 │   known to (since): Alice (#16), Bob (#16)
 └─> create Test:X@XXXXXXXX
     with: { p = 'Alice', p2 = 'Bob' }
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:145]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:148]
 
-TX #18 1969-12-31T23:58:20Z [Test:151] version: 14
+TX #18 1969-12-31T23:58:20Z [Test:154] version: 14
 #18:0 version: 14
 │   known to (since): Alice (#18)
 └─> create Test:Recursive@XXXXXXXX
     with: { p = 'Alice' }
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:154]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:157]
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:340]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:346]
 
-TX #21 1969-12-31T23:58:20Z [Test:345] version: 14
+TX #21 1969-12-31T23:58:20Z [Test:351] version: 14
 #21:0 version: 14
 │   known to (since): Alice (#21)
 └─> create Test:NestingLimitExercise@XXXXXXXX
     with: { p = 'Alice' }
 
-mustFailAt actAs: {'Alice'} readAs: {} [Test:346]
+mustFailAt actAs: {'Alice'} readAs: {} [Test:352]
 
 active contracts:
    00049c3d61768cf931aa2b97a7ac28002d7673c3f8b996798d87227106e178286e, 00067f889bdf49aa670596cab1a5907d75596d971df3477087c88ca86f281cee85, 00154fe9827fdb40afae4ba484f3f51159d99a27c1463928ec761043c28353b76c, 007e5c9342585588fff0855b297c6e06bfb6a3d62578a28da860af02a98048bd68, 00945c0656f04cdd9f6a85cb466acb0edcd75ea0f618362e83b92164c4cee523e9, 00bf46b75494167be56ef270a63cbc740370b75c98fb517457d9859d55796f7fbf, 00e52b332d66bbf5ac835144e35bf339a7ab319e505e005d1ddd9aed313764dd51

--- a/daml-lf/tests/scenario/stable/mustfails/Test.daml
+++ b/daml-lf/tests/scenario/stable/mustfails/Test.daml
@@ -24,32 +24,34 @@ template TwoParties
     signatory p
     signatory p2
 
-    controller p can
-      Hello: Text
-        do pure "hello"
+    choice Hello: Text
+      controller p
+      do pure "hello"
 
-    controller p2 can
-      World: Text
-        do pure "world"
+    choice World: Text
+      controller p2
+      do pure "world"
 
 template ToTwoParties
   with p: Party
        p2: Party
   where
     signatory p
+    observer p2
 
-    controller p2 can
-      Convert: ContractId TwoParties
-        do create TwoParties with p; p2
+    choice Convert: ContractId TwoParties
+      controller p2
+      do create TwoParties with p; p2
 
 template NoCtrls
   with p: Party
        xs: List Party
   where
     signatory p
-    controller xs can
-      NoController: ()
-        do pure ()
+    observer xs
+    choice NoController: ()
+      controller xs
+      do pure ()
 
 template NoSignatory
   with
@@ -62,24 +64,25 @@ template X
        p2: Party
   where
     signatory p
-    controller p2 can
-      Swap: ContractId X
-        do create X with p = p2; p2 = p
+    observer p2
+    choice Swap: ContractId X
+      controller p2
+      do create X with p = p2; p2 = p
 
 template Recursive
   with p: Party
   where
     signatory p
 
-    controller p can
-      Recursive_Archive: ()
-        do pure ()
+    choice Recursive_Archive: ()
+      controller p
+      do pure ()
 
-      ArchiveAndRecreate: ContractId Recursive
-        with selfCid: ContractId Recursive
-        do
-          exercise selfCid Recursive_Archive
-          create Recursive with p
+    choice ArchiveAndRecreate: ContractId Recursive
+      with selfCid: ContractId Recursive
+      controller p
+      do exercise selfCid Recursive_Archive
+         create Recursive with p
 
 -- 1. Exceptions
 
@@ -323,7 +326,9 @@ template NestingLimitCreate
   where
     signatory p
 
-    controller p can NestingLimitCreate_Choose : () do pure ()
+    choice NestingLimitCreate_Choose : ()
+      controller p
+      do pure ()
 
 template NestingLimitExercise
   with
@@ -331,9 +336,10 @@ template NestingLimitExercise
   where
     signatory p
 
-    controller p can
-      NestingLimitExercise_Choose: () with x: Nesting0
-        do pure ()
+    choice NestingLimitExercise_Choose: ()
+      with x: Nesting0
+      controller p
+      do pure ()
 
 nestingLimitCreate = scenario do
   alice <- getParty "Alice"


### PR DESCRIPTION
If we want to kill this, as a first step let’s stop using it in tests.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
