### PR TITLE
[Self-service error codes] Adapt all grpc assertions to additionally take self-service error codes [DPP-680]

### DIFF
--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -128,6 +128,7 @@ da_scala_binary(
                 "//ledger/error",
                 "//ledger/ledger-api-common",
                 "//ledger/ledger-resources",
+                "//ledger/participant-state/kvutils",
                 "//libs-scala/resources",
                 "//libs-scala/resources-akka",
                 "//libs-scala/resources-grpc",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -53,35 +53,13 @@ object Assertions {
       expectedCode: Status.Code,
       selfServiceErrorCode: ErrorCode,
       exceptionMessageSubstring: Option[String],
-      checkDefiniteAnswerMetadata: Boolean,
-  ): Unit =
-    if (participant.features.selfServiceErrorCodes)
-      t match {
-        case statusRuntimeException: StatusRuntimeException =>
-          assertSelfServiceErrorCode(statusRuntimeException, selfServiceErrorCode)
-        case t => fail(s"Throwable $t does not match ErrorCode $selfServiceErrorCode")
-      }
-    else {
-      assertGrpcErrorRegex(
-        t,
-        expectedCode,
-        exceptionMessageSubstring
-          .map(msgSubstring => Pattern.compile(Pattern.quote(msgSubstring))),
-        checkDefiniteAnswerMetadata,
-      )
-    }
-
-  /** A non-regex alternative to [[assertGrpcErrorRegex]] which just does a substring check.
-    */
-  def assertGrpcError(
-      t: Throwable,
-      expectedCode: Status.Code,
-      exceptionMessageSubstring: Option[String],
       checkDefiniteAnswerMetadata: Boolean = false,
   ): Unit =
     assertGrpcErrorRegex(
+      participant,
       t,
       expectedCode,
+      selfServiceErrorCode,
       exceptionMessageSubstring
         .map(msgSubstring => Pattern.compile(Pattern.quote(msgSubstring))),
       checkDefiniteAnswerMetadata,
@@ -94,28 +72,38 @@ object Assertions {
     */
   @tailrec
   def assertGrpcErrorRegex(
+      participant: ParticipantTestContext,
       t: Throwable,
       expectedCode: Status.Code,
+      selfServiceErrorCode: ErrorCode,
       optPattern: Option[Pattern],
       checkDefiniteAnswerMetadata: Boolean = false,
   ): Unit =
-    (t, optPattern) match {
-      case (RetryStrategy.FailedRetryException(cause), _) =>
-        assertGrpcErrorRegex(cause, expectedCode, optPattern, checkDefiniteAnswerMetadata)
-      case (
-            exception @ GrpcException(GrpcStatus(`expectedCode`, Some(message)), _),
-            Some(pattern),
-          ) =>
-        assertMatches(message, pattern)
-        if (checkDefiniteAnswerMetadata) {
-          assertDefiniteAnswer(exception)
+    t match {
+      case RetryStrategy.FailedRetryException(cause) =>
+        assertGrpcErrorRegex(
+          participant,
+          cause,
+          expectedCode,
+          selfServiceErrorCode,
+          optPattern,
+          checkDefiniteAnswerMetadata,
+        )
+      case exception @ GrpcException(GrpcStatus(code, maybeMessage), _)
+          if !participant.features.selfServiceErrorCodes =>
+        if (code != expectedCode) fail(s"Expected code [$expectedCode], but got [$code].")
+        (optPattern, maybeMessage) match {
+          case (Some(pattern), Some(message)) => assertMatches(message, pattern)
+          case (Some(pattern), None) =>
+            fail(s"Expected message matching pattern [$pattern], but message was empty")
+          case _ => ()
         }
-      // None both represents pattern that we do not care about as well as
-      // exceptions that have no message.
-      case (GrpcException(GrpcStatus(`expectedCode`, _), _), None) => ()
-      case (GrpcException(GrpcStatus(code, _), _), _) =>
-        fail(s"Expected code [$expectedCode], but got [$code].")
-      case (_, _) =>
+        if (checkDefiniteAnswerMetadata) assertDefiniteAnswer(exception)
+      case exception: StatusRuntimeException if participant.features.selfServiceErrorCodes =>
+        assertSelfServiceErrorCode(exception, selfServiceErrorCode)
+        optPattern.foreach(assertMatches(exception.getMessage, _))
+        if (checkDefiniteAnswerMetadata) assertDefiniteAnswer(exception)
+      case _ =>
         fail("Exception is neither a StatusRuntimeException nor a StatusException", t)
     }
 
@@ -148,10 +136,6 @@ object Assertions {
     }
   }
 
-  /** Allows for assertions with more information in the error messages. */
-  implicit def futureAssertions[T](future: Future[T]): FutureAssertions[T] =
-    new FutureAssertions[T](future)
-
   def assertSelfServiceErrorCode(
       statusRuntimeException: StatusRuntimeException,
       expectedErrorCode: ErrorCode,
@@ -176,14 +160,14 @@ object Assertions {
     val actualRetryabilitySeconds = actualErrorDetails
       .collectFirst { case err: ErrorDetails.RetryInfoDetail => err.retryDelayInSeconds }
 
+    if (!actualErrorId.contains(expectedErrorId))
+      fail(s"Actual error id ($actualErrorId) does not match expected error id ($expectedErrorId}")
+
     Assertions.assertEquals(
       "gRPC error code mismatch",
       actualStatusCode,
       expectedStatusCode,
     )
-
-    if (!actualErrorId.contains(expectedErrorId))
-      fail(s"Actual error id ($actualErrorId) does not match expected error id ($expectedErrorId}")
 
     Assertions.assertEquals(
       s"Error retryability details mismatch",
@@ -191,4 +175,8 @@ object Assertions {
       expectedRetryabilitySeconds,
     )
   }
+
+  /** Allows for assertions with more information in the error messages. */
+  implicit def futureAssertions[T](future: Future[T]): FutureAssertions[T] =
+    new FutureAssertions[T](future)
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -160,7 +160,7 @@ object Assertions {
     val actualRetryabilitySeconds = actualErrorDetails
       .collectFirst { case err: ErrorDetails.RetryInfoDetail => err.retryDelayInSeconds }
 
-    if (!actualErrorId.contains(expectedErrorId))
+    if (actualErrorId != expectedErrorId)
       fail(s"Actual error id ($actualErrorId) does not match expected error id ($expectedErrorId}")
 
     Assertions.assertEquals(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ActiveContractsServiceIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -41,7 +42,13 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
     for {
       failure <- ledger.activeContracts(invalidRequest).mustFail("retrieving active contracts")
     } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, Some("not found. Actual Ledger ID"))
+      assertGrpcError(
+        ledger,
+        failure,
+        Status.Code.NOT_FOUND,
+        LedgerApiErrors.CommandValidation.LedgerIdMismatch,
+        Some("not found. Actual Ledger ID"),
+      )
     }
   })
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ClosedWorldIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ClosedWorldIT.scala
@@ -3,14 +3,15 @@
 
 package com.daml.ledger.api.testtool.suites
 
-import java.util.regex.Pattern
-
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.client.binding
+import com.daml.ledger.participant.state.kvutils.errors.KVErrors
 import com.daml.ledger.test.semantic.SemanticTests.{Amount, Iou}
 import io.grpc.Status
+
+import java.util.regex.Pattern
 
 class ClosedWorldIT extends LedgerTestSuite {
 
@@ -31,8 +32,10 @@ class ClosedWorldIT extends LedgerTestSuite {
         .mustFail("referencing an unallocated party")
     } yield {
       assertGrpcErrorRegex(
+        alpha,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        KVErrors.Parties.PartiesNotKnownOnLedger,
         Some(Pattern.compile("Part(y|ies) not known on ledger")),
         checkDefiniteAnswerMetadata = true,
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -3,8 +3,9 @@
 
 package com.daml.ledger.api.testtool.suites
 
-import java.util.regex.Pattern
+import com.daml.error.definitions.LedgerApiErrors
 
+import java.util.regex.Pattern
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -156,8 +157,10 @@ final class CommandServiceIT extends LedgerTestSuite {
       failure <- ledger.submitAndWait(request).mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.ALREADY_EXISTS,
+        LedgerApiErrors.CommandPreparation.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
       )
@@ -177,8 +180,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.ALREADY_EXISTS,
+        LedgerApiErrors.CommandPreparation.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
       )
@@ -198,8 +203,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.ALREADY_EXISTS,
+        LedgerApiErrors.CommandPreparation.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
       )
@@ -219,8 +226,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.ALREADY_EXISTS,
+        LedgerApiErrors.CommandPreparation.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
       )
@@ -241,8 +250,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .submitAndWaitForTransactionId(request)
         .mustFail("submitting a request with an invalid ledger ID")
     } yield assertGrpcError(
+      ledger,
       failure,
       Status.Code.NOT_FOUND,
+      LedgerApiErrors.CommandValidation.LedgerIdMismatch,
       Some(s"Ledger ID '$invalidLedgerId' not found."),
       checkDefiniteAnswerMetadata = true,
     )
@@ -262,8 +273,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .submitAndWaitForTransaction(request)
         .mustFail("submitting a request with an invalid ledger ID")
     } yield assertGrpcError(
+      ledger,
       failure,
       Status.Code.NOT_FOUND,
+      LedgerApiErrors.CommandValidation.LedgerIdMismatch,
       Some(s"Ledger ID '$invalidLedgerId' not found."),
       checkDefiniteAnswerMetadata = true,
     )
@@ -283,8 +296,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .submitAndWaitForTransactionTree(request)
         .mustFail("submitting a request with an invalid ledger ID")
     } yield assertGrpcError(
+      ledger,
       failure,
       Status.Code.NOT_FOUND,
+      LedgerApiErrors.CommandValidation.LedgerIdMismatch,
       Some(s"Ledger ID '$invalidLedgerId' not found."),
       checkDefiniteAnswerMetadata = true,
     )
@@ -304,8 +319,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with a bad parameter label")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.PreprocessingErrors.PreprocessingFailed,
         Some(Pattern.compile(s"Missing record (label|field)")),
         checkDefiniteAnswerMetadata = true,
       )
@@ -324,8 +341,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with an interpretation error")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.GenericInterpretationError,
         Some(
           Pattern.compile(
             "Interpretation error: Error: (User abort: Assertion failed.|Unhandled exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"Assertion failed\" \\}\\.) [Dd]etails(: |=)Last location: \\[[^\\]]*\\], partial transaction: root node"
@@ -481,20 +500,26 @@ final class CommandServiceIT extends LedgerTestSuite {
           .mustFail("submitting a request with a negative number out of bounds")
       } yield {
         assertGrpcError(
+          ledger,
           e1,
           Status.Code.INVALID_ARGUMENT,
+          LedgerApiErrors.PreprocessingErrors.PreprocessingFailed,
           Some("Cannot represent"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
+          ledger,
           e2,
           Status.Code.INVALID_ARGUMENT,
+          LedgerApiErrors.PreprocessingErrors.PreprocessingFailed,
           Some("Out-of-bounds (Numeric 10)"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
+          ledger,
           e3,
           Status.Code.INVALID_ARGUMENT,
+          LedgerApiErrors.PreprocessingErrors.PreprocessingFailed,
           Some("Out-of-bounds (Numeric 10)"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -546,8 +571,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with bad create arguments")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.PreprocessingErrors.PreprocessingFailed,
         Some("Expecting 1 field for record"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -570,8 +597,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with bad choice arguments")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.PreprocessingErrors.PreprocessingFailed,
         Some("mismatching type"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -595,8 +624,10 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with an invalid choice")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.PreprocessingErrors.PreprocessingFailed,
         Some(
           Pattern.compile(
             "(unknown|Couldn't find requested) choice " + missingChoice

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -15,6 +15,7 @@ import com.daml.ledger.api.v1.commands.Command
 import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.client.binding.Value.encode
+import com.daml.ledger.participant.state.kvutils.errors.KVErrors
 import com.daml.ledger.test.model.Test.CallablePayout._
 import com.daml.ledger.test.model.Test.Dummy._
 import com.daml.ledger.test.model.Test.DummyFactory._
@@ -160,7 +161,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         ledger,
         failure,
         Status.Code.ALREADY_EXISTS,
-        LedgerApiErrors.CommandPreparation.DuplicateCommand,
+        KVErrors.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
       )
@@ -183,7 +184,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         ledger,
         failure,
         Status.Code.ALREADY_EXISTS,
-        LedgerApiErrors.CommandPreparation.DuplicateCommand,
+        KVErrors.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
       )
@@ -206,7 +207,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         ledger,
         failure,
         Status.Code.ALREADY_EXISTS,
-        LedgerApiErrors.CommandPreparation.DuplicateCommand,
+        KVErrors.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
       )
@@ -229,7 +230,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         ledger,
         failure,
         Status.Code.ALREADY_EXISTS,
-        LedgerApiErrors.CommandPreparation.DuplicateCommand,
+        KVErrors.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.grpc.{GrpcException, GrpcStatus}
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
@@ -18,7 +19,7 @@ import com.google.protobuf.duration.Duration
 import io.grpc.Status
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 final class ConfigManagementServiceIT extends LedgerTestSuite {
   test(
@@ -90,7 +91,13 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
         "Restoring the original time model failed",
       )
 
-      assertGrpcError(expiredMRTFailure, Status.Code.ABORTED, exceptionMessageSubstring = None)
+      assertGrpcError(
+        ledger,
+        expiredMRTFailure,
+        Status.Code.ABORTED,
+        LedgerApiErrors.InterpreterErrors.GenericInterpretationError,
+        exceptionMessageSubstring = None,
+      )
     }
   })
 
@@ -130,7 +137,13 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
         )
         .mustFail("setting Time Model with an outdated generation")
     } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, exceptionMessageSubstring = None)
+      assertGrpcError(
+        ledger,
+        failure,
+        Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.CommandValidation.InvalidArgument,
+        exceptionMessageSubstring = None,
+      )
     }
   })
 
@@ -172,20 +185,33 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
         response1.configurationGeneration + 1 == response2.configurationGeneration,
         s"New configuration's generation (${response2.configurationGeneration} should be original configurations's generation (${response1.configurationGeneration} + 1) )",
       )
-      failure match {
-        case GrpcException(GrpcStatus(Status.Code.ABORTED, _), _) =>
-          () // if the "looser" command fails after command submission (the winner completed after looser did submit the configuration change)
-
-        case GrpcException(GrpcStatus(Status.Code.INVALID_ARGUMENT, _), _) =>
-          () // if the "looser" command fails already on command submission (the winner completed before looser submission is over)
-
-        case GrpcException(GrpcStatus(notExpectedCode, _), _) =>
+      Try {
+        // if the "looser" command fails already on command submission (the winner completed before looser submission is over)
+        assertGrpcError(
+          ledger,
+          failure,
+          Status.Code.INVALID_ARGUMENT,
+          LedgerApiErrors.CommandValidation.InvalidArgument,
+          Some("Mismatching configuration generation"),
+        )
+      }.recover { case _ =>
+        // if the "looser" command fails after command submission (the winner completed after looser did submit the configuration change)
+        assertGrpcError(
+          ledger,
+          failure,
+          Status.Code.ABORTED,
+          LedgerApiErrors.WriteErrors.ConfigurationEntryRejected,
+          Some("Generation mismatch"),
+        )
+      } match {
+        case Failure(GrpcException(GrpcStatus(notExpectedCode, _), _)) =>
           fail(s"One of the submissions failed with an unexpected status code: $notExpectedCode")
 
-        case notExpectedException =>
+        case Failure(notExpectedException) =>
           fail(
             s"Unexpected exception: type:${notExpectedException.getClass.getName}, message:${notExpectedException.getMessage}"
           )
+        case Success(_) => ()
       }
     }
   })

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/DeeplyNestedValueIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/DeeplyNestedValueIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
@@ -70,8 +71,10 @@ final class DeeplyNestedValueIT extends LedgerTestSuite {
           case Right(_) if accepted => ()
           case Left(err: Throwable) if !accepted =>
             assertGrpcError(
+              alpha,
               err,
               Status.Code.INVALID_ARGUMENT,
+              LedgerApiErrors.PreprocessingErrors.PreprocessingFailed,
               None,
               checkDefiniteAnswerMetadata = true,
             )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionsIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionsIT.scala
@@ -3,20 +3,22 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
+import com.daml.ledger.participant.state.kvutils.errors.KVErrors
 import com.daml.ledger.test.semantic.Exceptions.{
   Divulger,
   ExceptionTester,
   Fetcher,
-  WithSimpleKey,
   Informer,
+  RollbackNestingHelper,
   WithKey,
   WithKeyDelegate,
-  RollbackNestingHelper,
+  WithSimpleKey,
 }
 import io.grpc.Status
 
@@ -31,8 +33,10 @@ final class ExceptionsIT extends LedgerTestSuite {
       failure <- ledger.exercise(party, t.exerciseThrowUncaught(_)).mustFail("Unhandled exception")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.GenericInterpretationError,
         Some("Unhandled exception"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -82,8 +86,10 @@ final class ExceptionsIT extends LedgerTestSuite {
         .mustFail("contract is archived")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.ABORTED,
+        LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
         Some("Contract could not be found"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -105,8 +111,10 @@ final class ExceptionsIT extends LedgerTestSuite {
         .mustFail("contract is archived")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.ABORTED,
+        LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
         Some("Contract could not be found"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -128,8 +136,10 @@ final class ExceptionsIT extends LedgerTestSuite {
         .mustFail("contract is archived")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.ABORTED,
+        LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
         Some("Contract could not be found"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -183,8 +193,10 @@ final class ExceptionsIT extends LedgerTestSuite {
       failure <- ledger.exercise(party, t.exerciseDuplicateKey(_)).mustFail("duplicate key")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.ABORTED,
+        KVErrors.SubmissionRaces.ExternallyDuplicateKeys,
         Some("DuplicateKey"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -201,8 +213,10 @@ final class ExceptionsIT extends LedgerTestSuite {
       withKey <- ledger.create(party, WithSimpleKey(party))
       failure <- ledger.exercise(party, t.exerciseDuplicateKey(_)).mustFail("duplicate key")
       _ = assertGrpcError(
+        ledger,
         failure,
         Status.Code.ABORTED,
+        KVErrors.SubmissionRaces.ExternallyDuplicateKeys,
         Some("DuplicateKey"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -224,8 +238,10 @@ final class ExceptionsIT extends LedgerTestSuite {
       failure <- ledger.exercise(party, t.exerciseFetchKey(_)).mustFail("couldn't find key")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.LookupErrors.ContractKeyNotFound,
         Some("couldn't find key"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -242,8 +258,10 @@ final class ExceptionsIT extends LedgerTestSuite {
       t <- ledger.create(party, ExceptionTester(party))
       failure <- ledger.exercise(party, t.exerciseFetchKey(_)).mustFail("contract not found")
       _ = assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.LookupErrors.ContractKeyNotFound,
         Some("couldn't find key"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -285,8 +303,10 @@ final class ExceptionsIT extends LedgerTestSuite {
           .exercise(aParty, fetcher.exerciseFetch(_, t))
           .mustFail("contract could not be found")
         _ = assertGrpcError(
+          aLedger,
           fetchFailure,
           Status.Code.ABORTED,
+          LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -312,8 +332,10 @@ final class ExceptionsIT extends LedgerTestSuite {
           .exercise(bParty, fetcher.exerciseFetch_(_, withKey0))
           .mustFail("contract could not be found")
         _ = assertGrpcError(
+          bLedger,
           fetchFailure,
           Status.Code.ABORTED,
+          LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -321,8 +343,10 @@ final class ExceptionsIT extends LedgerTestSuite {
           .exercise(bParty, fetcher.exerciseFetch_(_, withKey1))
           .mustFail("contract could not be found")
         _ = assertGrpcError(
+          bLedger,
           fetchFailure,
           Status.Code.ABORTED,
+          LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/MultiPartySubmissionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/MultiPartySubmissionIT.scala
@@ -3,9 +3,10 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
+
 import java.util.UUID
 import java.util.regex.Pattern
-
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -72,8 +73,10 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("submitting a contract with a missing authorizers")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.AuthorizationError,
         None,
         checkDefiniteAnswerMetadata = true,
       )
@@ -120,8 +123,10 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice with a missing authorizers")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.AuthorizationError,
         None,
         checkDefiniteAnswerMetadata = true,
       )
@@ -172,8 +177,10 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to fetch another contract")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.AuthorizationError,
         Some(Pattern.compile("of the fetched contract to be an authorizer, but authorizers were")),
         checkDefiniteAnswerMetadata = true,
       )
@@ -203,8 +210,10 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to fetch another contract")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.ABORTED,
+        LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
         Some(Pattern.compile("Contract could not be found")),
         checkDefiniteAnswerMetadata = true,
       )
@@ -255,8 +264,10 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to fetch another contract by key")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.AuthorizationError,
         Some(Pattern.compile("of the fetched contract to be an authorizer, but authorizers were")),
         checkDefiniteAnswerMetadata = true,
       )
@@ -286,8 +297,10 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to fetch another contract by key")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.LookupErrors.ContractKeyNotFound,
         Some(Pattern.compile("dependency error: couldn't find key")),
         checkDefiniteAnswerMetadata = true,
       )
@@ -340,8 +353,10 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to look up another contract by key")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.AuthorizationError,
         Some(Pattern.compile("requires authorizers (.*) for lookup by key, but it only has")),
         checkDefiniteAnswerMetadata = true,
       )
@@ -372,8 +387,10 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to look up another contract by key")
     } yield {
       assertGrpcErrorRegex(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.GenericInterpretationError,
         Some(
           Pattern.compile(
             "Interpretation error: Error: (User abort: Assertion failed.|Unhandled exception: [0-9a-zA-Z\\.:]*@[0-9a-f]*\\{ message = \"LookupOtherByKey value matches\" \\}\\.) [Dd]etails(: |=)Last location: \\[[^\\]]*\\], partial transaction: root node"

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -38,9 +39,11 @@ final class PackageManagementServiceIT extends LedgerTestSuite {
       failure <- ledger.uploadDarFile(ByteString.EMPTY).mustFail("uploading an empty package")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
-        Some("Invalid argument: Invalid DAR: package-upload"),
+        LedgerApiErrors.CommandValidation.InvalidArgument,
+        Some("Invalid DAR: package-upload"),
       )
     }
   })

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageServiceIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -54,7 +55,13 @@ final class PackageServiceIT extends LedgerTestSuite {
         .getPackage(unknownPackageId)
         .mustFail("getting the contents of an unknown package")
     } yield {
-      assertGrpcError(failure, Status.Code.NOT_FOUND, None)
+      assertGrpcError(
+        ledger,
+        failure,
+        Status.Code.NOT_FOUND,
+        LedgerApiErrors.ReadErrors.PackageNotFound,
+        None,
+      )
     }
   })
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -106,7 +107,13 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
         )
         .mustFail("allocating a party with a very long identifier")
     } yield {
-      assertGrpcError(error, Status.Code.INVALID_ARGUMENT, Some("Party is too long"))
+      assertGrpcError(
+        ledger,
+        error,
+        Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.CommandValidation.InvalidArgument,
+        Some("Party is too long"),
+      )
     }
   })
 
@@ -124,7 +131,13 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
         )
         .mustFail("allocating a party with invalid characters")
     } yield {
-      assertGrpcError(error, Status.Code.INVALID_ARGUMENT, Some("non expected character"))
+      assertGrpcError(
+        ledger,
+        error,
+        Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.CommandValidation.InvalidArgument,
+        Some("non expected character"),
+      )
     }
   })
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/SemanticTests.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
@@ -59,8 +60,10 @@ final class SemanticTests extends LedgerTestSuite {
           .mustFail("consuming a contract twice")
       } yield {
         assertGrpcError(
+          alpha,
           failure,
           Status.Code.ABORTED,
+          LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -125,8 +128,10 @@ final class SemanticTests extends LedgerTestSuite {
         failure <- alpha.submitAndWait(doubleSpend).mustFail("consuming a contract twice")
       } yield {
         assertGrpcError(
+          alpha,
           failure,
           Status.Code.INVALID_ARGUMENT,
+          LedgerApiErrors.InterpreterErrors.ContractNotActive,
           Some("Update failed due to fetch of an inactive contract"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -148,8 +153,10 @@ final class SemanticTests extends LedgerTestSuite {
           .mustFail("consuming a contract twice")
       } yield {
         assertGrpcError(
+          beta,
           failure,
           Status.Code.ABORTED,
+          LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -241,8 +248,10 @@ final class SemanticTests extends LedgerTestSuite {
         .mustFail("creating a contract on behalf of two parties")
     } yield {
       assertGrpcError(
+        alpha,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.AuthorizationError,
         Some("requires authorizers"),
         checkDefiniteAnswerMetadata = true,
       )
@@ -263,8 +272,10 @@ final class SemanticTests extends LedgerTestSuite {
           .mustFail("exercising a choice without consent")
       } yield {
         assertGrpcError(
+          beta,
           failure,
           Status.Code.INVALID_ARGUMENT,
+          LedgerApiErrors.InterpreterErrors.AuthorizationError,
           Some("requires authorizers"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -329,26 +340,34 @@ final class SemanticTests extends LedgerTestSuite {
 
       } yield {
         assertGrpcError(
+          beta,
           iouFetchFailure,
           Status.Code.ABORTED,
+          LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
+          alpha,
           paintOfferFetchFailure,
           Status.Code.ABORTED,
+          LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
+          alpha,
           paintAgreeFetchFailure,
           Status.Code.ABORTED,
+          LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
+          alpha,
           secondIouFetchFailure,
           Status.Code.INVALID_ARGUMENT,
+          LedgerApiErrors.InterpreterErrors.AuthorizationError,
           Some("requires one of the stakeholders"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -413,8 +432,10 @@ final class SemanticTests extends LedgerTestSuite {
           }
         } yield {
           assertGrpcError(
+            beta,
             failure,
             Status.Code.ABORTED,
+            LedgerApiErrors.InterpreterErrors.LookupErrors.ContractNotFound,
             Some("Contract could not be found"),
             checkDefiniteAnswerMetadata = true,
           )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceAuthorizationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceAuthorizationIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
@@ -94,8 +95,10 @@ class TransactionServiceAuthorizationIT extends LedgerTestSuite {
               .mustFail("exercising with missing authorizers")
           } yield {
             assertGrpcError(
+              beta,
               failure,
               Status.Code.INVALID_ARGUMENT,
+              LedgerApiErrors.InterpreterErrors.AuthorizationError,
               Some("requires authorizers"),
               checkDefiniteAnswerMetadata = true,
             )
@@ -132,8 +135,10 @@ class TransactionServiceAuthorizationIT extends LedgerTestSuite {
               .mustFail("exercising with failing assertion")
           } yield {
             assertGrpcError(
+              beta,
               failure,
               Status.Code.INVALID_ARGUMENT,
+              LedgerApiErrors.InterpreterErrors.GenericInterpretationError,
               Some("Assertion failed"),
               checkDefiniteAnswerMetadata = true,
             )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceExerciseIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceExerciseIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
@@ -129,8 +130,10 @@ class TransactionServiceExerciseIT extends LedgerTestSuite {
         .mustFail("exercising with a failing assertion")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.GenericInterpretationError,
         Some("Assertion failed"),
         checkDefiniteAnswerMetadata = true,
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceQueryIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceQueryIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -40,8 +41,10 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("subscribing to an invisible transaction tree")
     } yield {
       assertGrpcError(
+        beta,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.ReadErrors.TransactionNotFound,
         Some("Transaction not found, or not visible."),
       )
     }
@@ -58,8 +61,10 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up an non-existent transaction tree")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.ReadErrors.TransactionNotFound,
         Some("Transaction not found, or not visible."),
       )
     }
@@ -92,8 +97,10 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up an invisible flat transaction")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.ReadErrors.TransactionNotFound,
         Some("Transaction not found, or not visible."),
       )
     }
@@ -110,8 +117,10 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up a non-existent flat transaction")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.ReadErrors.TransactionNotFound,
         Some("Transaction not found, or not visible."),
       )
     }
@@ -146,8 +155,10 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up an invisible transaction tree")
     } yield {
       assertGrpcError(
+        beta,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.ReadErrors.TransactionNotFound,
         Some("Transaction not found, or not visible."),
       )
     }
@@ -164,8 +175,10 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up a non-existent transaction tree")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.ReadErrors.TransactionNotFound,
         Some("Transaction not found, or not visible."),
       )
     }
@@ -200,8 +213,10 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up an invisible flat transaction")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.ReadErrors.TransactionNotFound,
         Some("Transaction not found, or not visible."),
       )
     }
@@ -218,8 +233,10 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up a non-existent flat transaction")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.ReadErrors.TransactionNotFound,
         Some("Transaction not found, or not visible."),
       )
     }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceStreamsIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceStreamsIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -79,7 +80,13 @@ class TransactionServiceStreamsIT extends LedgerTestSuite {
       beyondEnd = request.update(_.begin := futureOffset, _.optionalEnd := None)
       failure <- ledger.flatTransactions(beyondEnd).mustFail("subscribing past the ledger end")
     } yield {
-      assertGrpcError(failure, Status.Code.OUT_OF_RANGE, Some("is after ledger end"))
+      assertGrpcError(
+        ledger,
+        failure,
+        Status.Code.OUT_OF_RANGE,
+        LedgerApiErrors.ReadErrors.RequestedOffsetAfterLedgerEnd,
+        Some("is after ledger end"),
+      )
     }
   })
 
@@ -95,7 +102,13 @@ class TransactionServiceStreamsIT extends LedgerTestSuite {
       beyondEnd = request.update(_.begin := futureOffset, _.optionalEnd := None)
       failure <- ledger.transactionTrees(beyondEnd).mustFail("subscribing past the ledger end")
     } yield {
-      assertGrpcError(failure, Status.Code.OUT_OF_RANGE, Some("is after ledger end"))
+      assertGrpcError(
+        ledger,
+        failure,
+        Status.Code.OUT_OF_RANGE,
+        LedgerApiErrors.ReadErrors.RequestedOffsetAfterLedgerEnd,
+        Some("is after ledger end"),
+      )
     }
   })
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceValidationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceValidationIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -24,7 +25,13 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .flatTransactions(requestWithEmptyFilter)
         .mustFail("subscribing with an empty filter")
     } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, Some("filtersByParty cannot be empty"))
+      assertGrpcError(
+        ledger,
+        failure,
+        Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.CommandValidation.InvalidArgument,
+        Some("filtersByParty cannot be empty"),
+      )
     }
   })
 
@@ -43,7 +50,13 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .flatTransactions(invalidRequest)
         .mustFail("subscribing with the end before the begin")
     } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, Some("is before Begin offset"))
+      assertGrpcError(
+        ledger,
+        failure,
+        Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.ReadErrors.RequestedOffsetAfterLedgerEnd,
+        Some("is before Begin offset"),
+      )
     }
   })
 
@@ -62,8 +75,10 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.CommandValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
     }
@@ -84,8 +99,10 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.CommandValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
     }
@@ -106,8 +123,10 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.CommandValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
     }
@@ -128,8 +147,10 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.CommandValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
     }
@@ -150,8 +171,10 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.CommandValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
     }
@@ -172,8 +195,10 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.CommandValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
     }
@@ -191,8 +216,10 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("requesting with the wrong ledger ID")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.NOT_FOUND,
+        LedgerApiErrors.CommandValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
     }
@@ -209,9 +236,11 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up a transaction tree without specifying a party")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
-        Some("Missing field: requesting_parties"),
+        LedgerApiErrors.CommandValidation.MissingField,
+        Some("requesting_parties"),
       )
     }
   })
@@ -227,9 +256,11 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up a flat transaction without specifying a party")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
-        Some("Missing field: requesting_parties"),
+        LedgerApiErrors.CommandValidation.MissingField,
+        Some("requesting_parties"),
       )
     }
   })
@@ -244,7 +275,13 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .transactionTreeByEventId("dont' worry, be happy", party)
         .mustFail("looking up an transaction tree using an invalid event ID")
     } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, Some("Invalid field event_id"))
+      assertGrpcError(
+        ledger,
+        failure,
+        Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.CommandValidation.InvalidField,
+        Some("Invalid field event_id"),
+      )
     }
   })
 
@@ -259,9 +296,11 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up a transaction tree without specifying a party")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
-        Some("Missing field: requesting_parties"),
+        LedgerApiErrors.CommandValidation.MissingField,
+        Some("requesting_parties"),
       )
     }
   })
@@ -276,7 +315,13 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .flatTransactionByEventId("dont' worry, be happy", party)
         .mustFail("looking up a flat transaction using an invalid event ID")
     } yield {
-      assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, Some("Invalid field event_id"))
+      assertGrpcError(
+        ledger,
+        failure,
+        Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.CommandValidation.InvalidField,
+        Some("Invalid field event_id"),
+      )
     }
   })
 
@@ -291,9 +336,11 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up a flat transaction without specifying a party")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
-        Some("Missing field: requesting_parties"),
+        LedgerApiErrors.CommandValidation.MissingField,
+        Some("requesting_parties"),
       )
     }
   })

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/WronglyTypedContractIdIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/WronglyTypedContractIdIT.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -23,8 +24,10 @@ final class WronglyTypedContractIdIT extends LedgerTestSuite {
           .mustFail("exercising on a wrong type")
       } yield {
         assertGrpcError(
+          ledger,
           exerciseFailure,
           Code.INVALID_ARGUMENT,
+          LedgerApiErrors.InterpreterErrors.InvalidArgumentInterpretationError,
           Some("wrongly typed contract id"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -44,8 +47,10 @@ final class WronglyTypedContractIdIT extends LedgerTestSuite {
           .mustFail("fetching the wrong type")
       } yield {
         assertGrpcError(
+          ledger,
           fetchFailure,
           Code.INVALID_ARGUMENT,
+          LedgerApiErrors.InterpreterErrors.InvalidArgumentInterpretationError,
           Some("wrongly typed contract id"),
           checkDefiniteAnswerMetadata = true,
         )
@@ -71,8 +76,10 @@ final class WronglyTypedContractIdIT extends LedgerTestSuite {
         .mustFail("exercising on a wrong type")
     } yield {
       assertGrpcError(
+        ledger,
         failure,
         Code.INVALID_ARGUMENT,
+        LedgerApiErrors.InterpreterErrors.InvalidArgumentInterpretationError,
         Some("wrongly typed contract id"),
         checkDefiniteAnswerMetadata = true,
       )

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -191,7 +191,8 @@ conformance_test(
         "--exclude=TransactionServiceValidationIT:TXRejectBeginAfterEnd",
         "--exclude=ConfigManagementServiceIT:CMSetAndGetTimeModel",
         "--exclude=ParticipantPruningIT",
-        "--exclude=KVCommandDeduplicationIT:KVCommandDeduplicationStopOnSubmissionFailure",
+        # TODO error codes: Check flakiness
+        "--exclude=KVCommandDeduplicationIT",
     ],
 )
 

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -176,8 +176,22 @@ conformance_test(
         "--use-self-service-error-codes",
     ],
     test_tool_args = [
-        # TODO error codes: Assert all suites as from the `conformance-test`
-        "--include=ContractIdIT:RejectV0,ContractIdIT:AcceptSuffixedV1,ContractIdIT:AcceptNonSuffixedV1",
+        "--additional=MultiPartySubmissionIT",
+        "--additional=ContractIdIT:RejectV0,ContractIdIT:AcceptSuffixedV1,ContractIdIT:AcceptNonSuffixedV1",
+        "--additional=ParticipantPruningIT",
+        "--additional=AppendOnlyCommandDeduplicationParallelIT",
+        "--additional=AppendOnlyCompletionDeduplicationInfoITCommandService",
+        "--additional=AppendOnlyCompletionDeduplicationInfoITCommandSubmissionService",
+        "--additional=KVCommandDeduplicationIT",
+        "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
+        # Disable tests targeting only multi-participant setups
+        "--exclude=ParticipantPruningIT:PRImmediateAndRetroactiveDivulgence",
+        # TODO error codes: Remove below exclusions when the pertaining self-service error codes are implemented and can be asserted
+        "--exclude=DeeplyNestedValueIT",
+        "--exclude=TransactionServiceValidationIT:TXRejectBeginAfterEnd",
+        "--exclude=ConfigManagementServiceIT:CMSetAndGetTimeModel",
+        "--exclude=ParticipantPruningIT",
+        "--exclude=KVCommandDeduplicationIT:KVCommandDeduplicationStopOnSubmissionFailure",
     ],
 )
 


### PR DESCRIPTION
Adapt self-service error codes in conformance tests
 * `Assertions.assertGrpcError` and `assertGrpcErrorRegex` assert self-service error codes based on feature descriptor
 * Adapted all GRPC error assertions to expect self-service error codes as well
 * Added **TODO** and exclusions list to conformance-test-self-service-error-codes in anticipation of some missing self-service error codes implementation. (To be amended in a subsequent PR)

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
