### PR TITLE
Remove `transactionNormalization` flag.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -311,7 +311,6 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
         readAs = readAs,
         validating = validating,
         contractKeyUniqueness = config.contractKeyUniqueness,
-        transactionNormalization = config.transactionNormalization,
       )
       interpretLoop(machine, ledgerTime)
     }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -17,7 +17,6 @@ import com.daml.lf.transaction.ContractKeyUniquenessMode
   * @param allowedLanguageVersions The range of language versions the
   *     engine is allowed to load.  The engine will crash if it asked
   *     to load a language version that is not included in this range.
-  * @param transactionNormalization Normalizes transaction nodes according to the LF version
   * @param stackTraceMode The flag enables the runtime support for
   *     stack trace.
   * @param profileDir The optional specifies the directory where to
@@ -30,7 +29,6 @@ import com.daml.lf.transaction.ContractKeyUniquenessMode
   */
 final case class EngineConfig(
     allowedLanguageVersions: VersionRange[language.LanguageVersion],
-    transactionNormalization: Boolean = true,
     packageValidation: Boolean = true,
     stackTraceMode: Boolean = false,
     profileDir: Option[Path] = None,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -763,7 +763,6 @@ private[lf] object Speedy {
         warningLog: WarningLog = newWarningLog,
         contractKeyUniqueness: ContractKeyUniquenessMode = ContractKeyUniquenessMode.On,
         commitLocation: Option[Location] = None,
-        transactionNormalization: Boolean = true,
     ): Machine = {
       val pkg2TxVersion =
         compiledPackages.interface.packageLanguageVersion.andThen(
@@ -786,7 +785,6 @@ private[lf] object Speedy {
               contractKeyUniqueness,
               submissionTime,
               initialSeeding,
-              transactionNormalization,
               committers,
             ),
           committers = committers,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -189,7 +189,6 @@ private[lf] object PartialTransaction {
       contractKeyUniqueness: ContractKeyUniquenessMode,
       submissionTime: Time.Timestamp,
       initialSeeds: InitialSeeding,
-      transactionNormalization: Boolean,
       committers: Set[Party],
   ) = PartialTransaction(
     pkg2TxVersion,
@@ -205,7 +204,6 @@ private[lf] object PartialTransaction {
     globalKeyInputs = Map.empty,
     localContracts = Set.empty,
     actionNodeLocations = BackStack.empty,
-    transactionNormalization = transactionNormalization,
   )
 
   type NodeSeeds = ImmArray[(NodeId, crypto.Hash)]
@@ -288,7 +286,6 @@ private[lf] case class PartialTransaction(
     globalKeyInputs: Map[GlobalKey, PartialTransaction.KeyMapping],
     localContracts: Set[Value.ContractId],
     actionNodeLocations: BackStack[Option[Location]],
-    transactionNormalization: Boolean,
 ) {
 
   import PartialTransaction._
@@ -351,20 +348,15 @@ private[lf] case class PartialTransaction(
   }
 
   /** normValue: converts a speedy value into a normalized regular value,
-    * unless 'transactionNormalization=false',
     * suitable for a transaction node of 'version' determined by 'templateId'
     */
   def normValue(templateId: TypeConName, svalue: SValue): Value = {
     val version = packageToTransactionVersion(templateId.packageId)
-    if (transactionNormalization) {
-      svalue.toNormalizedValue(version)
-    } else {
-      svalue.toUnnormalizedValue
-    }
+    svalue.toNormalizedValue(version)
   }
 
   private def normByKey(version: TxVersion, byKey: Boolean): Boolean = {
-    if (transactionNormalization && (version < TxVersion.minByKey)) {
+    if (version < TxVersion.minByKey) {
       false
     } else {
       byKey

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -28,7 +28,6 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
     ContractKeyUniquenessMode.On,
     data.Time.Timestamp.Epoch,
     InitialSeeding.TransactionSeed(transactionSeed),
-    transactionNormalization = true,
     committers,
   )
 


### PR DESCRIPTION
Transactions produced by the engine are now normalized unconditionally.

CHANGELOG_BEGIN
CHANGELOG_END
