### PR TITLE
interfaces: Syntax highlighting for interfaces

### DIFF
--- a/compiler/daml-extension/syntaxes/daml12.tmLanguage.xml
+++ b/compiler/daml-extension/syntaxes/daml12.tmLanguage.xml
@@ -409,6 +409,7 @@
 			| with
 			| choice
 			| template
+			| interface
 			| key
 			| maintainer
 			| daml

--- a/compiler/daml-extension/syntaxes/daml12.tmLanguage.xml
+++ b/compiler/daml-extension/syntaxes/daml12.tmLanguage.xml
@@ -410,6 +410,7 @@
 			| choice
 			| template
 			| interface
+			| implements
 			| key
 			| maintainer
 			| daml


### PR DESCRIPTION
Highlight `interface` and `implements` as daml keywords.

I tested it locally:

<img width="478" alt="image" src="https://user-images.githubusercontent.com/63245722/134351144-e55083e8-7ce5-4fbb-a822-bfb5530d8467.png">

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
