### PR TITLE
Enable experimental nix command

### DIFF
--- a/ci/dev-env-push.py
+++ b/ci/dev-env-push.py
@@ -104,7 +104,7 @@ def main():
         shutil.rmtree(nix_cache_dir)
 
     # copy to nix cache
-    cmd = ["nix", "copy", "--to", store_url, "-f", "./nix", "tools", "ci-cached"]
+    cmd = ["nix", "--extra-experimental-features", "nix-command", "copy", "--to", store_url, "-f", "./nix", "tools", "ci-cached"]
     log_cmd(cmd)
     proc = subprocess.run(
             cmd,

--- a/ci/dev-env-push.py
+++ b/ci/dev-env-push.py
@@ -104,7 +104,7 @@ def main():
         shutil.rmtree(nix_cache_dir)
 
     # copy to nix cache
-    cmd = ["nix", "--extra-experimental-features", "nix-command", "copy", "--to", store_url, "-f", "./nix", "tools", "ci-cached"]
+    cmd = ["nix", "copy", "--to", store_url, "-f", "./nix", "tools", "ci-cached"]
     log_cmd(cmd)
     proc = subprocess.run(
             cmd,

--- a/dev-env/etc/nix.conf
+++ b/dev-env/etc/nix.conf
@@ -18,5 +18,3 @@ build-users-group =
 
 # Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
 http2 = false
-
-extra-experimental-features = nix-command

--- a/dev-env/etc/nix.conf
+++ b/dev-env/etc/nix.conf
@@ -18,3 +18,5 @@ build-users-group =
 
 # Work around sporadic segfaults. See https://github.com/digital-asset/daml/pull/4427
 http2 = false
+
+extra-experimental-features = nix-command


### PR DESCRIPTION
Nix 2.4 got released which confusingly marked the nix command as
experimental despite it being actively worked on and being more stable
than before.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
