### PR TITLE
Fix speedy performance benchmark

### DIFF
--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -77,23 +77,7 @@ class CollectAuthorityState {
       step += 1
       machine.run() match {
         case SResultScenarioGetParty(_, callback) => callback(cachedParty(step))
-        case SResultScenarioSubmit(committers, commands, location, mustFail, callback) =>
-          assert(!mustFail)
-          val api = new CannedLedgerApi(step, cachedContract)
-          ScenarioRunner.submit(
-            machine.compiledPackages,
-            api,
-            committers,
-            Set.empty,
-            SExpr.SEValue(commands),
-            location,
-            crypto.Hash.hashPrivateKey(step.toString),
-            doEnrichment = false,
-          ) match {
-            case ScenarioRunner.Commit(_, value, _) =>
-              callback(value)
-            case ScenarioRunner.SubmissionError(err, _) => crash(s"Submission failed $err")
-          }
+        case SResultScenarioSubmit(_, _, _, _, callback) => callback(cachedCommit(step))
         case SResultNeedContract(_, _, _, _) =>
           crash("Off-ledger need contract callback")
         case SResultFinalValue(v) => finalValue = v


### PR DESCRIPTION
Reinstate use of `cachedCommit` in the `CollectAuthority` benchmark, so only speedy execution gets measured (as intended!)

- This has the effect of speeding up the benchmark run by a factor of about x25
- so prior to this change, only about 4% of the measured time was actually in speedy code
 