### PR TITLE
[docs] Replace AdoptOpenJDK suggestion by Adoptium

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -12,7 +12,7 @@ The Daml Connect SDK currently runs on Windows, macOS and Linux.
 You need to install:
 
 1. `Visual Studio Code <https://code.visualstudio.com/download>`_.
-2. JDK 8 or greater. If you don't already have a JDK installed, try `AdoptOpenJDK <https://adoptopenjdk.net>`_.
+2. JDK 8 or greater. If you don't already have a JDK installed, try `Eclipse Adoptium <https://adoptium.net>`_.
 
    As part of the installation process you might need to set up the ``JAVA_HOME`` variable. You can find here the instructions on how to do it on :doc:`Windows,macOS, and Linux <path-variables>`.
 


### PR DESCRIPTION
In the installation instructions, suggest Adoptium as JDK source

[AdoptOpenJDK has moved to the Eclipse foundation](
https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/)

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
