### PR TITLE
Improve wording for the active contracts service description

### DIFF
--- a/docs/source/app-dev/services.rst
+++ b/docs/source/app-dev/services.rst
@@ -159,7 +159,7 @@ Active contracts service
 
 Use the **active contracts service** to obtain a party-specific view of all contracts that are active on the ledger at the time of the request.
 
-The active contracts service returns its response as a stream of batches of the created events that would re-create the state being reported (the size of these batches is left to the ledger implementation). As part of the last message message, the offset at which which the reported active contract set was valid is included. This offset can be used to subscribe to the "flat transactions" stream to keep a consistent view of the active contract set without querying the active contract service further.
+The active contracts service returns its response as a stream of batches of the created events that would re-create the state being reported (the size of these batches is left to the ledger implementation). As part of the last message message, the offset at which the reported active contract set was valid is included. This offset can be used to subscribe to the "flat transactions" stream to keep a consistent view of the active contract set without querying the active contract service further.
 
 This is most important at application start, if the application needs to synchronize its initial state with a known view of the ledger. Without this service, the only way to do this would be to read the Transaction Stream from the beginning of the ledger, which can be prohibitively expensive with a large ledger.
 

--- a/docs/source/app-dev/services.rst
+++ b/docs/source/app-dev/services.rst
@@ -159,7 +159,7 @@ Active contracts service
 
 Use the **active contracts service** to obtain a party-specific view of all contracts that are active on the ledger at the time of the request.
 
-The active contracts service returns its response as a stream of batches of the created events that would re-create the state being reported (the size of these batches is left to the ledger implementation). After all contracts have been reported, one final message includes the offset at which this was the state. This offset can be used to subscribe to the "flat transactions" stream to keep a consistent view of the active contract set without querying the active contract service further.
+The active contracts service returns its response as a stream of batches of the created events that would re-create the state being reported (the size of these batches is left to the ledger implementation). As part of the last message message, the offset at which which the reported active contract set was valid is included. This offset can be used to subscribe to the "flat transactions" stream to keep a consistent view of the active contract set without querying the active contract service further.
 
 This is most important at application start, if the application needs to synchronize its initial state with a known view of the ledger. Without this service, the only way to do this would be to read the Transaction Stream from the beginning of the ledger, which can be prohibitively expensive with a large ledger.
 

--- a/docs/source/app-dev/services.rst
+++ b/docs/source/app-dev/services.rst
@@ -157,9 +157,9 @@ You can get these included in requests related to Transactions by setting the ``
 Active contracts service
 ========================
 
-Use the **active contracts service** to obtain a party-specific view of all contracts currently active on the ledger.
+Use the **active contracts service** to obtain a party-specific view of all contracts that are active on the ledger at the time of the request.
 
-The active contracts service returns the current contract set as a set of created events that would re-create the state being reported. Each created event has a ledger offset where it occurs. You can infer the ledger offset of the contract set from the ledger offset of the last event you receive.
+The active contracts service returns its response as a stream of batches of the created events that would re-create the state being reported (the size of these batches is left to the ledger implementation). After all contracts have been reported, one final message includes the offset at which this was the state. This offset can be used to subscribe to the "flat transactions" stream to keep a consistent view of the active contract set without querying the active contract service further.
 
 This is most important at application start, if the application needs to synchronize its initial state with a known view of the ledger. Without this service, the only way to do this would be to read the Transaction Stream from the beginning of the ledger, which can be prohibitively expensive with a large ledger.
 


### PR DESCRIPTION
This should eliminate sources of confusion as mentioned here: https://discuss.daml.com/t/offset-is-null-while-getting-active-contracts/3118

changelog_begin
[Docs] Improved description of the purpose and usage of the active contracts service
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
