### PR TITLE
Make LargeTransactionTest use ValueEnricher

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -7,7 +7,7 @@ package engine
 import com.daml.lf.data.Ref.{Identifier, Name, PackageId}
 import com.daml.lf.language.{Ast, LookupError}
 import com.daml.lf.transaction.Node.{GenNode, KeyWithMaintainers}
-import com.daml.lf.transaction.{CommittedTransaction, Node, NodeId, VersionedTransaction}
+import com.daml.lf.transaction.{Node, NodeId, VersionedTransaction}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.VersionedValue
 import com.daml.lf.speedy.SValue
@@ -169,7 +169,7 @@ final class ValueEnricher(
         } yield exe.copy(chosenValue = choiceArg, exerciseResult = result, key = key)
     }
 
-  def enrichTransaction(tx: CommittedTransaction): Result[CommittedTransaction] = {
+  def enrichTransaction(tx: VersionedTransaction[NodeId]): Result[VersionedTransaction[NodeId]] = {
     for {
       normalizedNodes <-
         tx.nodes.foldLeft[Result[Map[NodeId, GenNode[NodeId]]]](ResultDone(Map.empty)) {
@@ -179,12 +179,10 @@ final class ValueEnricher(
               normalizedNode <- enrichNode(node)
             } yield nodes.updated(nid, normalizedNode)
         }
-    } yield CommittedTransaction(
-      VersionedTransaction(
-        version = tx.version,
-        nodes = normalizedNodes,
-        roots = tx.roots,
-      )
+    } yield VersionedTransaction(
+      version = tx.version,
+      nodes = normalizedNodes,
+      roots = tx.roots,
     )
   }
 

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -9,7 +9,7 @@ import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.engine.{Engine, ValueEnricher, Result, ResultDone, ResultError}
 import com.daml.lf.engine.preprocessing.ValueTranslator
 import com.daml.lf.language.{Ast, LookupError}
-import com.daml.lf.transaction.{GlobalKey, NodeId, SubmittedTransaction, CommittedTransaction}
+import com.daml.lf.transaction.{GlobalKey, NodeId, SubmittedTransaction}
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.lf.speedy._
 import com.daml.lf.speedy.SResult._
@@ -434,7 +434,7 @@ object ScenarioRunner {
           case ResultDone(x) => x
           case x => crash(s"unexpected Result when enriching value: $x")
         }
-      SubmittedTransaction(consume(enricher.enrichTransaction(CommittedTransaction(tx))))
+      SubmittedTransaction(consume(enricher.enrichTransaction(tx)))
     }
 
     @tailrec

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -44,7 +44,12 @@ import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.engine.{Engine, ValueEnricher, Result, ResultDone}
 import com.daml.lf.language.Ast
 import com.daml.lf.ledger.EventId
-import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction, TransactionCommitter}
+import com.daml.lf.transaction.{
+  GlobalKey,
+  CommittedTransaction,
+  SubmittedTransaction,
+  TransactionCommitter,
+}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -96,7 +101,9 @@ private[sandbox] final class InMemoryLedger(
   }
 
   private def enrichTX(tx: LedgerEntry.Transaction): LedgerEntry.Transaction = {
-    tx.copy(transaction = consumeEnricherResult(enricher.enrichTransaction(tx.transaction)))
+    tx.copy(transaction =
+      CommittedTransaction(consumeEnricherResult(enricher.enrichTransaction(tx.transaction)))
+    )
   }
 
   private val logger = ContextualizedLogger.get(this.getClass)


### PR DESCRIPTION

Make `LargeTransactionTest` use `ValueEnricher`  so it can work with normalized transactions coming out of the engine.

This change paves the way to remove the `transactionNormalization` flag, and to always normalize transactions coming out of the engine.

(Aside: generalize type of `enrichTransaction` to work for _submitted_ and _committed_ transactions & adapt existing callers)


CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
