### PR TITLE
Extract UtilLF module from daml-lf-conversion to its own library

### DIFF
--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -54,6 +54,7 @@ da_haskell_library(
         "//compiler/damlc/daml-ghc-util",
         "//compiler/damlc/daml-ide-core",
         "//compiler/damlc/daml-lf-conversion",
+        "//compiler/damlc/daml-lf-util",
         "//compiler/damlc/daml-opts",
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-package-config",

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -33,10 +33,10 @@ import qualified DA.Daml.LF.TypeChecker as LF
 import DA.Daml.LF.Ast.Optics (packageRefs)
 import qualified DA.Daml.LF.ReplClient as ReplClient
 import DA.Daml.LFConversion (convertModule)
-import DA.Daml.LFConversion.UtilLF (buildPackage)
 import DA.Daml.Options.Types
 import qualified DA.Daml.Preprocessor.Records as Preprocessor
 import DA.Daml.UtilGHC
+import DA.Daml.UtilLF (buildPackage)
 import Data.Bifunctor (first)
 import Data.Functor.Alt
 import Data.Functor.Bind

--- a/compiler/damlc/daml-ide-core/BUILD.bazel
+++ b/compiler/damlc/daml-ide-core/BUILD.bazel
@@ -58,6 +58,7 @@ da_haskell_library(
         "//compiler/daml-lf-tools",
         "//compiler/damlc/daml-doctest",
         "//compiler/damlc/daml-lf-conversion",
+        "//compiler/damlc/daml-lf-util",
         "//compiler/damlc/daml-opts",
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/damlc/daml-rule-types",

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -91,7 +91,6 @@ import Development.IDE.Core.RuleTypes.Daml
 import DA.Bazel.Runfiles
 import DA.Daml.DocTest
 import DA.Daml.LFConversion (convertModule)
-import DA.Daml.LFConversion.UtilLF
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.InferSerializability as Serializability
 import qualified DA.Daml.LF.PrettyScenario as LF
@@ -99,6 +98,7 @@ import qualified DA.Daml.LF.Proto3.Archive as Archive
 import qualified DA.Daml.LF.ScenarioServiceClient as SS
 import qualified DA.Daml.LF.Simplifier as LF
 import qualified DA.Daml.LF.TypeChecker as LF
+import DA.Daml.UtilLF
 import qualified DA.Pretty as Pretty
 import SdkVersion (damlStdlib)
 

--- a/compiler/damlc/daml-ide/BUILD.bazel
+++ b/compiler/damlc/daml-ide/BUILD.bazel
@@ -36,7 +36,7 @@ da_haskell_library(
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/damlc/daml-ide-core",
-        "//compiler/damlc/daml-lf-conversion",
+        "//compiler/damlc/daml-lf-util",
         "//compiler/damlc/daml-rule-types",
         "//compiler/damlc/daml-visual",
         "//libs-haskell/da-hs-base",

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
@@ -8,8 +8,8 @@ module DA.Daml.LanguageServer.CodeLens
     ) where
 
 import Control.Monad.IO.Class
-import DA.Daml.LFConversion.UtilLF (sourceLocToRange)
 import qualified DA.Daml.LF.Ast as LF
+import DA.Daml.UtilLF (sourceLocToRange)
 import qualified Data.Aeson as Aeson
 import Development.IDE.Core.Service.Daml
 import Data.Foldable

--- a/compiler/damlc/daml-lf-conversion/BUILD.bazel
+++ b/compiler/damlc/daml-lf-conversion/BUILD.bazel
@@ -39,6 +39,7 @@ da_haskell_library(
         "//compiler/daml-lf-proto",
         "//compiler/daml-lf-tools",
         "//compiler/damlc/daml-ghc-util",
+        "//compiler/damlc/daml-lf-util",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -81,9 +81,9 @@ module DA.Daml.LFConversion
     ) where
 
 import           DA.Daml.LFConversion.Primitives
-import           DA.Daml.LFConversion.UtilLF
 import           DA.Daml.LFConversion.MetadataEncoding
 import           DA.Daml.UtilGHC
+import           DA.Daml.UtilLF
 
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -8,8 +8,8 @@
 -- | The DAML-LF primitives, matched with their type, and using 'primitive' on the libraries side.
 module DA.Daml.LFConversion.Primitives(convertPrim) where
 
-import           DA.Daml.LFConversion.UtilLF
 import           DA.Daml.LF.Ast
+import           DA.Daml.UtilLF
 import           DA.Pretty (renderPretty)
 import qualified Data.Text as T
 import qualified Data.List as L

--- a/compiler/damlc/daml-lf-util/BUILD.bazel
+++ b/compiler/damlc/daml-lf-util/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:haskell.bzl",
+    "da_haskell_library",
+)
+
+da_haskell_library(
+    name = "daml-lf-util",
+    srcs = glob(["src/**/*.hs"]),
+    hackage_deps = [
+        "base",
+        "bytestring",
+        "lsp-types",
+        "ghc-lib-parser",
+        "text",
+    ],
+    repl_ghci_args = ["-hide-package=ghc"],
+    src_strip_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-proto",
+        "//libs-haskell/da-hs-base",
+    ],
+)

--- a/compiler/damlc/daml-lf-util/src/DA/Daml/UtilLF.hs
+++ b/compiler/damlc/daml-lf-util/src/DA/Daml/UtilLF.hs
@@ -4,8 +4,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- | DAML-LF utility functions, may move to the LF utility if they are generally useful
-module DA.Daml.LFConversion.UtilLF(
-    module DA.Daml.LFConversion.UtilLF
+module DA.Daml.UtilLF (
+    module DA.Daml.UtilLF
     ) where
 
 import           DA.Daml.LF.Ast

--- a/compiler/damlc/stable-packages/BUILD.bazel
+++ b/compiler/damlc/stable-packages/BUILD.bazel
@@ -16,7 +16,7 @@ da_haskell_library(
     deps = [
         "//compiler/daml-lf-ast",
         "//compiler/daml-lf-proto",
-        "//compiler/damlc/daml-lf-conversion",
+        "//compiler/damlc/daml-lf-util",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/damlc/stable-packages/lib/DA/Daml/StablePackages.hs
+++ b/compiler/damlc/stable-packages/lib/DA/Daml/StablePackages.hs
@@ -15,7 +15,7 @@ import qualified Data.Text as T
 
 import DA.Daml.LF.Ast
 import DA.Daml.LF.Proto3.Archive
-import DA.Daml.LFConversion.UtilLF
+import DA.Daml.UtilLF
 
 allStablePackages :: [Package]
 allStablePackages =

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -171,7 +171,7 @@ da_haskell_library(
         "//compiler/daml-lf-proto",
         "//compiler/damlc/daml-compiler",
         "//compiler/damlc/daml-ide-core",
-        "//compiler/damlc/daml-lf-conversion",
+        "//compiler/damlc/daml-lf-util",
         "//compiler/damlc/daml-opts",
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//compiler/scenario-service/client",

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -11,7 +11,7 @@ module DA.Test.DamlcIntegration
 import           DA.Bazel.Runfiles
 import           DA.Daml.Options
 import           DA.Daml.Options.Types
-import           DA.Daml.LFConversion.UtilLF
+import           DA.Daml.UtilLF
 import           DA.Test.Util (standardizeQuotes)
 
 import           DA.Daml.LF.Ast as LF hiding (IsTest)


### PR DESCRIPTION
Similar to #11260, this moves the `DA.Daml.LFConversion.UtilLF` (now DA.Daml.UtilLF) into its own library, thus allowing `daml-lf-conversion` to depend on `daml-preprocessor` without forming a cycle.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
