### PR TITLE
Split daml kvutils proto [KVL-1090]

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerWriter.scala
@@ -9,7 +9,7 @@ import com.daml.api.util.TimeProvider
 import com.daml.caching.Cache
 import com.daml.ledger.api.health.{HealthStatus, Healthy}
 import com.daml.ledger.on.memory.InMemoryLedgerWriter._
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.api.{CommitMetadata, LedgerWriter}
 import com.daml.ledger.participant.state.kvutils.export.LedgerDataExporter
 import com.daml.ledger.participant.state.kvutils.{KeyValueCommitting, Raw}

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_configuration.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_configuration.proto
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Protocol buffer messages used by the participant state key-value utilities
+// for implementing a Daml ledger backed by a key-value store.
+//
+// These messages should only be produced and consumed by the methods in
+// `KeyValueCommitting`, `KeyValueConsumption` and `KeyValueSubmission` objects.
+//
+
+syntax = "proto3";
+
+package com.daml.ledger.participant.state.kvutils;
+
+option java_package = "com.daml.ledger.participant.state.kvutils";
+option csharp_namespace = "Com.Daml.Ledger.Participant.State.KVUtils";
+
+import "google/protobuf/timestamp.proto";
+import "com/daml/ledger/configuration/ledger_configuration.proto";
+
+// Configuration change request to change the ledger configuration.
+message DamlConfigurationSubmission {
+  // A unique string scoped to a particular participant for matching the
+  // request with the result.
+  // Implementers are free to select adequate mechanism e.g. UUID or similar.
+  string submission_id = 1;
+
+  // Submitting participant's id.
+  string participant_id = 2;
+
+  // The maximum record time after which the submission will be rejected.
+  // Allows submitter to control when the request times out and to retry.
+  google.protobuf.Timestamp maximum_record_time = 3;
+
+  // The new configuration that replaces the current configuration.
+  com.daml.ledger.configuration.LedgerConfiguration configuration = 4;
+}
+
+// Configuration entry that records a configuration change.
+// Also used in state to look up latest configuration.
+// When a configuration exists, only the participant that
+// submitted previously can change it.
+message DamlConfigurationEntry {
+  // The submission from which this configuration originated.
+  string submission_id = 1;
+
+  // Submitting participant's id.
+  string participant_id = 2;
+
+  // The ledger configuration.
+  com.daml.ledger.configuration.LedgerConfiguration configuration = 3;
+}

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_configuration_rejection.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_configuration_rejection.proto
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Protocol buffer messages used by the participant state key-value utilities
+// for implementing a Daml ledger backed by a key-value store.
+//
+// These messages should only be produced and consumed by the methods in
+// `KeyValueCommitting`, `KeyValueConsumption` and `KeyValueSubmission` objects.
+//
+
+syntax = "proto3";
+
+package com.daml.ledger.participant.state.kvutils;
+
+option java_package = "com.daml.ledger.participant.state.kvutils";
+option csharp_namespace = "Com.Daml.Ledger.Participant.State.KVUtils";
+
+import "com/daml/ledger/configuration/ledger_configuration.proto";
+import "com/daml/ledger/participant/state/kvutils/rejection_reason.proto";
+
+// A log entry describing a rejected configuration change.
+message DamlConfigurationRejectionEntry {
+  // A unique string scoped to a particular participant for matching the
+  // request with the result.
+  string submission_id = 1;
+
+  // Submitting participant's id.
+  string participant_id = 2;
+
+  // The new proposed configuration that was rejected.
+  com.daml.ledger.configuration.LedgerConfiguration configuration = 3;
+
+  oneof reason {
+    com.daml.ledger.participant.state.kvutils.ParticipantNotAuthorized participant_not_authorized = 4;
+    com.daml.ledger.participant.state.kvutils.GenerationMismatch generation_mismatch = 5;
+    com.daml.ledger.participant.state.kvutils.Invalid invalid_configuration = 6;
+    com.daml.ledger.participant.state.kvutils.TimedOut timed_out = 7;
+    com.daml.ledger.participant.state.kvutils.Duplicate duplicate_submission = 8;
+  }
+}

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_kvutils.proto
@@ -21,9 +21,9 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "com/daml/daml_lf_dev/daml_lf.proto";
 import "com/daml/lf/transaction.proto";
-import "com/daml/lf/value.proto";
-import "com/daml/ledger/configuration/ledger_configuration.proto";
-
+import "com/daml/ledger/participant/state/kvutils/rejection_reason.proto";
+import "com/daml/ledger/participant/state/kvutils/daml_configuration.proto";
+import "com/daml/ledger/participant/state/kvutils/daml_configuration_rejection.proto";
 // Envelope with which we wrap all kvutils messages that are sent over the network
 // or persisted on disk. The envelope specifies the kvutils version that defines how
 // a message is decoded and processed. Optionally the message payload may be stored
@@ -203,34 +203,34 @@ message DamlTransactionRejectionEntry {
   oneof reason {
 
     // Rejections used by both participant.state v1 and v2 API.
-    Duplicate duplicate_command = 6;
-    SubmitterCannotActViaParticipant submitter_cannot_act_via_participant = 8;
-    InvalidLedgerTime invalid_ledger_time = 9;
+    com.daml.ledger.participant.state.kvutils.Duplicate duplicate_command = 6;
+    com.daml.ledger.participant.state.kvutils.SubmitterCannotActViaParticipant submitter_cannot_act_via_participant = 8;
+    com.daml.ledger.participant.state.kvutils.InvalidLedgerTime invalid_ledger_time = 9;
 
     //
     // Rejections used by participant.state.v1 API.
     // Note that these are deprecated.
     //
-    Inconsistent inconsistent = 2 [deprecated = true];
-    Disputed disputed = 3 [deprecated = true];
-    ResourcesExhausted resources_exhausted = 4 [deprecated = true];
-    PartyNotKnownOnLedger party_not_known_on_ledger = 7 [deprecated = true];
+    com.daml.ledger.participant.state.kvutils.Inconsistent inconsistent = 2 [deprecated = true];
+    com.daml.ledger.participant.state.kvutils.Disputed disputed = 3 [deprecated = true];
+    com.daml.ledger.participant.state.kvutils.ResourcesExhausted resources_exhausted = 4 [deprecated = true];
+    com.daml.ledger.participant.state.kvutils.PartyNotKnownOnLedger party_not_known_on_ledger = 7 [deprecated = true];
 
     //
     // Rejections used by participant.state.v2 API.
     //
-    ValidationFailure validation_failure = 10;
-    DuplicateKeys internally_duplicate_keys = 11;
-    InconsistentKeys internally_inconsistent_keys = 12;
-    InconsistentContracts externally_inconsistent_contracts = 13;
-    DuplicateKeys externally_duplicate_keys = 14;
-    InconsistentKeys externally_inconsistent_keys = 15;
-    MissingInputState missing_input_state = 16;
-    RecordTimeOutOfRange record_time_out_of_range = 17;
-    CausalMonotonicityViolated causal_monotonicity_violated = 18;
-    SubmittingPartyNotKnownOnLedger submitting_party_not_known_on_ledger = 19;
-    PartiesNotKnownOnLedger parties_not_known_on_ledger = 20;
-    InvalidParticipantState invalid_participant_state = 21;
+    com.daml.ledger.participant.state.kvutils.ValidationFailure validation_failure = 10;
+    com.daml.ledger.participant.state.kvutils.DuplicateKeys internally_duplicate_keys = 11;
+    com.daml.ledger.participant.state.kvutils.InconsistentKeys internally_inconsistent_keys = 12;
+    com.daml.ledger.participant.state.kvutils.InconsistentContracts externally_inconsistent_contracts = 13;
+    com.daml.ledger.participant.state.kvutils.DuplicateKeys externally_duplicate_keys = 14;
+    com.daml.ledger.participant.state.kvutils.InconsistentKeys externally_inconsistent_keys = 15;
+    com.daml.ledger.participant.state.kvutils.MissingInputState missing_input_state = 16;
+    com.daml.ledger.participant.state.kvutils.RecordTimeOutOfRange record_time_out_of_range = 17;
+    com.daml.ledger.participant.state.kvutils.CausalMonotonicityViolated causal_monotonicity_violated = 18;
+    com.daml.ledger.participant.state.kvutils.SubmittingPartyNotKnownOnLedger submitting_party_not_known_on_ledger = 19;
+    com.daml.ledger.participant.state.kvutils.PartiesNotKnownOnLedger parties_not_known_on_ledger = 20;
+    com.daml.ledger.participant.state.kvutils.InvalidParticipantState invalid_participant_state = 21;
   }
 }
 // A public package upload.
@@ -267,64 +267,10 @@ message DamlPackageUploadRejectionEntry {
   string participant_id = 2;
 
   oneof reason {
-    Invalid invalid_package = 3;
-    ParticipantNotAuthorized participant_not_authorized = 4;
-    Duplicate duplicate_submission = 5;
+    com.daml.ledger.participant.state.kvutils.Invalid invalid_package = 3;
+    com.daml.ledger.participant.state.kvutils.ParticipantNotAuthorized participant_not_authorized = 4;
+    com.daml.ledger.participant.state.kvutils.Duplicate duplicate_submission = 5;
   }
-}
-
-// Configuration change request to change the ledger configuration.
-message DamlConfigurationSubmission {
-  // A unique string scoped to a particular participant for matching the
-  // request with the result.
-  // Implementers are free to select adequate mechanism e.g. UUID or similar.
-  string submission_id = 1;
-
-  // Submitting participant's id.
-  string participant_id = 2;
-
-  // The maximum record time after which the submission will be rejected.
-  // Allows submitter to control when the request times out and to retry.
-  google.protobuf.Timestamp maximum_record_time = 3;
-
-  // The new configuration that replaces the current configuration.
-  com.daml.ledger.configuration.LedgerConfiguration configuration = 4;
-}
-
-// A log entry describing a rejected configuration change.
-message DamlConfigurationRejectionEntry {
-  // A unique string scoped to a particular participant for matching the
-  // request with the result.
-  string submission_id = 1;
-
-  // Submitting participant's id.
-  string participant_id = 2;
-
-  // The new proposed configuration that was rejected.
-  com.daml.ledger.configuration.LedgerConfiguration configuration = 3;
-
-  oneof reason {
-    ParticipantNotAuthorized participant_not_authorized = 4;
-    GenerationMismatch generation_mismatch = 5;
-    Invalid invalid_configuration = 6;
-    TimedOut timed_out = 7;
-    Duplicate duplicate_submission = 8;
-  }
-}
-
-// Configuration entry that records a configuration change.
-// Also used in state to look up latest configuration.
-// When a configuration exists, only the participant that
-// submitted previously can change it.
-message DamlConfigurationEntry {
-  // The submission from which this configuration originated.
-  string submission_id = 1;
-
-  // Submitting participant's id.
-  string participant_id = 2;
-
-  // The ledger configuration.
-  com.daml.ledger.configuration.LedgerConfiguration configuration = 3;
 }
 
 // An allocation of party name and assignment of a party to a given
@@ -356,10 +302,10 @@ message DamlPartyAllocationRejectionEntry {
   string participant_id = 2;
 
   oneof reason {
-    AlreadyExists already_exists = 3;
-    Invalid invalid_name = 4;
-    ParticipantNotAuthorized participant_not_authorized = 5;
-    Duplicate duplicate_submission = 6;
+    com.daml.ledger.participant.state.kvutils.AlreadyExists already_exists = 3;
+    com.daml.ledger.participant.state.kvutils.Invalid invalid_name = 4;
+    com.daml.ledger.participant.state.kvutils.ParticipantNotAuthorized participant_not_authorized = 5;
+    com.daml.ledger.participant.state.kvutils.Duplicate duplicate_submission = 6;
   }
 }
 
@@ -374,245 +320,3 @@ message DamlOutOfTimeBoundsEntry {
   google.protobuf.Timestamp too_late_from = 4;
 }
 
-// Daml state key. [[KeyValueCommitting]] produces effects that are committed
-// to the ledger from the `DamlSubmission`: a log entry to be created, and
-// the set of Daml state updates.
-// The field numbers below must match with the corresponding entries in `DamlStateValue`.
-message DamlStateKey {
-  oneof key {
-    string package_id = 1;
-    string contract_id = 2;
-    DamlCommandDedupKey command_dedup = 3;
-    string party = 4;
-    DamlContractKey contract_key = 5;
-    google.protobuf.Empty configuration = 6;
-    DamlSubmissionDedupKey submission_dedup = 7;
-  }
-}
-
-// Daml state values pointed to by `DamlStateKey`.
-// The field numbers below must match with the corresponding entries in `DamlStateKey`.
-message DamlStateValue {
-  oneof value {
-    daml_lf_dev.Archive archive = 1;
-    DamlContractState contract_state = 2;
-    DamlCommandDedupValue command_dedup = 3;
-    DamlPartyAllocation party = 4;
-    DamlContractKeyState contract_key_state = 5;
-    DamlConfigurationEntry configuration_entry = 6;
-    DamlSubmissionDedupValue submission_dedup = 7;
-  }
-}
-
-message DamlCommandDedupKey {
-  repeated string submitters = 1;
-  string application_id = 2;
-  string command_id = 3;
-}
-
-message DamlCommandDedupValue {
-  reserved 1; // was record_time
-  // the time until when future commands with the same
-  // deduplication key will be rejected due to a duplicate submission
-  google.protobuf.Timestamp deduplicated_until = 2;
-}
-
-message DamlSubmissionDedupKey {
-  enum SubmissionKind {
-    PARTY_ALLOCATION = 0;
-    PACKAGE_UPLOAD = 1;
-    CONFIGURATION = 2;
-  }
-
-  SubmissionKind submission_kind = 1;
-
-  // A unique string scoped to a particular participant.
-  string submission_id = 2;
-
-  // Uploading participant's id.
-  string participant_id = 3;
-}
-
-message DamlSubmissionDedupValue {
-  reserved 1; // was record_time
-}
-
-// Daml contract state, recording the activeness state of a contract.
-// The contract instance itself is stored within the transaction in a log entry.
-// See https://github.com/digital-asset/daml/issues/734 for future work on contract
-// instance storage.
-message DamlContractState {
-  // The time from which the contract is active.
-  // This is the same value as the ledger_effective_time of the transaction
-  // that created this contract.
-  google.protobuf.Timestamp active_at = 1;
-
-  // Optional, if set the contract has been archived.
-  google.protobuf.Timestamp archived_at = 2;
-
-  reserved 3; // was archived_by_entry
-
-  // The parties to which this contract has been explicitly disclosed, that is,
-  // the parties which witnessed the creation of the contract.
-  repeated string locally_disclosed_to = 4;
-
-  // The parties to which this contract has been disclosed to after the creation
-  // of the contract (i.e. divulged to).
-  // https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
-  repeated string divulged_to = 5;
-
-  // The contract key set by the contract. Optional.
-  DamlContractKey contract_key = 6;
-
-  // The contract instance.
-  com.daml.lf.transaction.ContractInstance contract_instance = 7;
-}
-
-message DamlContractKey {
-  // The Daml template identifier of the contract that created this key.
-  com.daml.lf.value.Identifier template_id = 1;
-
-  reserved 2; // This was key serialized as a VersionedValue. Replaced by hash.
-
-  // Hash of the contract key value, produced by KeyHasher.
-  bytes hash = 3;
-}
-
-// Stored information about a given party.
-// Party tenancy is immutable and cannot change once recorded.
-// TODO: Add concept of party allocation time. It would have to follow similar pattern
-// as LET for transactions, so that party allocation submissions remain verifiable by
-// the committers/validators.
-message DamlPartyAllocation {
-  // Id of participant where the party is hosted.
-  string participant_id = 1;
-  // A display name associated with the given party.
-  string display_name = 2;
-}
-
-// The state of a contract key.
-message DamlContractKeyState {
-  // The contract to which the key points to.
-  // If unset the key is inactive.
-  string contract_id = 1;
-
-  // The time from which the contract is active.
-  // This is the same value as the ledger_effective_time of the transaction
-  // that created this contract.
-  google.protobuf.Timestamp active_at = 2;
-}
-
-// Errors
-
-//
-// Used by participant.state.v1 API.
-//
-
-// The transaction relied on contracts or keys being active that were no longer active.
-message Inconsistent {
-  string details = 1;
-}
-
-// The transaction has been disputed.
-// Dispute occurs when the Daml model conformance or authorization fails.
-message Disputed {
-  string details = 1;
-}
-
-// Committer did not have sufficient resources to process the transaction.
-message ResourcesExhausted {
-  string details = 1;
-}
-
-// The transaction submission exceeded its maximum record time.
-message MaximumRecordTimeExceeded {
-  string details = 1;
-}
-
-// The ledger time of the transaction submission violates some constraint.
-message InvalidLedgerTime {
-  string details = 1;
-  google.protobuf.Timestamp ledger_time = 2;
-  google.protobuf.Timestamp lower_bound = 3;
-  google.protobuf.Timestamp upper_bound = 4;
-}
-
-// The committer has already seen a command/submission with the same deduplication
-// key during its implementation specific deduplication window.
-message Duplicate {
-  string details = 1;
-}
-
-// A party mentioned as a stakeholder or actor has not been on-boarded on
-// the ledger.
-message PartyNotKnownOnLedger {
-  string details = 1;
-}
-
-// The submitting party cannot act via the participant to which the request has been sent.
-message SubmitterCannotActViaParticipant {
-  string details = 1;
-  string submitter_party = 2;
-  string participant_id = 3;
-}
-
-// Submitted request content was not valid: a Daml package, a party name
-// or a configuration.
-message Invalid {
-  string details = 1;
-}
-
-// Participant not authorized to submit the request.
-message ParticipantNotAuthorized {
-  string details = 1;
-}
-
-// A mismatch in the configuration generation, that is, the
-// new configuration did not carry a generation that was one
-// larger than previous generation.
-message GenerationMismatch {
-  int64 expected_generation = 1;
-}
-
-// The request timed out, e.g. record time exceeded maximum record time.
-message TimedOut {
-  google.protobuf.Timestamp record_time = 1;
-  google.protobuf.Timestamp maximum_record_time = 2;
-}
-
-// The requested entity already exists.
-message AlreadyExists {
-  string details = 1;
-}
-
-//
-// Rejections used by participant.state.v2 API.
-//
-message ValidationFailure {
-  string details = 1;
-}
-message DuplicateKeys {
-}
-message InconsistentKeys {
-}
-message InconsistentContracts {
-}
-message MissingInputState {
-  DamlStateKey key = 1;
-}
-message InvalidParticipantState {
-  string details = 1;
-  map<string, string> metadata = 2;
-}
-message RecordTimeOutOfRange {
-  google.protobuf.Timestamp minimum_record_time = 1;
-  google.protobuf.Timestamp maximum_record_time = 2;
-}
-message CausalMonotonicityViolated {
-}
-message SubmittingPartyNotKnownOnLedger {
-  string submitter_party = 1;
-}
-message PartiesNotKnownOnLedger {
-  repeated string parties = 1;
-}

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_state.proto
@@ -1,0 +1,145 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package com.daml.ledger.participant.state.kvutils;
+
+option java_package = "com.daml.ledger.participant.state.kvutils";
+option csharp_namespace = "Com.Daml.Ledger.Participant.State.KVUtils";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+import "com/daml/daml_lf_dev/daml_lf.proto";
+import "com/daml/lf/transaction.proto";
+import "com/daml/lf/value.proto";
+import "com/daml/ledger/participant/state/kvutils/daml_configuration.proto";
+
+// Daml state key. [[KeyValueCommitting]] produces effects that are committed
+// to the ledger from the `DamlSubmission`: a log entry to be created, and
+// the set of Daml state updates.
+// The field numbers below must match with the corresponding entries in `DamlStateValue`.
+message DamlStateKey {
+  oneof key {
+    string package_id = 1;
+    string contract_id = 2;
+    DamlCommandDedupKey command_dedup = 3;
+    string party = 4;
+    DamlContractKey contract_key = 5;
+    google.protobuf.Empty configuration = 6;
+    DamlSubmissionDedupKey submission_dedup = 7;
+  }
+}
+
+// Daml state values pointed to by `DamlStateKey`.
+// The field numbers below must match with the corresponding entries in `DamlStateKey`.
+message DamlStateValue {
+  oneof value {
+    daml_lf_dev.Archive archive = 1;
+    DamlContractState contract_state = 2;
+    DamlCommandDedupValue command_dedup = 3;
+    DamlPartyAllocation party = 4;
+    DamlContractKeyState contract_key_state = 5;
+    com.daml.ledger.participant.state.kvutils.DamlConfigurationEntry configuration_entry = 6;
+    DamlSubmissionDedupValue submission_dedup = 7;
+  }
+}
+
+message DamlCommandDedupKey {
+  repeated string submitters = 1;
+  string application_id = 2;
+  string command_id = 3;
+}
+
+message DamlCommandDedupValue {
+  reserved 1; // was record_time
+  // the time until when future commands with the same
+  // deduplication key will be rejected due to a duplicate submission
+  google.protobuf.Timestamp deduplicated_until = 2;
+}
+
+message DamlSubmissionDedupKey {
+  enum SubmissionKind {
+    PARTY_ALLOCATION = 0;
+    PACKAGE_UPLOAD = 1;
+    CONFIGURATION = 2;
+  }
+
+  SubmissionKind submission_kind = 1;
+
+  // A unique string scoped to a particular participant.
+  string submission_id = 2;
+
+  // Uploading participant's id.
+  string participant_id = 3;
+}
+
+message DamlSubmissionDedupValue {
+  reserved 1; // was record_time
+}
+
+// Daml contract state, recording the activeness state of a contract.
+// The contract instance itself is stored within the transaction in a log entry.
+// See https://github.com/digital-asset/daml/issues/734 for future work on contract
+// instance storage.
+message DamlContractState {
+  // The time from which the contract is active.
+  // This is the same value as the ledger_effective_time of the transaction
+  // that created this contract.
+  google.protobuf.Timestamp active_at = 1;
+
+  // Optional, if set the contract has been archived.
+  google.protobuf.Timestamp archived_at = 2;
+
+  reserved 3; // was archived_by_entry
+
+  // The parties to which this contract has been explicitly disclosed, that is,
+  // the parties which witnessed the creation of the contract.
+  repeated string locally_disclosed_to = 4;
+
+  // The parties to which this contract has been disclosed to after the creation
+  // of the contract (i.e. divulged to).
+  // https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
+  repeated string divulged_to = 5;
+
+  // The contract key set by the contract. Optional.
+  DamlContractKey contract_key = 6;
+
+  // The contract instance.
+  com.daml.lf.transaction.ContractInstance contract_instance = 7;
+}
+
+message DamlContractKey {
+  // The Daml template identifier of the contract that created this key.
+  com.daml.lf.value.Identifier template_id = 1;
+
+  reserved 2; // This was key serialized as a VersionedValue. Replaced by hash.
+
+  // Hash of the contract key value, produced by KeyHasher.
+  bytes hash = 3;
+}
+
+// Stored information about a given party.
+// Party tenancy is immutable and cannot change once recorded.
+// TODO: Add concept of party allocation time. It would have to follow similar pattern
+// as LET for transactions, so that party allocation submissions remain verifiable by
+// the committers/validators.
+message DamlPartyAllocation {
+  // Id of participant where the party is hosted.
+  string participant_id = 1;
+  // A display name associated with the given party.
+  string display_name = 2;
+}
+
+// The state of a contract key.
+message DamlContractKeyState {
+  // The contract to which the key points to.
+  // If unset the key is inactive.
+  string contract_id = 1;
+
+  // The time from which the contract is active.
+  // This is the same value as the ledger_effective_time of the transaction
+  // that created this contract.
+  google.protobuf.Timestamp active_at = 2;
+}
+

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/rejection_reason.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/rejection_reason.proto
@@ -1,0 +1,128 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package com.daml.ledger.participant.state.kvutils;
+
+option java_package = "com.daml.ledger.participant.state.kvutils";
+option csharp_namespace = "Com.Daml.Ledger.Participant.State.KVUtils";
+
+import "google/protobuf/timestamp.proto";
+import "com/daml/ledger/participant/state/kvutils/daml_state.proto";
+
+// Errors
+
+//
+// Used by participant.state.v1 API.
+//
+
+// The transaction relied on contracts or keys being active that were no longer active.
+message Inconsistent {
+  string details = 1;
+}
+
+// The transaction has been disputed.
+// Dispute occurs when the Daml model conformance or authorization fails.
+message Disputed {
+  string details = 1;
+}
+
+// Committer did not have sufficient resources to process the transaction.
+message ResourcesExhausted {
+  string details = 1;
+}
+
+// The transaction submission exceeded its maximum record time.
+message MaximumRecordTimeExceeded {
+  string details = 1;
+}
+
+// The ledger time of the transaction submission violates some constraint.
+message InvalidLedgerTime {
+  string details = 1;
+  google.protobuf.Timestamp ledger_time = 2;
+  google.protobuf.Timestamp lower_bound = 3;
+  google.protobuf.Timestamp upper_bound = 4;
+}
+
+// The committer has already seen a command/submission with the same deduplication
+// key during its implementation specific deduplication window.
+message Duplicate {
+  string details = 1;
+}
+
+// A party mentioned as a stakeholder or actor has not been on-boarded on
+// the ledger.
+message PartyNotKnownOnLedger {
+  string details = 1;
+}
+
+// The submitting party cannot act via the participant to which the request has been sent.
+message SubmitterCannotActViaParticipant {
+  string details = 1;
+  string submitter_party = 2;
+  string participant_id = 3;
+}
+
+// Submitted request content was not valid: a Daml package, a party name
+// or a configuration.
+message Invalid {
+  string details = 1;
+}
+
+// Participant not authorized to submit the request.
+message ParticipantNotAuthorized {
+  string details = 1;
+}
+
+// A mismatch in the configuration generation, that is, the
+// new configuration did not carry a generation that was one
+// larger than previous generation.
+message GenerationMismatch {
+  int64 expected_generation = 1;
+}
+
+// The request timed out, e.g. record time exceeded maximum record time.
+message TimedOut {
+  google.protobuf.Timestamp record_time = 1;
+  google.protobuf.Timestamp maximum_record_time = 2;
+}
+
+// The requested entity already exists.
+message AlreadyExists {
+  string details = 1;
+}
+
+//
+// Rejections used by participant.state.v2 API.
+//
+message ValidationFailure {
+  string details = 1;
+}
+message DuplicateKeys {
+}
+message InconsistentKeys {
+}
+message InconsistentContracts {
+}
+message MissingInputState {
+  com.daml.ledger.participant.state.kvutils.DamlStateKey key = 1;
+}
+message InvalidParticipantState {
+  string details = 1;
+  map<string, string> metadata = 2;
+}
+message RecordTimeOutOfRange {
+  google.protobuf.Timestamp minimum_record_time = 1;
+  google.protobuf.Timestamp maximum_record_time = 2;
+}
+message CausalMonotonicityViolated {
+}
+message SubmittingPartyNotKnownOnLedger {
+  string submitter_party = 1;
+}
+message PartiesNotKnownOnLedger {
+  repeated string parties = 1;
+}
+

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/wire/submission.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/wire/submission.proto
@@ -8,6 +8,8 @@ option java_multiple_files = true;
 option csharp_namespace = "Com.Daml.Ledger.Participant.State.KVUtils.Wire";
 
 import "com/daml/ledger/participant/state/kvutils/daml_kvutils.proto";
+import "com/daml/ledger/participant/state/kvutils/daml_configuration.proto";
+import "com/daml/ledger/participant/state/kvutils/daml_state.proto";
 
 // A submission to the ledger: a payload and its inputs if any.
 // Produced by [[KeyValueSubmission]].

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -31,9 +31,17 @@ import com.google.protobuf.any.{Any => AnyProto}
 import com.google.rpc.code.Code
 import com.google.rpc.error_details.ErrorInfo
 import com.google.rpc.status.Status
-
 import java.io.StringWriter
 import java.time.{Duration, Instant}
+
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlCommandDedupKey,
+  DamlContractKey,
+  DamlStateKey,
+  DamlSubmissionDedupKey,
+}
+import com.daml.ledger.participant.state.kvutils.RejectionReason._
+
 import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.participant.state.kvutils
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils => Proto}
+import com.daml.ledger.participant.state.kvutils.{DamlState => ProtoState}
 import com.google.protobuf.ByteString
 
 import scala.util.Try
@@ -22,7 +23,7 @@ object Envelope {
 
   final case class LogEntryMessage(logEntry: Proto.DamlLogEntry) extends Message
 
-  final case class StateValueMessage(value: Proto.DamlStateValue) extends Message
+  final case class StateValueMessage(value: ProtoState.DamlStateValue) extends Message
 
   final case class SubmissionBatchMessage(value: wire.DamlSubmissionBatch) extends Message
 
@@ -59,10 +60,10 @@ object Envelope {
   def enclose(logEntry: Proto.DamlLogEntry, compression: Boolean): Raw.Envelope =
     enclose(Proto.Envelope.MessageKind.LOG_ENTRY, logEntry.toByteString, compression)
 
-  def enclose(stateValue: Proto.DamlStateValue): Raw.Envelope =
+  def enclose(stateValue: ProtoState.DamlStateValue): Raw.Envelope =
     enclose(stateValue, compression = DefaultCompression)
 
-  def enclose(stateValue: Proto.DamlStateValue, compression: Boolean): Raw.Envelope =
+  def enclose(stateValue: ProtoState.DamlStateValue, compression: Boolean): Raw.Envelope =
     enclose(Proto.Envelope.MessageKind.STATE_VALUE, stateValue.toByteString, compression)
 
   def enclose(batch: wire.DamlSubmissionBatch): Raw.Envelope =
@@ -98,7 +99,7 @@ object Envelope {
           parseMessageSafe(() => wire.DamlSubmission.parseFrom(uncompressedMessage))
             .map(SubmissionMessage)
         case Proto.Envelope.MessageKind.STATE_VALUE =>
-          parseMessageSafe(() => Proto.DamlStateValue.parseFrom(uncompressedMessage))
+          parseMessageSafe(() => ProtoState.DamlStateValue.parseFrom(uncompressedMessage))
             .map(StateValueMessage)
         case Proto.Envelope.MessageKind.SUBMISSION_BATCH =>
           parseMessageSafe(() => wire.DamlSubmissionBatch.parseFrom(uncompressedMessage))
@@ -126,13 +127,13 @@ object Envelope {
       case msg => Left(s"Expected submission, got ${msg.getClass}")
     }
 
-  def openStateValue(envelopeBytes: Raw.Envelope): Either[String, Proto.DamlStateValue] =
+  def openStateValue(envelopeBytes: Raw.Envelope): Either[String, ProtoState.DamlStateValue] =
     open(envelopeBytes).flatMap {
       case StateValueMessage(entry) => Right(entry)
       case msg => Left(s"Expected state value, got ${msg.getClass}")
     }
 
-  def openStateValue(envelopeBytes: Array[Byte]): Either[String, Proto.DamlStateValue] =
+  def openStateValue(envelopeBytes: Array[Byte]): Either[String, ProtoState.DamlStateValue] =
     open(envelopeBytes).flatMap {
       case StateValueMessage(entry) => Right(entry)
       case msg => Left(s"Expected state value, got ${msg.getClass}")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.lf.data.Ref
 
 /** Errors thrown by kvutils.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -7,6 +7,11 @@ import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions._
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlContractKey,
+  DamlStateKey,
+  DamlStateValue,
+}
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.kvutils.committer.transaction.TransactionCommitter
 import com.daml.ledger.participant.state.kvutils.committer.{

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -6,7 +6,9 @@ package com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.grpc.GrpcStatuses
 import com.daml.ledger.participant.state.kvutils.Conversions._
+import com.daml.ledger.participant.state.kvutils.DamlConfigurationRejection.DamlConfigurationRejectionEntry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.ledger.participant.state.v2.Update.CommandRejected.FinalReason
 import com.daml.ledger.participant.state.v2.{DivulgedContract, TransactionMeta, Update}
 import com.daml.lf.data.Ref

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
@@ -6,7 +6,9 @@ package com.daml.ledger.participant.state.kvutils
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions._
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationSubmission
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.v2.{SubmitterInfo, TransactionMeta}
 import com.daml.lf.data.Ref

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -3,7 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntryId, DamlStateKey}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.google.protobuf.ByteString
 
 object Raw {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -5,11 +5,8 @@ package com.daml.ledger.participant.state.kvutils.committer
 
 import java.time.Instant
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntry,
-  DamlStateKey,
-  DamlStateValue,
-}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntry
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.{DamlStateMap, Err}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -6,13 +6,12 @@ package com.daml.ledger.participant.state.kvutils.committer
 import com.codahale.metrics.Timer
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationEntry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlConfigurationEntry,
   DamlLogEntry,
   DamlOutOfTimeBoundsEntry,
-  DamlStateKey,
-  DamlStateValue,
 }
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.kvutils._
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -9,7 +9,23 @@ import com.daml.ledger.participant.state.kvutils.Conversions.{
   configDedupKey,
   configurationStateKey,
 }
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.{
+  DamlConfigurationEntry,
+  DamlConfigurationSubmission,
+}
+import com.daml.ledger.participant.state.kvutils.DamlConfigurationRejection.DamlConfigurationRejectionEntry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlStateValue,
+  DamlSubmissionDedupValue,
+}
+import com.daml.ledger.participant.state.kvutils.RejectionReason.{
+  Duplicate,
+  GenerationMismatch,
+  Invalid,
+  ParticipantNotAuthorized,
+  TimedOut,
+}
 import com.daml.ledger.participant.state.kvutils.committer.Committer._
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.lf.data.Time.Timestamp

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -7,8 +7,17 @@ import java.util.concurrent.Executors
 
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.participant.state.kvutils.Conversions.packageUploadDedupKey
-import com.daml.ledger.participant.state.kvutils.DamlKvutils
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlStateKey,
+  DamlStateValue,
+  DamlSubmissionDedupValue,
+}
+import com.daml.ledger.participant.state.kvutils.RejectionReason.{
+  Duplicate,
+  Invalid,
+  ParticipantNotAuthorized,
+}
 import com.daml.ledger.participant.state.kvutils.committer.Committer.buildLogEntryWithOptionalRecordTime
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.lf
@@ -178,7 +187,7 @@ final private[kvutils] class PackageCommitter(
           ctx.recordTime,
           uploadEntry.getSubmissionId,
           uploadEntry.getParticipantId,
-          _.setInvalidPackage(DamlKvutils.Invalid.newBuilder.setDetails(message)),
+          _.setInvalidPackage(Invalid.newBuilder.setDetails(message)),
         )
       } else {
         StepContinue(partialResult)
@@ -243,7 +252,7 @@ final private[kvutils] class PackageCommitter(
             ctx.recordTime,
             uploadEntry.getSubmissionId,
             uploadEntry.getParticipantId,
-            _.setInvalidPackage(DamlKvutils.Invalid.newBuilder.setDetails(message)),
+            _.setInvalidPackage(Invalid.newBuilder.setDetails(message)),
           )
       }
     }
@@ -321,7 +330,7 @@ final private[kvutils] class PackageCommitter(
             ctx.recordTime,
             uploadEntry.getSubmissionId,
             uploadEntry.getParticipantId,
-            _.setInvalidPackage(DamlKvutils.Invalid.newBuilder.setDetails(message)),
+            _.setInvalidPackage(Invalid.newBuilder.setDetails(message)),
           )
       }
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
@@ -5,6 +5,18 @@ package com.daml.ledger.participant.state.kvutils.committer
 
 import com.daml.ledger.participant.state.kvutils.Conversions.partyAllocationDedupKey
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlPartyAllocation,
+  DamlStateKey,
+  DamlStateValue,
+  DamlSubmissionDedupValue,
+}
+import com.daml.ledger.participant.state.kvutils.RejectionReason.{
+  AlreadyExists,
+  Duplicate,
+  Invalid,
+  ParticipantNotAuthorized,
+}
 import com.daml.ledger.participant.state.kvutils.committer.Committer.buildLogEntryWithOptionalRecordTime
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.lf.data.Ref

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/SubmissionExecutor.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/SubmissionExecutor.scala
@@ -3,11 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntry,
-  DamlStateKey,
-  DamlStateValue,
-}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntry
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.DamlStateMap
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejection.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejection.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.participant.state.kvutils.committer.transaction
 import java.time.Instant
 
 import com.daml.ledger.configuration.LedgerTimeModel
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.ledger.participant.state.kvutils.Err
 import com.daml.lf
 import com.daml.lf.data.Ref

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -11,6 +11,14 @@ import java.time.Instant
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions._
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlCommandDedupValue,
+  DamlContractKeyState,
+  DamlContractState,
+  DamlStateKey,
+  DamlStateValue,
+}
+import com.daml.ledger.participant.state.kvutils.RejectionReason.Duplicate
 import com.daml.ledger.participant.state.kvutils.committer.Committer._
 import com.daml.ledger.participant.state.kvutils.committer._
 import com.daml.ledger.participant.state.kvutils.committer.transaction.validation.{

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidator.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.participant.state.kvutils.Conversions.{
   packageStateKey,
   parseTimestamp,
 }
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlContractState, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlContractState, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,
   Rejection,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
 
 import com.daml.ledger.participant.state.kvutils.Conversions
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+import com.daml.ledger.participant.state.kvutils.DamlState.{
   DamlContractKey,
   DamlContractKeyState,
   DamlContractState,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.metrics.MetricName
 
 /** The participant-state key-value utilities provide methods to succinctly implement

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CommitStrategy.scala
@@ -3,12 +3,8 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntry,
-  DamlLogEntryId,
-  DamlStateKey,
-  DamlStateValue,
-}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntry, DamlLogEntryId}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DefaultStateKeySerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DefaultStateKeySerializationStrategy.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.ledger.participant.state.kvutils.Raw
 
 /** Default state key serialization strategy that does not prefix keys.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
@@ -3,12 +3,8 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntry,
-  DamlLogEntryId,
-  DamlStateKey,
-  DamlStateValue,
-}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntry, DamlLogEntryId}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.lf.data.Ref

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.validator.reading.{DamlLedgerStateReader, LedgerStateReader}
 import com.daml.logging.LoggingContext

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateKeySerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateKeySerializationStrategy.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.ledger.participant.state.kvutils.Raw
 
 /** Determines how we namespace and serialize state keys.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 
 import scala.collection.SortedMap

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import com.codahale.metrics.Timer
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.wire._
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
 import com.daml.ledger.participant.state.kvutils.{DamlStateMap, Envelope, KeyValueCommitting, Raw}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -9,6 +9,7 @@ import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.wire._
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
 import com.daml.ledger.participant.state.kvutils.export.{

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.validator.batch
 
 import com.daml.caching.Cache
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.validator.caching.{
   CacheUpdatePolicy,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import akka.stream.Materializer
 import com.daml.caching.Cache
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v2.SubmissionResult
 import com.daml.ledger.validator._

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/ConflictDetection.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/ConflictDetection.scala
@@ -3,12 +3,9 @@
 
 package com.daml.ledger.validator.batch
 
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntry.PayloadCase._
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntry,
-  DamlStateKey,
-  DamlStateValue,
-}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.lf.value.ValueCoder
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.validator.caching
 
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.ledger.validator.{
   CommitStrategy,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicy.scala
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.daml.ledger.validator.caching
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 
 /** Cache update policy that allows writing to-be-committed packages back to the cache and read
   * immutable values such as packages and party allocations from the ledger.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger
 
 import com.daml.caching.ConcurrentCache
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateValue
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateValue
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.lf.data.Ref
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/KeyNotPresentInInputException.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/KeyNotPresentInInputException.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 
 final class KeyNotPresentInInputException(key: DamlStateKey)
     extends IllegalStateException(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
 import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.validator.preexecution
 
 import java.time.Instant
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.export.{
   LedgerDataExporter,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategy.scala
@@ -3,12 +3,8 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntry,
-  DamlLogEntryId,
-  DamlStateKey,
-  DamlStateValue,
-}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntry, DamlLogEntryId}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.validator.preexecution.RawPreExecutingCommitStrategy.{InputState, ReadSet}
 import com.daml.ledger.validator.{

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/HasDamlStateValue.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/HasDamlStateValue.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateValue
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateValue
 
 /** This typeclass signifies that implementor contains an optional Daml state value.
   *

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.Raw
 
 package object reading {

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -10,6 +10,7 @@ import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.DeduplicationPeriod
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.v2.{SubmitterInfo, TransactionMeta}

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
@@ -6,6 +6,15 @@ package com.daml.ledger.validator
 import java.util.UUID
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlCommandDedupKey,
+  DamlContractKey,
+  DamlContractKeyState,
+  DamlContractState,
+  DamlStateKey,
+  DamlStateValue,
+  DamlSubmissionDedupKey,
+}
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.lf.data.Ref

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.validator.HasDamlStateValue
 import com.daml.ledger.validator.reading.StateReader
 import com.daml.logging.LoggingContext

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -31,8 +31,19 @@ import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks.{Table, forAll}
 import org.scalatest.wordspec.AnyWordSpec
-
 import java.time.{Duration, Instant}
+
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.RejectionReason.{
+  Disputed,
+  Duplicate,
+  Inconsistent,
+  InvalidLedgerTime,
+  PartyNotKnownOnLedger,
+  ResourcesExhausted,
+  SubmitterCannotActViaParticipant,
+}
+
 import scala.annotation.nowarn
 import scala.collection.immutable.{ListMap, ListSet}
 import scala.collection.mutable

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/EnvelopeSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/EnvelopeSpec.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.participant.state.kvutils
 
 import com.daml.ledger.participant.state.kvutils.wire._
-import com.daml.ledger.participant.state.kvutils.{DamlKvutils => Proto}
+import com.daml.ledger.participant.state.kvutils.{DamlKvutils => Proto, DamlState => ProtoState}
 import com.google.protobuf.ByteString
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -22,7 +22,7 @@ class EnvelopeSpec extends AnyWordSpec with Matchers {
       Envelope.open(Envelope.enclose(logEntry)) shouldEqual
         Right(Envelope.LogEntryMessage(logEntry))
 
-      val stateValue = Proto.DamlStateValue.getDefaultInstance
+      val stateValue = ProtoState.DamlStateValue.getDefaultInstance
       Envelope.open(Envelope.enclose(stateValue)) shouldEqual
         Right(Envelope.StateValueMessage(stateValue))
     }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -7,6 +7,7 @@ import java.time.Duration
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.Configuration
+import com.daml.ledger.participant.state.kvutils.DamlConfigurationRejection.DamlConfigurationRejectionEntry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -9,6 +9,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlLogEntry,
   DamlTransactionRejectionEntry,
 }
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateValue
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.v2.Update
@@ -487,10 +488,10 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
         // Check that all contracts and keys are in the archived state.
         finalState.damlState.foreach { case (_, v) =>
           v.getValueCase match {
-            case DamlKvutils.DamlStateValue.ValueCase.CONTRACT_KEY_STATE =>
+            case DamlStateValue.ValueCase.CONTRACT_KEY_STATE =>
               v.getContractKeyState.getContractId shouldBe Symbol("empty")
 
-            case DamlKvutils.DamlStateValue.ValueCase.CONTRACT_STATE =>
+            case DamlStateValue.ValueCase.CONTRACT_STATE =>
               val cs = v.getContractState
               cs.hasArchivedAt shouldBe true
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
@@ -4,10 +4,11 @@
 package com.daml.ledger.participant.state.kvutils
 
 import java.time.Duration
+
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.{DeduplicationPeriod => ApiDeduplicationPeriod}
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlCommandDedupKey, DamlStateKey}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlCommandDedupKey, DamlStateKey}
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.v2.{SubmitterInfo, TransactionMeta}
 import com.daml.lf.crypto

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
@@ -4,9 +4,12 @@
 package com.daml.ledger.participant.state.kvutils
 
 import java.time.Instant
+
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.grpc.GrpcStatuses
 import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, parseInstant}
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationEntry
+import com.daml.ledger.participant.state.kvutils.DamlConfigurationRejection.DamlConfigurationRejectionEntry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntry.PayloadCase._
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.KeyValueConsumption.{

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
@@ -9,6 +9,7 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlPartyAllocation, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateReader.offsetForUpdate
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateReaderSpec._
 import com.daml.ledger.participant.state.kvutils.{Envelope, OffsetBuilder, Raw}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+import com.daml.ledger.participant.state.kvutils.DamlState.{
   DamlPartyAllocation,
   DamlStateKey,
   DamlStateValue,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -10,7 +10,9 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.protobuf.LedgerConfiguration
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
 import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, configurationStateKey}
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationEntry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.Err
 import com.daml.ledger.participant.state.kvutils.TestHelpers.{createCommitContext, theDefaultConfig}
 import com.daml.ledger.participant.state.kvutils.committer.CommitterSpec._

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.participant.state.kvutils.committer
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlConfigurationSubmission
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationSubmission
 import com.daml.ledger.participant.state.kvutils.TestHelpers
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
 import com.daml.lf.data.Time.Timestamp

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
@@ -9,6 +9,7 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.lf.archive.Decode

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -8,7 +8,14 @@ import java.time
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions.{buildDuration, buildTimestamp}
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationEntry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlCommandDedupValue,
+  DamlPartyAllocation,
+  DamlStateKey,
+  DamlStateValue,
+}
 import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
 import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepStop}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
@@ -9,11 +9,8 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.Conversions.configurationStateKey
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlCommandDedupValue,
-  DamlConfigurationEntry,
-  DamlStateValue,
-}
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationEntry
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlCommandDedupValue, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.TestHelpers.{
   createCommitContext,
   createEmptyTransactionEntry,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
@@ -4,9 +4,16 @@
 package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
 
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
+
 import com.codahale.metrics.MetricRegistry
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlContractState,
+  DamlStateKey,
+  DamlStateValue,
+}
+import com.daml.ledger.participant.state.kvutils.RejectionReason.CausalMonotonicityViolated
 import com.daml.ledger.participant.state.kvutils.TestHelpers.{createCommitContext, lfTuple}
 import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidatorSpec.scala
@@ -8,6 +8,13 @@ import java.util.UUID
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlContractKey,
+  DamlContractKeyState,
+  DamlContractState,
+  DamlStateKey,
+  DamlStateValue,
+}
 import com.daml.ledger.participant.state.kvutils.TestHelpers.{
   createCommitContext,
   createTransactionEntry,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.validator.ArgumentMatchers.{anyExecutionContext, anyLoggingContext}
 import com.daml.ledger.validator.LogAppendingCommitStrategySpec._

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapterSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+import com.daml.ledger.participant.state.kvutils.DamlState.{
   DamlPartyAllocation,
   DamlStateKey,
   DamlStateValue,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -7,7 +7,8 @@ import java.time.Clock
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.caching.Cache
-import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationSubmission
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.wire.{DamlSubmission, DamlSubmissionBatch}
 import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.validator.ArgumentMatchers.{anyExecutionContext, anyLoggingContext}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -8,6 +8,7 @@ import java.time.Clock
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.export.{
   NoOpLedgerDataExporter,
   SubmissionAggregator,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/ConflictDetectionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/ConflictDetectionSpec.scala
@@ -5,6 +5,12 @@ package com.daml.ledger.validator.batch
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlContractKey,
+  DamlPartyAllocation,
+  DamlStateKey,
+  DamlStateValue,
+}
 import com.daml.lf.value.ValueOuterClass
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingCommitStrategySpec.scala
@@ -4,12 +4,8 @@
 package com.daml.ledger.validator.caching
 
 import com.daml.caching.{Cache, WeightedCache}
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntry,
-  DamlLogEntryId,
-  DamlStateKey,
-  DamlStateValue,
-}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntry, DamlLogEntryId}
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.caching.`Message Weight`
 import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.ledger.validator.CommitStrategy

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicySpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator.caching
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.ledger.validator.TestHelper
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -7,7 +7,9 @@ import java.time.Instant
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.Configuration
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationSubmission
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.kvutils.wire.{DamlSubmission, DamlSubmissionBatch}
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmissionBatch.CorrelatedSubmission

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
@@ -4,7 +4,7 @@ package com.daml.ledger.validator.preexecution
 
 import java.time.Instant
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateKey
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.`export`.{
   LedgerDataExporter,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategySpec.scala
@@ -4,14 +4,17 @@
 package com.daml.ledger.validator.preexecution
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlContractState,
   DamlLogEntry,
   DamlPartyAllocationRejectionEntry,
+}
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlContractState,
   DamlStateKey,
   DamlStateValue,
 }
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
-import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Raw}
+import com.daml.ledger.participant.state.kvutils.Raw
+import com.daml.ledger.participant.state.kvutils.RejectionReason.Duplicate
 import com.daml.ledger.validator.StateKeySerializationStrategy
 import com.daml.ledger.validator.TestHelper.{
   aLogEntry,
@@ -114,7 +117,7 @@ object RawPreExecutingCommitStrategySpec {
   private val aRejectionLogEntry = DamlLogEntry.newBuilder
     .setPartyAllocationRejectionEntry(
       DamlPartyAllocationRejectionEntry.newBuilder
-        .setDuplicateSubmission(DamlKvutils.Duplicate.getDefaultInstance)
+        .setDuplicateSubmission(Duplicate.getDefaultInstance)
         .setParticipantId("a participant ID")
         .setSubmissionId("a submission")
     )

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupport.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import akka.stream.Materializer
 import com.daml.ledger.on.memory.{InMemoryLedgerStateAccess, InMemoryState, Index}
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateValue
+import com.daml.ledger.participant.state.kvutils.DamlState.DamlStateValue
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting
 import com.daml.ledger.participant.state.kvutils.export.{
   NoOpLedgerDataExporter,

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparison.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparison.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
 import com.daml.ledger.participant.state.kvutils
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.export.WriteSet
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.WriteSetComparison._
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Envelope, Raw}
@@ -129,7 +130,7 @@ final class RawWriteSetComparison(stateKeySerializationStrategy: StateKeySeriali
       rawEnvelope: Raw.Envelope,
   ): Either[String, Either[
     (DamlKvutils.DamlLogEntryId, DamlKvutils.DamlLogEntry),
-    (DamlKvutils.DamlStateKey, DamlKvutils.DamlStateValue),
+    (DamlStateKey, DamlStateValue),
   ]] =
     Envelope.open(rawEnvelope) match {
       case Left(errorMessage) =>
@@ -142,9 +143,9 @@ final class RawWriteSetComparison(stateKeySerializationStrategy: StateKeySeriali
           Right(Left(logEntryId -> logEntry))
       case Right(Envelope.StateValueMessage(value)) =>
         val key = stateKeySerializationStrategy.deserializeStateKey(Raw.StateKey(rawKey.bytes))
-        if (key.getKeyCase == DamlKvutils.DamlStateKey.KeyCase.KEY_NOT_SET)
+        if (key.getKeyCase == DamlStateKey.KeyCase.KEY_NOT_SET)
           Left("State key not set.")
-        else if (value.getValueCase == DamlKvutils.DamlStateValue.ValueCase.VALUE_NOT_SET)
+        else if (value.getValueCase == DamlStateValue.ValueCase.VALUE_NOT_SET)
           Left("State value not set.")
         else
           Right(Right(key -> value))

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupportSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupportSpec.scala
@@ -8,13 +8,12 @@ import java.time.{Duration, Instant, ZoneOffset, ZonedDateTime}
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationSubmission
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlConfigurationSubmission,
   DamlLogEntry,
   DamlPartyAllocationEntry,
-  DamlStateKey,
-  DamlSubmissionDedupKey,
 }
+import com.daml.ledger.participant.state.kvutils.DamlState.{DamlStateKey, DamlSubmissionDedupKey}
 import com.daml.ledger.participant.state.kvutils.export.{SubmissionInfo, WriteSet}
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.RawPreExecutingCommitStrategySupportSpec._
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
@@ -4,12 +4,14 @@
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
 import com.daml.ledger.configuration.protobuf.LedgerConfiguration
+import com.daml.ledger.participant.state.kvutils.DamlConfiguration.DamlConfigurationEntry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlConfigurationEntry,
   DamlLogEntry,
   DamlLogEntryId,
-  DamlPartyAllocation,
   DamlPartyAllocationEntry,
+}
+import com.daml.ledger.participant.state.kvutils.DamlState.{
+  DamlPartyAllocation,
   DamlStateKey,
   DamlStateValue,
 }


### PR DESCRIPTION
### Pull Request Checklist

- Reorganize the kvutils proto file into multiple easier to manage files
- Binary compatibility is preserved
- Imports for generated code are changed

Open items: 
- Should we split the file further, extracting transactions, log entries, package uploads, and so on into different files?
- To avoid circular imports we had to split the entries related to configuration into 2 files, `daml_configuration.proto` and `daml_configuration_rejection.proto`. I'm not really a fan of this as they really belong together. The other option would be to split the new file `daml_state.proto` into `daml_state_key.proto` and `daml_state_value.proto` but I have no strong opinion as to which split would be better.
 
- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
