### PR TITLE
Data dependencies deserialize imports

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -742,13 +742,16 @@ isConstraint = \case
 
 genModule :: Env -> LF.PackageRef -> LF.ModuleName -> Gen Module
 genModule env pkgRef modName = do
-    let Config{..} = envConfig env
-        origin = case pkgRef of
-            LF.PRImport pkgId
-                | Just unitId <- MS.lookup pkgId configStablePackages -> FromCurrentSdk unitId
-                | otherwise -> FromPackage pkgId
-            LF.PRSelf -> FromPackage configSelfPkgId
-    genModuleAux (envConfig env) origin modName
+    let config = envConfig env
+        origin = importOriginFromPackageRef config pkgRef
+    genModuleAux config origin modName
+
+importOriginFromPackageRef :: Config -> LF.PackageRef -> ImportOrigin
+importOriginFromPackageRef Config {..} = \case
+    LF.PRImport pkgId
+        | Just unitId <- MS.lookup pkgId configStablePackages -> FromCurrentSdk unitId
+        | otherwise -> FromPackage pkgId
+    LF.PRSelf -> FromPackage configSelfPkgId
 
 genStableModule :: Env -> UnitId -> LF.ModuleName -> Gen Module
 genStableModule env currentSdkPkg = genModuleAux (envConfig env) (FromCurrentSdk currentSdkPkg)


### PR DESCRIPTION
This reads the value of the `$$imports` value in the previously generated DAML-LF and produces the corresponding imports with `emitModRef`

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
