### PR TITLE
fix templates build for Windows (#11165)

### DIFF
--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -62,8 +62,12 @@ genrule(
     ],
     outs = ["templates-tarball.tar.gz"],
     cmd = """
-        SRC=templates
-        OUT=templates-tarball
+        SRC=$$(mktemp -d)
+        OUT=$$(mktemp -d)/templates-tarball
+        trap "rm -rf $$SRC $$OUT" EXIT
+        mkdir -p $$OUT
+
+        cp -rL templates/* $$SRC/
 
         PATCH_TOOL=$$PWD/$(location @patch_dev_env//:patch)
         cp -rL $$SRC/create-daml-app $$SRC/gsg-trigger
@@ -105,7 +109,9 @@ genrule(
         mkdir -p $$OUT/daml-patterns
         tar xf $(location //docs:daml-patterns) --strip-components=1 -C $$OUT/daml-patterns
 
-        $(execpath //bazel_tools/sh:mktgz) $@ templates-tarball
+        DIR=$$(pwd)
+        cd $$OUT/..
+        $$DIR/$(execpath //bazel_tools/sh:mktgz) $$DIR/$@ templates-tarball
     """,
     tools = [
         "//bazel_tools/sh:mktgz",


### PR DESCRIPTION
On Windows, we run without a sandbox, which means that the `gsg-trigger`
folder might already exist and be patched, because we work directly in
the source tree.

This changes the script to work with temp dirs instead.

CHANGELOG_BEGIN
CHANGELOG_END