### PR TITLE
[JSON-API] surrogate template id cache

### DIFF
--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -42,7 +42,11 @@ da_scala_library(
     deps = [
         "//daml-lf/data",
         "//daml-lf/transaction",
+        "//ledger/caching",
+        "//ledger/metrics",
         "//libs-scala/scala-utils",
+        "@maven//:io_dropwizard_metrics_metrics_core",
+        "@maven//:org_slf4j_slf4j_api",
     ],
 )
 

--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -42,11 +42,12 @@ da_scala_library(
     deps = [
         "//daml-lf/data",
         "//daml-lf/transaction",
+        "//ledger-service/utils",
         "//ledger/caching",
         "//ledger/metrics",
+        "//libs-scala/contextualized-logging",
         "//libs-scala/scala-utils",
         "@maven//:io_dropwizard_metrics_metrics_core",
-        "@maven//:org_slf4j_slf4j_api",
     ],
 )
 

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/QueryBackend.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/QueryBackend.scala
@@ -3,6 +3,7 @@
 
 package com.daml.http.dbbackend
 
+import com.daml.metrics.Metrics
 import scalaz.syntax.std.option._
 import scalaz.syntax.std.string._
 
@@ -19,7 +20,10 @@ private[http] sealed abstract class QueryBackend {
   // with `Queries` as that type's responsibility.
   type Conf
 
-  def queries(tablePrefix: String, conf: Conf)(implicit sqli: SqlInterpol): Queries
+  def queries(tablePrefix: String, conf: Conf)(implicit
+      sqli: SqlInterpol,
+      metrics: Metrics,
+  ): Queries
 
   def parseConf(kvs: RawConf): Either[String, Conf]
 }
@@ -34,7 +38,10 @@ private[dbbackend] object PostgresQueryBackend extends QueryBackend {
   type SqlInterpol = Queries.SqlInterpolation.StringArray
   type Conf = Unit
 
-  override def queries(tablePrefix: String, conf: Conf)(implicit sqli: SqlInterpol) =
+  override def queries(tablePrefix: String, conf: Conf)(implicit
+      sqli: SqlInterpol,
+      metrics: Metrics,
+  ) =
     new PostgresQueries(tablePrefix)
 
   override def parseConf(kvs: RawConf) = Right(())
@@ -44,7 +51,10 @@ private[dbbackend] object OracleQueryBackend extends QueryBackend {
   type SqlInterpol = Queries.SqlInterpolation.Unused
   type Conf = DisableContractPayloadIndexing
 
-  override def queries(tablePrefix: String, conf: Conf)(implicit sqli: SqlInterpol) =
+  override def queries(tablePrefix: String, conf: Conf)(implicit
+      sqli: SqlInterpol,
+      metrics: Metrics,
+  ) =
     new OracleQueries(tablePrefix, conf)
 
   override def parseConf(kvs: RawConf): Either[String, Conf] =

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/QueryBackend.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/QueryBackend.scala
@@ -20,7 +20,7 @@ private[http] sealed abstract class QueryBackend {
   // with `Queries` as that type's responsibility.
   type Conf
 
-  def queries(tablePrefix: String, conf: Conf)(implicit
+  def queries(tablePrefix: String, conf: Conf, tpIdCacheMaxEntries: Long)(implicit
       sqli: SqlInterpol,
       metrics: Metrics,
   ): Queries
@@ -38,11 +38,11 @@ private[dbbackend] object PostgresQueryBackend extends QueryBackend {
   type SqlInterpol = Queries.SqlInterpolation.StringArray
   type Conf = Unit
 
-  override def queries(tablePrefix: String, conf: Conf)(implicit
+  override def queries(tablePrefix: String, conf: Conf, tpIdCacheMaxEntries: Long)(implicit
       sqli: SqlInterpol,
       metrics: Metrics,
   ) =
-    new PostgresQueries(tablePrefix)
+    new PostgresQueries(tablePrefix, tpIdCacheMaxEntries)
 
   override def parseConf(kvs: RawConf) = Right(())
 }
@@ -51,11 +51,11 @@ private[dbbackend] object OracleQueryBackend extends QueryBackend {
   type SqlInterpol = Queries.SqlInterpolation.Unused
   type Conf = DisableContractPayloadIndexing
 
-  override def queries(tablePrefix: String, conf: Conf)(implicit
+  override def queries(tablePrefix: String, conf: Conf, tpIdCacheMaxEntries: Long)(implicit
       sqli: SqlInterpol,
       metrics: Metrics,
   ) =
-    new OracleQueries(tablePrefix, conf)
+    new OracleQueries(tablePrefix, conf, tpIdCacheMaxEntries)
 
   override def parseConf(kvs: RawConf): Either[String, Conf] =
     kvs

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/SurrogateTemplateIdCache.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/SurrogateTemplateIdCache.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http.dbbackend
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.caching.SizedCache
+import com.daml.http.dbbackend.Queries.SurrogateTpId
+import com.daml.metrics.Metrics
+import org.slf4j.LoggerFactory
+
+object SurrogateTemplateIdCache {
+  private val logger = LoggerFactory.getLogger(classOf[SurrogateTemplateIdCache])
+  private val maxSize = 1000L
+}
+
+trait SurrogateTemplateIdCache {
+  import SurrogateTemplateIdCache.{logger, maxSize}
+
+  private val metrics = new Metrics(new MetricRegistry)
+
+  private val underlying = {
+    SizedCache.from[String, java.lang.Long](
+      SizedCache.Configuration(maxSize),
+      metrics.daml.HttpJsonApi.surrogateTemplateIdCache,
+    )
+  }
+
+  final def tpIdCachedValue(packageId: String, moduleName: String, entityName: String) = {
+    val key = s"$packageId-$moduleName-$entityName"
+    val res = underlying.getIfPresent(key).map(x => SurrogateTpId(x.toLong))
+    logger.trace(s"Fetched cached value for key ($key) : $res")
+    res
+  }
+
+  final def setTpIdCacheValue(
+      packageId: String,
+      moduleName: String,
+      entityName: String,
+      tpId: SurrogateTpId,
+  ) = {
+    val key = s"$packageId-$moduleName-$entityName"
+    logger.trace(s"Set cached value for key ($key) : $tpId")
+    underlying.put(key, SurrogateTpId.unwrap(tpId))
+  }
+
+  //for testing purposes.
+  import metrics.daml.HttpJsonApi.{surrogateTemplateIdCache => cacheStats}
+  final def tpIdCacheHits = cacheStats.hitCount.getCount
+  final def tpIdCacheMiss = cacheStats.missCount.getCount
+
+}

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/SurrogateTemplateIdCache.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/SurrogateTemplateIdCache.scala
@@ -11,7 +11,7 @@ import com.daml.metrics.Metrics
 
 object SurrogateTemplateIdCache {
   private val logger = ContextualizedLogger.get(getClass)
-  final val MAX_ENTRIES = 10L
+  final val MaxEntries = 10L
 }
 
 class SurrogateTemplateIdCache(metrics: Metrics, maxEntries: Long) {

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/SurrogateTemplateIdCache.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/SurrogateTemplateIdCache.scala
@@ -11,15 +11,15 @@ import com.daml.metrics.Metrics
 
 object SurrogateTemplateIdCache {
   private val logger = ContextualizedLogger.get(getClass)
-  private val maxSize = 1000L
+  final val MAX_ENTRIES = 10L
 }
 
-class SurrogateTemplateIdCache(metrics: Metrics) {
-  import SurrogateTemplateIdCache.{logger, maxSize}
+class SurrogateTemplateIdCache(metrics: Metrics, maxEntries: Long) {
+  import SurrogateTemplateIdCache.logger
 
   private val underlying = {
     SizedCache.from[String, java.lang.Long](
-      SizedCache.Configuration(maxSize),
+      SizedCache.Configuration(maxEntries),
       metrics.daml.HttpJsonApi.surrogateTemplateIdCache,
     )
   }

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/SurrogateTemplateIdCache.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/SurrogateTemplateIdCache.scala
@@ -3,21 +3,19 @@
 
 package com.daml.http.dbbackend
 
-import com.codahale.metrics.MetricRegistry
 import com.daml.caching.SizedCache
 import com.daml.http.dbbackend.Queries.SurrogateTpId
+import com.daml.http.util.Logging.InstanceUUID
+import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import com.daml.metrics.Metrics
-import org.slf4j.LoggerFactory
 
 object SurrogateTemplateIdCache {
-  private val logger = LoggerFactory.getLogger(classOf[SurrogateTemplateIdCache])
+  private val logger = ContextualizedLogger.get(getClass)
   private val maxSize = 1000L
 }
 
-trait SurrogateTemplateIdCache {
+class SurrogateTemplateIdCache(metrics: Metrics) {
   import SurrogateTemplateIdCache.{logger, maxSize}
-
-  private val metrics = new Metrics(new MetricRegistry)
 
   private val underlying = {
     SizedCache.from[String, java.lang.Long](
@@ -26,19 +24,21 @@ trait SurrogateTemplateIdCache {
     )
   }
 
-  final def tpIdCachedValue(packageId: String, moduleName: String, entityName: String) = {
+  final def getCacheValue(packageId: String, moduleName: String, entityName: String)(implicit
+      lc: LoggingContextOf[InstanceUUID]
+  ) = {
     val key = s"$packageId-$moduleName-$entityName"
     val res = underlying.getIfPresent(key).map(x => SurrogateTpId(x.toLong))
     logger.trace(s"Fetched cached value for key ($key) : $res")
     res
   }
 
-  final def setTpIdCacheValue(
+  final def setCacheValue(
       packageId: String,
       moduleName: String,
       entityName: String,
       tpId: SurrogateTpId,
-  ) = {
+  )(implicit lc: LoggingContextOf[InstanceUUID]) = {
     val key = s"$packageId-$moduleName-$entityName"
     logger.trace(s"Set cached value for key ($key) : $tpId")
     underlying.put(key, SurrogateTpId.unwrap(tpId))
@@ -46,7 +46,7 @@ trait SurrogateTemplateIdCache {
 
   //for testing purposes.
   import metrics.daml.HttpJsonApi.{surrogateTemplateIdCache => cacheStats}
-  final def tpIdCacheHits = cacheStats.hitCount.getCount
-  final def tpIdCacheMiss = cacheStats.missCount.getCount
+  private[http] final def getHitCount = cacheStats.hitCount.getCount
+  private[http] final def getMissCount = cacheStats.missCount.getCount
 
 }

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
@@ -43,6 +43,7 @@ private[http] final case class Config(
     logEncoder: LogEncoder = LogEncoder.Plain,
     metricsReporter: Option[MetricsReporter] = None,
     metricsReportingInterval: FiniteDuration = 10 seconds,
+    surrogateTpIdCacheMaxEntries: Option[Long] = None,
 ) extends StartSettings
 
 private[http] object Config {

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/OptionParser.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/OptionParser.scala
@@ -96,6 +96,14 @@ class OptionParser(getEnvVar: String => Option[String])(implicit
         s" Defaults to the `max-inbound-message-size` setting."
     )
 
+  opt[Long]("max-template-id-cache-entries")
+    .action((x, c) => c.copy(surrogateTpIdCacheMaxEntries = Some(x)))
+    .optional()
+    .text(
+      s"Optional max cache size in entries for storing surrogate template id mappings." +
+        s" Defaults to ${Config.Empty.surrogateTpIdCacheMaxEntries}"
+    )
+
   opt[Int]("max-inbound-message-size")
     .action((x, c) => c.copy(maxInboundMessageSize = x))
     .optional()

--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -243,6 +243,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
   private def initializeDb(c: JdbcConfig)(implicit
       ec: ExecutionContext,
       lc: LoggingContextOf[InstanceUUID],
+      metrics: Metrics,
   ): Future[ContractDao] =
     for {
       dao <- Future(ContractDao(c, poolSize = PoolSize.Integration))

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -63,7 +63,6 @@ hj_scalacopts = lf_scalacopts + [
             "//ledger-service/jwt",
             "//ledger-service/lf-value-json",
             "//ledger-service/utils",
-            "//ledger/caching",
             "//ledger/ledger-api-auth",
             "//ledger/ledger-api-common",
             "//ledger/ledger-resources",

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -115,6 +115,7 @@ json_deps_shared = [
     "//daml-lf/interface",
     "//daml-lf/transaction",
     "//language-support/scala/bindings-akka",
+    "//ledger/metrics",
     "//ledger-api/rs-grpc-bridge",
     "//ledger-service/db-backend",
     "//ledger-service/jwt",
@@ -127,6 +128,7 @@ json_deps_shared = [
     "//libs-scala/ports",
     "//libs-scala/scala-utils",
     "@maven//:ch_qos_logback_logback_classic",
+    "@maven//:io_dropwizard_metrics_metrics_core",
 ]
 
 json_deps = {
@@ -221,6 +223,7 @@ daml_compile(
             "//daml-lf/transaction-test-lib",
             "//language-support/scala/bindings-akka",
             "//ledger-service/db-backend",
+            "//ledger/metrics",
             "//ledger-service/http-json-cli:{}".format(edition),
             "//ledger-service/cli-opts",
             "//ledger-service/lf-value-json",
@@ -228,6 +231,7 @@ daml_compile(
             "//libs-scala/db-utils",
             "//libs-scala/scala-utils",
             "//libs-scala/scalatest-utils",
+            "@maven//:io_dropwizard_metrics_metrics_core",
             "@maven//:org_scalatest_scalatest_compatible",
         ],
     )
@@ -279,6 +283,7 @@ alias(
             "//daml-lf/transaction-test-lib",
             "//language-support/scala/bindings-akka",
             "//ledger-api/rs-grpc-bridge",
+            "//ledger/metrics",
             "//ledger-service/http-json-cli:{}".format(edition),
             "//ledger-service/http-json-testing:{}".format(edition),
             "//ledger-service/db-backend",
@@ -298,6 +303,7 @@ alias(
             "//runtime-components/non-repudiation",
             "//runtime-components/non-repudiation-postgresql",
             "//runtime-components/non-repudiation-testing",
+            "@maven//:io_dropwizard_metrics_metrics_core",
             "@maven//:org_scalatest_scalatest_compatible",
         ],
     )
@@ -364,6 +370,7 @@ alias(
             "//language-support/scala/bindings-akka",
             "//ledger-api/rs-grpc-bridge",
             "//ledger-service/db-backend",
+            "//ledger/metrics",
             "//ledger-service/http-json-cli:{}".format(edition),
             "//ledger-service/http-json-testing:{}".format(edition),
             "//ledger-service/jwt",
@@ -376,6 +383,7 @@ alias(
             "//libs-scala/scala-utils",
             "//runtime-components/non-repudiation",
             "//runtime-components/non-repudiation-postgresql",
+            "@maven//:io_dropwizard_metrics_metrics_core",
             "@maven//:org_scalatest_scalatest_compatible",
         ],
     )
@@ -437,6 +445,7 @@ test_suite(
             "//ledger/ledger-api-auth",
             "//ledger/ledger-api-common",
             "//ledger/ledger-resources",
+            "//ledger/metrics",
             "//ledger/participant-integration-api",
             "//ledger/participant-integration-api:participant-integration-api-tests-lib",
             "//ledger/sandbox",
@@ -449,6 +458,7 @@ test_suite(
             "//libs-scala/resources",
             "//libs-scala/timer-utils",
             "@maven//:eu_rekawek_toxiproxy_toxiproxy_java_2_1_3",
+            "@maven//:io_dropwizard_metrics_metrics_core",
             "@maven//:org_scalatest_scalatest_compatible",
         ],
     )
@@ -486,11 +496,15 @@ da_scala_benchmark_jmh(
         "//language-support/scala/bindings",
         "//ledger-service/db-backend",
         "//ledger-service/http-json-cli:base",
+        "//ledger-service/utils",
+        "//ledger/metrics",
+        "//libs-scala/contextualized-logging",
         "//libs-scala/db-utils",
         "//libs-scala/doobie-slf4j",
         "//libs-scala/oracle-testing",
         "//libs-scala/ports",
         "@maven//:com_oracle_database_jdbc_ojdbc8",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -63,6 +63,7 @@ hj_scalacopts = lf_scalacopts + [
             "//ledger-service/jwt",
             "//ledger-service/lf-value-json",
             "//ledger-service/utils",
+            "//ledger/caching",
             "//ledger/ledger-api-auth",
             "//ledger/ledger-api-common",
             "//ledger/ledger-resources",

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
@@ -5,6 +5,7 @@ package com.daml.http.dbbackend
 
 import com.daml.http.dbbackend.Queries.SurrogateTpId
 import com.daml.http.domain.{Party, TemplateId}
+import com.daml.http.util.Logging.instanceUUIDLogCtx
 import doobie.implicits._
 import org.openjdk.jmh.annotations._
 import scalaz.OneAnd
@@ -43,9 +44,11 @@ class QueryBenchmark extends ContractDaoBenchmark {
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime))
   def run(): Unit = {
     implicit val driver: SupportedJdbcDriver.TC = dao.jdbcDriver
-    val result = dao
-      .transact(ContractDao.selectContracts(OneAnd(Party(party), Set.empty), tpid, fr"1 = 1"))
-      .unsafeRunSync()
+    val result = instanceUUIDLogCtx(implicit lc =>
+      dao
+        .transact(ContractDao.selectContracts(OneAnd(Party(party), Set.empty), tpid, fr"1 = 1"))
+        .unsafeRunSync()
+    )
     assert(result.size == batchSize)
   }
 }

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
@@ -9,6 +9,7 @@ import com.daml.lf.iface
 import com.daml.http.dbbackend.Queries.SurrogateTpId
 import com.daml.http.domain.{Party, TemplateId}
 import com.daml.http.query.ValuePredicate
+import com.daml.http.util.Logging.instanceUUIDLogCtx
 import org.openjdk.jmh.annotations._
 import scalaz.OneAnd
 import spray.json._
@@ -67,9 +68,11 @@ class QueryPayloadBenchmark extends ContractDaoBenchmark {
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime))
   def run(): Unit = {
     implicit val sjd: SupportedJdbcDriver.TC = dao.jdbcDriver
-    val result = dao
-      .transact(ContractDao.selectContracts(OneAnd(Party(party), Set.empty), tpid, whereClause))
-      .unsafeRunSync()
+    val result = instanceUUIDLogCtx(implicit lc =>
+      dao
+        .transact(ContractDao.selectContracts(OneAnd(Party(party), Set.empty), tpid, whereClause))
+        .unsafeRunSync()
+    )
     assert(result.size == batchSize)
   }
 }

--- a/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
+++ b/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
@@ -7,6 +7,7 @@ import akka.http.javadsl.model.ws.PeerClosedConnectionException
 import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.stream.{KillSwitches, UniqueKillSwitch}
 import akka.stream.scaladsl.{Keep, Sink}
+import com.codahale.metrics.MetricRegistry
 
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success}
@@ -14,6 +15,7 @@ import com.daml.http.domain.Offset
 import com.daml.http.json.{JsonError, SprayJson}
 import com.daml.http.util.FutureUtil
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.metrics.Metrics
 import com.daml.timer.RetryStrategy
 import eu.rekawek.toxiproxy.model.ToxicDirection
 import org.scalatest._
@@ -375,6 +377,7 @@ final class FailureTests
     import DbStartupOps._, com.daml.http.dbbackend.DbStartupMode._,
     com.daml.http.dbbackend.JdbcConfig, com.daml.dbutils
     val bc = jdbcConfig_.baseConfig
+    implicit val metrics: Metrics = new Metrics(new MetricRegistry())
     val dao = dbbackend.ContractDao(
       JdbcConfig(
         // discarding other settings

--- a/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
@@ -3,8 +3,10 @@
 
 package com.daml.http
 
+import com.codahale.metrics.MetricRegistry
 import com.daml.dbutils.ConnectionPool.PoolSize
 import com.daml.http.dbbackend.JdbcConfig
+import com.daml.metrics.Metrics
 import com.daml.testing.postgresql.PostgresAroundAll
 import org.scalatest.Inside
 import org.scalatest.AsyncTestSuite
@@ -14,6 +16,7 @@ trait HttpServicePostgresInt extends AbstractHttpServiceIntegrationTestFuns with
   this: AsyncTestSuite with Matchers with Inside =>
 
   override final def jdbcConfig: Option[JdbcConfig] = Some(jdbcConfig_)
+  protected implicit val metics = new Metrics(new MetricRegistry)
 
   // has to be lazy because jdbcConfig_ is NOT initialized yet
   protected lazy val dao = dbbackend.ContractDao(jdbcConfig_, poolSize = PoolSize.Integration)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -232,6 +232,7 @@ private class ContractsFetch(
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,
+      lc: LoggingContextOf[InstanceUUID],
   ): ConnectionIO[BeginBookmark[domain.Offset]] = {
 
     import domain.Offset._
@@ -479,6 +480,7 @@ private[http] object ContractsFetch {
   )(implicit
       log: doobie.LogHandler,
       sjd: SupportedJdbcDriver.TC,
+      lc: LoggingContextOf[InstanceUUID],
   ): ConnectionIO[Map[K, SurrogateTpId]] = {
     import doobie.implicits._, cats.instances.vector._, cats.syntax.functor._,
     cats.syntax.traverse._
@@ -515,7 +517,11 @@ private[http] object ContractsFetch {
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   private def insertAndDelete(
       step: InsertDeleteStep[Any, PreInsertContract]
-  )(implicit log: doobie.LogHandler, sjd: SupportedJdbcDriver.TC): ConnectionIO[Unit] = {
+  )(implicit
+      log: doobie.LogHandler,
+      sjd: SupportedJdbcDriver.TC,
+      lc: LoggingContextOf[InstanceUUID],
+  ): ConnectionIO[Unit] = {
     import doobie.implicits._, cats.syntax.functor._
     surrogateTemplateIds(step.inserts.iterator.map(_.templateId).toSet).flatMap { stidMap =>
       import cats.syntax.apply._, cats.instances.vector._

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -390,6 +390,8 @@ class ContractsService(
             parties: OneAnd[Set, domain.Party],
             templateId: domain.TemplateId.RequiredPkg,
             queryParams: Map[String, JsValue],
+        )(implicit
+            lc: LoggingContextOf[InstanceUUID]
         ): doobie.ConnectionIO[Vector[domain.ActiveContract[JsValue]]] = {
           val predicate = valuePredicate(templateId, queryParams)
           ContractDao.selectContracts(parties, templateId, predicate.toSqlWhereClause)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -84,6 +84,7 @@ object Main {
         s", nonRepudiationCertificateFile=${config.nonRepudiation.certificateFile: Option[Path]}" +
         s", nonRepudiationPrivateKeyFile=${config.nonRepudiation.privateKeyFile: Option[Path]}" +
         s", nonRepudiationPrivateKeyAlgorithm=${config.nonRepudiation.privateKeyAlgorithm: Option[String]}" +
+        s", surrogateTpIdCacheMaxEntries=${config.surrogateTpIdCacheMaxEntries: Option[Long]}" +
         ")"
     )
 
@@ -106,7 +107,8 @@ object Main {
     }
 
     val contractDao = metricsResource.asFuture.map { implicit metrics =>
-      val contractDao = config.jdbcConfig.map(c => ContractDao(c))
+      val contractDao =
+        config.jdbcConfig.map(c => ContractDao(c, config.surrogateTpIdCacheMaxEntries))
       (contractDao, config.jdbcConfig) match {
         case (Some(dao), Some(c)) =>
           import cats.effect.IO

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -105,56 +105,61 @@ object Main {
       Await.result(asys.terminate(), 10.seconds)
     }
 
-    val contractDao = config.jdbcConfig.map(c => ContractDao(c))
-
-    (contractDao, config.jdbcConfig) match {
-      case (Some(dao), Some(c)) =>
-        import cats.effect.IO
-        def terminateProcess(errorCode: Int): Unit = {
-          logger.info("Terminating process...")
-          terminate()
-          System.exit(errorCode)
-        }
-        Try(
-          dao
-            .isValid(120)
-            .attempt
-            .flatMap {
-              case Left(ex) =>
-                logger.error("Unexpected error while checking database connection", ex)
-                IO.pure(some(ErrorCodes.StartupError))
-              case Right(false) =>
-                logger.error("Database connection is not valid.")
-                IO.pure(some(ErrorCodes.StartupError))
-              case Right(true) =>
-                DbStartupOps
-                  .fromStartupMode(dao, c.dbStartupMode)
-                  .map(success =>
-                    if (success)
-                      if (DbStartupOps.shouldStart(c.dbStartupMode)) none
-                      else some(ErrorCodes.Ok)
-                    else some(ErrorCodes.StartupError)
-                  )
-            }
-            .unsafeRunSync()
-        ).fold(
-          { ex =>
-            logger
-              .error("Unexpected error while checking connection or DB schema initialization", ex)
-            terminateProcess(ErrorCodes.StartupError)
-          },
-          _.foreach(terminateProcess),
-        )
-      case _ =>
+    val contractDao = metricsResource.asFuture.map { implicit metrics =>
+      val contractDao = config.jdbcConfig.map(c => ContractDao(c))
+      (contractDao, config.jdbcConfig) match {
+        case (Some(dao), Some(c)) =>
+          import cats.effect.IO
+          def terminateProcess(errorCode: Int): Unit = {
+            logger.info("Terminating process...")
+            terminate()
+            System.exit(errorCode)
+          }
+          Try(
+            dao
+              .isValid(120)
+              .attempt
+              .flatMap {
+                case Left(ex) =>
+                  logger.error("Unexpected error while checking database connection", ex)
+                  IO.pure(some(ErrorCodes.StartupError))
+                case Right(false) =>
+                  logger.error("Database connection is not valid.")
+                  IO.pure(some(ErrorCodes.StartupError))
+                case Right(true) =>
+                  DbStartupOps
+                    .fromStartupMode(dao, c.dbStartupMode)
+                    .map(success =>
+                      if (success)
+                        if (DbStartupOps.shouldStart(c.dbStartupMode)) none
+                        else some(ErrorCodes.Ok)
+                      else some(ErrorCodes.StartupError)
+                    )
+              }
+              .unsafeRunSync()
+          ).fold(
+            { ex =>
+              logger
+                .error("Unexpected error while checking connection or DB schema initialization", ex)
+              terminateProcess(ErrorCodes.StartupError)
+            },
+            _.foreach(terminateProcess),
+          )
+        case _ =>
+      }
+      contractDao
     }
 
-    val serviceF: Future[HttpService.Error \/ (ServerBinding, Option[ContractDao])] =
+    val serviceF: Future[HttpService.Error \/ (ServerBinding, Option[ContractDao])] = {
       metricsResource.asFuture.flatMap(implicit metrics =>
-        HttpService.start(
-          startSettings = config,
-          contractDao = contractDao,
+        contractDao.flatMap(dao =>
+          HttpService.start(
+            startSettings = config,
+            contractDao = dao,
+          )
         )
       )
+    }
 
     discard {
       sys.addShutdownHook {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -495,6 +495,8 @@ object WebSocketService {
       def streamPredicate(
           q: Map[domain.TemplateId.RequiredPkg, HashSet[LfV]],
           unresolved: Set[OptionalPkg],
+      )(implicit
+          lc: LoggingContextOf[InstanceUUID]
       ) =
         StreamPredicate(
           q.keySet,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -70,7 +70,7 @@ class ContractDao private (
 }
 
 object ContractDao {
-  import ConnectionPool.PoolSize, SurrogateTemplateIdCache.MAX_ENTRIES
+  import ConnectionPool.PoolSize, SurrogateTemplateIdCache.MaxEntries
   private[this] val supportedJdbcDrivers = Map[String, SupportedJdbcDriver.Available](
     "org.postgresql.Driver" -> SupportedJdbcDriver.Postgres,
     "oracle.jdbc.OracleDriver" -> SupportedJdbcDriver.Oracle,
@@ -94,7 +94,7 @@ object ContractDao {
         .toRight(
           s"JDBC driver ${cfg.baseConfig.driver} is not one of ${supportedJdbcDrivers.keySet}"
         )
-      sjdc <- configureJdbc(cfg, sjda, tpIdCacheMaxEntries.getOrElse(MAX_ENTRIES))
+      sjdc <- configureJdbc(cfg, sjda, tpIdCacheMaxEntries.getOrElse(MaxEntries))
     } yield {
       implicit val sjd: SupportedJdbcDriver.TC = sjdc
       //pool for connections awaiting database access

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -3,8 +3,10 @@
 
 package com.daml.http.dbbackend
 
+import cats.Applicative
 import cats.effect._
 import cats.syntax.apply._
+import com.daml.caching.SizedCache
 import com.daml.dbutils.ConnectionPool
 import com.daml.doobie.logging.Slf4jLogHandler
 import com.daml.http.domain
@@ -71,6 +73,12 @@ object ContractDao {
   private[this] val supportedJdbcDrivers = Map[String, SupportedJdbcDriver.Available](
     "org.postgresql.Driver" -> SupportedJdbcDriver.Postgres,
     "oracle.jdbc.OracleDriver" -> SupportedJdbcDriver.Oracle,
+  )
+
+  private val enableCache = sys.env.get("SURROGATE_TPID_CACHE").exists(x => x.toBoolean)
+
+  private val surrogateTemplateCache = SizedCache.from[domain.TemplateId[String], java.lang.Long](
+    SizedCache.Configuration(1000)
   )
 
   def supportedJdbcDriverNames(available: Set[String]): Set[String] =
@@ -263,12 +271,33 @@ object ContractDao {
   private[this] def surrogateTemplateId(templateId: domain.TemplateId.RequiredPkg)(implicit
       log: LogHandler,
       sjd: SupportedJdbcDriver.TC,
-  ) =
-    sjd.q.queries.surrogateTemplateId(
-      templateId.packageId,
-      templateId.moduleName,
-      templateId.entityName,
-    )
+  ) = {
+    if (enableCache) {
+      surrogateTemplateCache
+        .getIfPresent(templateId)
+        .map { tpId =>
+          Applicative[fconn.ConnectionIO].pure(Queries.SurrogateTpId(tpId.toLong))
+        }
+        .getOrElse {
+          sjd.q.queries
+            .surrogateTemplateId(
+              templateId.packageId,
+              templateId.moduleName,
+              templateId.entityName,
+            )
+            .map { b =>
+              surrogateTemplateCache.put(templateId, Queries.SurrogateTpId.unwrap(b))
+              b
+            }
+        }
+    } else {
+      sjd.q.queries.surrogateTemplateId(
+        templateId.packageId,
+        templateId.moduleName,
+        templateId.entityName,
+      )
+    }
+  }
 
   private def toDomain(templateId: domain.TemplateId.RequiredPkg)(
       a: Queries.DBContract[_, JsValue, JsValue, Vector[String]]

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/SupportedJdbcDriver.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/SupportedJdbcDriver.scala
@@ -3,6 +3,7 @@
 
 package com.daml.http.dbbackend
 
+import com.daml.metrics.Metrics
 import scalaz.Liskov, Liskov.<~<
 
 /** Incompatible JDBC operations and settings, selected by
@@ -15,7 +16,8 @@ final class SupportedJdbcDriver[+Q] private (
 ) {
   import SupportedJdbcDriver.{Staged, Configured}
   def configure(tablePrefix: String, extraConf: Map[String, String])(implicit
-      Q: Q <~< Staged
+      Q: Q <~< Staged,
+      metrics: Metrics,
   ): Either[String, SupportedJdbcDriver.TC] = {
     val staged: Staged = Q(q)
     import staged.{backend, ipol}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/SupportedJdbcDriver.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/SupportedJdbcDriver.scala
@@ -15,7 +15,8 @@ final class SupportedJdbcDriver[+Q] private (
     private[http] val q: Q,
 ) {
   import SupportedJdbcDriver.{Staged, Configured}
-  def configure(tablePrefix: String, extraConf: Map[String, String])(implicit
+  def configure(tablePrefix: String, extraConf: Map[String, String], tpIdCacheMaxEntries: Long)(
+      implicit
       Q: Q <~< Staged,
       metrics: Metrics,
   ): Either[String, SupportedJdbcDriver.TC] = {
@@ -25,7 +26,7 @@ final class SupportedJdbcDriver[+Q] private (
       new SupportedJdbcDriver(
         label,
         retrySqlStates,
-        new Configured(backend.queries(tablePrefix, conf)),
+        new Configured(backend.queries(tablePrefix, conf, tpIdCacheMaxEntries)),
       )
     }
   }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -8,6 +8,7 @@ import json.JsonProtocol.LfValueCodec.{apiValueToJsValue, jsValueToApiValue}
 import com.daml.lf.data.{Decimal, ImmArray, Numeric, Ref, SortedLookupList, Time}
 import ImmArray.ImmArraySeq
 import com.codahale.metrics.MetricRegistry
+import com.daml.http.dbbackend.SurrogateTemplateIdCache
 import com.daml.lf.iface
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.test.TypedValueGenerators.{genAddendNoListMap, RNil, ValueAddend => VA}
@@ -307,7 +308,8 @@ class ValuePredicateTest
         // we aren't running the SQL, just looking at it
         import org.scalatest.EitherValues._
         implicit val metrics: Metrics = new Metrics(new MetricRegistry())
-        implicit val sjd: dbbackend.SupportedJdbcDriver.TC = backend.configure("", Map.empty).value
+        implicit val sjd: dbbackend.SupportedJdbcDriver.TC =
+          backend.configure("", Map.empty, SurrogateTemplateIdCache.MAX_ENTRIES).value
         val frag = vp.toSqlWhereClause
         frag.toString should ===(sql.toString)
         fragmentElems(frag) should ===(fragmentElems(sql))

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -309,7 +309,7 @@ class ValuePredicateTest
         import org.scalatest.EitherValues._
         implicit val metrics: Metrics = new Metrics(new MetricRegistry())
         implicit val sjd: dbbackend.SupportedJdbcDriver.TC =
-          backend.configure("", Map.empty, SurrogateTemplateIdCache.MAX_ENTRIES).value
+          backend.configure("", Map.empty, SurrogateTemplateIdCache.MaxEntries).value
         val frag = vp.toSqlWhereClause
         frag.toString should ===(sql.toString)
         fragmentElems(frag) should ===(fragmentElems(sql))

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -7,10 +7,11 @@ package query
 import json.JsonProtocol.LfValueCodec.{apiValueToJsValue, jsValueToApiValue}
 import com.daml.lf.data.{Decimal, ImmArray, Numeric, Ref, SortedLookupList, Time}
 import ImmArray.ImmArraySeq
+import com.codahale.metrics.MetricRegistry
 import com.daml.lf.iface
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.test.TypedValueGenerators.{genAddendNoListMap, RNil, ValueAddend => VA}
-
+import com.daml.metrics.Metrics
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalactic.source
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -305,6 +306,7 @@ class ValuePredicateTest
       ) { (backend, sql: doobie.Fragment) =>
         // we aren't running the SQL, just looking at it
         import org.scalatest.EitherValues._
+        implicit val metrics: Metrics = new Metrics(new MetricRegistry())
         implicit val sjd: dbbackend.SupportedJdbcDriver.TC = backend.configure("", Map.empty).value
         val frag = vp.toSqlWhereClause
         frag.toString should ===(sql.toString)

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -727,6 +727,8 @@ final class Metrics(val registry: MetricRegistry) {
     object HttpJsonApi {
       private val Prefix: MetricName = daml.Prefix :+ "http_json_api"
 
+      val surrogateTemplateIdCache = new CacheMetrics(registry, Prefix :+ "surrogate_tpid_cache")
+
       // Meters how long processing of a command submission request takes
       val commandSubmissionTimer: Timer = registry.timer(Prefix :+ "command_submission_timing")
       // Meters how long processing of a query GET request takes


### PR DESCRIPTION
Initial changes to add a surrogate_template_id cache to reduce db queries ([#10266](https://github.com/digital-asset/daml/issues/10266))

CHANGELOG_BEGIN
CHANGELOG_END

Preliminary results for this 


- With Gatling multi-user performance tests for oracle with a single template but about 10k queries across 100 parallel users, we see some improvement in throughput and latency in the higher percentiles.


```
No Surrogate template id cache (baseline)
================================================================================
---- SyncFetchByQuery ----------------------------------------------------------
> Number of requests                                 10000 (OK=10000  KO=-     )
> Min. response time                                    23 (OK=23     KO=-     )
> Max. response time                                   701 (OK=701    KO=-     )
> Mean response time                                   125 (OK=125    KO=-     )
> Std. deviation                                        41 (OK=41     KO=-     )
> response time 90th percentile                        125 (OK=125    KO=-     )
> response time 95th percentile                        148 (OK=148    KO=-     )
> response time 99th percentile                        188 (OK=188    KO=-     )
> response time 99.9th percentile                      221 (OK=221    KO=-     )
> Mean requests/second                               78.74 (OK=78.74  KO=-     )
---- Response time distribution ------------------------------------------------
> t < 800 ms                                         10000 (100%)
> 800 ms < t < 1200 ms                                   0 (  -%)
> t > 1200 ms                                            0 (  -%)
> failed                                                 0 (  -%)
================================================================================



With Surrogate template id cache (regression)
================================================================================
---- SyncFetchByQuery ----------------------------------------------------------
> Number of requests                                 10000 (OK=10000  KO=-     )
> Min. response time                                    21 (OK=21     KO=-     )
> Max. response time                                   633 (OK=633    KO=-     )
> Mean response time                                   106 (OK=106    KO=-     )
> Std. deviation                                        34 (OK=34     KO=-     )
> response time 90th percentile                        106 (OK=106    KO=-     )
> response time 95th percentile                        125 (OK=125    KO=-     )
> response time 99th percentile                        156 (OK=156    KO=-     )
> response time 99.9th percentile                      186 (OK=186    KO=-     )
> Mean requests/second                              93.458 (OK=93.458 KO=-     )
---- Response time distribution ------------------------------------------------
> t < 800 ms                                         10000 (100%)
> 800 ms < t < 1200 ms                                   0 (  -%)
> t > 1200 ms                                            0 (  -%)
> failed                                                 0 (  -%)
================================================================================
```


- with JMH `QueryBenchmark` (i.e `ContractDaoBenchmarks`) we didn't see any significant difference, even with increased templates.
```
==> /var/tmp/withCacheBench.log (baseline) <==
Result "com.daml.http.dbbackend.QueryBenchmark.run":
  5.514 ±(99.9%) 0.494 ops/s [Average]
  (min, avg, max) = (4.900, 5.514, 5.859), stdev = 0.327
  CI (99.9%): [5.020, 6.008] (assumes normal distribution)


# Run complete. Total time: 00:03:32

Benchmark           (batchSize)  (extraParties)  (extraTemplates)   Mode  Cnt  Score   Error  Units
QueryBenchmark.run         1000               1                 1  thrpt   10  7.350 ± 0.804  ops/s
QueryBenchmark.run         1000               1                10  thrpt   10  6.478 ± 0.377  ops/s
QueryBenchmark.run         1000               1                20  thrpt   10  5.514 ± 0.494  ops/s

==> /var/tmp/noCacheBench.log (regression)<==
Result "com.daml.http.dbbackend.QueryBenchmark.run":
  5.580 ±(99.9%) 0.296 ops/s [Average]
  (min, avg, max) = (5.217, 5.580, 5.811), stdev = 0.196
  CI (99.9%): [5.284, 5.876] (assumes normal distribution)


# Run complete. Total time: 00:03:28

Benchmark           (batchSize)  (extraParties)  (extraTemplates)   Mode  Cnt  Score   Error  Units
QueryBenchmark.run         1000               1                 1  thrpt   10  7.539 ± 0.326  ops/s
QueryBenchmark.run         1000               1                10  thrpt   10  6.480 ± 0.201  ops/s
QueryBenchmark.run         1000               1                20  thrpt   10  5.580 ± 0.296  ops/s
```

I haven't looked at the QueryBenchmarks in detail and the reason for the insignificant difference but from the multi-user performance tests there seems to be some benefits seen with the cache (also this benefit seems logical)

 


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
