### PR TITLE
Add cocreature as a codeowner of the docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -85,7 +85,7 @@ NOTICES     @garyverhaegen-da @aherrmann-da @cocreature @dasormeter
 /navigator/backend/src/main/scala/com/digitalasset/navigator/json/    @S11001001
 
 # Misc
-/docs/              @cocreature @stefanobaghino-da 
+/docs/              @cocreature @stefanobaghino-da
 /libs-scala/        @stefanobaghino-da @SamirTalwar-DA
 /libs-scala/contextualized-logging/    @S11001001
 /libs-scala/scala-utils/    @S11001001

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -85,7 +85,7 @@ NOTICES     @garyverhaegen-da @aherrmann-da @cocreature @dasormeter
 /navigator/backend/src/main/scala/com/digitalasset/navigator/json/    @S11001001
 
 # Misc
-/docs/              @bame-da @nemanja-da @cocreature
+/docs/              @cocreature @stefanobaghino-da 
 /libs-scala/        @stefanobaghino-da @SamirTalwar-DA
 /libs-scala/contextualized-logging/    @S11001001
 /libs-scala/scala-utils/    @S11001001

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -85,7 +85,7 @@ NOTICES     @garyverhaegen-da @aherrmann-da @cocreature @dasormeter
 /navigator/backend/src/main/scala/com/digitalasset/navigator/json/    @S11001001
 
 # Misc
-/docs/              @bame-da @nemanja-da
+/docs/              @bame-da @nemanja-da @cocreature
 /libs-scala/        @stefanobaghino-da @SamirTalwar-DA
 /libs-scala/contextualized-logging/    @S11001001
 /libs-scala/scala-utils/    @S11001001


### PR DESCRIPTION
Currently we have no active codeowner of the docs which is an
unfortunate situation since PRs just end up sitting until someone
happens to find it or someone else asks for a ping.

Not necessarily saying I’m the right one to review all docs but I can
at least make sure PRs advance.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
