### PR TITLE
ledger-api-client: Generate a submission id if it's empty in the `CommandClient` [KVL-1104]

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -236,6 +236,11 @@ private[commands] class CommandTracker[Context](
         val submissionId = commands.submissionId
         val commandId = commands.commandId
         logger.trace(s"Begin tracking of command $commandId for submission $submissionId.")
+        if (commands.submissionId.isEmpty) {
+          throw new IllegalArgumentException(
+            s"The submission id for the command $commandId is empty. This should not happen."
+          )
+        }
         if (pendingCommands.contains(TrackedCommandKey(submissionId, commandId))) {
           // TODO return an error identical to the server side duplicate command error once that's defined.
           throw new IllegalStateException(

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -152,6 +152,20 @@ class CommandTrackerFlowTest
       }
     }
 
+    "a command is submitted without a submission id" should {
+
+      "throw an exception" in {
+        val Handle(submissions, results, _, _) =
+          runCommandTrackingFlow(allSubmissionsSuccessful)
+
+        submissions.sendNext(newSubmission("", commandId))
+
+        val actualException = results.expectError()
+        actualException shouldBe an[IllegalArgumentException]
+        actualException.getMessage shouldBe s"The submission id for the command $commandId is empty. This should not happen."
+      }
+    }
+
     "the stream fails" should {
 
       "expose internal state as materialized value" in {
@@ -328,6 +342,7 @@ class CommandTrackerFlowTest
             CommandSubmission(
               Commands(
                 commandId = commandId,
+                submissionId = submissionId,
                 deduplicationPeriod =
                   Commands.DeduplicationPeriod.DeduplicationTime(deduplicationTime),
               )


### PR DESCRIPTION
Replaces: https://github.com/digital-asset/daml/pull/10919

It turns out that even though we enrich submission requests with the submission id if it's empty (#10882), it gets bypassed when using the `CommandClient`.
Therefore, we generate a submission id if it's empty in `CommandClient.commandUpdaterFlow` and fail fast if the submission id is empty in the `CommandTracker` to indicate a bug.

This change is covered by tests that started failing here: https://dev.azure.com/digitalasset/daml/_build/results?buildId=88924&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=ac0b0b0f-051f-52f7-8fb3-a7e384b0dde9&l=2461

Needs to be backported to the 1.17 release branch.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
