### PR TITLE
DPP-463 switch sandbox tests to append only

### DIFF
--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -322,17 +322,28 @@ SERVERS = {
     },
 }
 
-# TODO append-only: only for temporary testing
-ONLY_POSTGRES_SERVER = {
-    "postgresql": {
-        "binary": ":sandbox-classic-ephemeral-postgresql",
-        "server_args": [
-            "--port=6865",
-            "--eager-package-loading",
-        ],
-    },
+# The in-memory ledger is deprecated, and does not support all operations (e.g., pruning)
+# TODO: remove this after removing the sandbox classic in-memory ledger
+NON_DEPRECATED_SERVERS = {
+    "postgresql": SERVERS["postgresql"],
+    "h2database": SERVERS["h2database"],
 }
 
+# TODO append-only: after removing the mutating schema, only run this on the in-memory ledger
+server_conformance_test(
+    name = "conformance-test-static-time-mutating-schema",
+    server_args = [
+        "--static-time",
+        "--contract-id-seeding=testing-weak",
+    ],
+    servers = SERVERS,
+    test_tool_args = [
+        "--open-world",
+        "--exclude=ClosedWorldIT",
+    ],
+)
+
+# Secondary conformance test: static time
 server_conformance_test(
     name = "conformance-test-static-time",
     lf_versions = [
@@ -342,26 +353,9 @@ server_conformance_test(
     server_args = [
         "--static-time",
         "--contract-id-seeding=testing-weak",
-    ],
-    servers = SERVERS,
-    test_tool_args = [
-        "--open-world",
-        "--exclude=ClosedWorldIT",
-    ],
-)
-
-# TODO append-only: only for temporary testing
-server_conformance_test(
-    name = "conformance-test-static-time-append-only",
-    lf_versions = [
-        "default",
-    ],
-    server_args = [
-        "--static-time",
-        "--contract-id-seeding=testing-weak",
         "--enable-append-only-schema",
     ],
-    servers = ONLY_POSTGRES_SERVER,
+    servers = NON_DEPRECATED_SERVERS,
     test_tool_args = [
         "--open-world",
         "--additional=AppendOnlyCommandDeduplicationParallelIT",
@@ -371,8 +365,9 @@ server_conformance_test(
     ],
 )
 
+# TODO append-only: after removing the mutating schema, only run this on the in-memory ledger
 server_conformance_test(
-    name = "conformance-test-wall-clock",
+    name = "conformance-test-wall-clock-mutating-schema",
     server_args = [
         "--wall-clock-time",
         "--contract-id-seeding=testing-weak",
@@ -384,15 +379,15 @@ server_conformance_test(
     ],
 )
 
-# TODO append-only: only for temporary testing
+# Main conformance test:
 server_conformance_test(
-    name = "conformance-test-wall-clock-append-only",
+    name = "conformance-test-wall-clock",
     server_args = [
         "--wall-clock-time",
         "--contract-id-seeding=testing-weak",
         "--enable-append-only-schema",
     ],
-    servers = ONLY_POSTGRES_SERVER,
+    servers = NON_DEPRECATED_SERVERS,
     test_tool_args = [
         "--open-world",
         "--additional=AppendOnlyCommandDeduplicationParallelIT",
@@ -405,12 +400,14 @@ server_conformance_test(
     ],
 )
 
+# Secondary conformance test: legacy contract Ids
 server_conformance_test(
     name = "conformance-test-legacy-cid",
     lf_versions = ["legacy"],
     server_args = [
         "--wall-clock-time",
         "--contract-id-seeding=no",
+        "--enable-append-only-schema",
     ],
     servers = SERVERS,
     test_tool_args = [
@@ -423,7 +420,10 @@ server_conformance_test(
 # It does not depend on the ledger backend, that's why it runs on a single (arbitrary) server.
 server_conformance_test(
     name = "conformance-test-contract-ids",
-    server_args = ["--contract-id-seeding=testing-weak"],
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--enable-append-only-schema",
+    ],
     servers = {"memory": SERVERS["memory"]},
     test_tool_args = [
         "--verbose",

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -322,92 +322,103 @@ SERVERS = {
     },
 }
 
-# The in-memory ledger is deprecated, and does not support all operations (e.g., pruning)
-# TODO: remove this after removing the sandbox classic in-memory ledger
-NON_DEPRECATED_SERVERS = {
+# =============================================================================
+# Conformance tests: supported ledger backend (append-only schema)
+# =============================================================================
+
+APPEND_ONLY_SCHEMA_SERVERS = {
     "postgresql": SERVERS["postgresql"],
     "h2database": SERVERS["h2database"],
 }
 
-# TODO append-only: after removing the mutating schema, only run this on the in-memory ledger
-server_conformance_test(
-    name = "conformance-test-static-time-mutating-schema",
-    server_args = [
-        "--static-time",
-        "--contract-id-seeding=testing-weak",
-    ],
-    servers = SERVERS,
-    test_tool_args = [
-        "--open-world",
-        "--exclude=ClosedWorldIT",
-    ],
-)
+# Server arguments that enable the append-only schema
+APPEND_ONLY_ARGS = [
+    "--enable-append-only-schema",
+]
 
-# Secondary conformance test: static time
+# Main conformance test: runs all applicable tests on all LF versions
 server_conformance_test(
-    name = "conformance-test-static-time",
+    name = "conformance-test",
     lf_versions = [
         "default",
         "preview",
     ],
     server_args = [
-        "--static-time",
         "--contract-id-seeding=testing-weak",
-        "--enable-append-only-schema",
-    ],
-    servers = NON_DEPRECATED_SERVERS,
+    ] + APPEND_ONLY_ARGS,
+    servers = APPEND_ONLY_SCHEMA_SERVERS,
     test_tool_args = [
         "--open-world",
         "--additional=AppendOnlyCommandDeduplicationParallelIT",
         "--additional=AppendOnlyCompletionDeduplicationInfoITCommandService",
         "--additional=AppendOnlyCompletionDeduplicationInfoITCommandSubmissionService",
+        "--additional=ContractIdIT:Accept",
         "--exclude=ClosedWorldIT",
     ],
 )
 
-# TODO append-only: after removing the mutating schema, only run this on the in-memory ledger
+# Main conformance test: participant pruning
+# Ideally these tests would be merged into the above ":conformance-test" target, but this triggers timeouts.
+# On a H2 database, these tests run 10x faster if they run in isolation (on an empty ledger).
 server_conformance_test(
-    name = "conformance-test-wall-clock-mutating-schema",
-    server_args = [
-        "--wall-clock-time",
-        "--contract-id-seeding=testing-weak",
+    name = "conformance-test-pruning",
+    lf_versions = [
+        "default",
+        "preview",
     ],
-    servers = SERVERS,
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+    ] + APPEND_ONLY_ARGS,
+    servers = APPEND_ONLY_SCHEMA_SERVERS,
     test_tool_args = [
         "--open-world",
-        "--exclude=ClosedWorldIT",
-    ],
-)
-
-# Main conformance test:
-server_conformance_test(
-    name = "conformance-test-wall-clock",
-    server_args = [
-        "--wall-clock-time",
-        "--contract-id-seeding=testing-weak",
-        "--enable-append-only-schema",
-    ],
-    servers = NON_DEPRECATED_SERVERS,
-    test_tool_args = [
-        "--open-world",
-        "--additional=AppendOnlyCommandDeduplicationParallelIT",
-        "--additional=AppendOnlyCompletionDeduplicationInfoITCommandService",
-        "--additional=AppendOnlyCompletionDeduplicationInfoITCommandSubmissionService",
-        "--additional=ParticipantPruningIT",
-        "--exclude=ClosedWorldIT",
+        "--include=ParticipantPruningIT",
         # Excluding tests that require using pruneAllDivulgedContracts option that is not supported by sandbox-classic
         "--exclude=ParticipantPruningIT:PRLocalAndNonLocalRetroactiveDivulgences,ParticipantPruningIT:PRRetroactiveDivulgences,ParticipantPruningIT:PRImmediateAndRetroactiveDivulgence",
     ],
 )
 
-# Secondary conformance test: legacy contract Ids
+# Secondary test: static time mode
+server_conformance_test(
+    name = "conformance-test-static-time",
+    server_args = [
+        "--static-time",
+        "--contract-id-seeding=testing-weak",
+    ] + APPEND_ONLY_ARGS,
+    servers = APPEND_ONLY_SCHEMA_SERVERS,
+    test_tool_args = [
+        "--open-world",
+        "--additional=AppendOnlyCommandDeduplicationParallelIT",
+        "--additional=AppendOnlyCompletionDeduplicationInfoITCommandService",
+        "--additional=AppendOnlyCompletionDeduplicationInfoITCommandSubmissionService",
+        "--exclude=ClosedWorldIT",
+    ],
+)
+
+# Secondary test: legacy contract Ids
 server_conformance_test(
     name = "conformance-test-legacy-cid",
     lf_versions = ["legacy"],
     server_args = [
-        "--wall-clock-time",
         "--contract-id-seeding=no",
-        "--enable-append-only-schema",
+    ] + APPEND_ONLY_ARGS,
+    servers = APPEND_ONLY_SCHEMA_SERVERS,
+    test_tool_args = [
+        "--open-world",
+        "--exclude=ClosedWorldIT",
+    ],
+)
+
+# =============================================================================
+# Conformance tests: deprecated ledger backends (mutating schema and in-memory ledger)
+# =============================================================================
+
+# TODO append-only: after removing the mutating schema, only run this on the in-memory ledger
+# Main conformance test
+server_conformance_test(
+    name = "conformance-test-mutating-schema",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
     ],
     servers = SERVERS,
     test_tool_args = [
@@ -416,17 +427,17 @@ server_conformance_test(
     ],
 )
 
-# This test asserts that the Daml engine is configured correctly for the sandbox executable.
-# It does not depend on the ledger backend, that's why it runs on a single (arbitrary) server.
+# TODO append-only: after removing the mutating schema, only run this on the in-memory ledger
+# Secondary test: static time mode
 server_conformance_test(
-    name = "conformance-test-contract-ids",
+    name = "conformance-test-mutating-schema-static-time",
     server_args = [
+        "--static-time",
         "--contract-id-seeding=testing-weak",
-        "--enable-append-only-schema",
     ],
-    servers = {"memory": SERVERS["memory"]},
+    servers = SERVERS,
     test_tool_args = [
-        "--verbose",
-        "--include=ContractIdIT:Accept",
+        "--open-world",
+        "--exclude=ClosedWorldIT",
     ],
 )

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -419,6 +419,8 @@ server_conformance_test(
     ],
 )
 
+# This test asserts that the Daml engine is configured correctly for the sandbox executable.
+# It does not depend on the ledger backend, that's why it runs on a single (arbitrary) server.
 server_conformance_test(
     name = "conformance-test-contract-ids",
     server_args = ["--contract-id-seeding=testing-weak"],

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -318,6 +318,8 @@ server_conformance_test(
     ],
 )
 
+# This test asserts that the Daml engine is configured correctly for the sandbox executable.
+# It does not depend on the ledger backend, that's why it runs on a single (arbitrary) server.
 server_conformance_test(
     name = "next-conformance-test-contract-ids",
     servers = {"memory": NEXT_SERVERS["memory"]},

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -272,52 +272,6 @@ NEXT_SERVERS = {
     },
 }
 
-server_conformance_test(
-    name = "next-conformance-test-static-time",
-    lf_versions = [
-        "default",
-        "latest",
-        "preview",
-    ],
-    server_args = [
-        "--static-time",
-    ],
-    servers = NEXT_SERVERS,
-    test_tool_args = [
-        "--open-world",
-        "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
-        "--exclude=ClosedWorldIT",
-    ],
-)
-
-server_conformance_test(
-    name = "next-conformance-test-wall-clock",
-    server_args = [
-        "--wall-clock-time",
-        "--max-deduplication-duration=PT5S",
-    ],
-    servers = NEXT_SERVERS,
-    test_tool_args = [
-        "--open-world",
-        "--additional=KVCommandDeduplicationIT",
-        "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
-        "--exclude=ClosedWorldIT",
-    ],
-)
-
-server_conformance_test(
-    name = "next-conformance-test-closed-world",
-    server_args = [
-        "--wall-clock-time",
-        "--implicit-party-allocation=false",
-    ],
-    servers = NEXT_SERVERS,
-    test_tool_args = [
-        "--verbose",
-        "--include=ClosedWorldIT",
-    ],
-)
-
 # This test asserts that the Daml engine is configured correctly for the sandbox executable.
 # It does not depend on the ledger backend, that's why it runs on a single (arbitrary) server.
 server_conformance_test(
@@ -329,20 +283,72 @@ server_conformance_test(
     ],
 )
 
-# TODO append-only: cleanup
+# Main conformance test: runs all applicable tests on all LF versions
 server_conformance_test(
     name = "next-conformance-test-append-only",
+    lf_versions = [
+        "default",
+        "latest",
+        "preview",
+    ],
     server_args = [
         "--enable-append-only-schema",
         "--max-deduplication-duration=PT5S",
     ],
-    servers = {"postgresql": NEXT_SERVERS["postgresql"]},
+    servers = NEXT_SERVERS,
     test_tool_args = [
         "--open-world",
         "--additional=AppendOnlyCommandDeduplicationParallelIT",
         "--additional=AppendOnlyCompletionDeduplicationInfoITCommandService",
         "--additional=AppendOnlyCompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=AppendOnlyKVCommandDeduplicationIT",
+        "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
+        "--exclude=ClosedWorldIT",
+    ],
+)
+
+# Secondary conformance test: closed world mode
+server_conformance_test(
+    name = "next-conformance-test-closed-world",
+    server_args = [
+        "--enable-append-only-schema",
+        "--wall-clock-time",
+        "--implicit-party-allocation=false",
+    ],
+    servers = NEXT_SERVERS,
+    test_tool_args = [
+        "--verbose",
+        "--include=ClosedWorldIT",
+    ],
+)
+
+# Secondary conformance test: static time mode
+server_conformance_test(
+    name = "next-conformance-test-static-time",
+    server_args = [
+        "--enable-append-only-schema",
+        "--static-time",
+    ],
+    servers = NEXT_SERVERS,
+    test_tool_args = [
+        "--open-world",
+        "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
+        "--exclude=ClosedWorldIT",
+    ],
+)
+
+# Deprecated conformance test: testing the mutating schema
+# TODO append-only: remove after removing the mutating schema
+server_conformance_test(
+    name = "next-conformance-test-mutating-schema",
+    server_args = [
+        "--wall-clock-time",
+        "--max-deduplication-duration=PT5S",
+    ],
+    servers = NEXT_SERVERS,
+    test_tool_args = [
+        "--open-world",
+        "--additional=KVCommandDeduplicationIT",
         "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
         "--exclude=ClosedWorldIT",
     ],

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -272,29 +272,26 @@ NEXT_SERVERS = {
     },
 }
 
-# This test asserts that the Daml engine is configured correctly for the sandbox executable.
-# It does not depend on the ledger backend, that's why it runs on a single (arbitrary) server.
-server_conformance_test(
-    name = "next-conformance-test-contract-ids",
-    servers = {"memory": NEXT_SERVERS["memory"]},
-    test_tool_args = [
-        "--verbose",
-        "--include=ContractIdIT:RejectV0,ContractIdIT:AcceptSuffixedV1,ContractIdIT:AcceptNonSuffixedV1",
-    ],
-)
+# =============================================================================
+# Conformance tests: supported ledger backend (append-only schema)
+# =============================================================================
+
+# Server arguments that enable the append-only schema
+APPEND_ONLY_ARGS = [
+    "--enable-append-only-schema",
+]
 
 # Main conformance test: runs all applicable tests on all LF versions
 server_conformance_test(
-    name = "next-conformance-test-append-only",
+    name = "next-conformance-test",
     lf_versions = [
         "default",
         "latest",
         "preview",
     ],
     server_args = [
-        "--enable-append-only-schema",
         "--max-deduplication-duration=PT5S",
-    ],
+    ] + APPEND_ONLY_ARGS,
     servers = NEXT_SERVERS,
     test_tool_args = [
         "--open-world",
@@ -303,18 +300,17 @@ server_conformance_test(
         "--additional=AppendOnlyCompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=AppendOnlyKVCommandDeduplicationIT",
         "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
+        "--additional=ContractIdIT:RejectV0,ContractIdIT:AcceptSuffixedV1,ContractIdIT:AcceptNonSuffixedV1",
         "--exclude=ClosedWorldIT",
     ],
 )
 
-# Secondary conformance test: closed world mode
+# Secondary test: closed world mode
 server_conformance_test(
     name = "next-conformance-test-closed-world",
     server_args = [
-        "--enable-append-only-schema",
-        "--wall-clock-time",
         "--implicit-party-allocation=false",
-    ],
+    ] + APPEND_ONLY_ARGS,
     servers = NEXT_SERVERS,
     test_tool_args = [
         "--verbose",
@@ -322,13 +318,12 @@ server_conformance_test(
     ],
 )
 
-# Secondary conformance test: static time mode
+# Secondary test: static time mode
 server_conformance_test(
     name = "next-conformance-test-static-time",
     server_args = [
-        "--enable-append-only-schema",
         "--static-time",
-    ],
+    ] + APPEND_ONLY_ARGS,
     servers = NEXT_SERVERS,
     test_tool_args = [
         "--open-world",
@@ -337,12 +332,14 @@ server_conformance_test(
     ],
 )
 
-# Deprecated conformance test: testing the mutating schema
+# =============================================================================
+# Conformance tests: deprecated ledger backends (mutating schema)
+# =============================================================================
+
 # TODO append-only: remove after removing the mutating schema
 server_conformance_test(
     name = "next-conformance-test-mutating-schema",
     server_args = [
-        "--wall-clock-time",
         "--max-deduplication-duration=PT5S",
     ],
     servers = NEXT_SERVERS,


### PR DESCRIPTION
This PR reorganizes the conformance tests run for `sandbox` and `sandbox-classic` such that tests are run with the append-only schema enabled. 