### PR TITLE
Switch on NonUnitStatements warning in daml-lf/transaction

### DIFF
--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -10,6 +10,10 @@ load(
     "silencer_plugin",
 )
 
+lf_scalacopts_stricter = lf_scalacopts + [
+    "-P:wartremover:traverser:org.wartremover.warts.NonUnitStatements",
+]
+
 #
 # Transaction and value protocol buffers
 #
@@ -53,7 +57,7 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = lf_scalacopts,
+    scalacopts = lf_scalacopts_stricter,
     tags = ["maven_coordinates=com.daml:daml-lf-transaction:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [
@@ -62,6 +66,7 @@ da_scala_library(
         "//daml-lf/data",
         "//daml-lf/language",
         "//libs-scala/nameof",
+        "//libs-scala/scala-utils",
         "@maven//:com_google_protobuf_protobuf_java",
     ],
 )

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import com.daml.lf.data.{Bytes, ImmArray, Ref, Time, Utf8}
 import com.daml.lf.value.Value
+import com.daml.scalautil.Statement.discard
 import scalaz.Order
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
@@ -133,16 +134,16 @@ object Hash {
     private val intBuffer = ByteBuffer.allocate(java.lang.Integer.BYTES)
 
     final def add(a: Int): this.type = {
-      intBuffer.rewind()
-      intBuffer.putInt(a).position(0)
+      discard(intBuffer.rewind())
+      discard(intBuffer.putInt(a).position(0))
       add(intBuffer)
     }
 
     private val longBuffer = ByteBuffer.allocate(java.lang.Long.BYTES)
 
     final def add(a: Long): this.type = {
-      longBuffer.rewind()
-      longBuffer.putLong(a).position(0)
+      discard(longBuffer.rewind())
+      discard(longBuffer.putLong(a).position(0))
       add(longBuffer)
     }
 
@@ -172,8 +173,7 @@ object Hash {
     @throws[HashingError]
     final def addCid(cid: Value.ContractId): this.type = {
       val bytes = cid2Bytes(cid)
-      add(bytes.length)
-      add(bytes)
+      add(bytes.length).add(bytes)
     }
 
     // In order to avoid hash collision, this should be used together

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/EventId.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/EventId.scala
@@ -15,11 +15,11 @@ case class EventId(
     nodeId: NodeId,
 ) {
   lazy val toLedgerString: LedgerString = {
-    val builder = new StringBuilder()
-    builder += '#'
-    builder ++= transactionId
-    builder += ':'
-    builder ++= nodeId.index.toString
+    val builder = (new StringBuilder()
+      += '#'
+      ++= transactionId
+      += ':'
+      ++= nodeId.index.toString)
     LedgerString.assertFromString(builder.result())
   }
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -204,7 +204,7 @@ object TransactionCoder {
   ) = {
     key match {
       case Some(key) =>
-        encodeKeyWithMaintainers(encodeCid, version, key).map { k => discard(setKey(k)) }
+        encodeKeyWithMaintainers(encodeCid, version, key).map(k => discard(setKey(k)))
       case None =>
         Right(())
     }
@@ -218,13 +218,9 @@ object TransactionCoder {
       setUnversioned: ByteString => GeneratedMessageV3.Builder[_],
   ): Either[EncodeError, Unit] = {
     if (version < TransactionVersion.minNoVersionValue) {
-      encodeVersionedValue(encodeCid, version, value).map { v =>
-        discard(setVersioned(v))
-      }
+      encodeVersionedValue(encodeCid, version, value).map(v => discard(setVersioned(v)))
     } else {
-      encodeValue(encodeCid, version, value).map { v =>
-        discard(setUnversioned(v))
-      }
+      encodeValue(encodeCid, version, value).map(v => discard(setUnversioned(v)))
     }
   }
 
@@ -254,7 +250,7 @@ object TransactionCoder {
     node match {
       case NodeRollback(children) =>
         val builder = TransactionOuterClass.NodeRollback.newBuilder()
-        children.foreach { id => discard(builder.addChildren(encodeNid.asString(id))) }
+        children.foreach(id => discard(builder.addChildren(encodeNid.asString(id))))
         for {
           _ <- Either.cond(
             test = enclosingVersion >= TransactionVersion.minExceptions || disableVersionCheck,
@@ -294,12 +290,12 @@ object TransactionCoder {
                     )
                       .map(builder.setContractInstance)
                   } else {
-                    encodeValue(encodeCid, nodeVersion, nc.arg).map { arg =>
+                    encodeValue(encodeCid, nodeVersion, nc.arg).map(arg =>
                       builder
                         .setTemplateId(ValueCoder.encodeIdentifier(nc.templateId))
                         .setArgUnversioned(arg)
                         .setAgreement(nc.agreementText)
-                    }
+                    )
                   }
                 _ <- encodeAndSetContractKey(
                   encodeCid,
@@ -338,7 +334,7 @@ object TransactionCoder {
                   .setConsuming(ne.consuming)
               )
               ne.actingParties.foreach(builder.addActors)
-              ne.children.foreach { id => discard(builder.addChildren(encodeNid.asString(id))) }
+              ne.children.foreach(id => discard(builder.addChildren(encodeNid.asString(id))))
               ne.signatories.foreach(builder.addSignatories)
               ne.stakeholders.foreach(builder.addStakeholders)
               ne.choiceObservers.foreach(builder.addObservers)
@@ -572,7 +568,7 @@ object TransactionCoder {
                 nodeVersion,
                 protoExe.getResultVersioned,
                 protoExe.getResultUnversioned,
-              ).map { v => Some(v) }
+              ).map(v => Some(v))
             }
           keyWithMaintainers <-
             decodeOptionalKeyWithMaintainers(decodeCid, nodeVersion, protoExe.getKeyWithMaintainers)
@@ -678,9 +674,7 @@ object TransactionCoder {
     val builder = TransactionOuterClass.Transaction
       .newBuilder()
       .setVersion(transaction.version.protoValue)
-    transaction.roots.foreach { nid =>
-      discard(builder.addRoots(encodeNid.asString(nid)))
-    }
+    transaction.roots.foreach(nid => discard(builder.addRoots(encodeNid.asString(nid))))
 
     transaction
       .fold[Either[EncodeError, TransactionOuterClass.Transaction.Builder]](

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -204,7 +204,7 @@ object TransactionCoder {
   ) = {
     key match {
       case Some(key) =>
-        encodeKeyWithMaintainers(encodeCid, version, key).map { k => discard(setKey(k)); () }
+        encodeKeyWithMaintainers(encodeCid, version, key).map { k => discard(setKey(k)) }
       case None =>
         Right(())
     }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -5,6 +5,7 @@ package com.daml.lf
 package value
 
 import com.daml.lf.data.Bytes
+import com.daml.scalautil.Statement.discard
 import Value.ContractId
 
 import scala.util.control.NoStackTrace
@@ -16,11 +17,10 @@ trait CidContainer[+A] {
   def mapCid(f: ContractId => ContractId): A
 
   def foreachCid(f: ContractId => Unit) = {
-    mapCid(cid => {
+    discard(mapCid(cid => {
       f(cid)
       cid
-    })
-    ()
+    }))
   }
 
   // We cheat using exceptions, to get a cheap implementation of traverse using the `map` function above.

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -9,6 +9,7 @@ import com.daml.lf.data.Ref.{Identifier, Name}
 import com.daml.lf.data._
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.TransactionVersion
+import com.daml.scalautil.Statement.discard
 import data.ScalazEqual._
 
 import scalaz.{@@, Equal, Order, Tag}
@@ -76,7 +77,7 @@ sealed abstract class Value extends CidContainer[Value] with Product with Serial
 
   def cids[Cid2 >: ContractId] = {
     val cids = Set.newBuilder[Cid2]
-    foreach1(cids += _)(this)
+    foreach1(x => discard(cids += x))(this)
     cids.result()
   }
 


### PR DESCRIPTION
Switch on `NonUnitStatements` wart detection in `daml-lf/transaction`
- and fix using `discard` or similar.

This change should make it less likely we get bitten by bugs such as that fixed in: #11032
