### PR TITLE
Fix invalid/misleading syntax in example docs

### DIFF
--- a/docs/source/daml/reference/updates.rst
+++ b/docs/source/daml/reference/updates.rst
@@ -181,7 +181,7 @@ Here's an example of a choice that uses a check on the current time:
 
 .. literalinclude:: ../code-snippets/Snippets.daml
    :language: daml
-   :lines: 42-46
+   :lines: 40-48
 
 .. _daml-ref-return:
 


### PR DESCRIPTION
The docs make it look like it's valid daml to write 

```haskell
  Complete : ()

        do
          -- bind the ledger effective time to the tchoose variable using getTime
          tchoose <- getTime
```
implying that binding a variable at the end of a do block is ok. This broadens the example to show the variable being used (it's possible that this was broken by a change to the snippets file)

This change now includes more context:

```Haskell
    controller party can
      -- A choice using a check on the current time
      Complete : ()

        do
          -- bind the ledger effective time to the tchoose variable using getTime
          tchoose <- getTime
          -- assert that tchoose is no earlier than the begin time
          assert (begin <= tchoose && tchoose < addRelTime begin period)
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
