### PR TITLE
interfaces: scala typechecker implementation

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -846,21 +846,18 @@ checkTemplate m t@(Template _loc tpl param precond signatories observers text ch
   where
     withPart p = withContext (ContextTemplate m t p)
 
-checkIfaceImplementation ::
-     MonadGamma m
-  => Qualified TypeConName
-  -> Qualified TypeConName
-  -> m ()
-checkIfaceImplementation tplTcon ifTcon
-  | qualPackage tplTcon == qualPackage ifTcon
-    && qualModule tplTcon == qualModule tplTcon = do
-    DefInterface {intChoices} <- inWorld $ lookupInterface ifTcon
-    forM_ intChoices $ \InterfaceChoice {ifcName, ifcConsuming, ifcArgType, ifcRetType} -> do
-      TemplateChoice {chcConsuming, chcArgBinder, chcReturnType} <- inWorld $ lookupChoice (tplTcon, ifcName)
-      unless (chcConsuming == ifcConsuming) $ throwWithContext $ EBadInterfaceChoiceImplConsuming ifcName ifcConsuming chcConsuming
-      unless (alphaType (snd chcArgBinder) ifcArgType) $ throwWithContext $ EBadInterfaceChoiceImplArgType ifcName ifcArgType (snd chcArgBinder)
-      unless (alphaType chcReturnType ifcRetType) $ throwWithContext $ EBadInterfaceChoiceImplRetType ifcName ifcRetType chcReturnType
-  | otherwise = throwWithContext $ EForeignInterfaceImplementation ifTcon
+checkIfaceImplementation :: MonadGamma m => Qualified TypeConName -> Qualified TypeConName -> m ()
+checkIfaceImplementation tplTcon ifTcon = do
+  DefInterface {intChoices} <- inWorld $ lookupInterface ifTcon
+  forM_ intChoices $ \InterfaceChoice {ifcName, ifcConsuming, ifcArgType, ifcRetType} -> do
+    TemplateChoice {chcConsuming, chcArgBinder, chcReturnType} <-
+      inWorld $ lookupChoice (tplTcon, ifcName)
+    unless (chcConsuming == ifcConsuming) $
+      throwWithContext $ EBadInterfaceChoiceImplConsuming ifcName ifcConsuming chcConsuming
+    unless (alphaType (snd chcArgBinder) ifcArgType) $
+      throwWithContext $ EBadInterfaceChoiceImplArgType ifcName ifcArgType (snd chcArgBinder)
+    unless (alphaType chcReturnType ifcRetType) $
+      throwWithContext $ EBadInterfaceChoiceImplRetType ifcName ifcRetType chcReturnType
 
 _checkFeature :: MonadGamma m => Feature -> m ()
 _checkFeature feature = do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -842,19 +842,18 @@ checkTemplate m t@(Template _loc tpl param precond signatories observers text ch
     withPart TPAgreement $ checkExpr text TText
     for_ choices $ \c -> withPart (TPChoice c) $ checkTemplateChoice tcon c
   whenJust mbKey $ checkTemplateKey param tcon
-  forM_ implements $ checkIfaceImplementation (moduleName m) tcon
+  forM_ implements $ checkIfaceImplementation tcon
   where
     withPart p = withContext (ContextTemplate m t p)
 
 checkIfaceImplementation ::
      MonadGamma m
-  => ModuleName
-  -> Qualified TypeConName
+  => Qualified TypeConName
   -> Qualified TypeConName
   -> m ()
-checkIfaceImplementation modName tplTcon ifTcon
-  | Qualified PRSelf m _tconName <- ifTcon
-  , m == modName = do
+checkIfaceImplementation tplTcon ifTcon
+  | qualPackage tplTcon == qualPackage ifTcon
+    && qualModule tplTcon == qualModule tplTcon = do
     DefInterface {intChoices} <- inWorld $ lookupInterface ifTcon
     forM_ intChoices $ \InterfaceChoice {ifcName, ifcConsuming, ifcArgType, ifcRetType} -> do
       TemplateChoice {chcConsuming, chcArgBinder, chcReturnType} <- inWorld $ lookupChoice (tplTcon, ifcName)

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -137,7 +137,6 @@ data Error
   | EBadInterfaceChoiceImplConsuming !ChoiceName !Bool !Bool
   | EBadInterfaceChoiceImplArgType !ChoiceName !Type !Type
   | EBadInterfaceChoiceImplRetType !ChoiceName !Type !Type
-  | EForeignInterfaceImplementation !(Qualified TypeConName)
 
 contextLocation :: Context -> Maybe SourceLoc
 contextLocation = \case
@@ -400,7 +399,6 @@ instance Pretty Error where
       , "Expected: " <> pretty ifaceRetType
       , "But got: " <> pretty tplRetType
       ]
-    EForeignInterfaceImplementation tcon -> "The definition and implementation for the interface " <> pretty tcon <> " need to be in the same module."
 
 prettyConsuming :: Bool -> Doc ann
 prettyConsuming consuming = if consuming then "consuming" else "non-consuming"

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Interface.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Interface.scala
@@ -207,6 +207,21 @@ private[lf] class Interface(signatures: PartialFunction[PackageId, PackageSignat
   ): Either[LookupError, TemplateChoiceSignature] =
     lookupChoice(tmpName, chName, Reference.Choice(tmpName, chName))
 
+  private[this] def lookupInterfaceChoice(
+      tmpName: TypeConName,
+      chName: ChoiceName,
+      context: => Reference,
+  ): Either[LookupError, InterfaceChoice] =
+    lookupInterface(tmpName, context).flatMap(
+      _.choices.get(chName).toRight(LookupError(Reference.Choice(tmpName, chName), context))
+    )
+
+  def lookupInterfaceChoice(
+      tmpName: TypeConName,
+      chName: ChoiceName,
+  ): Either[LookupError, InterfaceChoice] =
+    lookupInterfaceChoice(tmpName, chName, Reference.Choice(tmpName, chName))
+
   private[this] def lookupTemplateKey(
       name: TypeConName,
       context: => Reference,

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Interface.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Interface.scala
@@ -179,6 +179,19 @@ private[lf] class Interface(signatures: PartialFunction[PackageId, PackageSignat
   def lookupTemplate(name: TypeConName): Either[LookupError, TemplateSignature] =
     lookupTemplate(name, Reference.Template(name))
 
+  private[this] def lookupInterface(
+      name: TypeConName,
+      context: => Reference,
+  ): Either[LookupError, DefInterface] =
+    lookupModule(name.packageId, name.qualifiedName.module, context).flatMap(
+      _.interfaces
+        .get(name.qualifiedName.name)
+        .toRight(LookupError(Reference.Interface(name), context))
+    )
+
+  def lookupInterface(name: TypeConName): Either[LookupError, DefInterface] =
+    lookupInterface(name, Reference.Interface(name))
+
   private[this] def lookupChoice(
       tmpName: TypeConName,
       chName: ChoiceName,

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LookupError.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LookupError.scala
@@ -95,6 +95,10 @@ object Reference {
     override def pretty: String = s"template $tyCon"
   }
 
+  final case class Interface(tyCon: TypeConName) extends Reference {
+    override def pretty: String = s"interface $tyCon"
+  }
+
   final case class TemplateKey(tyCon: TypeConName) extends Reference {
     override def pretty: String = s"template without contract key $tyCon."
   }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Collision.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Collision.scala
@@ -63,10 +63,9 @@ private[validation] object Collision {
       case dDef @ Ast.DDataType(_, _, Ast.DataEnum(values)) =>
         val enumDef = NEnumDef(module, defName, dDef)
         enumDef :: values.toList.map(NEnumCon(enumDef, _))
-      case Ast.DDataType(_, _, Ast.DataInterface) =>
-        // TODO https://github.com/digital-asset/daml/issues/10810
-        //  handle interfaces
-        List.empty
+      case iDef @ Ast.DDataType(_, _, Ast.DataInterface) =>
+        val interfaceDef = NInterface(module, defName, iDef)
+        interfaceDef :: List.empty
       case _: Ast.DValue =>
         // ignore values
         List.empty

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/NamedEntity.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/NamedEntity.scala
@@ -143,4 +143,19 @@ object NamedEntity {
     def pretty: String = s"variant constructor $modName:${dfn.name}:$name"
   }
 
+  final case class NInterface(
+      module: NModDef,
+      name: DottedName,
+      dfn: Ast.DDataType,
+  ) extends NamedEntity {
+
+    def modName: ModuleName = module.name
+
+    val fullyResolvedName: DottedName =
+      module.fullyResolvedName ++ name.toUpperCase
+
+    override def toString: String = s"NInterface($modName:$name)"
+
+    def pretty: String = s"interface $modName:$name"
+  }
 }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -467,11 +467,32 @@ private[validation] object Typing {
       choices.values.foreach { case InterfaceChoice(name, consuming, argType, returnType) =>
         val tplChoice = handleLookup(ctx, interface.lookupChoice(tplTcon, name))
         if (tplChoice.consuming != consuming)
-          throw EBadInterfaceChoiceImplConsuming(ctx, ifaceTcon, tplTcon, name, consuming, tplChoice.consuming)
+          throw EBadInterfaceChoiceImplConsuming(
+            ctx,
+            ifaceTcon,
+            tplTcon,
+            name,
+            consuming,
+            tplChoice.consuming,
+          )
         if (!alphaEquiv(tplChoice.argBinder._2, argType))
-          throw EBadInterfaceChoiceImplArgType(ctx, ifaceTcon, tplTcon, name, argType, tplChoice.argBinder._2)
+          throw EBadInterfaceChoiceImplArgType(
+            ctx,
+            ifaceTcon,
+            tplTcon,
+            name,
+            argType,
+            tplChoice.argBinder._2,
+          )
         if (!alphaEquiv(tplChoice.returnType, returnType))
-          throw EBadInterfaceChoiceImplRetType(ctx, ifaceTcon, tplTcon, name, returnType, tplChoice.returnType)
+          throw EBadInterfaceChoiceImplRetType(
+            ctx,
+            ifaceTcon,
+            tplTcon,
+            name,
+            returnType,
+            tplChoice.returnType,
+          )
       }
     }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -463,9 +463,6 @@ private[validation] object Typing {
     }
 
     def checkIfaceImplementation(tplTcon: TypeConName, ifaceTcon: TypeConName): Unit = {
-      if (
-        !(tplTcon.packageId == ifaceTcon.packageId && tplTcon.qualifiedName.module == ifaceTcon.qualifiedName.module)
-      ) throw EForeignInterfaceImplementation(ctx, ifaceTcon, tplTcon)
       val DefInterface(choices) = handleLookup(ctx, interface.lookupInterface(ifaceTcon))
       choices.values.foreach { case InterfaceChoice(name, consuming, argType, returnType) =>
         val tplChoice = handleLookup(ctx, interface.lookupChoice(tplTcon, name))

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -416,15 +416,6 @@ final case class EModuleVersionDependencies(
 
   override def context: Context = NoContext
 }
-final case class EForeignInterfaceImplementation(
-    context: Context,
-    iface: TypeConName,
-    template: TypeConName,
-) extends ValidationError {
-
-  override protected def prettyInternal: String =
-    s"The template $template and the implementation for the interface $iface need to be in the same module."
-}
 
 final case class EBadInterfaceChoiceImplConsuming(
     context: Context,

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -419,41 +419,50 @@ final case class EModuleVersionDependencies(
 final case class EForeignInterfaceImplementation(
     context: Context,
     iface: TypeConName,
+    template: TypeConName,
 ) extends ValidationError {
 
   override protected def prettyInternal: String =
-    s"The definition and implementation for the interface $iface need to be in the same module."
+    s"The template $template and the implementation for the interface $iface need to be in the same module."
 }
 
 final case class EBadInterfaceChoiceImplConsuming(
     context: Context,
+    iface: TypeConName,
+    template: TypeConName,
     choice: ChoiceName,
     ifaceConsuming: Boolean,
     tplConsuming: Boolean,
 ) extends ValidationError {
 
+  def prettyConsuming(consuming: Boolean): String = if (consuming) "consuming" else "non-consuming"
+
   override protected def prettyInternal: String =
-    s"Choice implementation and interface definition for $choice differ in consuming/non-consuming behaviour.\nExpected: $ifaceConsuming\nBut got: $tplConsuming\n"
+    s"The implementation of the choice $choice of interface $iface in template $template differs from the interface definition in the consuming/non-consuming behaviour.\nExpected: ${prettyConsuming(ifaceConsuming)}\n But got: ${prettyConsuming(tplConsuming)}"
 }
 
 final case class EBadInterfaceChoiceImplArgType(
     context: Context,
+    iface: TypeConName,
+    template: TypeConName,
     choice: ChoiceName,
     ifaceArgType: Type,
     tplArgType: Type,
 ) extends ValidationError {
 
   override protected def prettyInternal: String =
-    s"Choice implementation and interface definition for $choice differ in argument type.\nExpected: $ifaceArgType\n But got: $tplArgType"
+    s"The implementation of the choice $choice of interface $iface in template $template differs from the interface definition in the argument type.\nExpected: $ifaceArgType\n But got: $tplArgType"
 }
 
 final case class EBadInterfaceChoiceImplRetType(
     context: Context,
+    iface: TypeConName,
+    template: TypeConName,
     choice: ChoiceName,
     ifaceRetType: Type,
     tplRetType: Type,
 ) extends ValidationError {
 
   override protected def prettyInternal: String =
-    s"Choice implementation and interface defintion for $choice differ in return type.\nExpected: $ifaceRetType\nBut got: $tplRetType"
+    s"The implementation of the choice $choice of interface $iface in template $template differs from the interface definition in the return type.\nExpected: $ifaceRetType\n But got: $tplRetType"
 }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -27,6 +27,9 @@ final case class ContextTemplate(tycon: TypeConName) extends Context {
 final case class ContextDefException(tycon: TypeConName) extends Context {
   def pretty: String = s"exception definition ${tycon.qualifiedName}"
 }
+final case class ContextDefInterface(tycon: TypeConName) extends Context {
+  def pretty: String = s"interface definition ${tycon.qualifiedName}"
+}
 final case class ContextDefValue(ref: ValueRef) extends Context {
   def pretty: String = s"value definition ${ref.qualifiedName}"
 }
@@ -366,6 +369,10 @@ final case class EIllegalHigherEnumType(context: Context, defn: TypeConName)
     extends ValidationError {
   protected def prettyInternal: String = s"illegal higher order enum type"
 }
+final case class EIllegalHigherInterfaceType(context: Context, defn: TypeConName)
+    extends ValidationError {
+  protected def prettyInternal: String = s"illegal higher interface type"
+}
 final case class EIllegalEnumArgument(context: Context, typ: Type) extends ValidationError {
   protected def prettyInternal: String = s"illegal non Unit enum argument"
 }
@@ -408,4 +415,45 @@ final case class EModuleVersionDependencies(
     s"package $pkgId using version $pkgLangVersion depends on package $depPkgId using newer version $dependencyLangVersion"
 
   override def context: Context = NoContext
+}
+final case class EForeignInterfaceImplementation(
+    context: Context,
+    iface: TypeConName,
+) extends ValidationError {
+
+  override protected def prettyInternal: String =
+    s"The definition and implementation for the interface $iface need to be in the same module."
+}
+
+final case class EBadInterfaceChoiceImplConsuming(
+    context: Context,
+    choice: ChoiceName,
+    ifaceConsuming: Boolean,
+    tplConsuming: Boolean,
+) extends ValidationError {
+
+  override protected def prettyInternal: String =
+    s"Choice implementation and interface definition for $choice differ in consuming/non-consuming behaviour.\nExpected: $ifaceConsuming\nBut got: $tplConsuming\n"
+}
+
+final case class EBadInterfaceChoiceImplArgType(
+    context: Context,
+    choice: ChoiceName,
+    ifaceArgType: Type,
+    tplArgType: Type,
+) extends ValidationError {
+
+  override protected def prettyInternal: String =
+    s"Choice implementation and interface definition for $choice differ in argument type.\nExpected: $ifaceArgType\n But got: $tplArgType"
+}
+
+final case class EBadInterfaceChoiceImplRetType(
+    context: Context,
+    choice: ChoiceName,
+    ifaceRetType: Type,
+    tplRetType: Type,
+) extends ValidationError {
+
+  override protected def prettyInternal: String =
+    s"Choice implementation and interface defintion for $choice differ in return type.\nExpected: $ifaceRetType\nBut got: $tplRetType"
 }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/CollisionSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/CollisionSpec.scala
@@ -15,6 +15,7 @@ class CollisionSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCh
   def check(pkg: Package): Unit =
     Collision.checkPackage(defaultPackageId, pkg)
 
+  // TODO add check for collision of interface names.
   "Collision validation" should {
 
     "detect collisions of record fields" in {

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -322,6 +322,7 @@ class TypingSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matcher
       }
     }
 
+    //TODO add a check for exerciseInterface/checkInterface.
     "infers proper type for Update" in {
       val testCases = Table(
         "expression" ->
@@ -799,6 +800,8 @@ class TypingSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matcher
       }
     }
 
+    //TODO add check for interface definitions.
+    //TODO add check for interface implementations.
     "reject ill formed template definition" in {
 
       val pkg =


### PR DESCRIPTION
This is the scala side of the lf typechecker for interfaces #10810 .

There's also a cosmetic change in the haskell typechecker I corrected.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
