### PR TITLE
LF: ContractInstance should be a CidContainer

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -202,7 +202,9 @@ object Value {
       template: Identifier,
       arg: Value,
       agreementText: String,
-  ) {
+  ) extends CidContainer[ContractInstance] {
+
+    override protected def self: this.type = this
 
     def map(f: Value => Value): ContractInstance =
       copy(arg = f(arg))


### PR DESCRIPTION
In #11419 we drop the implicit call that convert ContractInstance in
CidContainer. Thie is used by Canton and should be restore.

Note that now ContractInstance is not polymorphic anymore, hence we
can inherite CidContainer instead of defining an implicit.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
