### PR TITLE
Fix SimpleDeduplicationBasic when participant deduplication is disabled [KVL-1083]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
@@ -77,7 +77,7 @@ private[testtool] abstract class CommandDeduplicationBase(
           // Note: the second submit() in this block is deduplicated and thus rejected by the ledger API server,
           // only one submission is therefore sent to the ledger.
           completion1 <- submitRequestAndAssertCompletionAccepted(ledger)(requestA1, party)
-          _ <- submitRequestAndAssertDeduplication(ledger)(requestA1)
+          _ <- submitRequestAndAssertDeduplication(ledger)(requestA1, party)
           // Wait until the end of first deduplication window
           _ <- Delayed.by(deduplicationWait)(())
 


### PR DESCRIPTION
The party was not passed down with participant deduplication disabled and would result in an invalid argument error.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
