### PR TITLE
Upgrade canton used by ledger-api-test-tool conformance tests

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -375,7 +375,7 @@ java_import(
     jars = glob(["lib/**/*.jar"]),
 )
         """,
-            sha256 = "24a7f8ef120878dba9d89d27563618bef104cf79c2278edf1401e5f28e4e24f4",
-            strip_prefix = "canton-community-0.28.0-SNAPSHOT",
-            urls = ["https://www.canton.io/releases/canton-community-20210919.tar.gz"],
+            sha256 = "31ced734e06039239c17a4ab6da75b629c0f2a637181408d7d7e828409a2e2ce",
+            strip_prefix = "canton-community-1.0.0-SNAPSHOT",
+            urls = ["https://www.canton.io/releases/canton-community-20211104.tar.gz"],
         )

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -88,7 +88,9 @@ conformance_test(
         ",ExceptionsIT,ExceptionRaceConditionIT" +  # need UCK mode - added below
         ",DeeplyNestedValueIT" +  # FIXME: Too deeply nested values flake with a time out (half of the time)
         ",CommandServiceIT:CSReturnStackTrace" +  # FIXME: Ensure canton returns stack trace
-        ",CommandDeduplicationIT:ParticipantCommandDeduplicationSimpleDeduplicationBasic,CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateSubmitterBasic,CommandDeduplicationIT:ParticipantCommandDeduplicationSimpleDeduplicationMixedClients" +  # sync vs async error (part of canton #6301)
+        ",CommandDeduplicationIT:ParticipantCommandDeduplicationSimpleDeduplicationBasic" +  # sync vs async error (part of canton #6301)
+        ",CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateSubmitterBasic" +
+        ",CommandDeduplicationIT:ParticipantCommandDeduplicationSimpleDeduplicationMixedClients" +
         # Also exclude "optional tests" - which are run separately below
         ",CompletionDeduplicationInfoITCommandService" +
         ",CompletionDeduplicationInfoITCommandSubmissionService" +
@@ -96,7 +98,10 @@ conformance_test(
         ",ContractIdIT" +
         ",MultiPartySubmissionIT" +
         ",ParticipantPruningIT" +
-        ",KVCommandDeduplicationIT",  # only for KV-utils
+        ",TLSOnePointThreeIT" +
+        ",TLSAtLeastOnePointTwoIT" +
+        ",KVCommandDeduplicationIT" +  # only for KV-utils
+        ",MonotonicRecordTimeIT",  # KV-utils specific
     ],
 ) if not is_windows else None
 
@@ -161,7 +166,7 @@ conformance_test(
         "--verbose",
         "--include=ContractIdIT:RejectV0,ContractIdIT:RejectNonSuffixedV1Cid,ContractIdIT:AcceptSuffixedV1Cid" +
         ",MultiPartySubmissionIT" +
-        # ",CommandDeduplicationParallelIT" +  # FIXME: Deduplication test not yet passing on canton - canton-#6301
+        ",CommandDeduplicationParallelIT" +
         ",CompletionDeduplicationInfoITCommandService,CompletionDeduplicationInfoITCommandSubmissionService",
         "--exclude=MultiPartySubmissionIT:MPSLookupOtherByKeyInvisible" +  # Enable once error parsing more permissive
         ",MultiPartySubmissionIT:MPSCreateInsufficientAuthorization" +  # canton returns INTERNAL instead of INVALID_ARGUMENT

--- a/ledger/ledger-api-test-tool-on-canton/canton.conf
+++ b/ledger/ledger-api-test-tool-on-canton/canton.conf
@@ -44,6 +44,7 @@ canton {
 
       crypto.provider = tink
 
+      ledger-api.enable-self-service-error-codes = false
       ledger-api.port = 5011
       admin-api.port = 5012
     }
@@ -61,6 +62,7 @@ canton {
 
       crypto.provider = tink
 
+      ledger-api.enable-self-service-error-codes = false
       ledger-api.port = 5021
       admin-api.port = 5022
     }
@@ -78,6 +80,7 @@ canton {
 
       crypto.provider = tink
 
+      ledger-api.enable-self-service-error-codes = false
       ledger-api.port = 5031
       admin-api.port = 5032
     }
@@ -95,6 +98,7 @@ canton {
 
       crypto.provider = tink
 
+      ledger-api.enable-self-service-error-codes = false
       ledger-api.port = 5041
       admin-api.port = 5042
     }

--- a/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf
+++ b/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf
@@ -1,1 +1,2 @@
 canton.domains.test_domain.domain-parameters.unique-contract-keys = true
+canton.parameters.participant.unique-contract-keys = true


### PR DESCRIPTION
This also eases the work on:
- switching to self-service error codes (for now we still run the suite using legacy error-codes in the ledger api server) - fyi @tudor-da
- open sourcing

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
