### PR TITLE
Add choice collisions in scala name collision checker

### DIFF
--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Collision.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Collision.scala
@@ -46,8 +46,12 @@ private[validation] object Collision {
       module: NModDef,
       astModule: Ast.Module,
   ): List[NamedEntity] =
-    astModule.definitions.toList.flatMap { case (defName, defn) => namedEntitiesFromDef(module, defName, defn) }
-    ++ astModule.templates.toList.flatMap { case (tplName, tpl) => namedEntitiesFromTemplate(module, tplName, tpl) }
+    (astModule.definitions.toList.flatMap { case (defName, defn) =>
+      namedEntitiesFromDef(module, defName, defn)
+    } ++
+      astModule.templates.toList.flatMap { case (tplName, tpl) =>
+        namedEntitiesFromTemplate(module, tplName, tpl)
+      })
 
   private def namedEntitiesFromDef(
       module: NModDef,
@@ -80,9 +84,8 @@ private[validation] object Collision {
       tplName: DottedName,
       tpl: Ast.Template,
   ): List[NamedEntity] =
-    (  tpl.choices.keys.map( NChoice(module, tplName, _) )
-    ++ tpl.implements.iterator.flatMap { case (iface, impl) =>
-          impl.inheritedChoices.iterator.map( NChoiceViaInterface(module, tplName, _, iface) )
-       }
-    ).toList
+    (tpl.choices.keys.map(NChoice(module, tplName, _)) ++
+      tpl.implements.iterator.flatMap { case (iface, impl) =>
+        impl.inheritedChoices.iterator.map(NChoiceViaInterface(module, tplName, _, iface))
+      }).toList
 }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Collision.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Collision.scala
@@ -38,15 +38,16 @@ private[validation] object Collision {
       modules: Iterable[(ModuleName, Ast.Module)]
   ): Iterable[NamedEntity] =
     modules.flatMap { case (modName, module) =>
-      val namedModule = NModDef(modName, module.definitions.toList)
-      namedModule :: namedEntitiesFromMod(namedModule, module.definitions.toList)
+      val namedModule = NModDef(modName)
+      namedModule :: namedEntitiesFromMod(namedModule, module)
     }
 
   private def namedEntitiesFromMod(
       module: NModDef,
-      defns: List[(DottedName, Ast.Definition)],
+      astModule: Ast.Module,
   ): List[NamedEntity] =
-    defns.flatMap { case (defName, defn) => namedEntitiesFromDef(module, defName, defn) }
+    astModule.definitions.toList.flatMap { case (defName, defn) => namedEntitiesFromDef(module, defName, defn) }
+    ++ astModule.templates.toList.flatMap { case (tplName, tpl) => namedEntitiesFromTemplate(module, tplName, tpl) }
 
   private def namedEntitiesFromDef(
       module: NModDef,
@@ -54,17 +55,17 @@ private[validation] object Collision {
       defn: Ast.Definition,
   ): List[NamedEntity] =
     defn match {
-      case dDef @ Ast.DDataType(_, _, Ast.DataRecord(fields)) =>
-        val recordDef = NRecDef(module, defName, dDef)
+      case Ast.DDataType(_, _, Ast.DataRecord(fields)) =>
+        val recordDef = NRecDef(module, defName)
         recordDef :: fields.toList.map { case (name, _) => NField(recordDef, name) }
-      case dDef @ Ast.DDataType(_, _, Ast.DataVariant(variants)) =>
-        val variantDef = NVarDef(module, defName, dDef)
+      case Ast.DDataType(_, _, Ast.DataVariant(variants)) =>
+        val variantDef = NVarDef(module, defName)
         variantDef :: variants.toList.map { case (name, _) => NVarCon(variantDef, name) }
-      case dDef @ Ast.DDataType(_, _, Ast.DataEnum(values)) =>
-        val enumDef = NEnumDef(module, defName, dDef)
+      case Ast.DDataType(_, _, Ast.DataEnum(values)) =>
+        val enumDef = NEnumDef(module, defName)
         enumDef :: values.toList.map(NEnumCon(enumDef, _))
-      case iDef @ Ast.DDataType(_, _, Ast.DataInterface) =>
-        val interfaceDef = NInterface(module, defName, iDef)
+      case Ast.DDataType(_, _, Ast.DataInterface) =>
+        val interfaceDef = NInterface(module, defName)
         interfaceDef :: List.empty
       case _: Ast.DValue =>
         // ignore values
@@ -72,7 +73,16 @@ private[validation] object Collision {
       case _: Ast.DTypeSyn =>
         val synDef = NSynDef(module, defName)
         synDef :: List.empty
-
     }
 
+  private def namedEntitiesFromTemplate(
+      module: NModDef,
+      tplName: DottedName,
+      tpl: Ast.Template,
+  ): List[NamedEntity] =
+    (  tpl.choices.keys.map( NChoice(module, tplName, _) )
+    ++ tpl.implements.iterator.flatMap { case (iface, impl) =>
+          impl.inheritedChoices.iterator.map( NChoiceViaInterface(module, tplName, _, iface) )
+       }
+    ).toList
 }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/NamedEntity.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/NamedEntity.scala
@@ -165,9 +165,9 @@ object NamedEntity {
         choiceName.toUpperCase
       )
 
-    override def toString: String = s"NChoice($modName:$tplName.$choiceName)"
+    override def toString: String = s"NChoice($modName:$tplName:$choiceName)"
 
-    def pretty: String = s"template choice $modName:$tplName.$choiceName"
+    def pretty: String = s"template choice $modName:$tplName:$choiceName"
   }
 
   final case class NChoiceViaInterface(
@@ -183,8 +183,8 @@ object NamedEntity {
         choiceName.toUpperCase
       )
 
-    override def toString: String = s"NChoiceViaInterface($modName:$tplName.$choiceName, $iface)"
+    override def toString: String = s"NChoiceViaInterface($modName:$tplName:$choiceName, $iface)"
 
-    def pretty: String = s"template choice $modName:$tplName.$choiceName (via interface $iface)"
+    def pretty: String = s"template choice $modName:$tplName:$choiceName (via interface $iface)"
   }
 }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/NamedEntity.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/NamedEntity.scala
@@ -4,8 +4,7 @@
 package com.daml.lf.validation
 
 import com.daml.lf.data.Ref
-import com.daml.lf.data.Ref.{DottedName, ModuleName, Name}
-import com.daml.lf.language.Ast
+import com.daml.lf.data.Ref.{DottedName, ModuleName, Name, ChoiceName, TypeConName}
 import com.daml.lf.validation.Util._
 
 sealed trait NamedEntity extends Product with Serializable {
@@ -18,12 +17,11 @@ object NamedEntity {
 
   final case class NModDef(
       name: ModuleName,
-      dfns: List[(DottedName, Ast.Definition)],
   ) extends NamedEntity {
 
     def modName: ModuleName = name
 
-    def fullyResolvedName: DottedName = name.toUpperCase
+    val fullyResolvedName: DottedName = name.toUpperCase
 
     override def toString = s"NModDef($name)"
 
@@ -33,7 +31,6 @@ object NamedEntity {
   final case class NRecDef(
       module: NModDef,
       name: DottedName,
-      dfn: Ast.DDataType,
   ) extends NamedEntity {
 
     def modName: ModuleName = module.name
@@ -49,7 +46,6 @@ object NamedEntity {
   final case class NVarDef(
       module: NModDef,
       name: DottedName,
-      dfn: Ast.DDataType,
   ) extends NamedEntity {
 
     def modName: ModuleName = module.name
@@ -65,7 +61,6 @@ object NamedEntity {
   final case class NEnumDef(
       module: NModDef,
       name: DottedName,
-      dfn: Ast.DDataType,
   ) extends NamedEntity {
 
     def modName: ModuleName = module.name
@@ -146,7 +141,6 @@ object NamedEntity {
   final case class NInterface(
       module: NModDef,
       name: DottedName,
-      dfn: Ast.DDataType,
   ) extends NamedEntity {
 
     def modName: ModuleName = module.name
@@ -157,5 +151,36 @@ object NamedEntity {
     override def toString: String = s"NInterface($modName:$name)"
 
     def pretty: String = s"interface $modName:$name"
+  }
+
+  final case class NChoice (
+    module: NModDef,
+    tplName: DottedName,
+    choiceName: ChoiceName,
+  ) extends NamedEntity {
+    def modName = module.modName
+
+    val fullyResolvedName: DottedName =
+      module.fullyResolvedName ++ tplName.toUpperCase + Name.assertFromString(choiceName.toUpperCase)
+
+    override def toString: String = s"NChoice($modName:$tplName.$choiceName)"
+
+    def pretty: String = s"template choice $modName:$tplName.$choiceName"
+  }
+
+  final case class NChoiceViaInterface (
+    module: NModDef,
+    tplName: DottedName,
+    choiceName: ChoiceName,
+    iface: TypeConName,
+  ) extends NamedEntity {
+    def modName = module.modName
+
+    val fullyResolvedName: DottedName =
+      module.fullyResolvedName ++ tplName.toUpperCase + Name.assertFromString(choiceName.toUpperCase)
+
+    override def toString: String = s"NChoiceViaInterface($modName:$tplName.$choiceName, $iface)"
+
+    def pretty: String = s"template choice $modName:$tplName.$choiceName (via interface $iface)"
   }
 }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/NamedEntity.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/NamedEntity.scala
@@ -16,7 +16,7 @@ sealed trait NamedEntity extends Product with Serializable {
 object NamedEntity {
 
   final case class NModDef(
-      name: ModuleName,
+      name: ModuleName
   ) extends NamedEntity {
 
     def modName: ModuleName = name
@@ -153,31 +153,35 @@ object NamedEntity {
     def pretty: String = s"interface $modName:$name"
   }
 
-  final case class NChoice (
-    module: NModDef,
-    tplName: DottedName,
-    choiceName: ChoiceName,
+  final case class NChoice(
+      module: NModDef,
+      tplName: DottedName,
+      choiceName: ChoiceName,
   ) extends NamedEntity {
     def modName = module.modName
 
     val fullyResolvedName: DottedName =
-      module.fullyResolvedName ++ tplName.toUpperCase + Name.assertFromString(choiceName.toUpperCase)
+      module.fullyResolvedName ++ tplName.toUpperCase + Name.assertFromString(
+        choiceName.toUpperCase
+      )
 
     override def toString: String = s"NChoice($modName:$tplName.$choiceName)"
 
     def pretty: String = s"template choice $modName:$tplName.$choiceName"
   }
 
-  final case class NChoiceViaInterface (
-    module: NModDef,
-    tplName: DottedName,
-    choiceName: ChoiceName,
-    iface: TypeConName,
+  final case class NChoiceViaInterface(
+      module: NModDef,
+      tplName: DottedName,
+      choiceName: ChoiceName,
+      iface: TypeConName,
   ) extends NamedEntity {
     def modName = module.modName
 
     val fullyResolvedName: DottedName =
-      module.fullyResolvedName ++ tplName.toUpperCase + Name.assertFromString(choiceName.toUpperCase)
+      module.fullyResolvedName ++ tplName.toUpperCase + Name.assertFromString(
+        choiceName.toUpperCase
+      )
 
     override def toString: String = s"NChoiceViaInterface($modName:$tplName.$choiceName, $iface)"
 


### PR DESCRIPTION
This brings the name collision checker in line with the LF spec.
This PR also adds collisions for inherited (interface) choices.
Closes #11137.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
