### PR TITLE
MonotonicRecordTimeIT doesn't run on pruned participants

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/MonotonicRecordTimeIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/MonotonicRecordTimeIT.scala
@@ -24,7 +24,7 @@ final class MonotonicRecordTimeIT extends LedgerTestSuite {
       _ <- Future.traverse(1 to Submissions) { _ =>
         ledger.create(party, Dummy(party))
       }
-      checkpoints <- ledger.checkpoints(Submissions, ledger.begin)(party)
+      checkpoints <- ledger.checkpoints(Submissions)(party)
     } yield {
       assertLength(s"At least $Submissions checkpoints available", Submissions, checkpoints)
 


### PR DESCRIPTION
Reading explicitly from ledger.begin causes the test to fail on a pruned
participant. The test framework automatically selects a ledger offset
observed at the start of the test anyway, so there's no need to
explicitly put ledger.begin as the starting offset for the checkpoints.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
