### PR TITLE
ledger-api-client: Throw an exception if the submission id is empty in `CommandTracker` [KVL-1104]

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -236,6 +236,11 @@ private[commands] class CommandTracker[Context](
         val submissionId = commands.submissionId
         val commandId = commands.commandId
         logger.trace(s"Begin tracking of command $commandId for submission $submissionId.")
+        if (commands.submissionId.isEmpty) {
+          throw new IllegalArgumentException(
+            s"The submission id for the command $commandId is empty. This should not happen."
+          )
+        }
         if (pendingCommands.contains(TrackedCommandKey(submissionId, commandId))) {
           // TODO return an error identical to the server side duplicate command error once that's defined.
           throw new IllegalStateException(

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -152,6 +152,20 @@ class CommandTrackerFlowTest
       }
     }
 
+    "a command is submitted without a submission id" should {
+
+      "throw an exception" in {
+        val Handle(submissions, results, _, _) =
+          runCommandTrackingFlow(allSubmissionsSuccessful)
+
+        submissions.sendNext(newSubmission("", commandId))
+
+        val actualException = results.expectError()
+        actualException shouldBe an[IllegalArgumentException]
+        actualException.getMessage shouldBe s"The submission id for the command $commandId is empty. This should not happen."
+      }
+    }
+
     "the stream fails" should {
 
       "expose internal state as materialized value" in {
@@ -328,6 +342,7 @@ class CommandTrackerFlowTest
             CommandSubmission(
               Commands(
                 commandId = commandId,
+                submissionId = submissionId,
                 deduplicationPeriod =
                   Commands.DeduplicationPeriod.DeduplicationTime(deduplicationTime),
               )


### PR DESCRIPTION
It turns out that even though we enrich submission requests with the submission id if it's empty (https://github.com/digital-asset/daml/pull/10882), it gets bypassed when using `CommandClient` (don't yet know how), and it breaks the integration with Canton.
Therefore, we throw an exception now if the submission id is empty, to indicate a bug. Later, we may want to change this one and the other exception below to a proper `CompletionFailure` that is returned by the stream.

Follow-up:
We either have to find a place where the submission ID isn't generated in the SDK or generate it in Canton.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
