### PR TITLE
Adds default keepalive support for postgreSQL [DPP-697]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -33,6 +33,12 @@ case class IndexerConfig(
     schemaMigrationAttempts: Int = DefaultSchemaMigrationAttempts,
     schemaMigrationAttemptBackoff: FiniteDuration = DefaultSchemaMigrationAttemptBackoff,
     haConfig: HaConfig = HaConfig(),
+    // PostgresSQL specific configurations
+    // Setting aggressive keep-alive defaults to aid prompt release of the locks on the server side.
+    // For reference https://www.postgresql.org/docs/13/runtime-config-connection.html#RUNTIME-CONFIG-CONNECTION-SETTINGS
+    postgresTcpKeepalivesIdle: Option[Int] = Some(10),
+    postgresTcpKeepalivesInterval: Option[Int] = Some(1),
+    postgresTcpKeepalivesCount: Option[Int] = Some(5),
 )
 
 object IndexerConfig {

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -50,7 +50,10 @@ object JdbcIndexer {
               case AsynchronousCommit => PostgresDataSourceConfig.SynchronousCommitValue.Off
               case LocalSynchronousCommit =>
                 PostgresDataSourceConfig.SynchronousCommitValue.Local
-            })
+            }),
+            tcpKeepalivesIdle = config.postgresTcpKeepalivesIdle,
+            tcpKeepalivesInterval = config.postgresTcpKeepalivesInterval,
+            tcpKeepalivesCount = config.postgresTcpKeepalivesCount,
           )
         ),
         haConfig = config.haConfig,

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -67,7 +67,7 @@ object ParallelIndexerFactory {
             timer <- ResourceOwner.forTimer(() => new Timer)
             // this DataSource will be used to spawn the main connection where we keep the Indexer Main Lock
             // The life-cycle of such connections matches the life-cycle of a protectedExecution
-            dataSource = storageBackend.createDataSource(jdbcUrl)
+            dataSource = storageBackend.createDataSource(jdbcUrl, dataSourceConfig)
           } yield HaCoordinator.databaseLockBasedHaCoordinator(
             connectionFactory = () => dataSource.getConnection,
             storageBackend = storageBackend,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresDataSourceConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresDataSourceConfig.scala
@@ -6,7 +6,11 @@ package com.daml.platform.store.backend.postgresql
 import com.daml.platform.store.backend.postgresql.PostgresDataSourceConfig.SynchronousCommitValue
 
 case class PostgresDataSourceConfig(
-    synchronousCommit: Option[SynchronousCommitValue] = None
+    synchronousCommit: Option[SynchronousCommitValue] = None,
+    // TCP keepalive configuration for postgres. See https://www.postgresql.org/docs/13/runtime-config-connection.html#RUNTIME-CONFIG-CONNECTION-SETTINGS for details
+    tcpKeepalivesIdle: Option[Int] = None, // corresponds to: tcp_keepalives_idle
+    tcpKeepalivesInterval: Option[Int] = None, // corresponds to: tcp_keepalives_interval
+    tcpKeepalivesCount: Option[Int] = None, // corresponds to: tcp_keepalives_count
 )
 
 object PostgresDataSourceConfig {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackend.scala
@@ -238,6 +238,12 @@ private[backend] object PostgresStorageBackend
     val hookFunctions = List(
       dataSourceConfig.postgresConfig.synchronousCommit.toList
         .map(synchCommitValue => exe(s"SET synchronous_commit TO ${synchCommitValue.pgSqlName}")),
+      dataSourceConfig.postgresConfig.tcpKeepalivesIdle.toList
+        .map(i => exe(s"SET tcp_keepalives_idle TO $i")),
+      dataSourceConfig.postgresConfig.tcpKeepalivesInterval.toList
+        .map(i => exe(s"SET tcp_keepalives_interval TO $i")),
+      dataSourceConfig.postgresConfig.tcpKeepalivesCount.toList
+        .map(i => exe(s"SET tcp_keepalives_count TO $i")),
       connectionInitHook.toList,
     ).flatten
     InitHookDataSourceProxy(pgSimpleDataSource, hookFunctions)


### PR DESCRIPTION
Problem: default keep alive is inherited for the OS for postgres which takes 2h
until the server releases held locks in corner cases. This can cause the indexer
being unable to start up due to HA exclusion.

Solution: setting reasonably small settings for connections, which hold locks.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
