### PR TITLE
LF: Deprecate  ensureNoCid and assertNoCid from CidContainer

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -100,7 +100,7 @@ private[lf] object Pretty {
           text("conflicts with a local contract ID")
       case ContractIdInContractKey(key) =>
         text("Contract IDs are not supported in contract keys:") &
-          prettyContractId(key.ensureNoCid.left.toOption.get)
+          prettyContractId(key.cids.head)
       case ValueExceedsMaxNesting =>
         text(s"Value exceeds maximum nesting value of 100")
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1747,16 +1747,11 @@ private[lf] object SBuiltin {
     v match {
       case SStruct(_, vals) =>
         val key = onLedger.ptx.normValue(templateId, vals.get(keyIdx))
-        key.ensureNoCid match {
-          case Right(keyVal) =>
-            Node.KeyWithMaintainers(
-              key = keyVal,
-              maintainers =
-                extractParties(NameOf.qualifiedNameOfCurrentFunc, vals.get(maintainerIdx)),
-            )
-          case Left(_) =>
-            throw SErrorDamlException(IE.ContractIdInContractKey(key))
-        }
+        key.foreachCid(_ => throw SErrorDamlException(IE.ContractIdInContractKey(key)))
+        Node.KeyWithMaintainers(
+          key = key,
+          maintainers = extractParties(NameOf.qualifiedNameOfCurrentFunc, vals.get(maintainerIdx)),
+        )
       case _ => throw SErrorCrash(location, s"Invalid key with maintainers: $v")
     }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -9,7 +9,6 @@ import com.daml.lf.data.Ref.{Identifier, Name}
 import com.daml.lf.data._
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.TransactionVersion
-import com.daml.scalautil.Statement.discard
 import data.ScalazEqual._
 
 import scalaz.{@@, Equal, Order, Tag}
@@ -75,12 +74,6 @@ sealed abstract class Value extends CidContainer[Value] with Product with Serial
     go
   }
 
-  def cids[Cid2 >: ContractId] = {
-    val cids = Set.newBuilder[Cid2]
-    foreach1(x => discard(cids += x))(this)
-    cids.result()
-  }
-
 }
 
 object Value {
@@ -100,13 +93,8 @@ object Value {
 
     override protected def self: this.type = this
 
-    final override def mapCid(f: ContractId => ContractId): VersionedValue =
+    override def mapCid(f: ContractId => ContractId): VersionedValue =
       copy(value = value.mapCid(f))
-
-    def foreach1(f: ContractId => Unit) =
-      value.foreach1(f)
-
-    def cids[Cid2 >: ContractId]: Set[Cid2] = value.cids
   }
 
   object VersionedValue {

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -7,7 +7,6 @@ package value
 import data.{Bytes, ImmArray, Ref}
 import Value._
 import Ref.{Identifier, Name}
-import com.daml.lf.transaction.TransactionVersion
 import test.ValueGenerators.{cidV0Gen, coidGen, idGen, nameGen}
 import test.TypedValueGenerators.{RNil, genAddend, ValueAddend => VA}
 import org.scalacheck.{Arbitrary, Gen}
@@ -30,17 +29,6 @@ class ValueSpec
     with Checkers
     with ScalaCheckPropertyChecks {
   import ValueSpec._
-
-  "VersionedValue" - {
-
-    "does not bump version when" - {
-
-      "ensureNoCid is used " in {
-        val value = VersionedValue(TransactionVersion.minVersion, ValueUnit)
-        value.ensureNoCid.map(_.version) shouldBe Right(TransactionVersion.minVersion)
-      }
-    }
-  }
 
   "ContractID.V1.build" - {
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
@@ -57,9 +57,7 @@ private[migration] class V3__Recompute_Key_Hash extends BaseJavaMigration {
           packageId = Ref.PackageId.assertFromString(rows.getString("package_id")),
           qualifiedName = Ref.QualifiedName.assertFromString(rows.getString("template_name")),
         )
-        val key = ValueSerializer
-          .deserializeValue(rows.getBinaryStream("contract_key"))
-          .assertNoCid(coid => s"Found contract ID $coid in contract key")
+        val key = ValueSerializer.deserializeValue(rows.getBinaryStream("contract_key"))
 
         hasNext = rows.next()
         contractId -> GlobalKey(templateId, key.value)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
@@ -159,9 +159,7 @@ private[platform] class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](
                 witnesses = disclosure(nodeId),
                 // A contract starts its life without being divulged at all.
                 divulgences = Map.empty,
-                key = nc.versionedKey.map(
-                  _.assertNoCid(coid => s"Contract ID ${coid.coid} found in contract key")
-                ),
+                key = nc.versionedKey,
                 signatories = nc.signatories,
                 observers = nc.stakeholders.diff(nc.signatories),
                 agreementText = nc.agreementText,
@@ -195,13 +193,7 @@ private[platform] class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](
               }
             case nlkup: Node.LookupByKey =>
               // Check that the stored lookup result matches the current result
-              val key = nlkup.key.key.ensureNoCid.fold(
-                coid =>
-                  throw new IllegalStateException(
-                    s"Contract ID ${coid.coid} found in contract key"
-                  ),
-                identity,
-              )
+              val key = nlkup.key.key
               val gk = GlobalKey(nlkup.templateId, key)
               val nodeParties = nlkup.key.maintainers
 


### PR DESCRIPTION
Before #10827 wich drops type parameters in Value, `CidContainer`'s,
`ensureNoCid` and `assertNoCid` were useful to convert `Value[ContractId]`
 to `Value[Nothing]`. They are now useless as converter, so we deprecate 
them.  

To check a value does not contain Contract Ids one should use
`foreachCid` or `cids` methods.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
