### PR TITLE
Implement LF desugaring of interface definitions

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -261,14 +261,16 @@ data Definition
   | DValue DefValue
   | DTemplate Template
   | DException DefException
+  | DInterface DefInterface
+  deriving Show
 
 moduleFromDefinitions :: ModuleName -> Maybe FilePath -> FeatureFlags -> [Definition] -> Module
 moduleFromDefinitions name path flags defs = do
-  let (syns, dats, vals, tpls, exps) = partitionDefinitions defs
-  Module name path flags (NM.fromList syns) (NM.fromList dats) (NM.fromList vals) (NM.fromList tpls) (NM.fromList exps) NM.empty -- TODO interfaces
+  let (syns, dats, vals, tpls, exps, ifs) = partitionDefinitions defs
+  Module name path flags (NM.fromList syns) (NM.fromList dats) (NM.fromList vals) (NM.fromList tpls) (NM.fromList exps) (NM.fromList ifs)
 
-partitionDefinitions :: [Definition] -> ([DefTypeSyn], [DefDataType], [DefValue], [Template], [DefException])
-partitionDefinitions = foldr f ([], [], [], [], [])
+partitionDefinitions :: [Definition] -> ([DefTypeSyn], [DefDataType], [DefValue], [Template], [DefException], [DefInterface])
+partitionDefinitions = foldr f ([], [], [], [], [], [])
   where
     f = \case
       DTypeSyn s  -> over _1 (s:)
@@ -276,6 +278,7 @@ partitionDefinitions = foldr f ([], [], [], [], [])
       DValue v    -> over _3 (v:)
       DTemplate t -> over _4 (t:)
       DException e -> over _5 (e:)
+      DInterface i -> over _6 (i:)
 
 -- | This is the analogue of GHC’s moduleNameString for the LF
 -- `ModuleName` type.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -171,6 +171,13 @@ featureExceptions = Feature
     , featureCppFlag = Just "DAML_EXCEPTIONS"
     }
 
+featureInterfaces :: Feature
+featureInterfaces = Feature
+    { featureName = "Daml Interfaces"
+    , featureMinVersion = versionDev
+    , featureCppFlag = Just "DAML_INTERFACE"
+    }
+
 featureExperimental :: Feature
 featureExperimental = Feature
     { featureName = "DAML Experimental"
@@ -195,6 +202,7 @@ allFeatures =
     , featureBigNumeric
     , featureExceptions
     , featureExperimental
+    , featureInterfaces
     ]
 
 featureVersionMap :: MS.Map T.Text Version

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
@@ -260,6 +260,15 @@ hasDamlExceptionCtx t
     | otherwise
     = False
 
+hasDamlInterfaceCtx :: TyCon -> Bool
+hasDamlInterfaceCtx t
+    | isAlgTyCon t
+    , [theta] <- tyConStupidTheta t
+    , TypeCon tycon [] <- theta
+    , NameIn GHC_Types "DamlInterface" <- tycon
+    = True
+hasDamlInterfaceCtx _ = False
+
 -- Pretty printing is very expensive, so clone the logic for when to add unique suffix
 varPrettyPrint :: Var -> T.Text
 varPrettyPrint (varName -> x) = getOccText x <> (if isSystemName x then "_" <> T.pack (show $ nameUnique x) else "")

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -23,6 +23,7 @@ module GHC.Types (
         ifThenElse,
         primitive, magic, external,
         DamlEnum,
+        DamlInterface,
 
 #ifdef DAML_NUMERIC
         Nat, Numeric,
@@ -164,6 +165,9 @@ data Text =
 -- | HIDE Used to tag single-constructor enum types.
 class DamlEnum
 instance DamlEnum
+
+class DamlInterface
+instance DamlInterface
 
 #ifdef DAML_NUMERIC
 

--- a/compiler/damlc/tests/daml-test-files/InterfaceDesugared.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceDesugared.daml
@@ -1,0 +1,34 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_INTERFACE
+-- @WARN Modules compiled with the DatatypeContexts language extension
+-- @ERROR interfaces are not implemented
+{-# LANGUAGE DatatypeContexts #-}
+
+module InterfaceDesugared where
+
+data Split = Split { splitAmount : Decimal }
+
+data Transfer = Transfer { newOwner : Party }
+
+class
+  ( HasExercise t Split (ContractId Token, ContractId Token)
+  , HasExercise t Transfer (ContractId Token)
+  ) => IsToken t where
+-- TODO https://github.com/digital-asset/daml/issues/10810
+-- enable once we support pure functions
+--  getAmount : t -> Decimal
+
+data GHC.Types.DamlInterface => Token = Token GHC.Types.Opaque
+
+instance HasExercise Token Split (ContractId Token, ContractId Token) where
+  exercise = GHC.Types.primitive @"UExercise"
+
+instance HasExercise Token Transfer (ContractId Token) where
+  exercise = GHC.Types.primitive @"UExercise"
+
+instance IsToken Token where
+-- TODO https://github.com/digital-asset/daml/issues/10810
+-- enable once we support pure functions
+--  getAmount = primitivInterface @"getAmount"


### PR DESCRIPTION
This only handles the interface definition, not the implementation in
the template. There are also a few rough edges:

1. It maks all choices as consuming.
2. it ignores locations

But for a poc that doesn’t seem too bad.

The tests don’t do anything super useful since the typechecker falls
over but I checked tha tthe generated LF looks more or less reasonable.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
