### PR TITLE
fix es ingest for missing files

### DIFF
--- a/infra/es_cluster.tf
+++ b/infra/es_cluster.tf
@@ -784,7 +784,7 @@ bulk_upload() {
 }
 
 patch() {
-  local job map
+  local job map file
   job="$1"
   # Replace shortened Scala test names by their long names.
   # See //bazel_tools:scala.bzl%da_scala_test_short_name_aspect.
@@ -796,7 +796,12 @@ patch() {
     # Generates a sed command to replace short labels by long labels.
     jq_command='to_entries | map("s|\(.key)\\b|\(.value)|g") | join(";")'
     sed_command="$(jq -r "$jq_command" <"$job/$map")"
-    sed -i "$sed_command" "$job"/{build-events,build-profile,test-events,test-profile}.json
+    for f in build-events build-profile test-events test-profile; do
+      file="$job/$f.json"
+      if [ -f "$file" ]; then
+        sed -i "$sed_command" "$file"
+      fi
+    done
   fi
 }
 


### PR DESCRIPTION
If a job fails at build time, there are not test logs to process.
Currently this means the ingestion process is going to be stuck in an
endless loop of retrying that job and failing on the missing file.

This change should let us process jobs with no test files.

CHANGELOG_BEGIN
CHANGELOG_END