### PR TITLE
Limit maximum number of concurrent tests

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -135,7 +135,9 @@ object Cli {
     opt[Int](name = "concurrent-test-runs")
       .optional()
       .action((v, c) => c.copy(concurrentTestRuns = v))
-      .text("Number of tests to run concurrently. Defaults to the number of available processors")
+      .text(
+        "Number of tests to run concurrently. Defaults to the number of available processors or 4, whichever is smaller."
+      )
 
     opt[Unit]("verbose")
       .abbr("v")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -46,7 +46,7 @@ object Config {
     mustFail = false,
     verbose = false,
     timeoutScaleFactor = tests.Defaults.TimeoutScaleFactor,
-    concurrentTestRuns = Runtime.getRuntime.availableProcessors(),
+    concurrentTestRuns = tests.Defaults.ConcurrentRuns,
     extract = false,
     tlsConfig = None,
     excluded = Set.empty,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Defaults.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Defaults.scala
@@ -11,4 +11,8 @@ object Defaults {
 
   val TimeoutScaleFactor: Double = 1.0
 
+  // Neither ledgers nor participants scale perfectly with the number of processors.
+  // We therefore limit the maximum number of concurrent tests, to avoid overwhelming the ledger.
+  val ConcurrentRuns: Int = List(Runtime.getRuntime.availableProcessors(), 4).min
+
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Defaults.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Defaults.scala
@@ -13,6 +13,6 @@ object Defaults {
 
   // Neither ledgers nor participants scale perfectly with the number of processors.
   // We therefore limit the maximum number of concurrent tests, to avoid overwhelming the ledger.
-  val ConcurrentRuns: Int = List(Runtime.getRuntime.availableProcessors(), 4).min
+  val ConcurrentRuns: Int = sys.runtime.availableProcessors min 4
 
 }

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -252,7 +252,6 @@ client_server_build(
     outs = ["%s.out" % REFERENCE_LEDGER_EXPORT_NAME],
     client = "//ledger/ledger-api-test-tool",
     client_args = [
-        "--concurrent-test-runs=4",
         "--timeout-scale-factor=20",
         "localhost:%PORT%",
         "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant


### PR DESCRIPTION
This PR limits the number of concurrent tests in the ledger API test tool. Otherwise the more CPUs you have, the flakier the test becomes.

Since our CI uses machines with 8 CPUs, this will reduce the number of concurrent tests from 8 to 4. This will increase the CI time slightly for fast ledgers, but should make the test more stable for slow ledgers (see below).

An alternative would be to set the upper bound to 8, and add `--concurrent-test-runs=2` to all sandbox conformance tests.

### Effect on the overall test time: sandbox classic (H2 index+ledger)

`//ledger/sandbox-classic:conformance-test-wall-clock-append-only-postgresql`, test run times on a local machine with 16 CPUs:
- `--concurrent-test-runs=16`: FAILED in 380s (7 tests timed out)
- `--concurrent-test-runs=8`: FAILED in 379s (1 test timed out)
- `--concurrent-test-runs=4`: 401s
- `--concurrent-test-runs=2`: 414s
- `--concurrent-test-runs=1`: 426s

### Effect on the overall test time: sandbox-on-x (H2 index, no-op ledger)

`//ledger/sandbox-on-x:conformance-test`, test run times on a local machine with 16 CPUs:
- `--concurrent-test-runs=16`: 27s
- `--concurrent-test-runs=8`: 32s
- `--concurrent-test-runs=4`: 42s
- `--concurrent-test-runs=2`: 66s

### Effect on the overall test time: ledger-on-sql (H2 index, kvutils Postgres ledger)

`//ledger/ledger-on-sql:conformance-test-append-only-postgres`, test run times on a local machine with 16 CPUs:
- `--concurrent-test-runs=16`: 175s
- `--concurrent-test-runs=8`: 197s
- `--concurrent-test-runs=4`: 208s
- `--concurrent-test-runs=2`: 254s