### PR TITLE
Bazel cache retry on connection reset by peer

### DIFF
--- a/nix/bazel-retry-cache.patch
+++ b/nix/bazel-retry-cache.patch
@@ -67,7 +67,7 @@ index 57741a8f28..6673149a20 100644
          workingDirectory,
          diskCachePath,
 diff --git a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
-index 350e1afa51..937dddd1b9 100644
+index 350e1afa51..db81481b60 100644
 --- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
 +++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
 @@ -59,9 +59,11 @@ import com.google.devtools.build.lib.exec.ModuleActionContextRegistry;
@@ -90,7 +90,7 @@ index 350e1afa51..937dddd1b9 100644
  import java.util.HashSet;
  import java.util.List;
  import java.util.Map;
-@@ -213,7 +216,26 @@ public final class RemoteModule extends BlazeModule {
+@@ -213,7 +216,31 @@ public final class RemoteModule extends BlazeModule {
                remoteOptions,
                creds,
                Preconditions.checkNotNull(env.getWorkingDirectory(), "workingDirectory"),
@@ -104,6 +104,11 @@ index 350e1afa51..937dddd1b9 100644
 +                     retry = true;
 +                   } else if (e instanceof HttpException) {
 +                     retry = true;
++                   } else if (e instanceof IOException) {
++                     String msg = e.getMessage().toLowerCase();
++                     if (msg.contains("connection reset by peer")) {
++                       retry = true;
++                     }
 +                   }
 +                   if (retry) {
 +                     System.err.println("RETRYING: " + e.toString());


### PR DESCRIPTION
@cocreature recently observed
```
NOT RETRYING: java.io.IOException: Connection reset by peer
```
in the Bazel build log.

This adds a case to our Bazel cache fetch retry patch to retry on this type of error as well.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
