### PR TITLE
Auto run/check security evidence generation

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -18,6 +18,7 @@ javafmt_args=(--set-exit-if-changed --replace)
 diff_mode=false
 dade_copyright_arg=update
 buildifier_target=//:buildifier-fix
+security_update_args=()
 
 ## Functions ##
 
@@ -72,6 +73,7 @@ USAGE
       javafmt_args=(--set-exit-if-changed --dry-run)
       dade_copyright_arg=check
       buildifier_target=//:buildifier
+      security_update_args+=(--test)
       ;;
     --diff)
       shift
@@ -119,6 +121,9 @@ echo "\
 ──██─────▐█▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓█▌
 ──██────▐█▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓█▌
 "
+
+# update security evidence
+run security/update.sh ${security_update_args[@]:-}
 
 # Check for correct copyrights
 run dade-copyright-headers "$dade_copyright_arg" .

--- a/security/update.sh
+++ b/security/update.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+is_test=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --test)
+      shift
+      is_test=1
+      ;;
+    *)
+      echo "$0: unknown argument $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# These commands should be run at the root of the repo.
+# We write backslash-colon instead of colon ro the grep does not pick up itself.
+
+if [[ $is_test = 1 ]]; then
+  git grep --line-number TEST_EVIDENCE\: | bazel run security:evidence-security | diff security-evidence.md -
+  exit $?
+else
+  git grep --line-number TEST_EVIDENCE\: | bazel run security:evidence-security > security-evidence.md
+  exit 0
+fi


### PR DESCRIPTION
Two modes:
- update: `security/update.sh` (run by `./fmt.sh`) 
- check up to date: `security/update.sh --test` (run by `./fmt.sh --test`) (run by `ci/build-unix.yaml`)