### PR TITLE
Fix Scala repl targets

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -570,9 +570,9 @@ def _create_scala_repl(
         **kwargs):
     name = name + "_repl"
     deps = resolve_scala_deps(deps, scala_deps, versioned_deps, versioned_scala_deps)
-    runtime_deps = resolve_scala_deps(runtime_deps, scala_runtime_deps)
+    runtime_deps = resolve_scala_deps(runtime_deps, scala_runtime_deps) + ["@maven//:org_jline_jline"]
     tags = tags + ["manual"]
-    scala_repl(name = name, deps = deps, runtime_deps = runtime_deps, tags = tags, **kwargs)
+    _wrap_rule(scala_repl, name = name, deps = deps, runtime_deps = runtime_deps, tags = tags, **kwargs)
 
 def da_scala_library(name, **kwargs):
     """


### PR DESCRIPTION
We need _wrap_rule to make sure plugins like wartremover are also
correctly applied here.

We need jline because otherwise the repl starts but then fails because
jline isn’t in scope.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
