### PR TITLE
Command deduplication - kvutils - Always use max deduplication duration as deduplication period [KVL-1098]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/CommandDeduplicationBase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/CommandDeduplicationBase.scala
@@ -27,7 +27,8 @@ private[testtool] abstract class CommandDeduplicationBase(
     case _ =>
       throw new IllegalArgumentException(s"Invalid timeout scale factor: $timeoutScaleFactor")
   }
-  val defaultDeduplicationWindowWait: FiniteDuration = deduplicationTime + ledgerTimeInterval * 2
+  val ledgerWaitInterval: FiniteDuration = ledgerTimeInterval * 2
+  val defaultDeduplicationWindowWait: FiniteDuration = deduplicationTime + ledgerWaitInterval
 
   def runGivenDeduplicationWait(context: ParticipantTestContext)(test: Duration => Future[Unit])(
       implicit ec: ExecutionContext

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/KVCommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/KVCommandDeduplicationIT.scala
@@ -27,11 +27,28 @@ final class KVCommandDeduplicationIT(timeoutScaleFactor: Double, ledgerTimeInter
   )(test: Duration => Future[Unit])(implicit ec: ExecutionContext): Future[Unit] = {
     // deduplication duration is increased by minSkew in the committer so we set the skew to a low value for testing
     val minSkew = 1.second.asProtobuf
-    runWithUpdatedOrFallbackTimeModel(
-      context,
-      _.update(_.minSkew := minSkew),
-      TimeModel.defaultInstance.update(_.minSkew := minSkew),
-    )(timeModel => test(defaultDeduplicationWindowWait.plus(timeModel.getMinSkew.asScala)))
+    context
+      .configuration()
+      .flatMap(ledgerConfiguration => {
+        val maxDeduplicationTime = ledgerConfiguration.maxDeduplicationTime
+          .getOrElse(
+            throw new IllegalStateException(
+              "Max deduplication time was not set and our deduplication period depends on it"
+            )
+          )
+          .asScala
+        assert(
+          maxDeduplicationTime <= 10.seconds,
+          s"Max deduplication time [$maxDeduplicationTime] is too high for the test.",
+        )
+        runWithUpdatedOrFallbackTimeModel(
+          context,
+          _.update(_.minSkew := minSkew),
+          TimeModel.defaultInstance.update(_.minSkew := minSkew),
+        )(timeModel =>
+          test(maxDeduplicationTime.plus(timeModel.getMinSkew.asScala).plus(ledgerWaitInterval))
+        )
+      })
   }
 
   private def runWithUpdatedOrFallbackTimeModel(

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -235,6 +235,7 @@ conformance_test(
         "--mutable-contract-state-cache",
         "--participant=participant-id=example1,port=6865",
         "--participant=participant-id=example2,port=6866",
+        "--max-deduplication-duration=PT10S",
     ],
     test_tool_args = [
         "--include=KVCommandDeduplicationIT",

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -288,6 +288,7 @@ conformance_test(
     server_args = [
         "--contract-id-seeding=testing-weak",
         "--participant=participant-id=example,port=6865",
+        "--max-deduplication-duration=PT10S",
     ],
     test_tool_args = [
         "--verbose",

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -305,6 +305,7 @@ da_scala_test_suite(
             server_args = [
                 "--contract-id-seeding=testing-weak",
                 "--participant participant-id=conformance-test,port=6865",
+                "--max-deduplication-duration=PT10S",
             ] + db.get("conformance_test_server_args", []),
             tags = db.get("conformance_test_tags", []),
             test_tool_args = db.get("conformance_test_tool_args", []) + [

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -39,6 +39,7 @@ final case class Config[Extra](
     participants: Seq[ParticipantConfig],
     maxInboundMessageSize: Int,
     configurationLoadTimeout: Duration,
+    maxDeduplicationDuration: Option[Duration],
     eventsPageSize: Int,
     eventsProcessingParallelism: Int,
     stateValueCache: caching.WeightedCache.Configuration,
@@ -52,7 +53,6 @@ final case class Config[Extra](
     enableMutableContractStateCache: Boolean,
     enableInMemoryFanOutForLedgerApi: Boolean,
     enableHa: Boolean, // TODO ha: remove after stable
-    maxDeduplicationDuration: Option[Duration],
     extra: Extra,
 ) {
   def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): Config[Extra] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -324,7 +324,8 @@ private[kvutils] class TransactionCommitter(
       transactionEntry: DamlTransactionEntrySummary,
   )(implicit loggingContext: LoggingContext): Unit = {
     val (_, config) = getCurrentConfiguration(defaultConfig, commitContext)
-    // Deduplication duration must be explicitly overwritten in a previous step (see [[TransactionCommitter.init]]) and set to ``config.maxDeduplicationTime``.
+    // Deduplication duration must be explicitly overwritten in a previous step
+    //  (see [[TransactionCommitter.overwriteDeduplicationPeriodWithMaxDuration]]) and set to ``config.maxDeduplicationTime``.
     if (!transactionEntry.submitterInfo.hasDeduplicationDuration) {
       throw Err.InvalidSubmission("Deduplication duration is not set.")
     }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -5,7 +5,10 @@ package com.daml.ledger.participant.state.kvutils
 
 import java.time.Duration
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntry, DamlTransactionRejectionEntry}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlLogEntry,
+  DamlTransactionRejectionEntry,
+}
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.v2.Update
@@ -16,7 +19,16 @@ import com.daml.lf.crypto.Hash
 import com.daml.lf.data.{FrontStack, Ref, SortedLookupList}
 import com.daml.lf.transaction.Node.NodeCreate
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.{ContractId, ValueList, ValueOptional, ValueParty, ValueRecord, ValueTextMap, ValueUnit, ValueVariant}
+import com.daml.lf.value.Value.{
+  ContractId,
+  ValueList,
+  ValueOptional,
+  ValueParty,
+  ValueRecord,
+  ValueTextMap,
+  ValueUnit,
+  ValueVariant,
+}
 import com.daml.logging.LoggingContext
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -197,7 +197,6 @@ class CommitterSpec
   }
 
   "runSteps" should {
-
     "stop at first StepStop" in {
       val expectedLogEntry = aLogEntry
       val instance = new TestCommitter {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -245,7 +245,7 @@ class TransactionCommitterSpec
           .build()
       }
 
-      "throw err for unsupported deduplication" in {
+      "throw an error for unsupported deduplication periods" in {
         forAll(
           Table[DamlSubmitterInfo.Builder => DamlSubmitterInfo.Builder](
             "deduplication setter",

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.participant.state.kvutils.Conversions.{buildDuration, bui
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
-import com.daml.ledger.participant.state.kvutils.committer._
+import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepStop}
 import com.daml.ledger.participant.state.kvutils.{Conversions, Err, committer}
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Time.Timestamp
@@ -266,7 +266,7 @@ class TransactionCommitterSpec
       }
     }
 
-    "overwrite deduplication period" should {
+    "overwriteDeduplicationPeriodWithMaxDuration" should {
       "set max deduplication duration as deduplication period" in {
         val maxDeduplicationDuration = time.Duration.ofSeconds(Random.nextLong())
         val config = theDefaultConfig.copy(maxDeduplicationTime = maxDeduplicationDuration)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -347,6 +347,7 @@ class TransactionCommitterSpec
 
       val (expectedContractInstance, txEntry) = txEntryWithDivulgedContract(builder, cid)
       val txEntryBuilder = txEntry.toBuilder
+      // deduplication duration is mandatory as we set the context dedup entry during blinding
       txEntryBuilder.getSubmitterInfoBuilder.setDeduplicationDuration(
         Duration.newBuilder().setSeconds(5)
       )

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -36,6 +36,7 @@ final case class SandboxConfig(
     damlPackages: List[File],
     timeProviderType: Option[TimeProviderType],
     configurationLoadTimeout: Duration,
+    maxDeduplicationDuration: Option[Duration],
     delayBeforeSubmittingLedgerConfiguration: Duration,
     timeModel: LedgerTimeModel,
     commandConfig: CommandConfiguration,
@@ -64,7 +65,6 @@ final case class SandboxConfig(
     sqlStartMode: Option[PostgresStartupMode],
     enableAppendOnlySchema: Boolean,
     enableCompression: Boolean,
-    maxDeduplicationDuration: Option[Duration],
 ) {
 
   def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): SandboxConfig =

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -341,6 +341,9 @@ server_conformance_test(
 
 server_conformance_test(
     name = "next-conformance-test-command-deduplication",
+    server_args = [
+        "--max-deduplication-duration=PT10S",
+    ],
     servers = NEXT_SERVERS,
     test_tool_args = [
         "--include=KVCommandDeduplicationIT",

--- a/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
+++ b/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
@@ -3,7 +3,7 @@
 
 package com.daml.nonrepudiation.postgresql
 
-import java.time.Clock
+import java.time.{Clock, Duration}
 
 import com.daml.doobie.logging.Slf4jLogHandler
 import com.daml.ledger.api.testtool.infrastructure.{
@@ -64,7 +64,10 @@ final class NonRepudiationProxyConformance
 
   it should "pass all conformance tests" in {
     implicit val context: ResourceContext = ResourceContext(executionContext)
-    val config = SandboxConfig.defaultConfig.copy(port = Port.Dynamic)
+    val config = SandboxConfig.defaultConfig.copy(
+      port = Port.Dynamic,
+      maxDeduplicationDuration = Some(Duration.ofSeconds(10)),
+    )
 
     val proxyName = InProcessServerBuilder.generateName()
     val proxyBuilder = InProcessServerBuilder.forName(proxyName)


### PR DESCRIPTION
### Pull Request Checklist
- overwrite the submitter info deduplication period to be max_deduplication_duration for all the transactions
- this guarantees that we use the same deduplication period for all the submissions. By doing so we have the guarantee that the behavior between forwards looking and backward-looking deduplication is the same.
- update the max_deduplication_duration to a value that can be used for testing for all the KV ledgers which run KVCommmandDeduplicationIT

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
