### PR TITLE
interfaces: Improve fixed choice lookup

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -712,7 +712,12 @@ object Ast {
       observers: E, // Observers of the contract.
       key: Option[GenTemplateKey[E]],
       implements: Map[TypeConName, GenTemplateImplements[E]],
-  )
+  ) {
+    lazy val inheritedChoices: Map[ChoiceName, TypeConName] =
+      implements.iterator.flatMap { case (iface, impl) =>
+        impl.inheritedChoices.iterator.map ( chName => (chName, iface) )
+      }.toMap
+  }
 
   final class GenTemplateCompanion[E] private[Ast] {
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -714,9 +714,9 @@ object Ast {
       implements: Map[TypeConName, GenTemplateImplements[E]],
   ) {
     lazy val inheritedChoices: Map[ChoiceName, TypeConName] =
-      implements.iterator.flatMap { case (iface, impl) =>
-        impl.inheritedChoices.iterator.map(chName => (chName, iface))
-      }.toMap
+      implements.flatMap { case (iface, impl) =>
+        impl.inheritedChoices.view.map(chName => (chName, iface))
+      }
   }
 
   final class GenTemplateCompanion[E] private[Ast] {

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -715,7 +715,7 @@ object Ast {
   ) {
     lazy val inheritedChoices: Map[ChoiceName, TypeConName] =
       implements.iterator.flatMap { case (iface, impl) =>
-        impl.inheritedChoices.iterator.map ( chName => (chName, iface) )
+        impl.inheritedChoices.iterator.map(chName => (chName, iface))
       }.toMap
   }
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/PackageInterface.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/PackageInterface.scala
@@ -6,7 +6,6 @@ package language
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.language.Ast._
-import scalaz._, std.list._, std.either._, syntax.traverse._
 
 private[lf] class PackageInterface(signatures: PartialFunction[PackageId, PackageSignature]) {
 
@@ -202,14 +201,13 @@ private[lf] class PackageInterface(signatures: PartialFunction[PackageId, Packag
       template.choices.get(chName) match {
         case Some(choice) => Right(choice)
         case None =>
-          // TODO https://github.com/digital-asset/daml/issues/10810
-          //  Improve lookup for fixed choices
-          for {
-            ifaces <- template.implements.keys.toList.traverse(lookupInterface(_, context))
-            choices = ifaces.flatMap(_.fixedChoices.get(chName).toList)
-            choice <-
-              choices.headOption.toRight(LookupError(Reference.Choice(tmpName, chName), context))
-          } yield choice
+          template.inheritedChoices.get(chName) match {
+            case None => Left(LookupError(Reference.Choice(tmpName, chName), context))
+            case Some(ifaceName) =>
+                lookupInterface(ifaceName, context).flatMap(iface =>
+                  iface.fixedChoices.get(chName).toRight(LookupError(Reference.Choice(ifaceName, chName), context))
+                )
+          }
       }
     )
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/PackageInterface.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/PackageInterface.scala
@@ -204,9 +204,11 @@ private[lf] class PackageInterface(signatures: PartialFunction[PackageId, Packag
           template.inheritedChoices.get(chName) match {
             case None => Left(LookupError(Reference.Choice(tmpName, chName), context))
             case Some(ifaceName) =>
-                lookupInterface(ifaceName, context).flatMap(iface =>
-                  iface.fixedChoices.get(chName).toRight(LookupError(Reference.Choice(ifaceName, chName), context))
-                )
+              lookupInterface(ifaceName, context).flatMap(iface =>
+                iface.fixedChoices
+                  .get(chName)
+                  .toRight(LookupError(Reference.Choice(ifaceName, chName), context))
+              )
           }
       }
     )


### PR DESCRIPTION
This PR adds a lazy map to match fixed choice names to their
interface, so we're not doing a linear search over every interface.

Part of #10810
Fixes #11346

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
