### PR TITLE
Add GrpcStatus.toProto(JavaStatus) -> ScalaStatus conversion [KVL-1143]

### DIFF
--- a/libs-scala/grpc-utils/src/main/scala/com/digitalasset/grpc/GrpcStatus.scala
+++ b/libs-scala/grpc-utils/src/main/scala/com/digitalasset/grpc/GrpcStatus.scala
@@ -26,14 +26,14 @@ object GrpcStatus {
     val code = status.getCode.value
     val description = Option(status.getDescription).getOrElse("")
     val statusJavaProto = io.grpc.protobuf.StatusProto.fromStatusAndTrailers(status, metadata)
-    StatusProto(code, description, details(statusJavaProto))
+    StatusProto(code, description, extractDetails(statusJavaProto))
   }
 
   def toProto(statusJavaProto: StatusJavaProto): StatusProto =
     StatusProto(
       code = statusJavaProto.getCode,
       message = statusJavaProto.getMessage,
-      details = details(statusJavaProto),
+      details = extractDetails(statusJavaProto),
     )
 
   def toJavaProto(status: StatusProto): StatusJavaProto = toJavaBuilder(status).build()
@@ -64,7 +64,7 @@ object GrpcStatus {
       status.getCode == code
   }
 
-  private def details(statusJavaProto: StatusJavaProto): Seq[AnyProto] =
+  private def extractDetails(statusJavaProto: StatusJavaProto): Seq[AnyProto] =
     statusJavaProto.getDetailsList.asScala.map(detail => AnyProto.fromJavaProto(detail)).toSeq
 
   val OK = new SpecificGrpcStatus(Code.OK)


### PR DESCRIPTION
## Description

This new utility will be used by KV to convert Java protobuf gRPC statuses produced by the error infrastructure into ScalaPB ones.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
