### PR TITLE
Explicit discard in daml-lf/interpreter

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -168,6 +168,10 @@ plugin_scalacopts = [
 lf_scalacopts = [
 ]
 
+lf_scalacopts_stricter = lf_scalacopts + [
+    "-P:wartremover:traverser:org.wartremover.warts.NonUnitStatements",
+]
+
 default_compile_arguments = {
     "unused_dependency_checker_mode": "error",
 }

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -7,12 +7,11 @@ load(
     "da_scala_test",
     "da_scala_test_suite",
     "lf_scalacopts",
+    "lf_scalacopts_stricter",
 )
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repl")
 
-lf_scalacopts_stricter = lf_scalacopts + [
-    "-P:wartremover:traverser:org.wartremover.warts.NonUnitStatements",
-]
+print(lf_scalacopts_stricter)
 
 da_scala_library(
     name = "interpreter",

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -10,6 +10,10 @@ load(
 )
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repl")
 
+lf_scalacopts_stricter = lf_scalacopts + [
+    "-P:wartremover:traverser:org.wartremover.warts.NonUnitStatements",
+]
+
 da_scala_library(
     name = "interpreter",
     srcs = glob(["src/main/**/*.scala"]),
@@ -19,7 +23,7 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_typelevel_paiges_core",
     ],
-    scalacopts = lf_scalacopts,
+    scalacopts = lf_scalacopts_stricter,
     tags = ["maven_coordinates=com.daml:daml-lf-interpreter:__VERSION__"],
     visibility = [
         "//compiler/repl-service:__subpackages__",

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -19,6 +19,8 @@ import com.daml.lf.transaction.{
 import com.daml.lf.value.Value
 import Value._
 
+import com.daml.scalautil.Statement.discard
+
 import scala.annotation.tailrec
 import scala.collection.compat._
 import scala.collection.immutable
@@ -325,7 +327,7 @@ object ScenarioLedger {
         case ValueList(vs) =>
           vs.foreach(collect)
         case ValueContractId(coid) =>
-          coids += coid
+          discard(coids += coid)
         case _: ValueCidlessLeaf => ()
         case ValueOptional(mbV) => mbV.foreach(collect)
         case ValueTextMap(map) => map.values.foreach(collect)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -15,6 +15,7 @@ import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.validation.{EUnknownDefinition, Validation, ValidationError}
+import com.daml.scalautil.Statement.discard
 import com.daml.nameof.NameOf
 import org.slf4j.LoggerFactory
 
@@ -297,6 +298,7 @@ private[lf] final class Compiler(
       module: Module,
   ): Iterable[(SDefinitionRef, SDefinition)] = {
     val builder = Iterable.newBuilder[(SDefinitionRef, SDefinition)]
+    def addDef(binding: (SDefinitionRef, SDefinition)) = discard(builder += binding)
 
     module.exceptions.foreach { case (defName, GenDefException(message)) =>
       val ref = ExceptionMessageDefRef(Identifier(pkgId, QualifiedName(module.name, defName)))
@@ -312,28 +314,25 @@ private[lf] final class Compiler(
 
     module.templates.foreach { case (tmplName, tmpl) =>
       val identifier = Identifier(pkgId, QualifiedName(module.name, tmplName))
-      builder += compileCreate(identifier, tmpl)
-      builder += compileFetch(identifier, tmpl)
-      builder += compileKey(identifier, tmpl)
-      builder += compileSignatories(identifier, tmpl)
-      builder += compileObservers(identifier, tmpl)
-      tmpl.implements.foreach(builder += compileImplements(identifier, _))
+      addDef(compileCreate(identifier, tmpl))
+      addDef(compileFetch(identifier, tmpl))
+      addDef(compileKey(identifier, tmpl))
+      addDef(compileSignatories(identifier, tmpl))
+      addDef(compileObservers(identifier, tmpl))
+      tmpl.implements.foreach(x => addDef(compileImplements(identifier, x)))
 
-      tmpl.choices.values.foreach(builder += compileChoice(identifier, tmpl, _))
+      tmpl.choices.values.foreach(x => addDef(compileChoice(identifier, tmpl, x)))
 
       tmpl.key.foreach { tmplKey =>
-        builder += compileFetchByKey(identifier, tmpl, tmplKey)
-        builder += compileLookupByKey(identifier, tmplKey)
-        tmpl.choices.values.foreach(
-          builder +=
-            compileChoiceByKey(identifier, tmpl, tmplKey, _)
-        )
+        addDef(compileFetchByKey(identifier, tmpl, tmplKey))
+        addDef(compileLookupByKey(identifier, tmplKey))
+        tmpl.choices.values.foreach(x => addDef(compileChoiceByKey(identifier, tmpl, tmplKey, x)))
       }
     }
 
     module.interfaces.foreach { case (ifaceName, iface) =>
       val identifier = Identifier(pkgId, QualifiedName(module.name, ifaceName))
-      builder += compileFetchInterface(identifier)
+      addDef(compileFetchInterface(identifier))
       iface.choices.values.foreach(
         builder += compileChoiceInterface(identifier, _)
       )
@@ -1613,7 +1612,7 @@ private[lf] final class Compiler(
               // we cannot process `rest` recursively without exposing ourselves to stack overflow.
               val exprs = rest.iterator.map { cmd =>
                 val expr = app(compileCommand(cmd), svar(tokenPos))
-                nextPosition()
+                discard(nextPosition())
                 expr
               }.toList
               SELet(exprs, SEValue.Unit)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -6,6 +6,7 @@ package speedy
 
 import com.daml.lf.data.Ref
 import com.daml.lf.language.Ast
+import com.daml.scalautil.Statement.discard
 import java.lang.System
 import java.nio.file.{Files, Path}
 import java.util.ArrayList
@@ -43,14 +44,14 @@ final class Profile {
   private[lf] val events: ArrayList[Event] = new ArrayList()
   var name: String = "Daml Engine profile"
 
-  def addOpenEvent(label: Label) = {
+  def addOpenEvent(label: Label): Unit = {
     val time = System.nanoTime()
-    events.add(Event(true, label, time))
+    discard(events.add(Event(true, label, time)))
   }
 
-  def addCloseEvent(label: Label) = {
+  def addCloseEvent(label: Label): Unit = {
     val time = System.nanoTime()
-    events.add(Event(false, label, time))
+    discard(events.add(Event(false, label, time)))
   }
 
   def writeSpeedscopeJson(path: Path) = {
@@ -66,39 +67,41 @@ object Profile {
 
   private[speedy] def unmangleLenient(str: String): String = {
     val builder = new StringBuilder(str.length)
+    def append(c: Char) = discard(builder.append(c))
+    def appendAll(cs: Array[Char]) = discard(builder.appendAll(cs))
     var i = 0
     while (i < str.length) {
       if (str(i) == '$' && i + 1 < str.length) {
         str(i + 1) match {
           case '$' =>
-            builder.append('$')
+            append('$')
             i += 2
           case 'u' if i + 5 < str.length =>
             try {
               val cp = Integer.parseUnsignedInt(str.substring(i + 2, i + 6), 16)
-              builder.appendAll(Character.toChars(cp))
+              appendAll(Character.toChars(cp))
               i += 6
             } catch {
               case _: NumberFormatException =>
-                builder.append('$')
+                append('$')
                 i += 1
             }
           case 'U' if i + 9 < str.length =>
             try {
               val cp = Integer.parseUnsignedInt(str.substring(i + 2, i + 10), 16)
-              builder.appendAll(Character.toChars(cp))
+              appendAll(Character.toChars(cp))
               i += 10
             } catch {
               case _: NumberFormatException =>
-                builder.append('$')
+                append('$')
                 i += 1
             }
           case _ =>
-            builder.append('$')
+            append('$')
             i += 1
         }
       } else {
-        builder.append(str(i))
+        append(str(i))
         i += 1
       }
     }
@@ -161,8 +164,8 @@ object Profile {
             case Some(index) => index
             case None =>
               val index = frames.size()
-              frames.add(FrameJson(unmangleLenient(label)))
-              frameIndices.put(label, index)
+              discard(frames.add(FrameJson(unmangleLenient(label))))
+              discard(frameIndices.put(label, index))
               index
           }
           val at = event.time - profile.start

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -711,7 +711,7 @@ private[lf] object SBuiltin {
         crash(s"type mismatch on record update: expected $id, got record of type ${record.id}")
       }
       val values2 = record.values.clone.asInstanceOf[util.ArrayList[SValue]]
-      values2.set(field, args.get(1))
+      discard(values2.set(field, args.get(1)))
       record.copy(values = values2)
     }
   }
@@ -727,7 +727,7 @@ private[lf] object SBuiltin {
       val values2 = record.values.clone.asInstanceOf[util.ArrayList[SValue]]
       var i = 0
       while (i < updateFields.length) {
-        values2.set(updateFields(i), args.get(i + 1))
+        discard(values2.set(updateFields(i), args.get(i + 1)))
         i += 1
       }
       record.copy(values = values2)
@@ -774,7 +774,7 @@ private[lf] object SBuiltin {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SStruct = {
       val struct = getSStruct(args, 0)
       val values2 = struct.values.clone.asInstanceOf[util.ArrayList[SValue]]
-      values2.set(fieldIndex, args.get(1))
+      discard(values2.set(fieldIndex, args.get(1)))
       struct.copy(values = values2)
     }
   }
@@ -786,7 +786,7 @@ private[lf] object SBuiltin {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SStruct = {
       val struct = getSStruct(args, 0)
       val values2 = struct.values.clone.asInstanceOf[util.ArrayList[SValue]]
-      values2.set(struct.fieldNames.indexOf(field), args.get(1))
+      discard(values2.set(struct.fieldNames.indexOf(field), args.get(1)))
       struct.copy(values = values2)
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -20,6 +20,7 @@ import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SBuiltin._
 import com.daml.nameof.NameOf
+import com.daml.scalautil.Statement.discard
 
 /** The speedy expression:
   * - de Bruijn indexed.
@@ -160,7 +161,7 @@ object SExpr {
       while (i < arity) {
         val arg = args(i)
         val v = arg.lookupValue(machine)
-        actuals.add(v)
+        discard(actuals.add(v))
         i += 1
       }
       builtin.execute(actuals, machine)
@@ -295,7 +296,7 @@ object SExpr {
       while (i < arity) {
         val arg = args(i)
         val v = arg.lookupValue(machine)
-        actuals.add(v)
+        discard(actuals.add(v))
         i += 1
       }
       val v = builtin.executePure(actuals)
@@ -318,7 +319,7 @@ object SExpr {
       while (i < arity) {
         val arg = args(i)
         val v = arg.lookupValue(machine)
-        actuals.add(v)
+        discard(actuals.add(v))
         i += 1
       }
       builtin.compute(actuals) match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -12,6 +12,7 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.transaction.TransactionVersion
 import com.daml.lf.value.Value.ValueArithmeticError
 import com.daml.lf.value.{Value => V}
+import com.daml.scalautil.Statement.discard
 import com.daml.nameof.NameOf
 
 import scala.jdk.CollectionConverters._
@@ -218,8 +219,7 @@ object SValue {
     @throws[SError.SError]
     // crashes if `k` contains type abstraction, function, Partially applied built-in or updates
     def comparable(k: SValue): Unit = {
-      `SMap Ordering`.compare(k, k)
-      ()
+      discard[Int](`SMap Ordering`.compare(k, k))
     }
 
     def apply(isTextMap: Boolean, entries: Iterator[(SValue, SValue)]): SMap = {
@@ -254,8 +254,10 @@ object SValue {
     val fields: ImmArray[Ref.Name] = ImmArray(ValueArithmeticError.fieldName)
     def apply(builtinName: String, args: ImmArray[String]): SAny = {
       val array = new util.ArrayList[SValue](1)
-      array.add(
-        SText(s"ArithmeticError while evaluating ($builtinName ${args.iterator.mkString(" ")}).")
+      discard(
+        array.add(
+          SText(s"ArithmeticError while evaluating ($builtinName ${args.iterator.mkString(" ")}).")
+        )
       )
       SAny(ValueArithmeticError.typ, SRecord(ValueArithmeticError.tyCon, fields, array))
     }
@@ -378,8 +380,8 @@ object SValue {
 
   private def entry(key: SValue, value: SValue) = {
     val args = new util.ArrayList[SValue](2)
-    args.add(key)
-    args.add(value)
+    discard(args.add(key))
+    discard(args.add(value))
     SStruct(entryFields, args)
   }
 
@@ -398,7 +400,7 @@ object SValue {
   ): util.ArrayList[SValue] = {
     val bs = new util.ArrayList[SValue](as.size)
     as.forEach { a =>
-      val _ = bs.add(f(a))
+      discard(bs.add(f(a)))
     }
     bs
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/WarningLog.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/WarningLog.scala
@@ -6,6 +6,7 @@ package com.daml.lf.speedy
 import org.slf4j.Logger
 import scala.collection.mutable.ArrayBuffer
 import com.daml.lf.data.Ref.Location
+import com.daml.scalautil.Statement.discard
 
 private[lf] final case class Warning(
     commitLocation: Option[Location],
@@ -20,7 +21,7 @@ private[lf] final class WarningLog(logger: Logger) {
 
   def add(warning: Warning): Unit = {
     logger.warn(warning.messageWithLocation)
-    buffer += warning
+    discard(buffer += warning)
   }
 
   def iterator: Iterator[Warning] = buffer.iterator

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -19,6 +19,7 @@ import com.daml.lf.transaction.{
 }
 import com.daml.lf.value.Value
 import com.daml.nameof.NameOf
+import com.daml.scalautil.Statement.discard
 
 import scala.collection.immutable.HashMap
 import scala.Ordering.Implicits.infixOrderingOps
@@ -306,13 +307,14 @@ private[lf] case class PartialTransaction(
           node: Node,
           rootPrefix: String,
       ): Unit = {
-        sb.append(rootPrefix)
-          .append("node ")
-          .append(nid)
-          .append(": ")
-          .append(node.toString)
-          .append(", ")
-        ()
+        discard(
+          sb.append(rootPrefix)
+            .append("node ")
+            .append(nid)
+            .append(": ")
+            .append(node.toString)
+            .append(", ")
+        )
       }
 
       def removeTrailingComma(): Unit = {

--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -7,12 +7,9 @@ load(
     "da_scala_library",
     "da_scala_test",
     "lf_scalacopts",
+    "lf_scalacopts_stricter",
     "silencer_plugin",
 )
-
-lf_scalacopts_stricter = lf_scalacopts + [
-    "-P:wartremover:traverser:org.wartremover.warts.NonUnitStatements",
-]
 
 #
 # Transaction and value protocol buffers


### PR DESCRIPTION
Add explicit `discard`s in `daml-lf/interpeter` to allow `NonUnitStatement` wart detector to be switched on.