### PR TITLE
Small lf value.cids regression fix (found by canton unit tests)

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -76,7 +76,7 @@ sealed abstract class Value extends CidContainer[Value] with Product with Serial
 
   def cids[Cid2 >: ContractId] = {
     val cids = Set.newBuilder[Cid2]
-    foreach1(cids += _)
+    foreach1(cids += _)(this)
     cids.result()
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -67,6 +67,14 @@ class ValueSpec
 
     }
 
+    "finds cid in contract id value" in {
+      val hash = crypto.Hash.hashPrivateKey("some other hash")
+      val cid = ContractId.V1(hash)
+      val value = Value.ValueContractId(cid)
+
+      value.cids shouldBe Set(cid)
+    }
+
   }
 
   "Equal" - {


### PR DESCRIPTION
value.Value.cids was not invoking foreach1 fully

changelog_begin
changelog_end

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
