### PR TITLE
Add fetch, exercise implementations for interfaces in speedy.

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -1021,13 +1021,13 @@ private[lf] final class Compiler(
   ): (SDefinitionRef, SDefinition) =
     topLevelFunction(ChoiceDefRef(ifaceId, choice.name), 2) { case List(cidPos, choiceArgPos, _) =>
       withEnv { _ =>
-        let (
+        let(
           SBUPreFetchInterface(ifaceId)(svar(cidPos))
         ) { tmplArgPos =>
-          SBUChoiceInterface(ifaceId, choice.name) (
+          SBUChoiceInterface(ifaceId, choice.name)(
             svar(cidPos),
             svar(choiceArgPos),
-            svar(tmplArgPos)
+            svar(tmplArgPos),
           )
         }
       }
@@ -1429,12 +1429,12 @@ private[lf] final class Compiler(
   ): (SDefinitionRef, SDefinition) =
     topLevelFunction(FetchDefRef(ifaceId), 2) { case List(cidPos, _) =>
       withEnv { _ =>
-        let (
+        let(
           SBUPreFetchInterface(ifaceId)(svar(cidPos))
         ) { tmplArgPos =>
-          SBUFetchInterface(ifaceId) (
+          SBUFetchInterface(ifaceId)(
             svar(cidPos),
-            svar(tmplArgPos)
+            svar(tmplArgPos),
           )
         }
       }
@@ -1472,8 +1472,8 @@ private[lf] final class Compiler(
   // But the existence of ImplementsDefRef implies that the template implements
   // the interface, which is useful in itself.
   private[this] def compileImplements(
-    tmplId: Identifier,
-    ifaceId: Identifier
+      tmplId: Identifier,
+      ifaceId: Identifier,
   ): (SDefinitionRef, SDefinition) =
     topLevelFunction(ImplementsDefRef(tmplId, ifaceId), 1) { case List(tmplPos) =>
       svar(tmplPos)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -330,6 +330,14 @@ private[lf] final class Compiler(
       }
     }
 
+    module.interfaces.foreach { case (ifaceName, iface) =>
+      val identifier = Identifier(pkgId, QualifiedName(module.name, ifaceName))
+      builder += compileFetchInterface(identifier)
+      iface.choices.values.foreach(
+        builder += compileChoiceInterface(identifier, _)
+      )
+    }
+
     builder.result()
   }
 
@@ -1006,6 +1014,17 @@ private[lf] final class Compiler(
     }
   }
 
+  private[this] def compileChoiceInterface(
+      ifaceId: TypeConName,
+      choice: InterfaceChoice,
+  ): (SDefinitionRef, SDefinition) =
+    topLevelFunction(ChoiceDefRef(ifaceId, choice.name), 3) { case List(cidPos, choiceArgPos, _) =>
+      SBUChoiceInterface(ifaceId, choice.name)(
+        svar(cidPos),
+        svar(choiceArgPos),
+      )
+    }
+
   private[this] def compileChoice(
       tmplId: TypeConName,
       tmpl: Template,
@@ -1395,6 +1414,13 @@ private[lf] final class Compiler(
     //   in <tmplArg>
     topLevelFunction(FetchDefRef(tmplId), 2) { case List(cidPos, tokenPos) =>
       compileFetchBody(tmplId, tmpl)(cidPos, None, tokenPos)
+    }
+
+  private[this] def compileFetchInterface(
+      ifaceId: Identifier
+  ): (SDefinitionRef, SDefinition) =
+    topLevelFunction(FetchDefRef(ifaceId), 2) { case List(cidPos, _) =>
+      SBUFetchInterface(ifaceId)(svar(cidPos))
     }
 
   private[this] def compileKey(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -782,9 +782,8 @@ private[lf] final class Compiler(
         compileBlock(bindings, body)
       case UpdateFetch(tmplId, coidE) =>
         FetchDefRef(tmplId)(compile(coidE))
-      case UpdateFetchInterface(_, _) =>
-        // TODO https://github.com/digital-asset/daml/issues/10810
-        sys.error("Interfaces not supported")
+      case UpdateFetchInterface(ifaceId, coidE) =>
+        FetchDefRef(ifaceId)(compile(coidE))
       case UpdateEmbedExpr(_, e) =>
         compileEmbedExpr(e)
       case UpdateCreate(tmplId, arg) =>
@@ -796,9 +795,8 @@ private[lf] final class Compiler(
           choiceId = chId,
           argument = compile(argE),
         )
-      case UpdateExerciseInterface(_, _, _, _) =>
-        // TODO https://github.com/digital-asset/daml/issues/10810
-        sys.error("Interfaces not supported")
+      case UpdateExerciseInterface(ifaceId, chId, cidE, argE) =>
+        ChoiceDefRef(ifaceId, chId)(compile(cidE), compile(argE))
       case UpdateExerciseByKey(tmplId, chId, keyE, argE) =>
         compileExerciseByKey(tmplId, compile(keyE), chId, compile(argE))
       case UpdateGetTime =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -238,6 +238,7 @@ object Profile {
       implicit val keyDefRef: Allowed[KeyDefRef] = allowAll
       implicit val signatoriesDefRef: Allowed[SignatoriesDefRef] = allowAll
       implicit val observersDefRef: Allowed[ObserversDefRef] = allowAll
+      implicit val implementsDefRef: Allowed[ImplementsDefRef] = allowAll
       implicit val choiceDefRef: Allowed[ChoiceDefRef] = allowAll
       implicit val fetchDefRef: Allowed[FetchDefRef] = allowAll
       implicit val choiceByKeyDefRef: Allowed[ChoiceByKeyDefRef] = allowAll
@@ -260,6 +261,7 @@ object Profile {
           case KeyDefRef(tmplRef) => s"keyAndMaintainers @${tmplRef.qualifiedName}"
           case SignatoriesDefRef(tmplRef) => s"signatories @${tmplRef.qualifiedName}"
           case ObserversDefRef(tmplRef) => s"observers @${tmplRef.qualifiedName}"
+          case ImplementsDefRef(tmplRef, ifaceId) => s"implements @${tmplRef.qualifiedName} @${ifaceId.qualifiedName}"
           case ChoiceDefRef(tmplRef, name) => s"exercise @${tmplRef.qualifiedName} ${name}"
           case FetchDefRef(tmplRef) => s"fetch @${tmplRef.qualifiedName}"
           case ChoiceByKeyDefRef(tmplRef, name) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -261,7 +261,8 @@ object Profile {
           case KeyDefRef(tmplRef) => s"keyAndMaintainers @${tmplRef.qualifiedName}"
           case SignatoriesDefRef(tmplRef) => s"signatories @${tmplRef.qualifiedName}"
           case ObserversDefRef(tmplRef) => s"observers @${tmplRef.qualifiedName}"
-          case ImplementsDefRef(tmplRef, ifaceId) => s"implements @${tmplRef.qualifiedName} @${ifaceId.qualifiedName}"
+          case ImplementsDefRef(tmplRef, ifaceId) =>
+            s"implements @${tmplRef.qualifiedName} @${ifaceId.qualifiedName}"
           case ChoiceDefRef(tmplRef, name) => s"exercise @${tmplRef.qualifiedName} ${name}"
           case FetchDefRef(tmplRef) => s"fetch @${tmplRef.qualifiedName}"
           case ChoiceByKeyDefRef(tmplRef, name) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1091,17 +1091,17 @@ private[lf] object SBuiltin {
               ifaceId, // not actually used, maybe this param should be dropped from SResultNeedContract
               onLedger.committers,
               { case V.ContractInst(actualTmplId, V.VersionedValue(_, arg), _) =>
-                  val keyExpr = SEApp(SEVal(KeyDefRef(actualTmplId)), Array(SELocS(1)))
-                  machine.pushKont(KCacheContract(machine, actualTmplId, coid))
-                  machine.ctrl = SELet1(
-                    SEImportValue(Ast.TTyCon(actualTmplId), arg),
-                    cachedContractStruct(
-                      SELocS(1),
-                      SEApp(SEVal(SignatoriesDefRef(actualTmplId)), Array(SELocS(1))),
-                      SEApp(SEVal(ObserversDefRef(actualTmplId)), Array(SELocS(1))),
-                      keyExpr,
-                    ),
-                  )
+                val keyExpr = SEApp(SEVal(KeyDefRef(actualTmplId)), Array(SELocS(1)))
+                machine.pushKont(KCacheContract(machine, actualTmplId, coid))
+                machine.ctrl = SELet1(
+                  SEImportValue(Ast.TTyCon(actualTmplId), arg),
+                  cachedContractStruct(
+                    SELocS(1),
+                    SEApp(SEVal(SignatoriesDefRef(actualTmplId)), Array(SELocS(1))),
+                    SEApp(SEVal(ObserversDefRef(actualTmplId)), Array(SELocS(1))),
+                    keyExpr,
+                  ),
+                )
               },
             )
           )
@@ -1133,11 +1133,10 @@ private[lf] object SBuiltin {
       // implements the interface.
       machine.compiledPackages.getDefinition(ImplementsDefRef(tmplId, ifaceId)) match {
         case Some(_) =>
-          machine.ctrl =
-            FetchDefRef(tmplId) (
-              SEValue(SContractId(coid)),
-              SEValue(SToken),
-            )
+          machine.ctrl = FetchDefRef(tmplId)(
+            SEValue(SContractId(coid)),
+            SEValue(SToken),
+          )
         case None =>
           machine.ctrl = SEDamlException(
             IE.WronglyTypedContract(coid, ifaceId, tmplId)
@@ -1157,7 +1156,7 @@ private[lf] object SBuiltin {
   ) extends SBuiltin(2) {
     override private[speedy] def execute(
         args: util.ArrayList[SValue],
-        machine: Machine
+        machine: Machine,
     ): Unit = {
       val coid = getSContractId(args, 0)
       val choiceArg = args.get(1)
@@ -1167,22 +1166,20 @@ private[lf] object SBuiltin {
       // implements the interface.
       machine.compiledPackages.getDefinition(ImplementsDefRef(tmplId, ifaceId)) match {
         case Some(_) =>
-          machine.ctrl =
-            ChoiceDefRef(tmplId, choiceName) (
-              SEValue(SContractId(coid)),
-              SEValue(choiceArg),
-              SEValue(SToken)
-            )
+          machine.ctrl = ChoiceDefRef(tmplId, choiceName)(
+            SEValue(SContractId(coid)),
+            SEValue(choiceArg),
+            SEValue(SToken),
+          )
         case None =>
           machine.ctrl = SEDamlException(
             IE.WronglyTypedContract(coid, ifaceId, tmplId)
             // TODO https://github.com/digital-asset/daml/issues/10810:
             //   Maybe create a more specific exception.
           )
+      }
     }
   }
-}
-
 
   /** $insertFetch[tid]
     *    :: ContractId a

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -465,6 +465,7 @@ object SExpr {
   final case class KeyDefRef(ref: DefinitionRef) extends SDefinitionRef
   final case class SignatoriesDefRef(ref: DefinitionRef) extends SDefinitionRef
   final case class ObserversDefRef(ref: DefinitionRef) extends SDefinitionRef
+  final case class ImplementsDefRef(ref: DefinitionRef, ifaceId: TypeConName) extends SDefinitionRef
 
   //
   // List builtins (equalList) are implemented as recursive

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -465,6 +465,11 @@ object SExpr {
   final case class KeyDefRef(ref: DefinitionRef) extends SDefinitionRef
   final case class SignatoriesDefRef(ref: DefinitionRef) extends SDefinitionRef
   final case class ObserversDefRef(ref: DefinitionRef) extends SDefinitionRef
+
+  /** ImplementsDefRef(ref=templateId, ifaceId) points to a function that converts a
+    * template value to an interface value. (This is currently an identity function.)
+    * The existence of this definition signals that the template implements the interface.
+    */
   final case class ImplementsDefRef(ref: DefinitionRef, ifaceId: TypeConName) extends SDefinitionRef
 
   //


### PR DESCRIPTION
This is based on the first PoC, but I tried to improve the cacheing situation a bit. And to do it all without changing any of the existing definitions.

I wasn't sure what the best way to pass "template implements interface" data from the Ast to the engine was. I ended up going with an `ImplementsDefRef` which is supposed to be a function that converts template value to an interface value (an identity function for now), and using its presence to perform the implements checks on fetch and exercise. If you have a better approach, I'm interested.

No tests yet, but it will be easier to test via daml.