### PR TITLE
Avoid unnecessarily decoding DALFs during dependency installation

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
@@ -15,7 +15,6 @@ import Control.Exception.Safe (tryAny)
 import Control.Lens (toListOf)
 import Control.Monad.Extra
 import DA.Daml.Compiler.Dar
-import DA.Daml.Compiler.DecodeDar (DecodedDalf(..), decodeDalf)
 import DA.Daml.Compiler.ExtractDar (ExtractedDar(..), extractDar)
 import DA.Daml.Helper.Ledger
 import qualified DA.Daml.LF.Ast as LF
@@ -226,9 +225,8 @@ dalfFileNameFromEntry entry =
 
 dalfFileName :: BS.ByteString -> FilePath -> IO FilePath
 dalfFileName bs fp = do
-    DecodedDalf {decodedDalfPkg} <- either fail pure $ decodeDalf Set.empty fp bs
-    let pkgId = T.unpack $ LF.unPackageId $ LF.dalfPackageId decodedDalfPkg
-    pure $ pkgId </> takeFileName fp
+    pkgId <- either (fail . DA.Pretty.renderPretty) pure $ Archive.decodeArchivePackageId bs
+    pure $ T.unpack (LF.unPackageId pkgId) </> takeFileName fp
 
 installDataDepDalf :: Bool -> FilePath -> FilePath -> BS.ByteString -> IO ()
 installDataDepDalf isMain = installDalf ([dataDepMarker] ++ [mainMarker | isMain])


### PR DESCRIPTION
We only need the package id which only requires decoding the header
which is exactly what decodearchivePackageId exists for.

On a large project this seems like a 10-20s improvement which is
pretty significant.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
