### PR TITLE
LF: Rename GenNode to Node

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -5,13 +5,7 @@ package com.daml.lf.engine
 
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.Party
-import com.daml.lf.transaction.Node.{
-  NodeRollback,
-  NodeCreate,
-  NodeExercises,
-  NodeFetch,
-  NodeLookupByKey,
-}
+import com.daml.lf.transaction.Node
 import com.daml.lf.transaction.{BlindingInfo, GenTransaction, NodeId, VersionedTransaction}
 import com.daml.lf.ledger._
 import com.daml.lf.data.Relation.Relation
@@ -69,11 +63,11 @@ object Blinding {
             go(filteredRoots :+ root, remainingRoots)
           } else {
             tx.nodes(root) match {
-              case nr: NodeRollback =>
+              case nr: Node.Rollback =>
                 go(filteredRoots, nr.children ++: remainingRoots)
-              case _: NodeFetch | _: NodeCreate | _: NodeLookupByKey =>
+              case _: Node.Fetch | _: Node.Create | _: Node.LookupByKey =>
                 go(filteredRoots, remainingRoots)
-              case ne: NodeExercises =>
+              case ne: Node.Exercise =>
                 go(filteredRoots, ne.children ++: remainingRoots)
             }
           }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -68,12 +68,12 @@ private[preprocessing] final class TransactionPreprocessor(
 
     val result = tx.roots.foldLeft(BackStack.empty[speedy.Command]) { (acc, id) =>
       tx.nodes.get(id) match {
-        case Some(node: Node.GenActionNode) =>
+        case Some(node: Node.Action) =>
           node match {
-            case create: Node.NodeCreate =>
+            case create: Node.Create =>
               val cmd = commandPreprocessor.unsafePreprocessCreate(create.templateId, create.arg)
               acc :+ cmd
-            case exe: Node.NodeExercises =>
+            case exe: Node.Exercise =>
               val cmd = exe.key match {
                 case Some(key) if exe.byKey =>
                   commandPreprocessor.unsafePreprocessExerciseByKey(
@@ -91,12 +91,12 @@ private[preprocessing] final class TransactionPreprocessor(
                   )
               }
               acc :+ cmd
-            case _: Node.NodeFetch =>
+            case _: Node.Fetch =>
               invalidRootNode(id, s"Transaction contains a fetch root node $id")
-            case _: Node.NodeLookupByKey =>
+            case _: Node.LookupByKey =>
               invalidRootNode(id, s"Transaction contains a lookup by key root node $id")
           }
-        case Some(_: Node.NodeRollback) =>
+        case Some(_: Node.Rollback) =>
           invalidRootNode(id, s"invalid transaction, root refers to a rollback node $id")
         case None =>
           invalidRootNode(id, s"invalid transaction, root refers to non-existing node $id")

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -30,7 +30,6 @@ import com.daml.lf.speedy.{InitialSeeding, SValue, svalue}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.command._
 import com.daml.lf.engine.Error.Interpretation
-import com.daml.lf.transaction.Node.{GenActionNode, GenNode}
 import com.daml.lf.transaction.test.TransactionBuilder.assertAsVersionedContract
 import org.scalactic.Equality
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -565,7 +564,7 @@ class EngineTest
     }
 
     "mark all the exercise nodes as performed byKey" in {
-      val expectedNodes = tx.nodes.collect { case (id, _: Node.NodeExercises) =>
+      val expectedNodes = tx.nodes.collect { case (id, _: Node.Exercise) =>
         id
       }
       val actualNodes = byKeyNodes(tx)
@@ -791,8 +790,8 @@ class EngineTest
       tx.roots should have length 2
       tx.nodes.keySet.toList should have length 2
       val ImmArray(create, exercise) = tx.roots.map(tx.nodes)
-      create shouldBe a[Node.NodeCreate]
-      exercise shouldBe a[Node.NodeExercises]
+      create shouldBe a[Node.Create]
+      exercise shouldBe a[Node.Exercise]
     }
 
     "reinterpret to the same result" in {
@@ -1090,7 +1089,7 @@ class EngineTest
       val bobView = Blinding.divulgedTransaction(blindingInfo.disclosure, bob, tx.transaction)
       bobView.nodes.size shouldBe 2
       findNodeByIdx(bobView.nodes, 0).getOrElse(fail("node not found")) match {
-        case Node.NodeExercises(
+        case Node.Exercise(
               coid,
               _,
               choice,
@@ -1115,7 +1114,7 @@ class EngineTest
       }
 
       findNodeByIdx(bobView.nodes, 1).getOrElse(fail("node not found")) match {
-        case create: Node.NodeCreate =>
+        case create: Node.Create =>
           create.templateId shouldBe templateId
           create.stakeholders shouldBe Set(alice, clara)
         case _ => fail("create event is expected")
@@ -1127,7 +1126,7 @@ class EngineTest
 
       claraView.nodes.size shouldBe 1
       findNodeByIdx(claraView.nodes, 1).getOrElse(fail("node not found")) match {
-        case create: Node.NodeCreate =>
+        case create: Node.Create =>
           create.templateId shouldBe templateId
           create.stakeholders shouldBe Set(alice, clara)
         case _ => fail("create event is expected")
@@ -1189,9 +1188,9 @@ class EngineTest
     val let = Time.Timestamp.now()
     val seeding = Engine.initialSeeding(submissionSeed, participant, let)
 
-    def actFetchActors(n: Node.GenNode): Set[Party] = {
+    def actFetchActors(n: Node): Set[Party] = {
       n match {
-        case Node.NodeFetch(_, _, actingParties, _, _, _, _, _) => actingParties
+        case Node.Fetch(_, _, actingParties, _, _, _, _, _) => actingParties
         case _ => Set()
       }
     }
@@ -1250,7 +1249,7 @@ class EngineTest
 
     "be retained when reinterpreting single fetch nodes" in {
       val Right((tx, txMeta)) = runExample(fetcher1Cid, clara)
-      val fetchNodes = tx.nodes.iterator.collect { case (nid, fetch: Node.NodeFetch) =>
+      val fetchNodes = tx.nodes.iterator.collect { case (nid, fetch: Node.Fetch) =>
         nid -> fetch
       }
 
@@ -1371,8 +1370,8 @@ class EngineTest
 
     def firstLookupNode(
         tx: GenTx
-    ): Option[(NodeId, Node.NodeLookupByKey)] =
-      tx.nodes.collectFirst { case (nid, nl @ Node.NodeLookupByKey(_, _, _, _)) =>
+    ): Option[(NodeId, Node.LookupByKey)] =
+      tx.nodes.collectFirst { case (nid, nl @ Node.LookupByKey(_, _, _, _)) =>
         nid -> nl
       }
 
@@ -1395,7 +1394,7 @@ class EngineTest
           lookupKey,
         )
 
-      val expectedByKeyNodes = tx.transaction.nodes.collect { case (id, _: Node.NodeLookupByKey) =>
+      val expectedByKeyNodes = tx.transaction.nodes.collect { case (id, _: Node.LookupByKey) =>
         id
       }
       val actualByKeyNodes = byKeyNodes(tx)
@@ -1577,7 +1576,7 @@ class EngineTest
         )
 
       tx.transaction.nodes.values.headOption match {
-        case Some(Node.NodeFetch(_, _, _, _, _, key, _, _)) =>
+        case Some(Node.Fetch(_, _, _, _, _, key, _, _)) =>
           key match {
             // just test that the maintainers match here, getting the key out is a bit hairier
             case Some(Node.KeyWithMaintainers(_, maintainers)) =>
@@ -1650,7 +1649,7 @@ class EngineTest
         )
 
       tx.transaction.nodes
-        .collectFirst { case (id, nf: Node.NodeFetch) =>
+        .collectFirst { case (id, nf: Node.Fetch) =>
           nf.key match {
             // just test that the maintainers match here, getting the key out is a bit hairier
             case Some(Node.KeyWithMaintainers(_, maintainers)) =>
@@ -1801,7 +1800,7 @@ class EngineTest
       val stx = suffix(tx)
 
       val ImmArray(_, exeNode1) = tx.transaction.roots
-      val Node.NodeExercises(_, _, _, _, _, _, _, _, _, children, _, _, _, _) =
+      val Node.Exercise(_, _, _, _, _, _, _, _, _, children, _, _, _, _) =
         tx.transaction.nodes(exeNode1)
       val nids = children.toSeq.take(2).toImmArray
 
@@ -1991,15 +1990,15 @@ class EngineTest
       )
       inside(run(command)) { case Right((tx, meta)) =>
         tx.nodes.size shouldBe 9
-        tx.nodes(NodeId(0)) shouldBe a[Node.NodeCreate]
-        tx.nodes(NodeId(1)) shouldBe a[Node.NodeExercises]
-        tx.nodes(NodeId(2)) shouldBe a[Node.NodeFetch]
-        tx.nodes(NodeId(3)) shouldBe a[Node.NodeLookupByKey]
-        tx.nodes(NodeId(4)) shouldBe a[Node.NodeCreate]
-        tx.nodes(NodeId(5)) shouldBe a[Node.NodeRollback]
-        tx.nodes(NodeId(6)) shouldBe a[Node.NodeFetch]
-        tx.nodes(NodeId(7)) shouldBe a[Node.NodeLookupByKey]
-        tx.nodes(NodeId(8)) shouldBe a[Node.NodeCreate]
+        tx.nodes(NodeId(0)) shouldBe a[Node.Create]
+        tx.nodes(NodeId(1)) shouldBe a[Node.Exercise]
+        tx.nodes(NodeId(2)) shouldBe a[Node.Fetch]
+        tx.nodes(NodeId(3)) shouldBe a[Node.LookupByKey]
+        tx.nodes(NodeId(4)) shouldBe a[Node.Create]
+        tx.nodes(NodeId(5)) shouldBe a[Node.Rollback]
+        tx.nodes(NodeId(6)) shouldBe a[Node.Fetch]
+        tx.nodes(NodeId(7)) shouldBe a[Node.LookupByKey]
+        tx.nodes(NodeId(8)) shouldBe a[Node.Create]
         meta.nodeSeeds.map(_._1.index) shouldBe ImmArray(0, 1, 4, 8)
       }
     }
@@ -2151,7 +2150,7 @@ object EngineTest {
   private def hash(s: String) = crypto.Hash.hashPrivateKey(s)
   private def participant = Ref.ParticipantId.assertFromString("participant")
   private def byKeyNodes(tx: VersionedTransaction) =
-    tx.nodes.collect { case (nodeId, node: GenActionNode) if node.byKey => nodeId }.toSet
+    tx.nodes.collect { case (nodeId, node: Node.Action) if node.byKey => nodeId }.toSet
 
   private val party = Party.assertFromString("Party")
   private val alice = Party.assertFromString("Alice")
@@ -2184,7 +2183,7 @@ object EngineTest {
     a
   }
 
-  private def findNodeByIdx[Cid](nodes: Map[NodeId, Node.GenNode], idx: Int) =
+  private def findNodeByIdx[Cid](nodes: Map[NodeId, Node], idx: Int) =
     nodes.collectFirst { case (nodeId, node) if nodeId.index == idx => node }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
@@ -2208,16 +2207,16 @@ object EngineTest {
   private[this] case class ReinterpretState(
       contracts: Map[ContractId, VersionedContractInstance],
       keys: Map[GlobalKey, ContractId],
-      nodes: HashMap[NodeId, GenNode] = HashMap.empty,
+      nodes: HashMap[NodeId, Node] = HashMap.empty,
       roots: BackStack[NodeId] = BackStack.empty,
       dependsOnTime: Boolean = false,
       nodeSeeds: BackStack[(NodeId, crypto.Hash)] = BackStack.empty,
   ) {
     def commit(tr: GenTx, meta: Tx.Metadata) = {
       val (newContracts, newKeys) = tr.fold((contracts, keys)) {
-        case ((contracts, keys), (_, exe: Node.NodeExercises)) =>
+        case ((contracts, keys), (_, exe: Node.Exercise)) =>
           (contracts - exe.targetCoid, keys)
-        case ((contracts, keys), (_, create: Node.NodeCreate)) =>
+        case ((contracts, keys), (_, create: Node.Create)) =>
           (
             contracts.updated(
               create.coid,
@@ -2262,21 +2261,21 @@ object EngineTest {
           for {
             state <- acc
             cmd = tx.transaction.nodes(nodeId) match {
-              case create: Node.NodeCreate =>
+              case create: Node.Create =>
                 CreateCommand(create.templateId, create.arg)
-              case fetch: Node.NodeFetch if fetch.byKey =>
+              case fetch: Node.Fetch if fetch.byKey =>
                 val key = fetch.key.getOrElse(sys.error("unexpected empty contract key")).key
                 FetchByKeyCommand(fetch.templateId, key)
-              case fetch: Node.NodeFetch =>
+              case fetch: Node.Fetch =>
                 FetchCommand(fetch.templateId, fetch.coid)
-              case lookup: Node.NodeLookupByKey =>
+              case lookup: Node.LookupByKey =>
                 LookupByKeyCommand(lookup.templateId, lookup.key.key)
-              case exe: Node.NodeExercises if exe.byKey =>
+              case exe: Node.Exercise if exe.byKey =>
                 val key = exe.key.getOrElse(sys.error("unexpected empty contract key")).key
                 ExerciseByKeyCommand(exe.templateId, key, exe.choiceId, exe.chosenValue)
-              case exe: Node.NodeExercises =>
+              case exe: Node.Exercise =>
                 ExerciseCommand(exe.templateId, exe.targetCoid, exe.choiceId, exe.chosenValue)
-              case _: Node.NodeRollback =>
+              case _: Node.Rollback =>
                 sys.error("unexpected rollback node")
             }
             currentStep <- engine

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -12,12 +12,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
 import com.daml.lf.language.Ast
 import com.daml.lf.scenario.ScenarioLedger
-import com.daml.lf.transaction.{
-  Node => N,
-  SubmittedTransaction,
-  VersionedTransaction,
-  Transaction => Tx,
-}
+import com.daml.lf.transaction.{Node, SubmittedTransaction, VersionedTransaction}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value._
 import com.daml.lf.command._
@@ -150,8 +145,8 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
         seed = hash("testLargeTransactionOneContract:create", txSize),
       )
     val contractId = firstRootNode(createCmdTx) match {
-      case create: N.NodeCreate => create.coid
-      case n => fail(s"Expected NodeCreate, but got: $n")
+      case create: Node.Create => create.coid
+      case n => fail(s"Expected Node.Create, but got: $n")
     }
     val exerciseCmd = toListContainerExerciseCmd(rangeOfIntsTemplateId, contractId)
     val (exerciseCmdTx, quanity) = measureWithResult(
@@ -181,8 +176,8 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
         seed = hash("testLargeTransactionManySmallContracts:create", num),
       )
     val contractId = firstRootNode(createCmdTx) match {
-      case create: N.NodeCreate => create.coid
-      case n @ _ => fail(s"Expected NodeCreate, but got: $n")
+      case create: Node.Create => create.coid
+      case n @ _ => fail(s"Expected Node.Create, but got: $n")
     }
     val exerciseCmd = toListOfIntContainers(rangeOfIntsTemplateId, contractId)
     val (exerciseCmdTx, quanity) = measureWithResult(
@@ -212,8 +207,8 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
         seed = hash("testLargeChoiceArgument:create", size),
       )
     val contractId = firstRootNode(createCmdTx) match {
-      case create: N.NodeCreate => create.coid
-      case n @ _ => fail(s"Expected NodeCreate, but got: $n")
+      case create: Node.Create => create.coid
+      case n @ _ => fail(s"Expected Node.Create, but got: $n")
     }
     val exerciseCmd = sizeExerciseCmd(listUtilTemplateId, contractId)(size)
     val (exerciseCmdTx, quantity) = measureWithResult(
@@ -252,14 +247,14 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
       expectedNumberOfContracts: Int,
   ): Assertion = {
 
-    val newContracts: List[N.GenNode] =
+    val newContracts: List[Node] =
       firstRootNode(exerciseCmdTx) match {
-        case ne: N.NodeExercises => ne.children.toList.map(nid => exerciseCmdTx.nodes(nid))
+        case ne: Node.Exercise => ne.children.toList.map(nid => exerciseCmdTx.nodes(nid))
         case n @ _ => fail(s"Unexpected match: $n")
       }
 
     newContracts.count {
-      case _: N.NodeCreate => true
+      case _: Node.Create => true
       case n @ _ => fail(s"Unexpected match: $n")
     } shouldBe expectedNumberOfContracts
   }
@@ -397,18 +392,18 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
     exerciseCmdTx.roots.length shouldBe 1
     exerciseCmdTx.nodes.size shouldBe 2
 
-    val createNode: N.GenNode = firstRootNode(exerciseCmdTx) match {
-      case ne: N.NodeExercises => exerciseCmdTx.nodes(ne.children.head)
+    val createNode: Node = firstRootNode(exerciseCmdTx) match {
+      case ne: Node.Exercise => exerciseCmdTx.nodes(ne.children.head)
       case n @ _ => fail(s"Unexpected match: $n")
     }
 
     createNode match {
-      case create: N.NodeCreate => create.arg
+      case create: Node.Create => create.arg
       case n @ _ => fail(s"Unexpected match: $n")
     }
   }
 
-  private def firstRootNode(tx: VersionedTransaction): Tx.Node = tx.nodes(tx.roots.head)
+  private def firstRootNode(tx: VersionedTransaction): Node = tx.nodes(tx.roots.head)
 
   private def measureWithResult[R](body: => R): (R, Quantity[Double]) = {
     lazy val result: R = body

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -66,7 +66,7 @@ object BlindingTransaction {
         nodeId: NodeId,
     ): BlindState =
       tx.nodes.get(nodeId) match {
-        case Some(action: Node.GenActionNode) =>
+        case Some(action: Node.Action) =>
           val witnesses = parentExerciseWitnesses union action.informeesOfNode
 
           // actions of every type are disclosed to their witnesses
@@ -74,16 +74,16 @@ object BlindingTransaction {
 
           action match {
 
-            case _: Node.NodeCreate => state
-            case _: Node.NodeLookupByKey => state
+            case _: Node.Create => state
+            case _: Node.LookupByKey => state
 
             // fetch & exercise nodes cause divulgence
 
-            case fetch: Node.NodeFetch =>
+            case fetch: Node.Fetch =>
               state
                 .divulgeCoidTo(parentExerciseWitnesses -- fetch.stakeholders, fetch.coid)
 
-            case ex: Node.NodeExercises =>
+            case ex: Node.Exercise =>
               val state1 =
                 state.divulgeCoidTo(
                   (parentExerciseWitnesses union ex.choiceObservers) -- ex.stakeholders,
@@ -98,7 +98,7 @@ object BlindingTransaction {
                 )
               }
           }
-        case Some(rollback: Node.NodeRollback) =>
+        case Some(rollback: Node.Rollback) =>
           // Rollback nodes are disclosed to the witnesses of the parent exercise.
           val state = state0.discloseNode(parentExerciseWitnesses, nodeId)
           rollback.children.foldLeft(state) { (s, childNodeId) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -7,11 +7,11 @@ package scenario
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
 import com.daml.lf.ledger._
-import com.daml.lf.transaction.Node._
 import com.daml.lf.transaction.{
   BlindingInfo,
   CommittedTransaction,
   GlobalKey,
+  Node,
   NodeId,
   SubmittedTransaction,
   Transaction => Tx,
@@ -46,12 +46,6 @@ object ScenarioLedger {
 
   def throwLedgerError(err: Error) =
     throw LedgerException(err)
-
-  /** The node of the transaction graph. Only differs from the update
-    * transaction node in the node identifier, where here the identifier
-    * is an eventId.
-    */
-  type Node = GenNode
 
   /** A transaction as it is committed to the ledger.
     *
@@ -463,7 +457,7 @@ object ScenarioLedger {
                   val idsToProcess = processingNode.copy(children = restOfNodeIds) :: restENPs
 
                   node match {
-                    case rollback: NodeRollback =>
+                    case rollback: Node.Rollback =>
                       val rollbackState =
                         RollbackBeginState(eventId, newCache.activeContracts, newCache.activeKeys)
                       processNodes(
@@ -475,7 +469,7 @@ object ScenarioLedger {
                         ) :: idsToProcess,
                       )
 
-                    case nc: NodeCreate =>
+                    case nc: Node.Create =>
                       val newCache1 =
                         newCache
                           .markAsActive(nc.coid)
@@ -491,7 +485,7 @@ object ScenarioLedger {
                       }
                       processNodes(mbNewCache2, idsToProcess)
 
-                    case NodeFetch(referencedCoid, templateId @ _, _, _, _, _, _, _) =>
+                    case Node.Fetch(referencedCoid, templateId @ _, _, _, _, _, _, _) =>
                       val newCacheP =
                         newCache.updateLedgerNodeInfo(referencedCoid)(info =>
                           info.copy(referencedBy = info.referencedBy + eventId)
@@ -499,7 +493,7 @@ object ScenarioLedger {
 
                       processNodes(Right(newCacheP), idsToProcess)
 
-                    case ex: NodeExercises =>
+                    case ex: Node.Exercise =>
                       val newCache0 =
                         newCache.updateLedgerNodeInfo(ex.targetCoid)(info =>
                           info.copy(
@@ -517,7 +511,7 @@ object ScenarioLedger {
                           val nc = newCache0_1
                             .nodeInfoByCoid(ex.targetCoid)
                             .node
-                            .asInstanceOf[NodeCreate]
+                            .asInstanceOf[Node.Create]
                           nc.key match {
                             case None => newCache0_1
                             case Some(keyWithMaintainers) =>
@@ -532,7 +526,7 @@ object ScenarioLedger {
                         ProcessingNode(Some(nodeId), ex.children.toList, None) :: idsToProcess,
                       )
 
-                    case nlkup: NodeLookupByKey =>
+                    case nlkup: Node.LookupByKey =>
                       nlkup.result match {
                         case None =>
                           processNodes(Right(newCache), idsToProcess)
@@ -654,7 +648,7 @@ case class ScenarioLedger(
       case None => LookupContractNotFound(coid)
       case Some(info) =>
         info.node match {
-          case create: NodeCreate =>
+          case create: Node.Create =>
             if (info.effectiveAt.compareTo(effectiveAt) > 0)
               LookupContractNotEffective(coid, create.templateId, info.effectiveAt)
             else if (info.consumedBy.nonEmpty)
@@ -673,7 +667,7 @@ case class ScenarioLedger(
             else
               LookupOk(coid, create.versionedCoinst, create.stakeholders)
 
-          case _: NodeExercises | _: NodeFetch | _: NodeLookupByKey | _: NodeRollback =>
+          case _: Node.Exercise | _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback =>
             LookupContractNotFound(coid)
         }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/CheckAuthorization.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/CheckAuthorization.scala
@@ -7,7 +7,7 @@ package speedy
 import com.daml.lf.data.Ref.Location
 import com.daml.lf.ledger.Authorize
 import com.daml.lf.ledger.FailedAuthorization
-import com.daml.lf.transaction.Node.{NodeCreate, NodeFetch, NodeLookupByKey, NodeExercises}
+import com.daml.lf.transaction.Node
 
 private[lf] object CheckAuthorization {
 
@@ -24,7 +24,7 @@ private[lf] object CheckAuthorization {
 
   private[lf] def authorizeCreate(
       optLocation: Option[Location],
-      create: NodeCreate,
+      create: Node.Create,
   )(
       auth: Authorize
   ): List[FailedAuthorization] = {
@@ -59,7 +59,7 @@ private[lf] object CheckAuthorization {
 
   private[lf] def authorizeFetch(
       optLocation: Option[Location],
-      fetch: NodeFetch,
+      fetch: Node.Fetch,
   )(
       auth: Authorize
   ): List[FailedAuthorization] = {
@@ -76,7 +76,7 @@ private[lf] object CheckAuthorization {
 
   private[lf] def authorizeLookupByKey(
       optLocation: Option[Location],
-      lbk: NodeLookupByKey,
+      lbk: Node.LookupByKey,
   )(
       auth: Authorize
   ): List[FailedAuthorization] = {
@@ -93,7 +93,7 @@ private[lf] object CheckAuthorization {
 
   private[lf] def authorizeExercise(
       optLocation: Option[Location],
-      ex: NodeExercises,
+      ex: Node.Exercise,
   )(
       auth: Authorize
   ): List[FailedAuthorization] = {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -34,7 +34,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   private[this] def contractIdsInOrder(ptx: PartialTransaction): Seq[Value.ContractId] = {
     inside(ptx.finish) { case CompleteTransaction(tx, _, _) =>
       tx.fold(Vector.empty[Value.ContractId]) {
-        case (acc, (_, create: Node.NodeCreate)) => acc :+ create.coid
+        case (acc, (_, create: Node.Create)) => acc :+ create.coid
         case (acc, _) => acc
       }
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -10,11 +10,11 @@ import com.daml.lf.data.Ref.Party
 import com.daml.lf.language.Ast.{Package, Expr, PrimLit, PLParty, EPrimLit, EApp}
 import com.daml.lf.language.{LanguageVersion, PackageInterface}
 import com.daml.lf.speedy.Compiler.FullStackTrace
-import com.daml.lf.speedy.PartialTransaction.{CompleteTransaction, IncompleteTransaction, LeafNode}
+import com.daml.lf.speedy.PartialTransaction.{CompleteTransaction, IncompleteTransaction}
 import com.daml.lf.speedy.SResult.SResultFinalValue
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.testing.parser.ParserParameters
-import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises, NodeRollback}
+import com.daml.lf.transaction.Node
 import com.daml.lf.transaction.NodeId
 import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.lf.validation.Validation
@@ -262,18 +262,18 @@ object ExceptionTest {
   private def shapeOfTransaction(tx: SubmittedTransaction): List[Tree] = {
     def trees(nid: NodeId): List[Tree] = {
       tx.nodes(nid) match {
-        case create: NodeCreate =>
+        case create: Node.Create =>
           create.arg match {
             case ValueRecord(_, ImmArray(_, (None, ValueInt64(n)))) =>
               List(C(n))
             case _ =>
               sys.error(s"unexpected create.arg: ${create.arg}")
           }
-        case _: LeafNode =>
+        case _: Node.LeafOnlyAction =>
           Nil
-        case node: NodeExercises =>
+        case node: Node.Exercise =>
           List(X(node.children.toList.flatMap(nid => trees(nid))))
-        case node: NodeRollback =>
+        case node: Node.Rollback =>
           List(R(node.children.toList.flatMap(nid => trees(nid))))
       }
     }

--- a/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/TransactionNormalizer.scala
+++ b/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/TransactionNormalizer.scala
@@ -20,9 +20,9 @@ object TransactionNormalizer {
         (acc, _, _) => (acc, false),
         (acc, nid, node) =>
           node match {
-            case _: Node.NodeCreate => acc + nid
-            case _: Node.NodeFetch => acc
-            case _: Node.NodeLookupByKey => acc
+            case _: Node.Create => acc + nid
+            case _: Node.Fetch => acc
+            case _: Node.LookupByKey => acc
           },
         (acc, _, _) => acc,
         (acc, _, _) => acc,
@@ -31,9 +31,9 @@ object TransactionNormalizer {
       tx.nodes
         .filter { case (nid, _) => keepNids.contains(nid) }
         .transform {
-          case (_, node: Node.NodeExercises) =>
+          case (_, node: Node.Exercise) =>
             node.copy(children = node.children.filter(keepNids.contains))
-          case (_, node: Node.NodeRollback) =>
+          case (_, node: Node.Rollback) =>
             node.copy(children = node.children.filter(keepNids.contains))
           case (_, keep) =>
             keep

--- a/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/TransactionNormalizerSpec.scala
+++ b/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/TransactionNormalizerSpec.scala
@@ -4,7 +4,6 @@
 package com.daml.lf.kv
 
 import com.daml.lf.transaction._
-import com.daml.lf.transaction.Node._
 import org.scalatest.wordspec.AnyWordSpec
 import com.daml.lf.value.test.ValueGenerators._
 import org.scalatest.matchers.should.Matchers
@@ -82,24 +81,24 @@ class TransactionNormalizerSpec
     }
   }
 
-  def isCreateOrExercise(node: GenNode): Boolean = {
+  def isCreateOrExercise(node: Node): Boolean = {
     node match {
-      case _: NodeExercises => true
-      case _: NodeCreate => true
+      case _: Node.Exercise => true
+      case _: Node.Create => true
       case _ => false
     }
   }
 
-  def nodeSansChildren(node: GenNode): GenNode = {
+  def nodeSansChildren(node: Node): Node = {
     node match {
-      case exe: NodeExercises => exe.copy(children = ImmArray.Empty)
+      case exe: Node.Exercise => exe.copy(children = ImmArray.Empty)
       case _ => node
     }
   }
 
-  def nodeChildren(node: GenNode): List[NodeId] = {
+  def nodeChildren(node: Node): List[NodeId] = {
     node match {
-      case exe: NodeExercises => exe.children.toList
+      case exe: Node.Exercise => exe.children.toList
       case _ => List()
     }
   }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
@@ -6,16 +6,6 @@ package transaction
 
 import com.daml.lf.value.{Value => Val}
 
-import com.daml.lf.transaction.Node.{
-  KeyWithMaintainers,
-  GenNode,
-  NodeCreate,
-  NodeFetch,
-  NodeLookupByKey,
-  NodeExercises,
-  NodeRollback,
-}
-
 class Normalization {
 
   /** This class provides methods to normalize a transaction and embedded values.
@@ -38,8 +28,7 @@ class Normalization {
     * longer need this separate normalization pass.
     */
 
-  private type KWM = KeyWithMaintainers[Val]
-  private type Node = GenNode
+  private type KWM = Node.KeyWithMaintainers[Val]
   private type VTX = VersionedTransaction
 
   def normalizeTx(vtx: VTX): VTX = {
@@ -61,12 +50,12 @@ class Normalization {
     import scala.Ordering.Implicits.infixOrderingOps
     node match {
 
-      case old: NodeCreate =>
+      case old: Node.Create =>
         old
           .copy(arg = normValue(old.version)(old.arg))
           .copy(key = old.key.map(normKWM(old.version)))
 
-      case old: NodeFetch =>
+      case old: Node.Fetch =>
         (if (old.version >= TransactionVersion.minByKey) {
            old
          } else {
@@ -76,7 +65,7 @@ class Normalization {
             key = old.key.map(normKWM(old.version))
           )
 
-      case old: NodeExercises =>
+      case old: Node.Exercise =>
         (if (old.version >= TransactionVersion.minByKey) {
            old
          } else {
@@ -88,12 +77,12 @@ class Normalization {
             key = old.key.map(normKWM(old.version)),
           )
 
-      case old: NodeLookupByKey =>
+      case old: Node.LookupByKey =>
         old.copy(
           key = normKWM(old.version)(old.key)
         )
 
-      case old: NodeRollback => old
+      case old: Node.Rollback => old
 
     }
   }
@@ -104,8 +93,8 @@ class Normalization {
 
   private def normKWM(version: TransactionVersion)(x: KWM): KWM = {
     x match {
-      case KeyWithMaintainers(key, maintainers) =>
-        KeyWithMaintainers(normValue(version)(key), maintainers)
+      case Node.KeyWithMaintainers(key, maintainers) =>
+        Node.KeyWithMaintainers(normValue(version)(key), maintainers)
     }
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -7,7 +7,6 @@ package transaction
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
 import com.daml.lf.ledger.FailedAuthorization
-import com.daml.lf.transaction.Node.GenNode
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 
@@ -16,7 +15,7 @@ import scala.collection.immutable.HashMap
 
 final case class VersionedTransaction private[lf] (
     version: TransactionVersion,
-    nodes: Map[NodeId, GenNode],
+    nodes: Map[NodeId, Node],
     override val roots: ImmArray[NodeId],
 ) extends HasTxNodes
     with value.CidContainer[VersionedTransaction]
@@ -56,7 +55,7 @@ final case class VersionedTransaction private[lf] (
   * Therefore, it is '''forbidden''' to create ill-formed instances, i.e., instances with `!isWellFormed.isEmpty`.
   */
 final case class GenTransaction(
-    nodes: Map[NodeId, Node.GenNode],
+    nodes: Map[NodeId, Node],
     roots: ImmArray[NodeId],
 ) extends HasTxNodes
     with value.CidContainer[GenTransaction] {
@@ -103,7 +102,7 @@ final case class GenTransaction(
               go(newErrors + NotWellFormedError(nid, DanglingNodeId), newVisited, nids)
             case Some(node) =>
               node match {
-                case nr: Node.NodeRollback =>
+                case nr: Node.Rollback =>
                   go(
                     newErrors,
                     newVisited,
@@ -113,8 +112,8 @@ final case class GenTransaction(
                       nr.children ++: nids
                     },
                   )
-                case _: Node.LeafOnlyActionNode => go(newErrors, newVisited, nids)
-                case ne: Node.NodeExercises =>
+                case _: Node.LeafOnlyAction => go(newErrors, newVisited, nids)
+                case ne: Node.Exercise =>
                   go(
                     newErrors,
                     newVisited,
@@ -142,7 +141,7 @@ final case class GenTransaction(
     * Nid is irrelevant to the content of the transaction.
     */
   def compareForest(other: GenTransaction)(
-      compare: (Node.GenNode, Node.GenNode) => Boolean
+      compare: (Node, Node) => Boolean
   ): Boolean = {
     @tailrec
     def go(toCompare: FrontStack[(NodeId, NodeId)]): Boolean =
@@ -152,44 +151,44 @@ final case class GenTransaction(
           val node1 = nodes(nid1)
           val node2 = other.nodes(nid2)
           node1 match {
-            case nr1: Node.NodeRollback => //TODO: can this be NodeRollback ?
+            case nr1: Node.Rollback => //TODO: can this be Node.Rollback ?
               node2 match {
-                case nr2: Node.NodeRollback => //TODO: and here
-                  val blankedNr1: Node.NodeRollback =
+                case nr2: Node.Rollback => //TODO: and here
+                  val blankedNr1: Node.Rollback =
                     nr1.copy(children = ImmArray.Empty)
-                  val blankedNr2: Node.NodeRollback =
+                  val blankedNr2: Node.Rollback =
                     nr2.copy(children = ImmArray.Empty)
                   compare(blankedNr1, blankedNr2) &&
                   nr1.children.length == nr2.children.length &&
                   go(nr1.children.zip(nr2.children) ++: rest)
                 case _ => false
               }
-            case nf1: Node.NodeFetch =>
+            case nf1: Node.Fetch =>
               node2 match {
-                case nf2: Node.NodeFetch => compare(nf1, nf2) && go(rest)
+                case nf2: Node.Fetch => compare(nf1, nf2) && go(rest)
                 case _ => false
               }
-            case nc1: Node.NodeCreate =>
+            case nc1: Node.Create =>
               node2 match {
-                case nc2: Node.NodeCreate =>
+                case nc2: Node.Create =>
                   compare(nc1, nc2) && go(rest)
                 case _ => false
               }
-            case ne1: Node.NodeExercises =>
+            case ne1: Node.Exercise =>
               node2 match {
-                case ne2: Node.NodeExercises =>
-                  val blankedNe1: Node.NodeExercises =
+                case ne2: Node.Exercise =>
+                  val blankedNe1: Node.Exercise =
                     ne1.copy(children = ImmArray.Empty)
-                  val blankedNe2: Node.NodeExercises =
+                  val blankedNe2: Node.Exercise =
                     ne2.copy(children = ImmArray.Empty)
                   compare(blankedNe1, blankedNe2) &&
                   ne1.children.length == ne2.children.length &&
                   go(ne1.children.zip(ne2.children) ++: rest)
                 case _ => false
               }
-            case nl1: Node.NodeLookupByKey =>
+            case nl1: Node.LookupByKey =>
               node2 match {
-                case nl2: Node.NodeLookupByKey =>
+                case nl2: Node.LookupByKey =>
                   compare(nl1, nl2) && go(rest)
                 case _ => false
               }
@@ -207,16 +206,16 @@ final case class GenTransaction(
   def serializable(f: Value => ImmArray[String]): ImmArray[String] = {
     fold(BackStack.empty[String]) { case (errs, (_, node)) =>
       node match {
-        case Node.NodeRollback(_) =>
+        case Node.Rollback(_) =>
           errs
-        case _: Node.NodeFetch => errs
-        case nc: Node.NodeCreate =>
+        case _: Node.Fetch => errs
+        case nc: Node.Create =>
           errs :++ f(nc.arg) :++ (nc.key match {
             case None => ImmArray.Empty
             case Some(key) => f(key.key)
           })
-        case ne: Node.NodeExercises => errs :++ f(ne.chosenValue)
-        case nlbk: Node.NodeLookupByKey => errs :++ f(nlbk.key.key)
+        case ne: Node.Exercise => errs :++ f(ne.chosenValue)
+        case nlbk: Node.LookupByKey => errs :++ f(nlbk.key.key)
       }
     }.toImmArray
   }
@@ -225,18 +224,18 @@ final case class GenTransaction(
   def foldValues[Z](z: Z)(f: (Z, Value) => Z): Z =
     fold(z) { case (z, (_, n)) =>
       n match {
-        case Node.NodeRollback(_) =>
+        case Node.Rollback(_) =>
           z
-        case c: Node.NodeCreate =>
+        case c: Node.Create =>
           val z1 = f(z, c.arg)
           val z2 = c.key match {
             case None => z1
             case Some(k) => f(z1, k.key)
           }
           z2
-        case nf: Node.NodeFetch => nf.key.fold(z)(k => f(z, k.key))
-        case e: Node.NodeExercises => f(z, e.chosenValue)
-        case lk: Node.NodeLookupByKey => f(z, lk.key.key)
+        case nf: Node.Fetch => nf.key.fold(z)(k => f(z, k.key))
+        case e: Node.Exercise => f(z, e.chosenValue)
+        case lk: Node.LookupByKey => f(z, lk.key.key)
       }
     }
 
@@ -258,15 +257,15 @@ sealed abstract class HasTxNodes {
     InconsistentKeys,
   }
 
-  def nodes: Map[NodeId, Node.GenNode]
+  def nodes: Map[NodeId, Node]
 
   def roots: ImmArray[NodeId]
 
   /** The union of the informees of a all the action nodes. */
   lazy val informees: Set[Ref.Party] =
     nodes.values.foldLeft(Set.empty[Ref.Party]) {
-      case (acc, node: Node.GenActionNode) => acc | node.informeesOfNode
-      case (acc, _: Node.NodeRollback) => acc
+      case (acc, node: Node.Action) => acc | node.informeesOfNode
+      case (acc, _: Node.Rollback) => acc
     }
 
   // We assume that rollback node cannot be a root of a transaction.
@@ -274,12 +273,12 @@ sealed abstract class HasTxNodes {
   // Canton handles rollback nodes itself so this is assumption still holds
   // within the Engine.
   @throws[IllegalArgumentException]
-  def rootNodes: ImmArray[Node.GenActionNode] =
+  def rootNodes: ImmArray[Node.Action] =
     roots.map(nid =>
       nodes(nid) match {
-        case action: Node.GenActionNode =>
+        case action: Node.Action =>
           action
-        case _: Node.NodeRollback =>
+        case _: Node.Rollback =>
           throw new IllegalArgumentException(
             s"invalid transaction, root refers to a Rollback node $nid"
           )
@@ -290,7 +289,7 @@ sealed abstract class HasTxNodes {
     *
     * Takes constant stack space. Crashes if the transaction is not well formed (see `isWellFormed`)
     */
-  final def foreach(f: (NodeId, Node.GenNode) => Unit): Unit = {
+  final def foreach(f: (NodeId, Node) => Unit): Unit = {
 
     @tailrec
     def go(toVisit: FrontStack[NodeId]): Unit = toVisit match {
@@ -299,9 +298,9 @@ sealed abstract class HasTxNodes {
         val node = nodes(nodeId)
         f(nodeId, node)
         node match {
-          case nr: Node.NodeRollback => go(nr.children ++: toVisit)
-          case _: Node.LeafOnlyActionNode => go(toVisit)
-          case ne: Node.NodeExercises => go(ne.children ++: toVisit)
+          case nr: Node.Rollback => go(nr.children ++: toVisit)
+          case _: Node.LeafOnlyAction => go(toVisit)
+          case ne: Node.Exercise => go(ne.children ++: toVisit)
         }
     }
 
@@ -312,7 +311,7 @@ sealed abstract class HasTxNodes {
     *
     * Takes constant stack space. Crashes if the transaction is not well formed (see `isWellFormed`)
     */
-  final def fold[A](z: A)(f: (A, (NodeId, Node.GenNode)) => A): A = {
+  final def fold[A](z: A)(f: (A, (NodeId, Node)) => A): A = {
     var acc = z
     foreach((nodeId, node) => acc = f(acc, (nodeId, node)))
     acc
@@ -325,7 +324,7 @@ sealed abstract class HasTxNodes {
     * transaction.
     */
   final def foldWithPathState[A, B](globalState0: A, pathState0: B)(
-      op: (A, B, NodeId, Node.GenNode) => (A, B)
+      op: (A, B, NodeId, Node) => (A, B)
   ): A = {
     var globalState = globalState0
 
@@ -337,10 +336,10 @@ sealed abstract class HasTxNodes {
         val (globalState1, newPathState) = op(globalState, pathState, nodeId, node)
         globalState = globalState1
         node match {
-          case nr: Node.NodeRollback =>
+          case nr: Node.Rollback =>
             go(nr.children.map(_ -> newPathState) ++: toVisit)
-          case _: Node.LeafOnlyActionNode => go(toVisit)
-          case ne: Node.NodeExercises =>
+          case _: Node.LeafOnlyAction => go(toVisit)
+          case ne: Node.Exercise =>
             go(ne.children.map(_ -> newPathState) ++: toVisit)
         }
     }
@@ -349,9 +348,9 @@ sealed abstract class HasTxNodes {
     globalState
   }
 
-  final def localContracts[Cid2 >: ContractId]: Map[Cid2, (NodeId, Node.NodeCreate)] =
-    fold(Map.empty[Cid2, (NodeId, Node.NodeCreate)]) {
-      case (acc, (nid, create: Node.NodeCreate)) =>
+  final def localContracts[Cid2 >: ContractId]: Map[Cid2, (NodeId, Node.Create)] =
+    fold(Map.empty[Cid2, (NodeId, Node.Create)]) {
+      case (acc, (nid, create: Node.Create)) =>
         acc.updated(create.coid, nid -> create)
       case (acc, _) => acc
     }
@@ -428,7 +427,7 @@ sealed abstract class HasTxNodes {
       rollbackEnd = (acc, _, _) => acc.endRollback(),
       leaf = (acc, _, leaf) =>
         leaf match {
-          case c: Node.NodeCreate => acc.create(c.coid)
+          case c: Node.Create => acc.create(c.coid)
           case _ => acc
         },
     ).currentState.inactiveCids
@@ -438,11 +437,11 @@ sealed abstract class HasTxNodes {
     */
   final def inputContracts[Cid2 >: ContractId]: Set[Cid2] =
     fold(Set.empty[Cid2]) {
-      case (acc, (_, Node.NodeExercises(coid, _, _, _, _, _, _, _, _, _, _, _, _, _))) =>
+      case (acc, (_, Node.Exercise(coid, _, _, _, _, _, _, _, _, _, _, _, _, _))) =>
         acc + coid
-      case (acc, (_, Node.NodeFetch(coid, _, _, _, _, _, _, _))) =>
+      case (acc, (_, Node.Fetch(coid, _, _, _, _, _, _, _))) =>
         acc + coid
-      case (acc, (_, Node.NodeLookupByKey(_, _, Some(coid), _))) =>
+      case (acc, (_, Node.LookupByKey(_, _, Some(coid), _))) =>
         acc + coid
       case (acc, _) => acc
     } -- localContracts.keySet
@@ -453,15 +452,15 @@ sealed abstract class HasTxNodes {
     */
   final def contractKeys: Set[GlobalKey] = {
     fold(Set.empty[GlobalKey]) {
-      case (acc, (_, node: Node.NodeCreate)) =>
+      case (acc, (_, node: Node.Create)) =>
         node.key.fold(acc)(key => acc + GlobalKey.assertBuild(node.templateId, key.key))
-      case (acc, (_, node: Node.NodeExercises)) =>
+      case (acc, (_, node: Node.Exercise)) =>
         node.key.fold(acc)(key => acc + GlobalKey.assertBuild(node.templateId, key.key))
-      case (acc, (_, node: Node.NodeFetch)) =>
+      case (acc, (_, node: Node.Fetch)) =>
         node.key.fold(acc)(key => acc + GlobalKey.assertBuild(node.templateId, key.key))
-      case (acc, (_, node: Node.NodeLookupByKey)) =>
+      case (acc, (_, node: Node.LookupByKey)) =>
         acc + GlobalKey.assertBuild(node.templateId, node.key.key)
-      case (acc, (_, _: Node.NodeRollback)) =>
+      case (acc, (_, _: Node.Rollback)) =>
         acc
     }
   }
@@ -518,7 +517,7 @@ sealed abstract class HasTxNodes {
               }
           }
         }
-      def handleExercise(exe: Node.NodeExercises) =
+      def handleExercise(exe: Node.Exercise) =
         assertKeyMapping(exe.templateId, exe.targetCoid, exe.key).map { state =>
           exe.key.fold(state) { key =>
             val gk = GlobalKey.assertBuild(exe.templateId, key.key)
@@ -532,7 +531,7 @@ sealed abstract class HasTxNodes {
           }
         }
 
-      def handleCreate(create: Node.NodeCreate) =
+      def handleCreate(create: Node.Create) =
         create.key.fold[Either[KeyInputError, State]](Right(this)) { key =>
           val gk = GlobalKey.assertBuild(create.templateId, key.key)
           val next = copy(keys = keys.updated(gk, Some(create.coid)))
@@ -546,7 +545,7 @@ sealed abstract class HasTxNodes {
         }
 
       def handleLookup(
-          lookup: Node.NodeLookupByKey
+          lookup: Node.LookupByKey
       ): Either[KeyInputError, State] = {
         val gk = GlobalKey.assertBuild(lookup.templateId, lookup.key.key)
         keys.get(gk) match {
@@ -564,14 +563,14 @@ sealed abstract class HasTxNodes {
       }
 
       def handleLeaf(
-          leaf: Node.LeafOnlyActionNode
+          leaf: Node.LeafOnlyAction
       ): Either[KeyInputError, State] =
         leaf match {
-          case create: Node.NodeCreate =>
+          case create: Node.Create =>
             handleCreate(create)
-          case fetch: Node.NodeFetch =>
+          case fetch: Node.Fetch =>
             assertKeyMapping(fetch.templateId, fetch.coid, fetch.key)
-          case lookup: Node.NodeLookupByKey =>
+          case lookup: Node.LookupByKey =>
             handleLookup(lookup)
         }
       def beginRollback: State =
@@ -614,11 +613,11 @@ sealed abstract class HasTxNodes {
       },
       rollbackBegin = (acc, _, _) => (acc, false),
       leaf = {
-        case (acc, _, create: Node.NodeCreate) =>
+        case (acc, _, create: Node.Create) =>
           create.key.fold(acc)(key =>
             acc.updated(GlobalKey.assertBuild(create.templateId, key.key), Some(create.coid))
           )
-        case (acc, _, _: Node.NodeFetch | _: Node.NodeLookupByKey) => acc
+        case (acc, _, _: Node.Fetch | _: Node.LookupByKey) => acc
       },
       exerciseEnd = (acc, _, _) => acc,
       rollbackEnd = (acc, _, _) => acc,
@@ -629,35 +628,35 @@ sealed abstract class HasTxNodes {
   // Exercise/rollback nodes are visited twice: when execution reaches them and when execution leaves their body.
   // On the first visit of an execution/rollback node, the caller can prevent traversal of the children
   final def foreachInExecutionOrder(
-      exerciseBegin: (NodeId, Node.NodeExercises) => Boolean,
-      rollbackBegin: (NodeId, Node.NodeRollback) => Boolean,
-      leaf: (NodeId, Node.LeafOnlyActionNode) => Unit,
-      exerciseEnd: (NodeId, Node.NodeExercises) => Unit,
-      rollbackEnd: (NodeId, Node.NodeRollback) => Unit,
+      exerciseBegin: (NodeId, Node.Exercise) => Boolean,
+      rollbackBegin: (NodeId, Node.Rollback) => Boolean,
+      leaf: (NodeId, Node.LeafOnlyAction) => Unit,
+      exerciseEnd: (NodeId, Node.Exercise) => Unit,
+      rollbackEnd: (NodeId, Node.Rollback) => Unit,
   ): Unit = {
     @tailrec
     def loop(
         currNodes: FrontStack[NodeId],
         stack: FrontStack[
-          ((NodeId, Either[Node.NodeRollback, Node.NodeExercises]), FrontStack[NodeId])
+          ((NodeId, Either[Node.Rollback, Node.Exercise]), FrontStack[NodeId])
         ],
     ): Unit =
       currNodes match {
         case FrontStackCons(nid, rest) =>
           nodes(nid) match {
-            case rb: Node.NodeRollback =>
+            case rb: Node.Rollback =>
               if (rollbackBegin(nid, rb)) {
                 loop(rb.children.toFrontStack, ((nid, Left(rb)), rest) +: stack)
               } else {
                 loop(rest, stack)
               }
-            case exe: Node.NodeExercises =>
+            case exe: Node.Exercise =>
               if (exerciseBegin(nid, exe)) {
                 loop(exe.children.toFrontStack, ((nid, Right(exe)), rest) +: stack)
               } else {
                 loop(rest, stack)
               }
-            case node: Node.LeafOnlyActionNode =>
+            case node: Node.LeafOnlyAction =>
               leaf(nid, node)
               loop(rest, stack)
           }
@@ -682,11 +681,11 @@ sealed abstract class HasTxNodes {
   // This method visits to all nodes of the transaction in execution order.
   // Exercise nodes are visited twice: when execution reaches them and when execution leaves their body.
   final def foldInExecutionOrder[A](z: A)(
-      exerciseBegin: (A, NodeId, Node.NodeExercises) => (A, Boolean),
-      rollbackBegin: (A, NodeId, Node.NodeRollback) => (A, Boolean),
-      leaf: (A, NodeId, Node.LeafOnlyActionNode) => A,
-      exerciseEnd: (A, NodeId, Node.NodeExercises) => A,
-      rollbackEnd: (A, NodeId, Node.NodeRollback) => A,
+      exerciseBegin: (A, NodeId, Node.Exercise) => (A, Boolean),
+      rollbackBegin: (A, NodeId, Node.Rollback) => (A, Boolean),
+      leaf: (A, NodeId, Node.LeafOnlyAction) => A,
+      exerciseEnd: (A, NodeId, Node.Exercise) => A,
+      rollbackEnd: (A, NodeId, Node.Rollback) => A,
   ): A = {
     var acc = z
     foreachInExecutionOrder(
@@ -763,15 +762,15 @@ object GenTransaction {
 
     tx.fold(State(Set.empty, Set.empty)) { case (state, (_, node)) =>
       node match {
-        case Node.NodeCreate(_, tmplId, _, _, _, _, Some(key), _) =>
+        case Node.Create(_, tmplId, _, _, _, _, Some(key), _) =>
           state.created(globalKey(tmplId, key.key))
-        case Node.NodeExercises(_, tmplId, _, true, _, _, _, _, _, _, _, Some(key), _, _) =>
+        case Node.Exercise(_, tmplId, _, true, _, _, _, _, _, _, _, Some(key), _, _) =>
           state.consumed(globalKey(tmplId, key.key))
-        case Node.NodeExercises(_, tmplId, _, false, _, _, _, _, _, _, _, Some(key), _, _) =>
+        case Node.Exercise(_, tmplId, _, false, _, _, _, _, _, _, _, Some(key), _, _) =>
           state.referenced(globalKey(tmplId, key.key))
-        case Node.NodeFetch(_, tmplId, _, _, _, Some(key), _, _) =>
+        case Node.Fetch(_, tmplId, _, _, _, Some(key), _, _) =>
           state.referenced(globalKey(tmplId, key.key))
-        case Node.NodeLookupByKey(tmplId, key, Some(_), _) =>
+        case Node.LookupByKey(tmplId, key, Some(_), _) =>
           state.referenced(globalKey(tmplId, key.key))
         case _ =>
           state
@@ -784,13 +783,12 @@ object Transaction {
 
   type Value = Value.VersionedValue
 
-  @deprecated("use com.daml.value.Value.VersionedContractInstance", since = "1.8.0")
+  @deprecated("use com.daml.value.Value.VersionedContractInstance", since = "1.18.0")
   type ContractInstance = Value.VersionedContractInstance
 
   /** Transaction nodes */
-  type Node = Node.GenNode
-  type ActionNode = Node.GenActionNode
-  type LeafNode = Node.LeafOnlyActionNode
+  type ActionNode = Node.Action
+  type LeafNode = Node.LeafOnlyAction
 
   @deprecated("use com.daml.transaction.VersionedTransaction", since = "1.18.0")
   type Transaction = VersionedTransaction

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/PlatformTypes.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/PlatformTypes.scala
@@ -3,25 +3,25 @@
 
 package com.daml.platform.common
 
-import com.daml.lf.transaction.{Node => N}
+import com.daml.lf.transaction.Node
 import com.daml.lf.{engine => E}
 import com.daml.lf.data.Ref
 
 object PlatformTypes {
 
-  type GenNode = N.GenNode
+  type GenNode = Node
 
-  type NodeCreate = N.NodeCreate
-  val NodeCreate: N.NodeCreate.type = N.NodeCreate
+  type NodeCreate = Node.Create
+  val NodeCreate: Node.Create.type = Node.Create
 
-  type NodeLookupByKey = N.NodeLookupByKey
-  val NodeLookupByKey: N.NodeLookupByKey.type = N.NodeLookupByKey
+  type NodeLookupByKey = Node.LookupByKey
+  val NodeLookupByKey: Node.LookupByKey.type = Node.LookupByKey
 
-  type NodeFetch = N.NodeFetch
-  val NodeFetch: N.NodeFetch.type = N.NodeFetch
+  type NodeFetch = Node.Fetch
+  val NodeFetch: Node.Fetch.type = Node.Fetch
 
-  type NodeExercises = N.NodeExercises
-  val NodeExercises: N.NodeExercises.type = N.NodeExercises
+  type NodeExercises = Node.Exercise
+  val NodeExercises: Node.Exercise.type = Node.Exercise
 
   type Event = E.Event
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
@@ -12,8 +12,7 @@ import com.daml.lf.data.LawlessTraversals._
 import com.daml.lf.data.Ref.Identifier
 import com.daml.lf.data.{Numeric, Ref}
 import com.daml.lf.ledger.EventId
-import com.daml.lf.transaction.Node.{KeyWithMaintainers, NodeCreate, NodeExercises}
-import com.daml.lf.transaction.NodeId
+import com.daml.lf.transaction.{Node, NodeId}
 import com.daml.lf.value.{Value => Lf}
 import com.google.protobuf.empty.Empty
 import com.google.protobuf.timestamp.Timestamp
@@ -174,13 +173,13 @@ object LfEngineToApi {
 
   def lfContractKeyToApiValue(
       verbose: Boolean,
-      lf: KeyWithMaintainers[LfValue],
+      lf: Node.KeyWithMaintainers[LfValue],
   ): Either[String, api.Value] =
     lfValueToApiValue(verbose, lf.key)
 
   def lfContractKeyToApiValue(
       verbose: Boolean,
-      lf: Option[KeyWithMaintainers[LfValue]],
+      lf: Option[Node.KeyWithMaintainers[LfValue]],
   ): Either[String, Option[api.Value]] =
     lf.fold[Either[String, Option[api.Value]]](Right(None))(
       lfContractKeyToApiValue(verbose, _).map(Some(_))
@@ -190,7 +189,7 @@ object LfEngineToApi {
       verbose: Boolean,
       trId: Ref.LedgerString,
       nodeId: NodeId,
-      node: NodeCreate,
+      node: Node.Create,
   ): Either[String, Event] =
     for {
       arg <- lfValueToApiRecord(verbose, node.arg)
@@ -214,7 +213,7 @@ object LfEngineToApi {
   def lfNodeExercisesToEvent(
       trId: Ref.LedgerString,
       nodeId: NodeId,
-      node: NodeExercises,
+      node: Node.Exercise,
   ): Either[String, Event] =
     Either.cond(
       node.consuming,
@@ -235,7 +234,7 @@ object LfEngineToApi {
       verbose: Boolean,
       eventId: EventId,
       witnessParties: Set[Ref.Party],
-      node: NodeCreate,
+      node: Node.Create,
   ): Either[String, TreeEvent] =
     for {
       arg <- lfValueToApiRecord(verbose, node.arg)
@@ -261,7 +260,7 @@ object LfEngineToApi {
       trId: Ref.LedgerString,
       eventId: EventId,
       witnessParties: Set[Ref.Party],
-      node: NodeExercises,
+      node: Node.Exercise,
       filterChildren: NodeId => Boolean,
   ): Either[String, TreeEvent] =
     for {

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V10_1__Populate_Event_Data.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V10_1__Populate_Event_Data.scala
@@ -10,7 +10,7 @@ import java.sql.Connection
 import anorm.{BatchSql, NamedParameter}
 import com.daml.lf.data.Ref
 import com.daml.lf.ledger.EventId
-import com.daml.lf.transaction.Node.NodeCreate
+import com.daml.lf.transaction.Node
 import com.daml.lf.transaction.VersionedTransaction
 import com.daml.platform.db.migration.translation.TransactionSerializer
 import com.daml.platform.store.Conversions._
@@ -51,8 +51,9 @@ private[migration] class V10_1__Populate_Event_Data extends BaseJavaMigration {
 
     val txs = loadTransactions(conn)
     val data = txs.flatMap { case (txId, tx) =>
-      tx.nodes.collect { case (nodeId, NodeCreate(cid, _, _, _, signatories, stakeholders, _, _)) =>
-        (cid, EventId(txId, nodeId), signatories, stakeholders -- signatories)
+      tx.nodes.collect {
+        case (nodeId, Node.Create(cid, _, _, _, signatories, stakeholders, _, _)) =>
+          (cid, EventId(txId, nodeId), signatories, stakeholders -- signatories)
       }
     }
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
@@ -15,8 +15,8 @@ package object v25_backfill_participant_events {
   import com.daml.lf.{transaction => lftx}
   private[migration] type NodeId = lftx.NodeId
   private[migration] type Transaction = lftx.VersionedTransaction
-  private[migration] type Create = lftx.Node.NodeCreate
-  private[migration] type Exercise = lftx.Node.NodeExercises
+  private[migration] type Create = lftx.Node.Create
+  private[migration] type Exercise = lftx.Node.Exercise
 
   import com.daml.lf.{data => lfdata}
   private[migration] type Party = lfdata.Ref.Party

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v29_fix_participant_events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v29_fix_participant_events/package.scala
@@ -15,8 +15,8 @@ package object v29_fix_participant_events {
   import com.daml.lf.{transaction => lftx}
   private[migration] type NodeId = lftx.NodeId
   private[migration] type Transaction = lftx.VersionedTransaction
-  private[migration] type Create = lftx.Node.NodeCreate
-  private[migration] type Exercise = lftx.Node.NodeExercises
+  private[migration] type Create = lftx.Node.Create
+  private[migration] type Exercise = lftx.Node.Exercise
 
   import com.daml.lf.{data => lfdata}
   private[migration] type Party = lfdata.Ref.Party

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -92,7 +92,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
               Some(meta.nodeSeeds),
               Some(
                 updateTx.nodes
-                  .collect { case (nodeId, node: Node.GenActionNode) if node.byKey => nodeId }
+                  .collect { case (nodeId, node: Node.Action) if node.byKey => nodeId }
                   .to(ImmArray)
               ),
             ),

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/package.scala
@@ -20,11 +20,11 @@ package object events {
 
   import com.daml.lf.{transaction => lftx}
   type NodeId = lftx.NodeId
-  type Node = lftx.Node.GenNode
-  type Create = lftx.Node.NodeCreate
-  type Exercise = lftx.Node.NodeExercises
-  type Fetch = lftx.Node.NodeFetch
-  type LookupByKey = lftx.Node.NodeLookupByKey
+  type Node = lftx.Node
+  type Create = lftx.Node.Create
+  type Exercise = lftx.Node.Exercise
+  type Fetch = lftx.Node.Fetch
+  type LookupByKey = lftx.Node.LookupByKey
   type Key = lftx.GlobalKey
   val Key = lftx.GlobalKey
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.transaction.Node.{KeyWithMaintainers, NodeCreate, NodeExercises, NodeFetch}
+import com.daml.lf.transaction.Node
 import com.daml.lf.transaction.TransactionVersion
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.value.Value.{VersionedContractInstance, ValueParty}
@@ -26,7 +26,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
       val builder = TransactionBuilder()
       val contractId = builder.newCid
       builder.add(
-        NodeCreate(
+        Node.Create(
           coid = contractId,
           templateId = someTemplateId,
           arg = someContractArgument,
@@ -43,7 +43,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
       val builder = TransactionBuilder()
       val contractId = builder.newCid
       builder.add(
-        NodeCreate(
+        Node.Create(
           coid = contractId,
           someTemplateId,
           someContractArgument,
@@ -51,7 +51,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
           signatories = Set(bob),
           stakeholders = Set(bob),
           key = Some(
-            KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
+            Node.KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
           ),
           version = TransactionVersion.minVersion,
         )
@@ -61,7 +61,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
     val tx3 = {
       val builder = TransactionBuilder()
       val rootExercise = builder.add(
-        NodeExercises(
+        Node.Exercise(
           targetCoid = create1,
           templateId = someTemplateId,
           choiceId = someChoiceName,
@@ -81,14 +81,14 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
         )
       )
       builder.add(
-        NodeFetch(
+        Node.Fetch(
           coid = create2,
           templateId = someTemplateId,
           actingParties = Set(bob),
           signatories = Set(bob),
           stakeholders = Set(bob),
           key = Some(
-            KeyWithMaintainers(ValueParty(bob), Set(bob))
+            Node.KeyWithMaintainers(ValueParty(bob), Set(bob))
           ),
           byKey = false,
           version = TransactionVersion.minVersion,
@@ -96,7 +96,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
         parentId = rootExercise,
       )
       val nestedExercise = builder.add(
-        NodeExercises(
+        Node.Exercise(
           targetCoid = create2,
           templateId = someTemplateId,
           choiceId = someChoiceName,
@@ -109,7 +109,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
           children = ImmArray.Empty,
           exerciseResult = Some(someChoiceResult),
           key = Some(
-            KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
+            Node.KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
           ),
           byKey = false,
           version = TransactionVersion.minVersion,
@@ -117,7 +117,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
         parentId = rootExercise,
       )
       builder.add(
-        NodeCreate(
+        Node.Create(
           coid = builder.newCid,
           someTemplateId,
           someContractArgument,
@@ -125,7 +125,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
           signatories = Set(bob),
           stakeholders = Set(alice, bob),
           key = Some(
-            KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
+            Node.KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
           ),
           version = TransactionVersion.minVersion,
         ),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
@@ -11,8 +11,7 @@ import com.daml.ledger.api.v1.transaction_service.GetTransactionTreesResponse
 import com.daml.ledger.offset.Offset
 import com.daml.lf.data.Ref
 import com.daml.lf.ledger.EventId
-import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
-import com.daml.lf.transaction.NodeId
+import com.daml.lf.transaction.{Node, NodeId}
 import com.daml.platform.ApiOffset
 import com.daml.platform.api.v1.event.EventOps.TreeEventOps
 import com.daml.platform.store.entries.LedgerEntry
@@ -58,7 +57,7 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
         .lookupTransactionTreeById(tx.transactionId, tx.actAs.toSet)
     } yield {
       inside(result.value.transaction) { case Some(transaction) =>
-        val (nodeId, createNode: NodeCreate) =
+        val (nodeId, createNode: Node.Create) =
           tx.transaction.nodes.head
         transaction.commandId shouldBe tx.commandId.get
         transaction.offset shouldBe ApiOffset.toApiString(offset)
@@ -92,7 +91,7 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
         .lookupTransactionTreeById(exercise.transactionId, exercise.actAs.toSet)
     } yield {
       inside(result.value.transaction) { case Some(transaction) =>
-        val (nodeId, exerciseNode: NodeExercises) =
+        val (nodeId, exerciseNode: Node.Exercise) =
           exercise.transaction.nodes.head
         transaction.commandId shouldBe exercise.commandId.get
         transaction.offset shouldBe ApiOffset.toApiString(offset)
@@ -126,11 +125,11 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
     } yield {
       inside(result.value.transaction) { case Some(transaction) =>
         val (createNodeId, createNode) =
-          tx.transaction.nodes.collectFirst { case (nodeId, node: NodeCreate) =>
+          tx.transaction.nodes.collectFirst { case (nodeId, node: Node.Create) =>
             nodeId -> node
           }.get
         val (exerciseNodeId, exerciseNode) =
-          tx.transaction.nodes.collectFirst { case (nodeId, node: NodeExercises) =>
+          tx.transaction.nodes.collectFirst { case (nodeId, node: Node.Exercise) =>
             nodeId -> node
           }.get
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.offset.Offset
 import com.daml.ledger.resources.ResourceContext
 import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.ledger.EventId
-import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
+import com.daml.lf.transaction.Node
 import com.daml.logging.LoggingContext
 import com.daml.platform.ApiOffset
 import com.daml.platform.api.v1.event.EventOps.EventOps
@@ -70,7 +70,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
         transaction.transactionId shouldBe tx.transactionId
         transaction.workflowId shouldBe tx.workflowId.getOrElse("")
         inside(transaction.events.loneElement.event.created) { case Some(created) =>
-          val (nodeId, createNode: NodeCreate) =
+          val (nodeId, createNode: Node.Create) =
             tx.transaction.nodes.head
           created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
           created.witnessParties should contain only (tx.actAs: _*)
@@ -104,7 +104,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
         ) shouldBe exercise.ledgerEffectiveTime
         transaction.workflowId shouldBe exercise.workflowId.getOrElse("")
         inside(transaction.events.loneElement.event.archived) { case Some(archived) =>
-          val (nodeId, exerciseNode: NodeExercises) =
+          val (nodeId, exerciseNode: Node.Exercise) =
             exercise.transaction.nodes.head
           archived.eventId shouldBe EventId(transaction.transactionId, nodeId).toLedgerString
           archived.witnessParties should contain only (exercise.actAs: _*)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/PostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/PostCommitValidationSpec.scala
@@ -495,7 +495,7 @@ object PostCommitValidationSpec {
 
   private val txBuilder = TxBuilder()
 
-  private def genTestCreate(): TxBuilder.Create =
+  private def genTestCreate(): Create =
     txBuilder.create(
       id = s"#${UUID.randomUUID}",
       templateId = "bar:baz",
@@ -505,7 +505,7 @@ object PostCommitValidationSpec {
       key = Some(ValueText("key")),
     )
 
-  private def genTestExercise(create: TxBuilder.Create): TxBuilder.Exercise =
+  private def genTestExercise(create: Create): Exercise =
     txBuilder.exercise(
       contract = create,
       choice = "SomeChoice",

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -16,7 +16,7 @@ import com.daml.lf.command.ApiCommand
 import com.daml.lf.crypto
 import com.daml.lf.crypto.Hash
 import com.daml.lf.data.{FrontStack, Ref, SortedLookupList}
-import com.daml.lf.transaction.Node.NodeCreate
+import com.daml.lf.transaction.Node
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{
   ContractId,
@@ -637,7 +637,7 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
   private def contractIdOfCreateTransaction(updates: Seq[Update]): ContractId =
     inside(updates) { case Seq(update: Update.TransactionAccepted) =>
-      inside(update.transaction.nodes.values.toSeq) { case Seq(create: NodeCreate) =>
+      inside(update.transaction.nodes.values.toSeq) { case Seq(create: Node.Create) =>
         create.coid
       }
     }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class ProjectionsSpec extends AnyWordSpec with Matchers {
 
   def makeCreateNode(cid: ContractId, signatories: Set[Party], stakeholders: Set[Party]) =
-    Node.NodeCreate(
+    Node.Create(
       coid = cid,
       templateId = Identifier.assertFromString("some-package:Foo:Bar"),
       arg = ValueText("foo"),
@@ -32,7 +32,7 @@ class ProjectionsSpec extends AnyWordSpec with Matchers {
       signatories: Set[Party],
       stakeholders: Set[Party],
   ) =
-    Node.NodeExercises(
+    Node.Exercise(
       targetCoid = target,
       templateId = Identifier(
         PackageId.assertFromString("some-package"),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -28,7 +28,7 @@ import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.Engine
 import com.daml.lf.transaction._
 import com.daml.lf.transaction.test.TransactionBuilder
-import com.daml.lf.transaction.test.TransactionBuilder.{Create, Exercise}
+import com.daml.lf.transaction.Node
 import com.daml.lf.value.Value.{ContractId, ValueRecord, ValueText}
 import com.daml.lf.value.{Value, ValueOuterClass}
 import com.daml.logging.LoggingContext
@@ -423,7 +423,7 @@ class TransactionCommitterSpec
       signatories: Set[Ref.Party] = Set(aKeyMaintainer),
       argument: Value = aDummyValue,
       keyAndMaintainer: Option[(String, String)] = Some(aKey -> aKeyMaintainer),
-  ): TransactionBuilder.Create =
+  ): Node.Create =
     txBuilder.create(
       id = contractId,
       templateId = "DummyModule:DummyTemplate",
@@ -433,7 +433,7 @@ class TransactionCommitterSpec
       key = keyAndMaintainer.map { case (key, maintainer) => lfTuple(maintainer, key) },
     )
 
-  def archive(create: Create, actingParties: Set[String]): Exercise =
+  def archive(create: Node.Create, actingParties: Set[String]): Node.Exercise =
     txBuilder.exercise(
       create,
       choice = "Archive",
@@ -443,7 +443,7 @@ class TransactionCommitterSpec
       result = Some(Value.ValueUnit),
     )
 
-  def archive(contractId: String, actingParties: Set[String]): Exercise =
+  def archive(contractId: String, actingParties: Set[String]): Node.Exercise =
     archive(create(contractId), actingParties)
 }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/ModelConformanceValidatorSpec.scala
@@ -386,7 +386,7 @@ class ModelConformanceValidatorSpec
       signatories: Set[Ref.Party] = Set(aKeyMaintainer),
       argument: Value = aDummyValue,
       keyAndMaintainer: Option[(String, String)] = Some(aKey -> aKeyMaintainer),
-  ): TransactionBuilder.Create = {
+  ): Node.Create = {
     txBuilder.create(
       id = contractId,
       templateId = aTemplateId,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidatorSpec.scala
@@ -35,7 +35,7 @@ import com.daml.ledger.validator.TestHelper.{makeContractIdStateKey, makeContrac
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.lf.transaction.test.TransactionBuilder
-import com.daml.lf.transaction.test.TransactionBuilder.{Create, Exercise}
+import com.daml.lf.transaction.Node
 import com.daml.lf.value.Value
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
@@ -279,7 +279,7 @@ class TransactionConsistencyValidatorSpec extends AnyWordSpec with Matchers {
     builder.buildSubmitted()
   }
 
-  private def newCreateNodeWithFixedKey(contractId: String): Create =
+  private def newCreateNodeWithFixedKey(contractId: String): Node.Create =
     create(contractId, signatories = Set("Alice"), keyAndMaintainer = Some(aKey -> "Alice"))
 
   private def create(
@@ -287,7 +287,7 @@ class TransactionConsistencyValidatorSpec extends AnyWordSpec with Matchers {
       signatories: Set[Ref.Party] = Set(aKeyMaintainer),
       argument: Value = aDummyValue,
       keyAndMaintainer: Option[(String, String)] = Some(aKey -> aKeyMaintainer),
-  ): TransactionBuilder.Create =
+  ): Node.Create =
     txBuilder.create(
       id = contractId,
       templateId = "DummyModule:DummyTemplate",
@@ -297,7 +297,7 @@ class TransactionConsistencyValidatorSpec extends AnyWordSpec with Matchers {
       key = keyAndMaintainer.map { case (key, maintainer) => lfTuple(maintainer, key) },
     )
 
-  private def archive(create: Create, actingParties: Set[Ref.Party]): Exercise =
+  private def archive(create: Node.Create, actingParties: Set[Ref.Party]): Node.Exercise =
     txBuilder.exercise(
       create,
       choice = "Archive",
@@ -307,7 +307,7 @@ class TransactionConsistencyValidatorSpec extends AnyWordSpec with Matchers {
       result = Some(Value.ValueUnit),
     )
 
-  private def archive(contractId: Value.ContractId, actingParties: Set[Ref.Party]): Exercise =
+  private def archive(contractId: Value.ContractId, actingParties: Set[Ref.Party]): Node.Exercise =
     archive(create(contractId), actingParties)
 
   private def validate(

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
@@ -6,14 +6,7 @@ package com.daml.ledger.participant.state.kvutils.tools.engine.replay
 import com.daml.lf.data._
 import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
-import com.daml.lf.transaction.{
-  GlobalKey,
-  Node,
-  NodeId,
-  SubmittedTransaction,
-  Transaction => Tx,
-  VersionedTransaction,
-}
+import com.daml.lf.transaction.{GlobalKey, Node, NodeId, SubmittedTransaction, VersionedTransaction}
 import com.daml.lf.value.Value
 
 import scala.collection.mutable
@@ -32,17 +25,17 @@ private[replay] final class Adapter(
     ).buildSubmitted()
 
   // drop value version and children
-  private[this] def adapt(node: Tx.Node): Node.GenNode =
+  private[this] def adapt(node: Node): Node =
     node match {
-      case rollback: Node.NodeRollback =>
+      case rollback: Node.Rollback =>
         rollback.copy(children = ImmArray.Empty)
-      case create: Node.NodeCreate =>
+      case create: Node.Create =>
         create.copy(
           templateId = adapt(create.templateId),
           arg = adapt(create.arg),
           key = create.key.map(adapt),
         )
-      case exe: Node.NodeExercises =>
+      case exe: Node.Exercise =>
         exe.copy(
           templateId = adapt(exe.templateId),
           chosenValue = adapt(exe.chosenValue),
@@ -50,12 +43,12 @@ private[replay] final class Adapter(
           exerciseResult = exe.exerciseResult.map(adapt),
           key = exe.key.map(adapt),
         )
-      case fetch: Node.NodeFetch =>
+      case fetch: Node.Fetch =>
         fetch.copy(
           templateId = adapt(fetch.templateId),
           key = fetch.key.map(adapt),
         )
-      case lookup: Node.NodeLookupByKey =>
+      case lookup: Node.LookupByKey =>
         lookup
           .copy(
             templateId = adapt(lookup.templateId),

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Replay.scala
@@ -177,9 +177,9 @@ private[replay] object Replay {
       val transactions = importer.read().map(_._1).flatMap(decodeSubmissionInfo)
       if (transactions.isEmpty) sys.error("no transaction find")
 
-      val createsNodes: Seq[Node.NodeCreate] =
+      val createsNodes: Seq[Node.Create] =
         transactions.flatMap(entry =>
-          entry.tx.nodes.values.collect { case create: Node.NodeCreate =>
+          entry.tx.nodes.values.collect { case create: Node.Create =>
             create
           }
         )
@@ -193,7 +193,7 @@ private[replay] object Replay {
 
       val benchmarks = transactions.flatMap { entry =>
         entry.tx.roots.map(entry.tx.nodes) match {
-          case ImmArray(exe: Node.NodeExercises) =>
+          case ImmArray(exe: Node.Exercise) =>
             val inputContracts = entry.tx.inputContracts
             List(
               BenchmarkState(

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparisonSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/StateUpdateComparisonSpec.scala
@@ -15,7 +15,7 @@ import com.daml.lf.crypto
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.test.TransactionBuilder
-import com.daml.lf.transaction.{BlindingInfo, CommittedTransaction, NodeId}
+import com.daml.lf.transaction.{BlindingInfo, CommittedTransaction, Node, NodeId}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import org.scalatest.matchers.should.Matchers
@@ -136,7 +136,7 @@ final class StateUpdateComparisonSpec
       signatories: Set[Ref.Party] = Set(aKeyMaintainer),
       argument: Value = aDummyValue,
       keyAndMaintainer: Option[(String, String)] = Some("key" -> aKeyMaintainer),
-  ): TransactionBuilder.Create =
+  ): Node.Create =
     TransactionBuilder().create(
       id = contractId,
       templateId = "DummyModule:DummyTemplate",


### PR DESCRIPTION
Following up #10827 and #10921 that drop type parameters from GenNode,
we rename GenNode into Node.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
