### PR TITLE
bump dotnet

### DIFF
--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -16,7 +16,7 @@ chmod +wx "$INSTALLER"
 chmod +wx "$EE_INSTALLER"
 
 if ! [ -f /C/Users/u/.dotnet/tools/azuresigntool.exe ]; then
-    "/C/Program Files/dotnet/dotnet.exe" tool install --global AzureSignTool
+    "/C/Program Files/dotnet/dotnet.exe" tool install --global AzureSignTool --version 3.0.0
 fi
 
 /C/Users/u/.dotnet/tools/azuresigntool.exe sign \

--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -22,6 +22,7 @@ fi
 /C/Users/u/.dotnet/tools/azuresigntool.exe sign \
   --azure-key-vault-url "$AZURE_KEY_VAULT_URL" \
   --azure-key-vault-client-id "$AZURE_CLIENT_ID" \
+  --azure-key-vault-tenant-id "$AZURE_TENANT_ID" \
   --azure-key-vault-client-secret "$AZURE_CLIENT_SECRET" \
   --azure-key-vault-certificate "$AZURE_KEY_VAULT_CERTIFICATE" \
   --description "Daml SDK installer" \

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -13,6 +13,7 @@ locals {
       suffix     = "",
       size       = 6,
       assignment = "default",
+      dotnet     = 2
     },
   ]
 }
@@ -147,7 +148,7 @@ net stop winrm
 sc.exe config winrm start=auto
 net start winrm
 
-& choco install dotnetcore-2.1-sdk --no-progress --yes 2>&1 | %%{ "$_" }
+& choco install dotnetcore-${local.w[count.index].dotnet}.1-sdk --no-progress --yes 2>&1 | %%{ "$_" }
 
 echo "== Installing the VSTS agent"
 

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -13,7 +13,7 @@ locals {
       suffix     = "",
       size       = 6,
       assignment = "default",
-      dotnet     = 2
+      dotnet     = 3
     },
     {
       suffix     = "-t",

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -15,6 +15,12 @@ locals {
       assignment = "default",
       dotnet     = 2
     },
+    {
+      suffix     = "-t",
+      size       = 6,
+      assignment = "default",
+      dotnet     = 3
+    },
   ]
 }
 

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -15,12 +15,6 @@ locals {
       assignment = "default",
       dotnet     = 3
     },
-    {
-      suffix     = "-t",
-      size       = 6,
-      assignment = "default",
-      dotnet     = 3
-    },
   ]
 }
 

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -13,7 +13,6 @@ locals {
       suffix     = "",
       size       = 6,
       assignment = "default",
-      dotnet     = 3
     },
   ]
 }
@@ -148,7 +147,7 @@ net stop winrm
 sc.exe config winrm start=auto
 net start winrm
 
-& choco install dotnetcore-${local.w[count.index].dotnet}.1-sdk --no-progress --yes 2>&1 | %%{ "$_" }
+& choco install dotnetcore-3.1-sdk --no-progress --yes 2>&1 | %%{ "$_" }
 
 echo "== Installing the VSTS agent"
 


### PR DESCRIPTION
This bumps dotnet to the version required by the latest azuresigntool, and pins azuresigntool for the future.

As usual for live CI upgrades, this will be rolled out using the blue/green approach. I'll keep each deployed commit in this branch.

CHANGELOG_BEGIN
CHANGELOG_END