### PR TITLE
Drop jdk8 override

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -8,20 +8,6 @@ let
 
   # package overrides
   overrides = _: pkgs: rec {
-    # nixpkgs ships with a very old version of openjdk on darwin
-    # because newer versions cause issues with jvmci. We don’t care
-    # about that so we upgrade it to the latest.
-    jdk8 =
-      if pkgs.stdenv.isDarwin then
-        pkgs.jdk8.overrideAttrs(oldAttrs: {
-          name = "zulu1.8.0_282-8.52.0.23";
-          src = pkgs.fetchurl {
-            url = "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-macosx_x64.zip";
-            sha256 = "04azr412azqx3cyj9fda0r025hbzypwbnpb44gi15s683ns63wd2";
-            curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
-          };
-        })
-      else pkgs.jdk8;
     nodejs = pkgs.nodejs-12_x;
     ephemeralpg = pkgs.ephemeralpg.overrideAttrs(oldAttrs: {
       installPhase = ''


### PR DESCRIPTION
The comment here is no longer accurate, Nix upgraded since so we
actually pin an older version for no reason. Perhaps somewhat
ironically while Nix upgraded they left the comment in their
derivation to not upgrade because of jvmci.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
