### PR TITLE
[WIP] Data dependencies propagate orphan instances

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -895,6 +895,27 @@ load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_depen
 buildifier_dependencies()
 
 nixpkgs_package(
+    name = "grpc_nix",
+    attribute_path = "grpc",
+    build_file_content = """
+load("@os_info//:os_info.bzl", "is_linux")
+cc_library(
+  name = "grpc_lib",
+  srcs = [":lib/libgrpc.so", ":lib/libgpr.so"] if is_linux else [":lib/libgrpc.dylib", ":lib/libgpr.dylib"],
+  visibility = ["//visibility:public"],
+  hdrs = [":include"],
+  includes = ["include"],
+)
+    """,
+    nix_file = "//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    # Remove once we upgrade to Bazel >=3.0. Until then `nix-build` output
+    # confuses the JAR query in `daml-sdk-head`.
+    quiet = True,
+    repositories = dev_env_nix_repos,
+)
+
+nixpkgs_package(
     name = "postgresql_nix",
     attribute_path = "postgresql_9_6",
     fail_not_supported = False,

--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -120,6 +120,9 @@ haskell_library(
         urls = ["https://github.com/digital-asset/daml-ghcide/archive/%s.tar.gz" % GHCIDE_REV],
     )
 
+    cbit_dep = "fat_cbits" if is_windows else ":cbits"
+    grpc_dep = "@com_github_grpc_grpc//:grpc" if is_windows else "@grpc_nix//:grpc_lib"
+
     http_archive(
         name = "grpc_haskell_core",
         build_file_content = """
@@ -146,7 +149,7 @@ c2hs_suite(
     compiler_flags = ["-XCPP", "-Wno-unused-imports", "-Wno-unused-record-wildcards"],
     visibility = ["//visibility:public"],
     deps = [
-        ":fat_cbits",
+        "{cbit_dep}",
     ],
 )
 
@@ -160,10 +163,10 @@ cc_library(
   hdrs = glob(["include/*.h"]),
   includes = ["include/"],
   deps = [
-    "@com_github_grpc_grpc//:grpc",
+    "{grpc_dep}",
   ]
 )
-""",
+""".format(cbit_dep = cbit_dep, grpc_dep = grpc_dep),
         patch_args = ["-p1"],
         patches = [
             "@com_github_digital_asset_daml//bazel_tools:grpc-haskell-core-cpp-options.patch",

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -282,10 +282,21 @@ generateSrcFromLf env = noLoc mod
     exports :: [LIE GhcPs]
     genState :: GenState
     ((exports, decls), genState) = runGen
-        ((,) <$> genExports <*> genDecls)
+        ((,) <$> genExports <*> genDecls <* genInstancesOnlyImports)
 
     modRefs :: Set ModRef
     modRefs = gsModRefs genState
+
+    genInstancesOnlyImports :: Gen ()
+    genInstancesOnlyImports = sequence_ $ do
+        Just LF.DefValue{dvalBinder=(_, ty)} <- [NM.lookup LFC.moduleImportsName . LF.moduleValues $ envMod env]
+        Just quals <- [LFC.decodeModuleImports ty]
+        LF.Qualified { LF.qualModule, LF.qualPackage } <- Set.toList quals
+        pure $ emitModRef ModRef
+            { modRefModule = qualModule
+            , modRefOrigin = importOriginFromPackageRef (envConfig env) qualPackage
+            , modRefImpSpec = EmptyImpSpec
+            }
 
     genExports :: Gen [LIE GhcPs]
     genExports = sequence $ selfReexport : classReexports

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -742,13 +742,16 @@ isConstraint = \case
 
 genModule :: Env -> LF.PackageRef -> LF.ModuleName -> Gen Module
 genModule env pkgRef modName = do
-    let Config{..} = envConfig env
-        origin = case pkgRef of
-            LF.PRImport pkgId
-                | Just unitId <- MS.lookup pkgId configStablePackages -> FromCurrentSdk unitId
-                | otherwise -> FromPackage pkgId
-            LF.PRSelf -> FromPackage configSelfPkgId
-    genModuleAux (envConfig env) origin modName
+    let config = envConfig env
+        origin = importOriginFromPackageRef config pkgRef
+    genModuleAux config origin modName
+
+importOriginFromPackageRef :: Config -> LF.PackageRef -> ImportOrigin
+importOriginFromPackageRef Config {..} = \case
+    LF.PRImport pkgId
+        | Just unitId <- MS.lookup pkgId configStablePackages -> FromCurrentSdk unitId
+        | otherwise -> FromPackage pkgId
+    LF.PRSelf -> FromPackage configSelfPkgId
 
 genStableModule :: Env -> UnitId -> LF.ModuleName -> Gen Module
 genStableModule env currentSdkPkg = genModuleAux (envConfig env) (FromCurrentSdk currentSdkPkg)

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -55,7 +55,7 @@ import Development.IDE.Core.API
 import Development.IDE.Core.Compile (compileModule, typecheckModule, RunSimplifier(..))
 import Development.IDE.Core.RuleTypes
 import Development.IDE.Core.RuleTypes.Daml
-import Development.IDE.Core.Rules.Daml (diagsToIdeResult, getDamlLfVersion, getExternalPackages, ideErrorPretty)
+import Development.IDE.Core.Rules.Daml (diagsToIdeResult, getDamlLfVersion, getExternalPackages, ideErrorPretty, modInfoDepOrphanModules)
 import Development.IDE.Core.Service
 import Development.IDE.Core.Shake
 import Development.IDE.GHC.Util
@@ -497,7 +497,8 @@ runRepl importPkgs opts replClient logger ideState = do
             let core = cgGutsToCoreModule safeMode cgGuts details
             PackageMap pkgMap <- useE' GeneratePackageMap file
             stablePkgs <- lift $ useNoFile_ GenerateStablePackages
-            case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) False file core details of
+            depOrphanModules <- lift $ modInfoDepOrphanModules . tmrModInfo <$> use_ TypeCheck file
+            case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) False file core depOrphanModules details of
                 Left diag -> handleIdeResult ([diag], Nothing)
                 Right v -> do
                    pkgs <- lift $ getExternalPackages file

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -193,6 +193,9 @@ data DalfDependency = DalfDependency
 getDlintIdeas :: NormalizedFilePath -> Action (Maybe ())
 getDlintIdeas f = runMaybeT $ fst <$> useE GetDlintDiagnostics f
 
+modInfoDepOrphanModules :: HomeModInfo -> [Module]
+modInfoDepOrphanModules = dep_orphs . mi_deps . hm_iface
+
 ideErrorPretty :: Pretty.Pretty e => NormalizedFilePath -> e -> FileDiagnostic
 ideErrorPretty fp = ideErrorText fp . T.pack . HughesPJPretty.prettyShow
 
@@ -260,8 +263,9 @@ generateRawDalfRule =
                     PackageMap pkgMap <- use_ GeneratePackageMap file
                     stablePkgs <- useNoFile_ GenerateStablePackages
                     DamlEnv{envIsGenerated} <- getDamlServiceEnv
+                    depOrphanModules <- modInfoDepOrphanModules . tmrModInfo <$> use_ TypeCheck file
                     -- GHC Core to Daml-LF
-                    case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core details of
+                    case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core depOrphanModules details of
                         Left e -> return ([e], Nothing)
                         Right v -> do
                             WhnfPackage pkg <- use_ GeneratePackageDeps file
@@ -409,8 +413,10 @@ generateSerializedDalfRule options =
                             PackageMap pkgMap <- use_ GeneratePackageMap file
                             stablePkgs <- useNoFile_ GenerateStablePackages
                             DamlEnv{envIsGenerated} <- getDamlServiceEnv
-                            let details = hm_details (tmrModInfo tm)
-                            case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core details of
+                            let modInfo = tmrModInfo tm
+                                details = hm_details modInfo
+                                depOrphanModules = modInfoDepOrphanModules modInfo
+                            case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core depOrphanModules details of
                                 Left e -> pure ([e], Nothing)
                                 Right rawDalf -> do
                                     -- LF postprocessing

--- a/compiler/damlc/daml-lf-conversion/BUILD.bazel
+++ b/compiler/damlc/daml-lf-conversion/BUILD.bazel
@@ -47,6 +47,7 @@ da_haskell_test(
     srcs = glob(["test/**/*.hs"]),
     hackage_deps = [
         "base",
+        "containers",
         "either",
         "ghc-lib-parser",
         "ghc-lib",

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -457,15 +457,17 @@ convertModule
     -> Bool
     -> NormalizedFilePath
     -> CoreModule
+    -> [GHC.Module]
     -> ModDetails
     -> Either FileDiagnostic LF.Module
-convertModule lfVersion pkgMap stablePackages isGenerated file x details = runConvertM (ConversionEnv file Nothing) $ do
+convertModule lfVersion pkgMap stablePackages isGenerated file x depOrphanModules details = runConvertM (ConversionEnv file Nothing) $ do
     definitions <- concatMapM (\bind -> resetFreshVarCounters >> convertBind env bind) binds
     types <- concatMapM (convertTypeDef env) (eltsUFM (cm_types x))
+    instancesOnlyModules <- convertDepOrphanModules env depOrphanModules
     templates <- convertTemplateDefs env
     exceptions <- convertExceptionDefs env
     interfaces <- convertInterfaces env (eltsUFM (cm_types x))
-    pure (LF.moduleFromDefinitions lfModName (Just $ fromNormalizedFilePath file) flags (types ++ templates ++ exceptions ++ definitions ++ interfaces))
+    pure (LF.moduleFromDefinitions lfModName (Just $ fromNormalizedFilePath file) flags (types ++ templates ++ exceptions ++ definitions ++ interfaces ++ instancesOnlyModules))
     where
         ghcModName = GHC.moduleName $ cm_module x
         thisUnitId = GHC.moduleUnitId $ cm_module x
@@ -685,6 +687,14 @@ convertClassDef env tycon
         ++ [minimalDef | not minimalIsDefault && newStyle]
         -- NOTE (SF): No reason to generate fundep & minimal metadata with old-style typeclasses,
         -- since data-dependencies support for old-style typeclasses is extremely limited.
+
+convertDepOrphanModules :: Env -> [GHC.Module] -> ConvertM [Definition]
+convertDepOrphanModules env availNames = do
+    qualifiedInstancesOnlyModules <- S.fromList <$>
+        convertGhcModule () env `mapM` availNames
+    let moduleImportsType = encodeModuleImports qualifiedInstancesOnlyModules
+        moduleImportsDef = DValue (mkMetadataStub moduleImportsName moduleImportsType)
+    pure [ moduleImportsDef]
 
 defNewtypeWorker :: NamedThing a => LF.ModuleName -> a -> TypeConName -> DataCon
     -> [(TypeVarName, LF.Kind)] -> [(FieldName, LF.Type)] -> Definition
@@ -1868,14 +1878,18 @@ rewriteStableQualified env q@(Qualified pkgRef modName obj) =
       Nothing -> q
       Just pkgId -> Qualified (PRImport pkgId) modName obj
 
-convertQualified :: NamedThing a => (T.Text -> t) -> Env -> a -> ConvertM (Qualified t)
-convertQualified toT env x = do
-  pkgRef <- nameToPkgRef env x
-  let modName = convertModuleName $ GHC.moduleName $ nameModule $ getName x
+convertGhcModule :: a -> Env -> GHC.Module -> ConvertM (Qualified a)
+convertGhcModule x env (GHC.Module unitId moduleName) = do
+  pkgRef <- unitIdToPkgRef env unitId
+  let modName = convertModuleName moduleName
   pure $ rewriteStableQualified env $ Qualified
     pkgRef
     modName
-    (toT $ getOccText x)
+    x
+
+convertQualified :: NamedThing a => (T.Text -> t) -> Env -> a -> ConvertM (Qualified t)
+convertQualified toT env x = do
+  convertGhcModule (toT (getOccText x)) env (nameModule (getName x))
 
 convertQualifiedTySyn :: NamedThing a => Env -> a -> ConvertM (Qualified TypeSynName)
 convertQualifiedTySyn = convertQualified (\t -> mkTypeSyn [t])
@@ -1885,8 +1899,12 @@ convertQualifiedTyCon = convertQualified (\t -> mkTypeCon [t])
 
 nameToPkgRef :: NamedThing a => Env -> a -> ConvertM LF.PackageRef
 nameToPkgRef env x =
-  maybe (pure LF.PRSelf) (convertUnitId thisUnitId pkgMap . moduleUnitId) $
-  Name.nameModule_maybe $ getName x
+  maybe (pure LF.PRSelf) (unitIdToPkgRef env . moduleUnitId) $
+    Name.nameModule_maybe $ getName x
+
+unitIdToPkgRef :: Env -> UnitId -> ConvertM LF.PackageRef
+unitIdToPkgRef env unitId =
+  convertUnitId thisUnitId pkgMap unitId
   where
     thisUnitId = envModuleUnitId env
     pkgMap = envPkgMap env

--- a/compiler/damlc/tests/daml-test-files/ModuleImports_Datatype.daml
+++ b/compiler/damlc/tests/daml-test-files/ModuleImports_Datatype.daml
@@ -1,0 +1,6 @@
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+module ModuleImports_Datatype (T (..)) where
+
+data T = T

--- a/compiler/damlc/tests/daml-test-files/ModuleImports_Main.daml
+++ b/compiler/damlc/tests/daml-test-files/ModuleImports_Main.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- This test checks that we produce an $$imports value including all modules from which this one imports instances.
+
+-- @ERROR range=14:10-14:23; • No explicit implementation for; either ‘-’ or ‘negate’; • In the instance declaration for ‘Additive Expr’
+-- @QUERY-LF .modules[]
+
+module ModuleImports_Main () where
+
+import ModuleImports_OrphanInstance ()

--- a/compiler/damlc/tests/daml-test-files/ModuleImports_OrphanInstance.daml
+++ b/compiler/damlc/tests/daml-test-files/ModuleImports_OrphanInstance.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module ModuleImports_OrphanInstance (T (..)) where
+
+import ModuleImports_Datatype (T (..))
+
+instance Show T where
+    show T = "T"

--- a/deps.bzl
+++ b/deps.bzl
@@ -216,6 +216,7 @@ def daml_deps():
         )
 
     if "com_github_grpc_grpc" not in native.existing_rules():
+        # This should be kept in sync with the grpc version we get from Nix.
         http_archive(
             name = "com_github_grpc_grpc",
             strip_prefix = "grpc-1.36.0",

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -11,6 +11,7 @@ let shared = rec {
     docker
     gawk
     gnutar
+    grpc
     grpcurl
     gzip
     imagemagick

--- a/stack-snapshot.yaml
+++ b/stack-snapshot.yaml
@@ -14,9 +14,7 @@ packages:
   - ghc-lib-parser-ex-8.8.5.8
   - bytestring-nums-0.3.6
   - extra-1.7.1
-  - github: awakesecurity/gRPC-haskell
-    commit: "0cb7999e9e89d0c17c5e1d917e97cc6e450b9346"
-    sha256: "531bbd4df2eca160be436074ade336a70cad3a6477df8d00d479440edfe9896b"
+  - grpc-haskell-0.0.1.0
   - grpc-haskell-core-0.0.0.0
   - fuzzy-0.1.0.0
   - lsp-1.2.0.0


### PR DESCRIPTION
Work so far:

I split this task in three parts:
1. Encoding/decoding the set of required imports, this code will live at `DA.Daml.LFConversion.MetadataEncoding`. 
    - This was fairly simple given the existing helper functions for encoding/decoding similar information to types.
2. Picking up the encoded set of imports in `DA.Daml.Compiler.DataDependencies` and adding it to the `hsmodImports` field in `generateSrcFromLf`
    - Also simple, especially given the existing `modRefImport` function.
3. Generating the encoded imports in `DA.Daml.LFConversion.convertModule`
    - This is where it got complicated, in particular getting the instances in scope at the module being processed. So far, I've tried:
      - `md_insts` field of `details :: ModDetails` argument: only includes instances defined _in the current module_.
      - `md_exports` field of `details :: ModDetails` argument: this includes functions, datatypes and classes, but not instances.
      - I also tried adding a parameter `visibleInstances :: [ClsInst]` to `convertModule`, and providing it as the result of calling [`hptInstances`](https://hackage.haskell.org/package/ghc-8.10.2/docs/HscTypes.html#v:hptInstances) on the available `hsc :: HscEnv`. Note that one of the callsites of `convertModule`, `generateRawDalfRule`, didn't have an available `hsc`, so I added a line 
      
        ```haskell
        hsc <- hscEnv <$> use_ GhcSession file
        ```
        However, on running this the value of `visibleInstances` turned out to be an empty list. I added some trace lines and noticed that the callstack goes through `generateRawDalfRule`, so perhaps just adding the `hsc` line isn't enough. The docstring for `generateRawDalfRule`, 

        ```haskell
        -- Generates the DALF for a module without adding serializability information
        -- or type checking it.
        ```
        makes me think that this is somewhat intentional, and that `generateRawDalfRule` shouldn't perform too much work, but I'm not sure how to reconcile that with what we need.
   -  I believe you also suggested using the `mg_inst_env` field of `ModGuts`, but I haven't been able to get my hands on a `ModGuts` value.

There's also the question of how to test this. For the encoding/decoding, I followed the approach of the other encoder/decoders in `DA.Daml.LFConversion.MetadataEncoding`. I'd also like to test that the generated `$$imports` value has the right type, and I found the `@QUERY-LF` pragma, but I found it hard to read the `json` file being queried.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
