### PR TITLE
Add command line option max-deduplication-duration for sandbox and KV [KVL-1098]

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -52,6 +52,7 @@ final case class Config[Extra](
     enableMutableContractStateCache: Boolean,
     enableInMemoryFanOutForLedgerApi: Boolean,
     enableHa: Boolean, // TODO ha: remove after stable
+    maxDeduplicationDuration: Option[Duration],
     extra: Extra,
 ) {
   def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): Config[Extra] =
@@ -87,6 +88,7 @@ object Config {
       enableMutableContractStateCache = false,
       enableInMemoryFanOutForLedgerApi = false,
       enableHa = false,
+      maxDeduplicationDuration = None,
       extra = extra,
     )
 
@@ -425,6 +427,17 @@ object Config {
           )
           .text(
             "Disable participant-side command deduplication."
+          )
+
+        opt[Duration]("max-deduplication-duration")
+          .optional()
+          .hidden()
+          .action((maxDeduplicationDuration, config) =>
+            config
+              .copy(maxDeduplicationDuration = Some(maxDeduplicationDuration))
+          )
+          .text(
+            "Max duration for command deduplication."
           )
 
         opt[Int]("max-inbound-message-size")

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -437,7 +437,7 @@ object Config {
               .copy(maxDeduplicationDuration = Some(maxDeduplicationDuration))
           )
           .text(
-            "Max duration for command deduplication."
+            "Maximum command deduplication duration."
           )
 
         opt[Int]("max-inbound-message-size")

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -94,10 +94,11 @@ trait ConfigProvider[ExtraConfig] {
     PartyConfiguration.default
 
   def initialLedgerConfig(config: Config[ExtraConfig]): InitialLedgerConfiguration = {
-    val defaultInitialConfiguration = Configuration.reasonableInitialConfiguration
     InitialLedgerConfiguration(
-      configuration = defaultInitialConfiguration.copy(maxDeduplicationTime =
-        config.maxDeduplicationDuration.getOrElse(defaultInitialConfiguration.maxDeduplicationTime)
+      configuration = Configuration.reasonableInitialConfiguration.copy(maxDeduplicationTime =
+        config.maxDeduplicationDuration.getOrElse(
+          Configuration.reasonableInitialConfiguration.maxDeduplicationTime
+        )
       ),
       // If a new index database is added to an already existing ledger,
       // a zero delay will likely produce a "configuration rejected" ledger entry,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -93,15 +93,19 @@ trait ConfigProvider[ExtraConfig] {
   def partyConfig(@unused config: Config[ExtraConfig]): PartyConfiguration =
     PartyConfiguration.default
 
-  def initialLedgerConfig(config: Config[ExtraConfig]): InitialLedgerConfiguration =
+  def initialLedgerConfig(config: Config[ExtraConfig]): InitialLedgerConfiguration = {
+    val defaultInitialConfiguration = Configuration.reasonableInitialConfiguration
     InitialLedgerConfiguration(
-      configuration = Configuration.reasonableInitialConfiguration,
+      configuration = defaultInitialConfiguration.copy(maxDeduplicationTime =
+        config.maxDeduplicationDuration.getOrElse(defaultInitialConfiguration.maxDeduplicationTime)
+      ),
       // If a new index database is added to an already existing ledger,
       // a zero delay will likely produce a "configuration rejected" ledger entry,
       // because at startup the indexer hasn't ingested any configuration change yet.
       // Override this setting for distributed ledgers where you want to avoid these superfluous entries.
       delayBeforeSubmitting = Duration.ZERO,
     )
+  }
 
   def timeServiceBackend(@unused config: Config[ExtraConfig]): Option[TimeServiceBackend] = None
 

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -342,6 +342,17 @@ class CommonCliBase(name: LedgerName) {
             " By default, compression is disabled."
         )
 
+      opt[Duration]("max-deduplication-duration")
+        .optional()
+        .hidden()
+        .action((maxDeduplicationDuration, config) =>
+          config
+            .copy(maxDeduplicationDuration = Some(maxDeduplicationDuration))
+        )
+        .text(
+          "Max duration for command deduplication."
+        )
+
       checkConfig(c => {
         if (c.enableCompression && !c.enableAppendOnlySchema)
           failure(

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -350,7 +350,7 @@ class CommonCliBase(name: LedgerName) {
             .copy(maxDeduplicationDuration = Some(maxDeduplicationDuration))
         )
         .text(
-          "Max duration for command deduplication."
+          "Maximum command deduplication duration."
         )
 
       checkConfig(c => {

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -64,6 +64,7 @@ final case class SandboxConfig(
     sqlStartMode: Option[PostgresStartupMode],
     enableAppendOnlySchema: Boolean,
     enableCompression: Boolean,
+    maxDeduplicationDuration: Option[Duration],
 ) {
 
   def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): SandboxConfig =
@@ -71,7 +72,12 @@ final case class SandboxConfig(
 
   lazy val initialLedgerConfiguration: InitialLedgerConfiguration =
     InitialLedgerConfiguration(
-      Configuration.reasonableInitialConfiguration.copy(timeModel = timeModel),
+      Configuration.reasonableInitialConfiguration.copy(
+        timeModel = timeModel,
+        maxDeduplicationTime = maxDeduplicationDuration.getOrElse(
+          Configuration.reasonableInitialConfiguration.maxDeduplicationTime
+        ),
+      ),
       delayBeforeSubmittingLedgerConfiguration,
     )
 }
@@ -137,6 +143,7 @@ object SandboxConfig {
       sqlStartMode = Some(DefaultSqlStartupMode),
       enableAppendOnlySchema = false,
       enableCompression = false,
+      maxDeduplicationDuration = None,
     )
 
   sealed abstract class EngineMode extends Product with Serializable


### PR DESCRIPTION
- We can use --max-deduplication-duration to configure the initial max deduplication duration for the ledger
- The main usage of this is specifying different max deduplication durations for tests.
- the max deduplication cannot be updated using the API

In a follow-up change, committer side deduplication will change to always use max_deduplication_duration as part of calculating the deduplication duration. This change allows us to modify the ledger config for tests

CHANGELOG_BEGIN

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
