### PR TITLE
[DPP-622] Add conformance tests that verifies TLSv1.0 and TLSv1 are disabled.

### DIFF
--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -284,7 +284,6 @@ conformance_test(
         "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:ca.crt))",
         "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.pem.enc))",
         "--tls-secrets-url https://raw.githubusercontent.com/digital-asset/daml/main/ledger/test-common/files/server-pem-decryption-parameters.json",
-        "--min-tls-version 1.2",
     ],
     test_tool_args = [
         "--verbose",

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -284,7 +284,7 @@ conformance_test(
         "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:ca.crt))",
         "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.pem.enc))",
         "--tls-secrets-url https://raw.githubusercontent.com/digital-asset/daml/main/ledger/test-common/files/server-pem-decryption-parameters.json",
-        "--min-tls-version 1.1",
+        "--min-tls-version 1.2",
     ],
     test_tool_args = [
         "--verbose",

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -264,6 +264,37 @@ conformance_test(
     ],
 )
 
+conformance_test(
+    name = "conformance-test-tls1.2-or-newer",
+    extra_data = [
+        "//ledger/test-common/test-certificates:client.crt",
+        "//ledger/test-common/test-certificates:client.pem",
+        "//ledger/test-common/test-certificates:server.crt",
+        "//ledger/test-common/test-certificates:server.pem",
+        "//ledger/test-common/test-certificates:server.pem.enc",
+        "//ledger/test-common/test-certificates:ca.crt",
+    ],
+    lf_versions = lf_version_configuration_versions,
+    ports = [6865],
+    server = "//ledger/ledger-on-memory:app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant=participant-id=example,port=6865",
+        "--crt $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.crt))",
+        "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:ca.crt))",
+        "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.pem.enc))",
+        "--tls-secrets-url https://raw.githubusercontent.com/digital-asset/daml/main/ledger/test-common/files/server-pem-decryption-parameters.json",
+        "--min-tls-version 1.1",
+    ],
+    test_tool_args = [
+        "--verbose",
+        "--crt $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:client.crt))",
+        "--cacrt $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:ca.crt))",
+        "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:client.pem))",
+        "--include=TLSAtLeastOnePointTwoIT",
+    ],
+)
+
 # This deliberately uses the deploy.jar since that’s what we ship
 # and we want to test that the extract option works there.
 # Given subleties in classpaths, it could potentially work

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TLSOnePointThreeIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TLSOnePointThreeIT.scala
@@ -25,7 +25,8 @@ import scala.util.{Failure, Success, Try}
   * - accepts TLSv1.3 connections,
   * - rejects TLSv1.2 (or lower) connections.
   */
-final class TLSOnePointThreeIT extends TlsIT {
+final class TLSOnePointThreeIT
+    extends TlsIT(shortIdentifierPrefix = "ServerOnTLSv13ConnectionFromClientOn") {
   testTlsConnection(clientTlsVersion = TlsVersion.V1_3, assertConnectionOk = true)
   testTlsConnection(clientTlsVersion = TlsVersion.V1_2, assertConnectionOk = false)
   testTlsConnection(clientTlsVersion = TlsVersion.V1_1, assertConnectionOk = false)
@@ -36,7 +37,8 @@ final class TLSOnePointThreeIT extends TlsIT {
   * - accepts either TLSv1.2 or TLSv1.3 connections,
   * - rejects TLSv1.1 (or lower) connections.
   */
-final class TLSAtLeastOnePointTwoIT extends TlsIT {
+final class TLSAtLeastOnePointTwoIT
+    extends TlsIT(shortIdentifierPrefix = "ServerOnTLSConnectionFromClientOn") {
   testTlsConnection(
     clientTlsVersions = Seq[TlsVersion](TlsVersion.V1_2, TlsVersion.V1_3),
     assertConnectionOk = true,
@@ -49,7 +51,7 @@ final class TLSAtLeastOnePointTwoIT extends TlsIT {
   *
   * It works by creating and exercising a series of client service stubs, each over different TLS version.
   */
-abstract class TlsIT extends LedgerTestSuite {
+abstract class TlsIT(shortIdentifierPrefix: String) extends LedgerTestSuite {
 
   def testTlsConnection(clientTlsVersion: TlsVersion, assertConnectionOk: Boolean): Unit = {
     testTlsConnection(
@@ -71,7 +73,7 @@ abstract class TlsIT extends LedgerTestSuite {
       .mkString("and")
 
     testGivenAllParticipants(
-      s"ConnectionOnTLSv13FromClientOn$clientTlsVersionsText",
+      s"$shortIdentifierPrefix$clientTlsVersionsText",
       s"A ledger API server should ${what} a ${clientTlsVersions} connection",
       allocate(NoParties),
     ) { implicit ec => (testContexts: Seq[ParticipantTestContext]) =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TLSOnePointThreeIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TLSOnePointThreeIT.scala
@@ -21,29 +21,58 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-/** Verifies that the given participant server correctly handles TLSv1.3 only mode.
-  *
-  * It works by creating and exercising a series of client service stubs, each over different TLS version.
-  * Only TLSv1.3 connection is expected to succeed.
-  * Connections over lower TLS versions are expected to fail.
+/** Verifies that a participant server correctly handles TLSv1.3 only mode, i.e.:
+  * - accepts TLSv1.3 connections,
+  * - rejects TLSv1.2 (or lower) connections.
   */
-final class TLSOnePointThreeIT extends LedgerTestSuite {
-
+final class TLSOnePointThreeIT extends TlsIT {
   testTlsConnection(clientTlsVersion = TlsVersion.V1_3, assertConnectionOk = true)
   testTlsConnection(clientTlsVersion = TlsVersion.V1_2, assertConnectionOk = false)
   testTlsConnection(clientTlsVersion = TlsVersion.V1_1, assertConnectionOk = false)
   testTlsConnection(clientTlsVersion = TlsVersion.V1, assertConnectionOk = false)
+}
+
+/** Verifies that a participant server disallows TLSv1.1 or older, i.e.:
+  * - accepts either TLSv1.2 or TLSv1.3 connections,
+  * - rejects TLSv1.1 (or lower) connections.
+  */
+final class TLSAtLeastOnePointTwoIT extends TlsIT {
+  testTlsConnection(
+    clientTlsVersions = Seq[TlsVersion](TlsVersion.V1_2, TlsVersion.V1_3),
+    assertConnectionOk = true,
+  )
+  testTlsConnection(clientTlsVersion = TlsVersion.V1_1, assertConnectionOk = false)
+  testTlsConnection(clientTlsVersion = TlsVersion.V1, assertConnectionOk = false)
+}
+
+/** Verifies that the given participant server correctly handles client connections over selected TLS versions.
+  *
+  * It works by creating and exercising a series of client service stubs, each over different TLS version.
+  */
+abstract class TlsIT extends LedgerTestSuite {
 
   def testTlsConnection(clientTlsVersion: TlsVersion, assertConnectionOk: Boolean): Unit = {
+    testTlsConnection(
+      clientTlsVersions = Seq(clientTlsVersion),
+      assertConnectionOk = assertConnectionOk,
+    )
+  }
+
+  def testTlsConnection(clientTlsVersions: Seq[TlsVersion], assertConnectionOk: Boolean): Unit = {
+
     val (what, assertionOnServerResponse) =
       if (assertConnectionOk)
         ("accept", assertSuccessfulConnection)
       else
         ("reject", assertFailedConnection)
 
+    val clientTlsVersionsText = clientTlsVersions
+      .map(_.version.replace(".", ""))
+      .mkString("and")
+
     testGivenAllParticipants(
-      s"ConnectionOnTLSv13FromClientOn${clientTlsVersion.version.replace(".", "")}",
-      s"A ledger API server should ${what} a ${clientTlsVersion} connection",
+      s"ConnectionOnTLSv13FromClientOn$clientTlsVersionsText",
+      s"A ledger API server should ${what} a ${clientTlsVersions} connection",
       allocate(NoParties),
     ) { implicit ec => (testContexts: Seq[ParticipantTestContext]) =>
       { case _ =>
@@ -68,7 +97,7 @@ final class TLSOnePointThreeIT extends LedgerTestSuite {
 
         // given
         val sslContext = tlsConfiguration
-          .client(enabledProtocols = Seq(clientTlsVersion))
+          .client(enabledProtocols = clientTlsVersions)
           .getOrElse(throw new IllegalStateException("Missing SslContext!"))
         val serviceStubOwner: ResourceOwner[LedgerIdentityServiceBlockingStub] = for {
           channel <- ResourceOwner.forChannel(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Tests.scala
@@ -76,6 +76,7 @@ object Tests {
       new ParticipantPruningIT,
       new MonotonicRecordTimeIT,
       new TLSOnePointThreeIT,
+      new TLSAtLeastOnePointTwoIT,
     )
 
   val retired: Vector[LedgerTestSuite] =


### PR DESCRIPTION
Because they are deprecated https://docs.microsoft.com/en-us/lifecycle/announcements/transport-layer-security-1x-disablement.




