### PR TITLE
LF: drop com.daml.lf.transaction.Transaction.Transaction type alias.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -12,7 +12,7 @@ import com.daml.lf.transaction.Node.{
   NodeFetch,
   NodeLookupByKey,
 }
-import com.daml.lf.transaction.{BlindingInfo, GenTransaction, NodeId, Transaction}
+import com.daml.lf.transaction.{BlindingInfo, GenTransaction, NodeId, VersionedTransaction}
 import com.daml.lf.ledger._
 import com.daml.lf.data.Relation.Relation
 
@@ -29,7 +29,7 @@ object Blinding {
     *
     *  @param tx transaction to be blinded
     */
-  def blind(tx: Transaction.Transaction): BlindingInfo =
+  def blind(tx: VersionedTransaction): BlindingInfo =
     BlindingTransaction.calculateBlindingInfo(tx)
 
   /** Returns the part of the transaction which has to be divulged to the given party.

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -11,7 +11,7 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.{InitialSeeding, PartialTransaction, Pretty, SError, SExpr}
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.speedy.SResult._
-import com.daml.lf.transaction.{SubmittedTransaction, Transaction => Tx}
+import com.daml.lf.transaction.{SubmittedTransaction, VersionedTransaction, Transaction => Tx}
 import com.daml.lf.transaction.Node._
 import java.nio.file.Files
 
@@ -484,7 +484,7 @@ object Engine {
       crypto.Hash.deriveTransactionSeed(submissionSeed, participant, submissionTime)
     )
 
-  private def profileDesc(tx: Tx.Transaction): String = {
+  private def profileDesc(tx: VersionedTransaction): String = {
     if (tx.roots.length == 1) {
       val makeDesc = (kind: String, tmpl: Ref.Identifier, extra: Option[String]) =>
         s"$kind:${tmpl.qualifiedName.name}${extra.map(extra => s":$extra").getOrElse("")}"

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2459,7 +2459,7 @@ object EngineTest {
     Validation.isReplayedBy(Normalization.normalizeTx(recorded), replayed)
   }
 
-  private def suffix(tx: Tx.Transaction) =
+  private def suffix(tx: VersionedTransaction) =
     data.assertRight(tx.suffixCid(_ => dummySuffix))
 
   private[this] case class ReinterpretState(
@@ -2503,13 +2503,13 @@ object EngineTest {
       engine: Engine,
       submitters: Set[Party],
       nodes: ImmArray[NodeId],
-      tx: Tx.Transaction,
+      tx: VersionedTransaction,
       txMeta: Tx.Metadata,
       ledgerEffectiveTime: Time.Timestamp,
       lookupPackages: PackageId => Option[Package],
       contracts: Map[ContractId, VersionedContractInstance] = Map.empty,
       keys: Map[GlobalKey, ContractId] = Map.empty,
-  ): Either[Error, (Tx.Transaction, Tx.Metadata)] = {
+  ): Either[Error, (VersionedTransaction, Tx.Metadata)] = {
 
     val nodeSeedMap = txMeta.nodeSeeds.toSeq.toMap
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -12,9 +12,12 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
 import com.daml.lf.language.Ast
 import com.daml.lf.scenario.ScenarioLedger
-import com.daml.lf.transaction.SubmittedTransaction
-import com.daml.lf.transaction.Transaction.Transaction
-import com.daml.lf.transaction.{Node => N, Transaction => Tx}
+import com.daml.lf.transaction.{
+  Node => N,
+  SubmittedTransaction,
+  VersionedTransaction,
+  Transaction => Tx,
+}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value._
 import com.daml.lf.command._
@@ -41,7 +44,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
         submitter: Party,
         effectiveAt: Time.Timestamp,
         tx: SubmittedTransaction,
-    ): Transaction =
+    ): VersionedTransaction =
       ScenarioLedger
         .commitTransaction(
           actAs = Set(submitter),
@@ -170,7 +173,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
     val ledger = new MutableLedger()
     val rangeOfIntsTemplateId = Identifier(largeTx._1, qn("LargeTransaction:RangeOfInts"))
     val createCmd = rangeOfIntsCreateCmd(rangeOfIntsTemplateId, 0, 1, num)
-    val createCmdTx: Transaction =
+    val createCmdTx: VersionedTransaction =
       submitCommand(ledger, engine)(
         submitter = party,
         cmd = createCmd,
@@ -201,7 +204,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
     val ledger = new MutableLedger()
     val listUtilTemplateId = Identifier(largeTx._1, qn("LargeTransaction:ListUtil"))
     val createCmd = listUtilCreateCmd(listUtilTemplateId)
-    val createCmdTx: Transaction =
+    val createCmdTx: VersionedTransaction =
       submitCommand(ledger, engine)(
         submitter = party,
         cmd = createCmd,
@@ -229,7 +232,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   private def qn(str: String): QualifiedName = QualifiedName.assertFromString(str)
 
   private def assertOneContractWithManyInts(
-      exerciseCmdTx: Transaction,
+      exerciseCmdTx: VersionedTransaction,
       expected: List[Long],
   ): Assertion = {
 
@@ -245,7 +248,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   }
 
   private def assertManyContractsOneIntPerContract(
-      exerciseCmdTx: Transaction,
+      exerciseCmdTx: VersionedTransaction,
       expectedNumberOfContracts: Int,
   ): Assertion = {
 
@@ -266,7 +269,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
       cmd: ApiCommand,
       cmdReference: String,
       seed: crypto.Hash,
-  ): Transaction = {
+  ): VersionedTransaction = {
     val effectiveAt = Time.Timestamp.now()
     def enrich(tx: SubmittedTransaction): SubmittedTransaction = {
       val enricher = new ValueEnricher(engine)
@@ -348,7 +351,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   }
 
   private def assertSizeExerciseTransaction(
-      exerciseCmdTx: Transaction,
+      exerciseCmdTx: VersionedTransaction,
       expected: Long,
   ): Assertion = {
 
@@ -364,7 +367,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   }
 
   private def extractResultFieldFromExerciseTransaction(
-      exerciseCmdTx: Transaction,
+      exerciseCmdTx: VersionedTransaction,
       fieldName: String,
   ): Value = {
 
@@ -388,7 +391,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
   }
 
   private def extractResultFromExerciseTransaction(
-      exerciseCmdTx: Transaction
+      exerciseCmdTx: VersionedTransaction
   ): Value = {
 
     exerciseCmdTx.roots.length shouldBe 1
@@ -405,7 +408,7 @@ class LargeTransactionTest extends AnyWordSpec with Matchers with BazelRunfiles 
     }
   }
 
-  private def firstRootNode(tx: Tx.Transaction): Tx.Node = tx.nodes(tx.roots.head)
+  private def firstRootNode(tx: VersionedTransaction): Tx.Node = tx.nodes(tx.roots.head)
 
   private def measureWithResult[R](body: => R): (R, Quantity[Double]) = {
     lazy val result: R = body

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -8,7 +8,7 @@ import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.transaction.BlindingInfo
 import com.daml.lf.transaction.Node
-import com.daml.lf.transaction.{NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{NodeId, VersionedTransaction}
 import com.daml.lf.value.Value.ContractId
 import com.daml.nameof.NameOf
 
@@ -55,7 +55,7 @@ object BlindingTransaction {
 
   /** Calculate blinding information for a transaction. */
   def calculateBlindingInfo(
-      tx: Tx.Transaction
+      tx: VersionedTransaction
   ): BlindingInfo = {
 
     val initialParentExerciseWitnesses: Set[Party] = Set.empty

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
@@ -8,7 +8,7 @@ import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.data.Time
 import com.daml.lf.ledger.EventId
 import com.daml.lf.speedy.SError.SError
-import com.daml.lf.transaction.{GlobalKey, Transaction}
+import com.daml.lf.transaction.{GlobalKey, VersionedTransaction}
 import com.daml.lf.value.Value.ContractId
 
 import scala.util.control.NoStackTrace
@@ -67,7 +67,7 @@ object Error {
   final case class CommitError(commitError: ScenarioLedger.CommitError) extends Error
 
   /** The transaction produced by the update expression in a 'mustFailAt' succeeded. */
-  final case class MustFailSucceeded(tx: Transaction.Transaction) extends Error
+  final case class MustFailSucceeded(tx: VersionedTransaction) extends Error
 
   /** Invalid party name supplied to 'getParty'. */
   final case class InvalidPartyName(name: String, msg: String) extends Error

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -7,7 +7,6 @@ package test
 
 import com.daml.lf.data._
 import com.daml.lf.language.LanguageVersion
-import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInstance, VersionedContractInstance}
 
@@ -51,7 +50,7 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
     nodeId
   }
 
-  def build(): Tx.Transaction = ids.synchronized {
+  def build(): VersionedTransaction = ids.synchronized {
     import TransactionVersion.Ordering
     val finalNodes = nodes.transform {
       case (nid, rb: TxRollBack) =>
@@ -226,7 +225,7 @@ object TransactionBuilder {
 
   def newCid: ContractId = newV1Cid
 
-  def just(node: Node, nodes: Node*): Tx.Transaction = {
+  def just(node: Node, nodes: Node*): VersionedTransaction = {
     val builder = TransactionBuilder()
     val _ = builder.add(node)
     for (node <- nodes) {
@@ -242,7 +241,7 @@ object TransactionBuilder {
     CommittedTransaction(just(node, nodes: _*))
 
   // not valid transactions.
-  val Empty: Tx.Transaction =
+  val Empty: VersionedTransaction =
     VersionedTransaction(
       TransactionVersion.minVersion, // A normalized empty tx is V10
       HashMap.empty,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -792,14 +792,9 @@ object Transaction {
   type ActionNode = Node.GenActionNode
   type LeafNode = Node.LeafOnlyActionNode
 
-  /** (Complete) transactions, which are the result of interpreting a
-    * ledger-update. These transactions are consumed by either the
-    * scenario-interpreter or the Daml-engine code. Both of these
-    * code-paths share the computations for segregating the
-    * transaction into party-specific ledgers and for computing
-    * divulgence of contracts.
-    */
+  @deprecated("use com.daml.transaction.VersionedTransaction", since = "1.8.0")
   type Transaction = VersionedTransaction
+  @deprecated("use com.daml.transaction.VersionedTransaction", since = "1.8.0")
   val Transaction: VersionedTransaction.type = VersionedTransaction
 
   /** Transaction meta data

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -792,9 +792,9 @@ object Transaction {
   type ActionNode = Node.GenActionNode
   type LeafNode = Node.LeafOnlyActionNode
 
-  @deprecated("use com.daml.transaction.VersionedTransaction", since = "1.8.0")
+  @deprecated("use com.daml.transaction.VersionedTransaction", since = "1.18.0")
   type Transaction = VersionedTransaction
-  @deprecated("use com.daml.transaction.VersionedTransaction", since = "1.8.0")
+  @deprecated("use com.daml.transaction.VersionedTransaction", since = "1.18.0")
   val Transaction: VersionedTransaction.type = VersionedTransaction
 
   /** Transaction meta data

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V10_1__Populate_Event_Data.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V10_1__Populate_Event_Data.scala
@@ -11,7 +11,7 @@ import anorm.{BatchSql, NamedParameter}
 import com.daml.lf.data.Ref
 import com.daml.lf.ledger.EventId
 import com.daml.lf.transaction.Node.NodeCreate
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.VersionedTransaction
 import com.daml.platform.db.migration.translation.TransactionSerializer
 import com.daml.platform.store.Conversions._
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
@@ -25,10 +25,10 @@ private[migration] class V10_1__Populate_Event_Data extends BaseJavaMigration {
     val statement = conn.createStatement()
     val rows = statement.executeQuery(SELECT_TRANSACTIONS)
 
-    new Iterator[(Ref.LedgerString, Tx.Transaction)] {
+    new Iterator[(Ref.LedgerString, VersionedTransaction)] {
       var hasNext: Boolean = rows.next()
 
-      def next(): (Ref.LedgerString, Tx.Transaction) = {
+      def next(): (Ref.LedgerString, VersionedTransaction) = {
         val transactionId = Ref.LedgerString.assertFromString(rows.getString("transaction_id"))
         val transaction = TransactionSerializer
           .deserializeTransaction(transactionId, rows.getBinaryStream("transaction"))

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
@@ -14,7 +14,7 @@ package object v25_backfill_participant_events {
 
   import com.daml.lf.{transaction => lftx}
   private[migration] type NodeId = lftx.NodeId
-  private[migration] type Transaction = lftx.Transaction.Transaction
+  private[migration] type Transaction = lftx.VersionedTransaction
   private[migration] type Create = lftx.Node.NodeCreate
   private[migration] type Exercise = lftx.Node.NodeExercises
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v29_fix_participant_events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v29_fix_participant_events/package.scala
@@ -14,7 +14,7 @@ package object v29_fix_participant_events {
 
   import com.daml.lf.{transaction => lftx}
   private[migration] type NodeId = lftx.NodeId
-  private[migration] type Transaction = lftx.Transaction.Transaction
+  private[migration] type Transaction = lftx.VersionedTransaction
   private[migration] type Create = lftx.Node.NodeCreate
   private[migration] type Exercise = lftx.Node.NodeExercises
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -258,13 +258,13 @@ private[state] object Conversions {
   private def assertEncode[X](context: => String, x: Either[ValueCoder.EncodeError, X]): X =
     x.fold(err => throw Err.EncodeError(context, err.errorMessage), identity)
 
-  def encodeTransaction(tx: Transaction.Transaction): TransactionOuterClass.Transaction =
+  def encodeTransaction(tx: VersionedTransaction): TransactionOuterClass.Transaction =
     assertEncode(
       "Transaction",
       TransactionCoder.encodeTransaction(TransactionCoder.NidEncoder, ValueCoder.CidEncoder, tx),
     )
 
-  def decodeTransaction(tx: TransactionOuterClass.Transaction): Transaction.Transaction =
+  def decodeTransaction(tx: TransactionOuterClass.Transaction): VersionedTransaction =
     assertDecode(
       "Transaction",
       TransactionCoder

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Projections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Projections.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.participant.state.kvutils
 
 import com.daml.lf.data.BackStack
 import com.daml.lf.data.Ref.Party
-import com.daml.lf.transaction.{BlindingInfo, NodeId, Transaction}
+import com.daml.lf.transaction.{BlindingInfo, NodeId, VersionedTransaction}
 
 final case class ProjectionRoots(
     party: Party,
@@ -24,7 +24,7 @@ object Projections {
     * we keep an explicit list of roots for each party.
     */
   def computePerPartyProjectionRoots(
-      tx: Transaction.Transaction,
+      tx: VersionedTransaction,
       blindingInfo: BlindingInfo,
   ): List[ProjectionRoots] = {
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/DamlTransactionEntrySummary.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/DamlTransactionEntrySummary.scala
@@ -12,20 +12,20 @@ import com.daml.ledger.participant.state.kvutils.store.events.{
 import com.daml.lf.crypto
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.VersionedTransaction
 
 import scala.jdk.CollectionConverters._
 
 private[kvutils] final class DamlTransactionEntrySummary(
     val submission: DamlTransactionEntry,
-    tx: => Tx.Transaction,
+    tx: => VersionedTransaction,
 ) {
   val ledgerEffectiveTime: Timestamp = parseTimestamp(submission.getLedgerEffectiveTime)
   val submitterInfo: DamlSubmitterInfo = submission.getSubmitterInfo
   val commandId: String = submitterInfo.getCommandId
   val submitters: List[Party] =
     submitterInfo.getSubmittersList.asScala.toList.map(Party.assertFromString)
-  lazy val transaction: Tx.Transaction = tx
+  lazy val transaction: VersionedTransaction = tx
   val submissionTime: Timestamp =
     Conversions.parseTimestamp(submission.getSubmissionTime)
   val submissionSeed: crypto.Hash =

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -6,9 +6,8 @@ package com.daml.ledger.participant.state.kvutils
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{BackStack, ImmArray}
 import com.daml.lf.engine.Blinding
-import com.daml.lf.transaction.Transaction.Transaction
 import com.daml.lf.transaction.test.TransactionBuilder
-import com.daml.lf.transaction.{Node, TransactionVersion}
+import com.daml.lf.transaction.{Node, TransactionVersion, VersionedTransaction}
 import com.daml.lf.value.Value.{ContractId, ValueText}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -53,7 +52,7 @@ class ProjectionsSpec extends AnyWordSpec with Matchers {
       version = TransactionVersion.minVersion,
     )
 
-  def project(tx: Transaction) = {
+  def project(tx: VersionedTransaction) = {
     val bi = Blinding.blind(tx)
     Projections.computePerPartyProjectionRoots(tx, bi)
   }

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
@@ -6,7 +6,14 @@ package com.daml.ledger.participant.state.kvutils.tools.engine.replay
 import com.daml.lf.data._
 import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
-import com.daml.lf.transaction.{GlobalKey, Node, NodeId, SubmittedTransaction, Transaction => Tx}
+import com.daml.lf.transaction.{
+  GlobalKey,
+  Node,
+  NodeId,
+  SubmittedTransaction,
+  Transaction => Tx,
+  VersionedTransaction,
+}
 import com.daml.lf.value.Value
 
 import scala.collection.mutable
@@ -18,7 +25,7 @@ private[replay] final class Adapter(
 
   private val interface = com.daml.lf.language.PackageInterface(packages)
 
-  def adapt(tx: Tx.Transaction): SubmittedTransaction =
+  def adapt(tx: VersionedTransaction): SubmittedTransaction =
     tx.foldWithPathState(TxBuilder(pkgLangVersion), Option.empty[NodeId])(
       (builder, parent, _, node) =>
         (builder, Some(parent.fold(builder.add(adapt(node)))(builder.add(adapt(node), _))))


### PR DESCRIPTION
After dropping type parameter from GenTransaction we do not
com.daml.lf.transaction.Transaction.Transaction type alias.  We use
instead directly com.daml.lf.transaction.VersionedTransaction, wich is
anyway more informative.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
