### PR TITLE
Lift out constraint tuples to synonyms in dfun contexts

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -1409,6 +1409,29 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             ]
         ]
 
+    , simpleImportTest "Constraint synonym context on instance"
+        [ "{-# LANGUAGE UndecidableInstances #-}"
+        , "module Lib where"
+
+        , "class C a where c : a"
+        , "instance C () where c = ()"
+
+        , "class D a where d : a"
+        , "instance D () where d = ()"
+
+        , "type CD a = (C a, D a)"
+
+        , "class E a where e : (a, a)"
+        , "instance (CD a) => E a where e = (c, d)"
+        ]
+        [ "{-# LANGUAGE TypeOperators #-}"
+        , "module Main where"
+        , "import Lib"
+
+        , "x : ((), ())"
+        , "x = e"
+        ]
+
     , testCaseSteps "User-defined exceptions" $ \step -> withTempDir $ \tmpDir -> do
         step "building project to be imported via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "lib")


### PR DESCRIPTION
This is because otherwise GHC expands them out as regular constraints.

Closes #11455
Similar to #9663

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
