### PR TITLE
Add test case for parallel command deduplication using mixed clients [KVL-1090]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/AppendOnlyCommandDeduplicationParallelIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/AppendOnlyCommandDeduplicationParallelIT.scala
@@ -70,12 +70,14 @@ class AppendOnlyCommandDeduplicationParallelIT extends LedgerTestSuite {
 
   test(
     s"DeduplicateParallelSubmissionsUsingMixedCommandServiceAndCommandSubmissionService",
-    "Commands submitted at the same, in parallel, using the CommandService the CommandSubmissionService, should be deduplicated",
+    "Commands submitted at the same, in parallel, using the CommandService and the CommandSubmissionService, should be deduplicated",
     allocate(SingleParty),
     runConcurrently = false,
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
     val submitAndWaitRequest = buildSubmitAndWaitRequest(ledger, party)
-    val submitRequest = buildSubmitRequest(ledger, party)
+    val submitRequest = buildSubmitRequest(ledger, party).update(
+      _.commands.commandId := submitAndWaitRequest.getCommands.commandId
+    )
     runTestWithSubmission[SubmitAndWaitRequest](
       ledger,
       party,


### PR DESCRIPTION
- Use CommandService and CommandSubmissionService in parallel to test command deduplication

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
