### PR TITLE
Fix Bazel cache download retry

### DIFF
--- a/nix/bazel-retry-cache.patch
+++ b/nix/bazel-retry-cache.patch
@@ -162,7 +162,7 @@ index a2e4abf9d8..93843a91dc 100644
 +  public long offset() { return offset; }
  }
 diff --git a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
-index 1efecd3bb1..a2366ea596 100644
+index 1efecd3bb1..3f360dda14 100644
 --- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
 +++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
 @@ -25,6 +25,7 @@ import com.google.common.util.concurrent.Futures;
@@ -281,7 +281,17 @@ index 1efecd3bb1..a2366ea596 100644
 -                outerF.setException(channelPromise.cause());
 -                return;
 -              }
--
++    return retrier.executeAsync(() -> {
++      DownloadCommand downloadCmd = new DownloadCommand(uri, casDownload, digest, wrappedOut, bytesDownloaded.get());
++      SettableFuture<Void> outerF = SettableFuture.create();
++      acquireDownloadChannel()
++          .addListener(
++              (Future<Channel> channelPromise) -> {
++                if (!channelPromise.isSuccess()) {
++                  outerF.setException(channelPromise.cause());
++                  return;
++                }
+ 
 -              Channel ch = channelPromise.getNow();
 -              ch.writeAndFlush(downloadCmd)
 -                  .addListener(
@@ -303,75 +313,61 @@ index 1efecd3bb1..a2366ea596 100644
 -                                try {
 -                                  refreshCredentials();
 -                                  getAfterCredentialRefresh(downloadCmd, outerF);
--                                  return;
++                Channel ch = channelPromise.getNow();
++                ch.writeAndFlush(downloadCmd)
++                    .addListener(
++                        (f) -> {
++                          try {
++                            if (f.isSuccess()) {
++                              outerF.set(null);
++                            } else {
++                              Throwable cause = f.cause();
++                              // cause can be of type HttpException, because Netty uses
++                              // Unsafe.throwException to
++                              // re-throw a checked exception that hasn't been declared in the method
++                              // signature.
++                              if (cause instanceof HttpException) {
++                                HttpResponse response = ((HttpException) cause).response();
++                                if (!dataWritten.get() && authTokenExpired(response)) {
++                                  // The error is due to an auth token having expired. Let's try
++                                  // again.
++                                  try {
++                                    refreshCredentials();
++                                    getAfterCredentialRefresh(downloadCmd, outerF);
++                                    return;
++                                  } catch (IOException e) {
++                                    cause.addSuppressed(e);
++                                  } catch (RuntimeException e) {
++                                    logger.atWarning().withCause(e).log("Unexpected exception");
++                                    cause.addSuppressed(e);
++                                  }
++                                } else if (cacheMiss(response.status())) {
++                                  outerF.setException(new CacheNotFoundException(digest));
+                                   return;
 -                                } catch (IOException e) {
 -                                  cause.addSuppressed(e);
 -                                } catch (RuntimeException e) {
 -                                  logger.atWarning().withCause(e).log("Unexpected exception");
 -                                  cause.addSuppressed(e);
--                                }
+                                 }
 -                              } else if (cacheMiss(response.status())) {
 -                                outerF.setException(new CacheNotFoundException(digest));
 -                                return;
--                              }
--                            }
+                               }
++                              outerF.setException(cause);
+                             }
 -                            outerF.setException(cause);
--                          }
++                          } finally {
++                            releaseDownloadChannel(ch);
+                           }
 -                        } finally {
 -                          releaseDownloadChannel(ch);
-+    return retrier.executeAsync(() -> {
-+      DownloadCommand downloadCmd = new DownloadCommand(uri, casDownload, digest, wrappedOut, bytesDownloaded.get());
-+      SettableFuture<Void> outerF = SettableFuture.create();
-+      acquireDownloadChannel()
-+              .addListener(
-+                      (Future<Channel> channelPromise) -> {
-+                        if (!channelPromise.isSuccess()) {
-+                          outerF.setException(channelPromise.cause());
-+                          return;
-                         }
-+
-+                        Channel ch = channelPromise.getNow();
-+                        ch.writeAndFlush(downloadCmd)
-+                                .addListener(
-+                                        (f) -> {
-+                                          try {
-+                                            if (f.isSuccess()) {
-+                                              outerF.set(null);
-+                                            } else {
-+                                              Throwable cause = f.cause();
-+                                              // cause can be of type HttpException, because Netty uses
-+                                              // Unsafe.throwException to
-+                                              // re-throw a checked exception that hasn't been declared in the method
-+                                              // signature.
-+                                              if (cause instanceof HttpException) {
-+                                                HttpResponse response = ((HttpException) cause).response();
-+                                                if (!dataWritten.get() && authTokenExpired(response)) {
-+                                                  // The error is due to an auth token having expired. Let's try
-+                                                  // again.
-+                                                  try {
-+                                                    refreshCredentials();
-+                                                    getAfterCredentialRefresh(downloadCmd, outerF);
-+                                                    return;
-+                                                  } catch (IOException e) {
-+                                                    cause.addSuppressed(e);
-+                                                  } catch (RuntimeException e) {
-+                                                    logger.atWarning().withCause(e).log("Unexpected exception");
-+                                                    cause.addSuppressed(e);
-+                                                  }
-+                                                } else if (cacheMiss(response.status())) {
-+                                                  outerF.setException(new CacheNotFoundException(digest));
-+                                                  return;
-+                                                }
-+                                              }
-+                                              outerF.setException(cause);
-+                                            }
-+                                          } finally {
-+                                            releaseDownloadChannel(ch);
-+                                          }
-+                                        });
-                       });
+-                        }
+-                      });
 -            });
 -    return outerF;
++                        });
++              });
 +      return outerF;
 +    });
    }


### PR DESCRIPTION
Bazel's HTTP remote cache client does not support retry on download (or upload) failure. Instead, it will rebuild the artifact locally. This is potentially slower than fetching from cache, and worse if the build action is not bit reproducible (like GHC compilation tends to be) then the local rebuild will trigger cache misses due to changed inputs down the line.

We already have a patch in place to enable retry in the HTTP cache client. Unfortunately, it has a bug: Bazel continues appending to the same file (`OutputStream` in general) without resetting the write offset to the beginning of the file. Meaning, after retry the file contains a duplicate prefix and Bazel's digest check fails and Bazel falls back to a local rebuild after all.

This PR fixes that issue. Bazel's internal API is structured in a way that doesn't allow to reset the write offset. Instead, this PR takes the same approach as Bazel's already existing GRPC cache client and only downloads the missing data with a range request, or discards the duplicate prefix if a range request is not supported by the HTTP server.

I have tested this patch locally against a bazel-remote HTTP cache (which doesn't support range requests) and an nginx HTTP cache (which does support range requests). I have also tested this patch on daml CI [here](https://dev.azure.com/digitalasset/daml/_build/results?buildId=92202&view=logs&jobId=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=7b720ed4-ea9c-5605-45fe-aca5cec61df4). Retries are logged with the prefix `RETRYING`. E.g.
```
RETRYING: com.google.devtools.build.lib.remote.http.HttpException: 502 Bad Gateway
```
Errors that don't trigger a retry are logged with the prefix `NOT RETRYING` (apart from cache misses). No such cases are expected and also not found in the CI logs. However, if they ever appear we can consider extending the retry logic to cover these errors as well.

This PR changes a patch, which can be awkward to review. The full diff against Bazel can be seen [here](https://github.com/aherrmann/bazel/commit/578318e9c535b039f636fcd857cf3815831f6998).

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
