### PR TITLE
fix hoogle by pinning nixpkgs

### DIFF
--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -112,7 +112,7 @@ curl -sSfL https://nixos.org/nix/install | sh
 . /home/hoogle/.nix-profile/etc/profile.d/nix.sh
 # Feel free to bump the commit, this was the latest
 # # at the time of creation.
-NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/c50e680b03adecae01fdd1ea4e44c82e641de0cf.tar.gz
+export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/c50e680b03adecae01fdd1ea4e44c82e641de0cf.tar.gz
 cat << EOF > /home/hoogle/hoogle_overlay.nix
 super:
 {


### PR DESCRIPTION
Hoogle has been down for at least 24h accoridng to user reports. What
seems to be happening is that our nixpkgs pinning is not taking effect,
and the nixpkgs version of Hoogle already includes the patch we are
trying to add. This confuses nix, which fails, and thus the boot
sequence is broken.

I've applied the minimal possible patch here (i.e. enforce the pin),
which gets things running again. I've already deployed this change.

We may want to look at bumping the nixpkgs snapshot.

CHANGELOG_BEGIN
CHANGELOG_END