### PR TITLE
Type reexports explicitly use 'type' namespace

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -336,16 +336,19 @@ generateSrcFromLf env = noLoc mod
             mkLIE = fmap noLoc . \case
                 LFC.ExportInfoVal name ->
                     IEVar NoExt
-                        <$> mkWrappedRdrName name
+                        <$> mkWrappedRdrName IEName name
                 LFC.ExportInfoTC name pieces fields ->
                     IEThingWith NoExt
-                        <$> mkWrappedRdrName name
+                        <$> mkWrappedRdrName IEType name
                         <*> pure NoIEWildcard
-                        <*> mapM mkWrappedRdrName pieces
+                        <*> mapM (mkWrappedRdrName IEName) pieces
                         <*> mapM mkFieldLblRdrName fields
 
-            mkWrappedRdrName :: LFC.QualName -> Gen (LIEWrappedName RdrName)
-            mkWrappedRdrName = fmap (noLoc . IEName . noLoc) . mkRdrName
+            mkWrappedRdrName ::
+                   (Located RdrName -> IEWrappedName RdrName)
+                -> LFC.QualName
+                -> Gen (LIEWrappedName RdrName)
+            mkWrappedRdrName f = fmap (noLoc . f . noLoc) . mkRdrName
 
             mkRdrName :: LFC.QualName -> Gen RdrName
             mkRdrName (LFC.QualName q) = do

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -1381,6 +1381,34 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             ]
         ]
 
+    , dataDependenciesTest "Using reexported type operators"
+        -- This test checks that we reconstruct reexported type operators properly.
+        [
+            (,) "Base.daml"
+            [ "{-# LANGUAGE TypeOperators #-}"
+            , "module Base (type (&) (..), type (+)) where"
+            , "data a & b = X ()"
+            , "type a + b = a & b"
+            ]
+        ,   (,) "Wrapper.daml"
+            [ "module Wrapper (module Base) where"
+            , "import Base"
+            ]
+        ]
+        [   (,) "Main.daml"
+            [ "{-# LANGUAGE TypeOperators #-}"
+            , "module Main where"
+            , "import Wrapper"
+            , "ampersand: Bool & Int"
+            , "ampersand = X ()"
+            , "plus: Int + Bool"
+            , "plus = X ()"
+            -- If reexported type operators were not imported correctly,
+            -- we'd get "missing type" or "expecting type constructor
+            -- but found a variable" errors from GHC.
+            ]
+        ]
+
     , testCaseSteps "User-defined exceptions" $ \step -> withTempDir $ \tmpDir -> do
         step "building project to be imported via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "lib")


### PR DESCRIPTION
This ensures that type operators are reexported correctly.

Closes #11447

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
