### PR TITLE
[DPP-589] Add CLI flag to select minimum enabled TLS version

### DIFF
--- a/bazel-java-deps.bzl
+++ b/bazel-java-deps.bzl
@@ -124,6 +124,7 @@ def install_java_deps():
             "io.grpc:grpc-services:{}".format(grpc_version),
             "io.grpc:grpc-stub:{}".format(grpc_version),
             # netty
+            "io.netty:netty-buffer:{}".format(netty_version),
             "io.netty:netty-codec-http2:{}".format(netty_version),
             "io.netty:netty-handler:{}".format(netty_version),
             "io.netty:netty-handler-proxy:{}".format(netty_version),

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -130,7 +130,7 @@ testConnection damlc scriptDar testDar ledgerPort mbTokenFile mbCaCrt = do
         [ "alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"Alice\")"
         , "debug =<< query @T alice"
         ]
-    let regexString = "^daml> daml>.*: \\[\\]\ndaml> Goodbye.\n$" :: String
+    let regexString = "^(Client TLS.*\\.\n)?daml> daml>.*: \\[\\]\ndaml> Goodbye.\n$" :: String
     let regex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexString
     unless (matchTest regex out) $
         assertFailure (show out <> " did not match " <> show regexString <> ".")

--- a/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
@@ -82,7 +82,7 @@ object Main {
     applicationId = "script-export",
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = config.tlsConfig.client,
+    sslContext = config.tlsConfig.client(),
     token = config.accessToken.flatMap(_.token),
   )
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -231,7 +231,7 @@ object Runner {
       applicationId = ApplicationId.unwrap(applicationId),
       ledgerIdRequirement = LedgerIdRequirement.none,
       commandClient = CommandClientConfiguration.default,
-      sslContext = tlsConfig.client,
+      sslContext = tlsConfig.client(),
       token = params.access_token,
       maxInboundMessageSize = maxInboundMessageSize,
     )

--- a/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
@@ -260,7 +260,7 @@ class Extractor[T](config: ExtractorConfig, target: T)(
         applicationId = config.appId,
         ledgerIdRequirement = LedgerIdRequirement.none,
         commandClient = CommandClientConfiguration(1, 1, java.time.Duration.ofSeconds(20L)),
-        sslContext = config.tlsConfig.client,
+        sslContext = config.tlsConfig.client(),
         token = tokenHolder.flatMap(_.token),
         maxInboundMessageSize = config.ledgerInboundMessageSizeMax,
       ),

--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -212,7 +212,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
       applicationId = ApplicationId.unwrap(applicationId),
       ledgerIdRequirement = LedgerIdRequirement.none,
       commandClient = CommandClientConfiguration.default,
-      sslContext = if (useTls) clientTlsConfig.client else None,
+      sslContext = if (useTls) clientTlsConfig.client() else None,
       token = token,
     )
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -85,7 +85,7 @@ object HttpService {
       applicationId = ApplicationId.unwrap(DummyApplicationId),
       ledgerIdRequirement = LedgerIdRequirement.none,
       commandClient = CommandClientConfiguration.default,
-      sslContext = tlsConfig.client,
+      sslContext = tlsConfig.client(),
       maxInboundMessageSize = maxInboundMessageSize,
     )
 

--- a/ledger/daml-on-sql/README.rst
+++ b/ledger/daml-on-sql/README.rst
@@ -226,6 +226,9 @@ which should serve decryption details as a JSON document like so:
 
 Sample command to start a server with private key encrypted: ``java -jar daml-on-sql-<version>.jar --pem server.pem.enc --crt server.crt --tls-secrets-url http://localhost:8080``.
 
+To specify minimum TLS version for the server, add either ``--tls-version 1.2`` or ``--tls-version 1.3``
+to the server's invocation.
+
 By default, the Ledger API requires client authentication as well. You can set a
 custom root CA certificate used to validate client certificates via ``--cacrt ca.crt``.
 You can change the client authentication mode via ``--client-auth none`` which

--- a/ledger/daml-on-sql/README.rst
+++ b/ledger/daml-on-sql/README.rst
@@ -226,7 +226,7 @@ which should serve decryption details as a JSON document like so:
 
 Sample command to start a server with private key encrypted: ``java -jar daml-on-sql-<version>.jar --pem server.pem.enc --crt server.crt --tls-secrets-url http://localhost:8080``.
 
-To specify minimum TLS version for the server, add either ``--tls-version 1.2`` or ``--tls-version 1.3``
+To specify minimum TLS version for the server, add either ``--min-tls-version 1.2`` or ``--min-tls-version 1.3``
 to the server's invocation.
 
 By default, the Ledger API requires client authentication as well. You can set a

--- a/ledger/daml-on-sql/README.rst
+++ b/ledger/daml-on-sql/README.rst
@@ -226,8 +226,7 @@ which should serve decryption details as a JSON document like so:
 
 Sample command to start a server with private key encrypted: ``java -jar daml-on-sql-<version>.jar --pem server.pem.enc --crt server.crt --tls-secrets-url http://localhost:8080``.
 
-To specify minimum TLS version for the server, add either ``--min-tls-version 1.2`` or ``--min-tls-version 1.3``
-to the server's invocation.
+To specify minimum TLS version for the server, add ``--min-tls-version <version>`` to the server invocation.
 
 By default, the Ledger API requires client authentication as well. You can set a
 custom root CA certificate used to validate client certificates via ``--cacrt ca.crt``.

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/LedgerApiBenchTool.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/LedgerApiBenchTool.scala
@@ -170,7 +170,7 @@ object LedgerApiBenchTool {
       .usePlaintext()
 
     if (tls.enabled) {
-      tls.client.map { sslContext =>
+      tls.client().map { sslContext =>
         logger.info(s"Setting up a managed channel with transport security...")
         channelBuilder
           .useTransportSecurity()

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -49,6 +49,7 @@ da_scala_library(
         "@maven//:commons_io_commons_io",
         "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_grpc_grpc_netty",
+        "@maven//:io_netty_netty_buffer",
         "@maven//:io_netty_netty_handler",
         "@maven//:org_slf4j_slf4j_api",
     ],
@@ -82,6 +83,9 @@ da_scala_library(
 da_scala_test_suite(
     name = "ledger-api-common-scala-tests",
     srcs = glob(["src/test/suite/**/*.scala"]),
+    data = [
+        "//ledger/test-common/test-certificates",
+    ],
     plugins = [
         silencer_plugin,
     ],
@@ -109,6 +113,7 @@ da_scala_test_suite(
     deps = [
         ":ledger-api-common",
         ":ledger-api-common-scala-tests-lib",
+        "//bazel_tools/runfiles:scala_runfiles",
         "//daml-lf/data",
         "//daml-lf/language",
         "//daml-lf/parser",
@@ -134,6 +139,7 @@ da_scala_test_suite(
         "@maven//:commons_codec_commons_codec",
         "@maven//:commons_io_commons_io",
         "@maven//:io_dropwizard_metrics_metrics_core",
+        "@maven//:io_netty_netty_common",
         "@maven//:io_netty_netty_handler",
         "@maven//:io_opentelemetry_opentelemetry_api",
         "@maven//:io_opentelemetry_opentelemetry_context",

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
@@ -3,69 +3,153 @@
 
 package com.daml.ledger.api.tls
 
+import com.daml.ledger.api.tls.TlsVersion.{TlsVersion, V1, V1_1, V1_2, V1_3}
+import io.grpc.netty.GrpcSslContexts
+import io.netty.buffer.ByteBufAllocator
+import io.netty.handler.ssl.{ClientAuth, SslContext}
+import org.slf4j.LoggerFactory
+
 import java.io.{ByteArrayInputStream, File, FileInputStream, InputStream}
 import java.nio.file.Files
-
-import io.grpc.netty.GrpcSslContexts
-import io.netty.handler.ssl.{ClientAuth, SslContext}
-
+import javax.net.ssl.SSLEngine
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
+final case class TlsInfo(
+    enabledCipherSuites: Seq[String],
+    enabledProtocols: Seq[String],
+    supportedCipherSuites: Seq[String],
+    supportedProtocols: Seq[String],
+)
+
+object TlsInfo {
+  def fromSslContext(sslContext: SslContext): TlsInfo = {
+    val engine: SSLEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT)
+    TlsInfo(
+      enabledCipherSuites = engine.getEnabledCipherSuites.toIndexedSeq,
+      enabledProtocols = engine.getEnabledProtocols.toIndexedSeq,
+      supportedCipherSuites = engine.getSupportedCipherSuites.toIndexedSeq,
+      supportedProtocols = engine.getSupportedProtocols.toIndexedSeq,
+    )
+  }
+}
+
 final case class TlsConfiguration(
     enabled: Boolean,
-    keyCertChainFile: Option[File], // mutual auth is disabled if null
-    keyFile: Option[File],
-    trustCertCollectionFile: Option[File], // System default if null
+    keyCertChainFile: Option[File] = None, // mutual auth is disabled if null
+    keyFile: Option[File] = None,
+    trustCertCollectionFile: Option[File] = None, // System default if null
     secretsUrl: Option[SecretsUrl] = None,
     clientAuth: ClientAuth =
       ClientAuth.REQUIRE, // Client auth setting used by the server. This is not used in the client configuration.
     enableCertRevocationChecking: Boolean = false,
-    protocols: Seq[String] = Seq.empty,
+    minimumServerProtocolVersion: Option[TlsVersion] = None,
 ) {
 
+  private val logger = LoggerFactory.getLogger(getClass)
+
   /** If enabled and all required fields are present, it returns an SslContext suitable for client usage */
-  def client: Option[SslContext] = {
-    if (enabled)
-      Some(
-        GrpcSslContexts
-          .forClient()
-          .keyManager(
-            keyCertChainFile.orNull,
-            keyFile.orNull,
-          )
-          .trustManager(trustCertCollectionFile.orNull)
-          .protocols(if (protocols.nonEmpty) protocols.asJava else null)
-          .build()
-      )
-    else None
+  def client(enabledProtocols: Seq[TlsVersion] = Seq.empty): Option[SslContext] = {
+    if (enabled) {
+      val enabledProtocolsNames =
+        if (enabledProtocols.isEmpty)
+          null
+        else
+          enabledProtocols.map(_.version).asJava
+      val sslContext = GrpcSslContexts
+        .forClient()
+        .keyManager(
+          keyCertChainFile.orNull,
+          keyFile.orNull,
+        )
+        .trustManager(trustCertCollectionFile.orNull)
+        .protocols(enabledProtocolsNames)
+        .sslProvider(SslContext.defaultClientProvider())
+        .build()
+      logTlsProtocolsAndCipherSuites(sslContext, isServer = false)
+      Some(sslContext)
+    } else None
   }
 
   /** If enabled and all required fields are present, it returns an SslContext suitable for server usage */
   def server: Option[SslContext] =
     if (enabled) {
+      val tlsInfo0 = scala.util.Using.resources(
+        keyCertChainInputStreamOrFail,
+        keyInputStreamOrFail,
+      ) { (keyCertChain: InputStream, key: InputStream) =>
+        val defaultSslContext: SslContext = GrpcSslContexts
+          .forServer(
+            keyCertChain,
+            key,
+          )
+          .trustManager(trustCertCollectionFile.orNull)
+          .clientAuth(clientAuth)
+          .protocols(null.asInstanceOf[java.lang.Iterable[String]])
+          .sslProvider(SslContext.defaultServerProvider())
+          .build()
+        val tlsInfo0 = TlsInfo.fromSslContext(defaultSslContext)
+        tlsInfo0
+      }
       scala.util.Using.resources(
         keyCertChainInputStreamOrFail,
         keyInputStreamOrFail,
       ) { (keyCertChain: InputStream, key: InputStream) =>
-        Some(
-          GrpcSslContexts
-            .forServer(
-              keyCertChain,
-              key,
-            )
-            .trustManager(trustCertCollectionFile.orNull)
-            .clientAuth(clientAuth)
-            .protocols(if (protocols.nonEmpty) protocols.asJava else null)
-            .build
-        )
-
+        val sslContext = GrpcSslContexts
+          .forServer(
+            keyCertChain,
+            key,
+          )
+          .trustManager(trustCertCollectionFile.orNull)
+          .clientAuth(clientAuth)
+          .protocols(protocolsNames(tlsInfo0))
+          .sslProvider(SslContext.defaultServerProvider())
+          .build()
+        logTlsProtocolsAndCipherSuites(sslContext, isServer = true)
+        Some(sslContext)
       }
-    } else None
+    } else {
+      logger.info(s"Server's TLS: Disabled.")
+      None
+    }
+
+  private[tls] def logTlsProtocolsAndCipherSuites(
+      sslContext: SslContext,
+      isServer: Boolean,
+  ): Unit = {
+    val who = if (isServer) "server" else "client"
+    val tlsInfo = TlsInfo.fromSslContext(sslContext)
+    logger.info(s"TLS $who: Enabled.")
+    logger.debug(s"TLS $who: Supported protocols: ${tlsInfo.supportedProtocols.mkString(", ")}.")
+    logger.info(s"TLS $who: Enabled protocols: ${tlsInfo.enabledProtocols.mkString(", ")}.")
+    logger.debug(
+      s"TLS $who: Supported cipher suites: ${tlsInfo.supportedCipherSuites.mkString(", ")}."
+    )
+    logger.info(s"TLS $who: Enabled cipher suites: ${tlsInfo.enabledCipherSuites.mkString(", ")}.")
+  }
 
   /** This is a side-effecting method. It modifies JVM TLS properties according to the TLS configuration. */
   def setJvmTlsProperties(): Unit =
     if (enabled && enableCertRevocationChecking) OcspProperties.enableOcsp()
+
+  private[tls] def protocolsNames(tlsInfo: TlsInfo): java.lang.Iterable[String] = {
+    minimumServerProtocolVersion match {
+      case None => null
+      case Some(tlsVersion) =>
+        val versions = tlsVersion match {
+          case V1 | V1_1 =>
+            throw new IllegalArgumentException(s"Unsupported TLS version: ${tlsVersion}")
+          case V1_2 => Seq[TlsVersion](V1_2, V1_3)
+          case V1_3 => Seq(V1_3)
+          case _ =>
+            throw new IllegalStateException(s"Could not recognize TLS version: |${tlsVersion}|!")
+        }
+        versions
+          .map(_.version)
+          .filter(tlsInfo.supportedProtocols.contains(_))
+          .asJava
+    }
+  }
 
   private[tls] def keyInputStreamOrFail: InputStream = {
     val keyFileOrFail = keyFile.getOrElse(

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
@@ -5,35 +5,14 @@ package com.daml.ledger.api.tls
 
 import com.daml.ledger.api.tls.TlsVersion.{TlsVersion, V1, V1_1, V1_2, V1_3}
 import io.grpc.netty.GrpcSslContexts
-import io.netty.buffer.ByteBufAllocator
 import io.netty.handler.ssl.{ClientAuth, SslContext}
 import org.slf4j.LoggerFactory
 
 import java.io.{ByteArrayInputStream, File, FileInputStream, InputStream}
 import java.lang
 import java.nio.file.Files
-import javax.net.ssl.SSLEngine
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
-
-final case class TlsInfo(
-    enabledCipherSuites: Seq[String],
-    enabledProtocols: Seq[String],
-    supportedCipherSuites: Seq[String],
-    supportedProtocols: Seq[String],
-)
-
-object TlsInfo {
-  def fromSslContext(sslContext: SslContext): TlsInfo = {
-    val engine: SSLEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT)
-    TlsInfo(
-      enabledCipherSuites = engine.getEnabledCipherSuites.toIndexedSeq,
-      enabledProtocols = engine.getEnabledProtocols.toIndexedSeq,
-      supportedCipherSuites = engine.getSupportedCipherSuites.toIndexedSeq,
-      supportedProtocols = engine.getSupportedProtocols.toIndexedSeq,
-    )
-  }
-}
 
 final case class TlsConfiguration(
     enabled: Boolean,
@@ -72,19 +51,25 @@ final case class TlsConfiguration(
     } else None
   }
 
-  /** If enabled and all required fields are present, it returns an SslContext suitable for server usage */
+  /** If enabled and all required fields are present, it returns an SslContext suitable for server usage
+    *
+    *  Details:
+    *  We create two instances of sslContext:
+    *  1) The first one with default protocols: in order to query it for a set of supported protocols.
+    *  2) The second one with a custom set of protocols to enable.
+    *     We have used previously obtained set of supported protocols to make sure every protocol we want to enable is supported.
+    *     @see [[javax.net.ssl.SSLEngine#setEnabledProtocols]]
+    */
   def server: Option[SslContext] =
     if (enabled) {
-
       val tlsInfo = scala.util.Using.resources(
         keyCertChainInputStreamOrFail,
         keyInputStreamOrFail,
       ) { (keyCertChain: InputStream, key: InputStream) =>
-        val protocols = null.asInstanceOf[lang.Iterable[String]]
         val defaultSslContext = buildServersSslContext(
           keyCertChain = keyCertChain,
           key = key,
-          protocols = protocols,
+          protocols = null.asInstanceOf[lang.Iterable[String]],
         )
         TlsInfo.fromSslContext(defaultSslContext)
       }
@@ -93,11 +78,10 @@ final case class TlsConfiguration(
         keyCertChainInputStreamOrFail,
         keyInputStreamOrFail,
       ) { (keyCertChain: InputStream, key: InputStream) =>
-        val protocols = protocolsNames(tlsInfo)
         val sslContext = buildServersSslContext(
           keyCertChain = keyCertChain,
           key = key,
-          protocols = protocols,
+          protocols = filterSupportedProtocols(tlsInfo),
         )
         logTlsProtocolsAndCipherSuites(sslContext, isServer = true)
         Some(sslContext)
@@ -129,22 +113,22 @@ final case class TlsConfiguration(
       sslContext: SslContext,
       isServer: Boolean,
   ): Unit = {
-    val who = if (isServer) "server" else "client"
+    val who = if (isServer) "Server" else "Client"
     val tlsInfo = TlsInfo.fromSslContext(sslContext)
-    logger.info(s"TLS $who: Enabled.")
-    logger.debug(s"TLS $who: Supported protocols: ${tlsInfo.supportedProtocols.mkString(", ")}.")
-    logger.info(s"TLS $who: Enabled protocols: ${tlsInfo.enabledProtocols.mkString(", ")}.")
+    logger.info(s"$who TLS - enabled.")
+    logger.debug(s"$who TLS - supported protocols: ${tlsInfo.supportedProtocols.mkString(", ")}.")
+    logger.info(s"$who TLS - enabled protocols: ${tlsInfo.enabledProtocols.mkString(", ")}.")
     logger.debug(
-      s"TLS $who: Supported cipher suites: ${tlsInfo.supportedCipherSuites.mkString(", ")}."
+      s"$who TLS $who - supported cipher suites: ${tlsInfo.supportedCipherSuites.mkString(", ")}."
     )
-    logger.info(s"TLS $who: Enabled cipher suites: ${tlsInfo.enabledCipherSuites.mkString(", ")}.")
+    logger.info(s"$who TLS - enabled cipher suites: ${tlsInfo.enabledCipherSuites.mkString(", ")}.")
   }
 
   /** This is a side-effecting method. It modifies JVM TLS properties according to the TLS configuration. */
   def setJvmTlsProperties(): Unit =
     if (enabled && enableCertRevocationChecking) OcspProperties.enableOcsp()
 
-  private[tls] def protocolsNames(tlsInfo: TlsInfo): java.lang.Iterable[String] = {
+  private[tls] def filterSupportedProtocols(tlsInfo: TlsInfo): java.lang.Iterable[String] = {
     minimumServerProtocolVersion match {
       case None => null
       case Some(tlsVersion) =>

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsInfo.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsInfo.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.tls
+
+import io.netty.buffer.ByteBufAllocator
+import io.netty.handler.ssl.SslContext
+
+import javax.net.ssl.SSLEngine
+
+final case class TlsInfo(
+    enabledCipherSuites: Seq[String],
+    enabledProtocols: Seq[String],
+    supportedCipherSuites: Seq[String],
+    supportedProtocols: Seq[String],
+)
+
+object TlsInfo {
+  def fromSslContext(sslContext: SslContext): TlsInfo = {
+    val engine: SSLEngine = sslContext.newEngine(ByteBufAllocator.DEFAULT)
+    TlsInfo(
+      enabledCipherSuites = engine.getEnabledCipherSuites.toIndexedSeq,
+      enabledProtocols = engine.getEnabledProtocols.toIndexedSeq,
+      supportedCipherSuites = engine.getSupportedCipherSuites.toIndexedSeq,
+      supportedProtocols = engine.getSupportedProtocols.toIndexedSeq,
+    )
+  }
+}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsVersion.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsVersion.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.tls
+
+object TlsVersion {
+
+  sealed abstract class TlsVersion(val version: String) {
+    override def toString: String = version
+  }
+
+  case object V1 extends TlsVersion("TLSv1")
+
+  case object V1_1 extends TlsVersion("TLSv1.1")
+
+  case object V1_2 extends TlsVersion("TLSv1.2")
+
+  case object V1_3 extends TlsVersion("TLSv1.3")
+
+}

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/tls/TlsConfigurationTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/tls/TlsConfigurationTest.scala
@@ -66,10 +66,10 @@ class TlsConfigurationTest extends AnyWordSpec with Matchers with BeforeAndAfter
   "TlsConfiguration" should {
 
     "configure server with TLS protocol versions" which {
-      "is TLS 1.3" in {
+      "is 1.3" in {
         getServerEnabledProtocols(Some(TlsVersion.V1_3)) shouldBe Seq("SSLv2Hello", "TLSv1.3")
       }
-      "is TLS 1.2" in {
+      "is 1.2" in {
         getServerEnabledProtocols(Some(TlsVersion.V1_2)) shouldBe Seq(
           "SSLv2Hello",
           "TLSv1.2",

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/tls/TlsConfigurationTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/tls/TlsConfigurationTest.scala
@@ -3,12 +3,15 @@
 
 package com.daml.ledger.api.tls
 
-import java.io.InputStream
+import com.daml.bazeltools.BazelRunfiles.rlocation
+import com.daml.ledger.api.tls.TlsVersion.TlsVersion
+import io.netty.handler.ssl.{OpenSslClientContext, OpenSslServerContext, SslContext}
+
+import java.io.{File, InputStream}
 import java.net.ConnectException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.security.Security
-
 import org.apache.commons.io.IOUtils
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
@@ -21,6 +24,21 @@ class TlsConfigurationTest extends AnyWordSpec with Matchers with BeforeAndAfter
 
   private val Enabled = "true"
   private val Disabled = "false"
+
+  private val List(
+    certChainFilePath,
+    privateKeyFilePath,
+    trustCertCollectionFilePath,
+    clientCertChainFilePath,
+    clientPrivateKeyFilePath,
+  ) = {
+    List("server.crt", "server.pem", "ca.crt", "client.crt", "client.pem").map { src =>
+      new File(rlocation("ledger/test-common/test-certificates/" + src))
+    }
+  }
+
+  println(clientCertChainFilePath)
+  println(clientPrivateKeyFilePath)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -46,6 +64,43 @@ class TlsConfigurationTest extends AnyWordSpec with Matchers with BeforeAndAfter
   }
 
   "TlsConfiguration" should {
+
+    "configure server with TLS protocol versions" which {
+      "is TLS 1.3" in {
+        getServerEnabledProtocols(Some(TlsVersion.V1_3)) shouldBe Seq("SSLv2Hello", "TLSv1.3")
+      }
+      "is TLS 1.2" in {
+        getServerEnabledProtocols(Some(TlsVersion.V1_2)) shouldBe Seq("SSLv2Hello", "TLSv1.2")
+      }
+      "is default" in {
+        getServerEnabledProtocols(None) shouldBe Seq(
+          "SSLv2Hello",
+          "TLSv1",
+          "TLSv1.1",
+          "TLSv1.2",
+          "TLSv1.3",
+        )
+      }
+    }
+
+    "configure client with TLS protocol versions" which {
+      "is TLS 1.3" in {
+        getClientEnabledProtocols(Some(TlsVersion.V1_3)) shouldBe Seq("SSLv2Hello", "TLSv1.3")
+      }
+      "is TLS 1.2" in {
+        getClientEnabledProtocols(Some(TlsVersion.V1_2)) shouldBe Seq("SSLv2Hello", "TLSv1.2")
+      }
+      "is default" in {
+        getClientEnabledProtocols(None) shouldBe Seq(
+          "SSLv2Hello",
+          "TLSv1",
+          "TLSv1.1",
+          "TLSv1.2",
+          "TLSv1.3",
+        )
+      }
+    }
+
     "set OCSP JVM properties" in {
       disableChecks()
       verifyOcsp(Disabled)
@@ -113,6 +168,30 @@ class TlsConfigurationTest extends AnyWordSpec with Matchers with BeforeAndAfter
       e.getCause shouldBe a[ConnectException]
       e.getCause.getMessage shouldBe "Mocked url 123"
     }
+  }
+
+  private def configWithProtocols(minTls: Option[TlsVersion]): TlsConfiguration = {
+    TlsConfiguration(
+      enabled = true,
+      keyCertChainFile = Some(certChainFilePath),
+      keyFile = Some(privateKeyFilePath),
+      trustCertCollectionFile = Some(trustCertCollectionFilePath),
+      minimumServerProtocolVersion = minTls,
+    )
+  }
+
+  private def getServerEnabledProtocols(minTls: Option[TlsVersion]): Seq[String] = {
+    val sslContext: Option[SslContext] = configWithProtocols(minTls).server
+    assume(sslContext.isDefined)
+    assume(sslContext.get.isInstanceOf[OpenSslServerContext])
+    TlsInfo.fromSslContext(sslContext.get).enabledProtocols
+  }
+
+  private def getClientEnabledProtocols(minTls: Option[TlsVersion]): Seq[String] = {
+    val sslContext = configWithProtocols(minTls).client()
+    assume(sslContext.isDefined)
+    assume(sslContext.get.isInstanceOf[OpenSslClientContext])
+    TlsInfo.fromSslContext(sslContext.get).enabledProtocols
   }
 
   private def disableChecks(): Unit = {

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -226,6 +226,7 @@ conformance_test(
         "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:ca.crt))",
         "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.pem.enc))",
         "--tls-secrets-url https://raw.githubusercontent.com/digital-asset/daml/main/ledger/test-common/files/server-pem-decryption-parameters.json",
+        "--tls-version 1.3",
     ],
     test_tool_args = [
         "--verbose",

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -226,7 +226,7 @@ conformance_test(
         "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:ca.crt))",
         "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.pem.enc))",
         "--tls-secrets-url https://raw.githubusercontent.com/digital-asset/daml/main/ledger/test-common/files/server-pem-decryption-parameters.json",
-        "--tls-version 1.3",
+        "--min-tls-version 1.3",
     ],
     test_tool_args = [
         "--verbose",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -241,7 +241,7 @@ object LedgerApiTestTool {
   ): ResourceOwner[Channel] = {
     logger.info(s"Setting up managed channel to participant at $host:$port...")
     val channelBuilder = NettyChannelBuilder.forAddress(host, port).usePlaintext()
-    for (ssl <- tlsConfig; sslContext <- ssl.client) {
+    for (ssl <- tlsConfig; sslContext <- ssl.client()) {
       logger.info("Setting up managed channel with transport security.")
       channelBuilder
         .useTransportSecurity()

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/Readers.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/Readers.scala
@@ -3,8 +3,10 @@
 
 package com.daml.platform.configuration
 
-import java.time.Duration
+import com.daml.ledger.api.tls.TlsVersion
+import com.daml.ledger.api.tls.TlsVersion.TlsVersion
 
+import java.time.Duration
 import io.netty.handler.ssl.ClientAuth
 import scopt.Read
 
@@ -22,6 +24,13 @@ object Readers {
     case "require" => ClientAuth.REQUIRE
     case _ =>
       throw new InvalidConfigException(s"""Must be one of "none", "optional", or "require".""")
+  }
+
+  implicit val tlsVersionRead: Read[TlsVersion] = Read.reads {
+    case "1.2" => TlsVersion.V1_2
+    case "1.3" => TlsVersion.V1_3
+    case _ =>
+      throw new InvalidConfigException(s"""Must be one of "1.2" or "1.3".""")
   }
 
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/apiserver/tls/TlsFixture.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/apiserver/tls/TlsFixture.scala
@@ -101,7 +101,7 @@ case class TlsFixture(
     applicationId = s"TlsCertificates-app",
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = clientTlsConfiguration.client,
+    sslContext = clientTlsConfiguration.client(),
     token = None,
   )
 

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -379,7 +379,7 @@ object Config {
             config.withTlsConfig(c => c.copy(clientAuth = clientAuth))
           )
 
-        opt[TlsVersion]("tls-version")
+        opt[TlsVersion]("min-tls-version")
           .optional()
           .text(
             "TLS: Indicates the minimum TLS version to enable. If specified must be either '1.2' or '1.3'."

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -8,8 +8,8 @@ import java.nio.file.Path
 import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-
 import com.daml.caching
+import com.daml.ledger.api.tls.TlsVersion.TlsVersion
 import com.daml.ledger.api.tls.{SecretsUrl, TlsConfiguration}
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.lf.VersionRange
@@ -377,6 +377,15 @@ object Config {
           )
           .action((clientAuth, config) =>
             config.withTlsConfig(c => c.copy(clientAuth = clientAuth))
+          )
+
+        opt[TlsVersion]("tls-version")
+          .optional()
+          .text(
+            "TLS: Indicates the minimum TLS version to enable. If specified must be either '1.2' or '1.3'."
+          )
+          .action((tlsVersion, config) =>
+            config.withTlsConfig(c => c.copy(minimumServerProtocolVersion = Some(tlsVersion)))
           )
 
         opt[Int]("max-commands-in-flight")

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
@@ -5,8 +5,7 @@ package com.daml.ledger.participant.state.kvutils.app
 
 import java.io.File
 import java.time.Duration
-
-import com.daml.ledger.api.tls.{SecretsUrl, TlsConfiguration}
+import com.daml.ledger.api.tls.{SecretsUrl, TlsConfiguration, TlsVersion}
 import com.daml.lf.data.Ref
 import io.netty.handler.ssl.ClientAuth
 import org.scalatest.OptionValues
@@ -92,6 +91,36 @@ final class ConfigSpec
         "key.enc",
       )
     ) shouldBe None
+  }
+
+  it should "fail parsing a bogus TLS version" in {
+    configParser(
+      Seq(
+        dumpIndexMetadataCommand,
+        "some-jdbc-url",
+        "--tls-version",
+        "111",
+      )
+    ) shouldBe None
+  }
+
+  it should "succeed parsing a supported TLS version" in {
+    val actual = configParser(
+      Seq(
+        dumpIndexMetadataCommand,
+        "some-jdbc-url",
+        "--tls-version",
+        "1.3",
+      )
+    )
+
+    actual should not be None
+    actual.get.tlsConfig shouldBe Some(
+      TlsConfiguration(
+        enabled = true,
+        minimumServerProtocolVersion = Some(TlsVersion.V1_3),
+      )
+    )
   }
 
   it should "succeed when server's private key is in plaintext and secret-url is not provided" in {

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
@@ -98,7 +98,7 @@ final class ConfigSpec
       Seq(
         dumpIndexMetadataCommand,
         "some-jdbc-url",
-        "--tls-version",
+        "--min-tls-version",
         "111",
       )
     ) shouldBe None
@@ -109,7 +109,7 @@ final class ConfigSpec
       Seq(
         dumpIndexMetadataCommand,
         "some-jdbc-url",
-        "--tls-version",
+        "--min-tls-version",
         "1.3",
       )
     )

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -176,6 +176,7 @@ da_scala_library(
         "//libs-scala/timer-utils",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:io_dropwizard_metrics_metrics_core",
+        "@maven//:io_netty_netty_handler",
         "@maven//:org_scalatest_scalatest_compatible",
         "@maven//:org_slf4j_slf4j_api",
     ],

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/TlsEnabledServerIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/TlsEnabledServerIT.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox
+
+import com.daml.ledger.api.tls.TlsVersion
+import com.daml.platform.sandbox.services.SandboxFixture
+
+class Tls1_2EnabledServerIT extends BaseTlsServerIT(Some(TlsVersion.V1_2)) with SandboxFixture
+
+class Tls1_3EnabledServerIT extends BaseTlsServerIT(Some(TlsVersion.V1_3)) with SandboxFixture

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/TlsIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/TlsIT.scala
@@ -4,10 +4,10 @@
 package com.daml.platform.sandbox
 
 import java.io.File
-
 import com.daml.bazeltools.BazelRunfiles._
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
-import com.daml.ledger.api.tls.TlsConfiguration
+import com.daml.ledger.api.tls.{TlsConfiguration, TlsVersion}
+import com.daml.ledger.api.tls.TlsVersion.TlsVersion
 import com.daml.ledger.api.v1.transaction_service.GetLedgerEndResponse
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
@@ -43,15 +43,15 @@ class TlsIT extends AsyncWordSpec with SandboxFixture with SuiteResourceManageme
       None,
     )
 
-  private def tlsEnabledConfig(protocols: Seq[String]): LedgerClientConfiguration =
+  private def tlsEnabledConfig(minimumProtocolVersion: TlsVersion): LedgerClientConfiguration =
     baseConfig.copy(sslContext =
       TlsConfiguration(
         enabled = true,
         Some(clientCertChainFilePath),
         Some(clientPrivateKeyFilePath),
         Some(trustCertCollectionFilePath),
-        protocols = protocols,
-      ).client
+        minimumServerProtocolVersion = Some(minimumProtocolVersion),
+      ).client()
     )
 
   override protected lazy val config: SandboxConfig =
@@ -62,12 +62,13 @@ class TlsIT extends AsyncWordSpec with SandboxFixture with SuiteResourceManageme
           Some(certChainFilePath),
           Some(privateKeyFilePath),
           Some(trustCertCollectionFilePath),
+          minimumServerProtocolVersion = None,
         )
       )
     )
 
-  private def clientF(protocol: String) =
-    LedgerClient.singleHost(serverHost, serverPort.value, tlsEnabledConfig(Seq(protocol)))
+  private def clientF(protocol: TlsVersion) =
+    LedgerClient.singleHost(serverHost, serverPort.value, tlsEnabledConfig(protocol))
 
   "A TLS-enabled server" should {
     "reject ledger queries when the client connects without tls" in {
@@ -79,14 +80,14 @@ class TlsIT extends AsyncWordSpec with SandboxFixture with SuiteResourceManageme
     }
 
     "serve ledger queries when the client presents a valid certificate" in {
-      def testWith(protocol: String): Future[GetLedgerEndResponse] =
+      def testWith(protocol: TlsVersion): Future[GetLedgerEndResponse] =
         withClue(s"Testing with $protocol") {
           clientF(protocol).flatMap(_.transactionClient.getLedgerEnd())
         }
 
       for {
-        _ <- testWith("TLSv1.2")
-        _ <- testWith("TLSv1.3")
+        _ <- testWith(TlsVersion.V1_1)
+        _ <- testWith(TlsVersion.V1_3)
       } yield succeed
     }
   }

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -5,11 +5,11 @@ package com.daml.platform.sandbox.cli
 
 import java.io.File
 import java.time.Duration
-
 import com.daml.buildinfo.BuildInfo
 import com.daml.jwt.JwtVerifierConfigurationCli
 import com.daml.ledger.api.auth.AuthServiceJWT
 import com.daml.ledger.api.domain.LedgerId
+import com.daml.ledger.api.tls.TlsVersion.TlsVersion
 import com.daml.ledger.api.tls.{SecretsUrl, TlsConfiguration}
 import com.daml.ledger.configuration.LedgerTimeModel
 import com.daml.lf.data.Ref
@@ -193,6 +193,15 @@ class CommonCliBase(name: LedgerName) {
                 )
               )(c => Some(c.copy(clientAuth = clientAuth)))
           )
+        )
+
+      opt[TlsVersion]("tls-version")
+        .optional()
+        .text(
+          "TLS: Indicates the minimum TLS version to enable. If specified must be either '1.2' or '1.3'."
+        )
+        .action((tlsVersion, config) =>
+          config.withTlsConfig(c => c.copy(minimumServerProtocolVersion = Some(tlsVersion)))
         )
 
       opt[Boolean]("cert-revocation-checking")

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -195,7 +195,7 @@ class CommonCliBase(name: LedgerName) {
           )
         )
 
-      opt[TlsVersion]("tls-version")
+      opt[TlsVersion]("min-tls-version")
         .optional()
         .text(
           "TLS: Indicates the minimum TLS version to enable. If specified must be either '1.2' or '1.3'."

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/BaseTlsServerIT.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/BaseTlsServerIT.scala
@@ -1,0 +1,167 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox
+
+import com.daml.bazeltools.BazelRunfiles._
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.ledger.api.tls.{TlsConfiguration, TlsVersion}
+import com.daml.ledger.api.tls.TlsVersion.TlsVersion
+import com.daml.ledger.api.v1.transaction_service.GetLedgerEndResponse
+import com.daml.ledger.client.LedgerClient
+import com.daml.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement,
+}
+import com.daml.platform.sandbox.config.SandboxConfig
+import io.netty.handler.ssl.ClientAuth
+import io.grpc.StatusRuntimeException
+import org.scalatest.Assertion
+import org.scalatest.exceptions.ModifiableMessage
+import org.scalatest.wordspec.AsyncWordSpec
+
+import java.io.File
+import scala.concurrent.Future
+
+abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
+    extends AsyncWordSpec
+    with AbstractSandboxFixture
+    with SuiteResourceManagementAroundAll {
+
+  minimumServerProtocolVersion match {
+    case Some(TlsVersion.V1_3) =>
+      "A server with TLSv1.3 or higher enabled" should {
+        "accept client connections secured equal of higher than TLSv1.3" in {
+          for {
+            _ <- assertSuccessfulClient(enabledProtocols = Seq(TlsVersion.V1_3))
+          } yield succeed
+        }
+        "reject client connections secured lower than TLSv1.3" in {
+          for {
+            _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1))
+            _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1_1))
+            _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1_2))
+          } yield succeed
+        }
+      }
+    case Some(TlsVersion.V1_2) =>
+      "A server with TLSv1.2 or higher enabled" should {
+        "accept client connections secured equal of higher than TLSv1.2" in {
+          for {
+            _ <- assertSuccessfulClient(enabledProtocols = Seq(TlsVersion.V1_3))
+            _ <- assertSuccessfulClient(enabledProtocols = Seq(TlsVersion.V1_2))
+          } yield succeed
+        }
+        "reject client connections secured lower than TLSv1.2" in {
+          for {
+            _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1))
+            _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1_1))
+          } yield succeed
+        }
+      }
+    case other =>
+      throw new IllegalArgumentException(s"Not test cases found for TLS version: |${other}|!")
+  }
+
+  protected val List(
+    certChainFilePath,
+    privateKeyFilePath,
+    trustCertCollectionFilePath,
+    clientCertChainFilePath,
+    clientPrivateKeyFilePath,
+  ) = {
+    List("server.crt", "server.pem", "ca.crt", "client.crt", "client.pem").map { src =>
+      new File(rlocation("ledger/test-common/test-certificates/" + src))
+    }
+  }
+
+  override protected def config: SandboxConfig =
+    super.config.copy(
+      tlsConfig = Some(
+        TlsConfiguration(
+          enabled = true,
+          Some(certChainFilePath),
+          Some(privateKeyFilePath),
+          Some(trustCertCollectionFilePath),
+          minimumServerProtocolVersion = minimumServerProtocolVersion,
+          clientAuth = ClientAuth.NONE,
+        )
+      )
+    )
+
+  private lazy val clientConfig_noTls: LedgerClientConfiguration =
+    LedgerClientConfiguration(
+      "appId",
+      LedgerIdRequirement.none,
+      CommandClientConfiguration.default,
+      None,
+    )
+
+  protected def assertFailedClient(enabledProtocols: Seq[TlsVersion]): Future[Assertion] = {
+    // given
+    val clientConfig = if (enabledProtocols.nonEmpty) {
+      getClientConfigWithTls(enabledProtocols)
+    } else {
+      clientConfig_noTls
+    }
+    val clueMsg = s"Client enabled following protocols: ${enabledProtocols}. "
+    val prependClueMsg: Throwable => Throwable = {
+      case e: ModifiableMessage[_] =>
+        e.modifyMessage(_.map(clueMsg + _))
+      case t => t
+    }
+
+    // when
+    recoverToSucceededIf[StatusRuntimeException] {
+      createLedgerClient(clientConfig).flatMap(_.transactionClient.getLedgerEnd())
+    }.transform(
+      identity,
+      prependClueMsg,
+    )
+  }
+
+  protected def assertSuccessfulClient(enabledProtocols: Seq[TlsVersion]): Future[Assertion] = {
+    // given
+    val clientConfig = if (enabledProtocols.nonEmpty) {
+      getClientConfigWithTls(enabledProtocols)
+    } else {
+      clientConfig_noTls
+    }
+    val clueMsg = s"Client enabled protocols: ${enabledProtocols}. "
+    val addClueThrowable: Throwable => Throwable = { t =>
+      new Throwable(clueMsg + "Test failed with an exception. See the cause.", t)
+    }
+
+    // when
+    val response: Future[GetLedgerEndResponse] =
+      createLedgerClient(clientConfig).flatMap(_.transactionClient.getLedgerEnd())
+
+    // then
+    response.value
+    response
+      .map { response =>
+        assert(response ne null)
+        assert(response.isInstanceOf[GetLedgerEndResponse])
+      }
+      .transform(identity, addClueThrowable)
+  }
+
+  private def getClientConfigWithTls(
+      enabledProtocols: Seq[TlsVersion]
+  ): LedgerClientConfiguration = {
+    val tlsConfiguration = TlsConfiguration(
+      enabled = true,
+      Some(clientCertChainFilePath),
+      Some(clientPrivateKeyFilePath),
+      Some(trustCertCollectionFilePath),
+    )
+    val sslContext = tlsConfiguration.client(enabledProtocols = enabledProtocols)
+    clientConfig_noTls.copy(sslContext = sslContext)
+  }
+
+  private def createLedgerClient(config: LedgerClientConfiguration): Future[LedgerClient] = {
+    LedgerClient.singleHost(hostIp = serverHost, port = serverPort.value, configuration = config)
+  }
+
+}

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/BaseTlsServerIT.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/BaseTlsServerIT.scala
@@ -39,6 +39,7 @@ abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
         }
         "reject client connections secured lower than TLSv1.3" in {
           for {
+            _ <- assertFailedClient(enabledProtocols = Seq.empty)
             _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1))
             _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1_1))
             _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1_2))
@@ -55,6 +56,7 @@ abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
         }
         "reject client connections secured lower than TLSv1.2" in {
           for {
+            _ <- assertFailedClient(enabledProtocols = Seq.empty)
             _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1))
             _ <- assertFailedClient(enabledProtocols = Seq(TlsVersion.V1_1))
           } yield succeed

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
@@ -6,9 +6,8 @@ package com.daml.platform.sandbox.cli
 import java.io.File
 import java.net.InetSocketAddress
 import java.nio.file.{Files, Paths}
-
 import com.daml.bazeltools.BazelRunfiles.rlocation
-import com.daml.ledger.api.tls.{SecretsUrl, TlsConfiguration}
+import com.daml.ledger.api.tls.{SecretsUrl, TlsConfiguration, TlsVersion}
 import com.daml.ledger.test.ModelTestDar
 import com.daml.lf.data.Ref
 import com.daml.metrics.MetricsReporter
@@ -139,6 +138,33 @@ abstract class CommonCliSpecBase(
           )
         ),
       )
+    }
+
+    "fail parsing a bogus TLS version" in {
+      checkOptionFail(
+        Array(
+          "--tls-version",
+          "111",
+        )
+      )
+    }
+
+    "succeed parsing a supported TLS version" in {
+      checkOption(
+        Array(
+          "--tls-version",
+          "1.3",
+        ),
+        _.copy(tlsConfig =
+          Some(
+            TlsConfiguration(
+              enabled = true,
+              minimumServerProtocolVersion = Some(TlsVersion.V1_3),
+            )
+          )
+        ),
+      )
+
     }
 
     "fail when server's private key is encrypted but secret-url is not provided" in {

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
@@ -143,7 +143,7 @@ abstract class CommonCliSpecBase(
     "fail parsing a bogus TLS version" in {
       checkOptionFail(
         Array(
-          "--tls-version",
+          "--min-tls-version",
           "111",
         )
       )
@@ -152,7 +152,7 @@ abstract class CommonCliSpecBase(
     "succeed parsing a supported TLS version" in {
       checkOption(
         Array(
-          "--tls-version",
+          "--min-tls-version",
           "1.3",
         ),
         _.copy(tlsConfig =

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Main.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Main.scala
@@ -5,6 +5,7 @@ package com.daml.platform.sandboxnext
 
 import com.daml.ledger.resources.ResourceContext
 import com.daml.cliopts.GlobalLogLevel
+import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.resources.ProgramResource
 
 object Main {
@@ -14,7 +15,7 @@ object Main {
     // so akka doesn't need to be clever and emit this warning when CTRL-C-ing the sandbox:
     // [CoordinatedShutdown(akka://sandbox)] Could not addJvmShutdownHook, due to: Shutdown in progress
     System.setProperty("akka.jvm-shutdown-hooks", "off")
-    val config = Cli.parse(args).getOrElse(sys.exit(1))
+    val config: SandboxConfig = Cli.parse(args).getOrElse(sys.exit(1))
     config.logLevel.foreach(GlobalLogLevel.set("Sandbox"))
     new ProgramResource(new Runner(config)).run(ResourceContext.apply)
   }

--- a/ledger/sandbox/src/test/suite/scala/platform/sandboxnext/TlsEnabledServerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/platform/sandboxnext/TlsEnabledServerIT.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandboxnext
+
+import com.daml.ledger.api.tls.TlsVersion
+import com.daml.platform.sandbox.BaseTlsServerIT
+
+class Tls1_2EnabledServerIT extends BaseTlsServerIT(Some(TlsVersion.V1_2)) with SandboxNextFixture
+
+class Tls1_3EnabledServerIT extends BaseTlsServerIT(Some(TlsVersion.V1_3)) with SandboxNextFixture

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -77,7 +77,7 @@ object RunnerMain {
           ledgerIdRequirement = LedgerIdRequirement.none,
           commandClient =
             CommandClientConfiguration.default.copy(defaultDeduplicationTime = config.commandTtl),
-          sslContext = config.tlsConfig.client,
+          sslContext = config.tlsConfig.client(),
           token = tokenHolder.flatMap(_.token),
           maxInboundMessageSize = config.maxInboundMessageSize,
         )

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
@@ -37,7 +37,7 @@ class Tls
 
   override protected def ledgerClientConfiguration =
     super.ledgerClientConfiguration
-      .copy(sslContext = TlsConfiguration(enabled = true, clientCrt, clientPem, caCrt).client)
+      .copy(sslContext = TlsConfiguration(enabled = true, clientCrt, clientPem, caCrt).client())
 
   "TLS" can {
     // We just need something simple to test the connection.


### PR DESCRIPTION

- Add support for specifying either 1.2 or 1.3 as minimum TLS versions for ledger api server.
- Log enabled protocols (~TLS versions) and cipher suites at server and client startup.
- Add integration tests against Sandbox-classic and Sandbox

CHANGELOG_BEGIN
Sandbox: Add CLI flag to select minimum enabled TLS version for participant server.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
