### PR TITLE
Switch triggers service time provider default to wall-clock time

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -172,11 +172,16 @@ private[trigger] object ServiceConfig {
         s"Optional HTTP entity upload timeout. Defaults to ${DefaultHttpEntityUploadTimeout.toSeconds} seconds."
       )
 
+    opt[Unit]('s', "static-time")
+      .optional()
+      .action((_, c) => c.copy(timeProviderType = TimeProviderType.Static))
+      .text("Use static time. When not specified, wall-clock time is used.")
+
     opt[Unit]('w', "wall-clock-time")
-      .action { (_, c) =>
-        c.copy(timeProviderType = TimeProviderType.WallClock)
-      }
-      .text("Use wall clock time (UTC). When not provided, static time is used.")
+      .optional()
+      .text(
+        "[DEPRECATED] Wall-clock time is the default. This flag has no effect. Use `-s` to enable static time."
+      )
 
     opt[Long]("ttl")
       .action { (t, c) =>
@@ -245,7 +250,7 @@ private[trigger] object ServiceConfig {
         authCallbackTimeout = DefaultAuthCallbackTimeout,
         maxHttpEntityUploadSize = DefaultMaxHttpEntityUploadSize,
         httpEntityUploadTimeout = DefaultHttpEntityUploadTimeout,
-        timeProviderType = TimeProviderType.Static,
+        timeProviderType = TimeProviderType.WallClock,
         commandTtl = Duration.ofSeconds(30L),
         init = false,
         jdbcConfig = None,

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/ServiceConfigTest.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/ServiceConfigTest.scala
@@ -3,6 +3,7 @@
 
 package com.daml.lf.engine.trigger
 
+import com.daml.platform.services.time.TimeProviderType
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -67,6 +68,27 @@ class ServiceConfigTest extends AnyWordSpec with Matchers with OptionValues {
         ),
         Set(),
       ) should ===(None)
+    }
+    "default to wall-clock time" in {
+      parse(baseOpts, Set()).value.timeProviderType should ===(TimeProviderType.WallClock)
+    }
+    "safely accept -w without effects" in {
+      parse(baseOpts :+ "-w", Set()).value.timeProviderType should ===(TimeProviderType.WallClock)
+    }
+    "safely accept --wall-clock-time without effects" in {
+      parse(baseOpts :+ "--wall-clock-time", Set()).value.timeProviderType should ===(
+        TimeProviderType.WallClock
+      )
+    }
+    "optionally use static time (-s)" in {
+      parse(baseOpts :+ "-s", Set()).value.timeProviderType should ===(
+        TimeProviderType.Static
+      )
+    }
+    "optionally use static time (--static-time)" in {
+      parse(baseOpts :+ "--static-time", Set()).value.timeProviderType should ===(
+        TimeProviderType.Static
+      )
     }
   }
 }


### PR DESCRIPTION
Fixes #10957

changelog_begin
[Triggers Service] The service now starts by default using wall-clock time instead
of static time. If you want to run using static time, you need to do so explicitly
using the new '-s' or '--static-time' CLI option. If you were already using '-w'
or '--wall-clock-time' the flag has no effect. It's anyway safe to leave it there.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
