### PR TITLE
Rebuild the `buf` image as part of the SDK release process [KVL-1088]

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -11,16 +11,16 @@ cd "$(dirname "$0")"
 # load the dev-env
 eval "$(dev-env/bin/dade-assist)"
 
-# Location of reference image used for buf breaking check.
+# Location of reference image used for `buf`'s protobuf breaking checks, including the Ledger API's.
 #
-# It should be re-built by running './fmt.sh --rebuild-buf-image' and then committed:
+# This `buf` image will be re-built and committed automatically as part of the SDK release process;
+# this means that all protobuf changes in the next SDK development cycle will be checked by `buf`
+# against the new SDK's protobufs, effectively considering them stable.
 #
-# 1. as part of a commit also containing breaking proto changes (that have been agreed to), and/or
-# 2. as part of a subsequent commit (e.g. in the same PR, in a later PR or as part of the SDK release process),
-#    when already committed proto changes become stable.
+# The `buf` image should be re-built manually only when making breaking protobuf changes that have
+# been agreed to and it should be part of the same commit also containing such changes.
 #
-# Proto changes that are part of an SDK release (especially RC and stable ones) should also be included in
-# the buf image.
+# To re-build it manually, run './fmt.sh --rebuild-buf-image'.
 
 buf_image="buf-stable-protos-image.bin"
 
@@ -45,7 +45,7 @@ run() {
   if [[ $is_test = 1 && $ret -gt 0 ]]; then
     log "command failed with return $ret"
     log
-    log "run ./fmt.sh to fix the issue"
+    log "run ./fmt.sh to fix formatting issues or ./fmt.sh --rebuild-buf-image if you intend to make a breaking change"
     exit 1
   fi
   return 0

--- a/release.sh
+++ b/release.sh
@@ -75,10 +75,13 @@ $0 snapshot SHA PREFIX
 
         Any non-ambiguous git commit reference can be given as SHA.
 
+$0 prepare snapshot
+        Prepares a snapshot; currently, this step updates the buf image.
+
 $0 new snapshot
-        Updates LATEST to add current commit as a new snapshot. Figures out
-        prefix version by keeping the same if the first line in LATEST is a
-        snapshot, and incrementing minor if the first line is stable.
+        Prepares a snapshot and updates LATEST to add current commit as a new snapshot.
+        Figures out prefix version by keeping the same if the first
+        line in LATEST is a snapshot, and incrementing minor if the first line is stable.
 
 $0 check
         Checks that each line of the LATEST file is well-formed.
@@ -99,7 +102,13 @@ commit_belongs_to_release_branch() {
       | grep -q -E '^origin/(main$|release/)'
 }
 
+prepare_snapshot() {
+    (./fmt.sh --rebuild-buf-image)
+}
+
 new_snapshot () {
+    prepare_snapshot
+
     local sha latest latest_prefix prefix new_line tmp
     sha=$(git rev-parse HEAD)
     if ! commit_belongs_to_release_branch $sha; then
@@ -143,6 +152,13 @@ case $1 in
                 echo "WARNING: Commit does not belong to a release branch."
             fi
             make_snapshot $(git rev-parse $2) $3
+        else
+            display_help
+        fi
+    ;;
+    prepare)
+        if [ $# -eq 2 ] && [ "$2" == 'snapshot' ]; then
+            prepare_snapshot
         else
             display_help
         fi

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -32,7 +32,7 @@ patches we backport to the 1.0 release branch).
    $ ./release.sh snapshot cc880e2 0.1.2
    cc880e290b2311d0bf05d58c7d75c50784c0131c 0.1.2-snapshot.20200513.4174.0.cc880e29
    ```
-   Then open a PR _to ber merged into the `main` branch_ (even if it's for a maintenance release)
+   Then open a PR _to be merged into the `main` branch_ (even if it's for a maintenance release)
    that should contain:
 
      - The files changed by the `./release.sh prepare snapshot` invocation above.

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -24,6 +24,7 @@ patches we backport to the 1.0 release branch).
    If you are manually creating the PR for an out-of-schedule snapshot, start
    _from latest `main`_ and run
    ```
+   ./release.sh prepare snapshot
    ./release.sh snapshot <sha> <prefix>
    ```
    for example:
@@ -31,13 +32,17 @@ patches we backport to the 1.0 release branch).
    $ ./release.sh snapshot cc880e2 0.1.2
    cc880e290b2311d0bf05d58c7d75c50784c0131c 0.1.2-snapshot.20200513.4174.0.cc880e29
    ```
-   Then open a PR _to be merged to `main`_ (even if it's for a maintenance release)
-   with the changed `LATEST` file, add the line produced by the `release.sh`
-   invocation in a meaningful position (if you’re not sure, [semver](https://semver.org/) ordering is
-   probably the right thing to do) and add the `Standard-Change` label. It
-   is better to add such a label _before confirming the PR's creation_, else
-   the associated CI check will fail and merging the PR will require you to
-   re-run it after all the other ones have completed successfully.
+   Then open a PR _to ber merged into the `main` branch_ (even if it's for a maintenance release)
+   that should contain:
+
+     - The files changed by the `./release.sh prepare snapshot` invocation above.
+     - The addition to `LATEST` in a meaningful position (if you’re not sure,
+       [semver](https://semver.org/) ordering is probably the right thing to do)
+       of the line produced by the `release.sh snapshot` invocation above.
+
+   Add the `Standard-Change` label _before  confirming the PR's creation_
+   (else the associated CI check will fail and merging the PR will require
+   you to re-run it after all the other ones have completed successfully).
 
 1. Once the PR has built, check that it was considered a release build by our
    CI. If you are working from an automated PR, check that it sent a message to

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -40,7 +40,7 @@ patches we backport to the 1.0 release branch).
        [semver](https://semver.org/) ordering is probably the right thing to do)
        of the line produced by the `release.sh snapshot` invocation above.
 
-   Add the `Standard-Change` label _before  confirming the PR's creation_
+   Add the `Standard-Change` label _before confirming the PR's creation_
    (else the associated CI check will fail and merging the PR will require
    you to re-run it after all the other ones have completed successfully).
 


### PR DESCRIPTION
## Description

- Ensures that all protobuf changes released as part of an SDK become stable.
- Avoids the need to manually update the `buf` image to stabilize protobuf changes.
- Still allows manually introducing breaking changes in an auditable way.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
