### PR TITLE
PoC: KV without participant deduplication [KVL-1083]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
@@ -77,7 +77,7 @@ private[testtool] abstract class CommandDeduplicationBase(
           // Note: the second submit() in this block is deduplicated and thus rejected by the ledger API server,
           // only one submission is therefore sent to the ledger.
           completion1 <- submitRequestAndAssertCompletionAccepted(ledger)(requestA1, party)
-          _ <- submitRequestAndAssertDeduplication(ledger)(requestA1)
+          _ <- submitRequestAndAssertDeduplication(ledger)(requestA1, party)
           // Wait until the end of first deduplication window
           _ <- Delayed.by(deduplicationWait)(())
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/KVCommandDeduplicationBase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/KVCommandDeduplicationBase.scala
@@ -50,15 +50,15 @@ abstract class KVCommandDeduplicationBase(
       runWithConfig(configuredParticipants) { (maxDeduplicationDuration, minSkew) =>
         for {
           completion1 <- submitRequestAndAssertCompletionAccepted(ledger)(request, party)
-          // participant side deduplication, sync result
-          _ <- submitRequestAndAssertSyncDeduplication(ledger, request)
-          // Wait for the end of participant deduplication
-          // We also add min skew to also validate the committer deduplication duration
-          _ <- Delayed.by(deduplicationDuration.plus(minSkew))(())
+//          // participant side deduplication, sync result
+//          _ <- submitRequestAndAssertSyncDeduplication(ledger, request)
+//          // Wait for the end of participant deduplication
+//          // We also add min skew to also validate the committer deduplication duration
+//          _ <- Delayed.by(deduplicationDuration.plus(minSkew))(())
           // Validate committer deduplication
           duplicateCompletion <- submitRequestAndAssertAsyncDeduplication(ledger)(request, party)
           // Wait for the end of committer deduplication, we already waited for minSkew
-          _ <- Delayed.by(maxDeduplicationDuration.minus(deduplicationDuration))(())
+          _ <- Delayed.by(maxDeduplicationDuration.plus(minSkew))(())
           // Deduplication has finished
           completion2 <- submitRequestAndAssertCompletionAccepted(ledger)(request, party)
           // Inspect created contracts

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/AppendOnlyKVCommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/AppendOnlyKVCommandDeduplicationIT.scala
@@ -23,7 +23,7 @@ class AppendOnlyKVCommandDeduplicationIT(
 
   override def deduplicationFeatures: CommandDeduplicationBase.DeduplicationFeatures =
     DeduplicationFeatures(
-      participantDeduplication = true,
+      participantDeduplication = false,
       appendOnlySchema = true,
     )
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -25,7 +25,7 @@ class KeyValueParticipantStateWriter(
     metrics: Metrics,
 ) extends WriteService {
 
-  override def isApiDeduplicationEnabled: Boolean = true
+  override def isApiDeduplicationEnabled: Boolean = false
 
   private val keyValueSubmission = new KeyValueSubmission(metrics)
 


### PR DESCRIPTION
This PoC disables participant-side command deduplication for KV and adapts tests to avoid relying on it.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
