### PR TITLE
Allocate parties sequentially in script export tests

### DIFF
--- a/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
+++ b/daml-script/export/integration-tests/reproduces-transactions/BUILD.bazel
@@ -16,6 +16,7 @@ da_scala_library(
         "//ledger/test-common:dar-files",
     ],
     scala_deps = [
+        "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:io_spray_spray_json",
@@ -58,6 +59,7 @@ da_scala_library(
 da_scala_test_suite(
     name = "reproduces-transactions",
     srcs = glob(["test-suite/scala/com/daml/script/export/*.scala"]),
+    resources = ["test-suite/resources/logback-test.xml"],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
@@ -66,6 +68,7 @@ da_scala_test_suite(
         "@maven//:org_scalatest_scalatest_freespec",
         "@maven//:org_scalatest_scalatest_matchers_core",
         "@maven//:org_scalatest_scalatest_shouldmatchers",
+        "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalaz_scalaz_core",
     ],
     deps = [

--- a/daml-script/export/integration-tests/reproduces-transactions/test-suite/resources/logback-test.xml
+++ b/daml-script/export/integration-tests/reproduces-transactions/test-suite/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.grpc.netty" level="WARN" />
+    <logger name="metrics" level="INFO" />
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
@@ -34,6 +34,7 @@ import com.daml.SdkVersion
 import com.daml.fs.Utils.deleteRecursively
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.lf.engine.script.ledgerinteraction.{GrpcLedgerClient, ScriptTimeMode}
+import com.typesafe.scalalogging.StrictLogging
 import scalaz.syntax.tag._
 import spray.json._
 
@@ -50,7 +51,9 @@ trait ReproducesTransactions
     with BeforeAndAfterEach
     with SuiteResourceManagementAroundAll
     with SandboxNextFixture
+    with StrictLogging
     with TestCommands {
+
   private val appId = domain.ApplicationId("script-export")
   private val clientConfiguration = LedgerClientConfiguration(
     applicationId = appId.unwrap,
@@ -103,15 +106,19 @@ trait ReproducesTransactions
       .runWith(Sink.seq)
 
   private def allocateParties(client: LedgerClient, numParties: Int): Future[List[Ref.Party]] =
-    List
-      .range(0, numParties)
-      // Allocate parties sequentially to avoid timeouts on CI.
-      .foldLeft[Future[List[Ref.Party]]](Future.successful(Nil)) { case (acc, _) =>
-        for {
-          ps <- acc
-          p <- client.partyManagementClient.allocateParty(None, None).map(_.party)
-        } yield ps :+ p
-      }
+    for {
+      _ <- Future { logger.debug("Allocating parties") }
+      ps <- List
+        .range(0, numParties)
+        // Allocate parties sequentially to avoid timeouts on CI.
+        .foldLeft[Future[List[Ref.Party]]](Future.successful(Nil)) { case (acc, _) =>
+          for {
+            ps <- acc
+            p <- client.partyManagementClient.allocateParty(None, None).map(_.party)
+          } yield ps :+ p
+        }
+      _ = logger.debug("Allocated parties")
+    } yield ps
 
   private val ledgerBegin = LedgerOffset(
     LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)
@@ -218,6 +225,9 @@ trait ReproducesTransactions
   private def testIou: (LedgerClient, Seq[Ref.Party]) => Future[Unit] = {
     case (client, Seq(p1, p2)) =>
       for {
+        _ <- Future {
+          logger.debug("Starting testIou")
+        }
         t0 <- submit(
           client,
           p1,


### PR DESCRIPTION
We’ve seen a few timeouts so this seems at least worth a try.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
