### PR TITLE
Pass `damlc build` logs through daml logger

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -28,6 +28,7 @@ import DA.Daml.LF.Proto3.Archive (encodeArchiveAndHash)
 import DA.Daml.Options (expandSdkPackages)
 import DA.Daml.Options.Types
 import DA.Daml.Package.Config
+import qualified DA.Service.Logger as Logger
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSC
@@ -61,11 +62,11 @@ import qualified Module as Ghc
 import HscTypes
 
 -- | Create a DAR file by running a ZipArchive action.
-createDarFile :: FilePath -> Zip.ZipArchive () -> IO ()
-createDarFile fp dar = do
+createDarFile :: Logger.Handle IO -> FilePath -> Zip.ZipArchive () -> IO ()
+createDarFile loggerH fp dar = do
     createDirectoryIfMissing True $ takeDirectory fp
     Zip.createArchive fp dar
-    putStrLn $ "Created " <> fp
+    Logger.logInfo loggerH $ "Created " <> T.pack fp
 
 ------------------------------------------------------------------------------
 {- | Builds a dar file.

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -451,8 +451,6 @@ execIde telemetry (Debug debug) enableScenarioService options =
           let threshold =
                   if debug
                   then Logger.Debug
-                  -- info is used pretty extensively for debug messages in our code base so
-                  -- I've set the no debug threshold at warning
                   else Logger.Info
           loggerH <- Logger.IO.newIOLogger
             stderr

--- a/compiler/damlc/lib/DA/Cli/Damlc/Base.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Base.hs
@@ -18,4 +18,4 @@ getLogger :: Options -> T.Text -> IO (Logger.Handle IO)
 getLogger Options {optDebug} name =
     if optDebug
         then Logger.IO.newStderrLogger Logger.Debug name
-        else Logger.IO.newStderrLogger Logger.Warning name
+        else Logger.IO.newStderrLogger Logger.Info name

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -361,7 +361,8 @@ tests Tools{damlc} = testGroup "Packaging" $
             , "data C = C Int"
             ]
         (exitCode, out, err) <- readProcessWithExitCode damlc ["build", "--project-root", projDir] ""
-        assertInfixOf "Created" out
+        out @?= ""
+        assertInfixOf "Created" err
         assertInfixOf "collision between variant A:B and module prefix A.B (from A.B.C)" err
         exitCode @?= ExitSuccess
 

--- a/compiler/damlc/tests/src/DamlcPkgManager.hs
+++ b/compiler/damlc/tests/src/DamlcPkgManager.hs
@@ -69,8 +69,7 @@ testsForRemoteDataDependencies damlc dar =
                             , "  signatory p"
                             ]
                     setEnv "DAML_PROJECT" projDir True
-                    (exitCode, _stdout, stderr) <- readProcessWithExitCode damlc ["build"] ""
-                    stderr @?= ""
+                    (exitCode, _stdout, _stderr) <- readProcessWithExitCode damlc ["build"] ""
                     exitCode @?= ExitSuccess
               , testCase "package name:version data-dependency" $
                 withTempDir $ \projDir -> do
@@ -98,8 +97,7 @@ testsForRemoteDataDependencies damlc dar =
                             , "  signatory p"
                             ]
                     setEnv "DAML_PROJECT" projDir True
-                    (exitCode, _stdout, stderr) <- readProcessWithExitCode damlc ["build"] ""
-                    stderr @?= ""
+                    (exitCode, _stdout, _stderr) <- readProcessWithExitCode damlc ["build"] ""
                     exitCode @?= ExitSuccess
                   -- check that a lock file is written
                     let lockFp = projDir </> "daml.lock"
@@ -115,8 +113,7 @@ testsForRemoteDataDependencies damlc dar =
                             , "  version: 0.0.1"
                             ]
                     removeDirectoryRecursive $ projDir </> ".daml"
-                    (exitCode, _stdout, stderr) <- readProcessWithExitCode damlc ["build"] ""
-                    stderr @?= ""
+                    (exitCode, _stdout, _stderr) <- readProcessWithExitCode damlc ["build"] ""
                     exitCode @?= ExitSuccess
                     lock <- readFile lockFp
                     lines lock @?=
@@ -139,8 +136,7 @@ testsForRemoteDataDependencies damlc dar =
                             , "  host: localhost"
                             , "  port: " <> show (sandboxPort + 1)
                             ]
-                    (exitCode, _stdout, stderr) <- readProcessWithExitCode damlc ["build"] ""
-                    stderr @?= ""
+                    (exitCode, _stdout, _stderr) <- readProcessWithExitCode damlc ["build"] ""
                     exitCode @?= ExitSuccess
               , testCase "Caching" $ do
                     InspectInfo {mainPackageId, packages} <- getDarInfo dar
@@ -194,8 +190,7 @@ testsForRemoteDataDependencies damlc dar =
                             , "  signatory p"
                             ]
                     setEnv "DAML_PROJECT" projDir True
-                    (exitCode, _stdout, stderr) <- readProcessWithExitCode damlc ["build"] ""
-                    stderr @?= ""
+                    (exitCode, _stdout, _stderr) <- readProcessWithExitCode damlc ["build"] ""
                     exitCode @?= ExitSuccess
               ]
     ]

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -56,6 +56,7 @@ data Options = Options
   , optScenarioServiceConfig :: ScenarioServiceConfig
   , optMaxConcurrency :: Int
   -- This controls the number of parallel gRPC requests
+  , optLogDebug :: String -> IO ()
   , optLogInfo :: String -> IO ()
   , optLogError :: String -> IO ()
   }
@@ -108,6 +109,7 @@ withScenarioService ver loggerH scenarioConfig f = do
                 { optMaxConcurrency = 5
                 , optServerJar = serverJar
                 , optScenarioServiceConfig = scenarioConfig
+                , optLogDebug = wrapLog Logger.logDebug
                 , optLogInfo = wrapLog Logger.logInfo
                 , optLogError = wrapLog Logger.logError
                 }


### PR DESCRIPTION
This gives us some timings which can be useful in some
circumstances (I want timings around data-dependencies next).

I also changed the default log level to INFO. The `damlc build` output
doesn’t get any noisier from that.

Example output:

```
2021-11-01 15:25:17.16 [INFO]  [build]  []
Compiling foobar to a DAR.

2021-11-01 15:25:17.80 [INFO]  [build]  []
Created .daml/dist/foobar-0.0.1.dar
```

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
