### PR TITLE
Handle fetchByKey callback correctly in scenario runner

### DIFF
--- a/compiler/damlc/tests/daml-test-files/ConsumedContractKey.daml
+++ b/compiler/damlc/tests/daml-test-files/ConsumedContractKey.daml
@@ -1,0 +1,36 @@
+-- @ERROR range=23:1-23:32; no contract with that key was found
+-- @ERROR range=33:1-33:29; consumed in same transaction
+module ConsumedContractKey where
+
+template Foo
+  with
+    signer: Party
+  where
+    signatory signer
+    key signer : Party
+    maintainer key
+    controller signer can
+      FetchKey : Foo
+        do
+          snd <$> fetchByKey @Foo signer
+      LookupKey : ()
+        do
+          None <- lookupByKey @Foo signer
+          pure ()
+      Fetch : Foo
+        do fetch self
+
+testFetchKeyFromConsumingChoice = do
+  alice <- getParty "Alice"
+  fooId <- alice `submit` create Foo with signer = alice
+  alice `submit` exercise fooId FetchKey
+
+testLookupKeyFromConsumingChoice = do
+  alice <- getParty "Alice"
+  fooId <- alice `submit` create Foo with signer = alice
+  alice `submit` exercise fooId LookupKey
+
+testFetchFromConsumingChoice = do
+  alice <- getParty "Alice"
+  fooId <- alice `submit` create Foo with signer = alice
+  alice `submit` exercise fooId Fetch

--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -32,6 +32,7 @@ da_scala_library(
         "//daml-lf/language",
         "//daml-lf/transaction",
         "//libs-scala/nameof",
+        "//libs-scala/scala-utils",
     ],
 )
 


### PR DESCRIPTION
fixes #10977

Turns out assertions are good unless they’re wrong …

This only affects scenarios, the engine never looks at the callback.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
