### PR TITLE
Remove update normalizer which was too aggresive [KVL-1091]

### DIFF
--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/UpdateNormalizer.scala
@@ -21,7 +21,6 @@ trait UpdateNormalizer {
 object UpdateNormalizer {
   private val MandatoryNormalizers = List(
     RecordTimeNormalizer,
-    RejectionReasonNormalizer,
     ConfigurationChangeRejectionNormalizer,
   )
 


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

As this normalizer removes all the details about the rejection, it makes it fairly impossible to apply follow-up normalizers which are more fine-grained.
Because of this, we remove the normalizer from the mandatory ones.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
