### PR TITLE
Increase timeout for non-repudation test

### DIFF
--- a/runtime-components/non-repudiation-postgresql/BUILD.bazel
+++ b/runtime-components/non-repudiation-postgresql/BUILD.bazel
@@ -37,6 +37,7 @@ da_scala_library(
 
 da_scala_test(
     name = "test",
+    size = "large",
     srcs = glob(["src/test/scala/**/*.scala"]),
     resources = [
         "src/test/resources/logback-test.xml",


### PR DESCRIPTION
When using the append-only schema, this test sometimes times out in CI due to a Bazel timeout.

On my local machine, the test time went up from 98s to 105s after enabling the append-only schema (well below the default 5min timeout).