### PR TITLE
Allow to use the Daml Driver for PostgreSQL on an existing schema

### DIFF
--- a/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
+++ b/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
@@ -70,6 +70,13 @@ private[sql] final class Cli(
         s"Maximum number of successfully interpreted commands waiting to be sequenced. The threshold is shared across all parties. Overflowing it will cause back-pressure, signaled by a `RESOURCE_EXHAUSTED` error code. Default is ${defaultConfig.maxParallelSubmissions}."
       )
 
+    parser
+      .opt[Boolean]("allow-existing-schema")
+      .action((value, config) => config.copy(allowExistingSchema = value))
+      .text(
+        "Do not abort if there are existing tables in the database schema. EXPERT ONLY. Defaults to false."
+      )
+
     // Ideally we would set the relevant options to `required()`, but it doesn't seem to work.
     // Even when the value is provided, it still reports that it's missing. Instead, we check the
     // configuration afterwards.

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -108,7 +108,7 @@ object SandboxServer {
     newLoggingContextWith(logging.participantId(config.participantId)) { implicit loggingContext =>
       logger.info("Running only schema migration scripts")
       new FlywayMigrations(config.jdbcUrl.get, config.enableAppendOnlySchema)
-        .migrate()
+        .migrate(config.allowExistingSchema)
     }
   }
 
@@ -333,6 +333,7 @@ final class SandboxServer(
             validatePartyAllocation = !config.implicitPartyAllocation,
             enableAppendOnlySchema = config.enableAppendOnlySchema,
             enableCompression = config.enableCompression,
+            allowExistingSchema = config.allowExistingSchema,
           )
         case None =>
           SandboxIndexAndWriteService.inMemory(

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -65,6 +65,7 @@ private[sandbox] object SandboxIndexAndWriteService {
       enableAppendOnlySchema: Boolean,
       enableCompression: Boolean,
       validatePartyAllocation: Boolean = false,
+      allowExistingSchema: Boolean,
   )(implicit
       mat: Materializer,
       loggingContext: LoggingContext,
@@ -92,6 +93,7 @@ private[sandbox] object SandboxIndexAndWriteService {
       validatePartyAllocation = validatePartyAllocation,
       enableAppendOnlySchema = enableAppendOnlySchema,
       enableCompression = enableCompression,
+      allowExistingSchema = allowExistingSchema,
     ).flatMap(ledger =>
       owner(
         ledger = MeteredLedger(ledger, metrics),

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -90,6 +90,7 @@ private[sandbox] object SqlLedger {
       validatePartyAllocation: Boolean,
       enableAppendOnlySchema: Boolean,
       enableCompression: Boolean,
+      allowExistingSchema: Boolean,
   )(implicit mat: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[Ledger] {
 
@@ -98,7 +99,7 @@ private[sandbox] object SqlLedger {
     override def acquire()(implicit context: ResourceContext): Resource[Ledger] =
       for {
         _ <- Resource.fromFuture(
-          new FlywayMigrations(jdbcUrl, enableAppendOnlySchema).migrate()
+          new FlywayMigrations(jdbcUrl, enableAppendOnlySchema).migrate(allowExistingSchema)
         )
         dao <- ledgerDaoOwner(servicesExecutionContext).acquire()
         _ <- startMode match {

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
@@ -97,6 +97,7 @@ private[sandbox] object LedgerResource {
           validatePartyAllocation = false,
           enableAppendOnlySchema = false,
           enableCompression = false,
+          allowExistingSchema = false,
         )
       } yield ledger
     )

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerOnMutableIndexSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerOnMutableIndexSpec.scala
@@ -458,6 +458,7 @@ final class SqlLedgerOnMutableIndexSpec
         validatePartyAllocation = false,
         enableAppendOnlySchema = false,
         enableCompression = false,
+        allowExistingSchema = false,
       ).acquire()(ResourceContext(system.dispatcher))
     createdLedgers += ledger
     ledger.asFuture

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -469,6 +469,7 @@ final class SqlLedgerSpec
         validatePartyAllocation = false,
         enableAppendOnlySchema = true,
         enableCompression = false,
+        allowExistingSchema = false,
       ).acquire()(ResourceContext(system.dispatcher))
     createdLedgers += ledger
     ledger.asFuture

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -67,6 +67,7 @@ final case class SandboxConfig(
     enableAppendOnlySchema: Boolean,
     enableCompression: Boolean,
     enableSelfServiceErrorCodes: Boolean,
+    allowExistingSchema: Boolean,
 ) {
 
   def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): SandboxConfig =
@@ -148,6 +149,7 @@ object SandboxConfig {
       enableAppendOnlySchema = false,
       enableCompression = false,
       enableSelfServiceErrorCodes = false,
+      allowExistingSchema = false,
     )
 
   sealed abstract class EngineMode extends Product with Serializable


### PR DESCRIPTION
Closes #11245

changelog_begin
[Daml Driver for PostgreSQL] `--allow-existing-schema` allows the Daml Driver for PostgreSQL to
be started alongside other services requiring persistence on a single database instance. Usage
means you can have conflicts in naming that you may need to resolve, but allows for simpler
deployment options.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
