### PR TITLE
make auth middleware aware that actAs => readAs

### DIFF
--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
@@ -67,7 +67,10 @@ class Server(config: Config) extends StrictLogging {
     } yield {
       (tokenPayload.admin || !claims.admin) &&
       claims.actAs.map(_.toString).toSet.subsetOf(tokenPayload.actAs.toSet) &&
-      claims.readAs.map(_.toString).toSet.subsetOf(tokenPayload.readAs.toSet) &&
+      claims.readAs
+        .map(_.toString)
+        .toSet
+        .subsetOf(tokenPayload.readAs.toSet ++ tokenPayload.actAs.toSet) &&
       ((claims.applicationId, tokenPayload.applicationId) match {
         // No requirement on app id
         case (None, _) => true


### PR DESCRIPTION
It seems a bit silly that the auth middleware would refuse a token that
has an `actAs` when it needs a `readAs`. (Unless I'm misunderstanding
and the difference between actAs and readAs is actually non-empty?)

CHANGELOG_BEGIN
- The auth middleware will now consider that actAs credentials are valid
  for readAs requests.
CHANGELOG_END