### PR TITLE
call npm instead of npm-cli.js in the puppeteer example

### DIFF
--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -83,7 +83,7 @@ beforeAll(async () => {
   // Disable automatically opening a browser using the env var described here:
   // https://github.com/facebook/create-react-app/issues/873#issuecomment-266318338
   const env = {...process.env, BROWSER: 'none'};
-  uiProc = spawn('npm-cli.js', ['run-script', 'start'], { env, stdio: 'inherit', detached: true});
+  uiProc = spawn('npm', ['run-script', 'start'], { env, stdio: 'inherit', detached: true});
   // Note(kill-npm-start): The `detached` flag starts the process in a new process group.
   // This allows us to kill the process with all its descendents after the tests finish,
   // following https://azimi.me/2014/12/31/kill-child_process-node-js.html.


### PR DESCRIPTION
I suppose this appears here:
https://docs.daml.com/getting-started/testing.html
