### PR TITLE
DPP-609 Add StorageBackendTestsDeduplication

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
@@ -13,7 +13,8 @@ trait StorageBackendSuite
     with StorageBackendTestsReset
     with StorageBackendTestsPruning
     with StorageBackendTestsDBLockForSuite
-    with StorageBackendTestsDebug
+    with StorageBackendTestsIntegrity
+    with StorageBackendTestsDeduplication
     with StorageBackendTestsTimestamps {
   this: AsyncFlatSpec =>
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsDeduplication.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsDeduplication.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.backend
+
+import org.scalatest.Inside
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.Future
+
+private[backend] trait StorageBackendTestsDeduplication
+    extends Matchers
+    with Inside
+    with StorageBackendSpec {
+  this: AsyncFlatSpec =>
+
+  behavior of "DeduplicationStorageBackend"
+
+  import StorageBackendTestValues._
+
+  it should "only allow one upsertDeduplicationEntry to insert a new entry" in {
+    val key = "deduplication key"
+    val submittedAt = Instant.EPOCH
+    val deduplicateUntil = submittedAt.plusSeconds(1)
+    val n = 8
+
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+      insertedRows <- Future.sequence(
+        Vector.fill(n)(
+          executeSql(backend.upsertDeduplicationEntry(key, submittedAt, deduplicateUntil))
+        )
+      )
+    } yield {
+      insertedRows.count(_ == 1) shouldBe 1 // One of the calls inserts a new row
+      insertedRows.count(_ == 0) shouldBe (n - 1) // All other calls don't write anything
+      succeed
+    }
+  }
+
+  it should "only allow one upsertDeduplicationEntry to update an existing expired entry" in {
+    val key = "deduplication key"
+    val submittedAt = Instant.EPOCH
+    val deduplicateUntil = submittedAt.plusSeconds(1)
+    val submittedAt2 = deduplicateUntil.plusSeconds(1)
+    val deduplicateUntil2 = submittedAt2.plusSeconds(1)
+    val n = 8
+
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+      insertedRows <- executeSql(
+        backend.upsertDeduplicationEntry(key, submittedAt, deduplicateUntil)
+      )
+      updatedRows <- Future.sequence(
+        Vector.fill(n)(
+          executeSql(backend.upsertDeduplicationEntry(key, submittedAt2, deduplicateUntil2))
+        )
+      )
+    } yield {
+      insertedRows shouldBe 1 // First call inserts a new row
+      updatedRows.count(
+        _ == 1
+      ) shouldBe 1 // One of the subsequent calls updates the now expired row
+      updatedRows.count(_ == 0) shouldBe (n - 1) // All other calls don't write anything
+      succeed
+    }
+  }
+
+  it should "not update or insert anything if there is an existing active entry" in {
+    val key = "deduplication key"
+    val submittedAt = Instant.EPOCH
+    val deduplicateUntil = submittedAt.plusSeconds(1)
+
+    for {
+      _ <- executeSql(backend.initializeParameters(someIdentityParams))
+      insertedRows <- executeSql(
+        backend.upsertDeduplicationEntry(key, submittedAt, deduplicateUntil)
+      )
+      updatedRows <- executeSql(
+        backend.upsertDeduplicationEntry(key, submittedAt, deduplicateUntil)
+      )
+    } yield {
+      insertedRows shouldBe 1 // First call inserts a new row
+      updatedRows shouldBe 0 // Second call doesn't write anything
+      succeed
+    }
+  }
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsIntegrity.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsIntegrity.scala
@@ -6,12 +6,12 @@ package com.daml.platform.store.backend
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-private[backend] trait StorageBackendTestsDebug extends Matchers with StorageBackendSpec {
+private[backend] trait StorageBackendTestsIntegrity extends Matchers with StorageBackendSpec {
   this: AsyncFlatSpec =>
 
   import StorageBackendTestValues._
 
-  behavior of "DebugStorageBackend"
+  behavior of "IntegrityStorageBackend"
 
   it should "find duplicate event ids" in {
     val updates = Vector(


### PR DESCRIPTION
After https://github.com/digital-asset/daml/pull/10976, `upsertDeduplicationEntry` should now be safe to call concurrently. This PR adds corresponding tests.