### PR TITLE
Save the submission time in the command deduplication value [KVL-1173]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
@@ -54,12 +54,11 @@ message DamlCommandDedupKey {
 
 message DamlCommandDedupValue {
   reserved 1; // was record_time
-  // the time until when future commands with the same
-  // deduplication key will be rejected due to a duplicate submission
+  // The time until when future commands with the same
+  // deduplication key will be rejected due to a duplicate submission.
   google.protobuf.Timestamp deduplicated_until = 2;
-  //The submission time of the initial command
-  // We use submission time because record time is not available during pre-execution
-  google.protobuf.Timestamp submission_time = 3;
+  // The submission time of the initial command.
+  // We use submission time because record time is not available during pre-execution.
 }
 
 message DamlSubmissionDedupKey {

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
@@ -57,6 +57,9 @@ message DamlCommandDedupValue {
   // the time until when future commands with the same
   // deduplication key will be rejected due to a duplicate submission
   google.protobuf.Timestamp deduplicated_until = 2;
+  //The submission time of the initial command
+  // We use submission time because record time is not available during pre-execution
+  google.protobuf.Timestamp submission_time = 3;
 }
 
 message DamlSubmissionDedupKey {

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
@@ -59,6 +59,7 @@ message DamlCommandDedupValue {
   google.protobuf.Timestamp deduplicated_until = 2;
   // The submission time of the initial command.
   // We use submission time because record time is not available during pre-execution.
+  google.protobuf.Timestamp submission_time = 3;
 }
 
 message DamlSubmissionDedupKey {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -328,13 +328,14 @@ private[kvutils] class TransactionCommitter(
     if (!transactionEntry.submitterInfo.hasDeduplicationDuration) {
       throw Err.InvalidSubmission("Deduplication duration is not set.")
     }
-    val commandDedupBuilder = DamlCommandDedupValue.newBuilder.setDeduplicatedUntil(
-      Conversions.buildTimestamp(
-        transactionEntry.submissionTime
-          .add(parseDuration(transactionEntry.submitterInfo.getDeduplicationDuration))
-          .add(config.timeModel.minSkew)
-      )
+    val deduplicateUntil = Conversions.buildTimestamp(
+      transactionEntry.submissionTime
+        .add(parseDuration(transactionEntry.submitterInfo.getDeduplicationDuration))
+        .add(config.timeModel.minSkew)
     )
+    val commandDedupBuilder = DamlCommandDedupValue.newBuilder
+      .setDeduplicatedUntil(deduplicateUntil)
+      .setSubmissionTime(Conversions.buildTimestamp(transactionEntry.submissionTime))
     // Set a deduplication entry.
     commitContext.set(
       commandDedupKey(transactionEntry.submitterInfo),


### PR DESCRIPTION
This will allow us to change the deduplication logic to use the submission time instead of deduplicate_until to determine if a command is a duplicate or not

CHANGELOG_BEGIN

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ x Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
