### PR TITLE
Check fixed choices in name collision checker

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -920,7 +920,6 @@ checkIfaceImplementation tplTcon TemplateImplements{..} = do
       Just InterfaceMethod{ifmType} ->
         checkExpr tpiMethodExpr (TCon tplTcon :-> ifmType)
 
-
 _checkFeature :: MonadGamma m => Feature -> m ()
 _checkFeature feature = do
     version <- getLfVersion

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -135,6 +135,7 @@ data Error
   | EDuplicateInterfaceChoiceName !TypeConName !ChoiceName
   | EDuplicateInterfaceMethodName !TypeConName !MethodName
   | EUnknownInterface !TypeConName
+  | EBadInheritedChoices { ebicInterface :: !(Qualified TypeConName), ebicExpected :: ![ChoiceName], ebicGot :: ![ChoiceName] }
   | EMissingInterfaceChoice !ChoiceName
   | EBadInterfaceChoiceImplConsuming !ChoiceName !Bool !Bool
   | EBadInterfaceChoiceImplArgType !ChoiceName !Type !Type
@@ -389,6 +390,12 @@ instance Pretty Error where
     EDuplicateInterfaceMethodName iface method ->
       "Duplicate method name '" <> pretty method <> "' in interface definition for " <> pretty iface
     EUnknownInterface tcon -> "Unknown interface: " <> pretty tcon
+    EBadInheritedChoices {ebicInterface, ebicExpected, ebicGot} ->
+      vcat
+      [ "List of inherited choices does not match interface definition for " <> pretty ebicInterface
+      , "Expected: " <> pretty ebicExpected
+      , "But got: " <> pretty ebicGot
+      ]
     EMissingInterfaceChoice ch -> "Missing interface choice implementation for " <> pretty ch
     EBadInterfaceChoiceImplConsuming ch ifaceConsuming tplConsuming ->
       vcat

--- a/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceChoiceCollision.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SINCE-LF-FEATURE DAML_INTERFACE
--- @ERROR Duplicate choice name 'MyArchive' in template T via interfaces.
+-- @ERROR name collision between choice InterfaceChoiceCollision:T.MyArchive (via interface InterfaceChoiceCollision:InterfaceA) and choice InterfaceChoiceCollision:T.MyArchive (via interface InterfaceChoiceCollision:InterfaceB)
 module InterfaceChoiceCollision where
 
 interface InterfaceA where


### PR DESCRIPTION
This is a follow up to #11364. This PR checks that the list of inherited
choice names is correct in the type checker, and moves the "fixed choice name
collision" check into the name collision checker, since it's now a local check.

Haskell side only for now. Part of #11137.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
