### PR TITLE
fix templates build for Windows

### DIFF
--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -111,7 +111,7 @@ genrule(
 
         DIR=$$(pwd)
         cd $$OUT/..
-        $$DIR/$(execpath //bazel_tools/sh:mktgz) $@ templates-tarball
+        $$DIR/$(execpath //bazel_tools/sh:mktgz) $$DIR/$@ templates-tarball
     """,
     tools = [
         "//bazel_tools/sh:mktgz",


### PR DESCRIPTION
On Windows, we run without a sandbox, which means that the `gsg-trigger`
folder might already exist and be patched, because we work directly in
the source tree.

This changes the script to work with temp dirs instead.

CHANGELOG_BEGIN
CHANGELOG_END