### PR TITLE
timestamp-conversions: A set of libraries for converting timestamps and durations.

### DIFF
--- a/libs-scala/timestamp-conversions/java-lf/BUILD.bazel
+++ b/libs-scala/timestamp-conversions/java-lf/BUILD.bazel
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+    "lf_scalacopts_stricter",
+)
+
+scalacopts = lf_scalacopts_stricter
+
+da_scala_library(
+    name = "java-lf",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scalacopts = scalacopts,
+    tags = ["maven_coordinates=com.daml:timestamps-java-lf:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//daml-lf/data",
+    ],
+)
+
+da_scala_test_suite(
+    name = "java-lf-tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatest_scalatest_core",
+        "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_scalatest_scalatest_wordspec",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+        "@maven//:org_scalaz_scalaz_core",
+    ],
+    scalacopts = scalacopts,
+    deps = [
+        ":java-lf",
+        "//daml-lf/data",
+    ],
+)

--- a/libs-scala/timestamp-conversions/java-lf/src/main/scala/com/daml/timestamps/JavaLf.scala
+++ b/libs-scala/timestamp-conversions/java-lf/src/main/scala/com/daml/timestamps/JavaLf.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.lf.data.Time.{Timestamp => LfTimestamp}
+
+import java.time.{Instant => JavaTimestamp}
+
+object JavaLf {
+  implicit class JavaToLfTimestampConversions(timestamp: JavaTimestamp) {
+    def asLf: LfTimestamp = LfTimestamp.assertFromInstant(timestamp)
+  }
+
+  implicit class LfToJavaTimestampConversions(timestamp: LfTimestamp) {
+    def asJava: JavaTimestamp = timestamp.toInstant
+  }
+}

--- a/libs-scala/timestamp-conversions/java-lf/src/test/scala/com/daml/timestamps/JavaLfTimestampConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/java-lf/src/test/scala/com/daml/timestamps/JavaLfTimestampConversionsSpec.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.lf.data.Time.{Timestamp => LfTimestamp}
+import com.daml.timestamps.JavaLf._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+final class JavaLfTimestampConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Java instant to a Daml-LF timestamp" should {
+    "convert to and fro" in {
+      // The set of Java instants is much larger than the set of Daml-LF timestamps, so we generate the latter.
+      forAll { (timestamp: LfTimestamp) =>
+        timestamp.asJava.asLf should be(timestamp)
+      }
+    }
+  }
+
+  private implicit val `Arbitrary LfTimestamp`: Arbitrary[LfTimestamp] = Arbitrary {
+    val specials = Seq(0, LfTimestamp.MinValue.micros, LfTimestamp.MaxValue.micros)
+    Gen
+      .chooseNum(LfTimestamp.MinValue.micros, LfTimestamp.MaxValue.micros, specials: _*)
+      .map(LfTimestamp.assertFromLong)
+  }
+}

--- a/libs-scala/timestamp-conversions/java-protobuf/BUILD.bazel
+++ b/libs-scala/timestamp-conversions/java-protobuf/BUILD.bazel
@@ -1,0 +1,42 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+    "lf_scalacopts_stricter",
+)
+
+scalacopts = lf_scalacopts_stricter
+
+da_scala_library(
+    name = "java-protobuf",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scalacopts = scalacopts,
+    tags = ["maven_coordinates=com.daml:timestamps-java-protobuf:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)
+
+da_scala_test_suite(
+    name = "java-javaprotobuf-tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatest_scalatest_core",
+        "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_scalatest_scalatest_wordspec",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+    ],
+    scalacopts = scalacopts,
+    deps = [
+        ":java-protobuf",
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)

--- a/libs-scala/timestamp-conversions/java-protobuf/src/main/scala/com/daml/timestamps/JavaProtobuf.scala
+++ b/libs-scala/timestamp-conversions/java-protobuf/src/main/scala/com/daml/timestamps/JavaProtobuf.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.google.protobuf.{Duration => JavaProtoDuration}
+
+import java.time.{Duration => JavaDuration}
+
+object JavaProtobuf {
+  implicit class JavaToJavaProtoDurationConversions(duration: JavaDuration) {
+    def asJavaProto: JavaProtoDuration =
+      JavaProtoDuration.newBuilder.setSeconds(duration.getSeconds).setNanos(duration.getNano).build
+  }
+
+  implicit class JavaProtoToJavaDurationConversions(duration: JavaProtoDuration) {
+    def asJava: JavaDuration =
+      JavaDuration.ofSeconds(duration.getSeconds, duration.getNanos.toLong)
+  }
+}

--- a/libs-scala/timestamp-conversions/java-protobuf/src/main/scala/com/daml/timestamps/JavaProtobuf.scala
+++ b/libs-scala/timestamp-conversions/java-protobuf/src/main/scala/com/daml/timestamps/JavaProtobuf.scala
@@ -3,9 +3,9 @@
 
 package com.daml.timestamps
 
-import com.google.protobuf.{Duration => JavaProtoDuration}
+import com.google.protobuf.{Duration => JavaProtoDuration, Timestamp => JavaProtoTimestamp}
 
-import java.time.{Duration => JavaDuration}
+import java.time.{Duration => JavaDuration, Instant => JavaTimestamp}
 
 object JavaProtobuf {
   implicit class JavaToJavaProtoDurationConversions(duration: JavaDuration) {
@@ -16,5 +16,18 @@ object JavaProtobuf {
   implicit class JavaProtoToJavaDurationConversions(duration: JavaProtoDuration) {
     def asJava: JavaDuration =
       JavaDuration.ofSeconds(duration.getSeconds, duration.getNanos.toLong)
+  }
+
+  implicit class JavaToJavaProtoTimestampConversions(timestamp: JavaTimestamp) {
+    def asJavaProto: JavaProtoTimestamp =
+      JavaProtoTimestamp.newBuilder
+        .setSeconds(timestamp.getEpochSecond)
+        .setNanos(timestamp.getNano)
+        .build
+  }
+
+  implicit class JavaProtoToJavaTimestampConversions(timestamp: JavaProtoTimestamp) {
+    def asJava: JavaTimestamp =
+      JavaTimestamp.ofEpochSecond(timestamp.getSeconds, timestamp.getNanos.toLong)
   }
 }

--- a/libs-scala/timestamp-conversions/java-protobuf/src/test/scala/com/daml/timestamps/JavaProtobufDurationConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/java-protobuf/src/test/scala/com/daml/timestamps/JavaProtobufDurationConversionsSpec.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.timestamps.JavaProtobuf._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.{Duration => JavaDuration}
+
+final class JavaProtobufDurationConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Java duration to a Protocol Buffers duration" should {
+    "convert to and fro" in {
+      forAll { (duration: JavaDuration) =>
+        duration.asJavaProto.asJava should be(duration)
+      }
+    }
+  }
+}

--- a/libs-scala/timestamp-conversions/java-protobuf/src/test/scala/com/daml/timestamps/JavaProtobufTimestampConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/java-protobuf/src/test/scala/com/daml/timestamps/JavaProtobufTimestampConversionsSpec.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.timestamps.JavaProtobuf._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.{Instant => JavaTimestamp}
+
+final class JavaProtobufTimestampConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Java instant to a Protocol Buffers timestamp" should {
+    "convert to and fro" in {
+      forAll { (timestamp: JavaTimestamp) =>
+        timestamp.asJavaProto.asJava should be(timestamp)
+      }
+    }
+  }
+}

--- a/libs-scala/timestamp-conversions/java-scala/BUILD.bazel
+++ b/libs-scala/timestamp-conversions/java-scala/BUILD.bazel
@@ -1,0 +1,42 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+    "lf_scalacopts_stricter",
+)
+
+scalacopts = lf_scalacopts_stricter
+
+da_scala_library(
+    name = "java-scala",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:org_scala_lang_modules_scala_java8_compat",
+    ],
+    scalacopts = scalacopts,
+    tags = ["maven_coordinates=com.daml:timestamps-java-scala:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+da_scala_test_suite(
+    name = "java-scala-tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatest_scalatest_core",
+        "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_scalatest_scalatest_wordspec",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+    ],
+    scalacopts = scalacopts,
+    deps = [
+        ":java-scala",
+        "//libs-scala/scala-utils",
+    ],
+)

--- a/libs-scala/timestamp-conversions/java-scala/src/main/scala/com/daml/timestamps/JavaScala.scala
+++ b/libs-scala/timestamp-conversions/java-scala/src/main/scala/com/daml/timestamps/JavaScala.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import java.time.{Duration => JavaDuration}
+import scala.compat.java8.DurationConverters
+import scala.concurrent.duration.{FiniteDuration => ScalaDuration}
+
+object JavaScala {
+  implicit class JavaToScalaDurationConversions(duration: JavaDuration) {
+    def asScala: ScalaDuration = DurationConverters.toScala(duration)
+  }
+
+  implicit class ScalaToJavaDurationConversions(duration: ScalaDuration) {
+    def asJava: JavaDuration = DurationConverters.toJava(duration)
+  }
+}

--- a/libs-scala/timestamp-conversions/java-scala/src/test/scala/com/daml/timestamps/JavaScalaDurationConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/java-scala/src/test/scala/com/daml/timestamps/JavaScalaDurationConversionsSpec.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.scalautil.Statement.discard
+import com.daml.timestamps.JavaScala._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scala.concurrent.duration.{FiniteDuration => ScalaDuration}
+
+import java.time.{Duration => JavaDuration}
+
+final class JavaScalaDurationConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Java duration to a Scala duration" should {
+    "convert to and fro" in {
+      // The set of Java durations is much larger than the set of Scala durations, so we generate the latter.
+      forAll { (duration: ScalaDuration) =>
+        whenever(isConvertibleToScala(duration.asJava)) {
+          duration.asJava.asScala should be(duration)
+        }
+      }
+    }
+  }
+
+  private def isConvertibleToScala(duration: JavaDuration) =
+    try {
+      discard(duration.asScala)
+      true
+    } catch {
+      case _: IllegalArgumentException => false
+    }
+}

--- a/libs-scala/timestamp-conversions/java-scalaprotobuf/BUILD.bazel
+++ b/libs-scala/timestamp-conversions/java-scalaprotobuf/BUILD.bazel
@@ -1,0 +1,44 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+    "lf_scalacopts_stricter",
+)
+
+scalacopts = lf_scalacopts_stricter
+
+da_scala_library(
+    name = "java-scalaprotobuf",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:com_thesamet_scalapb_lenses",
+        "@maven//:com_thesamet_scalapb_scalapb_runtime",
+    ],
+    scalacopts = scalacopts,
+    tags = ["maven_coordinates=com.daml:timestamps-java-scalaprotobuf:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+da_scala_test_suite(
+    name = "java-scalaprotobuf-tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:com_thesamet_scalapb_lenses",
+        "@maven//:com_thesamet_scalapb_scalapb_runtime",
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatest_scalatest_core",
+        "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_scalatest_scalatest_wordspec",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+    ],
+    scalacopts = scalacopts,
+    deps = [
+        ":java-scalaprotobuf",
+    ],
+)

--- a/libs-scala/timestamp-conversions/java-scalaprotobuf/src/main/scala/com/daml/timestamps/JavaScalaProtobuf.scala
+++ b/libs-scala/timestamp-conversions/java-scalaprotobuf/src/main/scala/com/daml/timestamps/JavaScalaProtobuf.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.google.protobuf.duration.{Duration => ScalaProtoDuration}
+
+import java.time.{Duration => JavaDuration}
+
+object JavaScalaProtobuf {
+  implicit class JavaToProtoDurationConversions(duration: JavaDuration) {
+    def asScalaProto: ScalaProtoDuration =
+      ScalaProtoDuration.of(duration.getSeconds, duration.getNano)
+  }
+
+  implicit class ScalaProtoToJavaDurationConversions(duration: ScalaProtoDuration) {
+    def asJava: JavaDuration =
+      duration.asJavaDuration
+  }
+}

--- a/libs-scala/timestamp-conversions/java-scalaprotobuf/src/main/scala/com/daml/timestamps/JavaScalaProtobuf.scala
+++ b/libs-scala/timestamp-conversions/java-scalaprotobuf/src/main/scala/com/daml/timestamps/JavaScalaProtobuf.scala
@@ -4,8 +4,9 @@
 package com.daml.timestamps
 
 import com.google.protobuf.duration.{Duration => ScalaProtoDuration}
+import com.google.protobuf.timestamp.{Timestamp => ScalaProtoTimestamp}
 
-import java.time.{Duration => JavaDuration}
+import java.time.{Duration => JavaDuration, Instant => JavaTimestamp}
 
 object JavaScalaProtobuf {
   implicit class JavaToProtoDurationConversions(duration: JavaDuration) {
@@ -16,5 +17,15 @@ object JavaScalaProtobuf {
   implicit class ScalaProtoToJavaDurationConversions(duration: ScalaProtoDuration) {
     def asJava: JavaDuration =
       duration.asJavaDuration
+  }
+
+  implicit class JavaToProtoTimestampConversions(timestamp: JavaTimestamp) {
+    def asScalaProto: ScalaProtoTimestamp =
+      ScalaProtoTimestamp.of(timestamp.getEpochSecond, timestamp.getNano)
+  }
+
+  implicit class ScalaProtoToJavaTimestampConversions(timestamp: ScalaProtoTimestamp) {
+    def asJava: JavaTimestamp =
+      timestamp.asJavaInstant
   }
 }

--- a/libs-scala/timestamp-conversions/java-scalaprotobuf/src/test/scala/com/daml/timestamps/JavaScalaProtobufDurationConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/java-scalaprotobuf/src/test/scala/com/daml/timestamps/JavaScalaProtobufDurationConversionsSpec.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.timestamps.JavaScalaProtobuf._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.{Duration => JavaDuration}
+
+final class JavaScalaProtobufDurationConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Java duration to a Scala Protocol Buffers duration" should {
+    "convert to and fro" in {
+      forAll { (duration: JavaDuration) =>
+        duration.asScalaProto.asJava should be(duration)
+      }
+    }
+  }
+}

--- a/libs-scala/timestamp-conversions/java-scalaprotobuf/src/test/scala/com/daml/timestamps/JavaScalaProtobufTimestampConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/java-scalaprotobuf/src/test/scala/com/daml/timestamps/JavaScalaProtobufTimestampConversionsSpec.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.timestamps.JavaScalaProtobuf._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.{Instant => JavaTimestamp}
+
+final class JavaScalaProtobufTimestampConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Java instant to a Scala Protocol Buffers timestamp" should {
+    "convert to and fro" in {
+      forAll { (timestamp: JavaTimestamp) =>
+        timestamp.asScalaProto.asJava should be(timestamp)
+      }
+    }
+  }
+}

--- a/libs-scala/timestamp-conversions/lf-javaprotobuf/BUILD.bazel
+++ b/libs-scala/timestamp-conversions/lf-javaprotobuf/BUILD.bazel
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+    "lf_scalacopts_stricter",
+)
+
+scalacopts = lf_scalacopts_stricter
+
+da_scala_library(
+    name = "lf-javaprotobuf",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scalacopts = scalacopts,
+    tags = ["maven_coordinates=com.daml:timestamps-lf-javaprotobuf:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//daml-lf/data",
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)
+
+da_scala_test_suite(
+    name = "lf-javaprotobuf-tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatest_scalatest_core",
+        "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_scalatest_scalatest_wordspec",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+        "@maven//:org_scalaz_scalaz_core",
+    ],
+    scalacopts = scalacopts,
+    deps = [
+        ":lf-javaprotobuf",
+        "//daml-lf/data",
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)

--- a/libs-scala/timestamp-conversions/lf-javaprotobuf/src/main/scala/com/daml/timestamps/LfJavaProtobuf.scala
+++ b/libs-scala/timestamp-conversions/lf-javaprotobuf/src/main/scala/com/daml/timestamps/LfJavaProtobuf.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.lf.data.Time.{Timestamp => LfTimestamp}
+import com.google.protobuf.{Timestamp => ProtoTimestamp}
+
+import java.util.concurrent.TimeUnit
+
+object LfJavaProtobuf {
+  implicit class LfToJavaProtoTimestampConversions(timestamp: LfTimestamp) {
+    def asJavaProto: ProtoTimestamp =
+      ProtoTimestamp.newBuilder
+        .setSeconds(timestamp.micros / 1000000)
+        .setNanos(((timestamp.micros % 1000000) * 1000).toInt)
+        .build
+  }
+
+  implicit class JavaProtoToLfTimestampConversions(timestamp: ProtoTimestamp) {
+    def asLf: LfTimestamp = {
+      val micros =
+        TimeUnit.SECONDS.toMicros(timestamp.getSeconds) +
+          TimeUnit.NANOSECONDS.toMicros(timestamp.getNanos.toLong)
+      LfTimestamp.assertFromLong(micros)
+    }
+  }
+}

--- a/libs-scala/timestamp-conversions/lf-javaprotobuf/src/test/scala/com/daml/timestamps/LfJavaProtobufTimestampConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/lf-javaprotobuf/src/test/scala/com/daml/timestamps/LfJavaProtobufTimestampConversionsSpec.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.lf.data.Time.{Timestamp => LfTimestamp}
+import com.daml.timestamps.LfJavaProtobuf._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+final class LfJavaProtobufTimestampConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Daml-LF timestamp to a Java Protocol Buffers timestamp" should {
+    "convert to and fro" in {
+      // The set of Protocol Buffers timestamps is much larger than the set of Daml-LF timestamps, so we generate the latter.
+      forAll { (timestamp: LfTimestamp) =>
+        timestamp.asJavaProto.asLf should be(timestamp)
+      }
+    }
+  }
+
+  private implicit val `Arbitrary LfTimestamp`: Arbitrary[LfTimestamp] = Arbitrary {
+    val specials = Seq(0, LfTimestamp.MinValue.micros, LfTimestamp.MaxValue.micros)
+    Gen
+      .chooseNum(LfTimestamp.MinValue.micros, LfTimestamp.MaxValue.micros, specials: _*)
+      .map(LfTimestamp.assertFromLong)
+  }
+}

--- a/libs-scala/timestamp-conversions/lf-scalaprotobuf/BUILD.bazel
+++ b/libs-scala/timestamp-conversions/lf-scalaprotobuf/BUILD.bazel
@@ -1,0 +1,49 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+    "lf_scalacopts_stricter",
+)
+
+scalacopts = lf_scalacopts_stricter
+
+da_scala_library(
+    name = "lf-scalaprotobuf",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:com_thesamet_scalapb_lenses",
+        "@maven//:com_thesamet_scalapb_scalapb_runtime",
+    ],
+    scalacopts = scalacopts,
+    tags = ["maven_coordinates=com.daml:timestamps-lf-scalaprotobuf:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//daml-lf/data",
+    ],
+)
+
+da_scala_test_suite(
+    name = "lf-scalaprotobuf-tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:com_thesamet_scalapb_lenses",
+        "@maven//:com_thesamet_scalapb_scalapb_runtime",
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatest_scalatest_core",
+        "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_scalatest_scalatest_wordspec",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+        "@maven//:org_scalaz_scalaz_core",
+    ],
+    scalacopts = scalacopts,
+    deps = [
+        ":lf-scalaprotobuf",
+        "//daml-lf/data",
+    ],
+)

--- a/libs-scala/timestamp-conversions/lf-scalaprotobuf/src/main/scala/com/daml/timestamps/LfScalaProtobuf.scala
+++ b/libs-scala/timestamp-conversions/lf-scalaprotobuf/src/main/scala/com/daml/timestamps/LfScalaProtobuf.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.lf.data.Time.{Timestamp => LfTimestamp}
+import com.google.protobuf.timestamp.{Timestamp => ProtoTimestamp}
+
+import java.util.concurrent.TimeUnit
+
+object LfScalaProtobuf {
+  implicit class LfToScalaProtoTimestampConversions(timestamp: LfTimestamp) {
+    def asScalaProto: ProtoTimestamp =
+      ProtoTimestamp.of(
+        seconds = timestamp.micros / 1000000,
+        nanos = ((timestamp.micros % 1000000) * 1000).toInt,
+      )
+  }
+
+  implicit class ScalaProtoToLfTimestampConversions(timestamp: ProtoTimestamp) {
+    def asLf: LfTimestamp = {
+      val micros =
+        TimeUnit.SECONDS.toMicros(timestamp.seconds) +
+          TimeUnit.NANOSECONDS.toMicros(timestamp.nanos.toLong)
+      LfTimestamp.assertFromLong(micros)
+    }
+  }
+}

--- a/libs-scala/timestamp-conversions/lf-scalaprotobuf/src/test/scala/com/daml/timestamps/LfScalaProtobufTimestampConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/lf-scalaprotobuf/src/test/scala/com/daml/timestamps/LfScalaProtobufTimestampConversionsSpec.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.lf.data.Time.{Timestamp => LfTimestamp}
+import com.daml.timestamps.LfScalaProtobuf._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+final class LfScalaProtobufTimestampConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Daml-LF timestamp to a Java Protocol Buffers timestamp" should {
+    "convert to and fro" in {
+      // The set of Protocol Buffers timestamps is much larger than the set of Daml-LF timestamps, so we generate the latter.
+      forAll { (timestamp: LfTimestamp) =>
+        timestamp.asScalaProto.asLf should be(timestamp)
+      }
+    }
+  }
+
+  private implicit val `Arbitrary LfTimestamp`: Arbitrary[LfTimestamp] = Arbitrary {
+    val specials = Seq(0, LfTimestamp.MinValue.micros, LfTimestamp.MaxValue.micros)
+    Gen
+      .chooseNum(LfTimestamp.MinValue.micros, LfTimestamp.MaxValue.micros, specials: _*)
+      .map(LfTimestamp.assertFromLong)
+  }
+}

--- a/libs-scala/timestamp-conversions/scala-javaprotobuf/BUILD.bazel
+++ b/libs-scala/timestamp-conversions/scala-javaprotobuf/BUILD.bazel
@@ -1,0 +1,46 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+    "lf_scalacopts_stricter",
+)
+
+scalacopts = lf_scalacopts_stricter
+
+da_scala_library(
+    name = "scala-javaprotobuf",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scalacopts = scalacopts,
+    tags = ["maven_coordinates=com.daml:timestamps-scala-javaprotobuf:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//libs-scala/timestamp-conversions/java-protobuf",
+        "//libs-scala/timestamp-conversions/java-scala",
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)
+
+da_scala_test_suite(
+    name = "scala-javaprotobuf-tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatest_scalatest_core",
+        "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_scalatest_scalatest_wordspec",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+    ],
+    scalacopts = scalacopts,
+    deps = [
+        ":scala-javaprotobuf",
+        "//libs-scala/scala-utils",
+        "//libs-scala/timestamp-conversions/java-scala",
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)

--- a/libs-scala/timestamp-conversions/scala-javaprotobuf/src/main/scala/com/daml/timestamps/ScalaJavaProtobuf.scala
+++ b/libs-scala/timestamp-conversions/scala-javaprotobuf/src/main/scala/com/daml/timestamps/ScalaJavaProtobuf.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.timestamps.JavaScala._
+import com.daml.timestamps.JavaProtobuf._
+import com.google.protobuf.{Duration => JavaProtoDuration}
+
+import scala.concurrent.duration.{FiniteDuration => ScalaDuration}
+
+object ScalaJavaProtobuf {
+  implicit class ScalaToJavaProtoDurationConversions(duration: ScalaDuration) {
+    def asJavaProto: JavaProtoDuration =
+      duration.asJava.asJavaProto
+  }
+
+  implicit class JavaProtoToScalaDurationConversions(duration: JavaProtoDuration) {
+    def asScala: ScalaDuration =
+      duration.asJava.asScala
+  }
+}

--- a/libs-scala/timestamp-conversions/scala-javaprotobuf/src/test/scala/com/daml/timestamps/ScalaJavaProtobufDurationConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/scala-javaprotobuf/src/test/scala/com/daml/timestamps/ScalaJavaProtobufDurationConversionsSpec.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.scalautil.Statement.discard
+import com.daml.timestamps.JavaScala._
+import com.daml.timestamps.ScalaJavaProtobuf._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.{Duration => JavaDuration}
+import scala.concurrent.duration.{FiniteDuration => ScalaDuration}
+
+final class ScalaJavaProtobufDurationConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Scala duration to a Java Protocol Buffers duration" should {
+    "convert to and fro" in {
+      forAll { (duration: ScalaDuration) =>
+        whenever(isConvertibleToScala(duration.asJava)) {
+          duration.asJavaProto.asScala should be(duration)
+        }
+      }
+    }
+  }
+
+  private def isConvertibleToScala(duration: JavaDuration) =
+    try {
+      discard(duration.asScala)
+      true
+    } catch {
+      case _: IllegalArgumentException => false
+    }
+}

--- a/libs-scala/timestamp-conversions/scala-protobuf/BUILD.bazel
+++ b/libs-scala/timestamp-conversions/scala-protobuf/BUILD.bazel
@@ -1,0 +1,50 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+    "lf_scalacopts_stricter",
+)
+
+scalacopts = lf_scalacopts_stricter
+
+da_scala_library(
+    name = "scala-protobuf",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:com_thesamet_scalapb_lenses",
+        "@maven//:com_thesamet_scalapb_scalapb_runtime",
+    ],
+    scalacopts = scalacopts,
+    tags = ["maven_coordinates=com.daml:timestamps-scala-protobuf:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//libs-scala/timestamp-conversions/java-scala",
+        "//libs-scala/timestamp-conversions/java-scalaprotobuf",
+    ],
+)
+
+da_scala_test_suite(
+    name = "scala-protobuf-tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:com_thesamet_scalapb_lenses",
+        "@maven//:com_thesamet_scalapb_scalapb_runtime",
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatest_scalatest_core",
+        "@maven//:org_scalatest_scalatest_matchers_core",
+        "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:org_scalatest_scalatest_wordspec",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+    ],
+    scalacopts = scalacopts,
+    deps = [
+        ":scala-protobuf",
+        "//libs-scala/scala-utils",
+        "//libs-scala/timestamp-conversions/java-scala",
+    ],
+)

--- a/libs-scala/timestamp-conversions/scala-protobuf/src/main/scala/com/daml/timestamps/ScalaProtobuf.scala
+++ b/libs-scala/timestamp-conversions/scala-protobuf/src/main/scala/com/daml/timestamps/ScalaProtobuf.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.timestamps.JavaScala._
+import com.daml.timestamps.JavaScalaProtobuf._
+import com.google.protobuf.duration.{Duration => ScalaProtoDuration}
+
+import scala.concurrent.duration.{FiniteDuration => ScalaDuration}
+
+object ScalaProtobuf {
+  implicit class ScalaToScalaProtoDurationConversions(duration: ScalaDuration) {
+    def asScalaProto: ScalaProtoDuration =
+      duration.asJava.asScalaProto
+  }
+
+  implicit class ScalaProtoToScalaDurationConversions(duration: ScalaProtoDuration) {
+    def asScala: ScalaDuration =
+      duration.asJava.asScala
+  }
+}

--- a/libs-scala/timestamp-conversions/scala-protobuf/src/test/scala/com/daml/timestamps/ScalaProtobufDurationConversionsSpec.scala
+++ b/libs-scala/timestamp-conversions/scala-protobuf/src/test/scala/com/daml/timestamps/ScalaProtobufDurationConversionsSpec.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timestamps
+
+import com.daml.scalautil.Statement.discard
+import com.daml.timestamps.JavaScala._
+import com.daml.timestamps.ScalaProtobuf._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.{Duration => JavaDuration}
+import scala.concurrent.duration.{FiniteDuration => ScalaDuration}
+
+final class ScalaProtobufDurationConversionsSpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+  "converting a Scala duration to a Scala Protocol Buffers duration" should {
+    "convert to and fro" in {
+      forAll { (duration: ScalaDuration) =>
+        whenever(isConvertibleToScala(duration.asJava)) {
+          duration.asScalaProto.asScala should be(duration)
+        }
+      }
+    }
+  }
+
+  private def isConvertibleToScala(duration: JavaDuration) =
+    try {
+      discard(duration.asScala)
+      true
+    } catch {
+      case _: IllegalArgumentException => false
+    }
+}

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -231,6 +231,8 @@
   type: jar-scala
 - target: //libs-scala/timer-utils:timer-utils
   type: jar-scala
+- target: //libs-scala/timestamp-conversions/java-lf:java-lf
+  type: jar-scala
 - target: //libs-scala/timestamp-conversions/java-protobuf:java-protobuf
   type: jar-scala
 - target: //libs-scala/timestamp-conversions/java-scala:java-scala

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -239,6 +239,10 @@
   type: jar-scala
 - target: //libs-scala/timestamp-conversions/java-scalaprotobuf:java-scalaprotobuf
   type: jar-scala
+- target: //libs-scala/timestamp-conversions/lf-javaprotobuf:lf-javaprotobuf
+  type: jar-scala
+- target: //libs-scala/timestamp-conversions/lf-scalaprotobuf:lf-scalaprotobuf
+  type: jar-scala
 - target: //libs-scala/timestamp-conversions/scala-javaprotobuf:scala-javaprotobuf
   type: jar-scala
 - target: //libs-scala/timestamp-conversions/scala-protobuf:scala-protobuf

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -231,7 +231,11 @@
   type: jar-scala
 - target: //libs-scala/timer-utils:timer-utils
   type: jar-scala
+- target: //libs-scala/timestamp-conversions/java-protobuf:java-protobuf
+  type: jar-scala
 - target: //libs-scala/timestamp-conversions/java-scala:java-scala
+  type: jar-scala
+- target: //libs-scala/timestamp-conversions/java-scalaprotobuf:java-scalaprotobuf
   type: jar-scala
 - target: //triggers/runner:trigger-runner-lib
   type: jar-scala

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -237,6 +237,10 @@
   type: jar-scala
 - target: //libs-scala/timestamp-conversions/java-scalaprotobuf:java-scalaprotobuf
   type: jar-scala
+- target: //libs-scala/timestamp-conversions/scala-javaprotobuf:scala-javaprotobuf
+  type: jar-scala
+- target: //libs-scala/timestamp-conversions/scala-protobuf:scala-protobuf
+  type: jar-scala
 - target: //triggers/runner:trigger-runner-lib
   type: jar-scala
 - target: //libs-scala/nameof:nameof

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -231,6 +231,8 @@
   type: jar-scala
 - target: //libs-scala/timer-utils:timer-utils
   type: jar-scala
+- target: //libs-scala/timestamp-conversions/java-scala:java-scala
+  type: jar-scala
 - target: //triggers/runner:trigger-runner-lib
   type: jar-scala
 - target: //libs-scala/nameof:nameof


### PR DESCRIPTION
I got fed up of writing converters between various different timestamp and duration types (and not knowing if I was inadvertently introducing bugs in doing so), so I decided to make libraries for all of them.

These provide implicit converters between:

  - _java-scala_: Java durations and Scala durations
  - _java-lf_: Java instants and Daml-LF timestamps
  - _java-protobuf_:
    - Java instants and Java Protocol Buffers timestamps
    - Java durations and Java Protocol Buffers durations
  - _java-scalaprotobuf_:
    - Java instants and Scala Protocol Buffers timestamps
    - Java durations and Scala Protocol Buffers durations
  - _scala-protobuf_: Scala durations and Scala Protocol Buffers durations
  - _scala-javaprotobuf_: Scala durations and Java Protocol Buffers durations
  - _lf-javaprotobuf_: Daml-LF timestamps and Java Protocol Buffers timestamps
  - _lf-scalaprotobuf_: Daml-LF timestamps and Scala Protocol Buffers timestamps

There are many small libraries so you can depend on what you need without bringing in extra dependencies. For example, if you don't use ScalaPB, you don't want to include it inadvertently.

They are currently not used, but I have plans to replace existing conversion functions with these.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
