### PR TITLE
Retry faster during startup

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -107,8 +107,8 @@ private[platform] object ReadOnlySqlLedger {
         case _: MismatchException.LedgerId => false
         case _ => false
       }
-      val retryDelay = 5.seconds
-      val maxAttempts = 100
+      val retryDelay = 100.millis
+      val maxAttempts = 3000 // give up after 5min
       RetryStrategy.constant(attempts = Some(maxAttempts), waitTime = retryDelay)(predicate) {
         (attempt, _) =>
           ledgerDao


### PR DESCRIPTION
Previously, the ledger API server waited 5sec if the indexer happened to not write the ledger id in time. Now it retries after 100ms.