### PR TITLE
Make Oracle tests exclusive

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -309,8 +309,11 @@ jobs:
           sleep 1
         done
         # Actually run some tests
+        # Note: Oracle tests all run sequentially because they all access the same Oracle instance,
+        # and we sometimes observe transient connection issues when running tests in parallel.
         bazel test \
           --config=oracle \
+          --test_strategy=exclusive \
           //ledger-service/http-json-oracle/... \
           //triggers/service:test-oracle \
           //ledger/participant-integration-api:participant-integration-api-tests-oracle \


### PR DESCRIPTION
This attempts to solve connection timeouts we often see in tests.

### Context

Symptoms seen in CI:
- Oracle tests are more flaky than Postgres tests
- Sometimes we see transient connnection errors in test logs, e.g., `java.sql.SQLTransientConnectionException: daml.index.db.connection.indexer - Connection is not available, request timed out after 250ms`

Local testing:
- Running all tests in parallel, 1 out of 7 runs had failing tests
- Running all tests sequentially, 10 out of 10 runs succeeded for all tests
- ...except for `http-json-oracle`, which is reproducibly failing locally

Speculation:
- Oracle tests all use the same database instance. By running tests sequentially, we decrease the likelihood of Oracle not being able to hand out connections fast enough.

Impact on CI run time:
- The `Linux_oracle` job completed in 15min when running tests sequentially and without cache, that should be the upper bound on the test time. With the default setup, the build takes 12min to complete. It looks like the tests do not parallelize well.

CI log with default tests:
```
INFO: Elapsed time: 403.905s, Critical Path: 227.49s

//ledger-service/http-json-oracle:integration-tests                      PASSED in 144.2s
//ledger/ledger-on-sql:conformance-test-oracle-1.14                      PASSED in 208.8s
//ledger/participant-integration-api:participant-integration-api-tests-oracle_test_suite_src_test_suite_scala_platform_indexer_ha_IndexerStabilityOracleSpec.scala PASSED in 25.1s
//ledger/participant-integration-api:participant-integration-api-tests-oracle_test_suite_src_test_suite_scala_platform_store_backend_StorageBackendOracleSpec.scala PASSED in 63.8s
//ledger/participant-integration-api:participant-integration-api-tests-oracle_test_suite_src_test_suite_scala_platform_store_dao_JdbcLedgerDaoOracleSpec.scala PASSED in 68.0s
//triggers/service:test-oracle_test_suite_src_test_suite_scala_com_daml_lf_engine_trigger_TriggerServiceTestAuthWithOracle.scala PASSED in 76.7s
//triggers/service:test-oracle_test_suite_src_test_suite_scala_com_daml_lf_engine_trigger_TriggerServiceTestWithOracle.scala PASSED in 68.0s
```

CI log with sequential tests:
```
INFO: Elapsed time: 529.426s, Critical Path: 238.12s

//ledger-service/http-json-oracle:integration-tests                      PASSED in 115.5s
//ledger/ledger-on-sql:conformance-test-oracle-1.14                      PASSED in 209.8s
//ledger/participant-integration-api:participant-integration-api-tests-oracle_test_suite_src_test_suite_scala_platform_indexer_ha_IndexerStabilityOracleSpec.scala PASSED in 13.6s
//ledger/participant-integration-api:participant-integration-api-tests-oracle_test_suite_src_test_suite_scala_platform_store_backend_StorageBackendOracleSpec.scala PASSED in 27.8s
//ledger/participant-integration-api:participant-integration-api-tests-oracle_test_suite_src_test_suite_scala_platform_store_dao_JdbcLedgerDaoOracleSpec.scala PASSED in 31.3s
//triggers/service:test-oracle_test_suite_src_test_suite_scala_com_daml_lf_engine_trigger_TriggerServiceTestAuthWithOracle.scala PASSED in 41.2s
//triggers/service:test-oracle_test_suite_src_test_suite_scala_com_daml_lf_engine_trigger_TriggerServiceTestWithOracle.scala PASSED in 34.2s
```