### PR TITLE
Add debugRaw corresponding to traceM in Haskell

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -540,13 +540,19 @@ traceId x = trace x x
 --
 -- Note that on some ledgers, those messages are not displayed at the default log level. For Sandbox, you can use `--log-level=debug` to include them.
 debug : (Show b, Action m) => b -> m ()
-debug x =
+debug x = debugRaw (show x)
+
+-- | `debugRaw msg` prints `msg` for debugging purposes.
+--
+-- Note that on some ledgers, those messages are not displayed at the default log level. For Sandbox, you can use `--log-level=debug` to include them.
+debugRaw : Action m => Text -> m ()
+debugRaw x =
   -- NOTE (MK): We introduce an explicit indirection via >>=
   -- to make sure that evaluating something like
   -- `debug x >> pure ()` does not print the debug statement.
   -- Instead it will only be printed when you execute the monadic
   -- action.
-  pure () >>= \_ -> pure (trace x ())
+  pure () >>= \_ -> pure (traceRaw x ())
 
 -- | Return the first element of a tuple.
 fst : (a, b) -> a

--- a/compiler/damlc/tests/daml-test-files/PreludeTest.daml
+++ b/compiler/damlc/tests/daml-test-files/PreludeTest.daml
@@ -407,3 +407,8 @@ testDateMinBoundPred : Scenario Date = do
 
 testDateMaxBoundSucc : Scenario Date = do
     return (succ maxBound)
+
+-- Only check that they are properly exposed & typecheck.
+testTypeCheckTrace = scenario do
+  debug 1
+  debugRaw "abc"


### PR DESCRIPTION
changelog_begin

- [Daml Stdlib] Add `debugRaw` as a convenience wrapper around
  `traceRaw` when used inside a do-block. `debugRaw` compares to
  `debug` like `traceRaw` compares to `trace` meaning it expects a
  `Text` instead of calling `show` on an expression.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
