### PR TITLE
releases: check component status page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 - [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
 - [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
 - [ ] Normal production system change, include purpose of change in description
+- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.
 
 NOTE: CI is not automatically run on non-members pull-requests for security
 reasons. The reviewer will have to comment with `/AzurePipelines run` to

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,8 @@ LATEST       @gerolf-da @bame-da @cocreature
 /infra/             @garyverhaegen-da
 azure-pipelines.yml @garyverhaegen-da
 azure-cron.yml      @garyverhaegen-da
+/release/           @garyverhaegen-da
+/release.sh         @garyverhaegen-da
 
 # Blackduck
 NOTICES     @garyverhaegen-da @aherrmann-da @cocreature @dasormeter
@@ -57,7 +59,7 @@ NOTICES     @garyverhaegen-da @aherrmann-da @cocreature @dasormeter
 /ledger/sandbox/                    @digital-asset/kv-participant @digital-asset/kv-committer
 
 # Owned by KV Participant except for IndexDB schema which is jointly owned with @meiersi-da
-/ledger/participant-integration-api/                    @digital-asset/kv-participant @meiersi-da 
+/ledger/participant-integration-api/                    @digital-asset/kv-participant @meiersi-da
 
 
 # KV Committer

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -17,6 +17,10 @@ patches we backport to the 1.0 release branch).
    that changes the `LATEST` file to remove the `-snapshot` suffix on the
    corresponding snapshot, and add the `Standard-Change` label.
 
+1. **[RC]** Before blessing a snapshot as a release candidate, make sure that
+   the [Component Status](../docs/source/support/component-statuses.rst) page
+   is up to date.
+
 1. **[SNAPSHOT]** For most snapshot releases, the PR is created automatically.
    Double-check the snapshot version: it may need incrementing. Ask on Slack
    (`#team-daml`) if you're not sure.


### PR DESCRIPTION
The component status page has been neglected as of late. Craig
suggested adding a step to the release checklist.

CHANGELOG_BEGIN
CHANGELOG_END