### PR TITLE
Make compatibility migrations `eternal`

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -128,7 +128,7 @@ first_post_7587_trigger_version = "1.7.0-snapshot.20201012.5405.0.af92198d"
 
 migration_test(
     name = "migration-stable",
-    timeout = "long",
+    timeout = "eternal",
     # Exclusive due to hardcoded postgres ports.
     tags = [
         "exclusive",
@@ -152,7 +152,7 @@ migration_test(
 
 migration_test(
     name = "migration-all",
-    timeout = "long",
+    timeout = "eternal",
     # Exclusive due to hardcoded postgres ports.
     tags = ["exclusive"],
     versions = platform_versions,


### PR DESCRIPTION
Not sure whether this is a good choice but I could not
find anything between `long` and `eternal`. This will bump
the timeout to 60 minutes (despite the ominous name).

See https://docs.bazel.build/versions/main/be/common-definitions.html#test.timeout

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
