### PR TITLE
CI: build PRs not merges

### DIFF
--- a/ci/prs.yml
+++ b/ci/prs.yml
@@ -1,14 +1,19 @@
 # Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-trigger: none
-
-pr:
-  autoCancel: true # cancel previous builds on push
+#trigger: none
+trigger:
   branches:
-    include:
-      - main
-      - release/*
+    exclude:
+    - main
+    - release/*
+
+pr: none
+# autoCancel: true # cancel previous builds on push
+# branches:
+#   include:
+#     - main
+#     - release/*
 
 jobs:
 - template: build.yml


### PR DESCRIPTION
On a PR build, Azure builds the result of merging the PR into `main`.
That used to be good, because it meant we had lower chances of ending up
with semantic conflicts between unrelated PRs.

Recently, though, Azure's behaviour has been a bit erratic as to which
commit it merges with. We're not entirely sure how big of an impact this
has on caching, but the only way we can think of to test is to disable
that behaviour and see what happens to our caching times.

This PR changes the YML file for PR builds to trigger on all branches
(except release branches), rather than on PRs.

CHANGELOG_BEGIN
CHANGELOG_END