### PR TITLE
Bump startup time in create-daml-app tests

### DIFF
--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -75,14 +75,19 @@ beforeAll(async () => {
     `--json-api-option=--port-file=${JSON_API_PORT_FILE_NAME}`,
   ];
 
+  console.debug("Starting daml start");
+
   startProc = spawn('daml', startArgs, startOpts);
 
   await waitOn({resources: [`file:${jsonApiPortFilePath}`]});
+
+  console.debug("daml start API are running");
 
   // Run `npm start` in another shell.
   // Disable automatically opening a browser using the env var described here:
   // https://github.com/facebook/create-react-app/issues/873#issuecomment-266318338
   const env = {...process.env, BROWSER: 'none'};
+  console.debug("Starting npm start");
   uiProc = spawn('npm-cli.js', ['run-script', 'start'], { env, stdio: 'inherit', detached: true});
   // Note(kill-npm-start): The `detached` flag starts the process in a new process group.
   // This allows us to kill the process with all its descendents after the tests finish,
@@ -90,10 +95,13 @@ beforeAll(async () => {
 
   // Ensure the UI server is ready by checking that the port is available.
   await waitOn({resources: [`tcp:localhost:${UI_PORT}`]});
+  console.debug("npm start is running");
 
   // Launch a single browser for all tests.
+  console.debug("Starting puppeteer");
   browser = await puppeteer.launch();
-}, 40_000);
+  console.debug("Puppeteer is running");
+}, 60_000);
 
 afterAll(async () => {
   // Kill the `daml start` process, allowing the sandbox and JSON API server to


### PR DESCRIPTION
We’ve seen this timeout a few times on CI. The version in the compat
tests already has a 60s timeout and that seems to work better so
here’s to hoping this helps.

I’ve also added some logs to see where it stops if it times out
again (jest hides console.log by default which is why this uses
console.debug by default).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
