### PR TITLE
Increase time model skew limits

### DIFF
--- a/ledger/ledger-configuration/src/main/scala/com/daml/ledger/configuration/LedgerTimeModel.scala
+++ b/ledger/ledger-configuration/src/main/scala/com/daml/ledger/configuration/LedgerTimeModel.scala
@@ -64,8 +64,8 @@ object LedgerTimeModel {
   val reasonableDefault: LedgerTimeModel =
     LedgerTimeModel(
       avgTransactionLatency = Duration.ofSeconds(0L),
-      minSkew = Duration.ofSeconds(120L),
-      maxSkew = Duration.ofSeconds(120L),
+      minSkew = Duration.ofSeconds(30L),
+      maxSkew = Duration.ofSeconds(30L),
     ).get
 
   def apply(

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -11,7 +11,6 @@ import com.daml.ledger.api.auth.AuthServiceJWT
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.tls.TlsVersion.TlsVersion
 import com.daml.ledger.api.tls.{SecretsUrl, TlsConfiguration}
-import com.daml.ledger.configuration.LedgerTimeModel
 import com.daml.lf.data.Ref
 import com.daml.platform.apiserver.SeedService.Seeding
 import com.daml.platform.common.LedgerIdMode
@@ -312,7 +311,7 @@ class CommonCliBase(name: LedgerName) {
           config.copy(timeModel = config.timeModel.copy(minSkew = duration, maxSkew = duration))
         }
         .text(
-          s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${LedgerTimeModel.reasonableDefault.maxSkew.getSeconds}."
+          s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${SandboxConfig.defaultConfig.timeModel.maxSkew.getSeconds}."
         )
 
       opt[Duration]("management-service-timeout")

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -119,7 +119,14 @@ object SandboxConfig {
       configurationLoadTimeout = Duration.ofSeconds(10),
       maxDeduplicationDuration = None,
       delayBeforeSubmittingLedgerConfiguration = Duration.ofSeconds(1),
-      timeModel = LedgerTimeModel.reasonableDefault,
+      // Sandbox is a slow ledger, use a big skew to avoid failing commands under load.
+      // If sandbox ever gets fast enough not to cause flakes in our tests,
+      // this can be reverted to LedgerTimeModel.reasonableDefault.
+      timeModel = LedgerTimeModel(
+        avgTransactionLatency = Duration.ofSeconds(0L),
+        minSkew = Duration.ofSeconds(120L),
+        maxSkew = Duration.ofSeconds(120L),
+      ).get,
       commandConfig = CommandConfiguration.default,
       submissionConfig = SubmissionConfiguration.default,
       tlsConfig = None,


### PR DESCRIPTION
The default is supposed to be used for "test and sandbox ledgers". Increasing the timeout means less tests will fail because the ledger couldn't handle a peak in command submissions. 