### PR TITLE
add `--max-inbound-message-size` flag to `daml ledger export`

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -510,9 +510,11 @@ runLedgerExport flags remainingArguments = do
         pure []
       else do
         args <- getDefaultArgs flags
+        let maxSizeArgs size = ["--max-inbound-message-size", show size]
+            extras = maybe [] maxSizeArgs $ fMaxReceiveLengthM flags
         -- TODO[AH]: Use parties from daml.yaml by default.
         -- TODO[AH]: Use SDK version from daml.yaml by default.
-        pure ["--host", host args, "--port", show (port args)]
+        pure $ ["--host", host args, "--port", show (port args)] <> extras
     withJar
       damlSdkJar
       [logbackArg]

--- a/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
@@ -135,6 +135,7 @@ trait ReproducesTransactions
         ),
         start = offset,
         end = ledgerEnd,
+        maxInboundMessageSize = Config.DefaultMaxInboundMessageSize,
         exportType = Some(
           ExportScript(
             outputPath = tmpDir,

--- a/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
@@ -20,6 +20,7 @@ final case class Config(
     start: LedgerOffset,
     end: LedgerOffset,
     exportType: Option[ExportType],
+    maxInboundMessageSize: Int,
 )
 
 sealed trait ExportType
@@ -39,6 +40,8 @@ final case class PartyConfig(
 )
 
 object Config {
+  val DefaultMaxInboundMessageSize: Int = 4194304
+
   def parse(args: Array[String]): Option[Config] =
     parser.parse(args, Empty)
 
@@ -99,6 +102,12 @@ object Config {
       .action((x, c) => c.copy(end = parseLedgerOffset(x)))
       .text(
         "The transaction offset (inclusive) for the end position of the export. Optional, by default the export includes the current end of the ledger."
+      )
+    opt[Int]("max-inbound-message-size")
+      .optional()
+      .action((x, c) => c.copy(maxInboundMessageSize = x))
+      .text(
+        s"Optional max inbound message size in bytes. Defaults to $DefaultMaxInboundMessageSize"
       )
     cmd("script")
       .action((_, c) => c.copy(exportType = Some(EmptyExportScript)))
@@ -172,5 +181,6 @@ object Config {
     start = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)),
     end = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
     exportType = None,
+    maxInboundMessageSize = DefaultMaxInboundMessageSize,
   )
 }

--- a/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
@@ -84,5 +84,6 @@ object Main {
     commandClient = CommandClientConfiguration.default,
     sslContext = config.tlsConfig.client(),
     token = config.accessToken.flatMap(_.token),
+    maxInboundMessageSize = config.maxInboundMessageSize,
   )
 }

--- a/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/ConfigSpec.scala
@@ -137,6 +137,18 @@ class ConfigSpec extends AnyFreeSpec with Matchers with OptionValues {
         optConfig.value.accessToken.value.token.value shouldBe token
       }
     }
+    "--max-inbound-message-size" - {
+      "unset" in {
+        val args = defaultRequiredArgs
+        val optConfig = Config.parse(args)
+        optConfig.value.maxInboundMessageSize shouldBe Config.DefaultMaxInboundMessageSize
+      }
+      "--max-inbound-message-size 9388608" in {
+        val args = defaultRequiredArgs ++ Array("--max-inbound-message-size", "9388608")
+        val optConfig = Config.parse(args)
+        optConfig.value.maxInboundMessageSize shouldBe 9388608
+      }
+    }
     "Output type" - {
       "missing" in {
         val args = ledgerArgs ++ partyArgs


### PR DESCRIPTION
Add support for `--max-inbound-message-size` flag to the [Ledger Export](https://docs.daml.com/tools/export/index.html) tool.

CHANGELOG_BEGIN

- [Daml Assistant] Add support for `--max-inbound-message-size` flag to the Ledger Export tool.

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_BEGIN` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
