### PR TITLE
Fix takeFilter for the test StreamConsumer 

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -628,7 +628,7 @@ private[testtool] final class ParticipantTestContext private[participant] (
     new StreamConsumer[CompletionStreamResponse](
       services.commandCompletion.completionStream(request, _)
     ).find(_.completions.nonEmpty)
-      .map(_.fold(Seq.empty[Completion])(_.completions).toVector)
+      .map(_.completions.toVector)
 
   def firstCompletions(parties: Party*): Future[Vector[Completion]] =
     firstCompletions(completionStreamRequest()(parties: _*))
@@ -639,7 +639,7 @@ private[testtool] final class ParticipantTestContext private[participant] (
     new StreamConsumer[CompletionStreamResponse](
       services.commandCompletion.completionStream(request, _)
     ).find(_.completions.exists(p))
-      .map(_.flatMap(_.completions.find(p)))
+      .map(_.completions.find(p))
 
   def findCompletion(parties: Party*)(p: Completion => Boolean): Future[Option[Completion]] =
     findCompletion(completionStreamRequest()(parties: _*))(p)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/AppendOnlyCommandDeduplicationParallelIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/AppendOnlyCommandDeduplicationParallelIT.scala
@@ -24,7 +24,6 @@ import com.daml.ledger.client.binding.Primitive.Party
 import com.daml.ledger.test.model.Test.{Dummy, DummyWithAnnotation}
 import io.grpc.Status
 import io.grpc.Status.Code
-import org.slf4j.LoggerFactory
 
 import scala.collection.compat._
 import scala.concurrent.duration._


### PR DESCRIPTION
### Pull Request Checklist
The ordering of the takeFilter for the strem observer was:
- size bound
- filter
- finite take

This meant that we would only take the `size bound` elements and then filter them keeping only the elements that match the filtering criteria.

Changed the ordering to first filter and then size bound, basically taking the size bounds elements that pass the filter criteria.

This is also consistent with the way 

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
