### PR TITLE
Port file was not written to... where?

### DIFF
--- a/compatibility/bazel_tools/daml_ledger/Sandbox.hs
+++ b/compatibility/bazel_tools/daml_ledger/Sandbox.hs
@@ -143,8 +143,8 @@ nullDevice
     | otherwise =  "/dev/null"
 
 readPortFile :: Int -> String -> IO Int
-readPortFile 0 _file = do
-  T.hPutStrLn stderr "Port file was not written to in time."
+readPortFile 0 file = do
+  T.hPutStrLn stderr ("Port file was not written to '" ++ file ++ "' in time.")
   exitFailure
 readPortFile n file = do
   fileContent <- catchJust (guard . shouldCatch) (readFile file) (const $ pure "")

--- a/libs-haskell/da-hs-base/src/DA/PortFile.hs
+++ b/libs-haskell/da-hs-base/src/DA/PortFile.hs
@@ -14,8 +14,8 @@ import System.IO
 import System.IO.Error
 
 readPortFile :: Int -> String -> IO Int
-readPortFile 0 _file = do
-  T.hPutStrLn stderr "Port file was not written to in time."
+readPortFile 0 file = do
+  T.hPutStrLn stderr ("Port file was not written to '" ++ file ++ "' in time.")
   exitFailure
 readPortFile n file = do
   fileContent <- catchJust (guard . shouldCatch) (readFile file) (const $ pure "")


### PR DESCRIPTION
Adds the information on where the port file could not be written.
From the current phrasing it appears the intention was to add the
information but ultimately wasn't.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
