### PR TITLE
[TS-BINDINGS] Flaky build and lint test.

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -368,16 +368,16 @@ test("createAndExercise", async () => {
 
   const [result, events] = await ledger.createAndExercise(
     buildAndLint.Main.Person.Birthday,
-    {name: 'Alice', party: ALICE_PARTY, age: '5', friends: []},
+    {name: 'Alice', party: ALICE_PARTY, age: '10', friends: []},
     {});
   expect(events).toMatchObject(
     [{created: {templateId: buildAndLint.Main.Person.templateId,
                 signatories: [ALICE_PARTY],
-                payload: {name: 'Alice', age: '5'}}},
+                payload: {name: 'Alice', age: '10'}}},
      {archived: {templateId: buildAndLint.Main.Person.templateId}},
      {created: {templateId: buildAndLint.Main.Person.templateId,
                 signatories: [ALICE_PARTY],
-                payload: {name: 'Alice', age: '6'}}}]);
+                payload: {name: 'Alice', age: '11'}}}]);
   expect((events[0] as {created: {contractId: string}}).created.contractId).toEqual((events[1] as {archived: {contractId: string}}).archived.contractId);
   expect(result).toEqual((events[2] as {created: {contractId: string}}).created.contractId);
 });


### PR DESCRIPTION
Modify contract key attribute age for `createAndExercise` to avoid contract key violation with contracts stored on the `create + fetch & exercise` test case

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
