### PR TITLE
Add deprecation output for sandbox classic

### DIFF
--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxMain.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxMain.scala
@@ -5,15 +5,28 @@ package com.daml.platform.sandbox
 
 import com.daml.ledger.resources.ResourceContext
 import com.daml.cliopts.GlobalLogLevel
+import com.daml.logging.ContextualizedLogger
+import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.resources.ProgramResource
 
 object SandboxMain {
 
+  private val logger = ContextualizedLogger.get(this.getClass)
+
   def main(args: Array[String]): Unit =
     new ProgramResource({
       val config: SandboxConfig = Cli.parse(args).getOrElse(sys.exit(1))
       config.logLevel.foreach(GlobalLogLevel.set("Sandbox"))
+
+      // Point users to non-deprecated ledgers
+      config.jdbcUrl.foreach(_ =>
+        newLoggingContext { implicit loggingContext =>
+          logger.info(
+            "Sandbox classic with persistence is deprecated. Use the Daml Driver for PostgreSQL if you need persistence."
+          )
+        }
+      )
       SandboxServer.owner(Name, config)
     }).run(ResourceContext.apply)
 


### PR DESCRIPTION
This PR adds a log line that reminds users that sandbox-classic in persistence mode is deprecated. The [CLI](https://github.com/digital-asset/daml/blob/main/ledger/sandbox-classic/src/main/scala/platform/sandbox/Cli.scala#L39) already describes persistence mode as being deprecated and points users to Daml Driver for Postgres. 

# Context

- Sandbox classic on H2 with append-only schema enabled is very slow. User experience would be bad in this mode.
- Conformance tests on H2 often time out, or take a very long time to finish. We want to improve CI speed/stability by only running a minimal set of tests on H2.
- We would be still reasonably sure sandbox-classic works on H2, but we want to discourage users from using it. And since sandbox-classic on Postgres is deprecated as well(?), we point all users to Daml Driver for Postgres if they try to use sandbox-classic with a database backend.