### PR TITLE
LF: clean up useless version checks

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -31,8 +31,6 @@ private[archive] class DecodeV1(minor: LV.Minor) {
       onlySerializableDataDefs: Boolean,
   ): Either[Error, Package] = attempt(NameOf.qualifiedNameOfCurrentFunc) {
     val internedStrings = lfPackage.getInternedStringsList.asScala.to(ImmArraySeq)
-    if (internedStrings.nonEmpty)
-      assertSince(LV.Features.internedPackageId, "interned strings table")
 
     val internedDottedNames =
       decodeInternedDottedNames(
@@ -289,10 +287,8 @@ private[archive] class DecodeV1(minor: LV.Minor) {
         throw Error.Parsing(s"invalid internedString table index $id")
       }
 
-    private[this] def getInternedPackageId(id: Int): PackageId = {
-      assertSince(LV.Features.internedPackageId, "interned PackageId")
+    private[this] def getInternedPackageId(id: Int): PackageId =
       eitherToParseError(PackageId.fromString(getInternedStr(id)))
-    }
 
     private[this] def getInternedName(id: Int, description: => String): Name = {
       assertSince(LV.Features.internedStrings, description)
@@ -361,7 +357,6 @@ private[archive] class DecodeV1(minor: LV.Minor) {
           case PLF.DefDataType.DataConsCase.VARIANT =>
             DataVariant(decodeFields(lfDataType.getVariant.getFieldsList.asScala))
           case PLF.DefDataType.DataConsCase.ENUM =>
-            assertSince(LV.Features.enum, "DefDataType.DataCons.Enum")
             assertEmpty(params, "params")
             DataEnum(decodeEnumCon(lfDataType.getEnum))
           case PLF.DefDataType.DataConsCase.DATACONS_NOT_SET =>
@@ -883,7 +878,6 @@ private[archive] class DecodeV1(minor: LV.Minor) {
           )
 
         case PLF.Expr.SumCase.ENUM_CON =>
-          assertSince(LV.Features.enum, "Expr.Enum")
           val enumCon = lfExpr.getEnumCon
           EEnumCon(
             decodeTypeConName(enumCon.getTycon),
@@ -1096,7 +1090,6 @@ private[archive] class DecodeV1(minor: LV.Minor) {
             ),
           )
         case PLF.CaseAlt.SumCase.ENUM =>
-          assertSince(LV.Features.enum, "CaseAlt.Enum")
           val enum = lfCaseAlt.getEnum
           CPEnum(
             tycon = decodeTypeConName(enum.getCon),
@@ -1731,7 +1724,7 @@ private[lf] object DecodeV1 {
         minVersion = contractIdTextConversions,
       ),
       BuiltinFunctionInfo(PARTY_TO_QUOTED_TEXT, BPartyToQuotedText, maxVersion = Some(exceptions)),
-      BuiltinFunctionInfo(CODE_POINTS_TO_TEXT, BCodePointsToText, minVersion = textPacking),
+      BuiltinFunctionInfo(CODE_POINTS_TO_TEXT, BCodePointsToText),
       BuiltinFunctionInfo(TEXT_TO_PARTY, BTextToParty),
       BuiltinFunctionInfo(TEXT_TO_INT64, BTextToInt64),
       BuiltinFunctionInfo(
@@ -1741,7 +1734,7 @@ private[lf] object DecodeV1 {
         maxVersion = Some(numeric),
       ),
       BuiltinFunctionInfo(TEXT_TO_NUMERIC, BTextToNumeric, minVersion = numeric),
-      BuiltinFunctionInfo(TEXT_TO_CODE_POINTS, BTextToCodePoints, minVersion = textPacking),
+      BuiltinFunctionInfo(TEXT_TO_CODE_POINTS, BTextToCodePoints),
       BuiltinFunctionInfo(SHA256_TEXT, BSHA256Text),
       BuiltinFunctionInfo(DATE_TO_UNIX_DAYS, BDateToUnixDays),
       BuiltinFunctionInfo(EXPLODE_TEXT, BExplodeText),

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -469,7 +469,6 @@ private[daml] class EncodeV1(minor: LV.Minor) {
           setString(binder, b.setBinderStr, b.setBinderInternedStr)
           builder.setVariant(b)
         case CPEnum(tyCon, con) =>
-          assertSince(LV.Features.enum, "CaseAlt.Enum")
           val b = PLF.CaseAlt.Enum.newBuilder()
           b.setCon(tyCon)
           setString(con, b.setConstructorStr, b.setConstructorInternedStr)
@@ -547,7 +546,6 @@ private[daml] class EncodeV1(minor: LV.Minor) {
           b.setVariantArg(arg)
           builder.setVariantCon(b)
         case EEnumCon(tyCon, con) =>
-          assertSince(LV.Features.enum, "Expr.Enum")
           val b = PLF.Expr.EnumCon.newBuilder().setTycon(tyCon)
           setString(con, b.setEnumConStr, b.setEnumConInternedStr)
           builder.setEnumCon(b.build())
@@ -669,7 +667,6 @@ private[daml] class EncodeV1(minor: LV.Minor) {
             PLF.DefDataType.Fields.newBuilder().accumulateLeft(variants)(_ addFields _)
           )
         case DataEnum(constructors) =>
-          assertSince(LV.Features.enum, "DefDataType.Enum")
           val b = PLF.DefDataType.EnumConstructors.newBuilder()
           constructors.foreach(
             setString(_, b.addConstructorsStr, b.addConstructorsInternedStr)

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -34,8 +34,6 @@ object LanguageVersion {
 
   object Features {
     val default = v1_6
-    val textPacking = v1_6
-    val enum = v1_6
     val internedPackageId = v1_6
     val internedStrings = v1_7
     val internedDottedNames = v1_7


### PR DESCRIPTION
Since SDK 1.0.0 the min LF version is 1.6.
We drop some checks that are now redundant.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
