### PR TITLE
Remove polymorphism from VersionedTransaction

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Error.scala
@@ -175,7 +175,7 @@ object Error {
     }
 
     final case class ReplayMismatch(
-        mismatch: transaction.ReplayMismatch[transaction.NodeId]
+        mismatch: transaction.ReplayMismatch
     ) extends Error {
       override def message: String = mismatch.message
     }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -169,7 +169,7 @@ final class ValueEnricher(
         } yield exe.copy(chosenValue = choiceArg, exerciseResult = result, key = key)
     }
 
-  def enrichTransaction(tx: VersionedTransaction[NodeId]): Result[VersionedTransaction[NodeId]] = {
+  def enrichTransaction(tx: VersionedTransaction): Result[VersionedTransaction] = {
     for {
       normalizedNodes <-
         tx.nodes.foldLeft[Result[Map[NodeId, GenNode[NodeId]]]](ResultDone(Map.empty)) {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2397,8 +2397,8 @@ object EngineTest {
 
   private def hash(s: String) = crypto.Hash.hashPrivateKey(s)
   private def participant = Ref.ParticipantId.assertFromString("participant")
-  private def byKeyNodes[Nid, _](tx: VersionedTransaction[Nid]) =
-    tx.nodes.collect { case (nodeId, node: GenActionNode[_]) if node.byKey => nodeId }.toSet
+  private def byKeyNodes(tx: VersionedTransaction) =
+    tx.nodes.collect { case (nodeId, node: GenActionNode[NodeId]) if node.byKey => nodeId }.toSet
 
   private val party = Party.assertFromString("Party")
   private val alice = Party.assertFromString("Alice")
@@ -2442,9 +2442,9 @@ object EngineTest {
   }
 
   private def isReplayedBy[Nid](
-      recorded: VersionedTransaction[Nid],
-      replayed: VersionedTransaction[Nid],
-  ): Either[ReplayMismatch[Nid], Unit] = {
+      recorded: VersionedTransaction,
+      replayed: VersionedTransaction,
+  ): Either[ReplayMismatch, Unit] = {
     // we normalize the LEFT arg before calling isReplayedBy to mimic the effect of serialization
     Validation.isReplayedBy(Normalization.normalizeTx(recorded), replayed)
   }

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -567,7 +567,7 @@ object ValueGenerators {
     }
   }
 
-  val noDanglingRefGenVersionedTransaction: Gen[VersionedTransaction[NodeId]] = {
+  val noDanglingRefGenVersionedTransaction: Gen[VersionedTransaction] = {
     for {
       tx <- noDanglingRefGenTransaction
       txVer <- transactionVersionGen()

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
@@ -16,7 +16,7 @@ import com.daml.lf.transaction.Node.{
   NodeRollback,
 }
 
-class Normalization[Nid] {
+class Normalization {
 
   /** This class provides methods to normalize a transaction and embedded values.
     *
@@ -39,8 +39,8 @@ class Normalization[Nid] {
     */
 
   private type KWM = KeyWithMaintainers[Val]
-  private type Node = GenNode[Nid]
-  private type VTX = VersionedTransaction[Nid]
+  private type Node = GenNode[NodeId]
+  private type VTX = VersionedTransaction
 
   def normalizeTx(vtx: VTX): VTX = {
     vtx match {
@@ -112,7 +112,7 @@ class Normalization[Nid] {
 }
 
 object Normalization {
-  def normalizeTx[Nid](tx: VersionedTransaction[Nid]): VersionedTransaction[Nid] = {
+  def normalizeTx(tx: VersionedTransaction): VersionedTransaction = {
     new Normalization().normalizeTx(tx)
   }
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -66,7 +66,7 @@ object TransactionVersion {
 
   private[lf] def asVersionedTransaction(
       tx: GenTransaction[NodeId]
-  ): VersionedTransaction[NodeId] = {
+  ): VersionedTransaction = {
     import scala.Ordering.Implicits.infixOrderingOps
 
     tx match {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Validation.scala
@@ -4,7 +4,7 @@
 package com.daml.lf
 package transaction
 
-private final class Validation[Nid]() {
+private final class Validation() {
 
   /** Whether `replayed` is the result of reinterpreting this transaction.
     *
@@ -20,9 +20,9 @@ private final class Validation[Nid]() {
     */
 
   private def isReplayedBy(
-      recorded: VersionedTransaction[Nid],
-      replayed: VersionedTransaction[Nid],
-  ): Either[ReplayMismatch[Nid], Unit] = {
+      recorded: VersionedTransaction,
+      replayed: VersionedTransaction,
+  ): Either[ReplayMismatch, Unit] = {
     if (recorded == replayed) {
       Right(())
     } else {
@@ -33,15 +33,15 @@ private final class Validation[Nid]() {
 
 object Validation {
   def isReplayedBy[Nid](
-      recorded: VersionedTransaction[Nid],
-      replayed: VersionedTransaction[Nid],
-  ): Either[ReplayMismatch[Nid], Unit] =
+      recorded: VersionedTransaction,
+      replayed: VersionedTransaction,
+  ): Either[ReplayMismatch, Unit] =
     new Validation().isReplayedBy(recorded, replayed)
 }
 
-final case class ReplayMismatch[Nid](
-    recordedTransaction: VersionedTransaction[Nid],
-    replayedTransaction: VersionedTransaction[Nid],
+final case class ReplayMismatch(
+    recordedTransaction: VersionedTransaction,
+    replayedTransaction: VersionedTransaction,
 ) extends Product
     with Serializable {
   def message: String =

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
@@ -24,10 +24,10 @@ package object transaction {
       Right(b.result())
     }
 
-  val SubmittedTransaction = DiscriminatedSubtype[VersionedTransaction[NodeId]]
+  val SubmittedTransaction = DiscriminatedSubtype[VersionedTransaction]
   type SubmittedTransaction = SubmittedTransaction.T
 
-  val CommittedTransaction = DiscriminatedSubtype[VersionedTransaction[NodeId]]
+  val CommittedTransaction = DiscriminatedSubtype[VersionedTransaction]
   type CommittedTransaction = CommittedTransaction.T
 
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
@@ -56,7 +56,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   private type OKWM = Option[KWM]
   private type Exe = NodeExercises[NodeId]
   private type Node = GenNode[NodeId]
-  private type VTX = VersionedTransaction[NodeId]
+  private type VTX = VersionedTransaction
 
   //--[samples]--
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ExecuteUpdateSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ExecuteUpdateSpec.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.{v2 => state}
 import com.daml.ledger.resources.TestResourceContext
 import com.daml.lf.data.{Bytes, ImmArray, Ref, Time}
-import com.daml.lf.transaction.{NodeId, TransactionVersion, VersionedTransaction}
+import com.daml.lf.transaction.{TransactionVersion, VersionedTransaction}
 import com.daml.lf.{crypto, transaction}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
@@ -45,7 +45,7 @@ final class ExecuteUpdateSpec
   private val offset = Offset(Bytes.assertFromString("01"))
   private val txId = Ref.TransactionId.fromInt(1)
   private val txMock = transaction.CommittedTransaction(
-    VersionedTransaction[NodeId](TransactionVersion.VDev, Map.empty, ImmArray.Empty)
+    VersionedTransaction(TransactionVersion.VDev, Map.empty, ImmArray.Empty)
   )
   private val someMetrics = new Metrics(new MetricRegistry)
   private val someParticipantId = Ref.ParticipantId.assertFromString("some-participant")

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/package.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/package.scala
@@ -10,7 +10,7 @@ import com.daml.lf.transaction.TransactionCoder.{
   encodeTransaction,
 }
 import com.daml.lf.transaction.TransactionOuterClass.Transaction
-import com.daml.lf.transaction.{NodeId, VersionedTransaction}
+import com.daml.lf.transaction.VersionedTransaction
 import com.daml.lf.value.ValueCoder._
 import com.daml.lf.value.ValueOuterClass
 import com.google.protobuf.ByteString
@@ -45,7 +45,7 @@ package object benchmark {
     * [[com.daml.lf.transaction.TransactionCoder.decodeTransaction]].
     * It's the Daml-LF representation of a transaction.
     */
-  private[lf] type DecodedTransaction = VersionedTransaction[NodeId]
+  private[lf] type DecodedTransaction = VersionedTransaction
 
   /** This is the output of a successful call to
     * [[com.daml.lf.value.ValueCoder.decodeValue]].


### PR DESCRIPTION
Remove `[Nid]` polymorphism from `VersionedTransaction` which was required precisely nowhere. Replace with concrete `NodeId`.

This change is consistent with the discriminated subtypes `SubmittedTransaction` and `CommittedTransaction` which are already not polymorphic.
