### PR TITLE
Explicitly import Java runtime from Nix/dadew

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -61,9 +61,17 @@ build --copt -DGRPC_BAZEL_BUILD
 
 # Bazel defaults to JDK9. This makes sure we run Nix provided JDK, and
 # avoid dreaded "Unrecognized VM option 'CompactStrings'" error
-build --host_javabase=@java_home//:javabase
-build --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:linux --javabase=@nixpkgs_java_runtime//:runtime
+build:linux --host_javabase=@nixpkgs_java_runtime//:runtime
+build:linux --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:linux --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:darwin --javabase=@nixpkgs_java_runtime//:runtime
+build:darwin --host_javabase=@nixpkgs_java_runtime//:runtime
+build:darwin --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:darwin --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:windows --host_javabase=@java_home//:javabase
+build:windows --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:windows --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 
 # Do not use a distinct configuration for "host", that is, binaries used
 # at build time should be the same as release binaries.

--- a/.bazelrc
+++ b/.bazelrc
@@ -69,7 +69,8 @@ build:darwin --javabase=@nixpkgs_java_runtime//:runtime
 build:darwin --host_javabase=@nixpkgs_java_runtime//:runtime
 build:darwin --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:darwin --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:windows --host_javabase=@java_home//:javabase
+build:windows --javabase=@dadew_java_runtime//:runtime
+build:windows --host_javabase=@dadew_java_runtime//:runtime
 build:windows --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:windows --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -594,9 +594,14 @@ load("@rules_haskell//tools:repositories.bzl", "rules_haskell_worker_dependencie
 # Call this after `daml_haskell_deps` to ensure that the right `stack` is used.
 rules_haskell_worker_dependencies()
 
-load("//bazel_tools:java.bzl", "java_home_runtime", "nixpkgs_java_configure")
+load("//bazel_tools:java.bzl", "dadew_java_configure", "java_home_runtime", "nixpkgs_java_configure")
 
 java_home_runtime(name = "java_home")
+
+dadew_java_configure(
+    name = "dadew_java_runtime",
+    dadew_path = "java-openjdk-8u302",
+) if is_windows else None
 
 nixpkgs_java_configure(
     attribute_path = "jdk8.home",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -594,9 +594,16 @@ load("@rules_haskell//tools:repositories.bzl", "rules_haskell_worker_dependencie
 # Call this after `daml_haskell_deps` to ensure that the right `stack` is used.
 rules_haskell_worker_dependencies()
 
-load("//bazel_tools:java.bzl", "java_home_runtime")
+load("//bazel_tools:java.bzl", "java_home_runtime", "nixpkgs_java_configure")
 
 java_home_runtime(name = "java_home")
+
+nixpkgs_java_configure(
+    attribute_path = "jdk8.home",
+    nix_file = "//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    repositories = dev_env_nix_repos,
+) if not is_windows else None
 
 # rules_go used here to compile a wrapper around the protoc-gen-scala plugin
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -594,9 +594,7 @@ load("@rules_haskell//tools:repositories.bzl", "rules_haskell_worker_dependencie
 # Call this after `daml_haskell_deps` to ensure that the right `stack` is used.
 rules_haskell_worker_dependencies()
 
-load("//bazel_tools:java.bzl", "dadew_java_configure", "java_home_runtime", "nixpkgs_java_configure")
-
-java_home_runtime(name = "java_home")
+load("//bazel_tools:java.bzl", "dadew_java_configure", "nixpkgs_java_configure")
 
 dadew_java_configure(
     name = "dadew_java_runtime",

--- a/bazel_tools/java.bzl
+++ b/bazel_tools/java.bzl
@@ -4,6 +4,7 @@
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("@os_info//:os_info.bzl", "is_windows")
 load("@com_github_google_bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 load("//bazel_tools:pkg.bzl", "pkg_empty_zip")
 
 _java_home_runtime_build_template = """
@@ -29,6 +30,125 @@ java_home_runtime = repository_rule(
     doc = "Define a `java_runtime` pointing to the JAVA_HOME environment variable.",
     environ = ["JAVA_HOME"],
 )
+
+_java_nix_file_content = """
+let
+  pkgs = import <nixpkgs> { config = {}; overlays = []; };
+in
+
+{ attrPath
+, attrSet
+, filePath
+}:
+
+let
+  javaHome =
+    if attrSet == null then
+      pkgs.lib.attrByPath (pkgs.lib.splitString "." attrPath) null pkgs
+    else
+      pkgs.lib.attrByPath (pkgs.lib.splitString "." attrPath) null attrSet
+    ;
+  javaHomePath =
+    if filePath == "" then
+      "${javaHome}"
+    else
+      "${javaHome}/${filePath}"
+    ;
+in
+
+assert javaHome != null;
+
+pkgs.runCommand "bazel-nixpkgs-java-runtime"
+  { executable = false;
+    # Pointless to do this on a remote machine.
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+  }
+  ''
+    n=$out/BUILD.bazel
+    mkdir -p "$(dirname "$n")"
+
+    cat >>$n <<EOF
+    load("@rules_java//java:defs.bzl", "java_runtime")
+    java_runtime(
+        name = "runtime",
+        java_home = r"${javaHomePath}",
+        visibility = ["//visibility:public"],
+    )
+    EOF
+  ''
+"""
+
+def nixpkgs_java_configure(
+        name = "nixpkgs_java_runtime",
+        attribute_path = None,
+        java_home_path = "",
+        repository = None,
+        repositories = {},
+        nix_file = None,
+        nix_file_content = "",
+        nix_file_deps = None,
+        nixopts = [],
+        fail_not_supported = True,
+        quiet = False):
+    """Define a Java runtime provided by nixpkgs.
+
+    Creates a `nixpkgs_package` for a `java_runtime` instance.
+
+    Args:
+      name: The name-prefix for the created external repositories.
+      attribute_path: string, The nixpkgs attribute path for `jdk.home`.
+      java_home_path: optional, string, The path to `JAVA_HOME` within the package.
+      repository: See [`nixpkgs_package`](#nixpkgs_package-repository).
+      repositories: See [`nixpkgs_package`](#nixpkgs_package-repositories).
+      nix_file: optional, Label, Obtain the runtime from the Nix expression defined in this file. Specify only one of `nix_file` or `nix_file_content`.
+      nix_file_content: optional, string, Obtain the runtime from the given Nix expression. Specify only one of `nix_file` or `nix_file_content`.
+      nix_file_deps: See [`nixpkgs_package`](#nixpkgs_package-nix_file_deps).
+      nixopts: See [`nixpkgs_package`](#nixpkgs_package-nixopts).
+      fail_not_supported: See [`nixpkgs_package`](#nixpkgs_package-fail_not_supported).
+      quiet: See [`nixpkgs_package`](#nixpkgs_package-quiet).
+    """
+    if attribute_path == None:
+        fail("'attribute_path' is required.", "attribute_path")
+
+    nix_expr = None
+    if nix_file and nix_file_content:
+        fail("Cannot specify both 'nix_file' and 'nix_file_content'.")
+    elif nix_file:
+        nix_expr = "import $(location {}) {{}}".format(nix_file)
+        nix_file_deps = depset(direct = [nix_file] + nix_file_deps).to_list()
+    elif nix_file_content:
+        nix_expr = nix_file_content
+    else:
+        nix_expr = "null"
+
+    nixopts = list(nixopts)
+    nixopts.extend([
+        "--argstr",
+        "attrPath",
+        attribute_path,
+        "--arg",
+        "attrSet",
+        nix_expr,
+        "--argstr",
+        "filePath",
+        java_home_path,
+    ])
+
+    kwargs = dict(
+        repository = repository,
+        repositories = repositories,
+        nix_file_deps = nix_file_deps,
+        nixopts = nixopts,
+        fail_not_supported = fail_not_supported,
+        quiet = quiet,
+    )
+    java_runtime = "@%s//:runtime" % name
+    nixpkgs_package(
+        name = name,
+        nix_file_content = _java_nix_file_content,
+        **kwargs
+    )
 
 def da_java_library(
         name,

--- a/bazel_tools/java.bzl
+++ b/bazel_tools/java.bzl
@@ -8,30 +8,6 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 load("//bazel_tools:pkg.bzl", "pkg_empty_zip")
 load("//bazel_tools/dev_env_tool:dev_env_tool.bzl", "dadew_tool_home", "dadew_where")
 
-_java_home_runtime_build_template = """
-java_runtime(
-    name = "{name}",
-    java_home = "{java_home}",
-    visibility = ["//visibility:public"],
-)
-"""
-
-def _java_home_runtime_impl(ctx):
-    java_home = ctx.os.environ.get("JAVA_HOME", default = "")
-    if java_home == "":
-        fail("Environment variable JAVA_HOME is empty.")
-    build_content = _java_home_runtime_build_template.format(
-        name = "javabase",
-        java_home = ctx.path(java_home),
-    )
-    ctx.file("BUILD", content = build_content, executable = False)
-
-java_home_runtime = repository_rule(
-    implementation = _java_home_runtime_impl,
-    doc = "Define a `java_runtime` pointing to the JAVA_HOME environment variable.",
-    environ = ["JAVA_HOME"],
-)
-
 _java_nix_file_content = """
 let
   pkgs = import <nixpkgs> { config = {}; overlays = []; };

--- a/bazel_tools/rules_scala_java_bin_path.patch
+++ b/bazel_tools/rules_scala_java_bin_path.patch
@@ -1,0 +1,29 @@
+diff --git a/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java b/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
+index 9fd8f9f..c14fb41 100644
+--- a/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
++++ b/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
+@@ -30,7 +30,7 @@ public class LauncherFileWriter {
+             .addKeyValuePair("binary_type", "Java")
+             .addKeyValuePair("workspace_name", workspaceName)
+             .addKeyValuePair("symlink_runfiles_enabled", "0")
+-            .addKeyValuePair("java_bin_path", workspaceName + "/" + javaBinPath)
++            .addKeyValuePair("java_bin_path", fullJavaBinPath(workspaceName, Paths.get(javaBinPath)).toString())
+             .addKeyValuePair("jar_bin_path", jarBinPath)
+             .addKeyValuePair("java_start_class", javaStartClass)
+             .addKeyValuePair("classpath", classpath)
+@@ -52,4 +52,15 @@ public class LauncherFileWriter {
+       out.flush();
+     }
+   }
++
++  private static Path fullJavaBinPath(String workspaceName, Path javaBinPath) {
++    if (javaBinPath.isAbsolute()) {
++      return javaBinPath;
++    } else if (javaBinPath.startsWith(Paths.get("external"))) {
++      // Paths under `external/` already have a workspace name.
++      return javaBinPath;
++    } else {
++      return Paths.get(workspaceName).resolve(javaBinPath);
++    }
++  }
+ }

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -61,9 +61,17 @@ build --copt -DGRPC_BAZEL_BUILD
 
 # Bazel defaults to JDK9. This makes sure we run Nix provided JDK, and
 # avoid dreaded "Unrecognized VM option 'CompactStrings'" error
-build --host_javabase=@java_home//:javabase
-build --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:linux --javabase=@nixpkgs_java_runtime//:runtime
+build:linux --host_javabase=@nixpkgs_java_runtime//:runtime
+build:linux --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:linux --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:darwin --javabase=@nixpkgs_java_runtime//:runtime
+build:darwin --host_javabase=@nixpkgs_java_runtime//:runtime
+build:darwin --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:darwin --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:windows --host_javabase=@java_home//:javabase
+build:windows --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:windows --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 
 # Do not use a distinct configuration for "host", that is, binaries used
 # at build time should be the same as release binaries.

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -69,7 +69,8 @@ build:darwin --javabase=@nixpkgs_java_runtime//:runtime
 build:darwin --host_javabase=@nixpkgs_java_runtime//:runtime
 build:darwin --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:darwin --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:windows --host_javabase=@java_home//:javabase
+build:windows --javabase=@dadew_java_runtime//:runtime
+build:windows --host_javabase=@dadew_java_runtime//:runtime
 build:windows --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:windows --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 

--- a/compatibility/WORKSPACE
+++ b/compatibility/WORKSPACE
@@ -294,9 +294,16 @@ daml_sdk_head(
     if ver != "0.0.0"
 ]
 
-load("@daml//bazel_tools:java.bzl", "java_home_runtime")
+load("@daml//bazel_tools:java.bzl", "java_home_runtime", "nixpkgs_java_configure")
 
 java_home_runtime(name = "java_home")
+
+nixpkgs_java_configure(
+    attribute_path = "jdk8.home",
+    nix_file = "@daml//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    repositories = dev_env_nix_repos,
+) if not is_windows else None
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 

--- a/compatibility/WORKSPACE
+++ b/compatibility/WORKSPACE
@@ -294,9 +294,14 @@ daml_sdk_head(
     if ver != "0.0.0"
 ]
 
-load("@daml//bazel_tools:java.bzl", "java_home_runtime", "nixpkgs_java_configure")
+load("@daml//bazel_tools:java.bzl", "dadew_java_configure", "java_home_runtime", "nixpkgs_java_configure")
 
 java_home_runtime(name = "java_home")
+
+dadew_java_configure(
+    name = "dadew_java_runtime",
+    dadew_path = "java-openjdk-8u302",
+) if is_windows else None
 
 nixpkgs_java_configure(
     attribute_path = "jdk8.home",

--- a/compatibility/WORKSPACE
+++ b/compatibility/WORKSPACE
@@ -294,9 +294,7 @@ daml_sdk_head(
     if ver != "0.0.0"
 ]
 
-load("@daml//bazel_tools:java.bzl", "dadew_java_configure", "java_home_runtime", "nixpkgs_java_configure")
-
-java_home_runtime(name = "java_home")
+load("@daml//bazel_tools:java.bzl", "dadew_java_configure", "nixpkgs_java_configure")
 
 dadew_java_configure(
     name = "dadew_java_runtime",

--- a/compatibility/deps.bzl
+++ b/compatibility/deps.bzl
@@ -128,6 +128,8 @@ def daml_deps():
             sha256 = rules_scala_sha256,
             patches = [
                 "@daml//bazel_tools:scala-escape-jvmflags.patch",
+                # Remove once https://github.com/bazelbuild/rules_scala/pull/1313 is merged
+                "@daml//bazel_tools:rules_scala_java_bin_path.patch",
             ],
             patch_args = ["-p1"],
         )

--- a/deps.bzl
+++ b/deps.bzl
@@ -149,6 +149,8 @@ def daml_deps():
                 "@com_github_digital_asset_daml//bazel_tools:scala-escape-jvmflags.patch",
                 # Remove once https://github.com/bazelbuild/rules_scala/pull/1261 is merged
                 "@com_github_digital_asset_daml//bazel_tools:rules_scala_suite_tags.patch",
+                # Remove once https://github.com/bazelbuild/rules_scala/pull/1313 is merged
+                "@com_github_digital_asset_daml//bazel_tools:rules_scala_java_bin_path.patch",
             ],
             patch_args = ["-p1"],
         )


### PR DESCRIPTION
Defines the Java runtime in a more hermetic way, by generating `java_runtime` definitions with Nix/dadew instead of pulling the path out of `JAVA_HOME`. Ideally, this would also allow us to drop `JAVA_HOME` in the Nix Bazel wrapper. However, there are still parts of the code-base that rely on that env-var.
Configures the Java runtime using the [`--javabase`](https://docs.bazel.build/versions/main/user-manual.html#flag--javabase) and [`--host_javabase`](https://docs.bazel.build/versions/main/user-manual.html#flag--host_javabase) flags.
This also fixes an issue with `rules_scala`'s launcher on Windows, which failed when using a `--javabase` with an absolute path. See https://github.com/bazelbuild/rules_scala/pull/1313.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
