### PR TITLE
Extract configuration_rejection.proto from daml_kvutils.proto [KVL-1090]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/daml_kvutils.proto
@@ -20,27 +20,6 @@ import "google/protobuf/timestamp.proto";
 import "com/daml/ledger/configuration/ledger_configuration.proto";
 import "com/daml/ledger/participant/state/kvutils/store/state.proto";
 
-// A log entry describing a rejected configuration change.
-message DamlConfigurationRejectionEntry {
-  // A unique string scoped to a particular participant for matching the
-  // request with the result.
-  string submission_id = 1;
-
-  // Submitting participant's id.
-  string participant_id = 2;
-
-  // The new proposed configuration that was rejected.
-  com.daml.ledger.configuration.LedgerConfiguration configuration = 3;
-
-  oneof reason {
-    ParticipantNotAuthorized participant_not_authorized = 4;
-    GenerationMismatch generation_mismatch = 5;
-    Invalid invalid_configuration = 6;
-    TimedOut timed_out = 7;
-    Duplicate duplicate_submission = 8;
-  }
-}
-
 // Errors
 
 //

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/events/configuration.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/events/configuration.proto
@@ -10,9 +10,6 @@ option csharp_namespace = "Com.Daml.Ledger.Participant.State.KVUtils.Store.Event
 
 import "com/daml/ledger/configuration/ledger_configuration.proto";
 
-// This message is in it's own file because `state.proto` depends on this message,
-// and it would introduce a circular dependency if kept in `daml_kvutils.proto`
-
 // Configuration entry that records a configuration change.
 // Also used in state to look up latest configuration.
 // When a configuration exists, only the participant that

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/events/configuration_rejection.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/events/configuration_rejection.proto
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+
+package com.daml.ledger.participant.state.kvutils.store.events;
+
+option java_package = "com.daml.ledger.participant.state.kvutils.store.events";
+option java_multiple_files = true;
+option csharp_namespace = "Com.Daml.Ledger.Participant.State.KVUtils.Store.Events";
+
+import "com/daml/ledger/configuration/ledger_configuration.proto";
+import "com/daml/ledger/participant/state/kvutils/daml_kvutils.proto";
+
+// This message is in it's own file because it would introduce a circular dependency if kept in `configuration.proto`
+
+// A log entry describing a rejected configuration change.
+message DamlConfigurationRejectionEntry {
+  // A unique string scoped to a particular participant for matching the
+  // request with the result.
+  string submission_id = 1;
+
+  // Submitting participant's id.
+  string participant_id = 2;
+
+  // The new proposed configuration that was rejected.
+  com.daml.ledger.configuration.LedgerConfiguration configuration = 3;
+
+  oneof reason {
+    ParticipantNotAuthorized participant_not_authorized = 4;
+    GenerationMismatch generation_mismatch = 5;
+    Invalid invalid_configuration = 6;
+    TimedOut timed_out = 7;
+    Duplicate duplicate_submission = 8;
+  }
+}

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/log_entry.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/log_entry.proto
@@ -13,6 +13,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "com/daml/ledger/participant/state/kvutils/daml_kvutils.proto";
 import "com/daml/ledger/participant/state/kvutils/store/events/configuration.proto";
+import "com/daml/ledger/participant/state/kvutils/store/events/configuration_rejection.proto";
 import "com/daml/ledger/participant/state/kvutils/store/events/package_upload.proto";
 import "com/daml/ledger/participant/state/kvutils/store/events/party_allocation.proto";
 import "com/daml/ledger/participant/state/kvutils/store/events/transaction.proto";
@@ -47,7 +48,7 @@ message DamlLogEntry {
     com.daml.ledger.participant.state.kvutils.store.events.DamlConfigurationEntry configuration_entry = 6;
 
     // A rejected configuration change.
-    DamlConfigurationRejectionEntry configuration_rejection_entry = 7;
+    com.daml.ledger.participant.state.kvutils.store.events.DamlConfigurationRejectionEntry configuration_rejection_entry = 7;
 
     // Allocation of a new Daml party and its assignment to a participant.
     com.daml.ledger.participant.state.kvutils.store.events.DamlPartyAllocationEntry party_allocation_entry = 8;

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -6,9 +6,9 @@ package com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.grpc.GrpcStatuses
 import com.daml.ledger.participant.state.kvutils.Conversions._
-import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.store.events.PackageUpload.DamlPackageUploadRejectionEntry
 import com.daml.ledger.participant.state.kvutils.store.events.{
+  DamlConfigurationRejectionEntry,
   DamlPartyAllocationRejectionEntry,
   DamlTransactionBlindingInfo,
   DamlTransactionEntry,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -11,12 +11,15 @@ import com.daml.ledger.participant.state.kvutils.Conversions.{
 }
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.committer.Committer._
+import com.daml.ledger.participant.state.kvutils.store.events.{
+  DamlConfigurationEntry,
+  DamlConfigurationRejectionEntry,
+}
 import com.daml.ledger.participant.state.kvutils.store.{
   DamlLogEntry,
   DamlStateValue,
   DamlSubmissionDedupValue,
 }
-import com.daml.ledger.participant.state.kvutils.store.events.DamlConfigurationEntry
 import com.daml.ledger.participant.state.kvutils.wire.{DamlConfigurationSubmission, DamlSubmission}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.entries.LoggingEntries

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -7,8 +7,8 @@ import java.time.Duration
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.Configuration
-import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.store.DamlLogEntry
+import com.daml.ledger.participant.state.kvutils.store.events.DamlConfigurationRejectionEntry
 import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
@@ -8,7 +8,6 @@ import java.time.Instant
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.grpc.GrpcStatuses
 import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, parseInstant}
-import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.KeyValueConsumption.{
   TimeBounds,
   logEntryToUpdate,
@@ -22,6 +21,7 @@ import com.daml.ledger.participant.state.kvutils.store.events.PackageUpload.{
 }
 import com.daml.ledger.participant.state.kvutils.store.events.{
   DamlConfigurationEntry,
+  DamlConfigurationRejectionEntry,
   DamlPartyAllocationEntry,
   DamlPartyAllocationRejectionEntry,
   DamlSubmitterInfo,


### PR DESCRIPTION
- the configuration rejection entry is not part of the same file as the configuration entry (configuration.proto) because it would introduce a circular dependency between the proto files (state -> configuration -> rejections (currently daml_kvutils.proto file) -> state)

CHANGELOG_BEGIN

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
