### PR TITLE
LF: drop ad-hoc FrontStack builders

### DIFF
--- a/daml-lf/data/src/main/2.12/com/daml/lf/data/AbstractImmArraySeq.scala
+++ b/daml-lf/data/src/main/2.12/com/daml/lf/data/AbstractImmArraySeq.scala
@@ -41,7 +41,7 @@ abstract class AbstractImmArraySeq[+A](array: ImmArray[A])
     bf match {
       case _: IASCanBuildFrom[A] => this
       case _: ImmArrayInstances.IACanBuildFrom[A] => toImmArray
-      case _: FrontStackInstances.FSCanBuildFrom[A] => FrontStack(toImmArray)
+      case _: FrontStackInstances.FSCanBuildFrom[A] => FrontStack.from(toImmArray)
       case _ => super.to(bf)
     }
 }

--- a/daml-lf/data/src/main/2.12/com/daml/lf/data/FrontStackInstances.scala
+++ b/daml-lf/data/src/main/2.12/com/daml/lf/data/FrontStackInstances.scala
@@ -8,8 +8,12 @@ import ScalazEqual.{equalBy, toIterableForScalazInstances}
 import scalaz.Equal
 
 import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
 
 private[data] abstract class FrontStackInstances {
+
+  def apply[T](elements: T*): FrontStack[T] = elements.to[FrontStack]
+
   implicit def equalInstance[A: Equal]: Equal[FrontStack[A]] = {
     import scalaz.std.iterable._
     equalBy(fs => toIterableForScalazInstances(fs.iterator), true)
@@ -28,9 +32,9 @@ private[data] abstract class FrontStackInstances {
 
 private[data] object FrontStackInstances {
   final class FSCanBuildFrom[A] extends CanBuildFrom[FrontStack[_], A, FrontStack[A]] {
-    override def apply(from: FrontStack[_]) = apply()
+    override def apply(from: FrontStack[_]): mutable.Builder[A, FrontStack[A]] = apply()
 
-    override def apply() =
-      ImmArray.newBuilder[A].mapResult(FrontStack(_))
+    override def apply(): mutable.Builder[A, FrontStack[A]] =
+      ImmArray.newBuilder[A].mapResult(FrontStack.from)
   }
 }

--- a/daml-lf/data/src/main/2.13/com/daml/lf/data/FrontStackInstances.scala
+++ b/daml-lf/data/src/main/2.13/com/daml/lf/data/FrontStackInstances.scala
@@ -6,12 +6,13 @@ package com.daml.lf.data
 import ScalazEqual.{equalBy, toIterableForScalazInstances}
 
 import scalaz.Equal
-import scala.collection.mutable.Builder
+import scala.collection.mutable
 
 abstract class FrontStackInstances extends scala.collection.IterableFactory[FrontStack] {
-  override def from[A](it: IterableOnce[A]) = (newBuilder ++= it).result()
-  override def newBuilder[A]: Builder[A, FrontStack[A]] =
-    ImmArray.newBuilder.mapResult(FrontStack(_))
+  override def from[A](it: IterableOnce[A]): FrontStack[A] =
+    FrontStack.from(ImmArray.from(it))
+  override def newBuilder[A]: mutable.Builder[A, FrontStack[A]] =
+    ImmArray.newBuilder.mapResult(FrontStack.from)
   implicit def equalInstance[A: Equal]: Equal[FrontStack[A]] = {
     import scalaz.std.iterable._
     equalBy(fs => toIterableForScalazInstances(fs.iterator), true)

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
@@ -53,7 +53,7 @@ final class BackStack[+A] private (fq: BQ[A], val length: Int) {
         case BQAppend(init, last) => go(init, last ++: acc)
         case BQEmpty => acc
       }
-    go(fq, FrontStack.empty)
+    go(fq, FrontStack.Empty)
   }
 
   /** O(1) */

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
@@ -3,19 +3,20 @@
 
 package com.daml.lf.data
 
-import FrontStack.{FQ, FQCons, FQEmpty, FQPrepend}
 import ScalazEqual.{orderBy, toIterableForScalazInstances}
-
 import scalaz.syntax.applicative._
 import scalaz.syntax.traverse._
 import scalaz.{Applicative, Order, Traverse}
 
 import scala.annotation.tailrec
+import scala.util.hashing.MurmurHash3
 
 /** A stack which allows to cons, prepend, and pop in constant time, and generate an ImmArray in linear time.
   * Very useful when needing to traverse stuff in topological order or similar situations.
   */
-final class FrontStack[+A] private (fq: FQ[A], val length: Int) {
+final class FrontStack[+A] private (fq: FrontStack.FQ[A], val length: Int) {
+
+  import FrontStack._
 
   /** O(n) */
   @throws[IndexOutOfBoundsException]
@@ -84,9 +85,7 @@ final class FrontStack[+A] private (fq: FQ[A], val length: Int) {
   }
 
   /** O(n) */
-  def map[B](f: A => B): FrontStack[B] = {
-    this.toImmArray.map(f) ++: FrontStack.empty
-  }
+  def map[B](f: A => B): FrontStack[B] = from(toImmArray.map(f))
 
   /** O(1) */
   def isEmpty: Boolean = length == 0
@@ -135,36 +134,20 @@ final class FrontStack[+A] private (fq: FQ[A], val length: Int) {
     case _ => false
   }
 
-  override def hashCode(): Int = toImmArray.hashCode()
+  override def hashCode(): Int =
+    MurmurHash3.orderedHash(toIterableForScalazInstances(iterator))
 
   /** O(n) */
   override def toString: String = "FrontStack(" + iterator.map(_.toString).mkString(",") + ")"
 }
 
 object FrontStack extends FrontStackInstances {
-  private[this] val emptySingleton: FrontStack[Nothing] = new FrontStack(FQEmpty, 0)
+  val Empty: FrontStack[Nothing] = new FrontStack(FQEmpty, 0)
 
-  def empty[A]: FrontStack[A] = emptySingleton
+  def empty[A]: FrontStack[A] = FrontStack.Empty
 
-  def apply[A](xs: ImmArray[A]): FrontStack[A] =
-    if (xs.length > 0) {
-      new FrontStack(FQPrepend(xs, FQEmpty), length = xs.length)
-    } else {
-      empty
-    }
-
-  def apply[T](element: T): FrontStack[T] =
-    new FrontStack(FQCons(element, FQEmpty), length = 1)
-
-  def apply[T](a: T, b: T): FrontStack[T] =
-    new FrontStack(FQCons(a, FQCons(b, FQEmpty)), length = 2)
-
-  // Slow; only use this in tests.
-  def apply[T](a: T, b: T, c: T, elements: T*): FrontStack[T] =
-    a +: b +: c +: apply(elements.to(ImmArray))
-
-  def apply[T](elements: Seq[T]): FrontStack[T] =
-    apply(elements.to(ImmArray))
+  def from[A](xs: ImmArray[A]): FrontStack[A] =
+    if (xs.isEmpty) Empty else new FrontStack(FQPrepend(xs, FQEmpty), length = xs.length)
 
   def unapply[T](xs: FrontStack[T]): Boolean = xs.isEmpty
 

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
@@ -354,6 +354,9 @@ final class ImmArray[+A] private (
     collect { case x if f(x) => x }
 
   override def hashCode(): Int = toSeq.hashCode()
+
+  def toFrontStack: FrontStack[A] = FrontStack.from(this)
+
 }
 
 object ImmArray extends ImmArrayInstances {

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/FrontStackSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/FrontStackSpec.scala
@@ -30,20 +30,6 @@ class FrontStackSpec
         FrontStack(x, y) should ===(x +: y +: FrontStack.empty)
       }
     }
-
-    "more than 2 elements are provided" should {
-      "behave the same as prepend" in forAll { (x: Int, y: Int, z: Int, rest: Seq[Int]) =>
-        FrontStack(x, y, z, rest: _*) should ===(
-          (Seq(x, y, z) ++ rest).to(ImmArray) ++: FrontStack.empty
-        )
-      }
-    }
-
-    "a sequence of elements is provided" should {
-      "behave the same as prepend" in forAll { xs: Seq[Int] =>
-        FrontStack(xs) should ===(xs.to(ImmArray) ++: FrontStack.empty)
-      }
-    }
   }
 
   "++:" should {

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -78,7 +78,7 @@ object Blinding {
     }
 
     GenTransaction(
-      roots = go(BackStack.empty, FrontStack(tx.roots)),
+      roots = go(BackStack.empty, tx.roots.toFrontStack),
       nodes = filteredNodes,
     )
   }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -149,7 +149,7 @@ private[lf] final class CommandPreprocessor(
       }
     }
 
-    go(FrontStack(cmds), BackStack.empty)
+    go(cmds.toFrontStack, BackStack.empty)
   }
 
 }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1162,7 +1162,7 @@ class EngineTest
         .translateValue(TList(TBuiltin(BTInt64)), list)
         .consume(lookupContract, lookupPackage, lookupKey)
 
-      res shouldEqual Right(SList(FrontStack(ImmArray(SInt64(1)))))
+      res shouldEqual Right(SList(FrontStack(SInt64(1))))
     }
 
     "translate average list" in {
@@ -1174,7 +1174,7 @@ class EngineTest
         .consume(lookupContract, lookupPackage, lookupKey)
 
       res shouldEqual Right(
-        SValue.SList(FrontStack(ImmArray(SInt64(1), SInt64(2), SInt64(3), SInt64(4), SInt64(5))))
+        SValue.SList(FrontStack(SInt64(1), SInt64(2), SInt64(3), SInt64(4), SInt64(5)))
       )
     }
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -334,7 +334,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   ): ExerciseCommand = {
     val choice = "Size"
     val choiceDefRef = Identifier(templateId.packageId, qn(s"LargeTransaction:$choice"))
-    val damlList = ValueList(FrontStack(elements = List.range(0L, size.toLong).map(ValueInt64)))
+    val damlList = ValueList(List.range(0L, size.toLong).map(ValueInt64).to(FrontStack))
     val choiceArgs = ValueRecord(Some(choiceDefRef), ImmArray((None, damlList)))
     ExerciseCommand(templateId, contractId, choice, choiceArgs)
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -372,7 +372,7 @@ private[lf] object SBuiltin {
   //
   final case object SBExplodeText extends SBuiltinPure(1) {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SList =
-      SList(FrontStack(Utf8.explode(getSText(args, 0)).map(SText)))
+      SList(FrontStack.from(Utf8.explode(getSText(args, 0)).map(SText)))
   }
 
   final case object SBImplodeText extends SBuiltinPure(1) {
@@ -507,7 +507,7 @@ private[lf] object SBuiltin {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SList = {
       val string = getSText(args, 0)
       val codePoints = Utf8.unpack(string)
-      SList(FrontStack(codePoints.map(SInt64)))
+      SList(FrontStack.from(codePoints.map(SInt64)))
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -366,13 +366,11 @@ object SValue {
 
   def toList(entries: TreeMap[SValue, SValue]): SList =
     SList(
-      FrontStack(
-        entries.iterator
-          .map { case (k, v) =>
-            entry(k, v)
-          }
-          .to(ImmArray)
-      )
+      entries.view
+        .map { case (k, v) =>
+          entry(k, v)
+        }
+        .to(FrontStack)
     )
 
   private def mapArrayList(

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1045,7 +1045,7 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
       "returns the keys in order" in {
 
         eval(e"GENMAP_KEYS @Text @Int64 ${buildMap("Int64", words: _*)}") shouldBe
-          Right(SList(FrontStack(sortedWords.map { case (k, _) => SText(k) })))
+          Right(SList(sortedWords.map { case (k, _) => SText(k) }.to(FrontStack)))
       }
     }
 
@@ -1053,7 +1053,7 @@ class SBuiltinTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
 
       "returns the values in order" in {
         eval(e"GENMAP_VALUES @Text @Int64 ${buildMap("Int64", words: _*)}") shouldBe
-          Right(SList(FrontStack(sortedWords.map { case (_, v) => SInt64(v.toLong) })))
+          Right(SList(sortedWords.map { case (_, v) => SInt64(v.toLong) }.to(FrontStack)))
       }
     }
 

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -150,7 +150,7 @@ object ValueGenerators {
   private def valueListGen(nesting: Int): Gen[ValueList[ContractId]] =
     for {
       values <- Gen.listOf(Gen.lzy(valueGen(nesting)))
-    } yield ValueList[ContractId](FrontStack(values))
+    } yield ValueList[ContractId](values.to(FrontStack))
 
   def valueListGen: Gen[ValueList[ContractId]] = valueListGen(0)
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -260,9 +260,7 @@ object ValueCoder {
             )
           case proto.Value.SumCase.LIST =>
             ValueList(
-              FrontStack(
-                protoValue.getList.getElementsList.asScala.map(go(newNesting, _)).to(ImmArray)
-              )
+              protoValue.getList.getElementsList.asScala.map(go(newNesting, _)).to(FrontStack)
             )
 
           case proto.Value.SumCase.VARIANT =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -408,7 +408,7 @@ object Converter {
             ("contractId", fromAnyContractId(scriptIds, toApiIdentifier(tplId), contractId.coid)),
             ("choice", SText(choiceName)),
             ("argument", anyChoice),
-            ("childEvents", SList(FrontStack(evs))),
+            ("childEvents", SList(evs.to(FrontStack))),
           ),
         )
     }
@@ -416,7 +416,7 @@ object Converter {
       events <- tree.rootEvents.traverse(translateTreeEvent(_)): Either[String, List[SValue]]
     } yield record(
       scriptIds.damlScript("SubmitFailure"),
-      ("rootEvents", SList(FrontStack(events))),
+      ("rootEvents", SList(events.to(FrontStack))),
     )
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -219,7 +219,8 @@ object ScriptF {
         )
         acs <- client.query(parties, tplId)
         res <- Converter.toFuture(
-          FrontStack(acs)
+          acs
+            .to(FrontStack)
             .traverse(
               Converter
                 .fromCreated(env.valueTranslator, _)
@@ -329,7 +330,7 @@ object ScriptF {
           partyDetails
             .traverse(details => Converter.fromPartyDetails(env.scriptIds, details))
         )
-      } yield SEApp(SEValue(continue), Array(SEValue(SList(FrontStack(partyDetails_)))))
+      } yield SEApp(SEValue(continue), Array(SEValue(SList(partyDetails_.to(FrontStack)))))
 
   }
   final case class GetTime(stackTrace: StackTrace, continue: SValue) extends Cmd {

--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/LedgerValue.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/LedgerValue.scala
@@ -61,7 +61,7 @@ object LedgerValue {
   private def convertList(apiList: api.value.List) = {
     for {
       values <- apiList.elements.toList.traverse(_.convert)
-    } yield V.ValueList(FrontStack(values))
+    } yield V.ValueList(values.to(FrontStack))
   }
 
   private def convertVariant(apiVariant: api.value.Variant) = {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValueValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValueValidator.scala
@@ -89,7 +89,7 @@ object ValueValidator {
               validatedValue <- validateValue(v)
             } yield values :+ validatedValue
         )
-        .map(elements => Lf.ValueList(FrontStack(elements.toImmArray)))
+        .map(elements => Lf.ValueList(elements.toFrontStack))
     case _: Sum.Unit => Right(ValueUnit)
     case Sum.Optional(o) =>
       o.value.fold[Either[StatusRuntimeException, domain.Value]](Right(Lf.ValueNone))(

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -703,7 +703,7 @@ class SubmitRequestValidatorTest
       "convert valid lists" in {
         val list = Value(Sum.List(ApiList(Seq(Value(api.int64), Value(api.int64)))))
         val expected =
-          Lf.ValueList(FrontStack(ImmArray(DomainMocks.values.int64, DomainMocks.values.int64)))
+          Lf.ValueList(FrontStack(DomainMocks.values.int64, DomainMocks.values.int64))
         validateValue(list) shouldEqual Right(expected)
       }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/index/TransactionConversion.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/TransactionConversion.scala
@@ -185,7 +185,7 @@ private[platform] object TransactionConversion {
           acc.toImmArray.toSeq
       }
 
-    go(FrontStack(tx.roots), BackStack.empty)
+    go(tx.roots.toFrontStack, BackStack.empty)
   }
 
   private def applyDisclosure(

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
@@ -7,7 +7,7 @@ package trigger
 
 import scalaz.std.either._
 import scalaz.syntax.traverse._
-import com.daml.lf.data.FrontStack
+import com.daml.lf.data.{FrontStack, ImmArray}
 import com.daml.lf.data.Ref._
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SValue
@@ -15,10 +15,10 @@ import com.daml.lf.speedy.SValue._
 import com.daml.lf.value.Value.ContractId
 import com.daml.ledger.api.v1.commands.{
   Command,
+  CreateAndExerciseCommand,
   CreateCommand,
   ExerciseByKeyCommand,
   ExerciseCommand,
-  CreateAndExerciseCommand,
 }
 import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.api.v1.event.{ArchivedEvent, CreatedEvent, Event}
@@ -244,7 +244,10 @@ object Converter {
     val messageTy = triggerIds.damlTriggerLowLevel("Message")
     val transactionTy = triggerIds.damlTriggerLowLevel("Transaction")
     for {
-      events <- FrontStack(t.events).traverse(fromEvent(valueTranslator, triggerIds, _)).map(SList)
+      events <- t.events
+        .to(ImmArray)
+        .traverse(fromEvent(valueTranslator, triggerIds, _))
+        .map(xs => SList(FrontStack.from(xs)))
       transactionId = fromTransactionId(triggerIds, t.transactionId)
       commandId = fromOptionalCommandId(triggerIds, t.commandId)
     } yield SVariant(
@@ -491,9 +494,10 @@ object Converter {
   ): Either[String, SValue] = {
     val activeContractsTy = triggerIds.damlTriggerLowLevel("ActiveContracts")
     for {
-      events <- FrontStack(createdEvents)
+      events <- createdEvents
+        .to(ImmArray)
         .traverse(fromCreatedEvent(valueTranslator, triggerIds, _))
-        .map(SList)
+        .map(xs => SList(FrontStack.from(xs)))
     } yield record(activeContractsTy, ("activeContracts", events))
   }
 


### PR DESCRIPTION
Following #10763, we drop the ad-hoc builders for `FrontStack`.

* Building a `Fronstack` from individuals elements should be done with
  standard scala buidler.

* Building a `Fronstack` from a `TraversableOne` should be done with
  the scala 2.13 `.to(FrontStack)` methd

* Building a `Fronstack` from a `ImmArray` should be done with the
  `toImmArray` method.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
