### PR TITLE
Drop ContractId typeparameter from Value

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -34,7 +34,7 @@ final class Conversions(
   private val ptxCoidToNodeId = incomplete
     .map(_.transaction.nodes)
     .getOrElse(Map.empty)
-    .collect { case (nodeId, node: N.NodeCreate[V.ContractId]) =>
+    .collect { case (nodeId, node: N.NodeCreate) =>
       node.coid -> ledger.ptxEventId(nodeId)
     }
 
@@ -486,7 +486,7 @@ final class Conversions(
             rollback.children.map(convertNodeId(eventId.transactionId, _)).toSeq.asJava
           )
         builder.setRollback(rollbackBuilder.build)
-      case create: N.NodeCreate[V.ContractId] =>
+      case create: N.NodeCreate =>
         val createBuilder =
           proto.Node.Create.newBuilder
             .setContractInstance(
@@ -500,7 +500,7 @@ final class Conversions(
 
         nodeInfo.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setCreate(createBuilder.build)
-      case fetch: N.NodeFetch[V.ContractId] =>
+      case fetch: N.NodeFetch =>
         builder.setFetch(
           proto.Node.Fetch.newBuilder
             .setContractId(coidToEventId(fetch.coid).toLedgerString)
@@ -509,7 +509,7 @@ final class Conversions(
             .addAllStakeholders(fetch.stakeholders.map(convertParty).asJava)
             .build
         )
-      case ex: N.NodeExercises[NodeId, V.ContractId] =>
+      case ex: N.NodeExercises[NodeId] =>
         nodeInfo.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         val exerciseBuilder =
           proto.Node.Exercise.newBuilder
@@ -534,7 +534,7 @@ final class Conversions(
 
         builder.setExercise(exerciseBuilder.build)
 
-      case lbk: N.NodeLookupByKey[V.ContractId] =>
+      case lbk: N.NodeLookupByKey =>
         nodeInfo.optLocation.foreach(loc => builder.setLocation(convertLocation(loc)))
         val lbkBuilder = proto.Node.LookupByKey.newBuilder
           .setTemplateId(convertIdentifier(lbk.templateId))
@@ -547,7 +547,7 @@ final class Conversions(
   }
 
   def convertKeyWithMaintainers(
-      key: N.KeyWithMaintainers[V.VersionedValue[V.ContractId]]
+      key: N.KeyWithMaintainers[V.VersionedValue]
   ): proto.KeyWithMaintainers = {
     proto.KeyWithMaintainers
       .newBuilder()
@@ -558,7 +558,7 @@ final class Conversions(
 
   def convertIncompleteTransactionNode(
       locationInfo: Map[NodeId, Ref.Location]
-  )(nodeWithId: (NodeId, N.GenNode[NodeId, V.ContractId])): proto.Node = {
+  )(nodeWithId: (NodeId, N.GenNode[NodeId])): proto.Node = {
     val (nodeId, node) = nodeWithId
     val optLocation = locationInfo.get(nodeId)
     val builder = proto.Node.newBuilder
@@ -576,7 +576,7 @@ final class Conversions(
                 .asJava
             )
         builder.setRollback(rollbackBuilder.build)
-      case create: N.NodeCreate[V.ContractId] =>
+      case create: N.NodeCreate =>
         val createBuilder =
           proto.Node.Create.newBuilder
             .setContractInstance(
@@ -592,7 +592,7 @@ final class Conversions(
         )
         optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setCreate(createBuilder.build)
-      case fetch: N.NodeFetch[V.ContractId] =>
+      case fetch: N.NodeFetch =>
         builder.setFetch(
           proto.Node.Fetch.newBuilder
             .setContractId(coidToEventId(fetch.coid).toLedgerString)
@@ -601,7 +601,7 @@ final class Conversions(
             .addAllStakeholders(fetch.stakeholders.map(convertParty).asJava)
             .build
         )
-      case ex: N.NodeExercises[NodeId, V.ContractId] =>
+      case ex: N.NodeExercises[NodeId] =>
         optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setExercise(
           proto.Node.Exercise.newBuilder
@@ -622,7 +622,7 @@ final class Conversions(
             .build
         )
 
-      case lookup: N.NodeLookupByKey[V.ContractId] =>
+      case lookup: N.NodeLookupByKey =>
         optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setLookupByKey({
           val builder = proto.Node.LookupByKey.newBuilder
@@ -662,10 +662,10 @@ final class Conversions(
 
   }
 
-  private def convertVersionedValue(value: V.VersionedValue[V.ContractId]): proto.Value =
+  private def convertVersionedValue(value: V.VersionedValue): proto.Value =
     convertValue(value.value)
 
-  def convertValue(value: V[V.ContractId]): proto.Value = {
+  def convertValue(value: V): proto.Value = {
     val builder = proto.Value.newBuilder
     value match {
       case V.ValueRecord(tycon, fields) =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -46,11 +46,11 @@ object Blinding {
     * transaction has Nid references that are not present in its nodes. Use `isWellFormed`
     * if you are getting the transaction from a third party.
     */
-  def divulgedTransaction[Nid, Cid](
+  def divulgedTransaction[Nid](
       divulgences: Relation[Nid, Party],
       party: Party,
-      tx: GenTransaction[Nid, Cid],
-  ): GenTransaction[Nid, Cid] = {
+      tx: GenTransaction[Nid],
+  ): GenTransaction[Nid] = {
     val partyDivulgences = Relation.invert(divulgences)(party)
     // Note that this relies on the local divulgence to be well-formed:
     // if an exercise node is divulged to A but some of its descendants
@@ -68,9 +68,9 @@ object Blinding {
             tx.nodes(root) match {
               case nr: NodeRollback[Nid] =>
                 go(filteredRoots, nr.children ++: remainingRoots)
-              case _: NodeFetch[Cid] | _: NodeCreate[Cid] | _: NodeLookupByKey[Cid] =>
+              case _: NodeFetch | _: NodeCreate | _: NodeLookupByKey =>
                 go(filteredRoots, remainingRoots)
-              case ne: NodeExercises[Nid, Cid] =>
+              case ne: NodeExercises[Nid] =>
                 go(filteredRoots, ne.children ++: remainingRoots)
             }
           }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -491,11 +491,11 @@ object Engine {
         s"$kind:${tmpl.qualifiedName.name}${extra.map(extra => s":$extra").getOrElse("")}"
       tx.nodes.get(tx.roots(0)).toList.head match {
         case _: NodeRollback[_] => "rollback"
-        case create: NodeCreate[_] => makeDesc("create", create.coinst.template, None)
-        case exercise: NodeExercises[_, _] =>
+        case create: NodeCreate => makeDesc("create", create.coinst.template, None)
+        case exercise: NodeExercises[_] =>
           makeDesc("exercise", exercise.templateId, Some(exercise.choiceId))
-        case fetch: NodeFetch[_] => makeDesc("fetch", fetch.templateId, None)
-        case lookup: NodeLookupByKey[_] => makeDesc("lookup", lookup.templateId, None)
+        case fetch: NodeFetch => makeDesc("fetch", fetch.templateId, None)
+        case lookup: NodeLookupByKey => makeDesc("lookup", lookup.templateId, None)
       }
     } else {
       s"compound:${tx.roots.length}"

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -96,11 +96,11 @@ object Error {
 
     final case class TypeMismatch(
         typ: Ast.Type,
-        value: Value[Value.ContractId],
+        value: Value,
         override val message: String,
     ) extends Error
 
-    final case class ValueNesting(culprit: Value[Value.ContractId]) extends Error {
+    final case class ValueNesting(culprit: Value) extends Error {
       override def message: String =
         s"Provided value exceeds maximum nesting level of ${Value.MAXIMUM_NESTING}"
     }
@@ -175,7 +175,7 @@ object Error {
     }
 
     final case class ReplayMismatch(
-        mismatch: transaction.ReplayMismatch[transaction.NodeId, Value.ContractId]
+        mismatch: transaction.ReplayMismatch[transaction.NodeId]
     ) extends Error {
       override def message: String = mismatch.message
     }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -41,7 +41,7 @@ sealed trait Result[+A] extends Product with Serializable {
   }
 
   def consume(
-      pcs: ContractId => Option[ContractInst[VersionedValue[ContractId]]],
+      pcs: ContractId => Option[ContractInst[VersionedValue]],
       packages: PackageId => Option[Package],
       keys: GlobalKeyWithMaintainers => Option[ContractId],
   ): Either[Error, A] = {
@@ -86,7 +86,7 @@ object ResultError {
   */
 final case class ResultNeedContract[A](
     acoid: ContractId,
-    resume: Option[ContractInst[VersionedValue[ContractId]]] => Result[A],
+    resume: Option[ContractInst[VersionedValue]] => Result[A],
 ) extends Result[A]
 
 /** Intermediate result indicating that a [[Package]] is required to complete the computation.
@@ -121,7 +121,7 @@ object Result {
 
   private[lf] def needContract[A](
       acoid: ContractId,
-      resume: ContractInst[VersionedValue[ContractId]] => Result[A],
+      resume: ContractInst[VersionedValue] => Result[A],
   ) =
     ResultNeedContract(
       acoid,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -30,7 +30,7 @@ private[lf] final class CommandPreprocessor(
   @throws[Error.Preprocessing.Error]
   def unsafePreprocessCreate(
       templateId: Ref.Identifier,
-      argument: Value[Value.ContractId],
+      argument: Value,
   ): speedy.Command.Create = {
     val arg = valueTranslator.unsafeTranslateValue(Ast.TTyCon(templateId), argument)
     speedy.Command.Create(templateId, arg)
@@ -41,7 +41,7 @@ private[lf] final class CommandPreprocessor(
       templateId: Ref.Identifier,
       contractId: Value.ContractId,
       choiceId: Ref.ChoiceName,
-      argument: Value[Value.ContractId],
+      argument: Value,
   ): speedy.Command.Exercise = {
     val cid = valueTranslator.unsafeTranslateCid(contractId)
     val choice = handleLookup(interface.lookupChoice(templateId, choiceId)).argBinder._2
@@ -52,9 +52,9 @@ private[lf] final class CommandPreprocessor(
   @throws[Error.Preprocessing.Error]
   def unsafePreprocessExerciseByKey(
       templateId: Ref.Identifier,
-      contractKey: Value[Value.ContractId],
+      contractKey: Value,
       choiceId: Ref.ChoiceName,
-      argument: Value[Value.ContractId],
+      argument: Value,
   ): speedy.Command.ExerciseByKey = {
     val choiceArgType = handleLookup(interface.lookupChoice(templateId, choiceId)).argBinder._2
     val ckTtype = handleLookup(interface.lookupTemplateKey(templateId)).typ
@@ -66,9 +66,9 @@ private[lf] final class CommandPreprocessor(
   @throws[Error.Preprocessing.Error]
   def unsafePreprocessCreateAndExercise(
       templateId: Ref.ValueRef,
-      createArgument: Value[Value.ContractId],
+      createArgument: Value,
       choiceId: Ref.ChoiceName,
-      choiceArgument: Value[Value.ContractId],
+      choiceArgument: Value,
   ): speedy.Command.CreateAndExercise = {
     val createArg =
       valueTranslator.unsafeTranslateValue(Ast.TTyCon(templateId), createArgument)
@@ -87,7 +87,7 @@ private[lf] final class CommandPreprocessor(
   @throws[Error.Preprocessing.Error]
   private[preprocessing] def unsafePreprocessLookupByKey(
       templateId: Ref.ValueRef,
-      contractKey: Value[Nothing],
+      contractKey: Value,
   ): speedy.Command.LookupByKey = {
     val ckTtype = handleLookup(interface.lookupTemplateKey(templateId)).typ
     val key = valueTranslator.unsafeTranslateValue(ckTtype, contractKey)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -159,7 +159,7 @@ private[engine] final class Preprocessor(
     * Fails if the nesting is too deep or if v0 does not match the type `ty0`.
     * Assumes ty0 is a well-formed serializable typ.
     */
-  def translateValue(ty0: Ast.Type, v0: Value[Value.ContractId]): Result[SValue] =
+  def translateValue(ty0: Ast.Type, v0: Value): Result[SValue] =
     safelyRun(getDependencies(List(ty0), List.empty)) {
       commandPreprocessor.valueTranslator.unsafeTranslateValue(ty0, v0)
     }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -7,7 +7,6 @@ package preprocessing
 
 import com.daml.lf.data.{BackStack, ImmArray}
 import com.daml.lf.transaction.{Node, NodeId, SubmittedTransaction}
-import com.daml.lf.value.Value.ContractId
 
 private[preprocessing] final class TransactionPreprocessor(
     commandPreprocessor: CommandPreprocessor
@@ -69,12 +68,12 @@ private[preprocessing] final class TransactionPreprocessor(
 
     val result = tx.roots.foldLeft(BackStack.empty[speedy.Command]) { (acc, id) =>
       tx.nodes.get(id) match {
-        case Some(node: Node.GenActionNode[_, ContractId]) =>
+        case Some(node: Node.GenActionNode[_]) =>
           node match {
-            case create: Node.NodeCreate[ContractId] =>
+            case create: Node.NodeCreate =>
               val cmd = commandPreprocessor.unsafePreprocessCreate(create.templateId, create.arg)
               acc :+ cmd
-            case exe: Node.NodeExercises[_, ContractId] =>
+            case exe: Node.NodeExercises[_] =>
               val cmd = exe.key match {
                 case Some(key) if exe.byKey =>
                   commandPreprocessor.unsafePreprocessExerciseByKey(
@@ -92,9 +91,9 @@ private[preprocessing] final class TransactionPreprocessor(
                   )
               }
               acc :+ cmd
-            case _: Node.NodeFetch[_] =>
+            case _: Node.NodeFetch =>
               invalidRootNode(id, s"Transaction contains a fetch root node $id")
-            case _: Node.NodeLookupByKey[_] =>
+            case _: Node.NodeLookupByKey =>
               invalidRootNode(id, s"Transaction contains a lookup by key root node $id")
           }
         case Some(_: Node.NodeRollback[NodeId]) =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -25,13 +25,13 @@ private[engine] final class ValueTranslator(
 
   @throws[Error.Preprocessing.Error]
   private def labeledRecordToMap(
-      fields: ImmArray[(Option[String], Value[ContractId])]
-  ): Option[Map[String, Value[ContractId]]] = {
+      fields: ImmArray[(Option[String], Value)]
+  ): Option[Map[String, Value]] = {
     @tailrec
     def go(
-        fields: ImmArray[(Option[String], Value[ContractId])],
-        map: Map[String, Value[ContractId]],
-    ): Option[Map[String, Value[ContractId]]] = {
+        fields: ImmArray[(Option[String], Value)],
+        map: Map[String, Value],
+    ): Option[Map[String, Value]] = {
       fields match {
         case ImmArray() => Some(map)
         case ImmArrayCons((None, _), _) => None
@@ -71,10 +71,10 @@ private[engine] final class ValueTranslator(
   @throws[Error.Preprocessing.Error]
   private[preprocessing] def unsafeTranslateValue(
       ty: Type,
-      value: Value[ContractId],
+      value: Value,
   ): SValue = {
 
-    def go(ty0: Type, value0: Value[ContractId], nesting: Int = 0): SValue =
+    def go(ty0: Type, value0: Value, nesting: Int = 0): SValue =
       if (nesting > Value.MAXIMUM_NESTING) {
         throw Error.Preprocessing.ValueNesting(value)
       } else {
@@ -255,7 +255,7 @@ private[engine] final class ValueTranslator(
   // This does not try to pull missing packages, return an error instead.
   def translateValue(
       ty: Type,
-      value: Value[ContractId],
+      value: Value,
   ): Either[Error.Preprocessing.Error, SValue] =
     safelyRun(unsafeTranslateValue(ty, value))
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -62,7 +62,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
 
     def get(submitter: Party, effectiveAt: Time.Timestamp)(
         id: ContractId
-    ): Option[ContractInst[VersionedValue[ContractId]]] = {
+    ): Option[ContractInst[VersionedValue]] = {
       ledger.lookupGlobalContract(
         ParticipantView(Set(submitter), Set.empty),
         effectiveAt,
@@ -148,7 +148,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
         seed = hash("testLargeTransactionOneContract:create", txSize),
       )
     val contractId = firstRootNode(createCmdTx) match {
-      case create: N.NodeCreate[ContractId] => create.coid
+      case create: N.NodeCreate => create.coid
       case n => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = toListContainerExerciseCmd(rangeOfIntsTemplateId, contractId)
@@ -179,7 +179,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
         seed = hash("testLargeTransactionManySmallContracts:create", num),
       )
     val contractId = firstRootNode(createCmdTx) match {
-      case create: N.NodeCreate[ContractId] => create.coid
+      case create: N.NodeCreate => create.coid
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = toListOfIntContainers(rangeOfIntsTemplateId, contractId)
@@ -210,7 +210,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
         seed = hash("testLargeChoiceArgument:create", size),
       )
     val contractId = firstRootNode(createCmdTx) match {
-      case create: N.NodeCreate[ContractId] => create.coid
+      case create: N.NodeCreate => create.coid
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
     val exerciseCmd = sizeExerciseCmd(listUtilTemplateId, contractId)(size)
@@ -236,7 +236,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
 
     val listValue = extractResultFieldFromExerciseTransaction(exerciseCmdTx, "list")
 
-    val list: FrontStack[Value[Value.ContractId]] = listValue match {
+    val list: FrontStack[Value] = listValue match {
       case ValueList(x) => x
       case f @ _ => fail(s"Unexpected match: $f")
     }
@@ -250,14 +250,14 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
       expectedNumberOfContracts: Int,
   ): Assertion = {
 
-    val newContracts: List[N.GenNode[NodeId, Value.ContractId]] =
+    val newContracts: List[N.GenNode[NodeId]] =
       firstRootNode(exerciseCmdTx) match {
-        case ne: N.NodeExercises[_, _] => ne.children.toList.map(nid => exerciseCmdTx.nodes(nid))
+        case ne: N.NodeExercises[_] => ne.children.toList.map(nid => exerciseCmdTx.nodes(nid))
         case n @ _ => fail(s"Unexpected match: $n")
       }
 
     newContracts.count {
-      case _: N.NodeCreate[ContractId] => true
+      case _: N.NodeCreate => true
       case n @ _ => fail(s"Unexpected match: $n")
     } shouldBe expectedNumberOfContracts
   }
@@ -344,7 +344,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
       expected: Long,
   ): Assertion = {
 
-    val value: Value[ContractId] =
+    val value: Value =
       extractResultFieldFromExerciseTransaction(exerciseCmdTx, "value")
 
     val actual: Long = value match {
@@ -358,18 +358,18 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   private def extractResultFieldFromExerciseTransaction(
       exerciseCmdTx: Transaction,
       fieldName: String,
-  ): Value[ContractId] = {
+  ): Value = {
 
-    val arg: Value[ContractId] =
+    val arg: Value =
       extractResultFromExerciseTransaction(exerciseCmdTx)
 
-    val fields: ImmArray[(Option[String], Value[ContractId])] =
+    val fields: ImmArray[(Option[String], Value)] =
       arg match {
         case ValueRecord(_, x: ImmArray[_]) => x
         case v @ _ => fail(s"Unexpected match: $v")
       }
 
-    val valueField: Option[(Option[String], Value[ContractId])] = fields.find { case (n, _) =>
+    val valueField: Option[(Option[String], Value)] = fields.find { case (n, _) =>
       n.contains(fieldName)
     }
 
@@ -381,18 +381,18 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
 
   private def extractResultFromExerciseTransaction(
       exerciseCmdTx: Transaction
-  ): Value[ContractId] = {
+  ): Value = {
 
     exerciseCmdTx.roots.length shouldBe 1
     exerciseCmdTx.nodes.size shouldBe 2
 
-    val createNode: N.GenNode[NodeId, ContractId] = firstRootNode(exerciseCmdTx) match {
-      case ne: N.NodeExercises[_, _] => exerciseCmdTx.nodes(ne.children.head)
+    val createNode: N.GenNode[NodeId] = firstRootNode(exerciseCmdTx) match {
+      case ne: N.NodeExercises[_] => exerciseCmdTx.nodes(ne.children.head)
       case n @ _ => fail(s"Unexpected match: $n")
     }
 
     createNode match {
-      case create: N.NodeCreate[ContractId] => create.arg
+      case create: N.NodeCreate => create.arg
       case n @ _ => fail(s"Unexpected match: $n")
     }
   }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
@@ -99,7 +99,7 @@ class PreprocessorSpec
     )
     import valueTranslator.unsafeTranslateValue
 
-    val testCases = Table[Ast.Type, Value[ContractId], speedy.SValue](
+    val testCases = Table[Ast.Type, Value, speedy.SValue](
       ("type", "value", "svalue"),
       (TUnit, ValueUnit, SValue.Unit),
       (TBool, ValueTrue, SValue.True),
@@ -181,7 +181,7 @@ class PreprocessorSpec
     "fails on too deep values" in {
 
       def mkMyList(n: Int) =
-        Iterator.range(0, n).foldLeft[Value[Nothing]](ValueVariant(None, myNilCons, ValueUnit)) {
+        Iterator.range(0, n).foldLeft[Value](ValueVariant(None, myNilCons, ValueUnit)) {
           case (v, n) =>
             ValueVariant(
               None,
@@ -199,7 +199,7 @@ class PreprocessorSpec
 
     def testCasesForCid(culprit: ContractId) = {
       val cid = ValueContractId(culprit)
-      Table[Ast.Type, Value[ContractId]](
+      Table[Ast.Type, Value](
         ("type" -> "value"),
         t"ContractId Mod:Record" -> cid,
         TList(typ) -> ValueList(FrontStack(cid)),

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ReinterpretTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ReinterpretTest.scala
@@ -50,7 +50,7 @@ class ReinterpretTest
     "daml-lf/tests/ReinterpretTests.dar"
   )
 
-  private val defaultContracts: Map[ContractId, ContractInst[VersionedValue[ContractId]]] =
+  private val defaultContracts: Map[ContractId, ContractInst[VersionedValue]] =
     Map(
       toContractId("ReinterpretTests:MySimple:1") ->
         ContractInst(
@@ -193,12 +193,12 @@ object ReinterpretTest {
     final case class Rollback(x: List[Shape]) extends Shape
     final case class Create() extends Shape
 
-    def ofTransaction(tx: GenTransaction[NodeId, ContractId]): Top = {
+    def ofTransaction(tx: GenTransaction[NodeId]): Top = {
       def ofNid(nid: NodeId): Shape = {
         tx.nodes(nid) match {
-          case node: NodeExercises[_, _] => Exercise(node.children.toList.map(ofNid))
+          case node: NodeExercises[_] => Exercise(node.children.toList.map(ofNid))
           case node: NodeRollback[_] => Rollback(node.children.toList.map(ofNid))
-          case _: NodeCreate[_] => Create()
+          case _: NodeCreate => Create()
           case _ => sys.error(s"Shape.ofTransaction, unexpected tx node")
         }
       }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueEnricherSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueEnricherSpec.scala
@@ -76,7 +76,7 @@ class ValueEnricherSpec extends AnyWordSpec with Matchers with TableDrivenProper
 
   "enrichValue" should {
 
-    val testCases = Table[Type, Value[ContractId], Value[ContractId]](
+    val testCases = Table[Type, Value, Value](
       ("type", "input", "expected output"),
       (TUnit, ValueUnit, ValueUnit),
       (TBool, ValueTrue, ValueTrue),
@@ -133,9 +133,9 @@ class ValueEnricherSpec extends AnyWordSpec with Matchers with TableDrivenProper
   "enrichTransaction" should {
 
     def buildTransaction(
-        contract: Value[ContractId],
-        key: Value[ContractId],
-        record: Value[ContractId],
+        contract: Value,
+        key: Value,
+        record: Value,
     ) = {
       val builder = new TransactionBuilder(_ => TransactionVersion.minTypeErasure)
       val create =
@@ -165,7 +165,7 @@ class ValueEnricherSpec extends AnyWordSpec with Matchers with TableDrivenProper
 
       val inputKey = ValueRecord(
         None,
-        ImmArray(
+        ImmArray[(String, Value)](
           "" -> ValueParty("Alice"),
           "" -> Value.ValueInt64(0),
         ),
@@ -174,7 +174,7 @@ class ValueEnricherSpec extends AnyWordSpec with Matchers with TableDrivenProper
       val inputContract =
         ValueRecord(
           None,
-          ImmArray(
+          ImmArray[(String, Value)](
             "" -> inputKey,
             "" -> Value.ValueNil,
           ),
@@ -191,7 +191,7 @@ class ValueEnricherSpec extends AnyWordSpec with Matchers with TableDrivenProper
 
       val outputKey = ValueRecord(
         Some("Mod:Key"),
-        ImmArray(
+        ImmArray[(String, Value)](
           "party" -> ValueParty("Alice"),
           "idx" -> Value.ValueInt64(0),
         ),
@@ -200,14 +200,14 @@ class ValueEnricherSpec extends AnyWordSpec with Matchers with TableDrivenProper
       val outputContract =
         ValueRecord(
           Some("Mod:Contract"),
-          ImmArray(
+          ImmArray[(String, Value)](
             "key" -> outputKey,
             "cids" -> Value.ValueNil,
           ),
         )
 
       val outputRecord =
-        ValueRecord(Some("Mod:Record"), ImmArray("field" -> ValueInt64(33)))
+        ValueRecord(Some("Mod:Record"), ImmArray[(String, Value)]("field" -> ValueInt64(33)))
 
       val outputTransaction = buildTransaction(
         outputContract,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -66,7 +66,7 @@ object BlindingTransaction {
         nodeId: NodeId,
     ): BlindState =
       tx.nodes.get(nodeId) match {
-        case Some(action: Node.GenActionNode[NodeId, ContractId]) =>
+        case Some(action: Node.GenActionNode[NodeId]) =>
           val witnesses = parentExerciseWitnesses union action.informeesOfNode
 
           // actions of every type are disclosed to their witnesses
@@ -74,16 +74,16 @@ object BlindingTransaction {
 
           action match {
 
-            case _: Node.NodeCreate[ContractId] => state
-            case _: Node.NodeLookupByKey[ContractId] => state
+            case _: Node.NodeCreate => state
+            case _: Node.NodeLookupByKey => state
 
             // fetch & exercise nodes cause divulgence
 
-            case fetch: Node.NodeFetch[ContractId] =>
+            case fetch: Node.NodeFetch =>
               state
                 .divulgeCoidTo(parentExerciseWitnesses -- fetch.stakeholders, fetch.coid)
 
-            case ex: Node.NodeExercises[NodeId, ContractId] =>
+            case ex: Node.NodeExercises[NodeId] =>
               val state1 =
                 state.divulgeCoidTo(
                   (parentExerciseWitnesses union ex.choiceObservers) -- ex.stakeholders,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -112,16 +112,16 @@ private[lf] object Pretty {
     node match {
       case NodeRollback(_) =>
         text("rollback")
-      case create: NodeCreate[Value.ContractId] =>
+      case create: NodeCreate =>
         "create" &: prettyContractInst(create.coinst)
-      case fetch: NodeFetch[Value.ContractId] =>
+      case fetch: NodeFetch =>
         "fetch" &: prettyContractId(fetch.coid)
-      case ex: NodeExercises[NodeId, Value.ContractId] =>
+      case ex: NodeExercises[NodeId] =>
         intercalate(text(", "), ex.actingParties.map(p => text(p))) &
           text("exercises") & text(ex.choiceId) + char(':') + prettyIdentifier(ex.templateId) &
           text("on") & prettyContractId(ex.targetCoid) /
           text("with") & prettyValue(false)(ex.chosenValue)
-      case lbk: NodeLookupByKey[Value.ContractId] =>
+      case lbk: NodeLookupByKey =>
         text("lookup by key") & prettyIdentifier(lbk.templateId) /
           text("key") & prettyKeyWithMaintainers(lbk.key) /
           (lbk.result match {
@@ -190,11 +190,11 @@ private[lf] object Pretty {
           prettyLoc(amf.optLocation)
     }
 
-  def prettyKeyWithMaintainers(key: KeyWithMaintainers[Value[ContractId]]): Doc =
+  def prettyKeyWithMaintainers(key: KeyWithMaintainers[Value]): Doc =
     // the maintainers are induced from the key -- so don't clutter
     prettyValue(false)(key.key)
 
-  def prettyVersionedKeyWithMaintainers(key: KeyWithMaintainers[Tx.Value[ContractId]]): Doc =
+  def prettyVersionedKeyWithMaintainers(key: KeyWithMaintainers[Tx.Value]): Doc =
     // the maintainers are induced from the key -- so don't clutter
     prettyValue(false)(key.key.value)
 
@@ -206,15 +206,15 @@ private[lf] object Pretty {
     val ppNode = ni.node match {
       case NodeRollback(children) =>
         text("rollback:") / stack(children.toList.map(prettyEventInfo(l, txId)))
-      case create: NodeCreate[ContractId] =>
+      case create: NodeCreate =>
         val d = "create" &: prettyVersionedContractInst(create.versionedCoinst)
         create.versionedKey match {
           case None => d
           case Some(key) => d / text("key") & prettyVersionedKeyWithMaintainers(key)
         }
-      case ea: NodeFetch[ContractId] =>
+      case ea: NodeFetch =>
         "ensure active" &: prettyContractId(ea.coid)
-      case ex: NodeExercises[NodeId, ContractId] =>
+      case ex: NodeExercises[NodeId] =>
         val children =
           if (ex.children.nonEmpty)
             text("children:") / stack(ex.children.toList.map(prettyEventInfo(l, txId)))
@@ -225,7 +225,7 @@ private[lf] object Pretty {
           text("on") & prettyContractId(ex.targetCoid) /
           (text("    ") + text("with") & prettyValue(false)(ex.chosenValue) / children)
             .nested(4)
-      case lbk: NodeLookupByKey[ContractId] =>
+      case lbk: NodeLookupByKey =>
         text("lookup by key") & prettyIdentifier(lbk.templateId) /
           text("key") & prettyVersionedKeyWithMaintainers(lbk.versionedKey) /
           (lbk.result match {
@@ -284,11 +284,11 @@ private[lf] object Pretty {
   def prettyEventId(n: EventId): Doc =
     text(n.toLedgerString)
 
-  def prettyContractInst(coinst: ContractInst[Value[ContractId]]): Doc =
+  def prettyContractInst(coinst: ContractInst[Value]): Doc =
     (prettyIdentifier(coinst.template) / text("with:") &
       prettyValue(false)(coinst.arg)).nested(4)
 
-  def prettyVersionedContractInst(coinst: ContractInst[Tx.Value[ContractId]]): Doc =
+  def prettyVersionedContractInst(coinst: ContractInst[Tx.Value]): Doc =
     (prettyIdentifier(coinst.template) / text("with:") &
       prettyValue(false)(coinst.arg.value)).nested(4)
 
@@ -312,12 +312,12 @@ private[lf] object Pretty {
   def prettyIdentifier(id: Identifier): Doc =
     text(id.qualifiedName.toString) + char('@') + prettyPackageId(id.packageId)
 
-  def prettyVersionedValue(verbose: Boolean)(v: Tx.Value[ContractId]): Doc =
+  def prettyVersionedValue(verbose: Boolean)(v: Tx.Value): Doc =
     prettyValue(verbose)(v.value)
 
   // Pretty print a value. If verbose then the top-level value is printed with type constructor
   // if possible.
-  def prettyValue(verbose: Boolean)(v: Value[ContractId]): Doc =
+  def prettyValue(verbose: Boolean)(v: Value): Doc =
     v match {
       case ValueInt64(i) => str(i)
       case ValueNumeric(d) => text(data.Numeric.toString(d))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1621,7 +1621,7 @@ private[lf] object SBuiltin {
       templateId: TypeConName,
       location: String,
       v: SValue,
-  ): Node.KeyWithMaintainers[V[Nothing]] =
+  ): Node.KeyWithMaintainers[V] =
     v match {
       case SStruct(_, vals) =>
         val key = onLedger.ptx.normValue(templateId, vals.get(keyIdx))
@@ -1643,7 +1643,7 @@ private[lf] object SBuiltin {
       templateId: TypeConName,
       where: String,
       optKey: SValue,
-  ): Option[Node.KeyWithMaintainers[V[Nothing]]] =
+  ): Option[Node.KeyWithMaintainers[V]] =
     optKey match {
       case SOptional(mbKey) => mbKey.map(extractKeyWithMaintainers(onLedger, templateId, where, _))
       case v => throw SErrorCrash(where, s"Expected optional key with maintainers, got: $v")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -388,7 +388,7 @@ object SExpr {
     }
   }
 
-  final case class SEImportValue(typ: Ast.Type, value: V[V.ContractId]) extends SExpr {
+  final case class SEImportValue(typ: Ast.Type, value: V) extends SExpr {
     def execute(machine: Machine): Unit = {
       machine.importValue(typ, value)
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -36,7 +36,7 @@ object SResult {
       // Callback
       // returns the next expression to evaluate.
       // In case of failure the call back does not throw but returns a SErrorDamlException
-      callback: ContractInst[Value.VersionedValue[ContractId]] => Unit,
+      callback: ContractInst[Value.VersionedValue] => Unit,
   ) extends SResult
 
   /** Machine needs a definition that was not present when the machine was

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -30,7 +30,7 @@ sealed trait SValue {
   /** Convert a speedy-value to a value which may not be correctly normalized.
     * And so the resulting value should not be serialized.
     */
-  def toUnnormalizedValue: V[V.ContractId] = {
+  def toUnnormalizedValue: V = {
     toValue(
       normalize = false
     )
@@ -38,7 +38,7 @@ sealed trait SValue {
 
   /** Convert a speedy-value to a value normalized according to the LF version.
     */
-  def toNormalizedValue(version: TransactionVersion): V[V.ContractId] = {
+  def toNormalizedValue(version: TransactionVersion): V = {
     import Ordering.Implicits.infixOrderingOps
     toValue(
       normalize = version >= TransactionVersion.minTypeErasure
@@ -47,7 +47,7 @@ sealed trait SValue {
 
   private def toValue(
       normalize: Boolean
-  ): V[V.ContractId] = {
+  ): V = {
 
     def maybeEraseTypeInfo[X](x: X): Option[X] =
       if (normalize) {
@@ -56,7 +56,7 @@ sealed trait SValue {
         Some(x)
       }
 
-    def go(v: SValue, maxNesting: Int = V.MAXIMUM_NESTING): V[V.ContractId] = {
+    def go(v: SValue, maxNesting: Int = V.MAXIMUM_NESTING): V = {
       if (maxNesting < 0)
         throw SError.SErrorDamlException(interpretation.Error.ValueExceedsMaxNesting)
       val nextMaxNesting = maxNesting - 1

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -103,7 +103,7 @@ private[lf] object Speedy {
       value: SValue,
       signatories: Set[Party],
       observers: Set[Party],
-      key: Option[Node.KeyWithMaintainers[V[Nothing]]],
+      key: Option[Node.KeyWithMaintainers[V]],
   ) {
     private[lf] val stakeholders: Set[Party] = signatories union observers;
   }
@@ -354,7 +354,7 @@ private[lf] object Speedy {
         arg: SValue,
         signatories: Set[Party],
         observers: Set[Party],
-        key: Option[Node.KeyWithMaintainers[V[Nothing]]],
+        key: Option[Node.KeyWithMaintainers[V]],
     ) =
       withOnLedger("addLocalContract") { onLedger =>
         onLedger.cachedContracts = onLedger.cachedContracts.updated(
@@ -609,7 +609,7 @@ private[lf] object Speedy {
     // com.daml.lf.engine.preprocessing.ValueTranslator.translateValue.
     // All the contract IDs contained in the value are considered global.
     // Raises an exception if missing a package.
-    private[speedy] def importValue(typ0: Type, value0: V[V.ContractId]): Unit = {
+    private[speedy] def importValue(typ0: Type, value0: V): Unit = {
 
       def assertRight[X](x: Either[LookupError, X]) =
         x match {
@@ -617,7 +617,7 @@ private[lf] object Speedy {
           case Left(error) => throw SErrorCrash(NameOf.qualifiedNameOfCurrentFunc, error.pretty)
         }
 
-      def go(ty: Type, value: V[V.ContractId]): SValue = {
+      def go(ty: Type, value: V): SValue = {
         def typeMismatch = throw SErrorCrash(
           NameOf.qualifiedNameOfCurrentFunc,
           s"mismatching type: $ty and value: $value",

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/CheckAuthorization.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/CheckAuthorization.scala
@@ -26,7 +26,7 @@ private[lf] object CheckAuthorization {
 
   private[lf] def authorizeCreate(
       optLocation: Option[Location],
-      create: NodeCreate[_],
+      create: NodeCreate,
   )(
       auth: Authorize
   ): List[FailedAuthorization] = {
@@ -61,7 +61,7 @@ private[lf] object CheckAuthorization {
 
   private[lf] def authorizeFetch(
       optLocation: Option[Location],
-      fetch: NodeFetch[_],
+      fetch: NodeFetch,
   )(
       auth: Authorize
   ): List[FailedAuthorization] = {
@@ -78,7 +78,7 @@ private[lf] object CheckAuthorization {
 
   private[lf] def authorizeLookupByKey(
       optLocation: Option[Location],
-      lbk: NodeLookupByKey[_],
+      lbk: NodeLookupByKey,
   )(
       auth: Authorize
   ): List[FailedAuthorization] = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -33,11 +33,11 @@ private[lf] object PartialTransaction {
   }
 
   type NodeIdx = Value.NodeIdx
-  type Node = Node.GenNode[NodeId, Value.ContractId]
-  type LeafNode = Node.LeafOnlyActionNode[Value.ContractId]
+  type Node = Node.GenNode[NodeId]
+  type LeafNode = Node.LeafOnlyActionNode
 
-  private type TX = GenTransaction[NodeId, Value.ContractId]
-  private type ExerciseNode = Node.NodeExercises[NodeId, Value.ContractId]
+  private type TX = GenTransaction[NodeId]
+  private type ExerciseNode = Node.NodeExercises[NodeId]
 
   private final case class IncompleteTxImpl(
       val transaction: TX,
@@ -149,11 +149,11 @@ private[lf] object PartialTransaction {
   final case class ExercisesContextInfo(
       targetId: Value.ContractId,
       templateId: TypeConName,
-      contractKey: Option[Node.KeyWithMaintainers[Value[Nothing]]],
+      contractKey: Option[Node.KeyWithMaintainers[Value]],
       choiceId: ChoiceName,
       consuming: Boolean,
       actingParties: Set[Party],
-      chosenValue: Value[Value.ContractId],
+      chosenValue: Value,
       signatories: Set[Party],
       stakeholders: Set[Party],
       choiceObservers: Set[Party],
@@ -327,8 +327,8 @@ private[lf] case class PartialTransaction(
       val rootNodes = {
         val allChildNodeIds: Set[NodeId] = nodes.values.iterator.flatMap {
           case rb: Node.NodeRollback[NodeId] => rb.children.toSeq
-          case _: Node.LeafOnlyActionNode[_] => Nil
-          case ex: Node.NodeExercises[NodeId, _] => ex.children.toSeq
+          case _: Node.LeafOnlyActionNode => Nil
+          case ex: Node.NodeExercises[NodeId] => ex.children.toSeq
         }.toSet
 
         nodes.keySet diff allChildNodeIds
@@ -354,7 +354,7 @@ private[lf] case class PartialTransaction(
     * unless 'transactionNormalization=false',
     * suitable for a transaction node of 'version' determined by 'templateId'
     */
-  def normValue(templateId: TypeConName, svalue: SValue): Value[Value.ContractId] = {
+  def normValue(templateId: TypeConName, svalue: SValue): Value = {
     val version = packageToTransactionVersion(templateId.packageId)
     if (transactionNormalization) {
       svalue.toNormalizedValue(version)
@@ -416,12 +416,12 @@ private[lf] case class PartialTransaction(
   def insertCreate(
       auth: Authorize,
       templateId: Ref.Identifier,
-      arg: Value[Value.ContractId],
+      arg: Value,
       agreementText: String,
       optLocation: Option[Location],
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[Node.KeyWithMaintainers[Value[Nothing]]],
+      key: Option[Node.KeyWithMaintainers[Value]],
   ): (Value.ContractId, PartialTransaction) = {
     val actionNodeSeed = context.nextActionChildSeed
     val discriminator =
@@ -512,7 +512,7 @@ private[lf] case class PartialTransaction(
       actingParties: Set[Party],
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[Node.KeyWithMaintainers[Value[Nothing]]],
+      key: Option[Node.KeyWithMaintainers[Value]],
       byKey: Boolean,
   ): PartialTransaction = {
     val nid = NodeId(nextNodeIdx)
@@ -538,7 +538,7 @@ private[lf] case class PartialTransaction(
       auth: Authorize,
       templateId: TypeConName,
       optLocation: Option[Location],
-      key: Node.KeyWithMaintainers[Value[Nothing]],
+      key: Node.KeyWithMaintainers[Value],
       result: Option[Value.ContractId],
   ): PartialTransaction = {
     val nid = NodeId(nextNodeIdx)
@@ -567,9 +567,9 @@ private[lf] case class PartialTransaction(
       signatories: Set[Party],
       stakeholders: Set[Party],
       choiceObservers: Set[Party],
-      mbKey: Option[Node.KeyWithMaintainers[Value[Nothing]]],
+      mbKey: Option[Node.KeyWithMaintainers[Value]],
       byKey: Boolean,
-      chosenValue: Value[Value.ContractId],
+      chosenValue: Value,
   ): PartialTransaction = {
     val nid = NodeId(nextNodeIdx)
     val ec =
@@ -621,7 +621,7 @@ private[lf] case class PartialTransaction(
   /** Close normally an exercise context.
     * Must match a `beginExercises`.
     */
-  def endExercises(value: Value[Value.ContractId]): PartialTransaction =
+  def endExercises(value: Value): PartialTransaction =
     context.info match {
       case ec: ExercisesContextInfo =>
         val exerciseNode =
@@ -664,7 +664,7 @@ private[lf] case class PartialTransaction(
 
   private[this] def makeExNode(ec: ExercisesContextInfo): ExerciseNode = {
     val version = packageToTransactionVersion(ec.templateId.packageId)
-    Node.NodeExercises[NodeId, Value.ContractId](
+    Node.NodeExercises[NodeId](
       targetCoid = ec.targetId,
       templateId = ec.templateId,
       choiceId = ec.choiceId,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
@@ -173,8 +173,8 @@ object NormalizeRollbackSpec {
 
   type Nid = NodeId
   type Cid = V.ContractId
-  type TX = GenTransaction[Nid, Cid]
-  type Node = GenNode[Nid, Cid]
+  type TX = GenTransaction[Nid]
+  type Node = GenNode[Nid]
   type RB = NodeRollback[Nid]
 
   def preOrderNidsOfTxIsIncreasingFromZero(tx: TX): Boolean = {
@@ -202,7 +202,7 @@ object NormalizeRollbackSpec {
     def fromNode(acc: List[Int], node: Node): List[Int] = {
       node match {
         case _: LeafNode => acc
-        case node: NodeExercises[_, _] => fromNids(acc, node.children.toList)
+        case node: NodeExercises[_] => fromNids(acc, node.children.toList)
         case node: NodeRollback[_] => fromNids(acc, node.children.toList)
       }
     }
@@ -278,13 +278,13 @@ object NormalizeRollbackSpec {
     def ofTransaction(tx: TX): Top = {
       def ofNid(nid: NodeId): Shape = {
         tx.nodes(nid) match {
-          case create: NodeCreate[_] =>
+          case create: NodeCreate =>
             create.arg match {
               case V.ValueInt64(n) => Create(n)
               case _ => sys.error(s"unexpected create.arg: ${create.arg}")
             }
           case leaf: LeafNode => sys.error(s"Shape.ofTransaction, unexpected leaf: $leaf")
-          case node: NodeExercises[_, _] => Exercise(node.children.toList.map(ofNid))
+          case node: NodeExercises[_] => Exercise(node.children.toList.map(ofNid))
           case node: NodeRollback[_] => Rollback(node.children.toList.map(ofNid))
         }
       }
@@ -295,7 +295,7 @@ object NormalizeRollbackSpec {
   private def toCid(s: String): V.ContractId.V1 =
     V.ContractId.V1(crypto.Hash.hashPrivateKey(s))
 
-  private def dummyCreateNode(n: Long): NodeCreate[V.ContractId] =
+  private def dummyCreateNode(n: Long): NodeCreate =
     NodeCreate(
       coid = toCid("dummyCid"),
       templateId = Ref.Identifier.assertFromString("-dummyPkg-:DummyModule:dummyName"),
@@ -309,7 +309,7 @@ object NormalizeRollbackSpec {
 
   private def dummyExerciseNode(
       children: ImmArray[NodeId]
-  ): NodeExercises[NodeId, V.ContractId] =
+  ): NodeExercises[NodeId] =
     NodeExercises(
       targetCoid = toCid("dummyTargetCoid"),
       templateId = Ref.Identifier(

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -35,7 +35,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   private[this] def contractIdsInOrder(ptx: PartialTransaction): Seq[Value.ContractId] = {
     inside(ptx.finish) { case CompleteTransaction(tx, _, _) =>
       tx.fold(Vector.empty[Value.ContractId]) {
-        case (acc, (_, create: Node.NodeCreate[Value.ContractId])) => acc :+ create.coid
+        case (acc, (_, create: Node.NodeCreate)) => acc :+ create.coid
         case (acc, _) => acc
       }
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -262,7 +262,7 @@ object ExceptionTest {
   private def shapeOfTransaction(tx: SubmittedTransaction): List[Tree] = {
     def trees(nid: NodeId): List[Tree] = {
       tx.nodes(nid) match {
-        case create: NodeCreate[_] =>
+        case create: NodeCreate =>
           create.arg match {
             case ValueRecord(_, ImmArray(_, (None, ValueInt64(n)))) =>
               List(C(n))
@@ -271,7 +271,7 @@ object ExceptionTest {
           }
         case _: LeafNode =>
           Nil
-        case node: NodeExercises[_, _] =>
+        case node: NodeExercises[_] =>
           List(X(node.children.toList.flatMap(nid => trees(nid))))
         case node: NodeRollback[_] =>
           List(R(node.children.toList.flatMap(nid => trees(nid))))

--- a/daml-lf/kv-transaction-support/BUILD.bazel
+++ b/daml-lf/kv-transaction-support/BUILD.bazel
@@ -11,9 +11,6 @@ load(
 da_scala_library(
     name = "kv-transaction-support",
     srcs = glob(["src/main/**/*.scala"]),
-    scala_deps = [
-        "@maven//:org_scalaz_scalaz_core",
-    ],
     scalacopts = lf_scalacopts,
     tags = ["maven_coordinates=com.daml:daml-lf-kv-transaction-support:__VERSION__"],
     visibility = ["//ledger/participant-state/kvutils:__subpackages__"],

--- a/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/TransactionNormalizer.scala
+++ b/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/TransactionNormalizer.scala
@@ -4,7 +4,6 @@
 package com.daml.lf.kv
 
 import com.daml.lf.transaction._
-import com.daml.lf.value.Value.ContractId
 
 object TransactionNormalizer {
 
@@ -21,9 +20,9 @@ object TransactionNormalizer {
         (acc, _, _) => (acc, false),
         (acc, nid, node) =>
           node match {
-            case _: Node.NodeCreate[_] => acc + nid
-            case _: Node.NodeFetch[_] => acc
-            case _: Node.NodeLookupByKey[_] => acc
+            case _: Node.NodeCreate => acc + nid
+            case _: Node.NodeFetch => acc
+            case _: Node.NodeLookupByKey => acc
           },
         (acc, _, _) => acc,
         (acc, _, _) => acc,
@@ -32,7 +31,7 @@ object TransactionNormalizer {
       tx.nodes
         .filter { case (nid, _) => keepNids.contains(nid) }
         .transform {
-          case (_, node: Node.NodeExercises[NodeId, ContractId]) =>
+          case (_, node: Node.NodeExercises[NodeId]) =>
             node.copy(children = node.children.filter(keepNids.contains))
           case (_, node: Node.NodeRollback[NodeId]) =>
             node.copy(children = node.children.filter(keepNids.contains))

--- a/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/TransactionNormalizerSpec.scala
+++ b/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/TransactionNormalizerSpec.scala
@@ -82,24 +82,24 @@ class TransactionNormalizerSpec
     }
   }
 
-  def isCreateOrExercise[N, C](node: GenNode[N, C]): Boolean = {
+  def isCreateOrExercise[N](node: GenNode[N]): Boolean = {
     node match {
-      case _: NodeExercises[_, _] => true
-      case _: NodeCreate[_] => true
+      case _: NodeExercises[_] => true
+      case _: NodeCreate => true
       case _ => false
     }
   }
 
-  def nodeSansChildren[N, C](node: GenNode[N, C]): GenNode[N, C] = {
+  def nodeSansChildren[N](node: GenNode[N]): GenNode[N] = {
     node match {
-      case exe: NodeExercises[_, _] => exe.copy(children = ImmArray.Empty)
+      case exe: NodeExercises[_] => exe.copy(children = ImmArray.Empty)
       case _ => node
     }
   }
 
-  def nodeChildren[N, C](node: GenNode[N, C]): List[N] = {
+  def nodeChildren[N](node: GenNode[N]): List[N] = {
     node match {
-      case exe: NodeExercises[_, _] => exe.children.toList
+      case exe: NodeExercises[_] => exe.children.toList
       case _ => List()
     }
   }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -223,7 +223,7 @@ object ScenarioRunner {
         coid: ContractId,
         actAs: Set[Party],
         readAs: Set[Party],
-        cbPresent: ContractInst[Value.VersionedValue[ContractId]] => Unit,
+        cbPresent: ContractInst[Value.VersionedValue] => Unit,
     ): Either[Error, Unit]
     def lookupKey(
         machine: Speedy.Machine,
@@ -249,7 +249,7 @@ object ScenarioRunner {
         acoid: ContractId,
         actAs: Set[Party],
         readAs: Set[Party],
-        callback: ContractInst[Value.VersionedValue[ContractId]] => Unit,
+        callback: ContractInst[Value.VersionedValue] => Unit,
     ): Either[Error, Unit] =
       handleUnsafe(lookupContractUnsafe(acoid, actAs, readAs, callback))
 
@@ -257,7 +257,7 @@ object ScenarioRunner {
         acoid: ContractId,
         actAs: Set[Party],
         readAs: Set[Party],
-        callback: ContractInst[Value.VersionedValue[ContractId]] => Unit,
+        callback: ContractInst[Value.VersionedValue] => Unit,
     ) = {
 
       val effectiveAt = ledger.currentTime

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -66,7 +66,7 @@ class CollectAuthorityState {
   // The maps are indexed by step number.
   private var cachedParty: Map[Int, Party] = Map()
   private var cachedCommit: Map[Int, SValue] = Map()
-  private var cachedContract: Map[Int, ContractInst[Value.VersionedValue[ContractId]]] = Map()
+  private var cachedContract: Map[Int, ContractInst[Value.VersionedValue]] = Map()
 
   // This is function that we benchmark
   def run(): Unit = {
@@ -157,12 +157,12 @@ class CollectAuthorityState {
 class CachedLedgerApi(initStep: Int, ledger: ScenarioLedger)
     extends ScenarioRunner.ScenarioLedgerApi(ledger) {
   var step = initStep
-  var cachedContract: Map[Int, ContractInst[Value.VersionedValue[ContractId]]] = Map()
+  var cachedContract: Map[Int, ContractInst[Value.VersionedValue]] = Map()
   override def lookupContract(
       coid: ContractId,
       actAs: Set[Party],
       readAs: Set[Party],
-      callback: ContractInst[Value.VersionedValue[ContractId]] => Unit,
+      callback: ContractInst[Value.VersionedValue] => Unit,
   ): Either[scenario.Error, Unit] = {
     step += 1
     super.lookupContract(
@@ -176,14 +176,14 @@ class CachedLedgerApi(initStep: Int, ledger: ScenarioLedger)
 
 class CannedLedgerApi(
     initStep: Int,
-    cachedContract: Map[Int, ContractInst[Value.VersionedValue[ContractId]]],
+    cachedContract: Map[Int, ContractInst[Value.VersionedValue]],
 ) extends ScenarioRunner.LedgerApi[Unit] {
   var step = initStep
   override def lookupContract(
       coid: ContractId,
       actAs: Set[Party],
       readAs: Set[Party],
-      callback: ContractInst[Value.VersionedValue[ContractId]] => Unit,
+      callback: ContractInst[Value.VersionedValue] => Unit,
   ): Either[scenario.Error, Unit] = {
     step += 1
     val coinst = cachedContract(step)

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -57,7 +57,7 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
         rb.copy(children = children(nid).toImmArray)
       case (nid, exe: TxExercise) =>
         exe.copy(children = children(nid).toImmArray)
-      case (_, node: Node.LeafOnlyActionNode[ContractId]) =>
+      case (_, node: Node.LeafOnlyActionNode) =>
         node
     }
     val finalRoots = roots.toImmArray
@@ -77,7 +77,7 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
   def newCid: ContractId = TransactionBuilder.newV1Cid
 
   def versionContract(contract: Value.ContractInst[Value]): value.Value.ContractInst[TxValue] =
-    Value.ContractInst.map1[Value, TxValue](transactionValue(contract.template))(contract)
+    contract.map(transactionValue(contract.template))
 
   private[this] def transactionValue(templateId: Ref.TypeConName): Value => TxValue =
     value.Value.VersionedValue(pkgTxVersion(templateId.packageId), _)
@@ -180,19 +180,19 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
 
 object TransactionBuilder {
 
-  type Value = value.Value[ContractId]
-  type TxValue = value.Value.VersionedValue[ContractId]
-  type Node = Node.GenNode[NodeId, ContractId]
-  type TxNode = Node.GenNode[NodeId, ContractId]
+  type Value = value.Value
+  type TxValue = value.Value.VersionedValue
+  type Node = Node.GenNode[NodeId]
+  type TxNode = Node.GenNode[NodeId]
 
-  type Create = Node.NodeCreate[ContractId]
-  type Exercise = Node.NodeExercises[NodeId, ContractId]
-  type Fetch = Node.NodeFetch[ContractId]
-  type LookupByKey = Node.NodeLookupByKey[ContractId]
+  type Create = Node.NodeCreate
+  type Exercise = Node.NodeExercises[NodeId]
+  type Fetch = Node.NodeFetch
+  type LookupByKey = Node.NodeLookupByKey
   type Rollback = Node.NodeRollback[NodeId]
   type KeyWithMaintainers = Node.KeyWithMaintainers[Value]
 
-  type TxExercise = Node.NodeExercises[NodeId, ContractId]
+  type TxExercise = Node.NodeExercises[NodeId]
   type TxRollback = Node.NodeRollback[NodeId]
   type TxKeyWithMaintainers = Node.KeyWithMaintainers[TxValue]
   type TxRollBack = Node.NodeRollback[NodeId]

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/TypedValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/TypedValueGenerators.scala
@@ -22,8 +22,7 @@ import iface.{
   PrimType => PT,
 }
 import scala.collection.compat._
-import scalaz.{@@, Order, Ordering, Tag, ~>}
-import scalaz.Id.Id
+import scalaz.{@@, Order, Ordering, Tag}
 import scalaz.syntax.bitraverse._
 import scalaz.syntax.traverse._
 import scalaz.std.option._
@@ -44,23 +43,24 @@ import Arbitrary.arbitrary
   */
 object TypedValueGenerators {
   sealed abstract class ValueAddend {
-    type Inj[Cid]
-    type IntroCtx[Cid] = Order[Cid]
+    type Inj
     def t: Type
-    def inj[Cid: IntroCtx](v: Inj[Cid]): Value[Cid]
-    def prj[Cid]: Value[Cid] => Option[Inj[Cid]]
-    implicit def injord[Cid: Order]: Order[Inj[Cid]]
-    implicit def injarb[Cid: Arbitrary: IntroCtx]: Arbitrary[Inj[Cid]]
-    implicit def injshrink[Cid: Shrink]: Shrink[Inj[Cid]]
+    def inj(v: Inj): Value
+    def prj: Value => Option[Inj]
+    implicit def injord: Order[Inj]
+    // We parametrize by the Arbitrary instance so we can limit
+    // contract id generation to comparable cids in some places.
+    implicit def injarb(implicit cid: Arbitrary[Value.ContractId]): Arbitrary[Inj]
+    implicit def injshrink(implicit shr: Shrink[Value.ContractId]): Shrink[Inj]
     final override def toString = s"${classOf[ValueAddend].getSimpleName}{t = ${t.toString}}"
   }
 
-  object ValueAddend extends PrimInstances[Lambda[a => ValueAddend { type Inj[_] = a }]] {
-    type Aux[Inj0[_]] = ValueAddend {
-      type Inj[Cid] = Inj0[Cid]
+  object ValueAddend extends PrimInstances[Lambda[a => ValueAddend { type Inj = a }]] {
+    type Aux[Inj0] = ValueAddend {
+      type Inj = Inj0
     }
     type NoCid[Inj0] = ValueAddend {
-      type Inj[_] = Inj0
+      type Inj = Inj0
     }
 
     private sealed abstract class NoCid0[Inj0](implicit
@@ -68,18 +68,18 @@ object TypedValueGenerators {
         arb: Arbitrary[Inj0],
         shr: Shrink[Inj0],
     ) extends ValueAddend {
-      type Inj[Cid] = Inj0
-      override final def injord[Cid: Order] = ord
-      override final def injarb[Cid: Arbitrary: IntroCtx] = arb
-      override final def injshrink[Cid: Shrink] = shr
+      type Inj = Inj0
+      override final def injord = ord
+      override final def injarb(implicit cid: Arbitrary[Value.ContractId]) = arb
+      override final def injshrink(implicit noshr: Shrink[Value.ContractId]) = shr
     }
 
-    def noCid[Inj0: Order: Arbitrary: Shrink](pt: PT, inj0: Inj0 => Value[Nothing])(
-        prj0: Value[Any] PartialFunction Inj0
+    def noCid[Inj0: Order: Arbitrary: Shrink](pt: PT, inj0: Inj0 => Value)(
+        prj0: Value PartialFunction Inj0
     ): NoCid[Inj0] = new NoCid0[Inj0] {
       override val t = TypePrim(pt, ImmArraySeq.empty)
-      override def inj[Cid: IntroCtx](v: Inj0) = inj0(v)
-      override def prj[Cid] = prj0.lift
+      override def inj(v: Inj0) = inj0(v)
+      override def prj = prj0.lift
     }
 
     import Value._, ValueGenerators.Implicits._, data.Utf8.ImplicitOrder._
@@ -97,136 +97,139 @@ object TypedValueGenerators {
       new NoCid0[Numeric] {
         override def t: Type = TypeNumeric(scale)
 
-        override def inj[Cid: IntroCtx](x: Numeric): Value[Cid] =
+        override def inj(x: Numeric): Value =
           ValueNumeric(Numeric.assertFromBigDecimal(scale, x))
 
-        override def prj[Cid]: Value[Cid] => Option[Numeric] = {
+        override def prj: Value => Option[Numeric] = {
           case ValueNumeric(x) => Numeric.fromBigDecimal(scale, x).toOption
           case _ => None
         }
       }
     }
 
-    val contractId: Aux[Id] = new ValueAddend {
-      type Inj[Cid] = Cid
+    val contractId: Aux[ContractId] = new ValueAddend {
+      type Inj = ContractId
       // TODO SC it probably doesn't make much difference for our initial use case,
       // but the proper arg should probably end up here, not Unit
       override val t = TypePrim(PT.ContractId, ImmArraySeq(TypePrim(PT.Unit, ImmArraySeq.empty)))
-      override def inj[Cid: IntroCtx](v: Cid) = ValueContractId(v)
-      override def prj[Cid] = {
+      override def inj(v: ContractId) = ValueContractId(v)
+      override def prj = {
         case ValueContractId(cid) => Some(cid)
         case _ => None
       }
-      override def injord[Cid](implicit ord: Order[Cid]) = ord
-      override def injarb[Cid](implicit cid: Arbitrary[Cid], _ign: Order[Cid]) = cid
-      override def injshrink[Cid](implicit shr: Shrink[Cid]) = shr
+      override def injord = implicitly[Order[ContractId]]
+      override def injarb(implicit cid: Arbitrary[Value.ContractId]) = Arbitrary(
+        ValueGenerators.coidGen
+      )
+      override def injshrink(implicit shr: Shrink[Value.ContractId]) =
+        implicitly[Shrink[ContractId]]
     }
 
-    type Compose[F[_], G[_], A] = F[G[A]]
-    def list(elt: ValueAddend): Aux[Compose[Vector, elt.Inj, *]] = new ValueAddend {
-      type Inj[Cid] = Vector[elt.Inj[Cid]]
+    def list(elt: ValueAddend): Aux[Vector[elt.Inj]] = new ValueAddend {
+      type Inj = Vector[elt.Inj]
       override val t = TypePrim(PT.List, ImmArraySeq(elt.t))
-      override def inj[Cid: IntroCtx](elts: Inj[Cid]) =
+      override def inj(elts: Inj) =
         ValueList(elts.map(elt.inj(_)).to(FrontStack))
-      override def prj[Cid] = {
+      override def prj = {
         case ValueList(v) =>
           import scalaz.std.vector._
           v.toImmArray.toSeq.to(Vector) traverse elt.prj
         case _ => None
       }
-      override def injord[Cid: Order] = {
+      override def injord = {
         import scalaz.std.iterable._ // compatible with SValue ordering
-        implicit val e: Order[elt.Inj[Cid]] = elt.injord
-        Order[Iterable[elt.Inj[Cid]]] contramap identity
+        implicit val e: Order[elt.Inj] = elt.injord
+        Order[Iterable[elt.Inj]] contramap identity
       }
-      override def injarb[Cid: Arbitrary: IntroCtx] = {
-        implicit val e: Arbitrary[elt.Inj[Cid]] = elt.injarb
-        Tag unsubst implicitly[Arbitrary[Vector[elt.Inj[Cid]] @@ Div3]]
+      override def injarb(implicit cid: Arbitrary[Value.ContractId]) = {
+        implicit val e: Arbitrary[elt.Inj] = elt.injarb
+        Tag unsubst implicitly[Arbitrary[Vector[elt.Inj] @@ Div3]]
       }
-      override def injshrink[Cid: Shrink] = {
+      override def injshrink(implicit shr: Shrink[Value.ContractId]) = {
         import elt.injshrink
-        implicitly[Shrink[Vector[elt.Inj[Cid]]]]
+        implicitly[Shrink[Vector[elt.Inj]]]
       }
     }
 
-    def optional(elt: ValueAddend): Aux[Compose[Option, elt.Inj, *]] = new ValueAddend {
-      type Inj[Cid] = Option[elt.Inj[Cid]]
+    def optional(elt: ValueAddend): Aux[Option[elt.Inj]] = new ValueAddend {
+      type Inj = Option[elt.Inj]
       override val t = TypePrim(PT.Optional, ImmArraySeq(elt.t))
-      override def inj[Cid: IntroCtx](oe: Inj[Cid]) = ValueOptional(oe map (elt.inj(_)))
-      override def prj[Cid] = {
+      override def inj(oe: Inj) = ValueOptional(oe map (elt.inj(_)))
+      override def prj = {
         case ValueOptional(v) => v traverse elt.prj
         case _ => None
       }
-      override def injord[Cid: Order] = {
-        implicit val e: Order[elt.Inj[Cid]] = elt.injord
-        Order[Option[elt.Inj[Cid]]]
+      override def injord = {
+        implicit val e: Order[elt.Inj] = elt.injord
+        Order[Option[elt.Inj]]
       }
-      override def injarb[Cid: Arbitrary: IntroCtx] = {
-        implicit val e: Arbitrary[elt.Inj[Cid]] = elt.injarb
-        implicitly[Arbitrary[Option[elt.Inj[Cid]]]]
+      override def injarb(implicit cid: Arbitrary[Value.ContractId]) = {
+        implicit val e: Arbitrary[elt.Inj] = elt.injarb
+        implicitly[Arbitrary[Option[elt.Inj]]]
       }
-      override def injshrink[Cid: Shrink] = {
+      override def injshrink(implicit cid: Shrink[Value.ContractId]) = {
         import elt.injshrink
-        implicitly[Shrink[Option[elt.Inj[Cid]]]]
+        implicitly[Shrink[Option[elt.Inj]]]
       }
     }
 
-    def map(elt: ValueAddend): Aux[Compose[SortedLookupList, elt.Inj, *]] = new ValueAddend {
-      type Inj[Cid] = SortedLookupList[elt.Inj[Cid]]
+    def map(elt: ValueAddend): Aux[SortedLookupList[elt.Inj]] = new ValueAddend {
+      type Inj = SortedLookupList[elt.Inj]
       override val t = TypePrim(PT.TextMap, ImmArraySeq(elt.t))
-      override def inj[Cid: IntroCtx](sll: SortedLookupList[elt.Inj[Cid]]) =
+      override def inj(sll: SortedLookupList[elt.Inj]) =
         ValueTextMap(sll map (elt.inj(_)))
-      override def prj[Cid] = {
+      override def prj = {
         case ValueTextMap(sll) => sll traverse elt.prj
         case _ => None
       }
-      override def injord[Cid: Order] = {
-        implicit val e: Order[elt.Inj[Cid]] = elt.injord[Cid]
-        Order[SortedLookupList[elt.Inj[Cid]]]
+      override def injord = {
+        implicit val e: Order[elt.Inj] = elt.injord
+        Order[SortedLookupList[elt.Inj]]
       }
-      override def injarb[Cid: Arbitrary: IntroCtx] = {
-        implicit val e: Arbitrary[elt.Inj[Cid]] = elt.injarb
-        Tag unsubst implicitly[Arbitrary[SortedLookupList[elt.Inj[Cid]] @@ Div3]]
+      override def injarb(implicit cid: Arbitrary[Value.ContractId]) = {
+        implicit val e: Arbitrary[elt.Inj] = elt.injarb
+        Tag unsubst implicitly[Arbitrary[SortedLookupList[elt.Inj] @@ Div3]]
       }
-      override def injshrink[Cid: Shrink] = Shrink.shrinkAny // XXX descend
+      override def injshrink(implicit shr: Shrink[Value.ContractId]) =
+        Shrink.shrinkAny // XXX descend
     }
 
     def genMap(key: ValueAddend, elt: ValueAddend): ValueAddend {
-      type Inj[Cid] = key.Inj[Cid] Map elt.Inj[Cid]
+      type Inj = key.Inj Map elt.Inj
     } = new ValueAddend {
-      type Inj[Cid] = key.Inj[Cid] Map elt.Inj[Cid]
+      type Inj = key.Inj Map elt.Inj
       override val t = TypePrim(PT.GenMap, ImmArraySeq(key.t, elt.t))
-      override def inj[Cid: IntroCtx](m: key.Inj[Cid] Map elt.Inj[Cid]) =
+      override def inj(m: key.Inj Map elt.Inj) =
         ValueGenMap {
           import key.{injord => keyorder}
-          implicit val skeyord: math.Ordering[key.Inj[Cid]] = Order[key.Inj[Cid]].toScalaOrdering
+          implicit val skeyord: math.Ordering[key.Inj] = Order[key.Inj].toScalaOrdering
           m.to(ImmArraySeq)
             .sortBy(_._1)
             .map { case (k, v) => (key.inj(k), elt.inj(v)) }
             .toImmArray
         }
-      override def prj[Cid] = {
+      override def prj = {
         case ValueGenMap(kvs) =>
-          kvs traverse (_.bitraverse(key.prj[Cid], elt.prj[Cid])) map (_.toSeq.toMap)
+          kvs traverse (_.bitraverse(key.prj, elt.prj)) map (_.toSeq.toMap)
         case _ => None
       }
-      override def injord[Cid: Order] = {
-        implicit val k: Order[key.Inj[Cid]] = key.injord
-        implicit val ki: math.Ordering[key.Inj[Cid]] = k.toScalaOrdering
-        implicit val e: Order[elt.Inj[Cid]] = elt.injord
+      override def injord = {
+        implicit val k: Order[key.Inj] = key.injord
+        implicit val ki: math.Ordering[key.Inj] = k.toScalaOrdering
+        implicit val e: Order[elt.Inj] = elt.injord
         // for compatibility with SValue ordering
-        Order[ImmArray[(key.Inj[Cid], elt.Inj[Cid])]] contramap { m =>
+        Order[ImmArray[(key.Inj, elt.Inj)]] contramap { m =>
           m.to(ImmArraySeq).sortBy(_._1).toImmArray
         }
       }
-      override def injarb[Cid: Arbitrary: IntroCtx] = {
-        implicit val k: Arbitrary[key.Inj[Cid]] = key.injarb
-        implicit val e: Arbitrary[elt.Inj[Cid]] = elt.injarb
-        Tag unsubst implicitly[Arbitrary[key.Inj[Cid] Map elt.Inj[Cid] @@ Div3]]
+      override def injarb(implicit arb: Arbitrary[Value.ContractId]) = {
+        implicit val k: Arbitrary[key.Inj] = key.injarb
+        implicit val e: Arbitrary[elt.Inj] = elt.injarb
+        Tag unsubst implicitly[Arbitrary[key.Inj Map elt.Inj @@ Div3]]
       }
-      override def injshrink[Cid: Shrink] = {
+      override def injshrink(implicit shr: Shrink[Value.ContractId]) = {
         import key.{injshrink => keyshrink}, elt.{injshrink => eltshrink}
-        implicitly[Shrink[key.Inj[Cid] Map elt.Inj[Cid]]]
+        implicitly[Shrink[key.Inj Map elt.Inj]]
       }
     }
 
@@ -236,24 +239,24 @@ object TypedValueGenerators {
         DefDataType(ImmArraySeq.empty, Record(spec.t.to(ImmArraySeq))),
         new ValueAddend {
           private[this] val lfvFieldNames = spec.t map { case (n, _) => Some(n) }
-          type Inj[Cid] = spec.HRec[Cid]
+          type Inj = spec.HRec
           override val t = TypeCon(TypeConName(name), ImmArraySeq.empty)
-          override def inj[Cid: IntroCtx](hl: Inj[Cid]) =
+          override def inj(hl: Inj) =
             ValueRecord(
               Some(name),
               implicitly[
-                Factory[(Some[Ref.Name], Value[Cid]), ImmArray[(Some[Ref.Name], Value[Cid])]]
+                Factory[(Some[Ref.Name], Value), ImmArray[(Some[Ref.Name], Value)]]
               ]
                 .fromSpecific(lfvFieldNames zip spec.injRec(hl)),
             )
-          override def prj[Cid] = {
+          override def prj = {
             case ValueRecord(_, fields) if fields.length == spec.t.length =>
               spec.prjRec(fields)
             case _ => None
           }
-          override def injord[Cid: Order] = spec.record[Cid]
-          override def injarb[Cid: Arbitrary: IntroCtx] = spec.recarb[Cid]
-          override def injshrink[Cid: Shrink] = spec.recshrink
+          override def injord = spec.record
+          override def injarb(implicit cid: Arbitrary[Value.ContractId]) = spec.recarb
+          override def injshrink(implicit shr: Shrink[Value.ContractId]) = spec.recshrink
         },
       )
 
@@ -262,21 +265,21 @@ object TypedValueGenerators {
       (
         DefDataType(ImmArraySeq.empty, Variant(spec.t.to(ImmArraySeq))),
         new ValueAddend {
-          type Inj[Cid] = spec.HVar[Cid]
+          type Inj = spec.HVar
           override val t = TypeCon(TypeConName(name), ImmArraySeq.empty)
-          override def inj[Cid: IntroCtx](cp: Inj[Cid]) = {
+          override def inj(cp: Inj) = {
             val (ctor, v) = spec.injVar(cp)
             ValueVariant(Some(name), ctor, v)
           }
-          override def prj[Cid] = {
+          override def prj = {
             case ValueVariant(_, name, vv) =>
               spec.prjVar get name flatMap (_(vv))
             case _ => None
           }
-          override def injord[Cid: Order] = spec.varord[Cid]
-          override def injarb[Cid: Arbitrary: IntroCtx] =
-            Arbitrary(Gen.oneOf(spec.vararb[Cid].toSeq).flatMap(_._2))
-          override def injshrink[Cid: Shrink] = spec.varshrink
+          override def injord = spec.varord
+          override def injarb(implicit cid: Arbitrary[Value.ContractId]) =
+            Arbitrary(Gen.oneOf(spec.vararb.toSeq).flatMap(_._2))
+          override def injshrink(implicit shr: Shrink[Value.ContractId]) = spec.varshrink
         },
       )
 
@@ -290,14 +293,16 @@ object TypedValueGenerators {
           type Member = Ref.Name
           override val values = members
           override val t = TypeCon(TypeConName(name), ImmArraySeq.empty)
-          override def inj[Cid: IntroCtx](v: Inj[Cid]) = ValueEnum(Some(name), v)
-          override def prj[Cid] = {
+          override def inj(v: Inj) = ValueEnum(Some(name), v)
+          override def prj = {
             case ValueEnum(_, dc) => get(dc)
             case _ => None
           }
-          override def injord[Cid: Order] = Order.orderBy(values.indexOf)
-          override def injarb[Cid: Arbitrary: IntroCtx] = Arbitrary(Gen.oneOf(values))
-          override def injshrink[Cid: Shrink] =
+          override def injord = Order.orderBy(values.indexOf)
+          override def injarb(implicit cid: Arbitrary[Value.ContractId]) = Arbitrary(
+            Gen.oneOf(values)
+          )
+          override def injshrink(implicit shr: Shrink[Value.ContractId]) =
             Shrink { ev =>
               if (!(values.headOption contains ev)) values.headOption.toStream
               else Stream.empty
@@ -306,7 +311,7 @@ object TypedValueGenerators {
       )
 
     sealed abstract class EnumAddend[+Values <: Seq[Ref.Name]] extends ValueAddend {
-      type Inj[Cid] = Member
+      type Inj = Member
       type Member <: Ref.Name
       val values: Values with Seq[Member]
       def get(m: Ref.Name): Option[Member] = values collectFirst { case v if m == v => v }
@@ -317,21 +322,20 @@ object TypedValueGenerators {
     import shapeless.{::, :+:, Coproduct, HList, Inl, Inr, Witness}
     import shapeless.labelled.{field, FieldType => :->>:}
 
-    type HRec[Cid] <: HList
-    type HVar[Cid] <: Coproduct
-    type IntroCtx[Cid] = Order[Cid]
+    type HRec <: HList
+    type HVar <: Coproduct
     def ::[K <: Symbol](h: K :->>: ValueAddend)(implicit ev: Witness.Aux[K]): RecVarSpec {
-      type HRec[Cid] = (K :->>: h.Inj[Cid]) :: self.HRec[Cid]
-      type HVar[Cid] = (K :->>: h.Inj[Cid]) :+: self.HVar[Cid]
+      type HRec = (K :->>: h.Inj) :: self.HRec
+      type HVar = (K :->>: h.Inj) :+: self.HVar
     } =
       new RecVarSpec {
         private[this] val fname = Ref.Name assertFromString ev.value.name
-        type HRec[Cid] = (K :->>: h.Inj[Cid]) :: self.HRec[Cid]
-        type HVar[Cid] = (K :->>: h.Inj[Cid]) :+: self.HVar[Cid]
+        type HRec = (K :->>: h.Inj) :: self.HRec
+        type HVar = (K :->>: h.Inj) :+: self.HVar
         override val t = (fname, h.t) :: self.t
-        override def injRec[Cid: IntroCtx](v: HRec[Cid]) =
+        override def injRec(v: HRec) =
           h.inj(v.head) :: self.injRec(v.tail)
-        override def prjRec[Cid](v: ImmArray[(_, Value[Cid])]) = v match {
+        override def prjRec(v: ImmArray[(_, Value)]) = v match {
           case ImmArrayCons(vh, vt) =>
             for {
               pvh <- h.prj(vh._2)
@@ -340,67 +344,65 @@ object TypedValueGenerators {
           case _ => None
         }
 
-        override def record[Cid: Order] = {
+        override def record = {
           import h.{injord => hord}, self.{record => tailord}
-          Order.orderBy { case ah :: at => (ah: h.Inj[Cid], at) }
+          Order.orderBy { case ah :: at => (ah: h.Inj, at) }
         }
 
-        override def recarb[Cid: Arbitrary: IntroCtx] = {
+        override def recarb(implicit cid: Arbitrary[Value.ContractId]) = {
           import self.{recarb => tailarb}, h.{injarb => headarb}
-          Arbitrary(arbitrary[(h.Inj[Cid], self.HRec[Cid])] map { case (vh, vt) =>
+          Arbitrary(arbitrary[(h.Inj, self.HRec)] map { case (vh, vt) =>
             field[K](vh) :: vt
           })
         }
 
-        override def recshrink[Cid: Shrink]: Shrink[HRec[Cid]] = {
+        override def recshrink(implicit shr: Shrink[Value.ContractId]): Shrink[HRec] = {
           import h.{injshrink => hshrink}, self.{recshrink => tshrink}
           Shrink { case vh :: vt =>
-            (Shrink.shrink(vh: h.Inj[Cid]) zip Shrink.shrink(vt)) map { case (nh, nt) =>
+            (Shrink.shrink(vh: h.Inj) zip Shrink.shrink(vt)) map { case (nh, nt) =>
               field[K](nh) :: nt
             }
           }
         }
 
-        override def injVar[Cid: IntroCtx](v: HVar[Cid]) = v match {
+        override def injVar(v: HVar) = v match {
           case Inl(hv) => (fname, h.inj(hv))
           case Inr(tl) => self.injVar(tl)
         }
 
         override val prjVar = {
-          val r = self.prjVar transform { (_, tf) =>
-            Lambda[Value ~> PrjResult](tv => tf(tv) map (Inr(_)))
-          }
+          val r = self.prjVar transform { (_, tf) => tv: Value => tf(tv) map (Inr(_)) }
           r.updated(
             fname,
-            Lambda[Value ~> PrjResult](hv => h.prj(hv) map (pv => Inl(field[K](pv)))),
+            (hv: Value) => h.prj(hv) map (pv => Inl(field[K](pv))),
           )
         }
 
-        override def varord[Cid: Order] =
+        override def varord =
           (a, b) =>
             (a, b) match {
-              case (Inr(at), Inr(bt)) => self.varord[Cid].order(at, bt)
+              case (Inr(at), Inr(bt)) => self.varord.order(at, bt)
               case (Inl(_), Inr(_)) => Ordering.LT
               case (Inr(_), Inl(_)) => Ordering.GT
-              case (Inl(ah), Inl(bh)) => h.injord[Cid].order(ah, bh)
+              case (Inl(ah), Inl(bh)) => h.injord.order(ah, bh)
             }
 
-        override def vararb[Cid: Arbitrary: IntroCtx] = {
+        override def vararb(implicit cid: Arbitrary[Value.ContractId]) = {
           val r =
-            self.vararb[Cid] transform { (_, ta) =>
+            self.vararb transform { (_, ta) =>
               ta map (Inr(_))
             }
           r.updated(
             fname, {
               import h.{injarb => harb}
-              arbitrary[h.Inj[Cid]] map (hv => Inl(field[K](hv)))
+              arbitrary[h.Inj] map (hv => Inl(field[K](hv)))
             },
           )
         }
 
-        override def varshrink[Cid: Shrink] = {
-          val lshr: Shrink[h.Inj[Cid]] = h.injshrink
-          val rshr: Shrink[self.HVar[Cid]] = self.varshrink
+        override def varshrink = {
+          val lshr: Shrink[h.Inj] = h.injshrink
+          val rshr: Shrink[self.HVar] = self.varshrink
           Shrink {
             case Inl(hv) => lshr shrink hv map (shv => Inl(field[K](shv)))
             case Inr(tl) => rshr shrink tl map (Inr(_))
@@ -409,43 +411,46 @@ object TypedValueGenerators {
       }
 
     private[TypedValueGenerators] val t: List[(Ref.Name, Type)]
-    private[TypedValueGenerators] def injRec[Cid: IntroCtx](v: HRec[Cid]): List[Value[Cid]]
-    private[TypedValueGenerators] def prjRec[Cid](v: ImmArray[(_, Value[Cid])]): Option[HRec[Cid]]
-    private[TypedValueGenerators] implicit def record[Cid: Order]: Order[HRec[Cid]]
-    private[TypedValueGenerators] implicit def recarb[Cid: Arbitrary: IntroCtx]
-        : Arbitrary[HRec[Cid]]
-    private[TypedValueGenerators] implicit def recshrink[Cid: Shrink]: Shrink[HRec[Cid]]
+    private[TypedValueGenerators] def injRec(v: HRec): List[Value]
+    private[TypedValueGenerators] def prjRec(v: ImmArray[(_, Value)]): Option[HRec]
+    private[TypedValueGenerators] implicit def record: Order[HRec]
+    private[TypedValueGenerators] implicit def recarb(implicit
+        cid: Arbitrary[Value.ContractId]
+    ): Arbitrary[HRec]
+    private[TypedValueGenerators] implicit def recshrink(implicit
+        shr: Shrink[Value.ContractId]
+    ): Shrink[HRec]
 
-    private[TypedValueGenerators] def injVar[Cid: IntroCtx](v: HVar[Cid]): (Ref.Name, Value[Cid])
-    private[TypedValueGenerators] type PrjResult[Cid] = Option[HVar[Cid]]
-    // could be made more efficient by replacing ~> with a Nat GADT,
-    // but the :+: case is tricky enough as it is
-    private[TypedValueGenerators] val prjVar: Map[Ref.Name, Value ~> PrjResult]
-    private[TypedValueGenerators] implicit def varord[Cid: Order]: Order[HVar[Cid]]
-    private[TypedValueGenerators] implicit def vararb[Cid: Arbitrary: IntroCtx]
-        : Map[Ref.Name, Gen[HVar[Cid]]]
-    private[TypedValueGenerators] implicit def varshrink[Cid: Shrink]: Shrink[HVar[Cid]]
+    private[TypedValueGenerators] def injVar(v: HVar): (Ref.Name, Value)
+    private[TypedValueGenerators] type PrjResult = Option[HVar]
+    private[TypedValueGenerators] val prjVar: Map[Ref.Name, Value => PrjResult]
+    private[TypedValueGenerators] implicit def varord: Order[HVar]
+    private[TypedValueGenerators] implicit def vararb(implicit
+        cid: Arbitrary[Value.ContractId]
+    ): Map[Ref.Name, Gen[HVar]]
+    private[TypedValueGenerators] implicit def varshrink: Shrink[HVar]
   }
 
   case object RNil extends RecVarSpec {
     import shapeless.{HNil, CNil}
-    type HRec[Cid] = HNil
-    type HVar[Cid] = CNil
+    type HRec = HNil
+    type HVar = CNil
     private[TypedValueGenerators] override val t = List.empty
-    private[TypedValueGenerators] override def injRec[Cid: IntroCtx](v: HNil) = List.empty
-    private[TypedValueGenerators] override def prjRec[Cid](v: ImmArray[(_, Value[Cid])]) =
+    private[TypedValueGenerators] override def injRec(v: HNil) = List.empty
+    private[TypedValueGenerators] override def prjRec(v: ImmArray[(_, Value)]) =
       Some(HNil)
-    private[TypedValueGenerators] override def record[Cid: Order] = (_, _) => Ordering.EQ
-    private[TypedValueGenerators] override def recarb[Cid: Arbitrary: IntroCtx] =
+    private[TypedValueGenerators] override def record = (_, _) => Ordering.EQ
+    private[TypedValueGenerators] override def recarb(implicit cid: Arbitrary[Value.ContractId]) =
       Arbitrary(Gen const HNil)
-    private[TypedValueGenerators] override def recshrink[Cid: Shrink] =
+    private[TypedValueGenerators] override def recshrink(implicit shr: Shrink[Value.ContractId]) =
       Shrink.shrinkAny
 
-    private[TypedValueGenerators] override def injVar[Cid: IntroCtx](v: CNil) = v.impossible
+    private[TypedValueGenerators] override def injVar(v: CNil) = v.impossible
     private[TypedValueGenerators] override val prjVar = Map.empty
-    private[TypedValueGenerators] override def varord[Cid: Order] = (v, _) => v.impossible
-    private[TypedValueGenerators] override def vararb[Cid: Arbitrary: IntroCtx] = Map.empty
-    private[TypedValueGenerators] override def varshrink[Cid: Shrink] = Shrink.shrinkAny
+    private[TypedValueGenerators] override def varord = (v, _) => v.impossible
+    private[TypedValueGenerators] override def vararb(implicit cid: Arbitrary[Value.ContractId]) =
+      Map.empty
+    private[TypedValueGenerators] override def varshrink = Shrink.shrinkAny
   }
 
   private[value] object RecVarSpec {
@@ -466,12 +471,12 @@ object TypedValueGenerators {
         sample,
       )
     import shapeless.record.Record
-    // supposing Cid = String, you can ascribe a matching value
+    // You can ascribe a matching value
     // using either the spec,
-    val sampleData: sample.HRec[String] =
+    val sampleData: sample.HRec =
       Record(foo = 42L, bar = "hi")
     // or the record VA
-    val sampleDataAgain: sampleAsRecord.Inj[String] = sampleData
+    val sampleDataAgain: sampleAsRecord.Inj = sampleData
     // ascription is not necessary; a correct `Record` expression already
     // has the correct type, as implicit conversion is not used at all
 
@@ -481,9 +486,9 @@ object TypedValueGenerators {
     // you can do so with `align`. The resulting error messages are far worse, so
     // I recommend just writing them in the correct order
     shapeless.test
-      .illTyped("""Record(bar = "bye", foo = 84L): sample.HRec[String]""", "type mismatch.*")
-    val backwardsSampleData: sample.HRec[String] =
-      Record(bar = "bye", foo = 84L).align[sample.HRec[String]]
+      .illTyped("""Record(bar = "bye", foo = 84L): sample.HRec""", "type mismatch.*")
+    val backwardsSampleData: sample.HRec =
+      Record(bar = "bye", foo = 84L).align[sample.HRec]
 
     // a RecVarSpec can be turned into a ValueAddend for variants
     val (sampleVariantDDT, sampleAsVariant) =
@@ -494,18 +499,18 @@ object TypedValueGenerators {
         ),
         sample,
       )
-    // supposing Cid = String, you can create a matching value with Coproduct
+    // You can create a matching value with Coproduct
     import shapeless.Coproduct, shapeless.syntax.singleton._
     val sampleVt =
-      Coproduct[sample.HVar[String]](Symbol("foo") ->> 42L)
+      Coproduct[sample.HVar](Symbol("foo") ->> 42L)
     val anotherSampleVt =
-      Coproduct[sample.HVar[String]](Symbol("bar") ->> "hi")
+      Coproduct[sample.HVar](Symbol("bar") ->> "hi")
     // and the `variant` function produces Inj as a synonym for HVar
     // just as `record` makes it a synonym for HRec
-    val samples: List[sampleAsVariant.Inj[String]] = List(sampleVt, anotherSampleVt)
+    val samples: List[sampleAsVariant.Inj] = List(sampleVt, anotherSampleVt)
     // Coproduct can be factored out, but the implicit resolution means you cannot
     // turn this into the obvious `map` call
-    val sampleCp = Coproduct[sample.HVar[String]]
+    val sampleCp = Coproduct[sample.HVar]
     val moreSamples = List(sampleCp(Symbol("foo") ->> 84L), sampleCp(Symbol("bar") ->> "bye"))
   }
 
@@ -567,9 +572,9 @@ object TypedValueGenerators {
   val genAddendNoListMap: Gen[ValueAddend] = indGenAddend((_, _) => Seq.empty)
 
   /** Generate a type and value guaranteed to conform to that type. */
-  def genTypeAndValue[Cid: Order](cid: Gen[Cid]): Gen[(Type, Value[Cid])] =
+  def genTypeAndValue(cid: Gen[Value.ContractId]): Gen[(Type, Value)] =
     for {
       addend <- genAddend
-      value <- addend.injarb(Arbitrary(cid), Order[Cid]).arbitrary
+      value <- addend.injarb(Arbitrary(cid)).arbitrary
     } yield (addend.t, addend.inj(value))
 }

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -109,7 +109,7 @@ object ValueGenerators {
       .map(Time.Timestamp.assertFromLong)
 
   // generate a variant with arbitrary value
-  private def variantGen(nesting: Int): Gen[ValueVariant[ContractId]] =
+  private def variantGen(nesting: Int): Gen[ValueVariant] =
     for {
       id <- idGen
       variantName <- nameGen
@@ -122,9 +122,9 @@ object ValueGenerators {
       value <- Gen.lzy(valueGen(nesting))
     } yield ValueVariant(toOption(id), variantName, value)
 
-  def variantGen: Gen[ValueVariant[ContractId]] = variantGen(0)
+  def variantGen: Gen[ValueVariant] = variantGen(0)
 
-  private def recordGen(nesting: Int): Gen[ValueRecord[ContractId]] =
+  private def recordGen(nesting: Int): Gen[ValueRecord] =
     for {
       id <- idGen
       toOption <- Gen
@@ -138,37 +138,37 @@ object ValueGenerators {
           Gen.lzy(valueGen(nesting)).map(x => if (label.isEmpty) (None, x) else (Some(label), x))
         )
       )
-    } yield ValueRecord[ContractId](toOption(id), labelledValues.to(ImmArray))
+    } yield ValueRecord(toOption(id), labelledValues.to(ImmArray))
 
-  def recordGen: Gen[ValueRecord[ContractId]] = recordGen(0)
+  def recordGen: Gen[ValueRecord] = recordGen(0)
 
-  private def valueOptionalGen(nesting: Int): Gen[ValueOptional[ContractId]] =
+  private def valueOptionalGen(nesting: Int): Gen[ValueOptional] =
     Gen.option(valueGen(nesting)).map(v => ValueOptional(v))
 
-  def valueOptionalGen: Gen[ValueOptional[ContractId]] = valueOptionalGen(0)
+  def valueOptionalGen: Gen[ValueOptional] = valueOptionalGen(0)
 
-  private def valueListGen(nesting: Int): Gen[ValueList[ContractId]] =
+  private def valueListGen(nesting: Int): Gen[ValueList] =
     for {
       values <- Gen.listOf(Gen.lzy(valueGen(nesting)))
-    } yield ValueList[ContractId](values.to(FrontStack))
+    } yield ValueList(values.to(FrontStack))
 
-  def valueListGen: Gen[ValueList[ContractId]] = valueListGen(0)
+  def valueListGen: Gen[ValueList] = valueListGen(0)
 
   private def valueMapGen(nesting: Int) =
     for {
       list <- Gen.listOf(for {
         k <- Gen.asciiPrintableStr; v <- Gen.lzy(valueGen(nesting))
       } yield k -> v)
-    } yield ValueTextMap[ContractId](SortedLookupList(Map(list: _*)))
+    } yield ValueTextMap(SortedLookupList(Map(list: _*)))
 
-  def valueMapGen: Gen[ValueTextMap[ContractId]] = valueMapGen(0)
+  def valueMapGen: Gen[ValueTextMap] = valueMapGen(0)
 
   private def valueGenMapGen(nesting: Int) =
     Gen
       .listOf(Gen.zip(Gen.lzy(valueGen(nesting)), Gen.lzy(valueGen(nesting))))
-      .map(list => ValueGenMap[ContractId](list.to(ImmArray)))
+      .map(list => ValueGenMap(list.to(ImmArray)))
 
-  def valueGenMapGen: Gen[ValueGenMap[ContractId]] = valueGenMapGen(0)
+  def valueGenMapGen: Gen[ValueGenMap] = valueGenMapGen(0)
 
   private val genHash: Gen[crypto.Hash] =
     Gen
@@ -206,10 +206,10 @@ object ValueGenerators {
 
   def coidGen: Gen[ContractId] = Gen.oneOf(cidV0Gen, cidV1Gen)
 
-  def coidValueGen: Gen[ValueContractId[ContractId]] =
+  def coidValueGen: Gen[ValueContractId] =
     coidGen.map(ValueContractId(_))
 
-  private def valueGen(nesting: Int): Gen[Value[ContractId]] = {
+  private def valueGen(nesting: Int): Gen[Value] = {
     Gen.sized(sz => {
       val newNesting = nesting + 1
       val nested = List(
@@ -254,9 +254,9 @@ object ValueGenerators {
       .map(s => Party.assertFromString(s.take(255).mkString))
   }
 
-  def valueGen: Gen[Value[ContractId]] = valueGen(0)
+  def valueGen: Gen[Value] = valueGen(0)
 
-  def versionedValueGen: Gen[VersionedValue[ContractId]] =
+  def versionedValueGen: Gen[VersionedValue] =
     for {
       value <- valueGen
       minVersion = TransactionBuilder.assertAssignVersion(value)
@@ -267,7 +267,7 @@ object ValueGenerators {
 
   val genNonEmptyParties: Gen[Set[Party]] = ^(party, genMaybeEmptyParties)((hd, tl) => tl + hd)
 
-  val contractInstanceGen: Gen[ContractInst[Value[Value.ContractId]]] = {
+  val contractInstanceGen: Gen[ContractInst[Value]] = {
     for {
       template <- idGen
       arg <- valueGen
@@ -275,14 +275,14 @@ object ValueGenerators {
     } yield ContractInst(template, arg, agreement)
   }
 
-  val versionedContractInstanceGen: Gen[ContractInst[Value.VersionedValue[Value.ContractId]]] =
+  val versionedContractInstanceGen: Gen[ContractInst[Value.VersionedValue]] =
     for {
       template <- idGen
       arg <- versionedValueGen
       agreement <- Arbitrary.arbitrary[String]
     } yield ContractInst(template, arg, agreement)
 
-  val keyWithMaintainersGen: Gen[KeyWithMaintainers[Value[Value.ContractId]]] = {
+  val keyWithMaintainersGen: Gen[KeyWithMaintainers[Value]] = {
     for {
       key <- valueGen
       maintainers <- genNonEmptyParties
@@ -294,7 +294,7 @@ object ValueGenerators {
     * 1. stakeholders may not be a superset of signatories
     * 2. key's maintainers may not be a subset of signatories
     */
-  val malformedCreateNodeGen: Gen[NodeCreate[Value.ContractId]] = {
+  val malformedCreateNodeGen: Gen[NodeCreate] = {
     for {
       version <- transactionVersionGen()
       node <- malformedCreateNodeGenWithVersion(version)
@@ -308,7 +308,7 @@ object ValueGenerators {
     */
   def malformedCreateNodeGenWithVersion(
       version: TransactionVersion
-  ): Gen[NodeCreate[Value.ContractId]] = {
+  ): Gen[NodeCreate] = {
     for {
       coid <- coidGen
       templateId <- idGen
@@ -329,13 +329,13 @@ object ValueGenerators {
     )
   }
 
-  val fetchNodeGen: Gen[NodeFetch[ContractId]] =
+  val fetchNodeGen: Gen[NodeFetch] =
     for {
       version <- transactionVersionGen()
       node <- fetchNodeGenWithVersion(version)
     } yield node
 
-  def fetchNodeGenWithVersion(version: TransactionVersion): Gen[NodeFetch[ContractId]] = {
+  def fetchNodeGenWithVersion(version: TransactionVersion): Gen[NodeFetch] = {
     for {
       coid <- coidGen
       templateId <- idGen
@@ -367,7 +367,7 @@ object ValueGenerators {
   }
 
   /** Makes exercise nodes with the given version and some random child IDs. */
-  val danglingRefExerciseNodeGen: Gen[NodeExercises[NodeId, Value.ContractId]] =
+  val danglingRefExerciseNodeGen: Gen[NodeExercises[NodeId]] =
     for {
       version <- transactionVersionGen()
       node <- danglingRefExerciseNodeGenWithVersion(version)
@@ -376,7 +376,7 @@ object ValueGenerators {
   /** Makes exercise nodes with the given version and some random child IDs. */
   def danglingRefExerciseNodeGenWithVersion(
       version: TransactionVersion
-  ): Gen[NodeExercises[NodeId, Value.ContractId]] = {
+  ): Gen[NodeExercises[NodeId]] = {
     for {
       targetCoid <- coidGen
       templateId <- idGen
@@ -412,7 +412,7 @@ object ValueGenerators {
     )
   }
 
-  val lookupNodeGen: Gen[NodeLookupByKey[ContractId]] =
+  val lookupNodeGen: Gen[NodeLookupByKey] =
     for {
       version <- transactionVersionGen()
       targetCoid <- coidGen
@@ -491,7 +491,7 @@ object ValueGenerators {
     *
     * This list is complete as of transaction version 5. -SC
     */
-  val malformedGenTransaction: Gen[GenTransaction[NodeId, ContractId]] = {
+  val malformedGenTransaction: Gen[GenTransaction[NodeId]] = {
     for {
       nodes <- Gen.listOf(danglingRefGenNode)
       roots <- Gen.listOf(Arbitrary.arbInt.arbitrary.map(NodeId(_)))
@@ -509,7 +509,7 @@ object ValueGenerators {
    *
    */
 
-  val noDanglingRefGenTransaction: Gen[GenTransaction[NodeId, ContractId]] = {
+  val noDanglingRefGenTransaction: Gen[GenTransaction[NodeId]] = {
 
     def nonDanglingRefNodeGen(
         maxDepth: Int,
@@ -528,7 +528,7 @@ object ValueGenerators {
             2 -> fetchNodeGen,
           )
           nodeWithChildren <- node match {
-            case node: NodeExercises[NodeId, Value.ContractId] =>
+            case node: NodeExercises[NodeId] =>
               for {
                 depth <- Gen.choose(0, maxDepth - 1)
                 nodeWithChildren <- nonDanglingRefNodeGen(depth, nodeId)
@@ -567,12 +567,12 @@ object ValueGenerators {
     }
   }
 
-  val noDanglingRefGenVersionedTransaction: Gen[VersionedTransaction[NodeId, ContractId]] = {
+  val noDanglingRefGenVersionedTransaction: Gen[VersionedTransaction[NodeId]] = {
     for {
       tx <- noDanglingRefGenTransaction
       txVer <- transactionVersionGen()
       nodeVersionGen = transactionVersionGen().filterNot(_ < txVer)
-      nodes <- tx.fold(Gen.const(HashMap.empty[NodeId, GenNode[NodeId, ContractId]])) {
+      nodes <- tx.fold(Gen.const(HashMap.empty[NodeId, GenNode[NodeId]])) {
         case (acc, (nodeId, node)) =>
           for {
             hashMap <- acc

--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -95,7 +95,6 @@ da_scala_test(
         "//daml-lf/interface",
         "//daml-lf/language",
         "//daml-lf/transaction-test-lib",
-        "//libs-scala/scalatest-utils",
         "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
@@ -109,10 +108,12 @@ da_scala_test(
     plugins = [
         silencer_plugin,
     ],
-    scala_deps = [
-        "@maven//:org_scalaz_scalaz_core",
-    ],
     scalacopts = lf_scalacopts,
+    versioned_scala_deps = {
+        "2.12": [
+            "@maven//:org_scalaz_scalaz_core",
+        ],
+    },
     deps = [
         ":transaction",
         "//daml-lf/data",

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -19,8 +19,7 @@ sealed abstract class Error extends Serializable with Product {
 object Error {
 
   /** Unhandled exceptions */
-  final case class UnhandledException(exceptionType: Ast.Type, value: Value[ContractId])
-      extends Error
+  final case class UnhandledException(exceptionType: Ast.Type, value: Value) extends Error
 
   /** User initiated error, via e.g. 'abort' or 'assert' */
   final case class UserError(message: String) extends Error
@@ -34,7 +33,7 @@ object Error {
   final case class TemplatePreconditionViolated(
       templateId: TypeConName,
       optLocation: Option[Location],
-      arg: Value[ContractId],
+      arg: Value,
   ) extends Error
 
   /** A fetch or an exercise on a transaction-local contract that has already
@@ -71,14 +70,14 @@ object Error {
   /** A create with a contract key failed because the list of maintainers was empty */
   final case class CreateEmptyContractKeyMaintainers(
       templateId: TypeConName,
-      arg: Value[ContractId],
-      key: Value[Nothing],
+      arg: Value,
+      key: Value,
   ) extends Error
 
   /** A fetch or lookup of a contract key without maintainers */
   final case class FetchEmptyContractKeyMaintainers(
       templateId: TypeConName,
-      key: Value[Nothing],
+      key: Value,
   ) extends Error
 
   /** We tried to fetch / exercise a contract of the wrong type --
@@ -106,7 +105,7 @@ object Error {
   // (//daml-lf/spec/contract-id.rst) for more details.
   final case class ContractIdComparability(globalCid: ContractId.V1) extends Error
 
-  final case class ContractIdInContractKey(key: Value[ContractId]) extends Error
+  final case class ContractIdInContractKey(key: Value) extends Error
 
   final case object ValueExceedsMaxNesting extends Error
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/command/Command.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/command/Command.scala
@@ -25,8 +25,7 @@ sealed abstract class ApiCommand extends Command
   *  @param templateId identifier of the template that the contract is instantiating
   *  @param argument value passed to the template
   */
-final case class CreateCommand(templateId: Identifier, argument: Value[Value.ContractId])
-    extends ApiCommand
+final case class CreateCommand(templateId: Identifier, argument: Value) extends ApiCommand
 
 /** Command for exercising a choice on an existing contract
   *
@@ -39,7 +38,7 @@ final case class ExerciseCommand(
     templateId: Identifier,
     contractId: Value.ContractId,
     choiceId: ChoiceName,
-    argument: Value[Value.ContractId],
+    argument: Value,
 ) extends ApiCommand
 
 /** Command for exercising a choice on an existing contract specified by its key
@@ -51,9 +50,9 @@ final case class ExerciseCommand(
   */
 final case class ExerciseByKeyCommand(
     templateId: Identifier,
-    contractKey: Value[Value.ContractId],
+    contractKey: Value,
     choiceId: ChoiceName,
-    argument: Value[Value.ContractId],
+    argument: Value,
 ) extends ApiCommand
 
 /** Command for creating a contract and exercising a choice
@@ -66,9 +65,9 @@ final case class ExerciseByKeyCommand(
   */
 final case class CreateAndExerciseCommand(
     templateId: Identifier,
-    createArgument: Value[Value.ContractId],
+    createArgument: Value,
     choiceId: ChoiceName,
-    choiceArgument: Value[Value.ContractId],
+    choiceArgument: Value,
 ) extends ApiCommand
 
 final case class FetchCommand(
@@ -78,12 +77,12 @@ final case class FetchCommand(
 
 final case class FetchByKeyCommand(
     templateId: Identifier,
-    key: Value[Value.ContractId],
+    key: Value,
 ) extends Command
 
 final case class LookupByKeyCommand(
     templateId: Identifier,
-    contractKey: Value[Value.ContractId],
+    contractKey: Value,
 ) extends Command
 
 /** Commands input adapted from ledger-api

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -180,7 +180,7 @@ object Hash {
     // with another data representing uniquely the type of `value`.
     // See for instance hash : Node.GlobalKey => SHA256Hash
     @throws[HashingError]
-    final def addTypedValue(value: Value[Value.ContractId]): this.type =
+    final def addTypedValue(value: Value): this.type =
       value match {
         case Value.ValueUnit =>
           add(0.toByte)
@@ -302,18 +302,18 @@ object Hash {
   // 1 - `templateId` is the identifier for a template with a key of type τ
   // 2 - `key` is a value of type τ
   @throws[HashingError]
-  def assertHashContractKey(templateId: Ref.Identifier, key: Value[Value.ContractId]): Hash =
+  def assertHashContractKey(templateId: Ref.Identifier, key: Value): Hash =
     builder(Purpose.ContractKey, noCid2String)
       .addIdentifier(templateId)
       .addTypedValue(key)
       .build
 
-  def safeHashContractKey(templateId: Ref.Identifier, key: Value[Nothing]): Hash =
+  def safeHashContractKey(templateId: Ref.Identifier, key: Value): Hash =
     assertHashContractKey(templateId, key)
 
   def hashContractKey(
       templateId: Ref.Identifier,
-      key: Value[Value.ContractId],
+      key: Value,
   ): Either[String, Hash] =
     handleError(assertHashContractKey(templateId, key))
 
@@ -322,7 +322,7 @@ object Hash {
   // 2 - `arg` is a value of type τ
   // The hash is not stable under suffixing of contract IDs
   @throws[HashingError]
-  def assertHashContractInstance(templateId: Ref.Identifier, arg: Value[Value.ContractId]): Hash =
+  def assertHashContractInstance(templateId: Ref.Identifier, arg: Value): Hash =
     builder(Purpose.ContractInstance, aCid2Bytes)
       .addIdentifier(templateId)
       .addTypedValue(arg)
@@ -330,7 +330,7 @@ object Hash {
 
   def hashContractInstnce(
       templateId: Ref.Identifier,
-      arg: Value[Value.ContractId],
+      arg: Value,
   ): Either[String, Hash] =
     handleError(assertHashContractInstance(templateId, arg))
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -6,14 +6,13 @@ package transaction
 
 import com.daml.lf.data.Ref
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.ContractId
 
 /** Useful in various circumstances -- basically this is what a ledger implementation must use as
   * a key. The 'hash' is guaranteed to be stable over time.
   */
 final class GlobalKey private (
     val templateId: Ref.TypeConName,
-    val key: Value[ContractId],
+    val key: Value,
     val hash: crypto.Hash,
 ) extends {
   override def equals(obj: Any): Boolean = obj match {
@@ -28,16 +27,16 @@ final class GlobalKey private (
 
 object GlobalKey {
 
-  def apply(templateId: Ref.TypeConName, key: Value[Nothing]): GlobalKey =
+  def apply(templateId: Ref.TypeConName, key: Value): GlobalKey =
     new GlobalKey(templateId, key, crypto.Hash.safeHashContractKey(templateId, key))
 
   // Will fail if key contains contract ids
-  def build(templateId: Ref.TypeConName, key: Value[ContractId]): Either[String, GlobalKey] =
+  def build(templateId: Ref.TypeConName, key: Value): Either[String, GlobalKey] =
     crypto.Hash.hashContractKey(templateId, key).map(new GlobalKey(templateId, key, _))
 
   // Like `build` but,  in case of error, throws an exception instead of returning a message.
   @throws[IllegalArgumentException]
-  def assertBuild(templateId: Ref.TypeConName, key: Value[ContractId]): GlobalKey =
+  def assertBuild(templateId: Ref.TypeConName, key: Value): GlobalKey =
     data.assertRight(build(templateId, key))
 }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/IncompleteTransaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/IncompleteTransaction.scala
@@ -5,14 +5,12 @@ package com.daml.lf
 package transaction
 
 import com.daml.lf.data.Ref.Location
-import com.daml.lf.value.Value
 
 trait IncompleteTransaction {
 
   type Nid = NodeId
-  type Cid = Value.ContractId
-  type TX = GenTransaction[Nid, Cid]
-  type ExerciseNode = Node.NodeExercises[Nid, Cid]
+  type TX = GenTransaction[Nid]
+  type ExerciseNode = Node.NodeExercises[Nid]
 
   def transaction: TX
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -6,7 +6,7 @@ package transaction
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{ImmArray, ScalazEqual}
-import com.daml.lf.value.Value.VersionedValue
+import com.daml.lf.value.Value.{ContractId, VersionedValue}
 import com.daml.lf.value._
 import scalaz.Equal
 import scalaz.syntax.equal._
@@ -16,47 +16,28 @@ import scalaz.syntax.equal._
   */
 object Node {
 
-  sealed abstract class GenNode[+Nid, +Cid]
+  sealed abstract class GenNode[+Nid]
       extends Product
       with Serializable
-      with CidContainer[GenNode[Nid, Cid]] {
-
-    def foreach2(fNid: Nid => Unit, fCid: Cid => Unit): Unit
+      with CidContainer[GenNode[Nid]] {
 
     def optVersion: Option[TransactionVersion] = this match {
-      case node: GenActionNode[_, _] => Some(node.version)
+      case node: GenActionNode[_] => Some(node.version)
       case _: NodeRollback[_] => None
     }
-  }
 
-  object GenNode extends CidContainer2[GenNode] {
-    override private[lf] def map2[A1, B1, A2, B2](
-        f1: A1 => A2,
-        f2: B1 => B2,
-    ): GenNode[A1, B1] => GenNode[A2, B2] = {
-      case action: GenActionNode[A1, B1] =>
-        GenActionNode.map2(f1, f2)(action)
-      case rollback: NodeRollback[A1] =>
-        rollback.copy(children = rollback.children.map(f1))
-    }
-
-    override private[lf] def foreach2[A, B](f1: A => Unit, f2: B => Unit): GenNode[A, B] => Unit = {
-      case action: GenActionNode[A, B] =>
-        GenActionNode.foreach2(f1, f2)(action)
-      case rollback: NodeRollback[A] =>
-        rollback.foreach2(f1, f2)
-    }
+    def mapNodeId[Nid2](f: Nid => Nid2): GenNode[Nid2]
   }
 
   /** action nodes parametrized over identifier type */
-  sealed abstract class GenActionNode[+Nid, +Cid]
-      extends GenNode[Nid, Cid]
+  sealed abstract class GenActionNode[+Nid]
+      extends GenNode[Nid]
       with ActionNodeInfo
-      with CidContainer[GenActionNode[Nid, Cid]] {
+      with CidContainer[GenActionNode[Nid]] {
 
     def version: TransactionVersion
 
-    private[lf] def updateVersion(version: TransactionVersion): GenNode[Nid, Cid]
+    private[lf] def updateVersion(version: TransactionVersion): GenNode[Nid]
 
     def templateId: TypeConName
 
@@ -75,195 +56,69 @@ object Node {
 
     def byKey: Boolean
 
-    def foreach2(fNid: Nid => Unit, fCid: Cid => Unit): Unit =
-      GenActionNode.foreach2(fNid, fCid)(this)
-
-    protected def versionValue[Cid2 >: Cid](v: Value[Cid2]): VersionedValue[Cid2] =
+    protected def versionValue[Cid2 >: ContractId](v: Value): VersionedValue =
       VersionedValue(version, v)
   }
 
-  object GenActionNode extends CidContainer2[GenActionNode] {
-
-    override private[lf] def map2[A1, A2, B1, B2](
-        f1: A1 => B1,
-        f2: A2 => B2,
-    ): GenActionNode[A1, A2] => GenActionNode[B1, B2] = {
-      case self @ NodeCreate(
-            coid,
-            _,
-            arg,
-            _,
-            _,
-            _,
-            key,
-            _,
-          ) =>
-        self.copy(
-          coid = f2(coid),
-          arg = Value.map1(f2)(arg),
-          key = key.map(KeyWithMaintainers.map1(Value.map1(f2))),
-        )
-      case self @ NodeFetch(
-            coid,
-            _,
-            _,
-            _,
-            _,
-            key,
-            _,
-            _,
-          ) =>
-        self.copy(
-          coid = f2(coid),
-          key = key.map(KeyWithMaintainers.map1(Value.map1(f2))),
-        )
-      case self @ NodeExercises(
-            targetCoid,
-            _,
-            _,
-            _,
-            _,
-            chosenValue,
-            _,
-            _,
-            _,
-            children,
-            exerciseResult,
-            key,
-            _,
-            _,
-          ) =>
-        self.copy(
-          targetCoid = f2(targetCoid),
-          chosenValue = Value.map1(f2)(chosenValue),
-          children = children.map(f1),
-          exerciseResult = exerciseResult.map(Value.map1(f2)),
-          key = key.map(KeyWithMaintainers.map1(Value.map1(f2))),
-        )
-      case self @ NodeLookupByKey(
-            _,
-            key,
-            result,
-            _,
-          ) =>
-        self.copy(
-          key = KeyWithMaintainers.map1(Value.map1(f2))(key),
-          result = result.map(f2),
-        )
-    }
-
-    override private[lf] def foreach2[A, B](
-        f1: A => Unit,
-        f2: B => Unit,
-    ): GenActionNode[A, B] => Unit = {
-      case NodeCreate(
-            coid,
-            templateI @ _,
-            arg,
-            agreementText @ _,
-            signatories @ _,
-            stakeholders @ _,
-            key,
-            _,
-          ) =>
-        f2(coid)
-        Value.foreach1(f2)(arg)
-        key.foreach(KeyWithMaintainers.foreach1(Value.foreach1(f2)))
-      case NodeFetch(
-            coid,
-            templateId @ _,
-            actingPartiesd @ _,
-            signatoriesd @ _,
-            stakeholdersd @ _,
-            key,
-            _,
-            _,
-          ) =>
-        f2(coid)
-        key.foreach(KeyWithMaintainers.foreach1(Value.foreach1(f2)))
-      case NodeExercises(
-            targetCoid,
-            templateId @ _,
-            choiceId @ _,
-            consuming @ _,
-            actingParties @ _,
-            chosenValue,
-            stakeholders @ _,
-            signatories @ _,
-            choiceObservers @ _,
-            children @ _,
-            exerciseResult,
-            key,
-            _,
-            _,
-          ) =>
-        f2(targetCoid)
-        Value.foreach1(f2)(chosenValue)
-        exerciseResult.foreach(Value.foreach1(f2))
-        key.foreach(KeyWithMaintainers.foreach1(Value.foreach1(f2)))
-        children.foreach(f1)
-      case NodeLookupByKey(
-            templateId @ _,
-            key,
-            result,
-            _,
-          ) =>
-        KeyWithMaintainers.foreach1(Value.foreach1(f2))(key)
-        result.foreach(f2)
-    }
+  /** A transaction node that can't possibly refer to `Nid`s. */
+  sealed trait LeafOnlyActionNode extends GenActionNode[Nothing] {
+    override def mapNodeId[Nid2](f: Nothing => Nid2): GenNode[Nid2] = this
   }
 
-  /** A transaction node that can't possibly refer to `Nid`s. */
-  sealed trait LeafOnlyActionNode[+Cid] extends GenActionNode[Nothing, Cid]
-
   /** Denotes the creation of a contract instance. */
-  final case class NodeCreate[+Cid](
-      coid: Cid,
+  final case class NodeCreate(
+      coid: ContractId,
       override val templateId: TypeConName,
-      arg: Value[Cid],
+      arg: Value,
       agreementText: String,
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[KeyWithMaintainers[Value[Cid]]],
+      key: Option[KeyWithMaintainers[Value]],
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
-  ) extends LeafOnlyActionNode[Cid]
+  ) extends LeafOnlyActionNode
       with ActionNodeInfo.Create {
 
     override def byKey: Boolean = false
 
-    override private[lf] def updateVersion(version: TransactionVersion): NodeCreate[Cid] =
+    override private[lf] def updateVersion(version: TransactionVersion): NodeCreate =
       copy(version = version)
 
-    def coinst: Value.ContractInst[Value[Cid]] =
+    final override def mapCid(f: ContractId => ContractId): NodeCreate =
+      copy(coid = f(coid), arg = arg.mapCid(f), key = key.map(_.mapCid(f)))
+
+    def coinst: Value.ContractInst[Value] =
       Value.ContractInst(templateId, arg, agreementText)
 
-    def versionedCoinst: Value.ContractInst[Value.VersionedValue[Cid]] =
+    def versionedCoinst: Value.ContractInst[Value.VersionedValue] =
       Value.ContractInst(templateId, versionValue(arg), agreementText)
 
-    def versionedKey: Option[KeyWithMaintainers[Value.VersionedValue[Cid]]] =
-      key.map(KeyWithMaintainers.map1(versionValue))
+    def versionedKey: Option[KeyWithMaintainers[Value.VersionedValue]] =
+      key.map(_.map(versionValue))
   }
 
   /** Denotes that the contract identifier `coid` needs to be active for the transaction to be valid. */
-  final case class NodeFetch[+Cid](
-      coid: Cid,
+  final case class NodeFetch(
+      coid: ContractId,
       override val templateId: TypeConName,
       actingParties: Set[Party],
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[KeyWithMaintainers[Value[Cid]]],
+      key: Option[KeyWithMaintainers[Value]],
       override val byKey: Boolean, // invariant (!byKey || exerciseResult.isDefined)
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
-  ) extends LeafOnlyActionNode[Cid]
+  ) extends LeafOnlyActionNode
       with ActionNodeInfo.Fetch {
 
-    override private[lf] def updateVersion(version: TransactionVersion): NodeFetch[Cid] =
+    override private[lf] def updateVersion(version: TransactionVersion): NodeFetch =
       copy(version = version)
 
-    def versionedKey: Option[KeyWithMaintainers[Value.VersionedValue[Cid]]] =
-      key.map(KeyWithMaintainers.map1(versionValue))
+    final override def mapCid(f: ContractId => ContractId): NodeFetch =
+      copy(coid = f(coid), key = key.map(_.mapCid(f)))
+
+    def versionedKey: Option[KeyWithMaintainers[Value.VersionedValue]] =
+      key.map(_.map(versionValue))
   }
 
   /** Denotes a transaction node for an exercise.
@@ -271,102 +126,106 @@ object Node {
     * to allow segregating the graph afterwards into party-specific
     * ledgers.
     */
-  final case class NodeExercises[+Nid, +Cid](
-      targetCoid: Cid,
+  final case class NodeExercises[+Nid](
+      targetCoid: ContractId,
       override val templateId: TypeConName,
       choiceId: ChoiceName,
       consuming: Boolean,
       actingParties: Set[Party],
-      chosenValue: Value[Cid],
+      chosenValue: Value,
       stakeholders: Set[Party],
       signatories: Set[Party],
       choiceObservers: Set[Party],
       children: ImmArray[Nid],
-      exerciseResult: Option[Value[Cid]],
-      key: Option[KeyWithMaintainers[Value[Cid]]],
+      exerciseResult: Option[Value],
+      key: Option[KeyWithMaintainers[Value]],
       override val byKey: Boolean, // invariant (!byKey || exerciseResult.isDefined)
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
-  ) extends GenActionNode[Nid, Cid]
+  ) extends GenActionNode[Nid]
       with ActionNodeInfo.Exercise {
 
     override private[lf] def updateVersion(
         version: TransactionVersion
-    ): NodeExercises[Nid, Cid] =
+    ): NodeExercises[Nid] =
       copy(version = version)
 
-    def versionedChosenValue: Value.VersionedValue[Cid] =
+    final override def mapCid(f: ContractId => ContractId): NodeExercises[Nid] = copy(
+      targetCoid = f(targetCoid),
+      chosenValue = chosenValue.mapCid(f),
+      exerciseResult = exerciseResult.map(_.mapCid(f)),
+      key = key.map(_.mapCid(f)),
+    )
+
+    override def mapNodeId[Nid2](f: Nid => Nid2): NodeExercises[Nid2] =
+      copy(children = children.map(f))
+
+    def versionedChosenValue: Value.VersionedValue =
       versionValue(chosenValue)
 
-    def versionedExerciseResult: Option[Value.VersionedValue[Cid]] =
+    def versionedExerciseResult: Option[Value.VersionedValue] =
       exerciseResult.map(versionValue)
 
-    def versionedKey: Option[KeyWithMaintainers[Value.VersionedValue[Cid]]] =
-      key.map(KeyWithMaintainers.map1(versionValue))
+    def versionedKey: Option[KeyWithMaintainers[Value.VersionedValue]] =
+      key.map(_.map(versionValue))
   }
 
-  final case class NodeLookupByKey[+Cid](
+  final case class NodeLookupByKey(
       override val templateId: TypeConName,
-      key: KeyWithMaintainers[Value[Cid]],
-      result: Option[Cid],
+      key: KeyWithMaintainers[Value],
+      result: Option[ContractId],
       // For the sake of consistency between types with a version field, keep this field the last.
       override val version: TransactionVersion,
-  ) extends LeafOnlyActionNode[Cid]
+  ) extends LeafOnlyActionNode
       with ActionNodeInfo.LookupByKey {
+
+    final override def mapCid(f: ContractId => ContractId): NodeLookupByKey =
+      copy(key = key.mapCid(f), result = result.map(f))
 
     override def keyMaintainers: Set[Party] = key.maintainers
     override def hasResult: Boolean = result.isDefined
     override def byKey: Boolean = true
 
-    override private[lf] def updateVersion(version: TransactionVersion): NodeLookupByKey[Cid] =
+    override private[lf] def updateVersion(version: TransactionVersion): NodeLookupByKey =
       copy(version = version)
 
-    def versionedKey: KeyWithMaintainers[Value.VersionedValue[Cid]] =
-      KeyWithMaintainers.map1[Value[Cid], Value.VersionedValue[Cid]](versionValue)(key)
+    def versionedKey: KeyWithMaintainers[Value.VersionedValue] =
+      key.map(versionValue)
   }
 
-  final case class KeyWithMaintainers[+Val](key: Val, maintainers: Set[Party])
-      extends CidContainer[KeyWithMaintainers[Val]] {
+  final case class KeyWithMaintainers[+Val](key: Val, maintainers: Set[Party]) {
 
-    override protected def self: this.type = this
-
-    def foreach1(f: Val => Unit): Unit =
-      KeyWithMaintainers.foreach1(f)(this)
+    def map[Val2](f: Val => Val2): KeyWithMaintainers[Val2] =
+      copy(key = f(key))
   }
 
-  object KeyWithMaintainers extends CidContainer1[KeyWithMaintainers] {
+  object KeyWithMaintainers {
+    implicit class CidContainerInstance[Val <: CidContainer[Val]](key: KeyWithMaintainers[Val])
+        extends CidContainer[KeyWithMaintainers[Val]] {
+      override def self = key
+      final override def mapCid(f: ContractId => ContractId): KeyWithMaintainers[Val] =
+        self.copy(key = self.key.mapCid(f))
+    }
+
     implicit def equalInstance[Val: Equal]: Equal[KeyWithMaintainers[Val]] =
       ScalazEqual.withNatural(Equal[Val].equalIsNatural) { (a, b) =>
         import a._
         val KeyWithMaintainers(bKey, bMaintainers) = b
         key === bKey && maintainers == bMaintainers
       }
-
-    override private[lf] def map1[A, B](
-        f: A => B
-    ): KeyWithMaintainers[A] => KeyWithMaintainers[B] =
-      x => x.copy(key = f(x.key))
-
-    override private[lf] def foreach1[A](f: A => Unit): KeyWithMaintainers[A] => Unit =
-      x => f(x.key)
-
   }
 
   final case class NodeRollback[+Nid](
       children: ImmArray[Nid]
-  ) extends GenNode[Nid, Nothing] {
+  ) extends GenNode[Nid] {
 
-    override def foreach2(fNid: Nid => Unit, fCid: Nothing => Unit): Unit =
-      children.foreach(fNid)
+    final override def mapCid(f: ContractId => ContractId): NodeRollback[Nid] = this
+    override def mapNodeId[Nid2](f: Nid => Nid2): NodeRollback[Nid2] =
+      copy(children.map(f))
 
-    override protected def self: GenNode[Nid, Nothing] = this
+    override protected def self: GenNode[Nid] = this
   }
 
 }
 
 final case class NodeId(index: Int)
-
-object NodeId {
-  implicit def cidMapperInstance[In, Out]: CidMapper[NodeId, NodeId, In, Out] =
-    CidMapper.trivialMapper
-}

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -9,53 +9,38 @@ import com.daml.lf.data._
 import com.daml.lf.ledger.FailedAuthorization
 import com.daml.lf.transaction.Node.GenNode
 import com.daml.lf.value.Value
+import com.daml.lf.value.Value.ContractId
 
 import scala.annotation.tailrec
 import scala.collection.immutable.HashMap
 
-final case class VersionedTransaction[Nid, +Cid] private[lf] (
+final case class VersionedTransaction[Nid] private[lf] (
     version: TransactionVersion,
-    nodes: Map[Nid, GenNode[Nid, Cid]],
+    nodes: Map[Nid, GenNode[Nid]],
     override val roots: ImmArray[Nid],
-) extends HasTxNodes[Nid, Cid]
-    with value.CidContainer[VersionedTransaction[Nid, Cid]]
+) extends HasTxNodes[Nid]
+    with value.CidContainer[VersionedTransaction[Nid]]
     with NoCopy {
 
   override protected def self: this.type = this
 
+  override def mapCid(f: ContractId => ContractId): VersionedTransaction[Nid] =
+    VersionedTransaction(
+      version,
+      nodes = nodes.map { case (nodeId, node) => nodeId -> node.mapCid(f) },
+      roots,
+    )
+
+  def mapNodeId[Nid2](f: Nid => Nid2): VersionedTransaction[Nid2] =
+    VersionedTransaction(
+      version,
+      nodes.map { case (nodeId, node) => f(nodeId) -> node.mapNodeId(f) },
+      roots.map(f),
+    )
+
   // O(1)
-  def transaction: GenTransaction[Nid, Cid] =
+  def transaction: GenTransaction[Nid] =
     GenTransaction(nodes, roots)
-
-}
-
-object VersionedTransaction extends value.CidContainer2[VersionedTransaction] {
-
-  override private[lf] def map2[A1, B1, A2, B2](
-      f1: A1 => A2,
-      f2: B1 => B2,
-  ): VersionedTransaction[A1, B1] => VersionedTransaction[A2, B2] = {
-    case VersionedTransaction(version, versionedNodes, roots) =>
-      val mapNode = GenNode.map2(f1, f2)
-      VersionedTransaction(
-        version,
-        versionedNodes.map { case (nid, node) =>
-          f1(nid) -> mapNode(node)
-        },
-        roots.map(f1),
-      )
-  }
-
-  override private[lf] def foreach2[A, B](
-      f1: A => Unit,
-      f2: B => Unit,
-  ): VersionedTransaction[A, B] => Unit = { case VersionedTransaction(_, versionedNodes, _) =>
-    val foreachNode = GenNode.foreach2(f1, f2)
-    versionedNodes.foreach { case (nid, node) =>
-      f1(nid)
-      foreachNode(node)
-    }
-  }
 
 }
 
@@ -70,25 +55,22 @@ object VersionedTransaction extends value.CidContainer2[VersionedTransaction] {
   * For performance reasons, users are not required to call `isWellFormed`.
   * Therefore, it is '''forbidden''' to create ill-formed instances, i.e., instances with `!isWellFormed.isEmpty`.
   */
-final case class GenTransaction[Nid, +Cid](
-    nodes: Map[Nid, Node.GenNode[Nid, Cid]],
+final case class GenTransaction[Nid](
+    nodes: Map[Nid, Node.GenNode[Nid]],
     roots: ImmArray[Nid],
-) extends HasTxNodes[Nid, Cid]
-    with value.CidContainer[GenTransaction[Nid, Cid]] {
+) extends HasTxNodes[Nid]
+    with value.CidContainer[GenTransaction[Nid]] {
 
   import GenTransaction._
 
   override protected def self: this.type = this
-
-  private[lf] def map2[Nid2, Cid2](
-      f: Nid => Nid2,
-      g: Cid => Cid2,
-  ): GenTransaction[Nid2, Cid2] =
-    GenTransaction.map2(f, g)(this)
-
-  /** Note: the provided function must be injective, otherwise the transaction will be corrupted. */
-  def mapNodeId[Nid2](f: Nid => Nid2): GenTransaction[Nid2, Cid] =
-    map2(f, identity)
+  override def mapCid(f: ContractId => ContractId): GenTransaction[Nid] =
+    copy(nodes = nodes.map { case (nodeId, node) => nodeId -> node.mapCid(f) })
+  def mapNodeId[Nid2](f: Nid => Nid2): GenTransaction[Nid2] =
+    copy(
+      nodes = nodes.map { case (nodeId, node) => f(nodeId) -> node.mapNodeId(f) },
+      roots = roots.map(f),
+    )
 
   /** This function checks the following properties:
     *
@@ -131,8 +113,8 @@ final case class GenTransaction[Nid, +Cid](
                       nr.children ++: nids
                     },
                   )
-                case _: Node.LeafOnlyActionNode[Cid] => go(newErrors, newVisited, nids)
-                case ne: Node.NodeExercises[Nid, Cid] =>
+                case _: Node.LeafOnlyActionNode => go(newErrors, newVisited, nids)
+                case ne: Node.NodeExercises[Nid] =>
                   go(
                     newErrors,
                     newVisited,
@@ -153,14 +135,14 @@ final case class GenTransaction[Nid, +Cid](
   /** Compares two Transactions up to renaming of Nids. You most likely want to use this rather than ==, since the
     * Nid is irrelevant to the content of the transaction.
     */
-  def equalForest[Cid2 >: Cid](other: GenTransaction[_, Cid2]): Boolean =
+  def equalForest(other: GenTransaction[_]): Boolean =
     compareForest(other)(_ == _)
 
   /** Compares two Transactions up to renaming of Nids. with the specified comparision of nodes
     * Nid is irrelevant to the content of the transaction.
     */
-  def compareForest[Nid2, Cid2](other: GenTransaction[Nid2, Cid2])(
-      compare: (Node.GenNode[Nothing, Cid], Node.GenNode[Nothing, Cid2]) => Boolean
+  def compareForest[Nid2](other: GenTransaction[Nid2])(
+      compare: (Node.GenNode[Nothing], Node.GenNode[Nothing]) => Boolean
   ): Boolean = {
     @tailrec
     def go(toCompare: FrontStack[(Nid, Nid2)]): Boolean =
@@ -182,32 +164,32 @@ final case class GenTransaction[Nid, +Cid](
                   go(nr1.children.zip(nr2.children) ++: rest)
                 case _ => false
               }
-            case nf1: Node.NodeFetch[Cid] =>
+            case nf1: Node.NodeFetch =>
               node2 match {
-                case nf2: Node.NodeFetch[Cid2] => compare(nf1, nf2) && go(rest)
+                case nf2: Node.NodeFetch => compare(nf1, nf2) && go(rest)
                 case _ => false
               }
-            case nc1: Node.NodeCreate[Cid] =>
+            case nc1: Node.NodeCreate =>
               node2 match {
-                case nc2: Node.NodeCreate[Cid2] =>
+                case nc2: Node.NodeCreate =>
                   compare(nc1, nc2) && go(rest)
                 case _ => false
               }
-            case ne1: Node.NodeExercises[Nid, Cid] =>
+            case ne1: Node.NodeExercises[Nid] =>
               node2 match {
-                case ne2: Node.NodeExercises[Nid2, Cid2] =>
-                  val blankedNe1: Node.NodeExercises[Nothing, Cid] =
+                case ne2: Node.NodeExercises[Nid2] =>
+                  val blankedNe1: Node.NodeExercises[Nothing] =
                     ne1.copy(children = ImmArray.Empty)
-                  val blankedNe2: Node.NodeExercises[Nothing, Cid2] =
+                  val blankedNe2: Node.NodeExercises[Nothing] =
                     ne2.copy(children = ImmArray.Empty)
                   compare(blankedNe1, blankedNe2) &&
                   ne1.children.length == ne2.children.length &&
                   go(ne1.children.zip(ne2.children) ++: rest)
                 case _ => false
               }
-            case nl1: Node.NodeLookupByKey[Cid] =>
+            case nl1: Node.NodeLookupByKey =>
               node2 match {
-                case nl2: Node.NodeLookupByKey[Cid2] =>
+                case nl2: Node.NodeLookupByKey =>
                   compare(nl1, nl2) && go(rest)
                 case _ => false
               }
@@ -222,47 +204,49 @@ final case class GenTransaction[Nid, +Cid](
   }
 
   /** checks that all the values contained are serializable */
-  def serializable(f: Value[Cid] => ImmArray[String]): ImmArray[String] = {
+  def serializable(f: Value => ImmArray[String]): ImmArray[String] = {
     fold(BackStack.empty[String]) { case (errs, (_, node)) =>
       node match {
         case Node.NodeRollback(_) =>
           errs
-        case _: Node.NodeFetch[Cid] => errs
-        case nc: Node.NodeCreate[Cid] =>
+        case _: Node.NodeFetch => errs
+        case nc: Node.NodeCreate =>
           errs :++ f(nc.coinst.arg) :++ (nc.key match {
             case None => ImmArray.Empty
             case Some(key) => f(key.key)
           })
-        case ne: Node.NodeExercises[Nid, Cid] => errs :++ f(ne.chosenValue)
-        case nlbk: Node.NodeLookupByKey[Cid] => errs :++ f(nlbk.key.key)
+        case ne: Node.NodeExercises[Nid] => errs :++ f(ne.chosenValue)
+        case nlbk: Node.NodeLookupByKey => errs :++ f(nlbk.key.key)
       }
     }.toImmArray
   }
 
   /** Visit every `Val`. */
-  def foldValues[Z](z: Z)(f: (Z, Value[Cid]) => Z): Z =
+  def foldValues[Z](z: Z)(f: (Z, Value) => Z): Z =
     fold(z) { case (z, (_, n)) =>
       n match {
         case Node.NodeRollback(_) =>
           z
-        case c: Node.NodeCreate[_] =>
+        case c: Node.NodeCreate =>
           val z1 = f(z, c.arg)
           val z2 = c.key match {
             case None => z1
             case Some(k) => f(z1, k.key)
           }
           z2
-        case nf: Node.NodeFetch[_] => nf.key.fold(z)(k => f(z, k.key))
-        case e: Node.NodeExercises[_, _] => f(z, e.chosenValue)
-        case lk: Node.NodeLookupByKey[_] => f(z, lk.key.key)
+        case nf: Node.NodeFetch => nf.key.fold(z)(k => f(z, k.key))
+        case e: Node.NodeExercises[_] => f(z, e.chosenValue)
+        case lk: Node.NodeLookupByKey => f(z, lk.key.key)
       }
     }
 
-  private[lf] def foreach2(fNid: Nid => Unit, fCid: Cid => Unit): Unit =
+  /*
+  private[lf] def foreach2(fNid: Nid => Unit, fCid: ContractI => Unit): Unit =
     GenTransaction.foreach2(fNid, fCid)(this)
+   */
 }
 
-sealed abstract class HasTxNodes[Nid, +Cid] {
+sealed abstract class HasTxNodes[Nid] {
 
   import Transaction.{
     KeyInput,
@@ -274,14 +258,14 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     InconsistentKeys,
   }
 
-  def nodes: Map[Nid, Node.GenNode[Nid, Cid]]
+  def nodes: Map[Nid, Node.GenNode[Nid]]
 
   def roots: ImmArray[Nid]
 
   /** The union of the informees of a all the action nodes. */
   lazy val informees: Set[Ref.Party] =
     nodes.values.foldLeft(Set.empty[Ref.Party]) {
-      case (acc, node: Node.GenActionNode[_, _]) => acc | node.informeesOfNode
+      case (acc, node: Node.GenActionNode[_]) => acc | node.informeesOfNode
       case (acc, _: Node.NodeRollback[_]) => acc
     }
 
@@ -290,10 +274,10 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
   // Canton handles rollback nodes itself so this is assumption still holds
   // within the Engine.
   @throws[IllegalArgumentException]
-  def rootNodes: ImmArray[Node.GenActionNode[Nid, Cid]] =
+  def rootNodes: ImmArray[Node.GenActionNode[Nid]] =
     roots.map(nid =>
       nodes(nid) match {
-        case action: Node.GenActionNode[Nid, Cid] =>
+        case action: Node.GenActionNode[Nid] =>
           action
         case _: Node.NodeRollback[_] =>
           throw new IllegalArgumentException(
@@ -306,7 +290,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     *
     * Takes constant stack space. Crashes if the transaction is not well formed (see `isWellFormed`)
     */
-  final def foreach(f: (Nid, Node.GenNode[Nid, Cid]) => Unit): Unit = {
+  final def foreach(f: (Nid, Node.GenNode[Nid]) => Unit): Unit = {
 
     @tailrec
     def go(toVisit: FrontStack[Nid]): Unit = toVisit match {
@@ -316,8 +300,8 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
         f(nodeId, node)
         node match {
           case nr: Node.NodeRollback[Nid] => go(nr.children ++: toVisit)
-          case _: Node.LeafOnlyActionNode[Cid] => go(toVisit)
-          case ne: Node.NodeExercises[Nid, Cid] => go(ne.children ++: toVisit)
+          case _: Node.LeafOnlyActionNode => go(toVisit)
+          case ne: Node.NodeExercises[Nid] => go(ne.children ++: toVisit)
         }
     }
 
@@ -328,7 +312,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     *
     * Takes constant stack space. Crashes if the transaction is not well formed (see `isWellFormed`)
     */
-  final def fold[A](z: A)(f: (A, (Nid, Node.GenNode[Nid, Cid])) => A): A = {
+  final def fold[A](z: A)(f: (A, (Nid, Node.GenNode[Nid])) => A): A = {
     var acc = z
     foreach((nodeId, node) => acc = f(acc, (nodeId, node)))
     acc
@@ -341,7 +325,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     * transaction.
     */
   final def foldWithPathState[A, B](globalState0: A, pathState0: B)(
-      op: (A, B, Nid, Node.GenNode[Nid, Cid]) => (A, B)
+      op: (A, B, Nid, Node.GenNode[Nid]) => (A, B)
   ): A = {
     var globalState = globalState0
 
@@ -355,8 +339,8 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
         node match {
           case nr: Node.NodeRollback[Nid] =>
             go(nr.children.map(_ -> newPathState) ++: toVisit)
-          case _: Node.LeafOnlyActionNode[Cid] => go(toVisit)
-          case ne: Node.NodeExercises[Nid, Cid] =>
+          case _: Node.LeafOnlyActionNode => go(toVisit)
+          case ne: Node.NodeExercises[Nid] =>
             go(ne.children.map(_ -> newPathState) ++: toVisit)
         }
     }
@@ -365,9 +349,9 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     globalState
   }
 
-  final def localContracts[Cid2 >: Cid]: Map[Cid2, (Nid, Node.NodeCreate[Cid2])] =
-    fold(Map.empty[Cid2, (Nid, Node.NodeCreate[Cid2])]) {
-      case (acc, (nid, create: Node.NodeCreate[Cid])) =>
+  final def localContracts[Cid2 >: ContractId]: Map[Cid2, (Nid, Node.NodeCreate)] =
+    fold(Map.empty[Cid2, (Nid, Node.NodeCreate)]) {
+      case (acc, (nid, create: Node.NodeCreate)) =>
         acc.updated(create.coid, nid -> create)
       case (acc, _) => acc
     }
@@ -376,7 +360,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     *  This includes transient contracts but it does not include contracts
     *  consumed in rollback nodes.
     */
-  final def consumedContracts[Cid2 >: Cid]: Set[Cid2] =
+  final def consumedContracts[Cid2 >: ContractId]: Set[Cid2] =
     foldInExecutionOrder(Set.empty[Cid2])(
       exerciseBegin = (acc, _, exe) => {
         if (exe.consuming) { (acc + exe.targetCoid, true) }
@@ -392,7 +376,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     * This includes both contracts that have been arachived and local
     * contracts whose create has been rolled back.
     */
-  final def inactiveContracts[Cid2 >: Cid]: Set[Cid2] = {
+  final def inactiveContracts[Cid2 >: ContractId]: Set[Cid2] = {
     final case class LedgerState(
         createdCids: Set[Cid2],
         inactiveCids: Set[Cid2],
@@ -444,7 +428,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
       rollbackEnd = (acc, _, _) => acc.endRollback(),
       leaf = (acc, _, leaf) =>
         leaf match {
-          case c: Node.NodeCreate[Cid2] => acc.create(c.coid)
+          case c: Node.NodeCreate => acc.create(c.coid)
           case _ => acc
         },
     ).currentState.inactiveCids
@@ -452,7 +436,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
 
   /** Returns the IDs of all input contracts that are used by this transaction.
     */
-  final def inputContracts[Cid2 >: Cid]: Set[Cid2] =
+  final def inputContracts[Cid2 >: ContractId]: Set[Cid2] =
     fold(Set.empty[Cid2]) {
       case (acc, (_, Node.NodeExercises(coid, _, _, _, _, _, _, _, _, _, _, _, _, _))) =>
         acc + coid
@@ -468,16 +452,16 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     * that refer transient contracts or that appear under a rollback node.
     */
   final def contractKeys(implicit
-      evidence: HasTxNodes[Nid, Cid] <:< HasTxNodes[_, Value.ContractId]
+      evidence: HasTxNodes[Nid] <:< HasTxNodes[_]
   ): Set[GlobalKey] = {
     evidence(this).fold(Set.empty[GlobalKey]) {
-      case (acc, (_, node: Node.NodeCreate[Value.ContractId])) =>
+      case (acc, (_, node: Node.NodeCreate)) =>
         node.key.fold(acc)(key => acc + GlobalKey.assertBuild(node.templateId, key.key))
-      case (acc, (_, node: Node.NodeExercises[_, Value.ContractId])) =>
+      case (acc, (_, node: Node.NodeExercises[_])) =>
         node.key.fold(acc)(key => acc + GlobalKey.assertBuild(node.templateId, key.key))
-      case (acc, (_, node: Node.NodeFetch[Value.ContractId])) =>
+      case (acc, (_, node: Node.NodeFetch)) =>
         node.key.fold(acc)(key => acc + GlobalKey.assertBuild(node.templateId, key.key))
-      case (acc, (_, node: Node.NodeLookupByKey[Value.ContractId])) =>
+      case (acc, (_, node: Node.NodeLookupByKey)) =>
         acc + GlobalKey.assertBuild(node.templateId, node.key.key)
       case (acc, (_, _: Node.NodeRollback[_])) =>
         acc
@@ -500,7 +484,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     "If a contract key contains a contract id"
   )
   final def contractKeyInputs(implicit
-      evidence: HasTxNodes[Nid, Cid] <:< HasTxNodes[_, Value.ContractId]
+      evidence: HasTxNodes[Nid] <:< HasTxNodes[_]
   ): Either[KeyInputError, Map[GlobalKey, KeyInput]] = {
     val evThis = evidence(this)
     val localContracts = evThis.localContracts
@@ -525,7 +509,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
       def assertKeyMapping(
           templateId: Identifier,
           cid: Value.ContractId,
-          optKey: Option[Node.KeyWithMaintainers[Value[Value.ContractId]]],
+          optKey: Option[Node.KeyWithMaintainers[Value]],
       ): Either[KeyInputError, State] =
         optKey.fold[Either[KeyInputError, State]](Right(this)) { key =>
           val gk = GlobalKey.assertBuild(templateId, key.key)
@@ -540,7 +524,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
               }
           }
         }
-      def handleExercise(exe: Node.NodeExercises[_, Value.ContractId]) =
+      def handleExercise(exe: Node.NodeExercises[_]) =
         assertKeyMapping(exe.templateId, exe.targetCoid, exe.key).map { state =>
           exe.key.fold(state) { key =>
             val gk = GlobalKey.assertBuild(exe.templateId, key.key)
@@ -554,7 +538,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
           }
         }
 
-      def handleCreate(create: Node.NodeCreate[Value.ContractId]) =
+      def handleCreate(create: Node.NodeCreate) =
         create.key.fold[Either[KeyInputError, State]](Right(this)) { key =>
           val gk = GlobalKey.assertBuild(create.templateId, key.key)
           val next = copy(keys = keys.updated(gk, Some(create.coid)))
@@ -568,7 +552,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
         }
 
       def handleLookup(
-          lookup: Node.NodeLookupByKey[Value.ContractId]
+          lookup: Node.NodeLookupByKey
       ): Either[KeyInputError, State] = {
         val gk = GlobalKey.assertBuild(lookup.templateId, lookup.key.key)
         keys.get(gk) match {
@@ -586,14 +570,14 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
       }
 
       def handleLeaf(
-          leaf: Node.LeafOnlyActionNode[Value.ContractId]
+          leaf: Node.LeafOnlyActionNode
       ): Either[KeyInputError, State] =
         leaf match {
-          case create: Node.NodeCreate[Value.ContractId] =>
+          case create: Node.NodeCreate =>
             handleCreate(create)
-          case fetch: Node.NodeFetch[Value.ContractId] =>
+          case fetch: Node.NodeFetch =>
             assertKeyMapping(fetch.templateId, fetch.coid, fetch.key)
-          case lookup: Node.NodeLookupByKey[Value.ContractId] =>
+          case lookup: Node.NodeLookupByKey =>
             handleLookup(lookup)
         }
       def beginRollback: State =
@@ -624,7 +608,7 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
     *  but it does not include any updates under rollback nodes.
     */
   final def updatedContractKeys(implicit
-      ev: HasTxNodes[Nid, Cid] <:< HasTxNodes[_, Value.ContractId]
+      ev: HasTxNodes[Nid] <:< HasTxNodes[_]
   ): Map[GlobalKey, Option[Value.ContractId]] = {
     ev(this).foldInExecutionOrder(Map.empty[GlobalKey, Option[Value.ContractId]])(
       exerciseBegin = {
@@ -639,11 +623,11 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
       },
       rollbackBegin = (acc, _, _) => (acc, false),
       leaf = {
-        case (acc, _, create: Node.NodeCreate[Value.ContractId]) =>
+        case (acc, _, create: Node.NodeCreate) =>
           create.key.fold(acc)(key =>
             acc.updated(GlobalKey.assertBuild(create.templateId, key.key), Some(create.coid))
           )
-        case (acc, _, _: Node.NodeFetch[_] | _: Node.NodeLookupByKey[_]) => acc
+        case (acc, _, _: Node.NodeFetch | _: Node.NodeLookupByKey) => acc
       },
       exerciseEnd = (acc, _, _) => acc,
       rollbackEnd = (acc, _, _) => acc,
@@ -654,17 +638,17 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
   // Exercise/rollback nodes are visited twice: when execution reaches them and when execution leaves their body.
   // On the first visit of an execution/rollback node, the caller can prevent traversal of the children
   final def foreachInExecutionOrder(
-      exerciseBegin: (Nid, Node.NodeExercises[Nid, Cid]) => Boolean,
+      exerciseBegin: (Nid, Node.NodeExercises[Nid]) => Boolean,
       rollbackBegin: (Nid, Node.NodeRollback[Nid]) => Boolean,
-      leaf: (Nid, Node.LeafOnlyActionNode[Cid]) => Unit,
-      exerciseEnd: (Nid, Node.NodeExercises[Nid, Cid]) => Unit,
+      leaf: (Nid, Node.LeafOnlyActionNode) => Unit,
+      exerciseEnd: (Nid, Node.NodeExercises[Nid]) => Unit,
       rollbackEnd: (Nid, Node.NodeRollback[Nid]) => Unit,
   ): Unit = {
     @tailrec
     def loop(
         currNodes: FrontStack[Nid],
         stack: FrontStack[
-          ((Nid, Either[Node.NodeRollback[Nid], Node.NodeExercises[Nid, Cid]]), FrontStack[Nid])
+          ((Nid, Either[Node.NodeRollback[Nid], Node.NodeExercises[Nid]]), FrontStack[Nid])
         ],
     ): Unit =
       currNodes match {
@@ -676,13 +660,13 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
               } else {
                 loop(rest, stack)
               }
-            case exe: Node.NodeExercises[Nid, Cid] =>
+            case exe: Node.NodeExercises[Nid] =>
               if (exerciseBegin(nid, exe)) {
                 loop(exe.children.toFrontStack, ((nid, Right(exe)), rest) +: stack)
               } else {
                 loop(rest, stack)
               }
-            case node: Node.LeafOnlyActionNode[Cid] =>
+            case node: Node.LeafOnlyActionNode =>
               leaf(nid, node)
               loop(rest, stack)
           }
@@ -707,10 +691,10 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
   // This method visits to all nodes of the transaction in execution order.
   // Exercise nodes are visited twice: when execution reaches them and when execution leaves their body.
   final def foldInExecutionOrder[A](z: A)(
-      exerciseBegin: (A, Nid, Node.NodeExercises[Nid, Cid]) => (A, Boolean),
+      exerciseBegin: (A, Nid, Node.NodeExercises[Nid]) => (A, Boolean),
       rollbackBegin: (A, Nid, Node.NodeRollback[Nid]) => (A, Boolean),
-      leaf: (A, Nid, Node.LeafOnlyActionNode[Cid]) => A,
-      exerciseEnd: (A, Nid, Node.NodeExercises[Nid, Cid]) => A,
+      leaf: (A, Nid, Node.LeafOnlyActionNode) => A,
+      exerciseEnd: (A, Nid, Node.NodeExercises[Nid]) => A,
       rollbackEnd: (A, Nid, Node.NodeRollback[Nid]) => A,
   ): A = {
     var acc = z
@@ -757,13 +741,13 @@ sealed abstract class HasTxNodes[Nid, +Cid] {
 
 }
 
-object GenTransaction extends value.CidContainer2[GenTransaction] {
+object GenTransaction {
 
-  type WithTxValue[Nid, +Cid] = GenTransaction[Nid, Cid]
+  type WithTxValue[Nid] = GenTransaction[Nid]
 
-  private[this] val Empty = GenTransaction[Nothing, Nothing](HashMap.empty, ImmArray.Empty)
+  private[this] val Empty = GenTransaction[Nothing](HashMap.empty, ImmArray.Empty)
 
-  private[lf] def empty[A, B, C]: GenTransaction[A, B] = Empty.asInstanceOf[GenTransaction[A, B]]
+  private[lf] def empty[A]: GenTransaction[A] = Empty.asInstanceOf[GenTransaction[A]]
 
   private[lf] case class NotWellFormedError[Nid](nid: Nid, reason: NotWellFormedErrorReason)
   private[lf] sealed trait NotWellFormedErrorReason
@@ -771,31 +755,9 @@ object GenTransaction extends value.CidContainer2[GenTransaction] {
   private[lf] case object OrphanedNode extends NotWellFormedErrorReason
   private[lf] case object AliasedNode extends NotWellFormedErrorReason
 
-  override private[lf] def map2[A1, A2, B1, B2](
-      f1: A1 => B1,
-      f2: A2 => B2,
-  ): GenTransaction[A1, A2] => GenTransaction[B1, B2] = { case GenTransaction(nodes, roots) =>
-    GenTransaction(
-      nodes = nodes.map { case (nodeId, node) =>
-        f1(nodeId) -> Node.GenNode.map2(f1, f2)(node)
-      },
-      roots = roots.map(f1),
-    )
-  }
-
-  override private[lf] def foreach2[A, B](
-      f1: A => Unit,
-      f2: B => Unit,
-  ): GenTransaction[A, B] => Unit = { case GenTransaction(nodes, _) =>
-    nodes.foreach { case (nodeId, node) =>
-      f1(nodeId)
-      Node.GenNode.foreach2(f1, f2)(node)
-    }
-  }
-
   // crashes if transaction's keys contain contract Ids.
   @throws[IllegalArgumentException]
-  def duplicatedContractKeys(tx: VersionedTransaction[NodeId, Value.ContractId]): Set[GlobalKey] = {
+  def duplicatedContractKeys(tx: VersionedTransaction[NodeId]): Set[GlobalKey] = {
 
     import GlobalKey.{assertBuild => globalKey}
 
@@ -829,14 +791,14 @@ object GenTransaction extends value.CidContainer2[GenTransaction] {
 
 object Transaction {
 
-  type Value[+Cid] = Value.VersionedValue[Cid]
+  type Value = Value.VersionedValue
 
-  type ContractInst[+Cid] = Value.ContractInst[Value[Cid]]
+  type ContractInst = Value.ContractInst[Value]
 
   /** Transaction nodes */
-  type Node = Node.GenNode[NodeId, Value.ContractId]
-  type ActionNode = Node.GenActionNode[NodeId, Value.ContractId]
-  type LeafNode = Node.LeafOnlyActionNode[Value.ContractId]
+  type Node = Node.GenNode[NodeId]
+  type ActionNode = Node.GenActionNode[NodeId]
+  type LeafNode = Node.LeafOnlyActionNode
 
   /** (Complete) transactions, which are the result of interpreting a
     * ledger-update. These transactions are consumed by either the
@@ -845,7 +807,7 @@ object Transaction {
     * transaction into party-specific ledgers and for computing
     * divulgence of contracts.
     */
-  type Transaction = VersionedTransaction[NodeId, Value.ContractId]
+  type Transaction = VersionedTransaction[NodeId]
   val Transaction: VersionedTransaction.type = VersionedTransaction
 
   /** Transaction meta data

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -5,7 +5,6 @@ package com.daml.lf
 package transaction
 
 import com.daml.lf.language.LanguageVersion
-import com.daml.lf.value.Value
 
 sealed abstract class TransactionVersion private (val protoValue: String, private val index: Int)
     extends Product
@@ -66,8 +65,8 @@ object TransactionVersion {
   }
 
   private[lf] def asVersionedTransaction(
-      tx: GenTransaction[NodeId, Value.ContractId]
-  ): VersionedTransaction[NodeId, Value.ContractId] = {
+      tx: GenTransaction[NodeId]
+  ): VersionedTransaction[NodeId] = {
     import scala.Ordering.Implicits.infixOrderingOps
 
     tx match {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Util.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Util.scala
@@ -15,9 +15,9 @@ object Util {
   // Fails if :
   // - `value0` contains GenMap and version < 1.11
   def normalizeValue(
-      value0: Value[ContractId],
+      value0: Value,
       version: TransactionVersion,
-  ): Either[String, Value[ContractId]] =
+  ): Either[String, Value] =
     try {
       Right(assertNormalizeValue(value0, version))
     } catch {
@@ -26,10 +26,10 @@ object Util {
 
   // unsafe version of `normalize`
   @throws[IllegalArgumentException]
-  def assertNormalizeValue[Cid](
-      value0: Value[Cid],
+  def assertNormalizeValue(
+      value0: Value,
       version: TransactionVersion,
-  ): Value[Cid] = {
+  ): Value = {
 
     import Ordering.Implicits.infixOrderingOps
 
@@ -43,7 +43,7 @@ object Util {
         x
       }
 
-    def go(value: Value[Cid]): Value[Cid] =
+    def go(value: Value): Value =
       value match {
         case ValueEnum(tyCon, cons) =>
           ValueEnum(handleTypeInfo(tyCon), cons)
@@ -54,7 +54,7 @@ object Util {
           )
         case ValueVariant(tyCon, variant, value) =>
           ValueVariant(handleTypeInfo(tyCon), variant, go(value))
-        case _: ValueCidlessLeaf | _: ValueContractId[_] => value
+        case _: ValueCidlessLeaf | _: ValueContractId => value
         case ValueList(values) =>
           ValueList(values.map(go))
         case ValueOptional(value) =>
@@ -77,25 +77,25 @@ object Util {
   }
 
   def normalizeVersionedValue(
-      value: VersionedValue[ContractId]
-  ): Either[String, VersionedValue[ContractId]] =
+      value: VersionedValue
+  ): Either[String, VersionedValue] =
     normalizeValue(value.value, value.version).map(normalized => value.copy(value = normalized))
 
   def normalizeContract(
-      contract: ContractInst[VersionedValue[ContractId]]
-  ): Either[String, ContractInst[VersionedValue[ContractId]]] =
+      contract: ContractInst[VersionedValue]
+  ): Either[String, ContractInst[VersionedValue]] =
     normalizeVersionedValue(contract.arg).map(normalized => contract.copy(arg = normalized))
 
   def normalizeKey(
-      key: Node.KeyWithMaintainers[Value[ContractId]],
+      key: Node.KeyWithMaintainers[Value],
       version: TransactionVersion,
-  ): Either[String, Node.KeyWithMaintainers[Value[ContractId]]] =
+  ): Either[String, Node.KeyWithMaintainers[Value]] =
     normalizeValue(key.key, version).map(normalized => key.copy(key = normalized))
 
   def normalizeOptKey(
-      key: Option[Node.KeyWithMaintainers[Value[ContractId]]],
+      key: Option[Node.KeyWithMaintainers[Value]],
       version: TransactionVersion,
-  ): Either[String, Option[Node.KeyWithMaintainers[Value[ContractId]]]] =
+  ): Either[String, Option[Node.KeyWithMaintainers[Value]]] =
     key match {
       case Some(value) => normalizeKey(value, version).map(Some(_))
       case None => Right(None)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
@@ -4,7 +4,7 @@
 package com.daml.lf
 package transaction
 
-private final class Validation[Nid, Cid]() {
+private final class Validation[Nid]() {
 
   /** Whether `replayed` is the result of reinterpreting this transaction.
     *
@@ -20,9 +20,9 @@ private final class Validation[Nid, Cid]() {
     */
 
   private def isReplayedBy(
-      recorded: VersionedTransaction[Nid, Cid],
-      replayed: VersionedTransaction[Nid, Cid],
-  ): Either[ReplayMismatch[Nid, Cid], Unit] = {
+      recorded: VersionedTransaction[Nid],
+      replayed: VersionedTransaction[Nid],
+  ): Either[ReplayMismatch[Nid], Unit] = {
     if (recorded == replayed) {
       Right(())
     } else {
@@ -32,16 +32,16 @@ private final class Validation[Nid, Cid]() {
 }
 
 object Validation {
-  def isReplayedBy[Nid, Cid](
-      recorded: VersionedTransaction[Nid, Cid],
-      replayed: VersionedTransaction[Nid, Cid],
-  ): Either[ReplayMismatch[Nid, Cid], Unit] =
+  def isReplayedBy[Nid](
+      recorded: VersionedTransaction[Nid],
+      replayed: VersionedTransaction[Nid],
+  ): Either[ReplayMismatch[Nid], Unit] =
     new Validation().isReplayedBy(recorded, replayed)
 }
 
-final case class ReplayMismatch[Nid, Cid](
-    recordedTransaction: VersionedTransaction[Nid, Cid],
-    replayedTransaction: VersionedTransaction[Nid, Cid],
+final case class ReplayMismatch[Nid](
+    recordedTransaction: VersionedTransaction[Nid],
+    replayedTransaction: VersionedTransaction[Nid],
 ) extends Product
     with Serializable {
   def message: String =

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
@@ -3,8 +3,6 @@
 
 package com.daml.lf
 
-import com.daml.lf.value.Value.ContractId
-
 import scala.collection.compat._
 
 package object transaction {
@@ -26,10 +24,10 @@ package object transaction {
       Right(b.result())
     }
 
-  val SubmittedTransaction = DiscriminatedSubtype[VersionedTransaction[NodeId, ContractId]]
+  val SubmittedTransaction = DiscriminatedSubtype[VersionedTransaction[NodeId]]
   type SubmittedTransaction = SubmittedTransaction.T
 
-  val CommittedTransaction = DiscriminatedSubtype[VersionedTransaction[NodeId, ContractId]]
+  val CommittedTransaction = DiscriminatedSubtype[VersionedTransaction[NodeId]]
   type CommittedTransaction = CommittedTransaction.T
 
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -5,174 +5,50 @@ package com.daml.lf
 package value
 
 import com.daml.lf.data.Bytes
+import Value.ContractId
 
 import scala.util.control.NoStackTrace
 
-sealed abstract class CidMapper[-A1, +A2, In, Out] {
-
-  def map(f: In => Out): A1 => A2
-
-  // We cheat using exceptions, to get a cheap implementation of traverse using the `map` function above.
-  // In practice, we abort the traversal using an exception as soon as we find an input we cannot map.
-  def traverse[L](f: In => Either[L, Out]): A1 => Either[L, A2] = {
-    case class Ball(x: L) extends Throwable with NoStackTrace
-    a =>
-      try {
-        Right(map(x => f(x).fold(y => throw Ball(y), identity))(a))
-      } catch {
-        case Ball(x) => Left(x)
-      }
-  }
-
-}
-
-object CidMapper {
-
-  type CidChecker[-A1, +A2, AllowCid] = CidMapper[A1, A2, Value.ContractId, AllowCid]
-
-  type NoCidChecker[-A1, +A2] = CidChecker[A1, A2, Nothing]
-
-  type CidSuffixer[-A1, +A2] =
-    CidMapper[A1, A2, Value.ContractId, Value.ContractId]
-
-  @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  private val _trivialMapper: CidMapper[Any, Any, Nothing, Any] =
-    new CidMapper[Any, Any, Nothing, Any] {
-      override def map(f: Nothing => Any): Any => Any = identity
-    }
-
-  def trivialMapper[X, In, Out]: CidMapper[X, X, In, Out] =
-    _trivialMapper.asInstanceOf[CidMapper[X, X, In, Out]]
-
-  private[value] def basicMapperInstance[Cid1, Cid2]: CidMapper[Cid1, Cid2, Cid1, Cid2] =
-    new CidMapper[Cid1, Cid2, Cid1, Cid2] {
-      override def map(f: Cid1 => Cid2): Cid1 => Cid2 = f
-    }
-}
-
 trait CidContainer[+A] {
-
-  import CidMapper._
 
   protected def self: A
 
-  final def ensureNoCid[B](implicit
-      checker: NoCidChecker[A, B]
-  ): Either[Value.ContractId, B] =
-    checker.traverse[Value.ContractId](Left(_))(self)
+  def mapCid(f: ContractId => ContractId): A
 
-  final def assertNoCid[B](message: Value.ContractId => String)(implicit
-      checker: NoCidChecker[A, B]
-  ): B =
+  def foreachCid(f: ContractId => Unit) = {
+    mapCid(cid => {
+      f(cid)
+      cid
+    })
+    ()
+  }
+
+  // We cheat using exceptions, to get a cheap implementation of traverse using the `map` function above.
+  // In practice, we abort the traversal using an exception as soon as we find an input we cannot map.
+  def traverseCid[L](f: ContractId => Either[L, ContractId]): Either[L, A] = {
+    case class Ball(x: L) extends Throwable with NoStackTrace
+    try {
+      Right(mapCid(x => f(x).fold(y => throw Ball(y), identity)))
+    } catch {
+      case Ball(x) => Left(x)
+    }
+  }
+
+  final def ensureNoCid: Either[Value.ContractId, A] =
+    traverseCid[Value.ContractId](Left(_))
+
+  final def assertNoCid(message: Value.ContractId => String): A =
     data.assertRight(ensureNoCid.left.map(message))
 
   // Sets the suffix of any the V1 ContractId `coid` of the container that are not already suffixed.
   // Uses `f(coid.discriminator)` as suffix.
-  final def suffixCid[B](f: crypto.Hash => Bytes)(implicit
-      suffixer: CidSuffixer[A, B]
-  ): Either[String, B] = {
-    suffixer.traverse[String] {
+  final def suffixCid(f: crypto.Hash => Bytes): Either[String, A] = {
+    traverseCid[String] {
       case Value.ContractId.V1(discriminator, Bytes.Empty) =>
         Value.ContractId.V1.build(discriminator, f(discriminator))
       case acoid @ Value.ContractId.V1(_, _) => Right(acoid)
       case acoid @ Value.ContractId.V0(_) => Right(acoid)
-    }(self)
+    }
   }
-
-}
-
-trait CidContainer1[F[_]] {
-
-  import CidMapper._
-
-  private[lf] def map1[A, B](f: A => B): F[A] => F[B]
-
-  private[lf] def foreach1[A](f: A => Unit): F[A] => Unit
-
-  protected final def cidMapperInstance[A1, A2, In, Out](implicit
-      mapper: CidMapper[A1, A2, In, Out]
-  ): CidMapper[F[A1], F[A2], In, Out] =
-    new CidMapper[F[A1], F[A2], In, Out] {
-      override def map(f: In => Out): F[A1] => F[A2] =
-        map1[A1, A2](mapper.map(f))
-    }
-
-  final implicit def noCidCheckerInstance[A1, A2](implicit
-      checker1: NoCidChecker[A1, A2]
-  ): NoCidChecker[F[A1], F[A2]] =
-    cidMapperInstance[A1, A2, Value.ContractId, Nothing]
-
-  final implicit def cidSuffixerInstance[A1, A2](implicit
-      resolver1: CidSuffixer[A1, A2]
-  ): CidSuffixer[F[A1], F[A2]] =
-    cidMapperInstance
-
-}
-
-trait CidContainer2[F[_, _]] {
-
-  import CidMapper._
-
-  private[lf] def map2[A1, B1, A2, B2](
-      f1: A1 => A2,
-      f2: B1 => B2,
-  ): F[A1, B1] => F[A2, B2]
-
-  private[lf] def foreach2[A, B](
-      f1: A => Unit,
-      f2: B => Unit,
-  ): F[A, B] => Unit
-
-  protected final def cidMapperInstance[A1, B1, A2, B2, In, Out](implicit
-      mapper1: CidMapper[A1, A2, In, Out],
-      mapper2: CidMapper[B1, B2, In, Out],
-  ): CidMapper[F[A1, B1], F[A2, B2], In, Out] =
-    new CidMapper[F[A1, B1], F[A2, B2], In, Out] {
-      override def map(f: In => Out): F[A1, B1] => F[A2, B2] = {
-        map2[A1, B1, A2, B2](mapper1.map(f), mapper2.map(f))
-      }
-    }
-
-  final implicit def cidSuffixerInstance[A1, B1, A2, B2](implicit
-      suffixer1: CidSuffixer[A1, A2],
-      suffixer2: CidSuffixer[B1, B2],
-  ): CidSuffixer[F[A1, B1], F[A2, B2]] =
-    cidMapperInstance
-
-}
-
-trait CidContainer3[F[_, _, _]] {
-
-  import CidMapper._
-
-  private[lf] def map3[A1, B1, C1, A2, B2, C2](
-      f1: A1 => A2,
-      f2: B1 => B2,
-      f3: C1 => C2,
-  ): F[A1, B1, C1] => F[A2, B2, C2]
-
-  private[lf] def foreach3[A, B, C](
-      f1: A => Unit,
-      f2: B => Unit,
-      f3: C => Unit,
-  ): F[A, B, C] => Unit
-
-  protected final def cidMapperInstance[A1, B1, C1, A2, B2, C2, In, Out](implicit
-      mapper1: CidMapper[A1, A2, In, Out],
-      mapper2: CidMapper[B1, B2, In, Out],
-      mapper3: CidMapper[C1, C2, In, Out],
-  ): CidMapper[F[A1, B1, C1], F[A2, B2, C2], In, Out] =
-    new CidMapper[F[A1, B1, C1], F[A2, B2, C2], In, Out] {
-      override def map(f: In => Out): F[A1, B1, C1] => F[A2, B2, C2] = {
-        map3[A1, B1, C1, A2, B2, C2](mapper1.map(f), mapper2.map(f), mapper3.map(f))
-      }
-    }
-
-  final implicit def cidSuffixerInstance[A1, B1, C1, A2, B2, C2](implicit
-      suffixer1: CidSuffixer[A1, A2],
-      suffixer2: CidSuffixer[B1, B2],
-      suffixer3: CidSuffixer[C1, C2],
-  ): CidSuffixer[F[A1, B1, C1], F[A2, B2, C2]] =
-    cidMapperInstance
 
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -20,8 +20,6 @@ import scala.language.implicitConversions
 class HashSpec extends AnyWordSpec with Matchers {
 
   @nowarn("msg=dead code following this construct")
-  private implicit val ordNo: scalaz.Order[Nothing] = (a, _) => a // principle of explosion
-
   private val packageId0 = Ref.PackageId.assertFromString("package")
 
   private val complexRecordT =
@@ -59,7 +57,7 @@ class HashSpec extends AnyWordSpec with Matchers {
         :: RNil,
     )._2
 
-  private val complexRecordV: complexRecordT.Inj[Nothing] =
+  private val complexRecordV: complexRecordT.Inj =
     HRecord(
       fInt0 = 0L,
       fInt1 = 123456L,
@@ -162,8 +160,8 @@ class HashSpec extends AnyWordSpec with Matchers {
           defRef(name = "Variant"),
           Symbol("A") ->> VA.unit :: Symbol("B") ->> VA.unit :: RNil,
         )._2
-      val value1 = variantT.inj(HSum[variantT.Inj[Nothing]](Symbol("A") ->> (())))
-      val value2 = variantT.inj(HSum[variantT.Inj[Nothing]](Symbol("B") ->> (())))
+      val value1 = variantT.inj(HSum[variantT.Inj](Symbol("A") ->> (())))
+      val value2 = variantT.inj(HSum[variantT.Inj](Symbol("B") ->> (())))
 
       val tid = defRef("module", "name")
 
@@ -336,7 +334,7 @@ class HashSpec extends AnyWordSpec with Matchers {
 
     "stable " in {
 
-      type V = Value[ContractId]
+      type V = Value
 
       val pkgId = Ref.PackageId.assertFromString("pkgId")
 
@@ -419,10 +417,10 @@ class HashSpec extends AnyWordSpec with Matchers {
         ._2
 
       val variants = List(
-        variantT1.inj(HSum[variantT1.Inj[Nothing]](Symbol("Left") ->> false)),
-        variantT1.inj(HSum[variantT1.Inj[Nothing]](Symbol("Left") ->> true)),
-        variantT1.inj(HSum[variantT1.Inj[Nothing]](Symbol("Right") ->> false)),
-        variantT2.inj(HSum[variantT1.Inj[Nothing]](Symbol("Left") ->> false)),
+        variantT1.inj(HSum[variantT1.Inj](Symbol("Left") ->> false)),
+        variantT1.inj(HSum[variantT1.Inj](Symbol("Left") ->> true)),
+        variantT1.inj(HSum[variantT1.Inj](Symbol("Right") ->> false)),
+        variantT2.inj(HSum[variantT1.Inj](Symbol("Left") ->> false)),
       )
 
       def list(elements: Boolean*) = VA.list(VA.bool).inj(elements.toVector)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -223,7 +223,7 @@ class TransactionCoderSpec
 
     "do tx with a lot of root nodes" in {
       val node =
-        NodeCreate[ContractId](
+        NodeCreate(
           coid = absCid("#test-cid"),
           templateId = Identifier.assertFromString("pkg-id:Test:Name"),
           arg = ValueParty(Party.assertFromString("francesco")),
@@ -271,7 +271,7 @@ class TransactionCoderSpec
         val shouldFail = node.choiceObservers.nonEmpty
 
         val normalized = normalizeNode(node) match {
-          case exe: NodeExercises[NodeId, ContractId] =>
+          case exe: NodeExercises[NodeId] =>
             exe.copy(
               choiceObservers = node.choiceObservers,
               exerciseResult = Some(Value.ValueText("not-missing")),
@@ -836,43 +836,43 @@ class TransactionCoderSpec
     }
   }
 
-  def withoutExerciseResult[Nid, Cid](gn: GenNode[Nid, Cid]): GenNode[Nid, Cid] =
+  def withoutExerciseResult[Nid](gn: GenNode[Nid]): GenNode[Nid] =
     gn match {
-      case ne: NodeExercises[Nid, Cid] => ne copy (exerciseResult = None)
+      case ne: NodeExercises[Nid] => ne copy (exerciseResult = None)
       case _ => gn
     }
-  def withoutContractKeyInExercise[Nid, Cid](gn: GenNode[Nid, Cid]): GenNode[Nid, Cid] =
+  def withoutContractKeyInExercise[Nid](gn: GenNode[Nid]): GenNode[Nid] =
     gn match {
-      case ne: NodeExercises[Nid, Cid] => ne copy (key = None)
+      case ne: NodeExercises[Nid] => ne copy (key = None)
       case _ => gn
     }
-  def withoutMaintainersInExercise[Nid, Cid](gn: GenNode[Nid, Cid]): GenNode[Nid, Cid] =
+  def withoutMaintainersInExercise[Nid](gn: GenNode[Nid]): GenNode[Nid] =
     gn match {
-      case ne: NodeExercises[Nid, Cid] =>
+      case ne: NodeExercises[Nid] =>
         ne copy (key = ne.key.map(_.copy(maintainers = Set.empty)))
       case _ => gn
     }
 
-  def withoutChoiceObservers[Nid, Cid](gn: GenNode[Nid, Cid]): GenNode[Nid, Cid] =
+  def withoutChoiceObservers[Nid](gn: GenNode[Nid]): GenNode[Nid] =
     gn match {
-      case ne: NodeExercises[Nid, Cid] =>
+      case ne: NodeExercises[Nid] =>
         ne.copy(choiceObservers = Set.empty)
       case _ => gn
     }
 
-  def hasChoiceObserves(tx: GenTransaction[_, _]): Boolean =
+  def hasChoiceObserves(tx: GenTransaction[_]): Boolean =
     tx.nodes.values.exists {
-      case ne: NodeExercises[_, _] => ne.choiceObservers.nonEmpty
+      case ne: NodeExercises[_] => ne.choiceObservers.nonEmpty
       case _ => false
     }
 
   private def absCid(s: String): ContractId =
     ContractId.assertFromString(s)
 
-  def versionNodes[Nid, Cid](
+  def versionNodes[Nid](
       version: TransactionVersion,
-      nodes: Map[Nid, GenNode[Nid, Cid]],
-  ): Map[Nid, GenNode[Nid, Cid]] =
+      nodes: Map[Nid, GenNode[Nid]],
+  ): Map[Nid, GenNode[Nid]] =
     nodes.view.mapValues(updateVersion(_, version)).toMap
 
   private def versionInIncreasingOrder(
@@ -891,25 +891,25 @@ class TransactionCoderSpec
       v2 <- Gen.oneOf(versions.filter(_ > v1))
     } yield (v1, v2)
 
-  private[this] def normalizeNode[Nid](node: Node.GenNode[Nid, ContractId]) =
+  private[this] def normalizeNode[Nid](node: Node.GenNode[Nid]) =
     node match {
       case rb: NodeRollback[Nid] => rb //nothing to normalize
-      case exe: NodeExercises[Nid, ContractId] => normalizeExe(exe)
-      case fetch: NodeFetch[ContractId] => normalizeFetch(fetch)
-      case create: NodeCreate[ContractId] => normalizeCreate(create)
-      case lookup: NodeLookupByKey[ContractId] => lookup
+      case exe: NodeExercises[Nid] => normalizeExe(exe)
+      case fetch: NodeFetch => normalizeFetch(fetch)
+      case create: NodeCreate => normalizeCreate(create)
+      case lookup: NodeLookupByKey => lookup
     }
 
   private[this] def normalizeCreate(
-      create: Node.NodeCreate[ContractId]
-  ): Node.NodeCreate[ContractId] = {
+      create: Node.NodeCreate
+  ): Node.NodeCreate = {
     create.copy(
       arg = normalize(create.arg, create.version),
       key = create.key.map(normalizeKey(_, create.version)),
     )
   }
 
-  private[this] def normalizeFetch(fetch: Node.NodeFetch[ContractId]) =
+  private[this] def normalizeFetch(fetch: Node.NodeFetch) =
     fetch.copy(
       key = fetch.key.map(normalizeKey(_, fetch.version)),
       byKey =
@@ -918,7 +918,7 @@ class TransactionCoderSpec
         else false,
     )
 
-  private[this] def normalizeExe[Nid](exe: Node.NodeExercises[Nid, ContractId]) =
+  private[this] def normalizeExe[Nid](exe: Node.NodeExercises[Nid]) =
     exe.copy(
       chosenValue = normalize(exe.chosenValue, exe.version),
       exerciseResult = exe.exerciseResult match {
@@ -941,33 +941,33 @@ class TransactionCoderSpec
     )
 
   private[this] def normalizeKey(
-      key: KeyWithMaintainers[Value[ContractId]],
+      key: KeyWithMaintainers[Value],
       version: TransactionVersion,
   ) = {
     key.copy(key = normalize(key.key, version))
   }
 
   private[this] def normalizeContract(
-      contract: ContractInst[Value.VersionedValue[Value.ContractId]]
+      contract: ContractInst[Value.VersionedValue]
   ) = {
     contract.copy(arg = normalizeValue(contract.arg))
   }
 
-  private[this] def normalizeValue(versionedValue: Value.VersionedValue[Value.ContractId]) = {
+  private[this] def normalizeValue(versionedValue: Value.VersionedValue) = {
     val Value.VersionedValue(version, value) = versionedValue
     Value.VersionedValue(version, normalize(value, version))
   }
 
   private[this] def normalize(
-      value0: Value[ContractId],
+      value0: Value,
       version: TransactionVersion,
-  ): Value[ContractId] = Util.assertNormalizeValue(value0, version)
+  ): Value = Util.assertNormalizeValue(value0, version)
 
-  private def updateVersion[Nid, Cid](
-      node: GenNode[Nid, Cid],
+  private def updateVersion[Nid](
+      node: GenNode[Nid],
       version: TransactionVersion,
-  ): GenNode[Nid, Cid] = node match {
-    case node: GenActionNode[_, _] => node.updateVersion(version)
+  ): GenNode[Nid] = node match {
+    case node: GenActionNode[_] => node.updateVersion(version)
     case node: Node.NodeRollback[_] => node
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
@@ -51,12 +51,12 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
 
   //--[types]--
 
-  private type Val = V[V.ContractId]
+  private type Val = V
   private type KWM = KeyWithMaintainers[Val]
   private type OKWM = Option[KWM]
-  private type Exe = NodeExercises[NodeId, V.ContractId]
-  private type Node = GenNode[NodeId, V.ContractId]
-  private type VTX = VersionedTransaction[NodeId, V.ContractId]
+  private type Exe = NodeExercises[NodeId]
+  private type Node = GenNode[NodeId]
+  private type VTX = VersionedTransaction[NodeId]
 
   //--[samples]--
 
@@ -253,29 +253,29 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
 
   //--[Create node tweaks]--
 
-  private val tweakCreateCoid = Tweak.single[Node] { case nc: Node.NodeCreate[_] =>
+  private val tweakCreateCoid = Tweak.single[Node] { case nc: Node.NodeCreate =>
     nc.copy(coid = changeContractId(nc.coid))
   }
-  private val tweakCreateTemplateId = Tweak.single[Node] { case nc: Node.NodeCreate[_] =>
+  private val tweakCreateTemplateId = Tweak.single[Node] { case nc: Node.NodeCreate =>
     nc.copy(templateId = changeTemplateId(nc.templateId))
   }
-  private val tweakCreateArg = Tweak.single[Node] { case nc: Node.NodeCreate[_] =>
+  private val tweakCreateArg = Tweak.single[Node] { case nc: Node.NodeCreate =>
     nc.copy(arg = changeValue(nc.arg))
   }
-  private val tweakCreateAgreementText = Tweak.single[Node] { case nc: Node.NodeCreate[_] =>
+  private val tweakCreateAgreementText = Tweak.single[Node] { case nc: Node.NodeCreate =>
     nc.copy(agreementText = changeText(nc.agreementText))
   }
-  private val tweakCreateSignatories = Tweak[Node] { case nc: Node.NodeCreate[_] =>
+  private val tweakCreateSignatories = Tweak[Node] { case nc: Node.NodeCreate =>
     tweakPartySet.run(nc.signatories).map { x => nc.copy(signatories = x) }
   }
-  private val tweakCreateStakeholders = Tweak[Node] { case nc: Node.NodeCreate[_] =>
+  private val tweakCreateStakeholders = Tweak[Node] { case nc: Node.NodeCreate =>
     tweakPartySet.run(nc.stakeholders).map { x => nc.copy(stakeholders = x) }
   }
   private def tweakCreateKey(tweakOptKeyMaintainers: Tweak[OKWM]) = Tweak[Node] {
-    case nc: Node.NodeCreate[_] =>
+    case nc: Node.NodeCreate =>
       tweakOptKeyMaintainers.run(nc.key).map { x => nc.copy(key = x) }
   }
-  private val tweakCreateVersion = Tweak.single[Node] { case nc: Node.NodeCreate[_] =>
+  private val tweakCreateVersion = Tweak.single[Node] { case nc: Node.NodeCreate =>
     nc.copy(version = changeVersion(nc.version))
   }
 
@@ -293,30 +293,30 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
 
   //--[Fetch node tweaks]--
 
-  private val tweakFetchCoid = Tweak.single[Node] { case nf: Node.NodeFetch[_] =>
+  private val tweakFetchCoid = Tweak.single[Node] { case nf: Node.NodeFetch =>
     nf.copy(coid = changeContractId(nf.coid))
   }
-  private val tweakFetchTemplateId = Tweak.single[Node] { case nf: Node.NodeFetch[_] =>
+  private val tweakFetchTemplateId = Tweak.single[Node] { case nf: Node.NodeFetch =>
     nf.copy(templateId = changeTemplateId(nf.templateId))
   }
-  private val tweakFetchActingPartiesNonEmpty = Tweak[Node] { case nf: Node.NodeFetch[_] =>
+  private val tweakFetchActingPartiesNonEmpty = Tweak[Node] { case nf: Node.NodeFetch =>
     tweakPartySet.run(nf.actingParties).map { x => nf.copy(actingParties = x) }
   }
-  private val tweakFetchSignatories = Tweak[Node] { case nf: Node.NodeFetch[_] =>
+  private val tweakFetchSignatories = Tweak[Node] { case nf: Node.NodeFetch =>
     tweakPartySet.run(nf.signatories).map { x => nf.copy(signatories = x) }
   }
-  private val tweakFetchStakeholders = Tweak[Node] { case nf: Node.NodeFetch[_] =>
+  private val tweakFetchStakeholders = Tweak[Node] { case nf: Node.NodeFetch =>
     tweakPartySet.run(nf.stakeholders).map { x => nf.copy(stakeholders = x) }
   }
   private def tweakFetchKey(tweakOptKeyMaintainers: Tweak[OKWM]) = Tweak[Node] {
-    case nf: Node.NodeFetch[_] =>
+    case nf: Node.NodeFetch =>
       tweakOptKeyMaintainers.run(nf.key).map { x => nf.copy(key = x) }
   }
   private def tweakFetchByKey(whenVersion: TransactionVersion => Boolean) = Tweak.single[Node] {
-    case nf: Node.NodeFetch[_] if whenVersion(nf.version) =>
+    case nf: Node.NodeFetch if whenVersion(nf.version) =>
       nf.copy(byKey = changeBoolean(nf.byKey))
   }
-  private val tweakFetchVersion = Tweak.single[Node] { case nf: Node.NodeFetch[_] =>
+  private val tweakFetchVersion = Tweak.single[Node] { case nf: Node.NodeFetch =>
     nf.copy(version = changeVersion(nf.version))
   }
 
@@ -334,16 +334,16 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
 
   //--[LookupByKey node tweaks]--
 
-  private val tweakLookupTemplateId = Tweak.single[Node] { case nl: Node.NodeLookupByKey[_] =>
+  private val tweakLookupTemplateId = Tweak.single[Node] { case nl: Node.NodeLookupByKey =>
     nl.copy(templateId = changeTemplateId(nl.templateId))
   }
-  private val tweakLookupKey = Tweak[Node] { case nl: Node.NodeLookupByKey[_] =>
+  private val tweakLookupKey = Tweak[Node] { case nl: Node.NodeLookupByKey =>
     tweakKeyMaintainers.run(nl.key).map { x => nl.copy(key = x) }
   }
-  private val tweakLookupResult = Tweak[Node] { case nl: Node.NodeLookupByKey[_] =>
+  private val tweakLookupResult = Tweak[Node] { case nl: Node.NodeLookupByKey =>
     tweakOptContractId.run(nl.result).map { x => nl.copy(result = x) }
   }
-  private val tweakLookupVersion = Tweak.single[Node] { case nl: Node.NodeLookupByKey[_] =>
+  private val tweakLookupVersion = Tweak.single[Node] { case nl: Node.NodeLookupByKey =>
     nl.copy(version = changeVersion(nl.version))
   }
 
@@ -357,34 +357,34 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
 
   //--[Exercise node tweaks]--
 
-  private val tweakExerciseTargetCoid = Tweak.single[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseTargetCoid = Tweak.single[Node] { case ne: Node.NodeExercises[_] =>
     ne.copy(targetCoid = changeContractId(ne.targetCoid))
   }
-  private val tweakExerciseTemplateId = Tweak.single[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseTemplateId = Tweak.single[Node] { case ne: Node.NodeExercises[_] =>
     ne.copy(templateId = changeTemplateId(ne.templateId))
   }
-  private val tweakExerciseChoiceId = Tweak.single[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseChoiceId = Tweak.single[Node] { case ne: Node.NodeExercises[_] =>
     ne.copy(choiceId = changeChoiceId(ne.choiceId))
   }
-  private val tweakExerciseConsuming = Tweak.single[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseConsuming = Tweak.single[Node] { case ne: Node.NodeExercises[_] =>
     ne.copy(consuming = changeBoolean(ne.consuming))
   }
-  private val tweakExerciseActingParties = Tweak[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseActingParties = Tweak[Node] { case ne: Node.NodeExercises[_] =>
     tweakPartySet.run(ne.actingParties).map { x => ne.copy(actingParties = x) }
   }
-  private val tweakExerciseChosenValue = Tweak.single[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseChosenValue = Tweak.single[Node] { case ne: Node.NodeExercises[_] =>
     ne.copy(chosenValue = changeValue(ne.chosenValue))
   }
-  private val tweakExerciseStakeholders = Tweak[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseStakeholders = Tweak[Node] { case ne: Node.NodeExercises[_] =>
     tweakPartySet.run(ne.stakeholders).map { x => ne.copy(stakeholders = x) }
   }
-  private val tweakExerciseSignatories = Tweak[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseSignatories = Tweak[Node] { case ne: Node.NodeExercises[_] =>
     tweakPartySet.run(ne.signatories).map { x => ne.copy(signatories = x) }
   }
-  private val tweakExerciseChoiceObservers = Tweak[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseChoiceObservers = Tweak[Node] { case ne: Node.NodeExercises[_] =>
     tweakPartySet.run(ne.choiceObservers).map { x => ne.copy(choiceObservers = x) }
   }
-  private val tweakExerciseExerciseResult = Tweak[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseExerciseResult = Tweak[Node] { case ne: Node.NodeExercises[_] =>
     ne.exerciseResult match {
       case None => List(ne.copy(exerciseResult = Some(samValue1)))
       case Some(v) =>
@@ -396,14 +396,14 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   }
 
   private def tweakExerciseKey(tweakOptKeyMaintainers: Tweak[OKWM]) = Tweak[Node] {
-    case ne: Node.NodeExercises[_, _] =>
+    case ne: Node.NodeExercises[_] =>
       tweakOptKeyMaintainers.run(ne.key).map { x => ne.copy(key = x) }
   }
   private def tweakExerciseByKey(whenVersion: TransactionVersion => Boolean) = Tweak.single[Node] {
-    case ne: Node.NodeExercises[_, _] if whenVersion(ne.version) =>
+    case ne: Node.NodeExercises[_] if whenVersion(ne.version) =>
       ne.copy(byKey = changeBoolean(ne.byKey))
   }
-  private val tweakExerciseVersion = Tweak.single[Node] { case ne: Node.NodeExercises[_, _] =>
+  private val tweakExerciseVersion = Tweak.single[Node] { case ne: Node.NodeExercises[_] =>
     ne.copy(version = changeVersion(ne.version))
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
@@ -50,12 +50,12 @@ class ValueCoderSpec
           whenever(Numeric.fromBigDecimal(s, d).isRight) {
             val Right(dec) = Numeric.fromBigDecimal(s, d)
             val value = ValueNumeric(dec)
-            val recoveredDecimal = ValueCoder.decodeValue[ContractId](
+            val recoveredDecimal = ValueCoder.decodeValue(
               ValueCoder.CidDecoder,
               TransactionVersion.minVersion,
               assertRight(
                 ValueCoder
-                  .encodeValue[ContractId](
+                  .encodeValue(
                     ValueCoder.CidEncoder,
                     TransactionVersion.minVersion,
                     value,
@@ -150,8 +150,8 @@ class ValueCoderSpec
     "do deep record" in {
       def toNat(
           i: Int,
-          acc: ValueRecord[Nothing] = ValueRecord(None, ImmArray.Empty),
-      ): ValueRecord[Nothing] =
+          acc: ValueRecord = ValueRecord(None, ImmArray.Empty),
+      ): ValueRecord =
         if (i <= 0) acc
         else toNat(i - 1, ValueRecord(None, ImmArray(None -> acc)))
 
@@ -178,13 +178,13 @@ class ValueCoderSpec
     }
   }
 
-  def testRoundTrip(value0: Value[ContractId], version: TransactionVersion): Assertion = {
+  def testRoundTrip(value0: Value, version: TransactionVersion): Assertion = {
     val normalizedValue = transaction.Util.assertNormalizeValue(value0, version)
     val encoded: proto.VersionedValue = assertRight(
       ValueCoder
         .encodeVersionedValue(ValueCoder.CidEncoder, VersionedValue(version, value0))
     )
-    val decoded: VersionedValue[ContractId] = assertRight(
+    val decoded: VersionedValue = assertRight(
       ValueCoder.decodeVersionedValue(ValueCoder.CidDecoder, encoded)
     )
 
@@ -195,7 +195,7 @@ class ValueCoderSpec
 
     val encodedSentOverWire: proto.VersionedValue =
       proto.VersionedValue.parseFrom(encoded.toByteArray)
-    val decodedSentOverWire: VersionedValue[ContractId] = assertRight(
+    val decodedSentOverWire: VersionedValue = assertRight(
       ValueCoder.decodeVersionedValue(ValueCoder.CidDecoder, encodedSentOverWire)
     )
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -8,10 +8,9 @@ import data.{Bytes, ImmArray, Ref}
 import Value._
 import Ref.{Identifier, Name}
 import com.daml.lf.transaction.TransactionVersion
-import test.ValueGenerators.{coidGen, idGen, nameGen}
+import test.ValueGenerators.{cidV0Gen, coidGen, idGen, nameGen}
 import test.TypedValueGenerators.{RNil, genAddend, ValueAddend => VA}
-import com.daml.scalatest.Unnatural
-import org.scalacheck.{Arbitrary, Gen, Shrink}
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.freespec.AnyFreeSpec
@@ -40,7 +39,7 @@ class ValueSpec
     "does not bump version when" - {
 
       "ensureNoCid is used " in {
-        val value = VersionedValue[ContractId](TransactionVersion.minVersion, ValueUnit)
+        val value = VersionedValue(TransactionVersion.minVersion, ValueUnit)
         val contract = ContractInst(tmplId, value, "agreed")
         value.ensureNoCid.map(_.version) shouldBe Right(TransactionVersion.minVersion)
         contract.ensureNoCid.map(_.arg.version) shouldBe Right(TransactionVersion.minVersion)
@@ -73,9 +72,9 @@ class ValueSpec
   "Equal" - {
     import com.daml.lf.value.test.ValueGenerators._
     import org.scalacheck.Arbitrary
-    type T = VersionedValue[Unnatural[ContractId]]
+    type T = VersionedValue
     implicit val arbT: Arbitrary[T] =
-      Arbitrary(versionedValueGen.map(VersionedValue.map1(Unnatural(_))))
+      Arbitrary(versionedValueGen)
 
     "obeys Equal laws" in checkLaws(SzP.equal.laws[T])
 
@@ -98,20 +97,21 @@ class ValueSpec
       check(p, minSuccessful(20))
     }
 
-  private def checkOrderPreserved[Cid: Arbitrary: Shrink: Order](
+  private def checkOrderPreserved(
       va: VA,
       scope: Value.LookupVariantEnum,
-  ) = {
+  )(implicit cid: Arbitrary[Value.ContractId]) = {
     import va.{injord, injarb, injshrink}
-    implicit val targetOrd: Order[Value[Cid]] = Tag unsubst Value.orderInstance(scope)
-    forAll(minSuccessful(20)) { (a: va.Inj[Cid], b: va.Inj[Cid]) =>
+    implicit val targetOrd: Order[Value] = Tag unsubst Value.orderInstance(scope)
+    forAll(minSuccessful(20)) { (a: va.Inj, b: va.Inj) =>
       (a ?|? b) should ===(va.inj(a) ?|? va.inj(b))
     }
   }
 
   "Order" - {
-    type Cid = Int
-    type T = Value[Cid]
+
+    // SContractId V1 ordering is nontotal so arbitrary generation of them is unsafe to use
+    implicit val cidArb: Arbitrary[Value.ContractId] = Arbitrary(cidV0Gen)
 
     val FooScope: Value.LookupVariantEnum =
       Map(fooVariantId -> ImmArray("quux", "baz"), fooEnumId -> ImmArray("quux", "baz"))
@@ -120,49 +120,49 @@ class ValueSpec
 
     "for primitive, matching types" - {
       val EmptyScope: Value.LookupVariantEnum = _ => None
-      implicit val ord: Order[T] = Tag unsubst Value.orderInstance(EmptyScope)
+      implicit val ord: Order[Value] = Tag unsubst Value.orderInstance(EmptyScope)
 
       "obeys order laws" in forAll(genAddend, minSuccessful(100)) { va =>
-        implicit val arb: Arbitrary[T] = va.injarb[Cid] map (va.inj(_))
-        checkLaws(SzP.order.laws[T])
+        implicit val arb: Arbitrary[Value] = va.injarb map (va.inj(_))
+        checkLaws(SzP.order.laws[Value])
       }
     }
 
     "for record and variant types" - {
-      implicit val ord: Order[T] = Tag unsubst Value.orderInstance(FooScope)
-      "obeys order laws" in forEvery(Table("va", fooRecord, fooVariant)) { va =>
-        implicit val arb: Arbitrary[T] = va.injarb[Cid] map (va.inj(_))
-        checkLaws(SzP.order.laws[T])
+      implicit val ord: Order[Value] = Tag unsubst Value.orderInstance(FooScope)
+      "obeys order laws" in forEvery(Table[VA]("va", fooRecord, fooVariant)) { va =>
+        implicit val arb: Arbitrary[Value] = va.injarb map (va.inj(_))
+        checkLaws(SzP.order.laws[Value])
       }
 
       "matches constructor rank" in {
-        val fooCp = shapeless.Coproduct[fooVariant.Inj[Cid]]
+        val fooCp = shapeless.Coproduct[fooVariant.Inj]
         val quux = fooCp(Symbol("quux") ->> 42L)
         val baz = fooCp(Symbol("baz") ->> 42L)
         (fooVariant.inj(quux) ?|? fooVariant.inj(baz)) shouldBe scalaz.Ordering.LT
       }
 
-      "preserves base order" in forEvery(Table("va", fooRecord, fooVariant)) { va =>
-        checkOrderPreserved[Cid](va, FooScope)
+      "preserves base order" in forEvery(Table[VA]("va", fooRecord, fooVariant)) { va =>
+        checkOrderPreserved(va, FooScope)
       }
     }
 
     "for enum types" - {
       "obeys order laws" in forAll(enumDetailsAndScopeGen, minSuccessful(20)) {
         case (details, scope) =>
-          implicit val ord: Order[T] = Tag unsubst Value.orderInstance(scope)
-          forEvery(Table("va", details.values.toSeq: _*)) { ea =>
-            implicit val arb: Arbitrary[T] = ea.injarb[Cid] map (ea.inj(_))
-            checkLaws(SzP.order.laws[T])
+          implicit val ord: Order[Value] = Tag unsubst Value.orderInstance(scope)
+          forEvery(Table[VA]("va", details.values.toSeq: _*)) { ea =>
+            implicit val arb: Arbitrary[Value] = ea.injarb map (ea.inj(_))
+            checkLaws(SzP.order.laws[Value])
           }
       }
 
       "matches constructor rank" in forAll(enumDetailsAndScopeGen, minSuccessful(20)) {
         case (details, scope) =>
-          implicit val ord: Order[T] = Tag unsubst Value.orderInstance(scope)
+          implicit val ord: Order[Value] = Tag unsubst Value.orderInstance(scope)
           forEvery(Table("va", details.values.toSeq: _*)) { ea =>
-            implicit val arb: Arbitrary[T] = ea.injarb[Cid] map (ea.inj(_))
-            forAll(minSuccessful(20)) { (a: T, b: T) =>
+            implicit val arb: Arbitrary[Value] = ea.injarb map (ea.inj(_))
+            forAll(minSuccessful(20)) { (a: Value, b: Value) =>
               inside((a, b)) { case (ValueEnum(_, ac), ValueEnum(_, bc)) =>
                 (a ?|? b) should ===((ea.values indexOf ac) ?|? (ea.values indexOf bc))
               }
@@ -172,8 +172,8 @@ class ValueSpec
 
       "preserves base order" in forAll(enumDetailsAndScopeGen, minSuccessful(20)) {
         case (details, scope) =>
-          forEvery(Table("va", details.values.toSeq: _*)) { ea =>
-            checkOrderPreserved[Cid](ea, scope)
+          forEvery(Table[VA]("va", details.values.toSeq: _*)) { ea =>
+            checkOrderPreserved(ea, scope)
           }
       }
     }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -135,7 +135,7 @@ object Converter {
   private def fromAnyTemplate(
       translator: preprocessing.ValueTranslator,
       templateId: Identifier,
-      argument: Value[ContractId],
+      argument: Value,
   ): Either[String, SValue] = {
     val anyTemplateTy = daInternalAny("AnyTemplate")
     for {
@@ -166,7 +166,7 @@ object Converter {
       translator: preprocessing.ValueTranslator,
       templateId: Identifier,
       choiceName: ChoiceName,
-      argument: Value[ContractId],
+      argument: Value,
   ): Either[String, SValue] = {
     val contractIdTy = daInternalAny("AnyChoice")
     for {
@@ -668,7 +668,7 @@ object Converter {
       lfValue <-
         try {
           Right(
-            jsValue.convertTo[Value[ContractId]](
+            jsValue.convertTo[Value](
               LfValueCodec.apiValueJsonReader(paramIface, damlLfTypeLookup(_))
             )
           )

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -65,7 +65,7 @@ import spray.json._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-object LfValueCodec extends ApiCodecCompressed[ContractId](false, false)
+object LfValueCodec extends ApiCodecCompressed(false, false)
 
 case class Participant(participant: String)
 case class ApiParameters(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -83,7 +83,7 @@ object ScriptF {
         case Left(err) => Left(err.pretty)
       }
 
-    def translateValue(ty: Ast.Type, value: Value[ContractId]): Either[String, SValue] =
+    def translateValue(ty: Ast.Type, value: Value): Either[String, SValue] =
       valueTranslator.translateValue(ty, value).left.map(_.toString)
 
   }
@@ -262,7 +262,7 @@ object ScriptF {
 
     private def translateKey(
         env: Env
-    )(id: Identifier, v: Value[ContractId]): Either[String, SValue] =
+    )(id: Identifier, v: Value): Either[String, SValue] =
       for {
         keyTy <- env.lookupKeyTy(id)
         translated <- env.valueTranslator.translateValue(keyTy, v).left.map(_.message)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/GrpcLedgerClient.scala
@@ -64,7 +64,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
   private def queryWithKey(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
       ec: ExecutionContext,
       mat: Materializer,
-  ): Future[Vector[(ScriptLedgerClient.ActiveContract, Option[Value[ContractId]])]] = {
+  ): Future[Vector[(ScriptLedgerClient.ActiveContract, Option[Value])]] = {
     val filter = transactionFilter(parties, templateId)
     val acsResponses =
       grpcClient.activeContractSetClient
@@ -77,7 +77,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
             case Left(err) => throw new ConverterException(err.toString)
             case Right(argument) => argument
           }
-          val key: Option[Value[ContractId]] = createdEvent.contractKey.map { key =>
+          val key: Option[Value] = createdEvent.contractKey.map { key =>
             ValueValidator.validateValue(key) match {
               case Left(err) => throw new ConverterException(err.toString)
               case Right(argument) => argument
@@ -116,7 +116,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
       key: SValue,
-      translateKey: (Identifier, Value[ContractId]) => Either[String, SValue],
+      translateKey: (Identifier, Value) => Either[String, SValue],
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -138,7 +138,7 @@ class JsonLedgerClient(
       val ctx = templateId.qualifiedName
       val ifaceType = Converter.toIfaceType(ctx, TTyCon(templateId)).toOption.get
       val parsedResults = queryResponse.results.map(r => {
-        val payload = r.payload.convertTo[Value[ContractId]](
+        val payload = r.payload.convertTo[Value](
           LfValueCodec.apiValueJsonReader(ifaceType, damlLfTypeLookup(_))
         )
         val cid = ContractId.assertFromString(r.contractId)
@@ -162,7 +162,7 @@ class JsonLedgerClient(
       val ctx = templateId.qualifiedName
       val ifaceType = Converter.toIfaceType(ctx, TTyCon(templateId)).toOption.get
       fetchResponse.result.map(r => {
-        val payload = r.payload.convertTo[Value[ContractId]](
+        val payload = r.payload.convertTo[Value](
           LfValueCodec.apiValueJsonReader(ifaceType, damlLfTypeLookup(_))
         )
         val cid = ContractId.assertFromString(r.contractId)
@@ -174,7 +174,7 @@ class JsonLedgerClient(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
       key: SValue,
-      translateKey: (Identifier, Value[ContractId]) => Either[String, SValue],
+      translateKey: (Identifier, Value) => Either[String, SValue],
   )(implicit ec: ExecutionContext, mat: Materializer) = {
     for {
       _ <- validateTokenParties(parties, "queryContractKey")
@@ -186,7 +186,7 @@ class JsonLedgerClient(
       val ctx = templateId.qualifiedName
       val ifaceType = Converter.toIfaceType(ctx, TTyCon(templateId)).toOption.get
       fetchResponse.result.map(r => {
-        val payload = r.payload.convertTo[Value[ContractId]](
+        val payload = r.payload.convertTo[Value](
           LfValueCodec.apiValueJsonReader(ifaceType, damlLfTypeLookup(_))
         )
         val cid = ContractId.assertFromString(r.contractId)
@@ -324,7 +324,7 @@ class JsonLedgerClient(
 
   private def create(
       tplId: Identifier,
-      argument: Value[ContractId],
+      argument: Value,
   ): Future[Either[StatusRuntimeException, List[ScriptLedgerClient.CreateResult]]] = {
     val jsonArgument = LfValueCodec.apiValueToJsValue(argument)
     commandRequest[CreateArgs, CreateResponse]("create", CreateArgs(tplId, jsonArgument))
@@ -337,7 +337,7 @@ class JsonLedgerClient(
       tplId: Identifier,
       contractId: ContractId,
       choice: ChoiceName,
-      argument: Value[ContractId],
+      argument: Value,
   ): Future[Either[StatusRuntimeException, List[ScriptLedgerClient.ExerciseResult]]] = {
     val choiceDef = envIface
       .typeDecls(tplId)
@@ -354,7 +354,7 @@ class JsonLedgerClient(
           ScriptLedgerClient.ExerciseResult(
             tplId,
             choice,
-            result.convertTo[Value[ContractId]](
+            result.convertTo[Value](
               LfValueCodec.apiValueJsonReader(choiceDef.returnType, damlLfTypeLookup(_))
             ),
           )
@@ -364,9 +364,9 @@ class JsonLedgerClient(
 
   private def exerciseByKey(
       tplId: Identifier,
-      key: Value[ContractId],
+      key: Value,
       choice: ChoiceName,
-      argument: Value[ContractId],
+      argument: Value,
   ): Future[Either[StatusRuntimeException, List[ScriptLedgerClient.ExerciseResult]]] = {
     val choiceDef = envIface
       .typeDecls(tplId)
@@ -384,7 +384,7 @@ class JsonLedgerClient(
         ScriptLedgerClient.ExerciseResult(
           tplId,
           choice,
-          result.convertTo[Value[ContractId]](
+          result.convertTo[Value](
             LfValueCodec.apiValueJsonReader(choiceDef.returnType, damlLfTypeLookup(_))
           ),
         )
@@ -394,9 +394,9 @@ class JsonLedgerClient(
 
   private def createAndExercise(
       tplId: Identifier,
-      template: Value[ContractId],
+      template: Value,
       choice: ChoiceName,
-      argument: Value[ContractId],
+      argument: Value,
   ): Future[Either[StatusRuntimeException, List[ScriptLedgerClient.CommandResult]]] = {
     val choiceDef = envIface
       .typeDecls(tplId)
@@ -417,7 +417,7 @@ class JsonLedgerClient(
           ScriptLedgerClient.ExerciseResult(
             tplId,
             choice,
-            result.convertTo[Value[ContractId]](
+            result.convertTo[Value](
               LfValueCodec.apiValueJsonReader(choiceDef.returnType, damlLfTypeLookup(_))
             ),
           ),
@@ -504,7 +504,7 @@ object JsonLedgerClient {
   final case class QueryResponse(results: List[ActiveContract])
   final case class ActiveContract(contractId: String, payload: JsValue)
   final case class FetchArgs(contractId: ContractId)
-  final case class FetchKeyArgs(templateId: Identifier, key: Value[ContractId])
+  final case class FetchKeyArgs(templateId: Identifier, key: Value)
   final case class FetchResponse(result: Option[ActiveContract])
 
   final case class CreateArgs(templateId: Identifier, payload: JsValue)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ScriptLedgerClient.scala
@@ -33,13 +33,13 @@ object ScriptLedgerClient {
   final case class ExerciseResult(
       templateId: Identifier,
       choice: ChoiceName,
-      result: Value[ContractId],
+      result: Value,
   ) extends CommandResult
 
   final case class ActiveContract(
       templateId: Identifier,
       contractId: ContractId,
-      argument: Value[ContractId],
+      argument: Value,
   )
 
   final case class TransactionTree(rootEvents: List[TreeEvent])
@@ -48,13 +48,13 @@ object ScriptLedgerClient {
       templateId: Identifier,
       contractId: ContractId,
       choice: ChoiceName,
-      argument: Value[ContractId],
+      argument: Value,
       childEvents: List[TreeEvent],
   ) extends TreeEvent
   final case class Created(
       templateId: Identifier,
       contractId: ContractId,
-      argument: Value[ContractId],
+      argument: Value,
   ) extends TreeEvent
 }
 
@@ -77,7 +77,7 @@ trait ScriptLedgerClient {
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
       key: SValue,
-      translateKey: (Identifier, Value[ContractId]) => Either[String, SValue],
+      translateKey: (Identifier, Value) => Either[String, SValue],
   )(implicit
       ec: ExecutionContext,
       mat: Materializer,

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -457,7 +457,7 @@ final class JsonApiIt
           inputValue = Some(
             JsArray(
               JsArray(JsString(party0), JsString(party1)),
-              ApiCodecCompressed.apiValueToJsValue(cids.toUnnormalizedValue.mapContractId(_.coid)),
+              ApiCodecCompressed.apiValueToJsValue(cids.toUnnormalizedValue),
             )
           ),
         )
@@ -475,18 +475,14 @@ final class JsonApiIt
           QualifiedName.assertFromString("ScriptTest:jsonMultiPartySubmissionCreateSingle"),
           inputValue = Some(JsString(party1)),
         )
-          .map(v =>
-            ApiCodecCompressed.apiValueToJsValue(v.toUnnormalizedValue.mapContractId(_.coid))
-          )
+          .map(v => ApiCodecCompressed.apiValueToJsValue(v.toUnnormalizedValue))
         clientsBoth <- getMultiPartyClients(List(party1, party2))
         cidBoth <- run(
           clientsBoth,
           QualifiedName.assertFromString("ScriptTest:jsonMultiPartySubmissionCreate"),
           inputValue = Some(JsArray(JsString(party1), JsString(party2))),
         )
-          .map(v =>
-            ApiCodecCompressed.apiValueToJsValue(v.toUnnormalizedValue.mapContractId(_.coid))
-          )
+          .map(v => ApiCodecCompressed.apiValueToJsValue(v.toUnnormalizedValue))
         clients2 <- getMultiPartyClients(List(party2), List(party1))
         r <- run(
           clients2,

--- a/extractor/src/main/scala/com/digitalasset/extractor/json/JsonConverters.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/json/JsonConverters.scala
@@ -7,18 +7,17 @@ import com.daml.lf.data.{ImmArray, SortedLookupList}
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.json.ApiCodecCompressed
 import com.daml.extractor.ledger.types.{Identifier, LedgerValue}
-import com.daml.extractor.ledger.types.LedgerValue._
 import com.daml.extractor.writers.postgresql.DataFormatState.MultiTableState
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.generic.semiauto._
 import io.circe.syntax._
-import scalaz.std.string._
 
 object JsonConverters {
-  import ApiCodecCompressed.JsonImplicits.StringJsonFormat
+
+  import ApiCodecCompressed.JsonImplicits.ContractIdFormat
   private[this] object LfValueSprayEnc
-      extends ApiCodecCompressed[String](
+      extends ApiCodecCompressed(
         encodeDecimalAsString = true,
         encodeInt64AsString = false,
       )
@@ -39,12 +38,12 @@ object JsonConverters {
   def toJsonString[A: Encoder](a: A): String =
     a.asJson.noSpaces
 
-  implicit val recordEncoder: Encoder[OfCid[V.ValueRecord]] = valueEncoder
+  implicit val recordEncoder: Encoder[V.ValueRecord] = valueEncoder
 
   implicit def valueEncoder[T <: LedgerValue]: Encoder[T] =
     t => sprayToCirce(LfValueSprayEnc.apiValueToJsValue(t))
 
-  implicit val variantEncoder: Encoder[OfCid[V.ValueVariant]] = valueEncoder
+  implicit val variantEncoder: Encoder[V.ValueVariant] = valueEncoder
 
   implicit val textMapEncoder: Encoder[SortedLookupList[LedgerValue]] =
     valueEncoder.contramap(V.ValueTextMap(_))

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Event.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Event.scala
@@ -18,7 +18,7 @@ final case class CreatedEvent(
     eventId: String,
     contractId: String,
     templateId: Identifier,
-    createArguments: OfCid[V.ValueRecord],
+    createArguments: V.ValueRecord,
     stakeholders: Set[String],
 ) extends Event
 

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/LedgerValue.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/LedgerValue.scala
@@ -19,8 +19,6 @@ import com.daml.lf.value.{Value => V}
 
 object LedgerValue {
 
-  type OfCid[F[+_]] = F[String]
-
   private val variantValueLens =
     ReqFieldLens.create[api.value.Variant, api.value.Value](Symbol("value"))
 
@@ -29,7 +27,7 @@ object LedgerValue {
   }
 
   final implicit class ApiRecordOps(val apiRecord: api.value.Record) extends AnyVal {
-    def convert: String \/ OfCid[V.ValueRecord] = convertRecord(apiRecord)
+    def convert: String \/ V.ValueRecord = convertRecord(apiRecord)
   }
 
   final implicit class ApiValueSumOps(val apiValueSum: api.value.Value.Sum) extends AnyVal {
@@ -42,7 +40,8 @@ object LedgerValue {
       case Sum.Map(map) => convertTextMap(map).widen
       case Sum.GenMap(entries) => convertGenMap(entries).widen
       case Sum.Bool(value) => V.ValueBool(value).right
-      case Sum.ContractId(value) => V.ValueContractId(value).right
+      case Sum.ContractId(value) =>
+        \/.fromEither(V.ContractId.fromString(value).map(V.ValueContractId))
       case Sum.Int64(value) => V.ValueInt64(value).right
       case Sum.Numeric(value) =>
         lfdata.Numeric
@@ -89,7 +88,7 @@ object LedgerValue {
   private def convertOptional(apiOptional: api.value.Optional) =
     apiOptional.value traverse (_.convert) map (V.ValueOptional(_))
 
-  private def convertTextMap(apiMap: api.value.Map): String \/ OfCid[V.ValueTextMap] =
+  private def convertTextMap(apiMap: api.value.Map): String \/ V.ValueTextMap =
     for {
       entries <- apiMap.entries.toList.traverse {
         case api.value.Map.Entry(k, Some(v)) => v.sum.convert.map(k -> _)
@@ -98,14 +97,14 @@ object LedgerValue {
       map <- SortedLookupList.fromImmArray(entries.to(ImmArray)).disjunction
     } yield V.ValueTextMap(map)
 
-  private def convertGenMap(apiMap: api.value.GenMap): String \/ OfCid[V.ValueGenMap] =
+  private def convertGenMap(apiMap: api.value.GenMap): String \/ V.ValueGenMap =
     apiMap.entries.toList
       .traverse { entry =>
         for {
-          k <- entry.key.fold[String \/ OfCid[V]](-\/("key field of GenMap.Entry must be defined"))(
+          k <- entry.key.fold[String \/ V](-\/("key field of GenMap.Entry must be defined"))(
             _.convert
           )
-          v <- entry.value.fold[String \/ OfCid[V]](
+          v <- entry.value.fold[String \/ V](
             -\/("value field of GenMap.Entry must be defined")
           )(_.convert)
         } yield k -> v

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/package.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/package.scala
@@ -6,5 +6,5 @@ package com.daml.extractor.ledger
 import com.daml.lf.value.Value
 
 package object types {
-  type LedgerValue = Value[String]
+  type LedgerValue = Value
 }

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/postgresql/Queries.scala
@@ -292,7 +292,7 @@ object Queries {
           fr0"${constructor: String}"
         case o @ V.ValueOptional(_) =>
           fr0"${toJsonString(o)}::jsonb"
-        case V.ValueContractId(value) => fr0"${value}"
+        case V.ValueContractId(value) => fr0"${value.coid}"
         case l @ V.ValueList(_) =>
           fr0"${toJsonString(l)}::jsonb"
         case V.ValueInt64(value) =>

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -246,7 +246,6 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
     tmplId.copy(packageId = None)
 
   import com.daml.lf.data.{Numeric => LfNumeric}
-  import com.daml.lf.value.Value.{ContractId => LfContractId}
   import com.daml.lf.value.test.TypedValueGenerators.{ValueAddend => VA}
   import shapeless.HList, shapeless.record.{Record => ShRecord}
 
@@ -265,7 +264,7 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
     v.RecordField(n, Some(v.Value(vs)))
   })
 
-  private[this] def argToApi(va: VA)(arg: va.Inj[LfContractId]): v.Record =
+  private[this] def argToApi(va: VA)(arg: va.Inj): v.Record =
     lfToApi(va.inj(arg)) match {
       case v.Value(v.Value.Sum.Record(r)) => removeRecordId(r)
       case _ => fail(s"${va.t} isn't a record type")

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -569,7 +569,7 @@ class ContractsService(
 object ContractsService {
   private type ApiValue = api.value.Value
 
-  private type LfValue = lf.value.Value[lf.value.Value.ContractId]
+  private type LfValue = lf.value.Value
 
   private final case class SearchValueFormat[-T](encode: T => (Error \/ JsValue))
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -745,7 +745,7 @@ object Endpoints {
   private type ApiRecord = lav1.value.Record
   private type ApiValue = lav1.value.Value
 
-  private type LfValue = lf.value.Value[lf.value.Value.ContractId]
+  private type LfValue = lf.value.Value
 
   private final class IntoServerError[-A](val run: A => Error) extends AnyVal
   private object IntoServerError extends IntoServerErrorLow {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -48,7 +48,7 @@ object domain {
     }
   }
 
-  type LfValue = lf.value.Value[lf.value.Value.ContractId]
+  type LfValue = lf.value.Value
 
   private def oneAndSet[A](p: A, sp: Set[A]) =
     OneAnd(p, sp - p)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsValueToApiValueConverter.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsValueToApiValueConverter.scala
@@ -20,7 +20,7 @@ class JsValueToApiValueConverter(lfTypeLookup: LfTypeLookup) {
   def jsValueToLfValue(
       lfId: lf.data.Ref.Identifier,
       jsValue: JsValue,
-  ): JsonError \/ lf.value.Value[lf.value.Value.ContractId] =
+  ): JsonError \/ lf.value.Value =
     \/.attempt(
       LfValueCodec.jsValueToApiValue(jsValue, lfId, lfTypeLookup)
     )(identity).liftErr(JsonError)
@@ -28,7 +28,7 @@ class JsValueToApiValueConverter(lfTypeLookup: LfTypeLookup) {
   def jsValueToLfValue(
       lfType: iface.Type,
       jsValue: JsValue,
-  ): JsonError \/ lf.value.Value[lf.value.Value.ContractId] =
+  ): JsonError \/ lf.value.Value =
     \/.attempt(
       LfValueCodec.jsValueToApiValue(jsValue, lfType, lfTypeLookup)
     )(identity).liftErr(JsonError)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -76,14 +76,14 @@ object JsonProtocol extends DefaultJsonProtocol with ExtraFormats {
     jsonFormat2(domain.AllocatePartyRequest)
 
   object LfValueCodec
-      extends ApiCodecCompressed[ContractId](
+      extends ApiCodecCompressed(
         encodeDecimalAsString = true,
         encodeInt64AsString = true,
       )
 
   // DB *must not* use stringly ints or decimals; see ValuePredicate Range comments
   object LfValueDatabaseCodec
-      extends ApiCodecCompressed[ContractId](
+      extends ApiCodecCompressed(
         encodeDecimalAsString = false,
         encodeInt64AsString = false,
       ) {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/query/ValuePredicate.scala
@@ -194,7 +194,7 @@ sealed abstract class ValuePredicate extends Product with Serializable {
 
 object ValuePredicate {
   type TypeLookup = Ref.Identifier => Option[iface.DefDataType.FWT]
-  type LfV = V[V.ContractId]
+  type LfV = V
   type SqlWhereClause = Vector[Fragment]
 
   val AlwaysFails: SqlWhereClause = Vector(sql"1 = 2")

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/ApiValueToLfValueConverter.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/ApiValueToLfValueConverter.scala
@@ -20,7 +20,7 @@ object ApiValueToLfValueConverter {
   }
 
   type ApiValueToLfValue =
-    lav1.value.Value => Error \/ lf.value.Value[lf.value.Value.ContractId]
+    lav1.value.Value => Error \/ lf.value.Value
 
   def apiValueToLfValue: ApiValueToLfValue = { a: lav1.value.Value =>
     \/.fromEither(ValueValidator.validateValue(a)).leftMap(e => Error(e))

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -12,15 +12,16 @@ import com.daml.http.dbbackend.SurrogateTemplateIdCache
 import com.daml.lf.iface
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.test.TypedValueGenerators.{genAddendNoListMap, RNil, ValueAddend => VA}
+import com.daml.lf.value.test.ValueGenerators.cidV0Gen
 import com.daml.metrics.Metrics
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary
 import org.scalactic.source
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import scalaz.{\/, Order}
+import scalaz.\/
 import spray.json._
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
@@ -32,13 +33,7 @@ class ValuePredicateTest
     with TableDrivenPropertyChecks {
   import ValuePredicateTest._
   type Cid = V.ContractId
-  private[this] implicit val arbCid: Arbitrary[Cid] = Arbitrary(
-    Gen.alphaStr map (t => V.ContractId.V0 assertFromString ('#' +: t))
-  )
-  // only V0 supported in this test atm
-  private[this] implicit val ordCid: Order[Cid] = Order[V.ContractId.V0] contramap (inside(_) {
-    case a0 @ V.ContractId.V0(_) => a0
-  })
+  private[this] implicit val arbCid: Arbitrary[Cid] = Arbitrary(cidV0Gen)
 
   import Ref.QualifiedName.{assertFromString => qn}
 
@@ -70,9 +65,9 @@ class ValuePredicateTest
   private[this] val dummyTypeCon = iface.TypeCon(iface.TypeConName(dummyId), ImmArraySeq.empty)
   private[this] val (eitherId, (eitherDDT, eitherVA)) = eitherT
   private[this] def valueAndTypeInObject(
-      v: V[Cid],
+      v: V,
       ty: iface.Type,
-  ): (V[Cid], ValuePredicate.TypeLookup) =
+  ): (V, ValuePredicate.TypeLookup) =
     (V.ValueRecord(Some(dummyId), ImmArray((Some(dummyFieldName), v))), typeInObject(ty))
   private[this] def typeInObject(ty: iface.Type): ValuePredicate.TypeLookup =
     Map(
@@ -83,7 +78,7 @@ class ValuePredicateTest
     ).lift
 
   "fromJsObject" should {
-    def c[M](query: String, ty: VA)(expected: ty.Inj[Cid], shouldMatch: M)(implicit
+    def c[M](query: String, ty: VA)(expected: ty.Inj, shouldMatch: M)(implicit
         pos: source.Position
     ) =
       (pos.lineNumber, query.parseJson, ty, ty.inj(expected), shouldMatch)
@@ -235,8 +230,8 @@ class ValuePredicateTest
       minSuccessful(100),
     ) { va =>
       import va.injshrink
-      implicit val arbInj: Arbitrary[va.Inj[Cid]] = va.injarb
-      forAll(minSuccessful(20)) { v: va.Inj[Cid] =>
+      implicit val arbInj: Arbitrary[va.Inj] = va.injarb
+      forAll(minSuccessful(20)) { v: va.Inj =>
         val expected = va.inj(v)
         val (wrappedExpected, defs) = valueAndTypeInObject(expected, va.t)
         val query = apiValueToJsValue(expected)

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -8,12 +8,13 @@ import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.ScalazEqual._
 import com.daml.lf.iface
 import com.daml.lf.value.{Value => V}
+import com.daml.lf.value.Value.ContractId
 import com.daml.lf.value.json.{NavigatorModelAliases => Model}
 import Model.{DamlLfIdentifier, DamlLfType, DamlLfTypeLookup}
 import ApiValueImplicits._
 import spray.json._
 import scalaz.{@@, Equal, Order, Tag}
-import scalaz.std.string._
+
 import scalaz.syntax.equal._
 import scalaz.syntax.std.string._
 
@@ -29,21 +30,20 @@ import scalaz.syntax.std.string._
   * @param encodeDecimalAsString Not used yet.
   * @param encodeInt64AsString Not used yet.
   */
-class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt64AsString: Boolean)(
+class ApiCodecCompressed(val encodeDecimalAsString: Boolean, val encodeInt64AsString: Boolean)(
     implicit
-    readCid: JsonReader[Cid],
-    writeCid: JsonWriter[Cid],
-    orderCid: Order[Cid],
+    readCid: JsonReader[ContractId],
+    writeCid: JsonWriter[ContractId],
 ) { self =>
 
   // ------------------------------------------------------------------------------------------------------------------
   // Encoding
   // ------------------------------------------------------------------------------------------------------------------
-  def apiValueToJsValue(value: V[Cid]): JsValue = value match {
-    case v: V.ValueRecord[Cid] => apiRecordToJsValue(v)
-    case v: V.ValueVariant[Cid] => apiVariantToJsValue(v)
+  def apiValueToJsValue(value: V): JsValue = value match {
+    case v: V.ValueRecord => apiRecordToJsValue(v)
+    case v: V.ValueVariant => apiVariantToJsValue(v)
     case v: V.ValueEnum => apiEnumToJsValue(v)
-    case v: V.ValueList[Cid] => apiListToJsValue(v)
+    case v: V.ValueList => apiListToJsValue(v)
     case V.ValueText(v) => JsString(v)
     case V.ValueInt64(v) => if (encodeInt64AsString) JsString((v: Long).toString) else JsNumber(v)
     case V.ValueNumeric(v) =>
@@ -61,25 +61,25 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
         case V.ValueOptional(Some(_)) => JsArray(apiValueToJsValue(v))
         case _ => apiValueToJsValue(v)
       }
-    case textMap: V.ValueTextMap[Cid] =>
+    case textMap: V.ValueTextMap =>
       apiMapToJsValue(textMap)
-    case genMap: V.ValueGenMap[Cid] =>
+    case genMap: V.ValueGenMap =>
       apiGenMapToJsValue(genMap)
   }
 
   @throws[SerializationException]
-  private[this] final def apiContractIdToJsValue(v: Cid): JsValue = v.toJson
+  private[this] final def apiContractIdToJsValue(v: ContractId): JsValue = v.toJson
 
-  private[this] def apiListToJsValue(value: V.ValueList[Cid]): JsValue =
+  private[this] def apiListToJsValue(value: V.ValueList): JsValue =
     JsArray(value.values.map(apiValueToJsValue(_)).toImmArray.toSeq: _*)
 
-  private[this] def apiVariantToJsValue(value: V.ValueVariant[Cid]): JsValue =
+  private[this] def apiVariantToJsValue(value: V.ValueVariant): JsValue =
     JsonVariant(value.variant, apiValueToJsValue(value.value))
 
   private[this] def apiEnumToJsValue(value: V.ValueEnum): JsValue =
     JsString(value.value)
 
-  private[ApiCodecCompressed] def apiRecordToJsValue(value: V.ValueRecord[Cid]): JsValue = {
+  private[ApiCodecCompressed] def apiRecordToJsValue(value: V.ValueRecord): JsValue = {
     val namedOrNoneFields = value.fields.toSeq collect {
       case (Some(k), v) => Some((k, v))
       case (_, V.ValueOptional(None)) => None
@@ -94,14 +94,14 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
       }: _*)
   }
 
-  private[this] def apiMapToJsValue(value: V.ValueTextMap[Cid]): JsValue =
+  private[this] def apiMapToJsValue(value: V.ValueTextMap): JsValue =
     JsObject(
       value.value
         .mapValue(apiValueToJsValue)
         .toHashMap
     )
 
-  private[this] def apiGenMapToJsValue(value: V.ValueGenMap[Cid]): JsValue =
+  private[this] def apiGenMapToJsValue(value: V.ValueGenMap): JsValue =
     JsArray(
       value.entries.map { case (key, value) =>
         JsArray(apiValueToJsValue(key), apiValueToJsValue(value))
@@ -113,13 +113,14 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
   // ------------------------------------------------------------------------------------------------------------------
 
   @throws[DeserializationException]
-  private[this] final def jsValueToApiContractId(value: JsValue): Cid = value.convertTo[Cid]
+  private[this] final def jsValueToApiContractId(value: JsValue): ContractId =
+    value.convertTo[ContractId]
 
   private[this] def jsValueToApiPrimitive(
       value: JsValue,
       prim: Model.DamlLfTypePrim,
       defs: Model.DamlLfTypeLookup,
-  ): V[Cid] = {
+  ): V = {
     (prim.typ, value).match2 {
       case Model.DamlLfPrimType.Int64 => {
         case JsString(v) => V.ValueInt64(assertDE(v.parseLong.leftMap(_.getMessage).toEither))
@@ -172,11 +173,11 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
       case Model.DamlLfPrimType.GenMap =>
         val Seq(kType, vType) = prim.typArgs;
         { case JsArray(entries) =>
-          implicit val keySort: Order[V[Cid] @@ defs.type] = decodedOrder(defs)
-          implicit val keySSort: math.Ordering[V[Cid] @@ defs.type] = keySort.toScalaOrdering
-          type OK[K] = Vector[(K, V[Cid])]
-          val decEntries: Vector[(V[Cid] @@ defs.type, V[Cid])] = Tag
-            .subst[V[Cid], OK, defs.type](entries.map {
+          implicit val keySort: Order[V @@ defs.type] = decodedOrder(defs)
+          implicit val keySSort: math.Ordering[V @@ defs.type] = keySort.toScalaOrdering
+          type OK[K] = Vector[(K, V)]
+          val decEntries: Vector[(V @@ defs.type, V)] = Tag
+            .subst[V, OK, defs.type](entries.map {
               case JsArray(Vector(key, value)) =>
                 jsValueToApiValue(key, kType, defs) ->
                   jsValueToApiValue(value, vType, defs)
@@ -185,7 +186,7 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
             })
             .sortBy(_._1)
           checkDups(decEntries)
-          V.ValueGenMap(Tag.unsubst[V[Cid], OK, defs.type](decEntries).to(ImmArray))
+          V.ValueGenMap(Tag.unsubst[V, OK, defs.type](decEntries).to(ImmArray))
         }
 
     }(fallback = deserializationError(s"Can't read ${value.prettyPrint} as $prim"))
@@ -197,13 +198,13 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
       case _ => false
     }
 
-  private[this] def decodedOrder(defs: Model.DamlLfTypeLookup): Order[V[Cid] @@ defs.type] = {
+  private[this] def decodedOrder(defs: Model.DamlLfTypeLookup): Order[V @@ defs.type] = {
     val scope: V.LookupVariantEnum = defs andThen (_ flatMap (_.dataType match {
       case iface.Variant(fields) => Some(fields.toImmArray map (_._1))
       case iface.Enum(ctors) => Some(ctors.toImmArray)
       case iface.Record(_) => None
     }))
-    Tag subst (Tag unsubst V.orderInstance[Cid](scope))
+    Tag subst (Tag unsubst V.orderInstance(scope))
   }
 
   @throws[DeserializationException]
@@ -222,7 +223,7 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
       id: DamlLfIdentifier,
       dt: Model.DamlLfDataType,
       defs: Model.DamlLfTypeLookup,
-  ): V[Cid] = {
+  ): V = {
     (dt, value).match2 {
       case Model.DamlLfRecord(fields) => {
         case JsObject(v) =>
@@ -298,7 +299,7 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
       value: JsValue,
       typ: Model.DamlLfType,
       defs: Model.DamlLfTypeLookup,
-  ): V[Cid] = {
+  ): V = {
     typ match {
       case prim: Model.DamlLfTypePrim =>
         jsValueToApiPrimitive(value, prim, defs)
@@ -327,22 +328,22 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
       value: JsValue,
       id: Model.DamlLfIdentifier,
       defs: Model.DamlLfTypeLookup,
-  ): V[Cid] = {
+  ): V = {
     val typeCon = Model.DamlLfTypeCon(Model.DamlLfTypeConName(id), ImmArraySeq())
     val dt = typeCon.instantiate(defs(id).getOrElse(deserializationError(s"Type $id not found")))
     jsValueToApiDataType(value, id, dt, defs)
   }
 
   /** Creates a JsonReader for Values with the relevant type information */
-  def apiValueJsonReader(typ: DamlLfType, defs: DamlLfTypeLookup): JsonReader[V[Cid]] =
+  def apiValueJsonReader(typ: DamlLfType, defs: DamlLfTypeLookup): JsonReader[V] =
     jsValueToApiValue(_, typ, defs)
 
   /** Creates a JsonReader for Values with the relevant type information */
-  def apiValueJsonReader(typ: DamlLfIdentifier, defs: DamlLfTypeLookup): JsonReader[V[Cid]] =
+  def apiValueJsonReader(typ: DamlLfIdentifier, defs: DamlLfTypeLookup): JsonReader[V] =
     jsValueToApiValue(_, typ, defs)
 
   /** Same as jsValueToApiType, but with unparsed input */
-  def stringToApiType(value: String, typ: Model.DamlLfType, defs: Model.DamlLfTypeLookup): V[Cid] =
+  def stringToApiType(value: String, typ: Model.DamlLfType, defs: Model.DamlLfTypeLookup): V =
     jsValueToApiValue(value.parseJson, typ, defs)
 
   /** Same as jsValueToApiType, but with unparsed input */
@@ -350,7 +351,7 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
       value: String,
       id: Model.DamlLfIdentifier,
       defs: Model.DamlLfTypeLookup,
-  ): V[Cid] =
+  ): V =
     jsValueToApiValue(value.parseJson, id, defs)
 
   private[this] def assertDE[A](ea: Either[String, A]): A =
@@ -359,17 +360,29 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
   private[json] def copy(
       encodeDecimalAsString: Boolean = this.encodeDecimalAsString,
       encodeInt64AsString: Boolean = this.encodeInt64AsString,
-  ): ApiCodecCompressed[Cid] =
-    new ApiCodecCompressed[Cid](
+  ): ApiCodecCompressed =
+    new ApiCodecCompressed(
       encodeDecimalAsString = encodeDecimalAsString,
       encodeInt64AsString = encodeInt64AsString,
     )
 }
 
-import DefaultJsonProtocol.StringJsonFormat
+private[json] object JsonContractIdFormat {
+  implicit val ContractIdFormat: JsonFormat[ContractId] =
+    new JsonFormat[ContractId] {
+      override def write(obj: ContractId) =
+        JsString(obj.coid)
+      override def read(json: JsValue) = json match {
+        case JsString(s) =>
+          ContractId.fromString(s).fold(deserializationError(_), identity)
+        case _ => deserializationError("ContractId must be a string")
+      }
+    }
+}
+import JsonContractIdFormat._
 
 object ApiCodecCompressed
-    extends ApiCodecCompressed[String](encodeDecimalAsString = true, encodeInt64AsString = true) {
+    extends ApiCodecCompressed(encodeDecimalAsString = true, encodeInt64AsString = true) {
   // ------------------------------------------------------------------------------------------------------------------
   // Implicits that can be imported to write JSON
   // ------------------------------------------------------------------------------------------------------------------
@@ -380,5 +393,6 @@ object ApiCodecCompressed
     implicit object ApiRecordJsonFormat extends RootJsonWriter[Model.ApiRecord] {
       def write(v: Model.ApiRecord): JsValue = apiRecordToJsValue(v)
     }
+    implicit val ContractIdFormat = JsonContractIdFormat.ContractIdFormat
   }
 }

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
@@ -65,15 +65,14 @@ trait NavigatorModelAliases[Cid] {
   type DamlLfEnum = iface.Enum
   val DamlLfEnum = iface.Enum
 
-  type OfCid[F[_]] = F[Cid]
-  type ApiValue = OfCid[V]
+  type ApiValue = V
   type ApiRecordField = (Option[DamlLfRef.Name], ApiValue)
-  type ApiRecord = OfCid[V.ValueRecord]
-  type ApiVariant = OfCid[V.ValueVariant]
-  type ApiList = OfCid[V.ValueList]
-  type ApiOptional = OfCid[V.ValueOptional]
-  type ApiMap = OfCid[V.ValueTextMap]
-  type ApiGenMap = OfCid[V.ValueGenMap]
+  type ApiRecord = V.ValueRecord
+  type ApiVariant = V.ValueVariant
+  type ApiList = V.ValueList
+  type ApiOptional = V.ValueOptional
+  type ApiMap = V.ValueTextMap
+  type ApiGenMap = V.ValueGenMap
 }
 
 object NavigatorModelAliases extends NavigatorModelAliases[String]

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValueValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValueValidator.scala
@@ -34,7 +34,7 @@ object ValueValidator {
       })
       .map(_.toImmArray)
 
-  def validateRecord(rec: api.Record): Either[StatusRuntimeException, Lf.ValueRecord[ContractId]] =
+  def validateRecord(rec: api.Record): Either[StatusRuntimeException, Lf.ValueRecord] =
     for {
       recId <- validateOptionalIdentifier(rec.recordId)
       fields <- validateRecordFields(rec.fields)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/PlatformTypes.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/PlatformTypes.scala
@@ -9,29 +9,29 @@ import com.daml.lf.data.Ref
 
 object PlatformTypes {
 
-  type GenNode[Nid, Cid] = N.GenNode[Nid, Cid]
+  type GenNode[Nid] = N.GenNode[Nid]
 
-  type NodeCreate[Cid] = N.NodeCreate[Cid]
+  type NodeCreate = N.NodeCreate
   val NodeCreate: N.NodeCreate.type = N.NodeCreate
 
-  type NodeLookupByKey[Cid] = N.NodeLookupByKey[Cid]
+  type NodeLookupByKey = N.NodeLookupByKey
   val NodeLookupByKey: N.NodeLookupByKey.type = N.NodeLookupByKey
 
-  type NodeFetch[Cid] = N.NodeFetch[Cid]
+  type NodeFetch = N.NodeFetch
   val NodeFetch: N.NodeFetch.type = N.NodeFetch
 
-  type NodeExercises[Nid, Cid] = N.NodeExercises[Nid, Cid]
+  type NodeExercises[Nid] = N.NodeExercises[Nid]
   val NodeExercises: N.NodeExercises.type = N.NodeExercises
 
-  type Event[Nid, Cid] = E.Event[Nid, Cid]
+  type Event[Nid] = E.Event[Nid]
 
-  type Events[Nid, Cid] = E.Event.Events[Nid, Cid]
+  type Events[Nid] = E.Event.Events[Nid]
   val Events: E.Event.Events.type = E.Event.Events
 
-  type CreateEvent[Cid] = E.CreateEvent[Cid]
+  type CreateEvent = E.CreateEvent
   val CreateEvent: E.CreateEvent.type = E.CreateEvent
 
-  type ExerciseEvent[Nid, Cid] = E.ExerciseEvent[Nid, Cid]
+  type ExerciseEvent[Nid] = E.ExerciseEvent[Nid]
   val ExerciseEvent: E.ExerciseEvent.type = E.ExerciseEvent
 
   def packageId(str: String): Ref.PackageId = Ref.PackageId.assertFromString(str)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
@@ -30,7 +30,7 @@ import com.google.protobuf.timestamp.Timestamp
   */
 object LfEngineToApi {
 
-  private[this] type LfValue[+Cid] = Lf[Cid]
+  private[this] type LfValue = Lf
 
   def toApiIdentifier(identifier: Identifier): api.Identifier = {
     api.Identifier(
@@ -46,13 +46,13 @@ object LfEngineToApi {
 
   def lfVersionedValueToApiRecord(
       verbose: Boolean,
-      recordValue: Lf.VersionedValue[Lf.ContractId],
+      recordValue: Lf.VersionedValue,
   ): Either[String, api.Record] =
     lfValueToApiRecord(verbose, recordValue.value)
 
   def lfValueToApiRecord(
       verbose: Boolean,
-      recordValue: LfValue[Lf.ContractId],
+      recordValue: LfValue,
   ): Either[String, api.Record] = {
     recordValue match {
       case Lf.ValueRecord(tycon, fields) =>
@@ -78,7 +78,7 @@ object LfEngineToApi {
 
   def lfVersionedValueToApiValue(
       verbose: Boolean,
-      lf: Option[Lf.VersionedValue[Lf.ContractId]],
+      lf: Option[Lf.VersionedValue],
   ): Either[String, Option[api.Value]] =
     lf.fold[Either[String, Option[api.Value]]](Right(None))(
       lfVersionedValueToApiValue(verbose, _).map(Some(_))
@@ -86,13 +86,13 @@ object LfEngineToApi {
 
   def lfVersionedValueToApiValue(
       verbose: Boolean,
-      value: Lf.VersionedValue[Lf.ContractId],
+      value: Lf.VersionedValue,
   ): Either[String, api.Value] =
     lfValueToApiValue(verbose, value.value)
 
   def lfValueToApiValue(
       verbose: Boolean,
-      value0: LfValue[Lf.ContractId],
+      value0: LfValue,
   ): Either[String, api.Value] =
     value0 match {
       case Lf.ValueUnit => Right(api.Value(api.Value.Sum.Unit(Empty())))
@@ -187,13 +187,13 @@ object LfEngineToApi {
 
   def lfContractKeyToApiValue(
       verbose: Boolean,
-      lf: KeyWithMaintainers[Lf.VersionedValue[Lf.ContractId]],
+      lf: KeyWithMaintainers[Lf.VersionedValue],
   ): Either[String, api.Value] =
     lfVersionedValueToApiValue(verbose, lf.key)
 
   def lfContractKeyToApiValue(
       verbose: Boolean,
-      lf: Option[KeyWithMaintainers[Lf.VersionedValue[Lf.ContractId]]],
+      lf: Option[KeyWithMaintainers[Lf.VersionedValue]],
   ): Either[String, Option[api.Value]] =
     lf.fold[Either[String, Option[api.Value]]](Right(None))(
       lfContractKeyToApiValue(verbose, _).map(Some(_))
@@ -203,7 +203,7 @@ object LfEngineToApi {
       verbose: Boolean,
       trId: Ref.LedgerString,
       nodeId: NodeId,
-      node: NodeCreate[Lf.ContractId],
+      node: NodeCreate,
   ): Either[String, Event] =
     for {
       arg <- lfValueToApiRecord(verbose, node.coinst.arg)
@@ -227,7 +227,7 @@ object LfEngineToApi {
   def lfNodeExercisesToEvent(
       trId: Ref.LedgerString,
       nodeId: NodeId,
-      node: NodeExercises[NodeId, Lf.ContractId],
+      node: NodeExercises[NodeId],
   ): Either[String, Event] =
     Either.cond(
       node.consuming,
@@ -248,7 +248,7 @@ object LfEngineToApi {
       verbose: Boolean,
       eventId: EventId,
       witnessParties: Set[Ref.Party],
-      node: NodeCreate[Lf.ContractId],
+      node: NodeCreate,
   ): Either[String, TreeEvent] =
     for {
       arg <- lfValueToApiRecord(verbose, node.coinst.arg)
@@ -274,7 +274,7 @@ object LfEngineToApi {
       trId: Ref.LedgerString,
       eventId: EventId,
       witnessParties: Set[Ref.Party],
-      node: NodeExercises[NodeId, Lf.ContractId],
+      node: NodeExercises[NodeId],
       filterChildren: NodeId => Boolean,
   ): Either[String, TreeEvent] =
     for {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/store/serialization/KeyHasher.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/store/serialization/KeyHasher.scala
@@ -9,7 +9,6 @@ import java.security.MessageDigest
 import com.daml.lf.data.{Numeric, Utf8}
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.ContractId
 
 /** @deprecated in favor of [[GlobalKey.hash]]
   */
@@ -49,7 +48,7 @@ object KeyHasher extends KeyHasher {
     * @param op operation to append a hash token
     * @return the final hash value
     */
-  def foldLeft[T](value: Value[ContractId], z: T, op: (T, HashToken) => T): T = {
+  def foldLeft[T](value: Value, z: T, op: (T, HashToken) => T): T = {
     import com.daml.lf.value.Value._
 
     value match {
@@ -128,7 +127,7 @@ object KeyHasher extends KeyHasher {
   // Do not use directly. It is package visible for testing purpose.
   private[serialization] def putValue(
       digest: MessageDigest,
-      value: Value[ContractId],
+      value: Value,
   ): MessageDigest = {
     // Then, write the value
     foldLeft[MessageDigest](

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/store/serialization/KeyHasherSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/store/serialization/KeyHasherSpec.scala
@@ -27,7 +27,7 @@ class KeyHasherSpec extends AnyWordSpec with Matchers {
   )
 
   private[this] def complexValue = {
-    val builder = ImmArray.newBuilder[(Option[Name], Value[Nothing])]
+    val builder = ImmArray.newBuilder[(Option[Name], Value)]
     builder += None -> ValueInt64(0)
     builder += None -> ValueInt64(123456)
     builder += None -> ValueInt64(-1)
@@ -343,7 +343,7 @@ class KeyHasherSpec extends AnyWordSpec with Matchers {
 
     "stable " in {
 
-      type Value = lf.value.Value[ContractId]
+      type Value = lf.value.Value
 
       val pkgId = Ref.PackageId.assertFromString("pkgId")
 

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -89,7 +89,7 @@ object domain {
         eventId: EventId,
         contractId: ContractId,
         templateId: Ref.Identifier,
-        createArguments: Lf.ValueRecord[ContractId],
+        createArguments: Lf.ValueRecord,
         witnessParties: immutable.Set[Ref.Party],
         signatories: immutable.Set[Ref.Party],
         observers: immutable.Set[Ref.Party],
@@ -213,7 +213,7 @@ object domain {
     final case class InvalidLedgerTime(description: String) extends RejectionReason
   }
 
-  type Value = Lf[Lf.ContractId]
+  type Value = Lf
 
   final case class RecordField(label: Option[Label], value: Value)
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V38__Update_value_versions.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V38__Update_value_versions.scala
@@ -13,10 +13,9 @@ import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 private[migration] final class V38__Update_value_versions extends BaseJavaMigration {
 
   import com.daml.lf
-  import lf.value.Value.ContractId
   import translation.ValueSerializer
 
-  private[this] type Value = lf.value.Value.VersionedValue[ContractId]
+  private[this] type Value = lf.value.Value.VersionedValue
 
   private[this] val BATCH_SIZE = 1000
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V4_1__Collect_Parties.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V4_1__Collect_Parties.scala
@@ -17,7 +17,6 @@ import com.daml.lf.transaction.Node.{
   NodeFetch,
   NodeLookupByKey,
 }
-import com.daml.lf.value.Value.ContractId
 import com.daml.platform.store.Conversions._
 import com.daml.platform.db.migration.translation.TransactionSerializer
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
@@ -108,21 +107,21 @@ private[migration] class V4_1__Collect_Parties extends BaseJavaMigration {
       .fold[Set[Ref.Party]](Set.empty) { case (parties, (_, node)) =>
         node match {
           case _: NodeRollback[_] => Set.empty
-          case nf: NodeFetch[ContractId] =>
+          case nf: NodeFetch =>
             parties
               .union(nf.signatories)
               .union(nf.stakeholders)
               .union(nf.actingParties)
-          case nc: NodeCreate[ContractId] =>
+          case nc: NodeCreate =>
             parties
               .union(nc.signatories)
               .union(nc.stakeholders)
-          case ne: NodeExercises[_, ContractId] =>
+          case ne: NodeExercises[_] =>
             parties
               .union(ne.signatories)
               .union(ne.stakeholders)
               .union(ne.actingParties)
-          case _: NodeLookupByKey[ContractId] =>
+          case _: NodeLookupByKey =>
             parties
         }
       }

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
@@ -15,8 +15,8 @@ package object v25_backfill_participant_events {
   import com.daml.lf.{transaction => lftx}
   private[migration] type NodeId = lftx.NodeId
   private[migration] type Transaction = lftx.Transaction.Transaction
-  private[migration] type Create = lftx.Node.NodeCreate[ContractId]
-  private[migration] type Exercise = lftx.Node.NodeExercises[NodeId, ContractId]
+  private[migration] type Create = lftx.Node.NodeCreate
+  private[migration] type Exercise = lftx.Node.NodeExercises[NodeId]
 
   import com.daml.lf.{data => lfdata}
   private[migration] type Party = lfdata.Ref.Party

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v29_fix_participant_events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v29_fix_participant_events/package.scala
@@ -15,8 +15,8 @@ package object v29_fix_participant_events {
   import com.daml.lf.{transaction => lftx}
   private[migration] type NodeId = lftx.NodeId
   private[migration] type Transaction = lftx.Transaction.Transaction
-  private[migration] type Create = lftx.Node.NodeCreate[ContractId]
-  private[migration] type Exercise = lftx.Node.NodeExercises[NodeId, ContractId]
+  private[migration] type Create = lftx.Node.NodeCreate
+  private[migration] type Exercise = lftx.Node.NodeExercises[NodeId]
 
   import com.daml.lf.{data => lfdata}
   private[migration] type Party = lfdata.Ref.Party

--- a/ledger/participant-integration-api/src/main/scala/db/migration/translation/ContractSerializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/translation/ContractSerializer.scala
@@ -6,17 +6,17 @@ package com.daml.platform.db.migration.translation
 import java.io.InputStream
 
 import com.daml.lf.transaction.{TransactionCoder, TransactionOuterClass}
-import com.daml.lf.value.Value.{ContractId, ContractInst, VersionedValue}
+import com.daml.lf.value.Value.{ContractInst, VersionedValue}
 import com.daml.lf.value.ValueCoder
 
 private[migration] trait ContractSerializer {
   def serializeContractInstance(
-      coinst: ContractInst[VersionedValue[ContractId]]
+      coinst: ContractInst[VersionedValue]
   ): Either[ValueCoder.EncodeError, Array[Byte]]
 
   def deserializeContractInstance(
       stream: InputStream
-  ): Either[ValueCoder.DecodeError, ContractInst[VersionedValue[ContractId]]]
+  ): Either[ValueCoder.DecodeError, ContractInst[VersionedValue]]
 }
 
 /** This is a preliminary serializer using protobuf as a payload type. Our goal on the long run is to use JSON as a payload.
@@ -24,18 +24,18 @@ private[migration] trait ContractSerializer {
 private[migration] object ContractSerializer extends ContractSerializer {
 
   override def serializeContractInstance(
-      coinst: ContractInst[VersionedValue[ContractId]]
+      coinst: ContractInst[VersionedValue]
   ): Either[ValueCoder.EncodeError, Array[Byte]] =
     TransactionCoder
-      .encodeContractInstance[ContractId](ValueCoder.CidEncoder, coinst)
+      .encodeContractInstance(ValueCoder.CidEncoder, coinst)
       .map(_.toByteArray())
 
   override def deserializeContractInstance(
       stream: InputStream
-  ): Either[ValueCoder.DecodeError, ContractInst[VersionedValue[ContractId]]] =
+  ): Either[ValueCoder.DecodeError, ContractInst[VersionedValue]] =
     ValueSerializer.handleDeprecatedValueVersions(
       TransactionCoder
-        .decodeVersionedContractInstance[ContractId](
+        .decodeVersionedContractInstance(
           ValueCoder.CidDecoder,
           TransactionOuterClass.ContractInstance.parseFrom(
             ValueSerializer.lfValueCodedInputStream(stream)

--- a/ledger/participant-integration-api/src/main/scala/db/migration/translation/TransactionSerializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/translation/TransactionSerializer.scala
@@ -7,8 +7,8 @@ import java.io.InputStream
 
 import com.daml.lf.data.Ref.LedgerString
 import com.daml.lf.transaction.{CommittedTransaction, TransactionCoder, TransactionOuterClass}
-import com.daml.lf.value.ValueCoder
 import com.daml.lf.value.ValueCoder.{DecodeError, EncodeError}
+import com.daml.lf.value.ValueCoder
 
 private[migration] trait TransactionSerializer {
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/translation/ValueSerializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/translation/ValueSerializer.scala
@@ -6,7 +6,7 @@ package db.migration.translation
 
 import java.io.InputStream
 
-import com.daml.lf.value.Value.{ContractId, VersionedValue}
+import com.daml.lf.value.Value.VersionedValue
 import com.daml.lf.value.{ValueCoder, ValueOuterClass}
 import com.google.protobuf.CodedInputStream
 import org.slf4j.LoggerFactory
@@ -45,7 +45,7 @@ private[migration] object ValueSerializer {
   }
 
   def serializeValue(
-      value: VersionedValue[ContractId],
+      value: VersionedValue,
       errorContext: => String,
   ): Array[Byte] = store.serialization.ValueSerializer.serializeValue(value, errorContext)
 
@@ -60,7 +60,7 @@ private[migration] object ValueSerializer {
   private[this] def deserializeValueHelper(
       stream: InputStream,
       errorContext: => Option[String],
-  ): VersionedValue[ContractId] =
+  ): VersionedValue =
     handleDeprecatedValueVersions(
       ValueCoder
         .decodeVersionedValue(
@@ -76,13 +76,13 @@ private[migration] object ValueSerializer {
 
   def deserializeValue(
       stream: InputStream
-  ): VersionedValue[ContractId] =
+  ): VersionedValue =
     deserializeValueHelper(stream, None)
 
   def deserializeValue(
       stream: InputStream,
       errorContext: => String,
-  ): VersionedValue[ContractId] =
+  ): VersionedValue =
     deserializeValueHelper(stream, Some(errorContext))
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/SpannedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/SpannedIndexService.scala
@@ -133,7 +133,7 @@ private[daml] final class SpannedIndexService(delegate: IndexService) extends In
       contractId: Value.ContractId,
   )(implicit
       loggingContext: LoggingContext
-  ): Future[Option[Value.ContractInst[Value.VersionedValue[Value.ContractId]]]] =
+  ): Future[Option[Value.ContractInst[Value.VersionedValue]]] =
     delegate.lookupActiveContract(readers, contractId)
 
   override def lookupContractKey(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -142,7 +142,7 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
       contractId: Value.ContractId,
   )(implicit
       loggingContext: LoggingContext
-  ): Future[Option[Value.ContractInst[Value.VersionedValue[Value.ContractId]]]] =
+  ): Future[Option[Value.ContractInst[Value.VersionedValue]]] =
     Timed.future(
       metrics.daml.services.index.lookupActiveContract,
       delegate.lookupActiveContract(readers, contractId),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -92,7 +92,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
               Some(meta.nodeSeeds),
               Some(
                 updateTx.nodes
-                  .collect { case (nodeId, node: Node.GenActionNode[_, _]) if node.byKey => nodeId }
+                  .collect { case (nodeId, node: Node.GenActionNode[_]) if node.byKey => nodeId }
                   .to(ImmArray)
               ),
             ),

--- a/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
@@ -214,7 +214,7 @@ private[platform] final class LedgerBackedIndexService(
       contractId: ContractId,
   )(implicit
       loggingContext: LoggingContext
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
+  ): Future[Option[ContractInst[Value.VersionedValue]]] =
     ledger.lookupContract(contractId, readers)
 
   override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -81,7 +81,7 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
       forParties: Set[Ref.Party],
   )(implicit
       loggingContext: LoggingContext
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
+  ): Future[Option[ContractInst[Value.VersionedValue]]] =
     Timed.future(metrics.daml.index.lookupContract, ledger.lookupContract(contractId, forParties))
 
   override def lookupKey(key: GlobalKey, forParties: Set[Ref.Party])(implicit

--- a/ledger/participant-integration-api/src/main/scala/platform/index/TransactionConversion.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/TransactionConversion.scala
@@ -9,7 +9,6 @@ import com.daml.lf.data.Relation.Relation
 import com.daml.lf.engine.Blinding
 import com.daml.lf.transaction.{CommittedTransaction, NodeId, Transaction => Tx}
 import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
-import com.daml.lf
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.v1.event.Event
 import com.daml.ledger.api.v1.transaction.{
@@ -32,11 +31,10 @@ import scala.annotation.tailrec
 
 private[platform] object TransactionConversion {
 
-  private type ContractId = lf.value.Value.ContractId
   private type Transaction = CommittedTransaction
   private type Node = Tx.Node
-  private type Create = NodeCreate[ContractId]
-  private type Exercise = NodeExercises[NodeId, ContractId]
+  private type Create = NodeCreate
+  private type Exercise = NodeExercises[NodeId]
 
   private def collect[A](tx: Transaction)(pf: PartialFunction[(NodeId, Node), A]): Seq[A] = {
     def handle(acc: Vector[A], nodeId: NodeId, node: Node): Vector[A] =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerState.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerState.scala
@@ -80,6 +80,6 @@ private[platform] trait ActiveLedgerState[ALS <: ActiveLedgerState[ALS]] {
 object ActiveLedgerState {
 
   type ReferencedContracts =
-    List[(Value.ContractId, Value.ContractInst[Value.VersionedValue[Value.ContractId]])]
+    List[(Value.ContractId, Value.ContractInst[Value.VersionedValue])]
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
@@ -131,13 +131,13 @@ private[platform] class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](
     def handleLeaf(
         state: AddTransactionState,
         nodeId: NodeId,
-        node: N.LeafOnlyActionNode[ContractId],
+        node: N.LeafOnlyActionNode,
     ): AddTransactionState =
       state.currentState.als match {
         case None => state
         case Some(als) =>
           node match {
-            case nf: N.NodeFetch[ContractId] =>
+            case nf: N.NodeFetch =>
               val nodeParties = nf.signatories
                 .union(nf.stakeholders)
                 .union(nf.actingParties)
@@ -145,7 +145,7 @@ private[platform] class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](
                 errs = contractCheck(als, nf.coid).fold(state.errs)(state.errs + _),
                 parties = state.parties.union(nodeParties),
               )
-            case nc: N.NodeCreate[ContractId] =>
+            case nc: N.NodeCreate =>
               val nodeParties = nc.signatories
                 .union(nc.stakeholders)
                 .union(nc.key.map(_.maintainers).getOrElse(Set.empty))
@@ -193,7 +193,7 @@ private[platform] class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](
                     )
                   }
               }
-            case nlkup: N.NodeLookupByKey[ContractId] =>
+            case nlkup: N.NodeLookupByKey =>
               // Check that the stored lookup result matches the current result
               val key = nlkup.key.key.ensureNoCid.fold(
                 coid => throw new IllegalStateException(s"Contract ID $coid found in contract key"),

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -116,7 +116,7 @@ private[platform] abstract class BaseLedger(
       forParties: Set[Ref.Party],
   )(implicit
       loggingContext: LoggingContext
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
+  ): Future[Option[ContractInst[Value.VersionedValue]]] =
     contractStore.lookupActiveContract(forParties, contractId)
 
   override def lookupFlatTransactionById(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/Contract.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/Contract.scala
@@ -17,7 +17,7 @@ import com.daml.lf.value.Value.{ContractId, ContractInst, VersionedValue}
 private[platform] sealed abstract class Contract {
   def id: ContractId
 
-  def contract: ContractInst[VersionedValue[ContractId]]
+  def contract: ContractInst[VersionedValue]
 
   /** For each party, the transaction id at which the contract was divulged */
   def divulgences: Map[Ref.Party, Ref.TransactionId]
@@ -39,7 +39,7 @@ private[platform] object Contract {
     */
   final case class DivulgedContract(
       id: Value.ContractId,
-      contract: ContractInst[VersionedValue[ContractId]],
+      contract: ContractInst[VersionedValue],
       divulgences: Map[Ref.Party, Ref.TransactionId],
   ) extends Contract
 
@@ -51,13 +51,13 @@ private[platform] object Contract {
       transactionId: Ref.TransactionId, // transaction id where the contract originates
       nodeId: NodeId,
       workflowId: Option[Ref.WorkflowId], // workflow id from where the contract originates
-      contract: ContractInst[VersionedValue[ContractId]],
+      contract: ContractInst[VersionedValue],
       witnesses: Set[Ref.Party],
       divulgences: Map[
         Ref.Party,
         Ref.TransactionId,
       ], // for each party, the transaction id at which the contract was divulged
-      key: Option[KeyWithMaintainers[VersionedValue[Nothing]]],
+      key: Option[KeyWithMaintainers[VersionedValue]],
       signatories: Set[Ref.Party],
       observers: Set[Ref.Party],
       agreementText: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/LfValueTranslationCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/LfValueTranslationCache.scala
@@ -68,15 +68,15 @@ object LfValueTranslationCache {
 
     object Value {
       final case class Create(
-          argument: VersionedValue[ContractId],
-          key: Option[VersionedValue[ContractId]],
+          argument: VersionedValue,
+          key: Option[VersionedValue],
       ) extends Value {
         override def assertCreate(): Create = this
         override def assertExercise(): Exercise = throw new UnexpectedTypeException(this)
       }
       final case class Exercise(
-          argument: VersionedValue[ContractId],
-          result: Option[VersionedValue[ContractId]],
+          argument: VersionedValue,
+          result: Option[VersionedValue],
       ) extends Value {
         override def assertCreate(): Create = throw new UnexpectedTypeException(this)
         override def assertExercise(): Exercise = this
@@ -101,6 +101,6 @@ object LfValueTranslationCache {
 
     final case class Key(contractId: ContractId)
 
-    final case class Value(argument: VersionedValue[ContractId])
+    final case class Value(argument: VersionedValue)
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
@@ -69,7 +69,7 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
       forParties: Set[Ref.Party],
   )(implicit
       loggingContext: LoggingContext
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]]
+  ): Future[Option[ContractInst[Value.VersionedValue]]]
 
   def lookupMaximumLedgerTime(
       contractIds: Set[ContractId]

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
@@ -41,7 +41,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait LfValueSerialization {
   def serialize(
       contractId: ContractId,
-      contractArgument: VersionedValue[ContractId],
+      contractArgument: VersionedValue,
   ): Array[Byte]
 
   /** Returns (contract argument, contract key) */
@@ -90,7 +90,7 @@ final class LfValueTranslation(
 
   private def serializeCreateArgOrThrow(
       contractId: ContractId,
-      arg: VersionedValue[ContractId],
+      arg: VersionedValue,
   ): Array[Byte] =
     ValueSerializer.serializeValue(
       value = arg,
@@ -133,7 +133,7 @@ final class LfValueTranslation(
 
   override def serialize(
       contractId: ContractId,
-      contractArgument: VersionedValue[ContractId],
+      contractArgument: VersionedValue,
   ): Array[Byte] = {
     cache.contracts.put(
       key = LfValueTranslationCache.ContractCache.Key(contractId),
@@ -197,7 +197,7 @@ final class LfValueTranslation(
       value: LfValue,
       verbose: Boolean,
       attribute: => String,
-      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value[ContractId]],
+      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value],
   )(implicit
       ec: ExecutionContext,
       loggingContext: LoggingContext,
@@ -222,7 +222,7 @@ final class LfValueTranslation(
       value: LfValue,
       verbose: Boolean,
       attribute: => String,
-      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value[ContractId]],
+      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value],
   )(implicit
       ec: ExecutionContext,
       loggingContext: LoggingContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/package.scala
@@ -14,17 +14,17 @@ package object events {
   import com.daml.lf.value.{Value => lfval}
   type ContractId = lfval.ContractId
   val ContractId = com.daml.lf.value.Value.ContractId
-  type Value = lfval.VersionedValue[ContractId]
+  type Value = lfval.VersionedValue
   type Contract = lfval.ContractInst[Value]
   val Contract = lfval.ContractInst
 
   import com.daml.lf.{transaction => lftx}
   type NodeId = lftx.NodeId
-  type Node = lftx.Node.GenNode[NodeId, ContractId]
-  type Create = lftx.Node.NodeCreate[ContractId]
-  type Exercise = lftx.Node.NodeExercises[NodeId, ContractId]
-  type Fetch = lftx.Node.NodeFetch[ContractId]
-  type LookupByKey = lftx.Node.NodeLookupByKey[ContractId]
+  type Node = lftx.Node.GenNode[NodeId]
+  type Create = lftx.Node.NodeCreate
+  type Exercise = lftx.Node.NodeExercises[NodeId]
+  type Fetch = lftx.Node.NodeFetch
+  type LookupByKey = lftx.Node.NodeLookupByKey
   type Key = lftx.GlobalKey
   val Key = lftx.GlobalKey
 
@@ -89,7 +89,7 @@ package object events {
 
   def convertLfValueKey(
       template: Identifier,
-      key: KeyWithMaintainers[lfval[ContractId]],
+      key: KeyWithMaintainers[lfval],
   ) =
     Key.assertBuild(template, key.key)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/package.scala
@@ -7,7 +7,7 @@ package object cache {
   import com.daml.lf.value.{Value => lfval}
   private[cache] type ContractId = lfval.ContractId
   private[cache] val ContractId = com.daml.lf.value.Value.ContractId
-  private[cache] type Value = lfval.VersionedValue[ContractId]
+  private[cache] type Value = lfval.VersionedValue
   private[cache] type Contract = lfval.ContractInst[Value]
 
   import com.daml.lf.{transaction => lftx}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
@@ -50,7 +50,7 @@ final class LfValueTranslation(
 
   private def serializeCreateArgOrThrow(
       contractId: ContractId,
-      arg: VersionedValue[ContractId],
+      arg: VersionedValue,
   ): Array[Byte] =
     ValueSerializer.serializeValue(
       value = arg,
@@ -84,7 +84,7 @@ final class LfValueTranslation(
 
   def serialize(
       contractId: ContractId,
-      contractArgument: VersionedValue[ContractId],
+      contractArgument: VersionedValue,
   ): Array[Byte] = {
     cache.contracts.put(
       key = LfValueTranslationCache.ContractCache.Key(contractId),
@@ -147,7 +147,7 @@ final class LfValueTranslation(
       value: LfValue,
       verbose: Boolean,
       attribute: => String,
-      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value[ContractId]],
+      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value],
   )(implicit
       ec: ExecutionContext,
       loggingContext: LoggingContext,
@@ -172,7 +172,7 @@ final class LfValueTranslation(
       value: LfValue,
       verbose: Boolean,
       attribute: => String,
-      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value[ContractId]],
+      enrich: LfValue => LfEngine.Result[com.daml.lf.value.Value],
   )(implicit
       ec: ExecutionContext,
       loggingContext: LoggingContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/package.scala
@@ -16,17 +16,17 @@ package object events {
   import com.daml.lf.value.{Value => lfval}
   private[events] type ContractId = lfval.ContractId
   private[events] val ContractId = com.daml.lf.value.Value.ContractId
-  private[events] type Value = lfval.VersionedValue[ContractId]
+  private[events] type Value = lfval.VersionedValue
   private[events] type Contract = lfval.ContractInst[Value]
   private[events] val Contract = lfval.ContractInst
 
   import com.daml.lf.{transaction => lftx}
   private[events] type NodeId = lftx.NodeId
-  private[events] type Node = lftx.Node.GenNode[NodeId, ContractId]
-  private[events] type Create = lftx.Node.NodeCreate[ContractId]
-  private[events] type Exercise = lftx.Node.NodeExercises[NodeId, ContractId]
-  private[events] type Fetch = lftx.Node.NodeFetch[ContractId]
-  private[events] type LookupByKey = lftx.Node.NodeLookupByKey[ContractId]
+  private[events] type Node = lftx.Node.GenNode[NodeId]
+  private[events] type Create = lftx.Node.NodeCreate
+  private[events] type Exercise = lftx.Node.NodeExercises[NodeId]
+  private[events] type Fetch = lftx.Node.NodeFetch
+  private[events] type LookupByKey = lftx.Node.NodeLookupByKey
   private[events] type Key = lftx.GlobalKey
   private[events] val Key = lftx.GlobalKey
 
@@ -108,7 +108,7 @@ package object events {
 
   private[events] def convertLfValueKey(
       template: Identifier,
-      key: KeyWithMaintainers[lfval[ContractId]],
+      key: KeyWithMaintainers[lfval],
   ) =
     Key.assertBuild(template, key.key)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
@@ -84,7 +84,7 @@ private[platform] trait LedgerDaoContractsReader {
 object LedgerDaoContractsReader {
   import com.daml.lf.value.{Value => lfval}
   private type ContractId = lfval.ContractId
-  private type Value = lfval.VersionedValue[ContractId]
+  private type Value = lfval.VersionedValue
   private type Contract = lfval.ContractInst[Value]
 
   sealed trait ContractState extends Product with Serializable {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/TransactionLogUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/TransactionLogUpdate.scala
@@ -9,7 +9,6 @@ import com.daml.ledger.offset.Offset
 import com.daml.lf.value.{Value => LfValue}
 import com.daml.lf.data.Ref.IdString
 import com.daml.lf.ledger.EventId
-import com.daml.platform.store.appendonlydao.events
 import com.daml.platform.store.appendonlydao.events.{ContractId, Identifier}
 import com.daml.platform.store.cache.MutableCacheBackedContractStore.EventSequentialId
 
@@ -79,11 +78,11 @@ object TransactionLogUpdate {
       templateId: Identifier,
       commandId: String,
       workflowId: String,
-      contractKey: Option[LfValue.VersionedValue[events.ContractId]],
+      contractKey: Option[LfValue.VersionedValue],
       treeEventWitnesses: Set[String],
       flatEventWitnesses: Set[String],
       submitters: Set[String],
-      createArgument: LfValue.VersionedValue[events.ContractId],
+      createArgument: LfValue.VersionedValue,
       createSignatories: Set[String],
       createObservers: Set[String],
       createAgreementText: Option[String],
@@ -100,15 +99,15 @@ object TransactionLogUpdate {
       templateId: Identifier,
       commandId: String,
       workflowId: String,
-      contractKey: Option[LfValue.VersionedValue[events.ContractId]],
+      contractKey: Option[LfValue.VersionedValue],
       treeEventWitnesses: Set[String],
       flatEventWitnesses: Set[String],
       submitters: Set[String],
       choice: String,
       actingParties: Set[IdString.Party],
       children: Seq[String],
-      exerciseArgument: LfValue.VersionedValue[ContractId],
-      exerciseResult: Option[LfValue.VersionedValue[ContractId]],
+      exerciseArgument: LfValue.VersionedValue,
+      exerciseResult: Option[LfValue.VersionedValue],
       consuming: Boolean,
   ) extends Event
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/serialization/ValueSerializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/serialization/ValueSerializer.scala
@@ -5,13 +5,13 @@ package com.daml.platform.store.serialization
 
 import java.io.InputStream
 
-import com.daml.lf.value.Value.{ContractId, VersionedValue}
+import com.daml.lf.value.Value.VersionedValue
 import com.daml.lf.value.{ValueCoder, ValueOuterClass}
 
 private[platform] object ValueSerializer {
 
   def serializeValue(
-      value: VersionedValue[ContractId],
+      value: VersionedValue,
       errorContext: => String,
   ): Array[Byte] =
     ValueCoder
@@ -21,7 +21,7 @@ private[platform] object ValueSerializer {
   private def deserializeValueHelper(
       stream: InputStream,
       errorContext: => Option[String],
-  ): VersionedValue[ContractId] =
+  ): VersionedValue =
     ValueCoder
       .decodeVersionedValue(
         ValueCoder.CidDecoder,
@@ -35,13 +35,13 @@ private[platform] object ValueSerializer {
 
   def deserializeValue(
       stream: InputStream
-  ): VersionedValue[ContractId] =
+  ): VersionedValue =
     deserializeValueHelper(stream, None)
 
   def deserializeValue(
       stream: InputStream,
       errorContext: => String,
-  ): VersionedValue[ContractId] =
+  ): VersionedValue =
     deserializeValueHelper(stream, Some(errorContext))
 
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoContractEventsStreamSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoContractEventsStreamSpec.scala
@@ -152,7 +152,7 @@ trait JdbcLedgerDaoContractEventsStreamSpec extends LoneElement {
       .runWith(Sink.seq)
       .map(_.map(_._2))
 
-  private def contract(cid: ContractId, contractArgument: LfValue[ContractId]): Contract =
+  private def contract(cid: ContractId, contractArgument: LfValue): Contract =
     createNode(cid, Set.empty, Set.empty, contractArgument = contractArgument)
       .copy(agreementText = "")
       .versionedCoinst

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionLogUpdatesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionLogUpdatesSpec.scala
@@ -13,7 +13,7 @@ import com.daml.lf.ledger.EventId
 import com.daml.lf.transaction.Node
 import com.daml.lf.transaction.Node.{KeyWithMaintainers, NodeCreate, NodeExercises}
 import com.daml.lf.value.Value
-import com.daml.platform.store.appendonlydao.events.{ContractId, NodeId}
+import com.daml.platform.store.appendonlydao.events.NodeId
 import com.daml.platform.store.entries.LedgerEntry
 import com.daml.platform.store.interfaces.TransactionLogUpdate
 import org.scalatest._
@@ -85,7 +85,7 @@ private[dao] trait JdbcLedgerDaoTransactionLogUpdatesSpec
       ) = result.splitAt(6)
 
       val contractKey =
-        t2.transaction.nodes.head._2.asInstanceOf[NodeCreate[ContractId]].key.get.key
+        t2.transaction.nodes.head._2.asInstanceOf[NodeCreate].key.get.key
       val exercisedContractKey = Map(offset2 -> contractKey, offset3 -> contractKey)
 
       val eventSequentialIdGen = new AtomicLong(from._2 + 1L)
@@ -106,7 +106,7 @@ private[dao] trait JdbcLedgerDaoTransactionLogUpdatesSpec
       actual: TransactionLogUpdate.Transaction,
       expected: LedgerEntry.Transaction,
       expectedOffset: Offset,
-      exercisedContractKey: Map[Offset, Value[ContractId]],
+      exercisedContractKey: Map[Offset, Value],
       eventSequentialIdRef: AtomicLong,
   ): Unit = {
     actual.transactionId shouldBe expected.transactionId
@@ -120,7 +120,7 @@ private[dao] trait JdbcLedgerDaoTransactionLogUpdatesSpec
 
     expected.transaction.nodes.toVector.sortBy(_._1.index).foreach { case (nodeId, value) =>
       value match {
-        case nodeCreate: NodeCreate[ContractId] =>
+        case nodeCreate: NodeCreate =>
           val expectedEventId = EventId(expected.transactionId, nodeId)
           val Some(actualCreated: TransactionLogUpdate.CreatedEvent) =
             actualEventsById.get(expectedEventId)
@@ -138,7 +138,7 @@ private[dao] trait JdbcLedgerDaoTransactionLogUpdatesSpec
           actualCreated.createAgreementText.value shouldBe nodeCreate.agreementText
           actualCreated.nodeIndex shouldBe nodeId.index
           actualCreated.eventSequentialId shouldBe eventSequentialIdRef.getAndIncrement()
-        case nodeExercises: NodeExercises[NodeId, ContractId] =>
+        case nodeExercises: NodeExercises[NodeId] =>
           val expectedEventId = EventId(expected.transactionId, nodeId)
           val Some(actualExercised: TransactionLogUpdate.ExercisedEvent) =
             actualEventsById.get(expectedEventId)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
@@ -12,7 +12,6 @@ import com.daml.lf.data.Ref
 import com.daml.lf.ledger.EventId
 import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
 import com.daml.lf.transaction.NodeId
-import com.daml.lf.value.Value.ContractId
 import com.daml.platform.ApiOffset
 import com.daml.platform.api.v1.event.EventOps.TreeEventOps
 import com.daml.platform.store.entries.LedgerEntry
@@ -58,7 +57,7 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
         .lookupTransactionTreeById(tx.transactionId, tx.actAs.toSet)
     } yield {
       inside(result.value.transaction) { case Some(transaction) =>
-        val (nodeId, createNode: NodeCreate[ContractId]) =
+        val (nodeId, createNode: NodeCreate) =
           tx.transaction.nodes.head
         transaction.commandId shouldBe tx.commandId.get
         transaction.offset shouldBe ApiOffset.toApiString(offset)
@@ -90,7 +89,7 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
         .lookupTransactionTreeById(exercise.transactionId, exercise.actAs.toSet)
     } yield {
       inside(result.value.transaction) { case Some(transaction) =>
-        val (nodeId, exerciseNode: NodeExercises[NodeId, ContractId]) =
+        val (nodeId, exerciseNode: NodeExercises[NodeId]) =
           exercise.transaction.nodes.head
         transaction.commandId shouldBe exercise.commandId.get
         transaction.offset shouldBe ApiOffset.toApiString(offset)
@@ -122,13 +121,12 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
     } yield {
       inside(result.value.transaction) { case Some(transaction) =>
         val (createNodeId, createNode) =
-          tx.transaction.nodes.collectFirst { case (nodeId, node: NodeCreate[ContractId]) =>
+          tx.transaction.nodes.collectFirst { case (nodeId, node: NodeCreate) =>
             nodeId -> node
           }.get
         val (exerciseNodeId, exerciseNode) =
-          tx.transaction.nodes.collectFirst {
-            case (nodeId, node: NodeExercises[NodeId, ContractId]) =>
-              nodeId -> node
+          tx.transaction.nodes.collectFirst { case (nodeId, node: NodeExercises[NodeId]) =>
+            nodeId -> node
           }.get
 
         transaction.commandId shouldBe tx.commandId.get

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -14,7 +14,6 @@ import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.ledger.EventId
 import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
 import com.daml.lf.transaction.NodeId
-import com.daml.lf.value.Value.ContractId
 import com.daml.logging.LoggingContext
 import com.daml.platform.ApiOffset
 import com.daml.platform.api.v1.event.EventOps.EventOps
@@ -68,7 +67,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
         transaction.transactionId shouldBe tx.transactionId
         transaction.workflowId shouldBe tx.workflowId.getOrElse("")
         inside(transaction.events.loneElement.event.created) { case Some(created) =>
-          val (nodeId, createNode: NodeCreate[ContractId]) =
+          val (nodeId, createNode: NodeCreate) =
             tx.transaction.nodes.head
           created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
           created.witnessParties should contain only (tx.actAs: _*)
@@ -100,7 +99,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
         transaction.effectiveAt.value.nanos shouldBe exercise.ledgerEffectiveTime.getNano
         transaction.workflowId shouldBe exercise.workflowId.getOrElse("")
         inside(transaction.events.loneElement.event.archived) { case Some(archived) =>
-          val (nodeId, exerciseNode: NodeExercises[NodeId, ContractId]) =
+          val (nodeId, exerciseNode: NodeExercises[NodeId]) =
             exercise.transaction.nodes.head
           archived.eventId shouldBe EventId(transaction.transactionId, nodeId).toLedgerString
           archived.witnessParties should contain only (exercise.actAs: _*)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcPipelinedInsertionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcPipelinedInsertionsSpec.scala
@@ -6,7 +6,6 @@ package com.daml.platform.store.dao
 import com.daml.ledger.offset.Offset
 import com.daml.lf.ledger.EventId
 import com.daml.lf.transaction.Node.NodeCreate
-import com.daml.lf.value.Value.ContractId
 import com.daml.platform.ApiOffset
 import com.daml.platform.indexer.CurrentOffset
 import com.daml.platform.store.entries.LedgerEntry
@@ -44,7 +43,7 @@ trait JdbcPipelinedInsertionsSpec extends Inside with OptionValues with Matchers
         transaction.transactionId shouldBe tx.transactionId
         transaction.workflowId shouldBe tx.workflowId.getOrElse("")
         inside(transaction.events.loneElement.event.created) { case Some(created) =>
-          val (nodeId, createNode: NodeCreate[ContractId]) =
+          val (nodeId, createNode: NodeCreate) =
             tx.transaction.nodes.head
           created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
           created.witnessParties should contain only (tx.actAs: _*)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/BuffersUpdaterSpec.scala
@@ -205,13 +205,13 @@ final class BuffersUpdaterSpec
       val createdLedgerEffectiveTime = Instant.ofEpochMilli(987654321L)
       val createdTemplateId = Ref.Identifier.assertFromString("create:template:id")
       val createdContractKey =
-        VersionedValue[ContractId](TransactionVersion.VDev, ValueInt64(1337L))
+        VersionedValue(TransactionVersion.VDev, ValueInt64(1337L))
       val createdFlatEventWitnesses = Set("alice", "charlie")
       val createArgument = VersionedValue(TransactionVersion.VDev, ValueText("arg"))
       val createAgreement = "agreement"
 
       val exercisedCid = ContractId.assertFromString("#exercisedCid")
-      val exercisedKey = VersionedValue[ContractId](TransactionVersion.VDev, ValueInt64(8974L))
+      val exercisedKey = VersionedValue(TransactionVersion.VDev, ValueInt64(8974L))
       val exercisedTemplateId = Ref.Identifier.assertFromString("exercised:template:id")
       val exercisedFlatEventWitnesses = Set("bob", "dan")
       val exercisedOffset = Offset.fromByteArray(BigInt(1337L).toByteArray)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ExecuteUpdateSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ExecuteUpdateSpec.scala
@@ -13,7 +13,6 @@ import com.daml.ledger.participant.state.{v2 => state}
 import com.daml.ledger.resources.TestResourceContext
 import com.daml.lf.data.{Bytes, ImmArray, Ref, Time}
 import com.daml.lf.transaction.{NodeId, TransactionVersion, VersionedTransaction}
-import com.daml.lf.value.Value.ContractId
 import com.daml.lf.{crypto, transaction}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
@@ -46,7 +45,7 @@ final class ExecuteUpdateSpec
   private val offset = Offset(Bytes.assertFromString("01"))
   private val txId = Ref.TransactionId.fromInt(1)
   private val txMock = transaction.CommittedTransaction(
-    VersionedTransaction[NodeId, ContractId](TransactionVersion.VDev, Map.empty, ImmArray.Empty)
+    VersionedTransaction[NodeId](TransactionVersion.VDev, Map.empty, ImmArray.Empty)
   )
   private val someMetrics = new Metrics(new MetricRegistry)
   private val someParticipantId = Ref.ParticipantId.assertFromString("some-participant")

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
@@ -1385,7 +1385,7 @@ object UpdateToDbDtoSpec {
   private val valueSerialization = new LfValueSerialization {
     override def serialize(
         contractId: ContractId,
-        contractArgument: Value.VersionedValue[ContractId],
+        contractArgument: Value.VersionedValue,
     ): Array[Byte] = emptyArray
 
     /** Returns (contract argument, contract key) */

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
@@ -22,7 +22,7 @@ trait ContractStore {
       contractId: ContractId,
   )(implicit
       loggingContext: LoggingContext
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]]
+  ): Future[Option[ContractInst[Value.VersionedValue]]]
 
   def lookupContractKey(readers: Set[Party], key: GlobalKey)(implicit
       loggingContext: LoggingContext

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
@@ -20,10 +20,10 @@ package v2 {
         eventId: EventId,
         contractId: Value.ContractId,
         templateId: Ref.Identifier,
-        argument: Value.VersionedValue[Value.ContractId],
+        argument: Value.VersionedValue,
         // TODO(JM,SM): understand witnessing parties
         stakeholders: Set[Ref.Party],
-        contractKey: Option[Value.VersionedValue[Value.ContractId]],
+        contractKey: Option[Value.VersionedValue],
         signatories: Set[Ref.Party],
         observers: Set[Ref.Party],
         agreementText: String,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -70,7 +70,7 @@ private[state] object Conversions {
       .build
   }
 
-  def encodeContractKey(tmplId: Ref.Identifier, key: Value[ContractId]): DamlContractKey =
+  def encodeContractKey(tmplId: Ref.Identifier, key: Value): DamlContractKey =
     encodeGlobalKey(
       GlobalKey
         .build(tmplId, key)
@@ -83,7 +83,7 @@ private[state] object Conversions {
   def globalKeyToStateKey(key: GlobalKey): DamlStateKey =
     DamlStateKey.newBuilder.setContractKey(encodeGlobalKey(key)).build
 
-  def contractKeyToStateKey(templateId: Ref.Identifier, key: Value[ContractId]): DamlStateKey =
+  def contractKeyToStateKey(templateId: Ref.Identifier, key: Value): DamlStateKey =
     DamlStateKey.newBuilder.setContractKey(encodeContractKey(templateId, key)).build
 
   def commandDedupKey(subInfo: DamlSubmitterInfo): DamlStateKey = {
@@ -250,7 +250,7 @@ private[state] object Conversions {
         ),
     )
 
-  def decodeVersionedValue(protoValue: ValueOuterClass.VersionedValue): VersionedValue[ContractId] =
+  def decodeVersionedValue(protoValue: ValueOuterClass.VersionedValue): VersionedValue =
     assertDecode(
       "ContractInstance",
       ValueCoder.decodeVersionedValue(ValueCoder.CidDecoder, protoValue),
@@ -258,7 +258,7 @@ private[state] object Conversions {
 
   def decodeContractInstance(
       coinst: TransactionOuterClass.ContractInstance
-  ): Value.ContractInst[VersionedValue[ContractId]] =
+  ): Value.ContractInst[VersionedValue] =
     assertDecode(
       "ContractInstance",
       TransactionCoder
@@ -266,7 +266,7 @@ private[state] object Conversions {
     )
 
   def encodeContractInstance(
-      coinst: Value.ContractInst[VersionedValue[Value.ContractId]]
+      coinst: Value.ContractInst[VersionedValue]
   ): TransactionOuterClass.ContractInstance =
     assertEncode(
       "ContractInstance",
@@ -330,14 +330,14 @@ private[state] object Conversions {
 
   def extractDivulgedContracts(
       damlTransactionBlindingInfo: DamlTransactionBlindingInfo
-  ): Either[Seq[String], Map[ContractId, Value.ContractInst[VersionedValue[ContractId]]]] = {
+  ): Either[Seq[String], Map[ContractId, Value.ContractInst[VersionedValue]]] = {
     val divulgences = damlTransactionBlindingInfo.getDivulgencesList.asScala.toVector
     if (divulgences.isEmpty) {
       Right(Map.empty)
     } else {
       val resultAccumulator: Either[Seq[String], mutable.Builder[
-        (ContractId, Value.ContractInst[VersionedValue[ContractId]]),
-        Map[ContractId, Value.ContractInst[VersionedValue[ContractId]]],
+        (ContractId, Value.ContractInst[VersionedValue]),
+        Map[ContractId, Value.ContractInst[VersionedValue]],
       ]] = Right(Map.newBuilder)
       divulgences
         .foldLeft(resultAccumulator) {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
@@ -143,7 +143,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
       commitContext: CommitContext
   )(
       contractId: Value.ContractId
-  ): Option[Value.ContractInst[Value.VersionedValue[Value.ContractId]]] =
+  ): Option[Value.ContractInst[Value.VersionedValue]] =
     commitContext
       .read(contractIdToStateKey(contractId))
       .map(_.getContractState)

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/SimplePackage.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/SimplePackage.scala
@@ -42,7 +42,7 @@ class SimplePackage(testDar: TestDar) {
       .next()
   }
 
-  def createCmd(templateId: Ref.Identifier, templateArg: Value[Value.ContractId]): CreateCommand =
+  def createCmd(templateId: Ref.Identifier, templateArg: Value): CreateCommand =
     CreateCommand(templateId, templateArg)
 
   def exerciseCmd(
@@ -71,7 +71,7 @@ class SimplePackage(testDar: TestDar) {
 
   def createAndExerciseCmd(
       templateId: Ref.Identifier,
-      templateArg: Value[Value.ContractId],
+      templateArg: Value,
       choiceName: Ref.ChoiceName,
   ): CreateAndExerciseCommand =
     CreateAndExerciseCommand(
@@ -107,14 +107,14 @@ class SimplePackage(testDar: TestDar) {
   private val simpleReplaceChoiceName: Ref.ChoiceName =
     Ref.ChoiceName.assertFromString("Replace")
 
-  def simpleCreateCmd(templateArg: Value[Value.ContractId]): CreateCommand =
+  def simpleCreateCmd(templateArg: Value): CreateCommand =
     createCmd(simpleTemplateId, templateArg)
 
   def simpleExerciseArchiveCmd(contractId: Value.ContractId): ExerciseCommand =
     exerciseCmd(contractId, simpleTemplateId, simpleArchiveChoiceName)
 
   def simpleCreateAndExerciseArchiveCmd(
-      templateArg: Value[Value.ContractId]
+      templateArg: Value
   ): CreateAndExerciseCommand =
     createAndExerciseCmd(simpleTemplateId, templateArg, simpleArchiveChoiceName)
 
@@ -124,8 +124,8 @@ class SimplePackage(testDar: TestDar) {
   def mkSimpleTemplateArg(
       owner: String,
       observer: String,
-      additionalContractValue: Value[Value.ContractId],
-  ): Value[Value.ContractId] =
+      additionalContractValue: Value,
+  ): Value =
     Value.ValueRecord(
       Some(simpleTemplateId),
       ImmArray(
@@ -142,13 +142,13 @@ class SimplePackage(testDar: TestDar) {
   private val simpleHolderReplaceHeldByKeyChoiceName: Ref.ChoiceName =
     Ref.ChoiceName.assertFromString("ReplaceHeldByKey")
 
-  def simpleHolderCreateCmd(arg: Value[Value.ContractId]): CreateCommand =
+  def simpleHolderCreateCmd(arg: Value): CreateCommand =
     createCmd(simpleHolderTemplateId, arg)
 
   def simpleHolderExerciseReplaceHeldByKeyCmd(contractId: Value.ContractId): ExerciseCommand =
     exerciseCmd(contractId, simpleHolderTemplateId, simpleHolderReplaceHeldByKeyChoiceName)
 
-  def mkSimpleHolderTemplateArg(owner: Ref.Party): Value[Value.ContractId] =
+  def mkSimpleHolderTemplateArg(owner: Ref.Party): Value =
     Value.ValueRecord(
       Some(simpleHolderTemplateId),
       ImmArray(Some(Ref.Name.assertFromString("owner")) -> Value.ValueParty(owner)),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -50,7 +50,7 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
   "transaction" should {
 
-    val templateArgs: Map[TestDar, SimplePackage => Value[ContractId]] = Map(
+    val templateArgs: Map[TestDar, SimplePackage => Value] = Map(
       SimplePackagePartyTestDar -> (_ => bobValue),
       SimplePackageOptionalTestDar -> (_ => ValueOptional(Some(bobValue))),
       SimplePackageListTestDar -> (_ => ValueList(FrontStack(bobValue))),
@@ -620,7 +620,7 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
   private def contractIdOfCreateTransaction(updates: Seq[Update]): ContractId =
     inside(updates) { case Seq(update: Update.TransactionAccepted) =>
-      inside(update.transaction.nodes.values.toSeq) { case Seq(create: NodeCreate[ContractId]) =>
+      inside(update.transaction.nodes.values.toSeq) { case Seq(create: NodeCreate) =>
         create.coid
       }
     }
@@ -628,7 +628,7 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
   private def simpleCreateCmd(simplePackage: SimplePackage): ApiCommand =
     simplePackage.simpleCreateCmd(mkSimpleCreateArg(simplePackage))
 
-  private def mkSimpleCreateArg(simplePackage: SimplePackage): Value[ContractId] =
+  private def mkSimpleCreateArg(simplePackage: SimplePackage): Value =
     simplePackage.mkSimpleTemplateArg("Alice", "Eve", bobValue)
 
   private def seed(i: Int): Hash = hash(this.getClass.getName + i.toString)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
@@ -96,7 +96,7 @@ class ModelConformanceValidatorSpec
       when(
         mockValidationResult.consume(
           any[Value.ContractId => Option[
-            Value.ContractInst[Value.VersionedValue[Value.ContractId]]
+            Value.ContractInst[Value.VersionedValue]
           ]],
           any[Ref.PackageId => Option[Ast.Package]],
           any[GlobalKeyWithMaintainers => Option[Value.ContractId]],
@@ -201,7 +201,7 @@ class ModelConformanceValidatorSpec
       when(
         mockValidationResult.consume(
           any[Value.ContractId => Option[
-            Value.ContractInst[Value.VersionedValue[Value.ContractId]]
+            Value.ContractInst[Value.VersionedValue]
           ]],
           any[Ref.PackageId => Option[Ast.Package]],
           any[GlobalKeyWithMaintainers => Option[Value.ContractId]],

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -66,7 +66,6 @@ da_scala_test(
         "@maven//:org_scalatest_scalatest_matchers_core",
         "@maven//:org_scalatest_scalatest_shouldmatchers",
         "@maven//:org_scalatest_scalatest_wordspec",
-        "@maven//:org_scalaz_scalaz_core",
     ],
     deps = [
         "@maven//:org_scalatest_scalatest_compatible",

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/package.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/package.scala
@@ -11,7 +11,6 @@ import com.daml.lf.transaction.TransactionCoder.{
 }
 import com.daml.lf.transaction.TransactionOuterClass.Transaction
 import com.daml.lf.transaction.{NodeId, VersionedTransaction}
-import com.daml.lf.value.Value.ContractId
 import com.daml.lf.value.ValueCoder._
 import com.daml.lf.value.ValueOuterClass
 import com.google.protobuf.ByteString
@@ -46,13 +45,13 @@ package object benchmark {
     * [[com.daml.lf.transaction.TransactionCoder.decodeTransaction]].
     * It's the Daml-LF representation of a transaction.
     */
-  private[lf] type DecodedTransaction = VersionedTransaction[NodeId, ContractId]
+  private[lf] type DecodedTransaction = VersionedTransaction[NodeId]
 
   /** This is the output of a successful call to
     * [[com.daml.lf.value.ValueCoder.decodeValue]].
     * It's the Daml-LF representation of a value.
     */
-  private[lf] type DecodedValue = value.Value.VersionedValue[ContractId]
+  private[lf] type DecodedValue = value.Value.VersionedValue
 
   private[lf] def assertDecode(transaction: EncodedTransaction): DecodedTransaction =
     assertDecode(decode(transaction))

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/SpeedyToValueBenchmark.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/SpeedyToValueBenchmark.scala
@@ -7,7 +7,6 @@ import com.daml.lf.benchmark.{BenchmarkWithLedgerExport, assertDecode}
 import com.daml.lf.engine.preprocessing.ValueTranslator
 import com.daml.lf.speedy.SValue
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.ContractId
 import org.openjdk.jmh.annotations.{Benchmark, Setup}
 
 class SpeedyToValueBenchmark extends BenchmarkWithLedgerExport {
@@ -28,7 +27,7 @@ class SpeedyToValueBenchmark extends BenchmarkWithLedgerExport {
   }
 
   @Benchmark
-  def run(): Vector[Value[ContractId]] =
+  def run(): Vector[Value] =
     speedyValues.map(_.toUnnormalizedValue)
 
 }

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/ValueTranslatorBenchmark.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/ValueTranslatorBenchmark.scala
@@ -7,13 +7,12 @@ import com.daml.lf.benchmark.{BenchmarkWithLedgerExport, TypedValue, assertDecod
 import com.daml.lf.engine.preprocessing.ValueTranslator
 import com.daml.lf.speedy.SValue
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.ContractId
 import org.openjdk.jmh.annotations.{Benchmark, Setup}
 
 class ValueTranslatorBenchmark extends BenchmarkWithLedgerExport {
 
   private var translator: ValueTranslator = _
-  private var decodedValues: Vector[TypedValue[Value[ContractId]]] = _
+  private var decodedValues: Vector[TypedValue[Value]] = _
 
   @Setup
   override def setup(): Unit = {

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/package.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/engine/package.scala
@@ -7,12 +7,11 @@ import com.daml.lf.benchmark.TypedValue
 import com.daml.lf.engine.preprocessing.ValueTranslator
 import com.daml.lf.speedy.SValue
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.ContractId
 
 package object engine {
 
   private[engine] def assertTranslate(translator: ValueTranslator)(
-      value: TypedValue[Value[ContractId]]
+      value: TypedValue[Value]
   ): SValue =
     translator
       .translateValue(value.valueType, value.value)

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/speedy/MachineImportValueBenchmark.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/speedy/MachineImportValueBenchmark.scala
@@ -8,13 +8,12 @@ import com.daml.lf.benchmark.{BenchmarkWithLedgerExport, TypedValue, assertDecod
 import com.daml.lf.data.Time
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.ContractId
 import org.openjdk.jmh.annotations.{Benchmark, Setup}
 
 class MachineImportValueBenchmark extends BenchmarkWithLedgerExport {
 
   private var machine: Speedy.Machine = _
-  private var decodedValues: Vector[TypedValue[Value[ContractId]]] = _
+  private var decodedValues: Vector[TypedValue[Value]] = _
 
   // Construct a machine for testing.
   private def testingMachine(

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
@@ -8,7 +8,6 @@ import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
 import com.daml.lf.transaction.{GlobalKey, Node, NodeId, SubmittedTransaction, Transaction => Tx}
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.ContractId
 
 import scala.collection.mutable
 
@@ -26,17 +25,17 @@ private[replay] final class Adapter(
     ).buildSubmitted()
 
   // drop value version and children
-  private[this] def adapt(node: Tx.Node): Node.GenNode[NodeId, ContractId] =
+  private[this] def adapt(node: Tx.Node): Node.GenNode[NodeId] =
     node match {
       case rollback: Node.NodeRollback[_] =>
         rollback.copy(children = ImmArray.Empty)
-      case create: Node.NodeCreate[ContractId] =>
+      case create: Node.NodeCreate =>
         create.copy(
           templateId = adapt(create.templateId),
           arg = adapt(create.arg),
           key = create.key.map(adapt),
         )
-      case exe: Node.NodeExercises[NodeId, ContractId] =>
+      case exe: Node.NodeExercises[NodeId] =>
         exe.copy(
           templateId = adapt(exe.templateId),
           chosenValue = adapt(exe.chosenValue),
@@ -44,12 +43,12 @@ private[replay] final class Adapter(
           exerciseResult = exe.exerciseResult.map(adapt),
           key = exe.key.map(adapt),
         )
-      case fetch: Node.NodeFetch[ContractId] =>
+      case fetch: Node.NodeFetch =>
         fetch.copy(
           templateId = adapt(fetch.templateId),
           key = fetch.key.map(adapt),
         )
-      case lookup: Node.NodeLookupByKey[ContractId] =>
+      case lookup: Node.NodeLookupByKey =>
         lookup
           .copy(
             templateId = adapt(lookup.templateId),
@@ -59,11 +58,11 @@ private[replay] final class Adapter(
 
   // drop value version
   private[this] def adapt(
-      k: Node.KeyWithMaintainers[Value[ContractId]]
-  ): Node.KeyWithMaintainers[Value[ContractId]] =
+      k: Node.KeyWithMaintainers[Value]
+  ): Node.KeyWithMaintainers[Value] =
     k.copy(adapt(k.key))
 
-  def adapt(coinst: Tx.ContractInst[ContractId]): Tx.ContractInst[ContractId] =
+  def adapt(coinst: Tx.ContractInst): Tx.ContractInst =
     coinst.copy(
       template = adapt(coinst.template),
       arg = coinst.arg.copy(value = adapt(coinst.arg.value)),
@@ -72,7 +71,7 @@ private[replay] final class Adapter(
   def adapt(gkey: GlobalKey): GlobalKey =
     GlobalKey.assertBuild(adapt(gkey.templateId), adapt(gkey.key))
 
-  private[this] def adapt(value: Value[ContractId]): Value[ContractId] =
+  private[this] def adapt(value: Value): Value =
     value match {
       case Value.ValueEnum(tycon, value) =>
         Value.ValueEnum(tycon.map(adapt), value)
@@ -88,7 +87,7 @@ private[replay] final class Adapter(
         Value.ValueTextMap(value.mapValue(adapt))
       case Value.ValueGenMap(entries) =>
         Value.ValueGenMap(entries.map { case (k, v) => adapt(k) -> adapt(v) })
-      case _: Value.ValueCidlessLeaf | _: Value.ValueContractId[ContractId] =>
+      case _: Value.ValueCidlessLeaf | _: Value.ValueContractId =>
         value
     }
 

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Replay.scala
@@ -45,7 +45,7 @@ final case class TxEntry(
 final case class BenchmarkState(
     name: String,
     transaction: TxEntry,
-    contracts: Map[ContractId, Tx.ContractInst[ContractId]],
+    contracts: Map[ContractId, Tx.ContractInst],
     contractKeys: Map[GlobalKey, ContractId],
 ) {
 
@@ -178,14 +178,14 @@ private[replay] object Replay {
       val transactions = importer.read().map(_._1).flatMap(decodeSubmissionInfo)
       if (transactions.isEmpty) sys.error("no transaction find")
 
-      val createsNodes: Seq[Node.NodeCreate[ContractId]] =
+      val createsNodes: Seq[Node.NodeCreate] =
         transactions.flatMap(entry =>
-          entry.tx.nodes.values.collect { case create: Node.NodeCreate[ContractId] =>
+          entry.tx.nodes.values.collect { case create: Node.NodeCreate =>
             create
           }
         )
 
-      val allContracts: Map[ContractId, Value.ContractInst[Tx.Value[ContractId]]] =
+      val allContracts: Map[ContractId, Value.ContractInst[Tx.Value]] =
         createsNodes.map(node => node.coid -> node.versionedCoinst).toMap
 
       val allContractsWithKey = createsNodes.flatMap { node =>
@@ -196,7 +196,7 @@ private[replay] object Replay {
 
       val benchmarks = transactions.flatMap { entry =>
         entry.tx.roots.map(entry.tx.nodes) match {
-          case ImmArray(exe: Node.NodeExercises[_, ContractId]) =>
+          case ImmArray(exe: Node.NodeExercises[_]) =>
             val inputContracts = entry.tx.inputContracts
             List(
               BenchmarkState(

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/DivulgedContract.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/DivulgedContract.scala
@@ -16,5 +16,5 @@ import com.daml.lf.value.Value
   */
 final case class DivulgedContract(
     contractId: Value.ContractId,
-    contractInst: Value.ContractInst[Value.VersionedValue[Value.ContractId]],
+    contractInst: Value.ContractInst[Value.VersionedValue],
 )

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/DivulgedContract.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/DivulgedContract.scala
@@ -16,5 +16,5 @@ import com.daml.lf.value.Value
   */
 final case class DivulgedContract(
     contractId: Value.ContractId,
-    contractInst: Value.ContractInst[Value.VersionedValue[Value.ContractId]],
+    contractInst: Value.ContractInst[Value.VersionedValue],
 )

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/TransactionCommitter.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/TransactionCommitter.scala
@@ -41,7 +41,7 @@ object LegacyTransactionCommitter extends TransactionCommitter {
         }
         .withDefault(identity)
 
-    CommittedTransaction(VersionedTransaction.map2(identity[NodeId], contractMapping)(transaction))
+    CommittedTransaction(transaction.mapCid(contractMapping))
 
   }
 

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -309,7 +309,7 @@ private[sandbox] final class InMemoryLedger(
       forParties: Set[Ref.Party],
   )(implicit
       loggingContext: LoggingContext
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
+  ): Future[Option[ContractInst[Value.VersionedValue]]] =
     Future.successful(this.synchronized {
       acs.activeContracts
         .get(contractId)

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ApiCodecVerbose.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ApiCodecVerbose.scala
@@ -59,7 +59,7 @@ object ApiCodecVerbose {
       JsObject(propType -> JsString(tagNumeric), propValue -> JsString(v.toUnscaledString))
     case V.ValueBool(v) => JsObject(propType -> JsString(tagBool), propValue -> JsBoolean(v))
     case V.ValueContractId(v) =>
-      JsObject(propType -> JsString(tagContractId), propValue -> JsString(v))
+      JsObject(propType -> JsString(tagContractId), propValue -> JsString(v.coid))
     case v: V.ValueTimestamp =>
       JsObject(propType -> JsString(tagTimestamp), propValue -> JsString(v.toIso8601))
     case v: V.ValueDate =>
@@ -145,7 +145,10 @@ object ApiCodecVerbose {
       case `tagNumeric` =>
         V.ValueNumeric(assertDE(LfDecimal fromString strField(value, propValue, "ApiNumeric")))
       case `tagBool` => V.ValueBool(boolField(value, propValue, "ApiBool"))
-      case `tagContractId` => V.ValueContractId(strField(value, propValue, "ApiContractId"))
+      case `tagContractId` =>
+        V.ValueContractId(
+          assertDE(V.ContractId.fromString(strField(value, propValue, "ApiContractId")))
+        )
       case `tagTimestamp` =>
         V.ValueTimestamp.fromIso8601(strField(value, propValue, "ApiTimestamp"))
       case `tagDate` => V.ValueDate.fromIso8601(strField(value, propValue, "ApiDate"))

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
@@ -8,7 +8,6 @@ import java.time.Instant
 import com.daml.lf.data.Ref
 import com.daml.lf.data.LawlessTraversals._
 import com.daml.lf.iface
-import com.daml.lf.value.Value.ContractId
 import com.daml.lf.value.{Value => V}
 import com.daml.ledger.api.{v1 => V1}
 import com.daml.ledger.api.refinements.ApiTypes
@@ -23,8 +22,6 @@ import scalaz.syntax.traverse._
 import scalaz.syntax.std.option._
 import scalaz.std.either._
 import scalaz.std.option._
-
-import scala.util.control.NoStackTrace
 
 case object LedgerApiV1 {
   // ------------------------------------------------------------------------------------------------------------------
@@ -261,7 +258,7 @@ case object LedgerApiV1 {
   ): Result[Model.ApiRecord] =
     for {
       lfr <- validateRecord(value).leftMap(sre => GenericConversionError(sre.getMessage))
-      cidMapped <- lfr mapContractId (_.coid) match {
+      cidMapped <- lfr match {
         case r: Model.ApiRecord => Right(r)
         case v => Left(GenericConversionError(s"validating record produced non-record $v"))
       }
@@ -412,7 +409,7 @@ case object LedgerApiV1 {
   ): Result[Model.ApiValue] =
     validateValue(value)
       .leftMap(sre => GenericConversionError(sre.getMessage))
-      .flatMap(vv => fillInTypeInfo(vv.mapContractId(_.coid), typ, ctx))
+      .flatMap(vv => fillInTypeInfo(vv, typ, ctx))
 
   /** Add `tycon`s and record field names where absent. */
   private def fillInTypeInfo(
@@ -422,7 +419,7 @@ case object LedgerApiV1 {
   ): Result[Model.ApiValue] =
     value match {
       case v: V.ValueEnum => fillInEnumTI(v, typ)
-      case _: V.ValueCidlessLeaf | _: V.ValueContractId[_] => Right(value)
+      case _: V.ValueCidlessLeaf | _: V.ValueContractId => Right(value)
       case v: Model.ApiOptional => fillInOptionalTI(v, typ, ctx)
       case v: Model.ApiMap => fillInTextMapTI(v, typ, ctx)
       case v: Model.ApiGenMap => fillInGenMapTI(v, typ, ctx)
@@ -436,28 +433,10 @@ case object LedgerApiV1 {
   // ------------------------------------------------------------------------------------------------------------------
 
   def writeArgument(value: Model.ApiValue): Result[V1.value.Value] =
-    wrapContractId(value) flatMap (vac =>
-      lfValueToApiValue(verbose = true, vac) leftMap GenericConversionError
-    )
+    lfValueToApiValue(verbose = true, value) leftMap GenericConversionError
 
   def writeRecordArgument(value: Model.ApiRecord): Result[V1.value.Record] =
-    wrapContractId(value) flatMap (vac =>
-      lfValueToApiRecord(verbose = true, vac) leftMap GenericConversionError
-    )
-
-  private[this] def wrapContractId(value: Model.ApiValue): Result[V[V.ContractId]] = {
-    final class NotACoid(message: String) extends RuntimeException(message) with NoStackTrace
-    // this is 100% cheating as Value should have Traverse instead
-    try Right(value mapContractId { coid =>
-      ContractId
-        .fromString(coid)
-        .fold(
-          e => throw new NotACoid(e),
-          identity,
-        )
-    })
-    catch { case e: NotACoid => Left(GenericConversionError(e.getMessage)) }
-  }
+    lfValueToApiRecord(verbose = true, value) leftMap GenericConversionError
 
   /** Write a composite command consisting of just the given command */
   def writeCommands(

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/query/filter/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/query/filter/package.scala
@@ -118,7 +118,7 @@ package object filter {
     def loop(argument: ApiValue, cursor: PropertyCursor): Either[DotNotFailure, Boolean] =
       argument match {
         case V.ValueContractId(value) =>
-          cursor.ensureLast("ContractId")(checkContained(value, expectedValue))
+          cursor.ensureLast("ContractId")(checkContained(value.coid, expectedValue))
         case V.ValueInt64(value) =>
           cursor.ensureLast("Int64")(checkContained(value.toString, expectedValue))
         case V.ValueNumeric(value) =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/query/project/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/query/project/package.scala
@@ -131,7 +131,7 @@ object project {
     @annotation.tailrec
     def loop(argument: ApiValue, cursor: PropertyCursor): Either[DotNotFailure, ProjectValue] =
       argument match {
-        case V.ValueContractId(value) => cursor.ensureLast("contractid")(StringValue(value))
+        case V.ValueContractId(value) => cursor.ensureLast("contractid")(StringValue(value.coid))
         case V.ValueInt64(value) => cursor.ensureLast("int64")(NumberValue(value))
         case V.ValueNumeric(value) =>
           cursor.ensureLast("numeric")(StringValue(value.toUnscaledString))

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
@@ -240,7 +240,7 @@ case object DamlConstants {
       ("fUnit", V.ValueUnit),
       ("fInt64", simpleInt64V),
       ("fParty", V.ValueParty(DamlLfRef.Party assertFromString "BANK1")),
-      ("fContractId", V.ValueContractId("C0")),
+      ("fContractId", V.ValueContractId(V.ContractId.assertFromString("#C0"))),
       ("fListOfText", V.ValueList(FrontStack(V.ValueText("foo"), V.ValueText("bar")))),
       ("fListOfUnit", V.ValueList(FrontStack(V.ValueUnit, V.ValueUnit))),
       ("fDate", simpleDateV),


### PR DESCRIPTION
99% of our usecases use Value[ContractId] so this PR just fixes it.

The few other usescases are:

1. Value[Nothing] which we use for keys. This is technically more
precise but we benefit very little from it.
2. Value[String] mostly because in a few places we are lazy.

We don’t have any code which benefits from being polymorphic in the
contract id type.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
