### PR TITLE
Increase timeout for non-repudation tests on Postgres

### DIFF
--- a/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
+++ b/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
@@ -114,6 +114,7 @@ final class NonRepudiationProxyConformance
           SigningInterceptor.signCommands(key, certificate)
         ),
         clientTlsConfiguration = config.tlsConfig,
+        timeoutScaleFactor = 2,
       )
 
       runner.runTests.map { summaries =>


### PR DESCRIPTION
The test can not only time out in Bazel (fixed in https://github.com/digital-asset/daml/pull/11281), it can also time out in the test runner.
