### PR TITLE
Include concurrency info in the output of the ledger API test tool

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -191,7 +191,15 @@ object LedgerApiTestTool {
         new ColorizedPrintStreamReporter(
           System.out,
           config.verbose,
-        ).report(summaries, excludedTestSummaries, identifierSuffix)
+        ).report(
+          summaries,
+          excludedTestSummaries,
+          Seq(
+            "identifierSuffix" -> identifierSuffix,
+            "concurrentTestRuns" -> config.concurrentTestRuns.toString,
+            "timeoutScaleFactor" -> config.timeoutScaleFactor.toString,
+          ),
+        )
         sys.exit(exitCode(summaries, config.mustFail))
       case Failure(exception: Errors.FrameworkException) =>
         logger.error(exception.getMessage)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -13,7 +13,7 @@ trait Reporter[A] {
   def report(
       results: Vector[LedgerTestSummary],
       skippedTests: Vector[LedgerTestSummary],
-      identifierSuffix: String,
+      runInfo: Seq[(String, String)],
   ): A
 }
 
@@ -112,7 +112,7 @@ object Reporter {
     override def report(
         results: Vector[LedgerTestSummary],
         excludedTests: Vector[LedgerTestSummary],
-        identifierSuffix: String,
+        runInfo: Seq[(String, String)],
     ): Unit = {
       s.println()
       s.println(blue("#" * 80))
@@ -124,7 +124,7 @@ object Reporter {
       s.println()
       s.println(yellow("### RUN INFORMATION"))
       s.println()
-      s.println(cyan(s"identifierSuffix = $identifierSuffix"))
+      runInfo.foreach { case (label, value) => s.println(cyan(s"$label = $value")) }
 
       val (successes, failures) = results.partition(_.result.isRight)
 


### PR DESCRIPTION
Example test output, after this PR:
```
################################################################################
#
# TEST REPORT, version: 0.0.0
#
################################################################################

### RUN INFORMATION

identifierSuffix = c6187d64efa
concurrentTestRuns = 4
timeoutScaleFactor = 1.0
```

The last two lines are added by this PR.