### PR TITLE
Bump size of ledger-on-memory tests

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -44,7 +44,7 @@ da_scala_library(
 
 da_scala_test_suite(
     name = "ledger-on-memory-tests",
-    size = "small",
+    size = "medium",
     srcs = glob(["src/test/suite/**/*.scala"]),
     data = [
         "//ledger/test-common:model-tests-default.dar",


### PR DESCRIPTION
On CI we’ve seen
//ledger/ledger-on-memory:ledger-on-memory-tests_test_suite_src_test_suite_scala_com_daml_ledger_on_memory_InMemoryLedgerReaderWriterIntegrationSpec.scala
run above the 60s timeout.

Even locally under load, it gets easily between 30s and 60s so CI
timing out is fairly reasonable.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
