### PR TITLE
[docs] Fix minor typo in doc of exerciseByKey in TS.

### DIFF
--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -568,7 +568,7 @@ class Ledger {
    * contract id.
    *
    * @param choice The choice to exercise.
-   * @param contractId The contract id of the contract to exercise.
+   * @param key The contract key of the contract to exercise.
    * @param argument The choice arguments.
    *
    * @typeparam T The contract template type.


### PR DESCRIPTION
changelog_begin
changelog_end
