### PR TITLE
Make H2 query improvements common [DPP-600]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -402,6 +402,23 @@ trait EventStorageBackendTemplate extends EventStorageBackend {
     )(connection)
   }
 
+  override def maxEventSequentialIdOfAnObservableEvent(
+      offset: Offset
+  )(connection: Connection): Option[Long] = {
+    import com.daml.platform.store.Conversions.OffsetToStatement
+    SQL"""
+SELECT max_esi FROM (
+  (SELECT max(event_sequential_id) AS max_esi FROM participant_events_consuming_exercise WHERE event_offset <= $offset GROUP BY event_offset ORDER BY event_offset DESC FETCH NEXT 1 ROW ONLY)
+  UNION ALL
+  (SELECT max(event_sequential_id) AS max_esi FROM participant_events_non_consuming_exercise WHERE event_offset <= $offset GROUP BY event_offset ORDER BY event_offset DESC FETCH NEXT 1 ROW ONLY)
+  UNION ALL
+  (SELECT max(event_sequential_id) AS max_esi FROM participant_events_create WHERE event_offset <= $offset GROUP BY event_offset ORDER BY event_offset DESC FETCH NEXT 1 ROW ONLY)
+) t
+ORDER BY max_esi DESC
+FETCH NEXT 1 ROW ONLY
+       """.as(long(1).singleOpt)(connection)
+  }
+
   override def pruneEvents(
       pruneUpToInclusive: Offset,
       pruneAllDivulgedContracts: Boolean,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
@@ -55,4 +55,6 @@ trait QueryStrategy {
 
   /** Boolean predicate */
   def isTrue(booleanColumnName: String): String
+
+  def nullAs(typeName: String): String = s"NULL::$typeName"
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackend.scala
@@ -5,11 +5,10 @@ package com.daml.platform.store.backend.h2
 
 import java.sql.Connection
 import java.time.Instant
-import anorm.{Row, SQL, SimpleSql}
+import anorm.SQL
 import com.daml.ledger.offset.Offset
 import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext
-import com.daml.platform.store.appendonlydao.events.ContractId
 import com.daml.platform.store.backend.EventStorageBackend.FilterParams
 import com.daml.platform.store.backend.common.ComposableQuery.{CompositeSql, SqlStringInterpolation}
 import com.daml.platform.store.backend.common.{
@@ -238,65 +237,5 @@ private[backend] object H2StorageBackend
       pruneAllDivulgedContracts: Boolean,
       connection: Connection,
   ): Unit = ()
-
-  override def activeContractSqlLiteral(
-      contractId: ContractId,
-      treeEventWitnessesClause: CompositeSql,
-      resultColumns: List[String],
-      coalescedColumns: String,
-  ): SimpleSql[Row] = {
-    import com.daml.platform.store.Conversions.ContractIdToStatement
-    SQL"""  WITH archival_event AS (
-               SELECT 1
-                 FROM participant_events_consuming_exercise, parameters
-                WHERE contract_id = $contractId
-                  AND event_sequential_id <= parameters.ledger_end_sequential_id
-                  AND $treeEventWitnessesClause  -- only use visible archivals
-                FETCH NEXT 1 ROW ONLY
-             ),
-             create_event AS (
-               SELECT contract_id, #${resultColumns.mkString(", ")}
-                 FROM participant_events_create, parameters
-                WHERE contract_id = $contractId
-                  AND event_sequential_id <= parameters.ledger_end_sequential_id
-                  AND $treeEventWitnessesClause
-                FETCH NEXT 1 ROW ONLY -- limit here to guide planner wrt expected number of results
-             ),
-             -- no visibility check, as it is used to backfill missing template_id and create_arguments for divulged contracts
-             create_event_unrestricted AS (
-               SELECT contract_id, #${resultColumns.mkString(", ")}
-                 FROM participant_events_create, parameters
-                WHERE contract_id = $contractId
-                  AND event_sequential_id <= parameters.ledger_end_sequential_id
-                FETCH NEXT 1 ROW ONLY -- limit here to guide planner wrt expected number of results
-             ),
-             divulged_contract AS (
-               SELECT divulgence_events.contract_id,
-                      -- Note: the divulgence_event.template_id can be NULL
-                      -- for certain integrations. For example, the KV integration exploits that
-                      -- every participant node knows about all create events. The integration
-                      -- therefore only communicates the change in visibility to the IndexDB, but
-                      -- does not include a full divulgence event.
-                      #$coalescedColumns
-                 FROM participant_events_divulgence divulgence_events LEFT OUTER JOIN create_event_unrestricted ON (divulgence_events.contract_id = create_event_unrestricted.contract_id),
-                      parameters
-                WHERE divulgence_events.contract_id = $contractId -- restrict to aid query planner
-                  AND divulgence_events.event_sequential_id <= parameters.ledger_end_sequential_id
-                  AND $treeEventWitnessesClause
-                ORDER BY divulgence_events.event_sequential_id
-                  -- prudent engineering: make results more stable by preferring earlier divulgence events
-                  -- Results might still change due to pruning.
-                FETCH NEXT 1 ROW ONLY
-             ),
-             create_and_divulged_contracts AS (
-               (SELECT * FROM create_event)   -- prefer create over divulgence events
-               UNION ALL
-               (SELECT * FROM divulged_contract)
-             )
-        SELECT contract_id, #${resultColumns.mkString(", ")}
-          FROM create_and_divulged_contracts
-         WHERE NOT EXISTS (SELECT 1 FROM archival_event)
-         FETCH NEXT 1 ROW ONLY"""
-  }
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
@@ -182,19 +182,6 @@ private[backend] object OracleStorageBackend
 
   override def eventStrategy: common.EventStrategy = OracleEventStrategy
 
-  // TODO FIXME: Use tables directly instead of the participant_events view.
-  def maxEventSequentialIdOfAnObservableEvent(
-      offset: Offset
-  )(connection: Connection): Option[Long] = {
-    import com.daml.platform.store.Conversions.OffsetToStatement
-    // This query could be: "select max(event_sequential_id) from participant_events where event_offset <= ${range.endInclusive}"
-    // however tests using PostgreSQL 12 with tens of millions of events have shown that the index
-    // on `event_offset` is not used unless we _hint_ at it by specifying `order by event_offset`
-    val limitClause = OracleQueryStrategy.limitClause(Some(1))
-    SQL"select max(event_sequential_id) from participant_events where event_offset <= $offset group by event_offset order by event_offset desc $limitClause"
-      .as(get[Long](1).singleOpt)(connection)
-  }
-
   override def createDataSource(
       jdbcUrl: String,
       dataSourceConfig: DataSourceStorageBackend.DataSourceConfig,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
@@ -129,6 +129,8 @@ private[backend] object OracleStorageBackend
       s"EXISTS (SELECT 1 FROM JSON_TABLE($arrayColumnName, '$$[*]' columns (value PATH '$$')) WHERE value = $elementColumnName)"
 
     override def isTrue(booleanColumnName: String): String = s"$booleanColumnName = 1"
+
+    override def nullAs(typeName: String): String = s"CAST(NULL AS $typeName)"
   }
 
   override def queryStrategy: QueryStrategy = OracleQueryStrategy
@@ -272,4 +274,6 @@ private[backend] object OracleStorageBackend
       pruneAllDivulgedContracts: Boolean,
       connection: Connection,
   ): Unit = ()
+
+  override val NullAsLedgerEffectiveTimeType: String = queryStrategy.nullAs("NUMBER")
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackend.scala
@@ -116,9 +116,10 @@ private[backend] object OracleStorageBackend
     override def arrayIntersectionNonEmptyClause(
         columnName: String,
         parties: Set[Ref.Party],
-    ): CompositeSql =
-      cSQL"EXISTS (SELECT 1 FROM JSON_TABLE(#$columnName, '$$[*]' columns (value PATH '$$')) WHERE value IN (${parties
-        .map(_.toString)}))"
+    ): CompositeSql = {
+      val inParties = parties.map(p => s"'$p'").mkString(", ")
+      cSQL"EXISTS (SELECT 1 FROM JSON_TABLE(#$columnName, '$$[*]' columns (value PATH '$$')) WHERE value IN (#$inParties))"
+    }
 
     override def columnEqualityBoolean(column: String, value: String): String =
       s"""case when ($column = $value) then 1 else 0 end"""

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackend.scala
@@ -212,18 +212,6 @@ private[backend] object PostgresStorageBackend
 
   override def eventStrategy: common.EventStrategy = PostgresEventStrategy
 
-  // TODO FIXME: Use tables directly instead of the participant_events view.
-  override def maxEventSequentialIdOfAnObservableEvent(
-      offset: Offset
-  )(connection: Connection): Option[Long] = {
-    import com.daml.platform.store.Conversions.OffsetToStatement
-    // This query could be: "select max(event_sequential_id) from participant_events where event_offset <= ${range.endInclusive}"
-    // however tests using PostgreSQL 12 with tens of millions of events have shown that the index
-    // on `event_offset` is not used unless we _hint_ at it by specifying `order by event_offset`
-    SQL"select max(event_sequential_id) from participant_events where event_offset <= $offset group by event_offset order by event_offset desc limit 1"
-      .as(get[Long](1).singleOpt)(connection)
-  }
-
   override def createDataSource(
       jdbcUrl: String,
       dataSourceConfig: DataSourceStorageBackend.DataSourceConfig,


### PR DESCRIPTION
### Motivation
This is a follow-up PR to #10888 . It ports H2-specific changes for all db types.

The aim is to start work on removing `participant_events` view as it proved to have negative impact on performance for H2 and Oracle.

### Testing
I've run the 800tps `sandbox-on-x` benchmark and observed no performance degradation.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
