### PR TITLE
Use Timestamp instead of Instant

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Time.scala
@@ -102,6 +102,10 @@ object Time {
     }
 
     @throws[IllegalArgumentException]
+    def subtract(duration: Duration): Timestamp =
+      add(duration.negated())
+
+    @throws[IllegalArgumentException]
     def addMicros(x: Long): Timestamp =
       Timestamp.assertFromLong(micros + x)
   }

--- a/ledger/ledger-configuration/src/main/scala/com/daml/ledger/configuration/LedgerTimeModel.scala
+++ b/ledger/ledger-configuration/src/main/scala/com/daml/ledger/configuration/LedgerTimeModel.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.configuration
 
-import java.time.{Duration, Instant}
+import java.time.Duration
 
 import com.daml.ledger.configuration.LedgerTimeModel._
 import com.daml.lf.data.Time.Timestamp
@@ -32,36 +32,29 @@ case class LedgerTimeModel private (
     * In particular, checks the skew condition: rt_TX - s_min <= lt_TX <= rt_TX + s_max.
     */
   def checkTime(
-      ledgerTime: Instant,
-      recordTime: Instant,
+      ledgerTime: Timestamp,
+      recordTime: Timestamp,
   ): Either[OutOfRange, Unit] = {
     val lowerBound = minLedgerTime(recordTime)
     val upperBound = maxLedgerTime(recordTime)
-    if (ledgerTime.isBefore(lowerBound) || ledgerTime.isAfter(upperBound)) {
+    if (ledgerTime < lowerBound || ledgerTime > upperBound) {
       Left(OutOfRange(ledgerTime, lowerBound, upperBound))
     } else {
       Right(())
     }
   }
 
-  def checkTime(
-      ledgerTime: Timestamp,
-      recordTime: Timestamp,
-  ): Either[OutOfRange, Unit] = {
-    checkTime(ledgerTime.toInstant, recordTime.toInstant)
-  }
+  private[ledger] def minLedgerTime(recordTime: Timestamp): Timestamp =
+    recordTime.subtract(minSkew)
 
-  private[ledger] def minLedgerTime(recordTime: Instant): Instant =
-    recordTime.minus(minSkew)
+  private[ledger] def maxLedgerTime(recordTime: Timestamp): Timestamp =
+    recordTime.add(maxSkew)
 
-  private[ledger] def maxLedgerTime(recordTime: Instant): Instant =
-    recordTime.plus(maxSkew)
+  private[ledger] def minRecordTime(ledgerTime: Timestamp): Timestamp =
+    ledgerTime.subtract(maxSkew)
 
-  private[ledger] def minRecordTime(ledgerTime: Instant): Instant =
-    ledgerTime.minus(maxSkew)
-
-  private[ledger] def maxRecordTime(ledgerTime: Instant): Instant =
-    ledgerTime.plus(minSkew)
+  private[ledger] def maxRecordTime(ledgerTime: Timestamp): Timestamp =
+    ledgerTime.add(minSkew)
 }
 
 object LedgerTimeModel {
@@ -88,7 +81,7 @@ object LedgerTimeModel {
       new LedgerTimeModel(avgTransactionLatency, minSkew, maxSkew)
     }
 
-  final case class OutOfRange(ledgerTime: Instant, lowerBound: Instant, upperBound: Instant) {
+  final case class OutOfRange(ledgerTime: Timestamp, lowerBound: Timestamp, upperBound: Timestamp) {
     lazy val message: String =
       s"Ledger time $ledgerTime outside of range [$lowerBound, $upperBound]"
   }

--- a/ledger/ledger-configuration/src/test/suite/scala/com/daml/ledger/configuration/LedgerTimeModelSpec.scala
+++ b/ledger/ledger-configuration/src/test/suite/scala/com/daml/ledger/configuration/LedgerTimeModelSpec.scala
@@ -4,14 +4,14 @@
 package com.daml.ledger.configuration
 
 import java.time._
-
 import com.daml.ledger.configuration.LedgerTimeModel.OutOfRange
+import com.daml.lf.data.Time.Timestamp
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class LedgerTimeModelSpec extends AnyWordSpec with Matchers {
 
-  private val referenceTime = Instant.EPOCH
+  private val referenceTime = Timestamp.Epoch
   private val epsilon = Duration.ofMillis(10L)
   private val defaultSkew = Duration.ofSeconds(30L)
   private val timeModel =
@@ -32,21 +32,21 @@ class LedgerTimeModelSpec extends AnyWordSpec with Matchers {
       }
 
       "succeed if the ledger time is higher than the record time and is within tolerance limit" in {
-        val result = timeModel.checkTime(referenceTime.plus(epsilon), referenceTime)
+        val result = timeModel.checkTime(referenceTime.add(epsilon), referenceTime)
 
         result should be(Right(()))
       }
 
       "succeed if the ledger time is equal to the high boundary" in {
-        val result = timeModel.checkTime(referenceTime.plus(timeModel.maxSkew), referenceTime)
+        val result = timeModel.checkTime(referenceTime.add(timeModel.maxSkew), referenceTime)
 
         result should be(Right(()))
       }
 
       "fail if the ledger time is higher than the high boundary" in {
-        val ledgerTime = referenceTime.plus(timeModel.maxSkew).plus(epsilon)
-        val minRecordTime = referenceTime.minus(defaultSkew)
-        val maxRecordTime = referenceTime.plus(defaultSkew)
+        val ledgerTime = referenceTime.add(timeModel.maxSkew).add(epsilon)
+        val minRecordTime = referenceTime.subtract(defaultSkew)
+        val maxRecordTime = referenceTime.add(defaultSkew)
 
         val result = timeModel.checkTime(ledgerTime, referenceTime)
 
@@ -54,21 +54,21 @@ class LedgerTimeModelSpec extends AnyWordSpec with Matchers {
       }
 
       "succeed if the ledger time is lower than the record time and is within tolerance limit" in {
-        val result = timeModel.checkTime(referenceTime.minus(epsilon), referenceTime)
+        val result = timeModel.checkTime(referenceTime.subtract(epsilon), referenceTime)
 
         result should be(Right(()))
       }
 
       "succeed if the ledger time is equal to the low boundary" in {
-        val result = timeModel.checkTime(referenceTime.minus(timeModel.minSkew), referenceTime)
+        val result = timeModel.checkTime(referenceTime.subtract(timeModel.minSkew), referenceTime)
 
         result should be(Right(()))
       }
 
       "fail if the ledger time is lower than the low boundary" in {
-        val ledgerTime = referenceTime.minus(timeModel.minSkew).minus(epsilon)
-        val minRecordTime = referenceTime.minus(defaultSkew)
-        val maxRecordTime = referenceTime.plus(defaultSkew)
+        val ledgerTime = referenceTime.subtract(timeModel.minSkew).subtract(epsilon)
+        val minRecordTime = referenceTime.subtract(defaultSkew)
+        val maxRecordTime = referenceTime.add(defaultSkew)
 
         val result = timeModel.checkTime(ledgerTime, referenceTime)
 
@@ -78,7 +78,7 @@ class LedgerTimeModelSpec extends AnyWordSpec with Matchers {
       "succeed if the ledger time is equal to the high boundary (asymmetric case)" in {
         val instance = createAsymmetricTimeModel(minSkew = largeSkew, maxSkew = smallSkew)
 
-        val result = instance.checkTime(referenceTime.plus(instance.maxSkew), referenceTime)
+        val result = instance.checkTime(referenceTime.add(instance.maxSkew), referenceTime)
 
         result should be(Right(()))
       }
@@ -86,7 +86,7 @@ class LedgerTimeModelSpec extends AnyWordSpec with Matchers {
       "succeed if the ledger time is equal to the low boundary (asymmetric case)" in {
         val instance = createAsymmetricTimeModel(minSkew = smallSkew, maxSkew = largeSkew)
 
-        val result = instance.checkTime(referenceTime.minus(instance.minSkew), referenceTime)
+        val result = instance.checkTime(referenceTime.subtract(instance.minSkew), referenceTime)
 
         result should be(Right(()))
       }
@@ -94,9 +94,9 @@ class LedgerTimeModelSpec extends AnyWordSpec with Matchers {
       "fail if the ledger time is higher than the high boundary (asymmetric case)" in {
         val instance = createAsymmetricTimeModel(minSkew = largeSkew, maxSkew = smallSkew)
 
-        val ledgerTime = referenceTime.plus(instance.maxSkew).plus(epsilon)
-        val minRecordTime = referenceTime.minus(largeSkew)
-        val maxRecordTime = referenceTime.plus(smallSkew)
+        val ledgerTime = referenceTime.add(instance.maxSkew).add(epsilon)
+        val minRecordTime = referenceTime.subtract(largeSkew)
+        val maxRecordTime = referenceTime.add(smallSkew)
 
         val result = instance.checkTime(ledgerTime, referenceTime)
 
@@ -106,9 +106,9 @@ class LedgerTimeModelSpec extends AnyWordSpec with Matchers {
       "fail if the ledger time is lower than the low boundary (asymmetric case)" in {
         val instance = createAsymmetricTimeModel(minSkew = smallSkew, maxSkew = largeSkew)
 
-        val ledgerTime = referenceTime.minus(instance.minSkew).minus(epsilon)
-        val minRecordTime = referenceTime.minus(smallSkew)
-        val maxRecordTime = referenceTime.plus(largeSkew)
+        val ledgerTime = referenceTime.subtract(instance.minSkew).subtract(epsilon)
+        val minRecordTime = referenceTime.subtract(smallSkew)
+        val maxRecordTime = referenceTime.add(largeSkew)
 
         val result = instance.checkTime(ledgerTime, referenceTime)
 
@@ -122,10 +122,10 @@ class LedgerTimeModelSpec extends AnyWordSpec with Matchers {
           maxSkew = Duration.ofSeconds(20L),
         ).get
 
-        val ledgerTime = Instant.parse("2000-01-01T12:00:00Z")
-        val recordTime = Instant.parse("2000-01-01T12:30:00Z")
-        val minRecordTime = Instant.parse("2000-01-01T12:29:50Z")
-        val maxRecordTime = Instant.parse("2000-01-01T12:30:20Z")
+        val ledgerTime = Timestamp.assertFromString("2000-01-01T12:00:00Z")
+        val recordTime = Timestamp.assertFromString("2000-01-01T12:30:00Z")
+        val minRecordTime = Timestamp.assertFromString("2000-01-01T12:29:50Z")
+        val maxRecordTime = Timestamp.assertFromString("2000-01-01T12:30:20Z")
 
         val result = timeModel.checkTime(ledgerTime, recordTime)
 

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerWriter.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.on.memory
 
-import java.time.Instant
-
 import com.daml.api.util.TimeProvider
 import com.daml.caching.Cache
 import com.daml.ledger.api.health.{HealthStatus, Healthy}
@@ -28,6 +26,7 @@ import com.daml.ledger.validator.preexecution.{
 import com.daml.ledger.validator.reading.{DamlLedgerStateReader, LedgerStateReader}
 import com.daml.ledger.validator.{SerializingStateReader, StateKeySerializationStrategy}
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.Engine
 import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
@@ -40,7 +39,7 @@ final class InMemoryLedgerWriter private[memory] (
     override val participantId: Ref.ParticipantId,
     dispatcher: Dispatcher[Index],
     offsetBuilder: KVOffsetBuilder,
-    now: () => Instant,
+    now: () => Timestamp,
     state: InMemoryState,
     committer: Committer,
     committerExecutionContext: ExecutionContext,
@@ -91,7 +90,7 @@ object InMemoryLedgerWriter {
       engine: Engine,
       committerExecutionContext: ExecutionContext,
   ) extends ResourceOwner[LedgerWriter] {
-    private val now = () => timeProvider.getCurrentTime
+    private val now = () => timeProvider.getCurrentTimestamp
 
     override def acquire()(implicit context: ResourceContext): Resource[LedgerWriter] =
       for {

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerWriterSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerWriterSpec.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.on.memory
 
-import java.time.Instant
-
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.api.CommitMetadata
@@ -12,6 +10,7 @@ import com.daml.ledger.participant.state.kvutils.{KVOffsetBuilder, Raw}
 import com.daml.ledger.participant.state.v2.SubmissionResult
 import com.daml.ledger.validator.LedgerStateAccess
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.telemetry.{NoOpTelemetryContext, TelemetryContext}
@@ -42,7 +41,7 @@ class InMemoryLedgerWriterSpec
           any[Ref.ParticipantId],
           any[String],
           any[Raw.Envelope],
-          any[Instant],
+          any[Timestamp],
           any[LedgerStateAccess[Any]],
         )(any[ExecutionContext])
       )
@@ -53,7 +52,7 @@ class InMemoryLedgerWriterSpec
         participantId = Ref.ParticipantId.assertFromString("participant ID"),
         dispatcher = mockDispatcher,
         offsetBuilder = new KVOffsetBuilder(0),
-        now = () => Instant.EPOCH,
+        now = () => Timestamp.Epoch,
         state = InMemoryState.empty,
         committer = mockCommitter,
         committerExecutionContext = executionContext,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -43,6 +43,7 @@ import com.daml.ledger.participant.state.kvutils.updates.TransactionRejections._
 import com.daml.ledger.participant.state.v2.Update.CommandRejected.FinalReason
 import com.daml.ledger.participant.state.v2.{CompletionInfo, SubmitterInfo}
 import com.daml.lf.data.Relation.Relation
+import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction._
 import com.daml.lf.value.Value.{ContractId, VersionedValue}
@@ -177,7 +178,7 @@ private[state] object Conversions {
 
   @nowarn("msg=deprecated")
   def parseCompletionInfo(
-      recordTime: Instant,
+      recordTime: Timestamp,
       subInfo: DamlSubmitterInfo,
   ): CompletionInfo = {
     val deduplicationPeriod = subInfo.getDeduplicationPeriodCase match {
@@ -196,7 +197,7 @@ private[state] object Conversions {
         // As the deduplicate until timestamp is always relative to record time, we take the duration
         // between record time and the previous timestamp as the deduplication period (duration).
         val until = parseInstant(subInfo.getDeduplicateUntil)
-        val duration = Duration.between(recordTime, until).abs()
+        val duration = Duration.between(recordTime.toInstant, until).abs()
         Some(
           DeduplicationPeriod.DeduplicationDuration(duration)
         )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -252,7 +252,7 @@ object KeyValueConsumption {
     val reason = Conversions.decodeTransactionRejectionEntry(rejEntry, errorVersionSwitch)
     Update.CommandRejected(
       recordTime = recordTime,
-      completionInfo = parseCompletionInfo(parseInstant(recordTime), rejEntry.getSubmitterInfo),
+      completionInfo = parseCompletionInfo(recordTime, rejEntry.getSubmitterInfo),
       reasonTemplate = reason,
     )
   }
@@ -281,7 +281,7 @@ object KeyValueConsumption {
     Update.TransactionAccepted(
       optCompletionInfo =
         if (txEntry.hasSubmitterInfo)
-          Some(parseCompletionInfo(parseInstant(recordTime), txEntry.getSubmitterInfo))
+          Some(parseCompletionInfo(recordTime, txEntry.getSubmitterInfo))
         else None,
       transactionMeta = TransactionMeta(
         ledgerEffectiveTime = parseTimestamp(txEntry.getLedgerEffectiveTime),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import java.time.Instant
-
 import com.daml.ledger.participant.state.kvutils.store.{DamlLogEntry, DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.{DamlStateMap, Err}
 import com.daml.lf.data.Ref
@@ -32,9 +30,9 @@ private[kvutils] case class CommitContext(
     mutable.HashMap.empty[DamlStateKey, DamlStateValue]
   private val accessedInputKeys: mutable.Set[DamlStateKey] = mutable.Set.empty[DamlStateKey]
 
-  var minimumRecordTime: Option[Instant] = None
-  var maximumRecordTime: Option[Instant] = None
-  var deduplicateUntil: Option[Instant] = None
+  var minimumRecordTime: Option[Timestamp] = None
+  var maximumRecordTime: Option[Timestamp] = None
+  var deduplicateUntil: Option[Timestamp] = None
 
   // Rejection log entry used for generating an out-of-time-bounds log entry in case of
   // pre-execution.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -112,10 +112,8 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
       successfulLogEntry = successfulLogEntry,
       stateUpdates = commitContext.getOutputs.toMap,
       outOfTimeBoundsLogEntry = constructOutOfTimeBoundsLogEntry(commitContext),
-      minimumRecordTime = commitContext.minimumRecordTime
-        .map(Timestamp.assertFromInstant),
-      maximumRecordTime = commitContext.maximumRecordTime
-        .map(Timestamp.assertFromInstant),
+      minimumRecordTime = commitContext.minimumRecordTime,
+      maximumRecordTime = commitContext.maximumRecordTime,
     )
   }
 
@@ -124,14 +122,14 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
       .map { rejectionLogEntry =>
         val builder = DamlOutOfTimeBoundsEntry.newBuilder
           .setEntry(rejectionLogEntry)
-        commitContext.minimumRecordTime.foreach { instant =>
-          builder.setTooEarlyUntil(buildTimestamp(instant))
+        commitContext.minimumRecordTime.foreach { timestamp =>
+          builder.setTooEarlyUntil(buildTimestamp(timestamp))
         }
-        commitContext.maximumRecordTime.foreach { instant =>
-          builder.setTooLateFrom(buildTimestamp(instant))
+        commitContext.maximumRecordTime.foreach { timestamp =>
+          builder.setTooLateFrom(buildTimestamp(timestamp))
         }
-        commitContext.deduplicateUntil.foreach { instant =>
-          builder.setDuplicateUntil(buildTimestamp(instant))
+        commitContext.deduplicateUntil.foreach { timestamp =>
+          builder.setDuplicateUntil(buildTimestamp(timestamp))
         }
         DamlLogEntry.newBuilder
           .setOutOfTimeBoundsEntry(builder)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -85,7 +85,7 @@ private[kvutils] class ConfigCommitter(
       } else {
         if (ctx.preExecute) {
           // Propagate the time bounds and defer the checks to post-execution.
-          ctx.maximumRecordTime = Some(maximumRecordTime.toInstant)
+          ctx.maximumRecordTime = Some(maximumRecordTime)
           setOutOfTimeBoundsLogEntry(result.submission, ctx)
         }
         StepContinue(result)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejection.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejection.scala
@@ -3,13 +3,12 @@
 
 package com.daml.ledger.participant.state.kvutils.committer.transaction
 
-import java.time.Instant
-
 import com.daml.ledger.configuration.LedgerTimeModel
 import com.daml.ledger.participant.state.kvutils.Err
 import com.daml.ledger.participant.state.kvutils.store.DamlStateKey
 import com.daml.lf
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 
 sealed trait Rejection {
   def description: String
@@ -68,8 +67,8 @@ object Rejection {
   }
 
   final case class RecordTimeOutOfRange(
-      minimumRecordTime: Instant,
-      maximumRecordTime: Instant,
+      minimumRecordTime: Timestamp,
+      maximumRecordTime: Timestamp,
   ) extends Rejection {
     override lazy val description: String =
       s"Record time is outside of valid range [$minimumRecordTime, $maximumRecordTime]"

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils.committer.transaction
 
-import java.time.Instant
-
 import com.codahale.metrics.Counter
 import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.committer.Committer.buildLogEntryWithOptionalRecordTime
@@ -46,8 +44,8 @@ private[transaction] class Rejections(metrics: Metrics) {
 
   def preExecutionOutOfTimeBoundsRejectionEntry(
       transactionEntry: DamlTransactionEntrySummary,
-      minimumRecordTime: Instant,
-      maximumRecordTime: Instant,
+      minimumRecordTime: Timestamp,
+      maximumRecordTime: Timestamp,
   ): DamlTransactionRejectionEntry =
     Conversions
       .encodeTransactionRejectionEntry(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataExporter.scala
@@ -39,7 +39,7 @@ final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
         .setParticipantId(submissionInfo.participantId: String)
         .setCorrelationId(submissionInfo.correlationId)
         .setSubmissionEnvelope(submissionInfo.submissionEnvelope.bytes)
-        .setRecordTime(Conversions.buildTimestamp(submissionInfo.recordTimeInstant))
+        .setRecordTime(Conversions.buildTimestamp(submissionInfo.recordTime))
         .build()
 
     private def buildWriteSet(writeSet: WriteSet): Iterable[LedgerExportEntry.WriteEntry] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
@@ -43,7 +43,7 @@ final class ProtobufBasedLedgerDataImporter(input: InputStream)
       Ref.ParticipantId.assertFromString(entrySubmissionInfo.getParticipantId),
       entrySubmissionInfo.getCorrelationId,
       Raw.Envelope(entrySubmissionInfo.getSubmissionEnvelope),
-      Conversions.parseInstant(entrySubmissionInfo.getRecordTime),
+      Conversions.parseTimestamp(entrySubmissionInfo.getRecordTime),
     )
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
@@ -3,14 +3,13 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-import java.time.Instant
-
 import com.daml.ledger.participant.state.kvutils.{CorrelationId, Raw}
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 
 case class SubmissionInfo(
     participantId: Ref.ParticipantId,
     correlationId: CorrelationId,
     submissionEnvelope: Raw.Envelope,
-    recordTimeInstant: Instant,
+    recordTime: Timestamp,
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/updates/TransactionRejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/updates/TransactionRejections.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.participant.state.kvutils.committer.transaction.Rejection
   InternallyInconsistentTransaction,
 }
 import com.daml.ledger.participant.state.kvutils.store.events._
-import com.daml.ledger.participant.state.kvutils.{Conversions, CorrelationId}
+import com.daml.ledger.participant.state.kvutils.CorrelationId
 import com.daml.ledger.participant.state.v2.Update
 import com.daml.ledger.participant.state.v2.Update.CommandRejected.FinalReason
 import com.daml.lf.data.Time.Timestamp
@@ -39,7 +39,7 @@ private[kvutils] object TransactionRejections {
     Update.CommandRejected(
       recordTime = recordTime,
       completionInfo = parseCompletionInfo(
-        Conversions.parseInstant(recordTime),
+        recordTime,
         rejectionEntry.getSubmitterInfo,
       ),
       reasonTemplate = FinalReason(
@@ -58,7 +58,7 @@ private[kvutils] object TransactionRejections {
     Update.CommandRejected(
       recordTime = recordTime,
       completionInfo = parseCompletionInfo(
-        Conversions.parseInstant(recordTime),
+        recordTime,
         rejectionEntry.getSubmitterInfo,
       ),
       reasonTemplate = FinalReason(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.validator.batch
 
-import java.time.Instant
-
 import akka.stream.Materializer
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.Raw
@@ -14,6 +12,7 @@ import com.daml.ledger.validator._
 import com.daml.ledger.validator.caching.{CacheUpdatePolicy, ImmutablesOnlyCacheUpdatePolicy}
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 import com.google.rpc.code.Code
 import com.google.rpc.status.Status
 
@@ -51,7 +50,7 @@ import scala.util.{Failure, Success}
   * @tparam LogResult  type of the offset used for a log entry
   */
 class BatchedValidatingCommitter[LogResult](
-    now: () => Instant,
+    now: () => Timestamp,
     keySerializationStrategy: StateKeySerializationStrategy,
     validator: BatchedSubmissionValidator[LogResult],
     stateValueCache: Cache[DamlStateKey, DamlStateValue],
@@ -102,7 +101,7 @@ class BatchedValidatingCommitter[LogResult](
 }
 
 object BatchedValidatingCommitter {
-  def apply[LogResult](now: () => Instant, validator: BatchedSubmissionValidator[LogResult])(
+  def apply[LogResult](now: () => Timestamp, validator: BatchedSubmissionValidator[LogResult])(
       implicit materializer: Materializer
   ): BatchedValidatingCommitter[LogResult] =
     new BatchedValidatingCommitter[LogResult](
@@ -114,7 +113,7 @@ object BatchedValidatingCommitter {
     )
 
   def apply[LogResult](
-      now: () => Instant,
+      now: () => Timestamp,
       validator: BatchedSubmissionValidator[LogResult],
       stateValueCache: Cache[DamlStateKey, DamlStateValue],
   )(implicit materializer: Materializer): BatchedValidatingCommitter[LogResult] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -80,8 +80,8 @@ class PreExecutingSubmissionValidator[StateValue, ReadSet, WriteSet](
         )
       } yield {
         PreExecutionOutput(
-          minRecordTime = preExecutionResult.minimumRecordTime.map(_.toInstant),
-          maxRecordTime = preExecutionResult.maximumRecordTime.map(_.toInstant),
+          minRecordTime = preExecutionResult.minimumRecordTime,
+          maxRecordTime = preExecutionResult.maximumRecordTime,
           successWriteSet = generatedWriteSets.successWriteSet,
           outOfTimeBoundsWriteSet = generatedWriteSets.outOfTimeBoundsWriteSet,
           readSet = commitStrategy.generateReadSet(fetchedInputs, preExecutionResult.readSet),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.validator.preexecution
 
-import java.time.Instant
-
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.export.{
   LedgerDataExporter,
@@ -20,6 +18,7 @@ import com.daml.ledger.validator.{
   LedgerStateOperationsReaderAdapter,
 }
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.ContextualizedLogger
 import com.daml.logging.LoggingContext.newLoggingContextWith
 
@@ -58,7 +57,7 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
       submittingParticipantId: Ref.ParticipantId,
       correlationId: String,
       submissionEnvelope: Raw.Envelope,
-      exportRecordTime: Instant,
+      exportRecordTime: Timestamp,
       ledgerStateAccess: LedgerStateAccess[Any],
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
     newLoggingContextWith(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutionOutput.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutionOutput.scala
@@ -3,13 +3,12 @@
 
 package com.daml.ledger.validator.preexecution
 
-import java.time.Instant
-
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 
 sealed case class PreExecutionOutput[+ReadSet, +WriteSet](
-    minRecordTime: Option[Instant],
-    maxRecordTime: Option[Instant],
+    minRecordTime: Option[Timestamp],
+    maxRecordTime: Option[Timestamp],
     successWriteSet: WriteSet,
     outOfTimeBoundsWriteSet: WriteSet,
     readSet: ReadSet,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/TimeBasedWriteSetSelector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/TimeBasedWriteSetSelector.scala
@@ -3,16 +3,15 @@
 
 package com.daml.ledger.validator.preexecution
 
-import java.time.Instant
-
 import com.daml.ledger.participant.state.kvutils.committer.transaction.Rejection
+import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 
 /** Selects a write set from a [[PreExecutionOutput]] based on the current time.
   * If the current time is within the bounds specified by the output, the success write set is
   * chosen, otherwise, the out-of-time-bounds write set is chosen.
   */
-final class TimeBasedWriteSetSelector[ReadSet, WriteSet](now: () => Instant)
+final class TimeBasedWriteSetSelector[ReadSet, WriteSet](now: () => Timestamp)
     extends WriteSetSelector[ReadSet, WriteSet] {
 
   final private val logger = ContextualizedLogger.get(getClass)
@@ -21,11 +20,9 @@ final class TimeBasedWriteSetSelector[ReadSet, WriteSet](now: () => Instant)
       preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet]
   )(implicit loggingContext: LoggingContext): WriteSet = {
     val recordTime = now()
-    val minRecordTime = preExecutionOutput.minRecordTime.getOrElse(Instant.MIN)
-    val maxRecordTime = preExecutionOutput.maxRecordTime.getOrElse(Instant.MAX)
-    val withinTimeBounds =
-      !recordTime.isBefore(minRecordTime) &&
-        !recordTime.isAfter(maxRecordTime)
+    val minRecordTime = preExecutionOutput.minRecordTime.getOrElse(Timestamp.MinValue)
+    val maxRecordTime = preExecutionOutput.maxRecordTime.getOrElse(Timestamp.MaxValue)
+    val withinTimeBounds = !(recordTime < minRecordTime) && !(recordTime > maxRecordTime)
     if (withinTimeBounds) {
       preExecutionOutput.successWriteSet
     } else {

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
@@ -10,11 +10,10 @@ import java.io.{
   PipedInputStream,
   PipedOutputStream,
 }
-import java.time.Instant
-
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.export.LedgerDataExportSpecBase._
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 import com.google.protobuf.ByteString
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -81,7 +80,7 @@ object LedgerDataExportSpecBase {
     participantId = Ref.ParticipantId.assertFromString("id"),
     correlationId = "parent",
     submissionEnvelope = Raw.Envelope(ByteString.copyFromUtf8("an envelope")),
-    recordTimeInstant = Instant.ofEpochSecond(123456, 123456789),
+    recordTime = Timestamp.assertFromLong(123456123456L),
   )
 
   private def keyValuePairOf(key: String, value: String): (Raw.Key, Raw.Envelope) =

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.participant.state.kvutils
 import com.daml.error.ValueSwitch
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.grpc.GrpcStatuses
-import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, parseInstant}
+import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
 import com.daml.ledger.participant.state.kvutils.KeyValueConsumption.{
   TimeBounds,
   logEntryToUpdate,
@@ -217,7 +217,7 @@ class KeyValueConsumptionSpec extends AnyWordSpec with Matchers {
         case Some(Update.CommandRejected(recordTime, completionInfo, FinalReason(status))) =>
           recordTime shouldBe aRecordTime
           completionInfo shouldBe Conversions.parseCompletionInfo(
-            parseInstant(recordTime),
+            recordTime,
             someSubmitterInfo,
           )
           completionInfo.submissionId shouldBe Some(someSubmitterInfo.getSubmissionId)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import java.time.{Duration, Instant}
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.codahale.metrics.MetricRegistry
@@ -43,8 +43,8 @@ class CommitterSpec
       val expectedOutputs =
         Map(DamlStateKey.getDefaultInstance -> DamlStateValue.getDefaultInstance)
       when(mockContext.getOutputs).thenReturn(expectedOutputs)
-      val expectedMinRecordTime = Instant.ofEpochSecond(100)
-      val expectedMaxRecordTime = Instant.ofEpochSecond(200)
+      val expectedMinRecordTime = Timestamp.assertFromLong(100 * 1000 * 1000)
+      val expectedMaxRecordTime = Timestamp.assertFromLong(200 * 1000 * 1000)
       when(mockContext.minimumRecordTime).thenReturn(Some(expectedMinRecordTime))
       when(mockContext.maximumRecordTime).thenReturn(Some(expectedMaxRecordTime))
       when(mockContext.deduplicateUntil).thenReturn(None)
@@ -63,8 +63,8 @@ class CommitterSpec
       actual.readSet shouldBe expectedReadSet
       actual.successfulLogEntry shouldBe aLogEntry
       actual.stateUpdates shouldBe expectedOutputs
-      actual.minimumRecordTime shouldBe Some(Timestamp.assertFromInstant(expectedMinRecordTime))
-      actual.maximumRecordTime shouldBe Some(Timestamp.assertFromInstant(expectedMaxRecordTime))
+      actual.minimumRecordTime shouldBe Some(expectedMinRecordTime)
+      actual.maximumRecordTime shouldBe Some(expectedMaxRecordTime)
     }
 
     "set min/max record time to None in case they are not available from context" in {
@@ -88,9 +88,9 @@ class CommitterSpec
       when(mockContext.outOfTimeBoundsLogEntry).thenReturn(Some(aRejectionLogEntry))
       when(mockContext.getOutputs).thenReturn(Iterable.empty)
       when(mockContext.getAccessedInputKeys).thenReturn(Set.empty[DamlStateKey])
-      val expectedMinRecordTime = Instant.ofEpochSecond(100)
-      val expectedMaxRecordTime = Instant.ofEpochSecond(200)
-      val expectedDuplicateUntil = Instant.ofEpochSecond(99)
+      val expectedMinRecordTime = Timestamp.assertFromLong(100 * 1000 * 1000)
+      val expectedMaxRecordTime = Timestamp.assertFromLong(200 * 1000 * 1000)
+      val expectedDuplicateUntil = Timestamp.assertFromLong(99 * 1000 * 1000)
       when(mockContext.minimumRecordTime).thenReturn(Some(expectedMinRecordTime))
       when(mockContext.maximumRecordTime).thenReturn(Some(expectedMaxRecordTime))
       when(mockContext.deduplicateUntil).thenReturn(Some(expectedDuplicateUntil))
@@ -122,12 +122,12 @@ class CommitterSpec
     }
 
     "throw in case out-of-time-bounds log entry is not set but min/max record time is" in {
-      val anInstant = Instant.ofEpochSecond(1234)
+      val aTimestamp = Timestamp.assertFromLong(1234 * 1000 * 1000)
       val combinations = Table(
         "min/max record time",
-        Some(anInstant) -> Some(anInstant),
-        Some(anInstant) -> None,
-        None -> Some(anInstant),
+        Some(aTimestamp) -> Some(aTimestamp),
+        Some(aTimestamp) -> None,
+        None -> Some(aTimestamp),
       )
 
       forAll(combinations) { case (minRecordTimeMaybe, maxRecordTimeMaybe) =>

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
@@ -78,7 +78,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
 
       instance.checkTtl(context, anEmptyResult)
 
-      context.maximumRecordTime shouldEqual Some(aRecordTime.toInstant)
+      context.maximumRecordTime shouldEqual Some(aRecordTime)
       context.outOfTimeBoundsLogEntry should not be empty
       context.outOfTimeBoundsLogEntry.foreach { actual =>
         actual.hasRecordTime shouldBe false

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
@@ -86,10 +86,14 @@ class LedgerTimeValidatorSpec extends AnyWordSpec with Matchers {
         )
 
         context.minimumRecordTime shouldEqual Some(
-          Instant.ofEpochSecond(2).minus(theDefaultConfig.timeModel.minSkew)
+          Timestamp.assertFromInstant(
+            Instant.ofEpochSecond(2).minus(theDefaultConfig.timeModel.minSkew)
+          )
         )
         context.maximumRecordTime shouldEqual Some(
-          Instant.ofEpochSecond(1).plus(theDefaultConfig.timeModel.maxSkew)
+          Timestamp.assertFromInstant(
+            Instant.ofEpochSecond(1).plus(theDefaultConfig.timeModel.maxSkew)
+          )
         )
         context.deduplicateUntil shouldBe empty
         context.outOfTimeBoundsLogEntry should not be empty
@@ -108,13 +112,15 @@ class LedgerTimeValidatorSpec extends AnyWordSpec with Matchers {
         )
 
         context.minimumRecordTime shouldEqual Some(
-          Instant.ofEpochSecond(3).plus(Timestamp.Resolution)
+          Timestamp.assertFromInstant(Instant.ofEpochSecond(3).plus(Timestamp.Resolution))
         )
         context.maximumRecordTime shouldEqual Some(
-          Instant.ofEpochSecond(1).plus(theDefaultConfig.timeModel.maxSkew)
+          Timestamp.assertFromInstant(
+            Instant.ofEpochSecond(1).plus(theDefaultConfig.timeModel.maxSkew)
+          )
         )
         context.deduplicateUntil shouldEqual Some(
-          Instant.ofEpochSecond(aDeduplicateUntil.getSeconds)
+          Timestamp.assertFromInstant(Instant.ofEpochSecond(aDeduplicateUntil.getSeconds))
         )
         context.outOfTimeBoundsLogEntry should not be empty
         context.outOfTimeBoundsLogEntry.foreach { actualOutOfTimeBoundsLogEntry =>

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -3,10 +3,9 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-import java.time.Instant
-
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 import com.google.protobuf.ByteString
 import org.mockito.{Mockito, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
@@ -19,7 +18,7 @@ final class InMemorySubmissionAggregatorSpec extends AnyWordSpec with Matchers w
         Ref.ParticipantId.assertFromString("participant-id"),
         "correlation ID",
         Raw.Envelope(ByteString.copyFromUtf8("the envelope")),
-        Instant.now(),
+        Timestamp.now(),
       )
       val writer = mock[LedgerDataWriter]
       val submission = new InMemorySubmissionAggregator(submissionInfo, writer)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -77,7 +77,7 @@ class BatchedSubmissionValidatorSpec
         .validateAndCommit(
           anInvalidEnvelope,
           aCorrelationId,
-          newRecordTime().toInstant,
+          newRecordTime(),
           aParticipantId,
           mock[DamlLedgerStateReader],
           mock[CommitStrategy[Unit]],
@@ -98,7 +98,7 @@ class BatchedSubmissionValidatorSpec
         .validateAndCommit(
           notASubmission,
           aCorrelationId,
-          newRecordTime().toInstant,
+          newRecordTime(),
           aParticipantId,
           mock[DamlLedgerStateReader],
           mock[CommitStrategy[Unit]],
@@ -125,7 +125,7 @@ class BatchedSubmissionValidatorSpec
         .validateAndCommit(
           Envelope.enclose(batchSubmission),
           aCorrelationId,
-          newRecordTime().toInstant,
+          newRecordTime(),
           aParticipantId,
           mock[DamlLedgerStateReader],
           mock[CommitStrategy[Unit]],
@@ -165,7 +165,7 @@ class BatchedSubmissionValidatorSpec
         .validateAndCommit(
           Envelope.enclose(partySubmission),
           aCorrelationId,
-          newRecordTime().toInstant,
+          newRecordTime(),
           aParticipantId,
           mockLedgerStateReader,
           mockCommit,
@@ -212,7 +212,7 @@ class BatchedSubmissionValidatorSpec
         .validateAndCommit(
           batchSubmissionBytes,
           "batch-correlationId",
-          newRecordTime().toInstant,
+          newRecordTime(),
           aParticipantId,
           mockLedgerStateReader,
           mockCommit,
@@ -281,7 +281,7 @@ class BatchedSubmissionValidatorSpec
         .validateAndCommit(
           Envelope.enclose(batchSubmission),
           "batch-correlationId",
-          newRecordTime().toInstant,
+          newRecordTime(),
           aParticipantId,
           mockLedgerStateReader,
           mockCommit,
@@ -331,7 +331,7 @@ class BatchedSubmissionValidatorSpec
         .validateAndCommit(
           batchSubmissionBytes,
           "batch-correlationId",
-          newRecordTime().toInstant,
+          newRecordTime(),
           aParticipantId,
           mockLedgerStateReader,
           mockCommit,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitterSpec.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.validator.batch
 
-import java.time.Instant
-
 import akka.stream.Materializer
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.Raw
@@ -14,6 +12,7 @@ import com.daml.ledger.validator.TestHelper.aParticipantId
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
 import com.daml.ledger.validator.{CommitStrategy, LedgerStateOperations}
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time.Timestamp
 import com.google.rpc.code.Code
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.MockitoSugar
@@ -35,7 +34,7 @@ class BatchedValidatingCommitterSpec
       whenValidateAndCommit(mockValidator)
         .thenReturn(Future.unit)
       val instance =
-        BatchedValidatingCommitter[Unit](() => Instant.now(), mockValidator)
+        BatchedValidatingCommitter[Unit](() => Timestamp.now(), mockValidator)
 
       instance
         .commit(
@@ -53,7 +52,7 @@ class BatchedValidatingCommitterSpec
       val mockValidator = mock[BatchedSubmissionValidator[Unit]]
       whenValidateAndCommit(mockValidator)
         .thenReturn(Future.failed(new IllegalArgumentException("Validation failure")))
-      val instance = BatchedValidatingCommitter[Unit](() => Instant.now(), mockValidator)
+      val instance = BatchedValidatingCommitter[Unit](() => Timestamp.now(), mockValidator)
 
       instance
         .commit(
@@ -78,7 +77,7 @@ class BatchedValidatingCommitterSpec
       mockValidator.validateAndCommit(
         any[Raw.Envelope](),
         anyString(),
-        any[Instant](),
+        any[Timestamp](),
         any[Ref.ParticipantId](),
         any[DamlLedgerStateReader](),
         any[CommitStrategy[Unit]](),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -3,8 +3,7 @@
 
 package com.daml.ledger.validator.preexecution
 
-import java.time.Instant
-
+import java.time.Duration
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
@@ -57,8 +56,8 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
       val actualInputState = Map(
         allDamlStateKeyTypes.head -> Some(DamlStateValue.getDefaultInstance)
       )
-      val expectedMinRecordTime = Some(recordTime.toInstant.minusSeconds(123))
-      val expectedMaxRecordTime = Some(recordTime.toInstant)
+      val expectedMinRecordTime = Some(recordTime.subtract(Duration.ofSeconds(123)))
+      val expectedMaxRecordTime = Some(recordTime)
       val expectedSuccessWriteSet = TestWriteSet("success")
       val expectedOutOfTimeBoundsWriteSet = TestWriteSet("failure")
       val expectedInvolvedParticipants = Set(TestHelpers.mkParticipantId(0))
@@ -167,8 +166,8 @@ object PreExecutingSubmissionValidatorSpec {
 
   private def createInstance(
       expectedReadSet: Set[DamlStateKey] = Set.empty,
-      expectedMinRecordTime: Option[Instant] = None,
-      expectedMaxRecordTime: Option[Instant] = None,
+      expectedMinRecordTime: Option[Timestamp] = None,
+      expectedMaxRecordTime: Option[Timestamp] = None,
       expectedSuccessWriteSet: TestWriteSet = TestWriteSet(""),
       expectedOutOfTimeBoundsWriteSet: TestWriteSet = TestWriteSet(""),
       expectedInvolvedParticipants: Set[ParticipantId] = Set.empty,
@@ -179,8 +178,8 @@ object PreExecutingSubmissionValidatorSpec {
       aLogEntry,
       Map.empty,
       aLogEntry,
-      expectedMinRecordTime.map(Timestamp.assertFromInstant),
-      expectedMaxRecordTime.map(Timestamp.assertFromInstant),
+      expectedMinRecordTime,
+      expectedMaxRecordTime,
     )
     when(
       mockCommitter.preExecuteSubmission(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitterSpec.scala
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.daml.ledger.validator.preexecution
 
-import java.time.Instant
-
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.`export`.{
   LedgerDataExporter,
@@ -16,6 +14,7 @@ import com.daml.ledger.validator.TestHelper.{FakeStateAccess, aParticipantId}
 import com.daml.ledger.validator.reading.StateReader
 import com.daml.ledger.validator.{LedgerStateOperations, LedgerStateWriteOperations}
 import com.daml.lf.data.Ref.ParticipantId
+import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
@@ -58,7 +57,7 @@ class PreExecutingValidatingCommitterSpec
           aParticipantId,
           "corid",
           Raw.Envelope.empty,
-          Instant.now(),
+          Timestamp.now(),
           new FakeStateAccess(mock[LedgerStateOperations[Unit]]),
         )
         .map { result =>
@@ -89,7 +88,7 @@ class PreExecutingValidatingCommitterSpec
           aParticipantId,
           "corid",
           Raw.Envelope.empty,
-          Instant.now(),
+          Timestamp.now(),
           new FakeStateAccess(mock[LedgerStateOperations[Unit]]),
         )
         .map { result =>

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -92,6 +92,7 @@ da_scala_binary(
     main_class = "com.daml.ledger.participant.state.kvutils.tools.integritycheck.Main",
     resources = glob(["integrity-check/src/main/resources/*"]),
     scala_deps = [
+        "@maven//:org_scalaz_scalaz_core",
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
     ],

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
@@ -62,7 +62,7 @@ final class LogAppendingCommitStrategySupport(
         .validateAndCommit(
           submissionInfo.submissionEnvelope,
           submissionInfo.correlationId,
-          submissionInfo.recordTimeInstant,
+          submissionInfo.recordTime,
           submissionInfo.participantId,
           ledgerStateReader,
           commitStrategy,

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupport.scala
@@ -3,9 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
-import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
-
 import akka.stream.Materializer
 import com.daml.ledger.on.memory.{InMemoryLedgerStateAccess, InMemoryState, Index}
 import com.daml.ledger.participant.state.kvutils.export.{
@@ -25,6 +23,7 @@ import com.daml.ledger.validator.preexecution.{
   TimeBasedWriteSetSelector,
 }
 import com.daml.ledger.validator.{SerializingStateReader, StateKeySerializationStrategy}
+import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
@@ -46,7 +45,7 @@ final class RawPreExecutingCommitStrategySupport(
   // record time as the current time. This effectively means that the committer thinks the
   // submission takes no time at all (0ms), which means that only submissions with invalid
   // timestamps will be out of bounds.
-  private val currentSubmissionRecordTime = new AtomicReference[Instant]()
+  private val currentSubmissionRecordTime = new AtomicReference[Timestamp]()
   private val postExecutionWriteSetSelector =
     new TimeBasedWriteSetSelector[
       RawPreExecutingCommitStrategy.ReadSet,
@@ -74,13 +73,13 @@ final class RawPreExecutingCommitStrategySupport(
       submissionInfo: SubmissionInfo
   )(implicit materializer: Materializer, loggingContext: LoggingContext): Future[WriteSet] = {
     val access = new WriteRecordingLedgerStateAccess(ledgerStateAccess)
-    currentSubmissionRecordTime.set(submissionInfo.recordTimeInstant)
+    currentSubmissionRecordTime.set(submissionInfo.recordTime)
     committer
       .commit(
         submissionInfo.participantId,
         submissionInfo.correlationId,
         submissionInfo.submissionEnvelope,
-        submissionInfo.recordTimeInstant,
+        submissionInfo.recordTime,
         access,
       )
       .map(_ => access.getWriteSet)

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactorySpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactorySpec.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
-import java.time.Instant
 import java.util.concurrent.TimeUnit
 import akka.stream.scaladsl.Sink
 import com.codahale.metrics.MetricRegistry
@@ -110,6 +109,6 @@ object LogAppendingReadServiceFactorySpec {
     participantId = Ref.ParticipantId.assertFromString(aParticipantId),
     "correlation ID",
     Raw.Envelope.empty,
-    Instant.EPOCH,
+    Timestamp.Epoch,
   )
 }

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/stores/ledger/RejectionSpec.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/stores/ledger/RejectionSpec.scala
@@ -3,10 +3,9 @@
 
 package com.daml.platform.sandbox.stores.ledger
 
-import java.time.Instant
-
 import com.daml.ledger.configuration.LedgerTimeModel
 import com.daml.ledger.participant.state.{v2 => state}
+import com.daml.lf.data.Time.Timestamp
 import com.google.protobuf.any.{Any => AnyProto}
 import com.google.rpc.error_details.ErrorInfo
 import com.google.rpc.status.{Status => StatusProto}
@@ -39,9 +38,9 @@ class RejectionSpec extends AnyWordSpec with Matchers {
 
   "Rejection.InvalidLedgerTime" should {
     "convert to a state rejection reason" in {
-      val ledgerTime = Instant.parse("2021-07-20T09:30:00Z")
-      val lowerBound = Instant.parse("2021-07-20T09:00:00Z")
-      val upperBound = Instant.parse("2021-07-20T09:10:00Z")
+      val ledgerTime = Timestamp.assertFromString("2021-07-20T09:30:00Z")
+      val lowerBound = Timestamp.assertFromString("2021-07-20T09:00:00Z")
+      val upperBound = Timestamp.assertFromString("2021-07-20T09:10:00Z")
       val outOfRange = LedgerTimeModel.OutOfRange(ledgerTime, lowerBound, upperBound)
 
       Rejection.InvalidLedgerTime(outOfRange).toStateRejectionReason should be(


### PR DESCRIPTION
Follow up for https://github.com/digital-asset/daml/pull/11183, this time for kvutils