### PR TITLE
Fix daml test-script ordering

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -136,17 +136,18 @@ object TestMain extends StrictLogging {
                 new Runner(compiledPackages, script, config.timeMode)
               val testRun: Future[Unit] = runner.runWithClients(clients)._2.map(_ => ())
               // Print test result and remember failure.
-              testRun.onComplete {
-                case Failure(exception) =>
-                  success.set(false)
-                  println(s"${id.qualifiedName} FAILURE ($exception)")
-                case Success(_) =>
-                  println(s"${id.qualifiedName} SUCCESS")
-              }
-              // Do not abort in case of failure, but complete all test runs.
-              testRun.recover { case _ =>
-                ()
-              }
+              testRun
+                .andThen {
+                  case Failure(exception) =>
+                    success.set(false)
+                    println(s"${id.qualifiedName} FAILURE ($exception)")
+                  case Success(_) =>
+                    println(s"${id.qualifiedName} SUCCESS")
+                }
+                .recover { case _ =>
+                  // Do not abort in case of failure, but complete all test runs.
+                  ()
+                }
           }
         } yield success.get()
 


### PR DESCRIPTION
The issue is that onComplete is not sequenced here. It’s close to
impossible to hit this by default but I added random delays which
triggered it reliably and confirmed that this fixes the issue.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
