### PR TITLE
[JSON-API] Increase timeout for HttpServiceIntegrationTests

### DIFF
--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -115,7 +115,12 @@ trait AbstractHttpServiceIntegrationTestFuns
       .fold(e => fail(s"cannot sign a JWT: ${e.shows}"), identity)
   }
 
-  implicit val `AHS asys`: ActorSystem = ActorSystem(testId)
+  import com.typesafe.config.ConfigFactory
+  private val customConf = ConfigFactory.parseString("""
+    akka.http.server.request-timeout = 60s
+  """)
+
+  implicit val `AHS asys`: ActorSystem = ActorSystem(testId, ConfigFactory.load(customConf))
   implicit val `AHS mat`: Materializer = Materializer(`AHS asys`)
   implicit val `AHS aesf`: ExecutionSequencerFactory =
     new AkkaExecutionSequencerPool(testId)(`AHS asys`)


### PR DESCRIPTION
Increase akka server request-timeout for HttpServiceIntegrationTests

CHANGELOG_BEGIN
CHANGELOG_END

Tested for flakyness with 20 runs
```
 $ bazel test -t- //ledger-service/http-json:integration-tests-ce --test_filter=com.daml.http.HttpServiceIntegrationTest --test_arg -z --test_arg "archiving a large number of contracts should succeed" --runs_per_test=20
INFO: Found 1 test target...
Target //ledger-service/http-json:integration-tests-ce up-to-date:
  bazel-bin/ledger-service/http-json/integration-tests-ce.jar
  bazel-bin/ledger-service/http-json/integration-tests-ce
INFO: Elapsed time: 423.476s, Critical Path: 330.61s
INFO: 21 processes: 1 internal, 20 processwrapper-sandbox.
INFO: Build completed successfully, 21 total actions
//ledger-service/http-json:integration-tests-ce                          PASSED in 325.7s
  Stats over 20 runs: max = 325.7s, min = 90.1s, avg = 276.7s, dev = 93.3s

Executed 1 out of 1 test: 1 test passes.
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
