### PR TITLE
Replace 1.14 min version conformance test by custom test

### DIFF
--- a/daml-lf/engine/BUILD.bazel
+++ b/daml-lf/engine/BUILD.bazel
@@ -44,6 +44,7 @@ da_scala_test_suite(
         ],
         exclude = [
             "src/test/**/LargeTransactionTest.scala",
+            "src/test/**/MinVersionTest.scala",
         ],
     ),
     data = [
@@ -111,5 +112,42 @@ da_scala_test(
         "//daml-lf/language",
         "//daml-lf/transaction",
         "@maven//:org_scalatest_scalatest_compatible",
+    ],
+)
+
+da_scala_test(
+    name = "test-min-version",
+    srcs = glob([
+        "src/test/**/MinVersionTest.scala",
+    ]),
+    data = [
+        "//ledger/test-common:dar-files-1.14",
+    ],
+    scala_deps = [
+        "@maven//:com_typesafe_akka_akka_actor",
+        "@maven//:com_typesafe_akka_akka_stream",
+    ],
+    scalacopts = lf_scalacopts,
+    deps = [
+        "//bazel_tools/runfiles:scala_runfiles",
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/data",
+        "//daml-lf/language",
+        "//language-support/scala/bindings-akka",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger/caching",
+        "//ledger/ledger-api-client",
+        "//ledger/ledger-api-common",
+        "//ledger/ledger-on-memory",
+        "//ledger/ledger-on-memory:ledger-on-memory-app",
+        "//ledger/ledger-resources",
+        "//ledger/participant-integration-api",
+        "//ledger/participant-state/kvutils/app",
+        "//ledger/test-common:dar-files-1.14-lib",
+        "//libs-scala/ports",
+        "//libs-scala/resources",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_netty_netty_handler",
     ],
 )

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MinVersionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MinVersionTest.scala
@@ -1,0 +1,161 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.MinVersionTest
+
+import java.io.{File, FileInputStream}
+import java.nio.file.{Files, Path}
+import java.util.stream.Collectors
+
+import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
+import com.daml.ledger.api.v1.commands.{CreateCommand, Command, Commands}
+import com.daml.ledger.api.v1.value._
+import com.daml.bazeltools.BazelRunfiles._
+import com.daml.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  OwnedResource,
+  SuiteResource,
+  SuiteResourceManagementAroundAll,
+}
+import com.daml.ledger.client.LedgerClient
+import com.daml.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement,
+}
+import com.daml.ledger.on.memory.Owner
+import com.daml.ledger.participant.state.kvutils.app.{
+  ParticipantConfig,
+  ParticipantIndexerConfig,
+  ParticipantRunMode,
+}
+import com.daml.ledger.participant.state.kvutils.{app => kvutils}
+import com.daml.ledger.resources.ResourceContext
+import com.daml.ledger.test.ModelTestDar
+import com.daml.lf.archive.DarDecoder
+import com.daml.lf.data.Ref
+import com.daml.lf.language.LanguageVersion.v1_14
+import com.daml.lf.VersionRange
+import com.daml.ports.Port
+import com.google.protobuf.ByteString
+import java.util.UUID
+import org.scalatest.Suite
+import org.scalatest.freespec.AsyncFreeSpec
+import scalaz.syntax.tag._
+
+final class MinVersionTest
+    extends AsyncFreeSpec
+    with SuiteResource[Port]
+    with AkkaBeforeAndAfterAll
+    with SuiteResourceManagementAroundAll {
+  self: Suite =>
+  private val darFile = new File(rlocation(ModelTestDar.path))
+  private val dar = DarDecoder.assertReadArchiveFromFile(darFile)
+
+  private val tmpDir = Files.createTempDirectory("testMultiParticipantFixture")
+  private val portfile = tmpDir.resolve("portfile")
+
+  override protected def afterAll(): Unit = {
+    Files.delete(portfile)
+    super.afterAll()
+
+  }
+
+  private def readPortfile(f: Path): Port = {
+    Port(Integer.parseInt(Files.readAllLines(f).stream.collect(Collectors.joining("\n"))))
+  }
+
+  private val ledgerClientConfig = LedgerClientConfiguration(
+    applicationId = "minversiontest",
+    ledgerIdRequirement = LedgerIdRequirement.none,
+    commandClient = CommandClientConfiguration.default,
+    sslContext = None,
+  )
+  // This is an integration test to make sure that the version restrictions for stable packages
+  // apply across the whole stack.
+
+  "MinVersionTest" - {
+    "can upload an LF 1.14 package and use it in a transaction" in {
+      for {
+        client <- LedgerClient.singleHost(
+          "localhost",
+          suiteResource.value.value,
+          ledgerClientConfig,
+        )
+        darByteString = ByteString.readFrom(new FileInputStream(darFile))
+        _ <- client.packageManagementClient.uploadDarFile(darByteString)
+        party <- client.partyManagementClient
+          .allocateParty(hint = None, displayName = None)
+          .map(_.party)
+        _ <- client.commandServiceClient.submitAndWaitForTransaction(
+          SubmitAndWaitRequest(
+            Some(
+              Commands(
+                ledgerId = client.ledgerId.unwrap,
+                applicationId = "minversiontest",
+                commandId = UUID.randomUUID.toString,
+                party = party,
+                commands = Seq(
+                  Command().withCreate(
+                    CreateCommand(
+                      templateId = Some(
+                        Identifier(
+                          packageId = dar.main._1,
+                          moduleName = "Iou",
+                          entityName = "Iou",
+                        )
+                      ),
+                      createArguments = Some(
+                        Record(
+                          None,
+                          Seq(
+                            RecordField("issuer", Some(Value().withParty(party))),
+                            RecordField("owner", Some(Value().withParty(party))),
+                            RecordField("currency", Some(Value().withText("EUR"))),
+                            RecordField("amount", Some(Value().withNumeric("10.0"))),
+                            RecordField("observers", Some(Value().withList(List()))),
+                          ),
+                        )
+                      ),
+                    )
+                  )
+                ),
+              )
+            )
+          )
+        )
+      } yield succeed
+    }
+  }
+
+  private val participantId = Ref.ParticipantId.assertFromString("participant1")
+  private val participant = ParticipantConfig(
+    mode = ParticipantRunMode.Combined,
+    participantId = participantId,
+    shardName = None,
+    address = Some("localhost"),
+    port = Port.Dynamic,
+    portFile = Some(portfile),
+    serverJdbcUrl = ParticipantConfig.defaultIndexJdbcUrl(participantId),
+    indexerConfig = ParticipantIndexerConfig(
+      allowExistingSchema = false
+    ),
+  )
+  override protected lazy val suiteResource = {
+    implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
+    new OwnedResource[ResourceContext, Port](
+      for {
+        _ <- Owner(
+          kvutils.Config
+            .createDefault(())
+            .copy(
+              participants = Seq(participant),
+              archiveFiles = Seq(),
+              // Bump min version to 1.14 and check that older stable packages are still accepted.
+              allowedLanguageVersions = VersionRange(min = v1_14, max = v1_14),
+            )
+        )
+      } yield (readPortfile(portfile))
+    )
+  }
+}

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -181,27 +181,6 @@ conformance_test(
     ],
 )
 
-# Feature test: --daml-lf-min-version-1.14-unsafe
-# This asserts that you can use the 1.14 packages despite their dependencies on a few stable packages in older LF versions.
-conformance_test(
-    name = "conformance-test-min-1.14",
-    lf_versions = ["1.14"],
-    ports = [6865],
-    server = ":app",
-    server_args = [
-        "--contract-id-seeding=testing-weak",
-        "--participant=participant-id=example,port=6865",
-        "--daml-lf-min-version-1.14-unsafe",
-        "--max-deduplication-duration=PT5S",
-        "--mutable-contract-state-cache",
-    ],
-    test_tool_args = [
-        "--additional=MultiPartySubmissionIT",
-        "--additional=KVCommandDeduplicationIT",
-        "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
-    ],
-)
-
 # Full conformance test (two participant setup)
 conformance_test(
     name = "conformance-test-multi-participant",

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -554,18 +554,6 @@ object Config {
             "Enable the development version of the Daml-LF language. Highly unstable. Should not be used in production."
           )
 
-        opt[Unit]("daml-lf-min-version-1.14-unsafe")
-          .optional()
-          .hidden()
-          .action((_, c) =>
-            c.copy(allowedLanguageVersions =
-              c.allowedLanguageVersions.copy(min = LanguageVersion.v1_14)
-            )
-          )
-          .text(
-            "Set minimum LF version for unstable packages to 1.14. Should not be used in production."
-          )
-
         // TODO append-only: remove after removing support for the current (mutating) schema
         opt[Unit]("index-append-only-schema")
           .optional()


### PR DESCRIPTION
We waste 2 minutes on most CI runs with the conformance test for no
good reason. Uploading the package & sending a command should be
sufficient as an integration test.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
