### PR TITLE
[JSON-API] Use sandbox-classic for perf tests

### DIFF
--- a/ledger-service/http-json-testing/BUILD.bazel
+++ b/ledger-service/http-json-testing/BUILD.bazel
@@ -59,12 +59,12 @@ hj_scalacopts = lf_scalacopts + [
             "//ledger/participant-integration-api",
             "//ledger/sandbox",
             "//ledger/sandbox:sandbox-scala-tests-lib",
+            "//ledger/sandbox-classic",
             "//ledger/sandbox-common",
             "//ledger/sandbox-common:sandbox-common-scala-tests-lib",
             "//libs-scala/contextualized-logging",
             "//libs-scala/db-utils",
             "//libs-scala/ports",
-            "//libs-scala/resources",
             "@maven//:io_dropwizard_metrics_metrics_core",
         ],
     )


### PR DESCRIPTION
HttpServiceTestFixture provides a sandbox-classic ledger used for performance tests

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
