### PR TITLE
Enable top level statement blank lines scalafmt rule 

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,3 +8,6 @@ runner.fatalWarnings = true
 trailingCommas = multiple
 # Disable scala doc wrapping (behavior changed in v3.0.0).
 docstrings.wrap = no
+newlines.topLevelStatementBlankLines = [
+  { blanks { after = 1 }, regex = "^Import" }
+]

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
@@ -25,6 +25,7 @@ class CommandPreprocessorSpec
 
   import com.daml.lf.testing.parser.Implicits._
   import com.daml.lf.transaction.test.TransactionBuilder.Implicits.{defaultPackageId => _, _}
+
   private implicit val defaultPackageId = defaultParserParameters.defaultPackageId
 
   private[this] val pkg =

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueTranslatorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ValueTranslatorSpec.scala
@@ -27,6 +27,7 @@ class ValueTranslatorSpec
   import Preprocessor.ArrayList
   import com.daml.lf.testing.parser.Implicits._
   import com.daml.lf.transaction.test.TransactionBuilder.Implicits.{defaultPackageId => _, _}
+
   private[this] implicit val defaultPackageId: Ref.PackageId =
     defaultParserParameters.defaultPackageId
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -391,6 +391,7 @@ private[lf] object Pretty {
 
     import com.daml.lf.language.Ast._
     import com.daml.lf.speedy.SExpr._
+
     def prettyAlt(index: Int)(alt: SCaseAlt): Doc = {
       val (pat, newIndex) = alt.pattern match {
         case SCPNil => (text("nil"), index)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -25,6 +25,7 @@ class SpeedyTest extends AnyWordSpec with Matchers {
 
   import SpeedyTest._
   import defaultParserParameters.{defaultPackageId => pkgId}
+
   def qualify(name: String) = Identifier(pkgId, QualifiedName.assertFromString(name))
 
   val pkgs = typeAndCompile(p"")

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/TypedValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/TypedValueGenerators.scala
@@ -84,6 +84,7 @@ object TypedValueGenerators {
 
     import Value._, ValueGenerators.Implicits._, data.Utf8.ImplicitOrder._
     import scalaz.std.anyVal._
+
     val text = noCid(PT.Text, ValueText) { case ValueText(t) => t }
     val int64 = noCid(PT.Int64, ValueInt64) { case ValueInt64(i) => i }
     val unit = noCid(PT.Unit, (_: Unit) => ValueUnit) { case ValueUnit => () }

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/UsedTypeParams.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/UsedTypeParams.scala
@@ -44,6 +44,7 @@ object UsedTypeParams {
 
   import VarianceConstraint.BaseResolution
   import Variance._
+
   private[this] type TVar = Ref.Name
 
   final class ResolvedVariance private (private val prior: Map[Identifier, ImmArraySeq[Variance]]) {

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/dbbackend/ContractDaoTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/dbbackend/ContractDaoTest.scala
@@ -85,6 +85,7 @@ class ContractDaoTest
 object ContractDaoTest {
   import org.scalacheck.Arbitrary, Arbitrary.arbitrary
   import ContractDao.Lagginess
+
   implicit def `arb Lagginess`[TpId: Arbitrary, Off: Arbitrary]: Arbitrary[Lagginess[TpId, Off]] =
     Arbitrary(arbitrary[(Set[TpId], Set[TpId], Off)].map((Lagginess[TpId, Off] _).tupled))
 }

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
@@ -37,6 +37,7 @@ import scala.util.{Failure, Success, Try}
 class Server(config: Config) extends StrictLogging {
   import com.daml.auth.middleware.api.JsonProtocol._
   import com.daml.auth.oauth2.api.JsonProtocol._
+
   implicit private val unmarshal: Unmarshaller[String, Uri] = Unmarshaller.strict(Uri(_))
 
   private def toRedirectUri(uri: Uri) =


### PR DESCRIPTION
This ensures there's a blank line after the imports are declared

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
