### PR TITLE
Stop using `controller … can` syntax in ledger tests

### DIFF
--- a/ledger/sandbox-perf/src/perf/resources/damls/LargeTransaction.daml
+++ b/ledger/sandbox-perf/src/perf/resources/damls/LargeTransaction.daml
@@ -54,25 +54,26 @@ template RangeOfInts
     size: Int
   where
     signatory party
-    controller party can
-      ToList: [Int]
-        do return (range start (\x -> x + step) size)
-      ToListContainer: ContractId ListContainer
-        do create ListContainer with party = party, list = (range start (\x -> x + step) size)
-      ToListOfIntContainers: [ContractId IntContainer]
-        do
-          let xs: [Int] = (range start (\x -> x + step) size)
-          mapA (\x -> create IntContainer with party = party, value = x) xs
+    choice ToList: [Int]
+      controller party
+      do return (range start (\x -> x + step) size)
+    choice ToListContainer: ContractId ListContainer
+      controller party
+      do create ListContainer with party = party, list = (range start (\x -> x + step) size)
+    choice ToListOfIntContainers: [ContractId IntContainer]
+      controller party
+      do let xs: [Int] = (range start (\x -> x + step) size)
+         mapA (\x -> create IntContainer with party = party, value = x) xs
 
 template ListUtil
   with
     party: Party
   where
     signatory party
-    controller party can
-      Size: ContractId IntContainer
-        with list: [Int]
-        do create IntContainer with party = party, value = (length list)
+    choice Size: ContractId IntContainer
+      with list: [Int]
+      controller party
+      do create IntContainer with party = party, value = (length list)
         
 rangeOfIntsToListTest = scenario do
     p <- getParty "Dummy"

--- a/ledger/test-common/src/main/daml/model/Iou.daml
+++ b/ledger/test-common/src/main/daml/model/Iou.daml
@@ -20,49 +20,45 @@ template Iou
 
     observer observers
 
-    controller owner can
+    -- Split the IOU by dividing the amount.
+    choice Iou_Split : (IouCid, IouCid)
+      with splitAmount: Decimal
+      controller owner
+      do let restAmount = amount - splitAmount
+         splitCid <- create this with amount = splitAmount
+         restCid <- create this with amount = restAmount
+         return (splitCid, restCid)
 
-      -- Split the IOU by dividing the amount.
-      Iou_Split : (IouCid, IouCid)
-         with
-          splitAmount: Decimal
-        do
-          let restAmount = amount - splitAmount
-          splitCid <- create this with amount = splitAmount
-          restCid <- create this with amount = restAmount
-          return (splitCid, restCid)
+    -- Merge two IOUs by aggregating their amounts.
+    choice Iou_Merge : IouCid
+      with otherCid: IouCid
+      controller owner
+      do otherIou <- fetch otherCid
+         -- Check the two IOU's are compatible
+         assert (
+           currency == otherIou.currency &&
+           owner == otherIou.owner &&
+           issuer == otherIou.issuer
+           )
+         -- Retire the old Iou
+         archive otherCid
+         -- Return the merged Iou
+         create this with amount = amount + otherIou.amount
 
-      -- Merge two IOUs by aggregating their amounts.
-      Iou_Merge : IouCid
-        with
-          otherCid: IouCid
-        do
-          otherIou <- fetch otherCid
-          -- Check the two IOU's are compatible
-          assert (
-            currency == otherIou.currency &&
-            owner == otherIou.owner &&
-            issuer == otherIou.issuer
-            )
-          -- Retire the old Iou
-          archive otherCid
-          -- Return the merged Iou
-          create this with amount = amount + otherIou.amount
+    choice Iou_Transfer : ContractId IouTransfer
+      with newOwner : Party
+      controller owner
+      do create IouTransfer with iou = this; newOwner
 
-      Iou_Transfer : ContractId IouTransfer
-        with
-          newOwner : Party
-        do create IouTransfer with iou = this; newOwner
+    choice Iou_AddObserver : IouCid
+      with newObserver : Party
+      controller owner
+      do create this with observers = newObserver :: observers
 
-      Iou_AddObserver : IouCid
-        with
-          newObserver : Party
-        do create this with observers = newObserver :: observers
-
-      Iou_RemoveObserver : IouCid
-        with
-          oldObserver : Party
-        do create this with observers = filter (/= oldObserver) observers
+    choice Iou_RemoveObserver : IouCid
+      with oldObserver : Party
+      controller owner
+      do create this with observers = filter (/= oldObserver) observers
 
 template IouTransfer
   with
@@ -70,17 +66,18 @@ template IouTransfer
     newOwner : Party
   where
     signatory iou.issuer, iou.owner
+    observer newOwner
 
-    controller iou.owner can
-      IouTransfer_Cancel : IouCid
-        do create iou
+    choice IouTransfer_Cancel : IouCid
+      controller iou.owner
+      do create iou
 
-    controller newOwner can
-      IouTransfer_Reject : IouCid
-        do create iou
+    choice IouTransfer_Reject : IouCid
+      controller newOwner
+      do create iou
 
-      IouTransfer_Accept : IouCid
-        do
-          create iou with
-            owner = newOwner
-            observers = []
+    choice IouTransfer_Accept : IouCid
+      controller newOwner
+      do create iou with
+           owner = newOwner
+           observers = []

--- a/ledger/test-common/src/main/daml/model/IouTrade.daml
+++ b/ledger/test-common/src/main/daml/model/IouTrade.daml
@@ -21,29 +21,30 @@ template IouTrade
     quoteAmount : Decimal
   where
     signatory buyer
+    observer seller
 
-    controller seller can
-      IouTrade_Accept : (IouCid, IouCid)
-        with
-          quoteIouCid : IouCid
-        do
-          baseIou <- fetch baseIouCid
-          baseIssuer === baseIou.issuer
-          baseCurrency === baseIou.currency
-          baseAmount === baseIou.amount
-          buyer === baseIou.owner
-          quoteIou <- fetch quoteIouCid
-          quoteIssuer === quoteIou.issuer
-          quoteCurrency === quoteIou.currency
-          quoteAmount === quoteIou.amount
-          seller === quoteIou.owner
-          quoteIouTransferCid <- exercise quoteIouCid Iou_Transfer with
-            newOwner = buyer
-          transferredQuoteIouCid <- exercise quoteIouTransferCid IouTransfer_Accept
-          baseIouTransferCid <- exercise baseIouCid Iou_Transfer with
-            newOwner = seller
-          transferredBaseIouCid <- exercise baseIouTransferCid IouTransfer_Accept
-          return (transferredQuoteIouCid, transferredBaseIouCid)
+    choice IouTrade_Accept : (IouCid, IouCid)
+      with
+        quoteIouCid : IouCid
+      controller seller
+      do baseIou <- fetch baseIouCid
+         baseIssuer === baseIou.issuer
+         baseCurrency === baseIou.currency
+         baseAmount === baseIou.amount
+         buyer === baseIou.owner
+         quoteIou <- fetch quoteIouCid
+         quoteIssuer === quoteIou.issuer
+         quoteCurrency === quoteIou.currency
+         quoteAmount === quoteIou.amount
+         seller === quoteIou.owner
+         quoteIouTransferCid <- exercise quoteIouCid Iou_Transfer with
+           newOwner = buyer
+         transferredQuoteIouCid <- exercise quoteIouTransferCid IouTransfer_Accept
+         baseIouTransferCid <- exercise baseIouCid Iou_Transfer with
+           newOwner = seller
+         transferredBaseIouCid <- exercise baseIouTransferCid IouTransfer_Accept
+         return (transferredQuoteIouCid, transferredBaseIouCid)
 
-      TradeProposal_Reject : ()
-        do return ()
+    choice TradeProposal_Reject : ()
+      controller seller
+      do return ()

--- a/ledger/test-common/src/main/daml/model/Test.daml
+++ b/ledger/test-common/src/main/daml/model/Test.daml
@@ -273,8 +273,9 @@ template BranchingControllers
     ctrlFalse : Party
   where
   signatory giver
-  observer ctrl
   let ctrl = if whichCtrl then ctrlTrue else ctrlFalse
+  observer ctrl
+
   choice Delete : ()
     controller ctrl
     do return ()

--- a/ledger/test-common/src/main/daml/model/Test.daml
+++ b/ledger/test-common/src/main/daml/model/Test.daml
@@ -18,41 +18,38 @@ template Dummy
 
     agreement (show operator <> " operates a dummy.")
 
-    controller operator can
-      DummyChoice1 : ()
-        do return ()
+    choice DummyChoice1 : ()
+      controller operator
+      do return ()
 
-    controller operator can
-      FailingChoice : ()
-        do assert False
-
-
-    controller operator can
-      nonconsuming Clone: ContractId Dummy
-        do create Dummy with operator
-
-    controller operator can
-      nonconsuming FailingClone : ()
-        do
-          clone <- exercise self Clone
-          exercise self FailingChoice
+    choice FailingChoice : ()
+      controller operator
+      do assert False
 
 
-    controller operator can
-      ConsumeIfTimeIsBetween : ()
-        with
-          begin : Time
-          end : Time
-        do
-          currentTime <- getTime
-          assert (begin <= currentTime)
-          assert (currentTime <= end)
+    nonconsuming choice Clone: ContractId Dummy
+      controller operator
+      do create Dummy with operator
 
-    controller operator can
-      WrapWithAddress : ContractId AddressWrapper
-        with address : Address
-        do
-          create AddressWrapper with operator; address
+    nonconsuming choice FailingClone : ()
+      controller operator
+      do clone <- exercise self Clone
+         exercise self FailingChoice
+
+
+    choice ConsumeIfTimeIsBetween : ()
+      with
+        begin : Time
+        end : Time
+      controller operator
+      do currentTime <- getTime
+         assert (begin <= currentTime)
+         assert (currentTime <= end)
+
+    choice WrapWithAddress : ContractId AddressWrapper
+      with address : Address
+      controller operator
+      do create AddressWrapper with operator; address
 
 data Address = Address
   { street: Text
@@ -75,10 +72,10 @@ template DummyWithParam
   where
     signatory operator
 
-    controller operator can
-      DummyChoice2 : ()
-        with paramString: Text
-        do return ()
+    choice DummyChoice2 : ()
+      with paramString: Text
+      controller operator
+      do return ()
 
 template DummyWithAnnotation
   with
@@ -93,12 +90,11 @@ template DummyFactory
   where
     signatory operator
 
-    controller operator can
-      DummyFactoryCall : ()
-        do
-          split <- create Dummy with operator
-          rest <- create DummyWithParam with operator
-          return ()
+    choice DummyFactoryCall : ()
+      controller operator
+      do split <- create Dummy with operator
+         rest <- create DummyWithParam with operator
+         return ()
 
 
 data OptionalInteger = SomeInteger Int | NoInteger
@@ -125,38 +121,35 @@ template ParameterShowcase
     maintainer key._1
 
     -- multiple argument choice
-    controller operator can
-      Choice1 : ContractId ParameterShowcase
-        with
-          newInteger: Int
-          newDecimal: Decimal
-          newText: Text
-          newBool: Bool
-          newTime: Time
-          newNestedOptionalInteger: NestedOptionalInteger
-          newIntegerList: [Int]
-          newOptionalText: Optional Text
-        do
-          let new = this with
-                { integer = newInteger
-                , decimal = newDecimal
-                , text = newText
-                , bool = newBool
-                , time = newTime
-                , nestedOptionalInteger = newNestedOptionalInteger
-                , integerList = newIntegerList
-                , optionalText = newOptionalText
-                }
-          create new
+    choice Choice1 : ContractId ParameterShowcase
+      with
+        newInteger: Int
+        newDecimal: Decimal
+        newText: Text
+        newBool: Bool
+        newTime: Time
+        newNestedOptionalInteger: NestedOptionalInteger
+        newIntegerList: [Int]
+        newOptionalText: Optional Text
+      controller operator
+      do let new = this with
+               { integer = newInteger
+               , decimal = newDecimal
+               , text = newText
+               , bool = newBool
+               , time = newTime
+               , nestedOptionalInteger = newNestedOptionalInteger
+               , integerList = newIntegerList
+               , optionalText = newOptionalText
+               }
+         create new
 
     -- single argument choice
-    controller operator can
-      Choice2 : ContractId ParameterShowcase
-        with
-          newInteger: Int
-        do
-          let new = this with integer = newInteger
-          create new
+    choice Choice2 : ContractId ParameterShowcase
+      with newInteger: Int
+      controller operator
+      do let new = this with integer = newInteger
+         create new
 
 template Agreement
   with
@@ -169,17 +162,17 @@ template Agreement
       show giver <> " promise to pay the " <>
       show receiver <> " on demand the sum of five pounds.")
 
-    controller giver can
-      AcceptTriProposal : ContractId TriAgreement
-        with cid : ContractId TriProposal
-        do
-          prop <- fetch cid
-          assert (prop.receiver == receiver && prop.giver == giver)
-          exercise cid TriProposalAccept
+    choice AcceptTriProposal : ContractId TriAgreement
+      with cid : ContractId TriProposal
+      controller giver
+      do prop <- fetch cid
+         assert (prop.receiver == receiver && prop.giver == giver)
+         exercise cid TriProposalAccept
 
-      UnrestrictedAcceptTriProposal : ContractId TriAgreement
-        with cid: ContractId TriProposal
-        do exercise cid TriProposalAccept
+    choice UnrestrictedAcceptTriProposal : ContractId TriAgreement
+      with cid: ContractId TriProposal
+      controller giver
+      do exercise cid TriProposalAccept
 
 template DummyContractFactory
  with
@@ -187,12 +180,11 @@ template DummyContractFactory
   where
     signatory operator
 
-    controller operator can
-      DummyContractFactoryCall : ContractId Dummy
-        do
-          split <- create Dummy with operator
-          rest <- create DummyWithParam with operator
-          pure split
+    choice DummyContractFactoryCall : ContractId Dummy
+      controller operator
+      do split <- create Dummy with operator
+         rest <- create DummyWithParam with operator
+         pure split
 
 template AgreementFactory
   with
@@ -200,13 +192,15 @@ template AgreementFactory
     giver: Party
   where
     signatory giver
+    observer receiver
 
-    controller receiver can
-      nonconsuming CreateAgreement : ContractId Agreement
-        do create Agreement with receiver, giver
+    nonconsuming choice CreateAgreement : ContractId Agreement
+      controller receiver
+      do create Agreement with receiver, giver
 
-      AgreementFactoryAccept : ContractId Agreement
-        do create Agreement with receiver, giver
+    nonconsuming choice AgreementFactoryAccept : ContractId Agreement
+      controller receiver
+      do create Agreement with receiver, giver
 
 template TriAgreement
   with
@@ -223,10 +217,11 @@ template TriProposal
     giver: Party
   where
     signatory operator
+    observer receiver, giver
 
-    controller [receiver, giver] can
-      TriProposalAccept : ContractId TriAgreement
-        do create TriAgreement with operator, receiver, giver
+    choice TriProposalAccept : ContractId TriAgreement
+      controller [receiver, giver]
+      do create TriAgreement with operator, receiver, giver
 
 template TextContainer
   with
@@ -235,9 +230,9 @@ template TextContainer
   where
     signatory operator
 
-    controller operator can
-      Consume : ()
-        do return ()
+    choice Consume : ()
+      controller operator
+      do return ()
 
 template NothingArgument
   with
@@ -246,9 +241,9 @@ template NothingArgument
   where
     signatory operator
 
-    controller operator can
-      Choose : ()
-        do return ()
+    choice Choose : ()
+      controller operator
+      do return ()
 
 template WithObservers
   with
@@ -258,9 +253,9 @@ template WithObservers
   signatory giver
   observer observers
 
-  controller giver can
-    Ping : ()
-      do return ()
+  choice Ping : ()
+    controller giver
+    do return ()
 
 template BranchingSignatories
   with
@@ -278,9 +273,11 @@ template BranchingControllers
     ctrlFalse : Party
   where
   signatory giver
-  controller (if whichCtrl then ctrlTrue else ctrlFalse) can
-    Delete : ()
-      do return ()
+  observer ctrl
+  let ctrl = if whichCtrl then ctrlTrue else ctrlFalse
+  choice Delete : ()
+    controller ctrl
+    do return ()
 
 
 template PayOut
@@ -301,12 +298,14 @@ template CallablePayout
     receiver: Party
   where
     signatory giver
-    controller receiver can
-      Call : ContractId PayOut
-        do create PayOut with receiver, giver
-      Transfer : ContractId CallablePayout
-        with newReceiver: Party
-          do create this with receiver = newReceiver
+    observer receiver
+    choice Call : ContractId PayOut
+      controller receiver
+      do create PayOut with receiver, giver
+    choice Transfer : ContractId CallablePayout
+      with newReceiver: Party
+      controller receiver
+      do create this with receiver = newReceiver
 
 template TextKey
   with
@@ -320,10 +319,9 @@ template TextKey
     key (tkParty, tkKey) : (Party, Text)
     maintainer key._1
 
-    controller tkParty can
-      TextKeyChoice : ()
-        do
-          return ()
+    choice TextKeyChoice : ()
+      controller tkParty
+      do return ()
 
 template TextKeyOperations
   with
@@ -332,46 +330,41 @@ template TextKeyOperations
   where
     signatory tkoParty
 
-    controller tkoParty can
-      nonconsuming TKOLookup: ()
-        with
-          keyToLookup: (Party, Text)
-          expected: Optional (ContractId TextKey)
-        do
-          actual <- lookupByKey @TextKey keyToLookup
-          assertMsg ("lookup matches (" <> show expected <> ", " <> show actual <> ")") (expected == actual)
+    nonconsuming choice TKOLookup: ()
+      with
+        keyToLookup: (Party, Text)
+        expected: Optional (ContractId TextKey)
+      controller tkoParty
+      do actual <- lookupByKey @TextKey keyToLookup
+         assertMsg ("lookup matches (" <> show expected <> ", " <> show actual <> ")") (expected == actual)
 
-    controller tkoParty can
-      nonconsuming TKOFetch: ()
-        with
-          keyToFetch: (Party, Text)
-          expectedCid: ContractId TextKey
-        do
-          (actualCid, actualContract) <- fetchByKey @TextKey keyToFetch
-          assertMsg "fetch contract id matches" (expectedCid == actualCid)
-          assertMsg "fetch contract matches" (keyToFetch == key actualContract)
+    nonconsuming choice TKOFetch: ()
+      with
+        keyToFetch: (Party, Text)
+        expectedCid: ContractId TextKey
+      controller tkoParty
+      do (actualCid, actualContract) <- fetchByKey @TextKey keyToFetch
+         assertMsg "fetch contract id matches" (expectedCid == actualCid)
+         assertMsg "fetch contract matches" (keyToFetch == key actualContract)
 
-    controller tkoParty can
-      nonconsuming TKOConsumeAndLookup: ()
-        with
-          cidToConsume: ContractId TextKey
-          keyToLookup: (Party, Text)
-        do
-          mbCid1 <- lookupByKey @TextKey keyToLookup
-          assertMsg "gets contract the first time" (mbCid1 == Some cidToConsume)
-          exercise cidToConsume TextKeyChoice
-          mbCid2 <- lookupByKey @TextKey keyToLookup
-          assertMsg "does not get contract after exercise" (mbCid2 == None)
+    nonconsuming choice TKOConsumeAndLookup: ()
+      with
+        cidToConsume: ContractId TextKey
+        keyToLookup: (Party, Text)
+      controller tkoParty
+      do mbCid1 <- lookupByKey @TextKey keyToLookup
+         assertMsg "gets contract the first time" (mbCid1 == Some cidToConsume)
+         exercise cidToConsume TextKeyChoice
+         mbCid2 <- lookupByKey @TextKey keyToLookup
+         assertMsg "does not get contract after exercise" (mbCid2 == None)
 
-    controller tkoParty can
-      nonconsuming TKOFetchAndRecreate : ()
-        with
-          keyToFetch: (Party, Text)
-        do
-          (cid, contract) <- fetchByKey @TextKey keyToFetch
-          exercise cid TextKeyChoice
-          cid2 <- create TextKey with tkParty = contract.tkParty, tkKey = contract.tkKey, tkDisclosedTo = contract.tkDisclosedTo
-          return ()
+    nonconsuming choice TKOFetchAndRecreate : ()
+      with keyToFetch: (Party, Text)
+      controller tkoParty
+      do (cid, contract) <- fetchByKey @TextKey keyToFetch
+         exercise cid TextKeyChoice
+         cid2 <- create TextKey with tkParty = contract.tkParty, tkKey = contract.tkKey, tkDisclosedTo = contract.tkDisclosedTo
+         return ()
 
 template LocalKeyVisibilityOperations
   with
@@ -409,21 +402,20 @@ template Divulgence2
     div2Fetcher: Party
   where
     signatory div2Signatory
+    observer div2Fetcher
 
-    controller div2Fetcher can
-      nonconsuming Divulgence2Fetch: ()
-        with
-          div1ToFetch: ContractId Divulgence1
-        do
-          _ <- fetch div1ToFetch
-          return ()
+    nonconsuming choice Divulgence2Fetch: ()
+      with
+        div1ToFetch: ContractId Divulgence1
+      controller div2Fetcher
+      do _ <- fetch div1ToFetch
+         return ()
 
-    controller div2Fetcher can
-      nonconsuming Divulgence2Archive: ()
-        with
-          div1ToArchive: ContractId Divulgence1
-        do
-          archive div1ToArchive
+    nonconsuming choice Divulgence2Archive: ()
+      with
+        div1ToArchive: ContractId Divulgence1
+      controller div2Fetcher
+      do archive div1ToArchive
 
 template DecimalRounding
   with
@@ -466,20 +458,19 @@ template Delegated
     key (owner, k) : (Party, Text)
     maintainer key._1
 
-    controller owner can
-      Recreate: () do
-        create this
-        return ()
+    choice Recreate: ()
+      controller owner
+      do create this
+         return ()
 
       -- Non-consuming choice to test that contract keys created and archived
       -- by transient contracts are properly handled.
-    controller owner can
-      nonconsuming CreateAnotherAndArchive: ()
-        with
-          k2: Text
-        do
-          cid <- create Delegated with owner = owner, k = k2
-          exercise cid Archive
+    nonconsuming choice CreateAnotherAndArchive: ()
+      with
+        k2: Text
+      controller owner
+      do cid <- create Delegated with owner = owner, k = k2
+         exercise cid Archive
 
 template Delegation
   with
@@ -489,28 +480,26 @@ template Delegation
     signatory owner
     observer delegate
 
-    controller delegate can
-      nonconsuming FetchDelegated: Delegated
-        with delegated: ContractId Delegated
-        do fetch delegated
+    nonconsuming choice FetchDelegated: Delegated
+      with delegated: ContractId Delegated
+      controller delegate
+      do fetch delegated
 
-    controller delegate can
-      nonconsuming FetchByKeyDelegated: ()
-        with
-          p: Party
-          k: Text
-        do
-          _ <- fetchByKey @Delegated (p, k)
-          pure ()
+    nonconsuming choice FetchByKeyDelegated: ()
+      with
+        p: Party
+        k: Text
+      controller delegate
+      do _ <- fetchByKey @Delegated (p, k)
+         pure ()
 
-    controller delegate can
-      nonconsuming LookupByKeyDelegated: ()
-        with
-          p: Party
-          k: Text
-        do
-          _ <- lookupByKey @Delegated (p, k)
-          pure ()
+    nonconsuming choice LookupByKeyDelegated: ()
+      with
+        p: Party
+        k: Text
+      controller delegate
+      do _ <- lookupByKey @Delegated (p, k)
+         pure ()
 
 
 template ShowDelegated
@@ -520,12 +509,11 @@ template ShowDelegated
   where
     signatory owner
     observer delegate
-    controller owner can
-      ShowIt : ()
-        with delegatedId: ContractId Delegated
-        do
-          fetch delegatedId
-          return ()
+    choice ShowIt : ()
+      with delegatedId: ContractId Delegated
+      controller owner
+      do fetch delegatedId
+         return ()
 
 testDivulgenceVisibility = scenario do
   owner <- getParty "owner"
@@ -579,14 +567,13 @@ template DivulgeWitnesses
     p_actor: Party
   where
     signatory p_actor
+    observer p_signatory
 
-    controller p_signatory can
-      Divulge: ()
-        with
-          toFetch: ContractId Witnesses
-        do
-          _ <- fetch toFetch
-          return ()
+    choice Divulge: ()
+      with toFetch: ContractId Witnesses
+      controller p_signatory
+      do _ <- fetch toFetch
+         return ()
 
 template MaintainerNotSignatory
   with
@@ -604,12 +591,11 @@ template CreateAndFetch
   where
     signatory p
 
-    controller p can
-      CreateAndFetch_Run: ()
-        do
-            cid <- create CreateAndFetch with p
-            _ <- fetch cid
-            return ()
+    choice CreateAndFetch_Run: ()
+      controller p
+      do cid <- create CreateAndFetch with p
+         _ <- fetch cid
+         return ()
 
 template Proposal
   with
@@ -617,12 +603,12 @@ template Proposal
     to: Party
   where
     signatory from
-    controller to can
-      ProposalAccept: ContractId Asset
-        with asset: ContractId Asset
-        do
-          fetch asset
-          exercise asset AssetTransfer with newOwner = from
+    observer to
+    choice ProposalAccept: ContractId Asset
+      with asset: ContractId Asset
+      controller to
+      do fetch asset
+         exercise asset AssetTransfer with newOwner = from
 
 template Asset
   with
@@ -630,12 +616,13 @@ template Asset
     owner: Party
   where
     signatory issuer
+    observer owner
     key issuer: Party
     maintainer key
-    controller owner can
-      AssetTransfer: ContractId Asset
-        with newOwner: Party
-        do create this with owner = newOwner
+    choice AssetTransfer: ContractId Asset
+      with newOwner: Party
+      controller owner
+      do create this with owner = newOwner
 
 template MultiPartyContract
   with
@@ -735,11 +722,11 @@ template WithKeyDivulgenceHelper
     withKeyOwner : Party
   where
     signatory divulgedTo
+    observer withKeyOwner
 
-    controller withKeyOwner can
-      nonconsuming WithKeyDivulgenceHelper_Fetch: ()
-        with
-          withKeyToFetch: ContractId WithKey
-        do
-          _ <- fetch withKeyToFetch
-          return ()
+    nonconsuming choice WithKeyDivulgenceHelper_Fetch: ()
+      with
+        withKeyToFetch: ContractId WithKey
+      controller withKeyOwner
+      do _ <- fetch withKeyToFetch
+         return ()

--- a/ledger/test-common/src/main/daml/package_management/PackageManagementTest.daml
+++ b/ledger/test-common/src/main/daml/package_management/PackageManagementTest.daml
@@ -13,6 +13,6 @@ template PackageManagementTestTemplate
   where
     signatory owner
 
-    controller owner can
-      TestChoice: ()
-        do return ()
+    choice TestChoice: ()
+      controller owner
+      do return ()

--- a/ledger/test-common/src/main/daml/performance/PingPong.daml
+++ b/ledger/test-common/src/main/daml/performance/PingPong.daml
@@ -31,9 +31,9 @@ template Pong
       signatory initiator, responder
       observer observers
 
-      controller initiator can
-        Ack : ()
-          do return ()
+      choice Ack : ()
+        controller initiator
+        do return ()
 
 main = scenario do
     [alice, bob] <- mapA getParty ["Alice", "Bob"]

--- a/ledger/test-common/src/main/daml/semantic/ContractIdTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/ContractIdTests.daml
@@ -17,7 +17,7 @@ template ContractRef
     signatory party
     key party: Party
     maintainer key
-    controller party can
-      Change: ContractId ContractRef
-        with newId: ContractId Contract
-        do create (ContractRef party newId)
+    choice Change: ContractId ContractRef
+      with newId: ContractId Contract
+      controller party
+      do create (ContractRef party newId)

--- a/ledger/test-common/src/main/daml/semantic/DeeplyNestedValue.daml
+++ b/ledger/test-common/src/main/daml/semantic/DeeplyNestedValue.daml
@@ -42,47 +42,41 @@ template Handler
     party : Party
   where
     signatory party
-    controller party can
-      nonconsuming Construct : Nat
-        with i : Int
-        do
-          pure $ toNat i
-      nonconsuming Destruct : Int
-        with n: Nat
-        do pure $ toInt n
-      nonconsuming ConstructThenDestruct : Int
-        with
-          i: Int
-        do
-          exercise self Destruct with n = toNat i
-      nonconsuming Create: ContractId Contract
-        with
-          i : Int
-        do
-          create Contract with
-            party = party
-            i = i
-            n = toNat i
-      nonconsuming CreateKey: ContractId ContractWithKey
-        with
-          i : Int
-        do
-          create ContractWithKey with
-            party = party
-            i = i
-      nonconsuming Fetch: Contract
-        with cid: ContractId Contract
-        do
-          fetch cid
-      nonconsuming FetchByKey: ContractId ContractWithKey
-        with
-          i: Int
-        do
-          (cid, _) <- fetchByKey @ContractWithKey (party, toNat i)
-          pure cid
-      nonconsuming LookupByKey: Optional (ContractId ContractWithKey)
-        with
-          i: Int
-        do
-          lookupByKey @ContractWithKey (party, toNat i)
-
+    nonconsuming choice Construct : Nat
+      with i : Int
+      controller party
+      do pure $ toNat i
+    nonconsuming choice Destruct : Int
+      with n: Nat
+      controller party
+      do pure $ toInt n
+    nonconsuming choice ConstructThenDestruct : Int
+      with i: Int
+      controller party
+      do exercise self Destruct with n = toNat i
+    nonconsuming choice Create: ContractId Contract
+      with i : Int
+      controller party
+      do create Contract with
+           party = party
+           i = i
+           n = toNat i
+    nonconsuming choice CreateKey: ContractId ContractWithKey
+      with i : Int
+      controller party
+      do create ContractWithKey with
+           party = party
+           i = i
+    nonconsuming choice Fetch: Contract
+      with cid: ContractId Contract
+      controller party
+      do fetch cid
+    nonconsuming choice FetchByKey: ContractId ContractWithKey
+      with i: Int
+      controller party
+      do (cid, _) <- fetchByKey @ContractWithKey (party, toNat i)
+         pure cid
+    nonconsuming choice LookupByKey: Optional (ContractId ContractWithKey)
+      with i: Int
+      controller party
+      do lookupByKey @ContractWithKey (party, toNat i)

--- a/ledger/test-common/src/main/daml/semantic/DivulgenceTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/DivulgenceTests.daml
@@ -16,23 +16,24 @@ template Divulgence
   where
     signatory divulgee, divulger
 
-    controller divulger can
-      nonconsuming Divulge: ()
-        with contractId: ContractId Contract
-          -- create an event so the transaction is visible on the GetTransactionTrees endpoint
-          do create Dummy with holder=divulger
-             fetch contractId
-             return ()
+    nonconsuming choice Divulge: ()
+      with contractId: ContractId Contract
+        -- create an event so the transaction is visible on the GetTransactionTrees endpoint
+      controller divulger
+      do create Dummy with holder=divulger
+         fetch contractId
+         return ()
 
-      nonconsuming CreateAndDisclose: ContractId Contract
-          do create Contract with party=divulger
+    nonconsuming choice CreateAndDisclose: ContractId Contract
+      controller divulger
+      do create Contract with party=divulger
 
-    controller divulgee can
-      nonconsuming CanFetch: ContractId Dummy
-        with contractId: ContractId Contract
-          do fetch contractId
-             -- create an event so the transaction is visible on the GetTransactionTrees endpoint
-             create Dummy with holder=divulgee
+    nonconsuming choice CanFetch: ContractId Dummy
+      with contractId: ContractId Contract
+      controller divulgee
+     do fetch contractId
+        -- create an event so the transaction is visible on the GetTransactionTrees endpoint
+        create Dummy with holder=divulgee
 
 template DivulgenceProposal
   with
@@ -40,10 +41,11 @@ template DivulgenceProposal
     other: Party
   where
     signatory sig
+    observer other
 
-    controller other can
-      Accept: ContractId Divulgence
-          do create Divulgence with divulger=sig, divulgee=other
+    choice Accept: ContractId Divulgence
+      controller other
+      do create Divulgence with divulger=sig, divulgee=other
 
 template DivulgeNotDiscloseTemplate
   with
@@ -52,12 +54,12 @@ template DivulgeNotDiscloseTemplate
   where
     signatory divulger
 
-    controller divulger can
-      nonconsuming DivulgeNoDisclose: ()
-        with divulgence: ContractId Divulgence
-          do contract <- create Contract with party=divulger
-             exercise divulgence Divulge with contractId=contract
-             return ()
+    nonconsuming choice DivulgeNoDisclose: ()
+      with divulgence: ContractId Divulgence
+      controller divulger
+      do contract <- create Contract with party=divulger
+         exercise divulgence Divulge with contractId=contract
+         return ()
 
 -- Dummy contracts are used to signal transactions on the TransactionTree service.
 -- It is structurally equal to the `Contract` template, but kept separate for the signalling purpose.

--- a/ledger/test-common/src/main/daml/semantic/ExceptionRaceTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/ExceptionRaceTests.daml
@@ -32,28 +32,26 @@ template ContractWithKey with
     key owner: Party
     maintainer key
 
-    controller owner can
-      ContractWithKey_Archive : ()
-        do
-          return ()
+    choice ContractWithKey_Archive : ()
+      controller owner
+      do return ()
 
-    controller owner can
-      nonconsuming ContractWithKey_Exercise : ()
-        do
-          return ()
+    nonconsuming choice ContractWithKey_Exercise : ()
+      controller owner
+      do return ()
 
 template FetchWrapper with
     fetcher : Party
     contractId : ContractId ContractWithKey
   where 
     signatory fetcher
-    controller fetcher can
-      nonconsuming FetchWrapper_Fetch: ()
-        do try do
-             _ <- fetch contractId
-             throw E
-           catch
-             E -> pure ()
+    nonconsuming choice FetchWrapper_Fetch: ()
+      controller fetcher
+      do try do
+           _ <- fetch contractId
+           throw E
+         catch
+           E -> pure ()
 
 template LookupResult with
     owner : Party
@@ -66,51 +64,48 @@ template LookupWrapper with
   where
     signatory owner
 
-    controller owner can
-      nonconsuming LookupWrapper_Lookup : ()
-        do try do
-             optionalContractId <- lookupByKey @ContractWithKey owner
-             throw (LookupException (isSome optionalContractId))
-           catch
-             (LookupException successful) -> do
-               create LookupResult with owner = owner, found = successful
-               pure ()
+    nonconsuming choice LookupWrapper_Lookup : ()
+      controller owner
+      do try do
+           optionalContractId <- lookupByKey @ContractWithKey owner
+           throw (LookupException (isSome optionalContractId))
+         catch
+           (LookupException successful) -> do
+             create LookupResult with owner = owner, found = successful
+             pure ()
 
 template CreateWrapper with
     owner : Party
   where
     signatory owner
-    controller owner can
-      nonconsuming CreateWrapper_CreateRollback : ()
-        do
-          try do
-            contract <- create ContractWithKey with owner
-            throw E
-          catch
-            E -> pure ()
+    nonconsuming choice CreateWrapper_CreateRollback : ()
+      controller owner
+      do try do
+           contract <- create ContractWithKey with owner
+           throw E
+         catch
+           E -> pure ()
 
 template ExerciseWrapper
   with
     owner : Party
   where
     signatory owner
-    controller owner can
-      nonconsuming ExerciseWrapper_ExerciseConsumingRollback : ()
-        with
-          cid : ContractId ContractWithKey
-        do
-          try do
-            contract <- exercise cid Archive
-            throw E
-          catch
-            E -> pure ()
-      nonconsuming ExerciseWrapper_ExerciseNonConsumingRollback : ()
-        with
-          cid : ContractId ContractWithKey
-        do
-          try do
-            contract <- exercise cid ContractWithKey_Exercise
-            throw E
+    nonconsuming choice ExerciseWrapper_ExerciseConsumingRollback : ()
+      with
+        cid : ContractId ContractWithKey
+      controller owner
+      do try do
+           contract <- exercise cid Archive
+           throw E
+         catch
+           E -> pure ()
+    nonconsuming choice ExerciseWrapper_ExerciseNonConsumingRollback : ()
+      with cid : ContractId ContractWithKey
+      controller owner
+      do try do
+           contract <- exercise cid ContractWithKey_Exercise
+           throw E
           catch
             E -> pure ()
 #endif

--- a/ledger/test-common/src/main/daml/semantic/RaceTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/RaceTests.daml
@@ -19,24 +19,22 @@ template ContractWithKey with
     key owner: Party
     maintainer key
 
-    controller owner can
-      ContractWithKey_Archive : ()
-        do
-          return ()
+    choice ContractWithKey_Archive : ()
+      controller owner
+      do return ()
 
-    controller owner can
-      nonconsuming ContractWithKey_Exercise : ()
-        do
-          return ()
+    nonconsuming choice ContractWithKey_Exercise : ()
+      controller owner
+      do return ()
 
 template FetchWrapper with
     fetcher : Party
     contractId : ContractId ContractWithKey
   where 
     signatory fetcher
-    controller fetcher can
-      nonconsuming FetchWrapper_Fetch: ContractWithKey
-        do fetch contractId
+    nonconsuming choice FetchWrapper_Fetch: ContractWithKey
+      controller fetcher
+      do fetch contractId
 
 template LookupResult with
     owner : Party
@@ -49,20 +47,18 @@ template LookupWrapper with
   where
     signatory owner
 
-    controller owner can
-      nonconsuming LookupWrapper_Lookup : ()
-        do
-          optionalContractId <- lookupByKey @ContractWithKey owner
-          create LookupResult with owner = owner, found = isSome optionalContractId
-          pure ()
+    nonconsuming choice LookupWrapper_Lookup : ()
+      controller owner
+      do optionalContractId <- lookupByKey @ContractWithKey owner
+         create LookupResult with owner = owner, found = isSome optionalContractId
+         pure ()
 
 template CreateWrapper with
     owner : Party
   where
     signatory owner
-    controller owner can
-      nonconsuming CreateWrapper_CreateTransient : ()
-        do
-          contract <- create ContractWithKey with owner
-          _ <- exercise contract ContractWithKey_Archive
-          return ()
+    nonconsuming choice CreateWrapper_CreateTransient : ()
+      controller owner
+      do contract <- create ContractWithKey with owner
+         _ <- exercise contract ContractWithKey_Archive
+         return ()

--- a/ledger/test-common/src/main/daml/semantic/SemanticTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/SemanticTests.daml
@@ -35,11 +35,14 @@ template Iou
    amount: Amount
  where
    signatory payer
-   controller owner can
-     Call: ContractId GetCash
-       do create GetCash with payer; owner; amount
-     Transfer: ContractId Iou with newOwner: Party
-       do create Iou with payer; owner = newOwner; amount
+   observer owner
+   choice Call: ContractId GetCash
+     controller owner
+     do create GetCash with payer; owner; amount
+   choice Transfer: ContractId Iou
+     with newOwner: Party
+     controller owner
+     do create Iou with payer; owner = newOwner; amount
 
 -- Needed to test fetch via the Ledger API
 template FetchIou
@@ -48,9 +51,9 @@ template FetchIou
     iouCid : ContractId Iou
   where
     signatory fetcher
-    controller fetcher can
-      FetchIou_Fetch: Iou
-        do fetch iouCid
+    choice FetchIou_Fetch: Iou
+      controller fetcher
+      do fetch iouCid
 
 template SharedContract
  with
@@ -59,12 +62,16 @@ template SharedContract
    owner2: Party
  where
    signatory payer
-   controller owner1 can
-       SharedContract_Consume1: () do pure ()
-   controller owner2 can
-       SharedContract_Consume2: () do pure ()
-   controller [owner1, owner2] can
-       SharedContract_BothConsume: () do pure ()
+   observer owner1, owner2
+   choice SharedContract_Consume1: ()
+     controller owner1
+     do pure ()
+   choice SharedContract_Consume2: ()
+     controller owner2
+     do pure ()
+   choice SharedContract_BothConsume: ()
+     controller [owner1, owner2]
+     do pure ()
 
 ------------------------------------------------------------
 -- Authorization testing templates
@@ -77,17 +84,19 @@ template PaintOffer
     amount: Amount
   where
     signatory painter
-    controller houseOwner can
-      PaintOffer_Accept: (ContractId Iou, ContractId PaintAgree)
-        with iouCid: ContractId Iou
-          do (,) <$> exercise iouCid Transfer with newOwner = painter
-                 <*> create PaintAgree with painter; houseOwner
-      PaintOffer_Counter: ContractId PaintCounterOffer
-        with iouCid: ContractId Iou
-          do iou <- fetch iouCid
-             assert $ obligor == iou.payer
-             assert $ houseOwner == iou.owner
-             create PaintCounterOffer with iouCid; painter; houseOwner; obligor; amount = iou.amount
+    observer houseOwner
+    choice PaintOffer_Accept: (ContractId Iou, ContractId PaintAgree)
+      with iouCid: ContractId Iou
+      controller houseOwner
+      do (,) <$> exercise iouCid Transfer with newOwner = painter
+             <*> create PaintAgree with painter; houseOwner
+    choice PaintOffer_Counter: ContractId PaintCounterOffer
+      with iouCid: ContractId Iou
+      controller houseOwner
+      do iou <- fetch iouCid
+         assert $ obligor == iou.payer
+         assert $ houseOwner == iou.owner
+         create PaintCounterOffer with iouCid; painter; houseOwner; obligor; amount = iou.amount
 
 -- Needed to test fetch via the Ledger API
 template FetchPaintOffer
@@ -96,9 +105,9 @@ template FetchPaintOffer
     offerCid : ContractId PaintOffer
   where
     signatory fetcher
-    controller fetcher can
-      FetchPaintOffer_Fetch: PaintOffer
-          do fetch offerCid
+    choice FetchPaintOffer_Fetch: PaintOffer
+      controller fetcher
+      do fetch offerCid
 
 template PaintCounterOffer
   with
@@ -109,11 +118,12 @@ template PaintCounterOffer
     amount: Amount
   where
     signatory houseOwner
-    controller painter can
-      PaintCounterOffer_Accept: (ContractId Iou, ContractId PaintAgree)
-        do offerCid <- create PaintOffer with painter; houseOwner; obligor; amount
-           -- This is delegation, the painter exercises the offer on behalf of the houseOwner.
-           exercise offerCid PaintOffer_Accept with iouCid
+    observer painter
+    choice PaintCounterOffer_Accept: (ContractId Iou, ContractId PaintAgree)
+      controller painter
+      do offerCid <- create PaintOffer with painter; houseOwner; obligor; amount
+         -- This is delegation, the painter exercises the offer on behalf of the houseOwner.
+         exercise offerCid PaintOffer_Accept with iouCid
 
 template PaintAgree
   with
@@ -129,9 +139,9 @@ template FetchPaintAgree
     agreeCid : ContractId PaintAgree
   where
     signatory fetcher
-    controller fetcher can
-      FetchPaintAgree_Fetch: PaintAgree
-        do fetch agreeCid
+    choice FetchPaintAgree_Fetch: PaintAgree
+      controller fetcher
+      do fetch agreeCid
 
 ------------------------------------------------------------
 -- Divulgence testing templates
@@ -145,12 +155,14 @@ template Token
     signatory issuer
     observer owner
 
-    controller owner can
-      Token_Transfer : ContractId Token
-        with newOwner : Party
-        do create Token with issuer; owner = newOwner; id
+    choice Token_Transfer : ContractId Token
+      with newOwner : Party
+      controller owner
+      do create Token with issuer; owner = newOwner; id
 
-      Token_Consume: () do pure ()
+    choice Token_Consume: ()
+      controller owner
+      do pure ()
 
 template Delegation
   with
@@ -160,20 +172,21 @@ template Delegation
     signatory owner
     observer delegate
 
-    controller delegate can
-      Delegation_Token_Consume: ()
-        with tokenId: ContractId Token
-        do exercise tokenId Token_Consume
+    choice Delegation_Token_Consume: ()
+      with tokenId: ContractId Token
+      controller delegate
+      do exercise tokenId Token_Consume
 
-    controller owner can
-      -- Divulgance to delegate as a consuming choice is
-      -- visible to the observer.
-      Delegation_Divulge_Token: ()
-        with tokenId: ContractId Token
-        do fetch tokenId
-           pure ()
+    -- Divulgance to delegate as a consuming choice is
+    -- visible to the observer.
+    choice Delegation_Divulge_Token: ()
+      with tokenId: ContractId Token
+      controller owner
+      do fetch tokenId
+         pure ()
 
-      nonconsuming Delegation_Wrong_Divulge_Token: ()
-        with tokenId: ContractId Token
-        do fetch tokenId
-           pure ()
+    nonconsuming choice Delegation_Wrong_Divulge_Token: ()
+      with tokenId: ContractId Token
+      controller owner
+      do fetch tokenId
+         pure ()


### PR DESCRIPTION
We’re planning to deprecate that in SDK 2.0 to reduce the confusion
around the implicit observer behavior so in preparation for that, this
PR drops the syntax from all ledger tests.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
