### PR TITLE
Add MINIMAL pragma for Additive type class

### DIFF
--- a/compiler/damlc/daml-prim-src/GHC/Num.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Num.daml
@@ -46,6 +46,7 @@ infixl 7 %
 -- * `negate` gives the additive inverse, ie: `x + negate x` = `aunit`
 --
 class Additive a  where
+    {-# MINIMAL (+), aunit, ((-) | negate) #-}
     -- | Add the two arguments together.
     (+)                 : a -> a -> a
     -- | The additive identity for the type. For example, for numbers, this is 0.

--- a/compiler/damlc/tests/daml-test-files/IncompleteAdditiveInstance.daml
+++ b/compiler/damlc/tests/daml-test-files/IncompleteAdditiveInstance.daml
@@ -1,0 +1,17 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @ERROR range=14:10-14:23; • No explicit implementation for; either ‘-’ or ‘negate’; • In the instance declaration for ‘Additive Expr’
+
+module IncompleteAdditiveInstance where
+
+data Numero = Zero | Uno | Dos | Tres
+
+data Expr = Add (Expr, Expr)
+          | Neg Expr
+          | Const Numero
+
+instance Additive Expr where
+  (+) = curry Add
+  -- negate = Neg -- uncomment to fix!
+  aunit = Const Zero


### PR DESCRIPTION
This ensures that the compiler gives an error if both `(-)` and `negate` are missing in an instance

Fixes #11000

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
