### PR TITLE
[Self-service error codes] Pass submission id as correlation id to error codes in Ledger API [DPP-684]

### DIFF
--- a/ledger/error/src/main/scala/com/daml/error/ContextualizedErrorLogger.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ContextualizedErrorLogger.scala
@@ -22,6 +22,14 @@ trait ContextualizedErrorLogger {
   def error(message: String, throwable: Throwable): Unit
 }
 
+/** Implementation of [[ContextualizedErrorLogger]] leveraging the //libs-scala/contextualized-logging
+  * as the logging stack.
+  *
+  * @param logger The logger.
+  * @param loggingContext The logging context.
+  * @param correlationId The correlation id, if present. The choice of the correlation id depends on the
+  *                      ledger integration. By default it should be the command submission id.
+  */
 class DamlContextualizedErrorLogger(
     logger: ContextualizedLogger,
     loggingContext: LoggingContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -12,7 +12,7 @@ import com.daml.error.{
 }
 import com.daml.error.definitions.{ErrorCauseExport, RejectionGenerators}
 import com.daml.ledger.api.DeduplicationPeriod
-import com.daml.ledger.api.domain.{LedgerId, Commands => ApiCommands}
+import com.daml.ledger.api.domain.{LedgerId, SubmissionId, Commands => ApiCommands}
 import com.daml.ledger.api.messages.command.submission.SubmitRequest
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.index.v2._
@@ -118,6 +118,14 @@ private[apiserver] final class ApiSubmissionService private[services] (
     withEnrichedLoggingContext(logging.commands(request.commands)) { implicit loggingContext =>
       logger.info("Submitting transaction")
       logger.trace(s"Commands: ${request.commands.commands.commands}")
+
+      implicit val contextualizedErrorLogger: ContextualizedErrorLogger =
+        new DamlContextualizedErrorLogger(
+          logger,
+          loggingContext,
+          request.commands.submissionId.map(SubmissionId.unwrap),
+        )
+
       val evaluatedCommand = ledgerConfigurationSubscription
         .latestConfiguration() match {
         case Some(ledgerConfiguration) =>
@@ -133,9 +141,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
           }
         case None =>
           Future.failed(
-            errorFactories.missingLedgerConfig(definiteAnswer = Some(false))(
-              new DamlContextualizedErrorLogger(logger, loggingContext, None)
-            )
+            errorFactories.missingLedgerConfig(definiteAnswer = Some(false))
           )
       }
       evaluatedCommand.andThen(logger.logErrorsOnCall[Unit])
@@ -145,7 +151,11 @@ private[apiserver] final class ApiSubmissionService private[services] (
       seed: crypto.Hash,
       commands: ApiCommands,
       ledgerConfig: Configuration,
-  )(implicit loggingContext: LoggingContext, telemetryContext: TelemetryContext): Future[Unit] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+      contextualizedErrorLogger: ContextualizedErrorLogger,
+  ): Future[Unit] =
     submissionService
       .deduplicateCommand(
         commands.commandId,
@@ -168,9 +178,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
         case _: CommandDeduplicationDuplicate =>
           metrics.daml.commands.deduplicatedCommands.mark()
           Future.failed(
-            errorFactories.duplicateCommandException(
-              new DamlContextualizedErrorLogger(logger, loggingContext, None)
-            )
+            errorFactories.duplicateCommandException
           )
       }
 
@@ -195,7 +203,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
 
   private def handleCommandExecutionResult(
       result: Either[ErrorCause, CommandExecutionResult]
-  ): Future[CommandExecutionResult] =
+  )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): Future[CommandExecutionResult] =
     result.fold(
       error => {
         metrics.daml.commands.failedCommandInterpretations.mark()
@@ -211,6 +219,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
   )(implicit
       loggingContext: LoggingContext,
       telemetryContext: TelemetryContext,
+      contextualizedErrorLogger: ContextualizedErrorLogger,
   ): Future[state.SubmissionResult] =
     for {
       result <- commandExecutor.execute(commands, submissionSeed, ledgerConfig)
@@ -326,16 +335,12 @@ private[apiserver] final class ApiSubmissionService private[services] (
 
   private def failedOnCommandExecution(
       error: ErrorCause
-  )(implicit loggingContext: LoggingContext): Future[CommandExecutionResult] = {
-    implicit val contextualizedErrorLogger: ContextualizedErrorLogger =
-      new DamlContextualizedErrorLogger(logger, loggingContext, None)
-
+  )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): Future[CommandExecutionResult] =
     errorCodesVersionSwitcher.chooseAsFailedFuture(
       v1 = toStatusExceptionV1(error),
       v2 = RejectionGenerators
         .commandExecutorError(cause = ErrorCauseExport.fromErrorCause(error)),
     )
-  }
 
   override def close(): Unit = ()
 


### PR DESCRIPTION
Submission id is passed as a correlation id in the `ContextualizedErrorLogger`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
