### PR TITLE
interfaces: protobuf decoder haskell side

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
@@ -21,6 +21,7 @@ data Error
   | EDuplicateTemplate TypeConName
   | DuplicateChoice ChoiceName
   | DuplicateException TypeConName
+  | DuplicateInterface TypeConName
   | UnsupportedMinorVersion T.Text
   | BadStringId Int32
   | BadDottedNameId Int32


### PR DESCRIPTION
This implements the protobuf decoder for the added interface definitions on the haskell side.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
