### PR TITLE
Prevent concurrent access to recorded request in mock

### DIFF
--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/CommandSubmissionServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/CommandSubmissionServiceImpl.scala
@@ -21,12 +21,14 @@ final class CommandSubmissionServiceImpl(getResponse: () => Future[Empty])
 
   @volatile private var submittedRequest: Option[SubmitRequest] = None
 
-  override def submit(request: SubmitRequest): Future[Empty] = {
+  override def submit(request: SubmitRequest): Future[Empty] = submittedRequest.synchronized {
     this.submittedRequest = Some(request)
     getResponse()
   }
 
-  def getSubmittedRequest: Option[SubmitRequest] = submittedRequest
+  def getSubmittedRequest: Option[SubmitRequest] = submittedRequest.synchronized {
+    submittedRequest
+  }
 }
 
 object CommandSubmissionServiceImpl {


### PR DESCRIPTION
The code above has been a source of flakes, initially apparently fixed
by the addition of `@volatile` to `submittedRequest` that for some reason
reappeared on MacOS CI nodes as of recently. This is probably not the
best fix for the issue, as these mocks were probably originally
thought to be used just once and have been adapted to be re-used
across multiple test calls, so feel free to suggest a different
approach.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
