### PR TITLE
[JSON-API] Make key_hash idx non unique 

### DIFF
--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -720,7 +720,7 @@ private final class PostgresQueries(tablePrefix: String, tpIdCacheMaxEntries: Lo
       s"""
         INSERT INTO $contractTableNameRaw
         VALUES (?, ?, ?::jsonb, ?, ?::jsonb, ?, ?, ?)
-        ON CONFLICT DO NOTHING
+        ON CONFLICT (key_hash) DO NOTHING
       """
     ).updateMany(dbcs)
   }
@@ -885,7 +885,7 @@ private final class OracleQueries(
     import spray.json.DefaultJsonProtocol._
     Update[DBContract[SurrogateTpId, DBContractKey, JsValue, JsValue]](
       s"""
-        INSERT /*+ ignore_row_on_dupkey_index($contractTableNameRaw(contract_id)) */
+        INSERT /*+ ignore_row_on_dupkey_index($contractTableNameRaw(key_hash)) */
         INTO $contractTableNameRaw (contract_id, tpid, key, key_hash, payload, signatories, observers, agreement_text)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       """

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -684,7 +684,7 @@ private final class PostgresQueries(tablePrefix: String, tpIdCacheMaxEntries: Lo
 
   private[this] val contractKeyHashIndexName = Fragment.const0(s"${tablePrefix}ckey_hash_idx")
   private[this] val contractKeyHashIndex = CreateIndex(
-    sql"""CREATE UNIQUE INDEX $contractKeyHashIndexName ON $contractTableName (key_hash)"""
+    sql"""CREATE INDEX $contractKeyHashIndexName ON $contractTableName (key_hash)"""
   )
 
   protected[this] override def extraDatabaseDdls =
@@ -720,7 +720,7 @@ private final class PostgresQueries(tablePrefix: String, tpIdCacheMaxEntries: Lo
       s"""
         INSERT INTO $contractTableNameRaw
         VALUES (?, ?, ?::jsonb, ?, ?::jsonb, ?, ?, ?)
-        ON CONFLICT (key_hash) DO NOTHING
+        ON CONFLICT (contract_id) DO NOTHING
       """
     ).updateMany(dbcs)
   }
@@ -845,7 +845,7 @@ private final class OracleQueries(
 
   private[this] val contractKeyHashIndexName = Fragment.const0(s"${tablePrefix}ckey_hash_idx")
   private[this] val contractKeyHashIndex = CreateIndex(
-    sql"""CREATE UNIQUE INDEX $contractKeyHashIndexName ON $contractTableName (key_hash)"""
+    sql"""CREATE INDEX $contractKeyHashIndexName ON $contractTableName (key_hash)"""
   )
 
   private[this] val indexPayload = CreateIndex(sql"""
@@ -885,7 +885,7 @@ private final class OracleQueries(
     import spray.json.DefaultJsonProtocol._
     Update[DBContract[SurrogateTpId, DBContractKey, JsValue, JsValue]](
       s"""
-        INSERT /*+ ignore_row_on_dupkey_index($contractTableNameRaw(key_hash)) */
+        INSERT /*+ ignore_row_on_dupkey_index($contractTableNameRaw(contract_id)) */
         INTO $contractTableNameRaw (contract_id, tpid, key, key_hash, payload, signatories, observers, agreement_text)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       """

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -720,7 +720,7 @@ private final class PostgresQueries(tablePrefix: String, tpIdCacheMaxEntries: Lo
       s"""
         INSERT INTO $contractTableNameRaw
         VALUES (?, ?, ?::jsonb, ?, ?::jsonb, ?, ?, ?)
-        ON CONFLICT (contract_id) DO NOTHING
+        ON CONFLICT DO NOTHING
       """
     ).updateMany(dbcs)
   }

--- a/ledger-service/http-json-oracle/BUILD.bazel
+++ b/ledger-service/http-json-oracle/BUILD.bazel
@@ -22,6 +22,7 @@ da_scala_test(
     data = [
         "//docs:quickstart-model.dar",
         "//ledger-service/http-json:Account.dar",
+        "//ledger-service/http-json:User.dar",
         "//ledger/test-common:dar-files",
         "//ledger/test-common/test-certificates",
     ],

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -185,6 +185,12 @@ daml_compile(
     visibility = ["//ledger-service:__subpackages__"],
 )
 
+daml_compile(
+    name = "User",
+    srcs = ["src/it/daml/User.daml"],
+    visibility = ["//ledger-service:__subpackages__"],
+)
+
 [
     da_scala_test(
         name = "tests-{}".format(edition),
@@ -337,6 +343,7 @@ alias(
         ] if scala_major_version == "2.12" else [],
         data = [
             ":Account.dar",
+            ":User.dar",
             "//docs:quickstart-model.dar",
             "//ledger/test-common:dar-files",
             "//ledger/test-common/test-certificates",

--- a/ledger-service/http-json/src/it/daml/User.daml
+++ b/ledger-service/http-json/src/it/daml/User.daml
@@ -1,0 +1,27 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module User where
+
+-- MAIN_TEMPLATE_BEGIN
+template User with
+    username: Party
+    following: [Party]
+  where
+    signatory username
+    observer following
+-- MAIN_TEMPLATE_END
+
+    key username: Party
+    maintainer key
+
+    -- FOLLOW_BEGIN
+    nonconsuming choice Follow: ContractId User with
+        userToFollow: Party
+      controller username
+      do
+        assertMsg "You cannot follow yourself" (userToFollow /= username)
+        assertMsg "You cannot follow the same user twice" (notElem userToFollow following)
+        archive self
+        create this with following = userToFollow :: following
+    -- FOLLOW_END

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
@@ -3,16 +3,8 @@
 
 package com.daml.http
 
-import akka.http.scaladsl.model.{StatusCodes, Uri}
-import com.daml.http.HttpServiceTestFixture.{getContractId, getResult}
-import com.daml.http.domain.ContractId
-import com.daml.http.util.ClientUtil.boxedRecord
 import com.daml.scalautil.Statement.discard
 import com.daml.testing.postgresql.PostgresAroundAll
-import com.daml.ledger.api.v1.{value => v}
-import com.daml.ledger.service.MetadataReader
-import com.daml.lf.data.Ref
-import org.scalatest.Assertion
 import spray.json.{JsString, JsValue}
 
 import scala.concurrent.Future
@@ -51,120 +43,6 @@ class HttpServiceWithPostgresIntTest
         actualCurrencyValues.sorted shouldBe expectedCurrencyValues.sorted
       }
     }
-  }
-
-  "Bug1" in withHttpServiceAndClient { (uri, encoder, _, client, _) =>
-    import scalaz.std.vector._
-    import scalaz.syntax.tag._
-    import scalaz.syntax.traverse._
-    import scalaz.std.scalaFuture._
-    import scalaz.std.option.some
-    import com.daml.ledger.api.refinements.{ApiTypes => lar}
-    import shapeless.record.{Record => ShRecord}
-    val partyIds = Vector("Alice", "Bob")
-    val partyManagement = client.partyManagementClient
-    def userCreateCommand(
-        username: domain.Party,
-        following: Seq[domain.Party] = Seq.empty,
-    ): domain.CreateCommand[v.Record, domain.TemplateId.OptionalPkg] = {
-      val templateId = domain.TemplateId(None, "User", "User")
-      val followingList = following.map(party => v.Value(v.Value.Sum.Party(party.unwrap)))
-      val arg = v.Record(
-        fields = List(
-          v.RecordField("username", Some(v.Value(v.Value.Sum.Party(username.unwrap)))),
-          v.RecordField(
-            "following",
-            some(v.Value(v.Value.Sum.List(v.List.of(followingList)))),
-          ),
-        )
-      )
-
-      domain.CreateCommand(templateId, arg, None)
-    }
-    def userExerciseFollowCommand(
-        contractId: lar.ContractId,
-        toFollow: domain.Party,
-    ): domain.ExerciseCommand[v.Value, domain.EnrichedContractId] = {
-      val templateId = domain.TemplateId(None, "User", "User")
-      val reference = domain.EnrichedContractId(Some(templateId), contractId)
-      val arg = recordFromFields(ShRecord(userToFollow = v.Value.Sum.Party(toFollow.unwrap)))
-      val choice = lar.Choice("Follow")
-
-      domain.ExerciseCommand(reference, choice, boxedRecord(arg), None)
-    }
-
-    def followUser(contractId: lar.ContractId, actAs: domain.Party, toFollow: domain.Party) = {
-      val exercise: domain.ExerciseCommand[v.Value, domain.EnrichedContractId] =
-        userExerciseFollowCommand(contractId, toFollow)
-      val exerciseJson: JsValue = encodeExercise(encoder)(exercise)
-
-      postJsonRequest(
-        uri.withPath(Uri.Path("/v1/exercise")),
-        exerciseJson,
-        headers = headersWithPartyAuth(actAs = List(actAs.unwrap)),
-      )
-        .map { case (exerciseStatus, exerciseOutput) =>
-          exerciseStatus shouldBe StatusCodes.OK
-          assertStatus(exerciseOutput, StatusCodes.OK)
-          ()
-        }
-
-    }
-    val packageId: Ref.PackageId = MetadataReader
-      .templateByName(metadataUser)(Ref.QualifiedName.assertFromString("User:User"))
-      .headOption
-      .map(_._1)
-      .getOrElse(fail(s"Cannot retrieve packageId"))
-
-    def queryUsers(fromPerspectiveOfParty: domain.Party) = {
-      val query = jsObject(s"""{
-             "templateIds": ["$packageId:User:User"],
-             "query": {}
-          }""")
-
-      postJsonRequest(
-        uri.withPath(Uri.Path("/v1/query")),
-        query,
-        headers = headersWithPartyAuth(actAs = List(fromPerspectiveOfParty.unwrap)),
-      ).map { case (searchStatus, searchOutput) =>
-        searchStatus shouldBe StatusCodes.OK
-        assertStatus(searchOutput, StatusCodes.OK)
-      }
-    }
-
-    partyIds
-      .traverse { p =>
-        partyManagement.allocateParty(Some(p), Some(s"$p & Co. LLC"))
-      }
-      .flatMap { allocatedParties =>
-        val commands = allocatedParties
-          .map(details =>
-            (
-              details.party.asInstanceOf[String],
-              userCreateCommand(domain.Party(details.party.asInstanceOf[String])),
-            )
-          )
-        for {
-          users <- commands.traverse { case (party, command) =>
-            postCreateCommand(
-              command,
-              encoder,
-              uri,
-              headers = headersWithPartyAuth(actAs = List(party)),
-            ).map { case (status, output) =>
-              status shouldBe StatusCodes.OK
-              assertStatus(output, StatusCodes.OK)
-              getContractId(getResult(output))
-            }: Future[ContractId]
-          }
-          aliceUserId = users(0)
-          bobUserId = users(1)
-          _ <- followUser(aliceUserId, domain.Party("Alice"), domain.Party("Bob"))
-          _ <- queryUsers(domain.Party("Bob"))
-          _ <- followUser(bobUserId, domain.Party("Bob"), domain.Party("Alice"))
-          _ <- queryUsers(domain.Party("Alice"))
-        } yield succeed
-      }: Future[Assertion]
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
@@ -3,8 +3,16 @@
 
 package com.daml.http
 
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import com.daml.http.HttpServiceTestFixture.{getContractId, getResult}
+import com.daml.http.domain.ContractId
+import com.daml.http.util.ClientUtil.boxedRecord
 import com.daml.scalautil.Statement.discard
 import com.daml.testing.postgresql.PostgresAroundAll
+import com.daml.ledger.api.v1.{value => v}
+import com.daml.ledger.service.MetadataReader
+import com.daml.lf.data.Ref
+import org.scalatest.Assertion
 import spray.json.{JsString, JsValue}
 
 import scala.concurrent.Future
@@ -43,6 +51,120 @@ class HttpServiceWithPostgresIntTest
         actualCurrencyValues.sorted shouldBe expectedCurrencyValues.sorted
       }
     }
+  }
+
+  "Bug1" in withHttpServiceAndClient { (uri, encoder, _, client, _) =>
+    import scalaz.std.vector._
+    import scalaz.syntax.tag._
+    import scalaz.syntax.traverse._
+    import scalaz.std.scalaFuture._
+    import scalaz.std.option.some
+    import com.daml.ledger.api.refinements.{ApiTypes => lar}
+    import shapeless.record.{Record => ShRecord}
+    val partyIds = Vector("Alice", "Bob")
+    val partyManagement = client.partyManagementClient
+    def userCreateCommand(
+        username: domain.Party,
+        following: Seq[domain.Party] = Seq.empty,
+    ): domain.CreateCommand[v.Record, domain.TemplateId.OptionalPkg] = {
+      val templateId = domain.TemplateId(None, "User", "User")
+      val followingList = following.map(party => v.Value(v.Value.Sum.Party(party.unwrap)))
+      val arg = v.Record(
+        fields = List(
+          v.RecordField("username", Some(v.Value(v.Value.Sum.Party(username.unwrap)))),
+          v.RecordField(
+            "following",
+            some(v.Value(v.Value.Sum.List(v.List.of(followingList)))),
+          ),
+        )
+      )
+
+      domain.CreateCommand(templateId, arg, None)
+    }
+    def userExerciseFollowCommand(
+        contractId: lar.ContractId,
+        toFollow: domain.Party,
+    ): domain.ExerciseCommand[v.Value, domain.EnrichedContractId] = {
+      val templateId = domain.TemplateId(None, "User", "User")
+      val reference = domain.EnrichedContractId(Some(templateId), contractId)
+      val arg = recordFromFields(ShRecord(userToFollow = v.Value.Sum.Party(toFollow.unwrap)))
+      val choice = lar.Choice("Follow")
+
+      domain.ExerciseCommand(reference, choice, boxedRecord(arg), None)
+    }
+
+    def followUser(contractId: lar.ContractId, actAs: domain.Party, toFollow: domain.Party) = {
+      val exercise: domain.ExerciseCommand[v.Value, domain.EnrichedContractId] =
+        userExerciseFollowCommand(contractId, toFollow)
+      val exerciseJson: JsValue = encodeExercise(encoder)(exercise)
+
+      postJsonRequest(
+        uri.withPath(Uri.Path("/v1/exercise")),
+        exerciseJson,
+        headers = headersWithPartyAuth(actAs = List(actAs.unwrap)),
+      )
+        .map { case (exerciseStatus, exerciseOutput) =>
+          exerciseStatus shouldBe StatusCodes.OK
+          assertStatus(exerciseOutput, StatusCodes.OK)
+          ()
+        }
+
+    }
+    val packageId: Ref.PackageId = MetadataReader
+      .templateByName(metadataUser)(Ref.QualifiedName.assertFromString("User:User"))
+      .headOption
+      .map(_._1)
+      .getOrElse(fail(s"Cannot retrieve packageId"))
+
+    def queryUsers(fromPerspectiveOfParty: domain.Party) = {
+      val query = jsObject(s"""{
+             "templateIds": ["$packageId:User:User"],
+             "query": {}
+          }""")
+
+      postJsonRequest(
+        uri.withPath(Uri.Path("/v1/query")),
+        query,
+        headers = headersWithPartyAuth(actAs = List(fromPerspectiveOfParty.unwrap)),
+      ).map { case (searchStatus, searchOutput) =>
+        searchStatus shouldBe StatusCodes.OK
+        assertStatus(searchOutput, StatusCodes.OK)
+      }
+    }
+
+    partyIds
+      .traverse { p =>
+        partyManagement.allocateParty(Some(p), Some(s"$p & Co. LLC"))
+      }
+      .flatMap { allocatedParties =>
+        val commands = allocatedParties
+          .map(details =>
+            (
+              details.party.asInstanceOf[String],
+              userCreateCommand(domain.Party(details.party.asInstanceOf[String])),
+            )
+          )
+        for {
+          users <- commands.traverse { case (party, command) =>
+            postCreateCommand(
+              command,
+              encoder,
+              uri,
+              headers = headersWithPartyAuth(actAs = List(party)),
+            ).map { case (status, output) =>
+              status shouldBe StatusCodes.OK
+              assertStatus(output, StatusCodes.OK)
+              getContractId(getResult(output))
+            }: Future[ContractId]
+          }
+          aliceUserId = users(0)
+          bobUserId = users(1)
+          _ <- followUser(aliceUserId, domain.Party("Alice"), domain.Party("Bob"))
+          _ <- queryUsers(domain.Party("Bob"))
+          _ <- followUser(bobUserId, domain.Party("Bob"), domain.Party("Alice"))
+          _ <- queryUsers(domain.Party("Alice"))
+        } yield succeed
+      }: Future[Assertion]
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -1830,7 +1830,6 @@ abstract class AbstractHttpServiceIntegrationTest
       import scalaz.syntax.traverse._
       import scalaz.std.scalaFuture._
       import shapeless.record.{Record => ShRecord}
-      import scalaz.std.option.some
       import com.daml.ledger.api.refinements.{ApiTypes => lar}
 
       val partyIds = Vector("Alice", "Bob").map(getUniqueParty)
@@ -1845,13 +1844,10 @@ abstract class AbstractHttpServiceIntegrationTest
       ): domain.CreateCommand[v.Record, domain.TemplateId.OptionalPkg] = {
         val templateId = domain.TemplateId(None, "User", "User")
         val followingList = following.map(party => v.Value(v.Value.Sum.Party(party.unwrap)))
-        val arg = v.Record(
-          fields = List(
-            v.RecordField("username", Some(v.Value(v.Value.Sum.Party(username.unwrap)))),
-            v.RecordField(
-              "following",
-              some(v.Value(v.Value.Sum.List(v.List.of(followingList)))),
-            ),
+        val arg = recordFromFields(
+          ShRecord(
+            username = v.Value.Sum.Party(username.unwrap),
+            following = v.Value.Sum.List(v.List.of(followingList)),
           )
         )
 

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -63,6 +63,8 @@ object AbstractHttpServiceIntegrationTestFuns {
 
   private[http] val dar3 = requiredResource(SemanticTestDar.path)
 
+  private[http] val userDar = requiredResource("ledger-service/http-json/User.dar")
+
   def sha256(source: Source[ByteString, Any])(implicit mat: Materializer): Try[String] = Try {
     import java.security.MessageDigest
     import javax.xml.bind.DatatypeConverter
@@ -103,6 +105,9 @@ trait AbstractHttpServiceIntegrationTestFuns
   protected val metadata2: MetadataReader.LfMetadata =
     MetadataReader.readFromDar(dar2).valueOr(e => fail(s"Cannot read dar2 metadata: $e"))
 
+  protected val metadataUser: MetadataReader.LfMetadata =
+    MetadataReader.readFromDar(userDar).valueOr(e => fail(s"Cannot read userDar metadata: $e"))
+
   protected val jwt: Jwt = jwtForParties(List("Alice"), List(), testId)
 
   protected val jwtAdminNoParty: Jwt = {
@@ -123,7 +128,7 @@ trait AbstractHttpServiceIntegrationTestFuns
   import tag.@@ // used for subtyping to make `AHS ec` beat executionContext
   implicit val `AHS ec`: ExecutionContext @@ this.type = tag[this.type](`AHS asys`.dispatcher)
 
-  override def packageFiles = List(dar1, dar2)
+  override def packageFiles = List(dar1, dar2, userDar)
 
   protected def getUniqueParty(name: String) = getUniquePartyAndAuthHeaders(name)._1
   protected def getUniquePartyAndAuthHeaders(name: String): (domain.Party, List[HttpHeader]) = {
@@ -269,7 +274,7 @@ trait AbstractHttpServiceIntegrationTestFuns
       at[K :->>: V]((fn.value.name, _))
   }
 
-  private[this] def recordFromFields[L <: HList, I <: HList](hlist: L)(implicit
+  protected[this] def recordFromFields[L <: HList, I <: HList](hlist: L)(implicit
       mapper: shapeless.ops.hlist.Mapper.Aux[RecordFromFields.type, L, I],
       lister: shapeless.ops.hlist.ToTraversable.Aux[I, Seq, (String, v.Value.Sum)],
   ): v.Record = v.Record(fields = hlist.map(RecordFromFields).to[Seq].map { case (n, vs) =>


### PR DESCRIPTION
### Pull Request Checklist

resolves a bug with the duplicate key conflict on query store, where the same contract is being witnessed twice by two separate parties.

changelog_begin

- [JSON-API] resolves a bug with the duplicate key conflict on query store, where the same contract is being witnessed twice by two separate parties

changelog_end

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
