### PR TITLE
Switch back to binary execution logs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,12 +31,12 @@ test:oracle --repo_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --tes
 # This will become the default in a future Bazel release.
 build --experimental_strict_action_env
 
-# Drop the heap size of Bazel to 3 GB and force TLS 1.2.
+# Drop the heap size of Bazel to 2 GB and force TLS 1.2.
 # With TLS 1.3, we run into the following error on Darwin.
 # > No subject alternative DNS name matching github-releases.githubusercontent.com found.
 # It looks like this is a result of SNI being broken on TLS 1.3 which results
 # in us getting a certificate for githubassets.com instead.
-startup --host_jvm_args=-Xms3g --host_jvm_args=-Xmx3g --host_jvm_args=-Djdk.tls.client.protocols=TLSv1.2
+startup --host_jvm_args=-Xms2g --host_jvm_args=-Xmx2g --host_jvm_args=-Djdk.tls.client.protocols=TLSv1.2
 
 # Enable sandboxing and caching for exclusive tests
 build --incompatible_exclusive_test_sandboxed

--- a/build.ps1
+++ b/build.ps1
@@ -64,7 +64,7 @@ bazel build //... `
   `-`-experimental_profile_include_target_label `
   `-`-build_event_json_file build-events.json `
   `-`-build_event_publish_all_actions `
-  `-`-execution_log_json_file ${ARTIFACT_DIRS}/logs/build_execution_windows.json
+  `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/logs/build_execution_windows.log
 
 bazel shutdown
 

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ bazel build //... \
   --experimental_profile_include_target_label \
   --build_event_json_file build-events.json \
   --build_event_publish_all_actions \
-  --execution_log_json_file "$ARTIFACT_DIRS/logs/build_execution${execution_log_postfix}.json"
+  --experimental_execution_log_file "$ARTIFACT_DIRS/logs/build_execution${execution_log_postfix}.log"
 
 # Set up a shared PostgreSQL instance.
 export POSTGRESQL_ROOT_DIR="${TMPDIR:-/tmp}/daml/postgresql"
@@ -79,7 +79,7 @@ bazel test //... \
   --experimental_profile_include_target_label \
   --build_event_json_file test-events.json \
   --build_event_publish_all_actions \
-  --execution_log_json_file "$ARTIFACT_DIRS/logs/test_execution${execution_log_postfix}.json"
+  --experimental_execution_log_file "$ARTIFACT_DIRS/logs/test_execution${execution_log_postfix}.log"
 
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' >/dev/null

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -31,12 +31,12 @@ test:oracle --repo_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --tes
 # This will become the default in a future Bazel release.
 build --experimental_strict_action_env
 
-# Drop the heap size of Bazel to 3 GB and force TLS 1.2.
+# Drop the heap size of Bazel to 2 GB and force TLS 1.2.
 # With TLS 1.3, we run into the following error on Darwin.
 # > No subject alternative DNS name matching github-releases.githubusercontent.com found.
 # It looks like this is a result of SNI being broken on TLS 1.3 which results
 # in us getting a certificate for githubassets.com instead.
-startup --host_jvm_args=-Xms3g --host_jvm_args=-Xmx3g --host_jvm_args=-Djdk.tls.client.protocols=TLSv1.2
+startup --host_jvm_args=-Xms2g --host_jvm_args=-Xmx2g --host_jvm_args=-Djdk.tls.client.protocols=TLSv1.2
 
 # Enable sandboxing and caching for exclusive tests
 build --incompatible_exclusive_test_sandboxed


### PR DESCRIPTION
We are seeing lots of OOM issues on Windows after having switched to
the JSON format. They seem to happen after the actual build has
happened while writing out the exec log so trying to revert back to
the binary format seems promising.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
