### PR TITLE
Restart the submission interpretation in case of a race [DPP-737]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/SpannedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/SpannedIndexService.scala
@@ -143,7 +143,9 @@ private[daml] final class SpannedIndexService(delegate: IndexService) extends In
 
   override def lookupMaximumLedgerTime(
       ids: Set[Value.ContractId]
-  )(implicit loggingContext: LoggingContext): Future[Option[Timestamp]] =
+  )(implicit
+      loggingContext: LoggingContext
+  ): Future[Either[Set[Value.ContractId], Option[Timestamp]]] =
     delegate.lookupMaximumLedgerTime(ids)
 
   override def getLedgerId()(implicit loggingContext: LoggingContext): Future[LedgerId] =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -158,7 +158,9 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
 
   override def lookupMaximumLedgerTime(
       ids: Set[Value.ContractId]
-  )(implicit loggingContext: LoggingContext): Future[Option[Timestamp]] =
+  )(implicit
+      loggingContext: LoggingContext
+  ): Future[Either[Set[Value.ContractId], Option[Timestamp]]] =
     Timed.future(
       metrics.daml.services.index.lookupMaximumLedgerTime,
       delegate.lookupMaximumLedgerTime(ids),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
@@ -90,13 +90,13 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
                   if (maxUsedTime.forall(_ <= commands.commands.ledgerEffectiveTime)) {
                     Future.successful(Right(cer))
                   } else if (!cer.dependsOnLedgerTime) {
-                    logger.debug(
+                    logger.info(
                       s"Advancing ledger effective time for the output from ${commands.commands.ledgerEffectiveTime} to $maxUsedTime"
                     )
                     Future.successful(Right(advanceOutputTime(cer, maxUsedTime)))
                   } else {
                     logger.info(
-                      s"Ledger time was used in the Daml code, but a different ledger effective time $maxUsedTime was determined afterwards. The transaction needs to be rerun with the new ledger effective time."
+                      s"Ledger time was used in the Daml code, but a different ledger effective time $maxUsedTime was determined afterwards."
                     )
                     val advancedCommands = advanceInputTime(commands, maxUsedTime)
                     retryOrError(advancedCommands)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
@@ -102,18 +102,15 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
                     retryOrError(advancedCommands)
                   }
               }
-              .recoverWith {
-                // An error while looking up the maximum ledger time for the used contracts
-                // most likely means that one of the contracts is already not active anymore,
-                // which can happen under contention.
-                // A retry would only be successful in case the archived contracts were referenced by key.
-                // Direct references to archived contracts will result in the same error.
+              .recover {
+                // An error while looking up the maximum ledger time for the used contracts. The nature of this error is not known.
+                // Not retrying automatically. All other automatically retryable cases are covered by the logic above.
                 case error =>
                   logger.info(
                     s"Lookup of maximum ledger time failed after ${maxRetries - retriesLeft}. Used contracts: ${usedContractIds
                       .mkString(", ")}. Details: $error"
                   )
-                  Future.successful(Left(ErrorCause.LedgerTime(maxRetries - retriesLeft)))
+                  Left(ErrorCause.LedgerTime(maxRetries - retriesLeft))
               }
       }
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
@@ -220,7 +220,7 @@ private[platform] final class LedgerBackedIndexService(
 
   override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
       loggingContext: LoggingContext
-  ): Future[Option[Timestamp]] =
+  ): Future[Either[Set[ContractId], Option[Timestamp]]] =
     ledger.lookupMaximumLedgerTime(ids)
 
   override def lookupContractKey(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -107,7 +107,7 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
 
   override def lookupMaximumLedgerTime(
       contractIds: Set[ContractId]
-  )(implicit loggingContext: LoggingContext): Future[Option[Timestamp]] =
+  )(implicit loggingContext: LoggingContext): Future[Either[Set[ContractId], Option[Timestamp]]] =
     Timed.future(
       metrics.daml.index.lookupMaximumLedgerTime,
       ledger.lookupMaximumLedgerTime(contractIds),

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -131,7 +131,7 @@ private[platform] abstract class BaseLedger(
 
   override def lookupMaximumLedgerTime(
       contractIds: Set[ContractId]
-  )(implicit loggingContext: LoggingContext): Future[Option[Timestamp]] =
+  )(implicit loggingContext: LoggingContext): Future[Either[Set[ContractId], Option[Timestamp]]] =
     contractStore.lookupMaximumLedgerTime(contractIds)
 
   override def getParties(parties: Seq[Ref.Party])(implicit

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
@@ -71,7 +71,7 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
 
   def lookupMaximumLedgerTime(
       contractIds: Set[ContractId]
-  )(implicit loggingContext: LoggingContext): Future[Option[Timestamp]]
+  )(implicit loggingContext: LoggingContext): Future[Either[Set[ContractId], Option[Timestamp]]]
 
   def lookupKey(key: GlobalKey, forParties: Set[Ref.Party])(implicit
       loggingContext: LoggingContext

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/ContractsReader.scala
@@ -4,6 +4,7 @@
 package com.daml.platform.store.appendonlydao.events
 
 import java.io.ByteArrayInputStream
+
 import com.codahale.metrics.Timer
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
@@ -26,14 +27,13 @@ private[appendonlydao] sealed class ContractsReader(
 
   override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
       loggingContext: LoggingContext
-  ): Future[Option[Timestamp]] =
+  ): Future[Either[Set[ContractId], Option[Timestamp]]] =
     Timed.future(
       metrics.daml.index.db.lookupMaximumLedgerTime,
       dispatcher
         .executeSql(metrics.daml.index.db.lookupMaximumLedgerTimeDbMetrics)(
           storageBackend.maximumLedgerTime(ids)
-        )
-        .map(_.get),
+        ),
     )
 
   /** Lookup a contract key state at a specific ledger offset.

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
@@ -24,7 +24,6 @@ import com.daml.scalautil.NeverEqualsOverride
 
 import javax.sql.DataSource
 import scala.annotation.unused
-import scala.util.Try
 
 /** Encapsulates the interface which hides database technology specific implementations.
   * Naming convention for the interface methods, which requiring Connection:
@@ -202,7 +201,9 @@ trait CompletionStorageBackend {
 
 trait ContractStorageBackend {
   def contractKeyGlobally(key: Key)(connection: Connection): Option[ContractId]
-  def maximumLedgerTime(ids: Set[ContractId])(connection: Connection): Try[Option[Timestamp]]
+  def maximumLedgerTime(ids: Set[ContractId])(
+      connection: Connection
+  ): Either[Set[ContractId], Option[Timestamp]]
   def keyState(key: Key, validAt: Long)(connection: Connection): KeyState
   def contractState(contractId: ContractId, before: Long)(
       connection: Connection

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ContractStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ContractStorageBackendTemplate.scala
@@ -28,9 +28,9 @@ import com.daml.platform.store.interfaces.LedgerDaoContractsReader.{
 }
 
 class ContractStorageBackendTemplate(
-                                      queryStrategy: QueryStrategy,
-                                      ledgerEndCache: LedgerEndCache,
-                                    ) extends ContractStorageBackend {
+    queryStrategy: QueryStrategy,
+    ledgerEndCache: LedgerEndCache,
+) extends ContractStorageBackend {
   override def contractKeyGlobally(key: Key)(connection: Connection): Option[ContractId] =
     contractKey(
       resultColumns = List("contract_id"),
@@ -92,7 +92,7 @@ class ContractStorageBackendTemplate(
   )(connection: Connection): Either[Set[ContractId], Option[Timestamp]] = {
     val lastEventSequentialId = ledgerEndCache()._2
     def lookup(id: ContractId): Option[Option[Timestamp]] =
-        maximumLedgerTimeSqlLiteral(id, lastEventSequentialId).as(
+      maximumLedgerTimeSqlLiteral(id, lastEventSequentialId).as(
         timestampFromMicros("ledger_effective_time").?.singleOpt
       )(
         connection

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -102,7 +102,8 @@ private[platform] class MutableCacheBackedContractStore(
 
         // failure cases
         case (acc, (cid, Some(Archived(_) | NotFound))) =>
-          acc.left.map(_ + cid).orElse(Left(Set(cid)))
+          val missingContracts = acc.left.getOrElse(Set.empty) + cid
+          Left(missingContracts)
         case (acc @ Left(_), _) => acc
       }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -3,6 +3,8 @@
 
 package com.daml.platform.store.cache
 
+import java.util.concurrent.atomic.AtomicReference
+
 import akka.stream.scaladsl.{Keep, RestartSource, Sink, Source}
 import akka.stream.{KillSwitches, Materializer, RestartSettings, UniqueKillSwitch}
 import akka.{Done, NotUsed}
@@ -26,11 +28,10 @@ import com.daml.platform.store.interfaces.LedgerDaoContractsReader.{
   KeyState,
 }
 
-import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
 import scala.util.control.NoStackTrace
-import scala.util.{Failure, Success, Try}
 
 private[platform] class MutableCacheBackedContractStore(
     metrics: Metrics,
@@ -74,30 +75,35 @@ private[platform] class MutableCacheBackedContractStore(
       loggingContext: LoggingContext
   ): Future[Either[Set[ContractId], Option[Timestamp]]] =
     Future
-      .fromTry(partitionCached(ids))
+      .successful(partitionCached(ids))
       .flatMap {
-        case (cached, toBeFetched) if toBeFetched.isEmpty =>
+        case Right((cached, toBeFetched)) if toBeFetched.isEmpty =>
           Future.successful(Right(Some(cached.max)))
-        case (cached, toBeFetched) =>
+        case Right((cached, toBeFetched)) =>
           contractsReader
             .lookupMaximumLedgerTime(toBeFetched)
             .map(_.map(_.map(m => (cached + m).max)))
+        case Left(missingContracts) => Future.successful(Left(missingContracts))
       }
 
   private def partitionCached(
       ids: Set[ContractId]
-  )(implicit loggingContext: LoggingContext) = {
+  )(implicit
+      loggingContext: LoggingContext
+  ): Either[Set[ContractId], (Set[Timestamp], Set[ContractId])] = {
     val cacheQueried = ids.map(id => id -> contractsCache.get(id))
 
     val cached = cacheQueried.view
-      .map(_._2)
-      .foldLeft(Try(Set.empty[Timestamp])) {
-        case (Success(timestamps), Some(active: Active)) =>
-          Success(timestamps + active.createLedgerEffectiveTime)
-        case (Success(_), Some(Archived(_))) => Failure(ContractNotFound(ids))
-        case (Success(_), Some(NotFound)) => Failure(ContractNotFound(ids))
-        case (Success(timestamps), None) => Success(timestamps)
-        case (failure, _) => failure
+      .foldLeft[Either[Set[ContractId], Set[Timestamp]]](Right(Set.empty[Timestamp])) {
+        // successful lookups
+        case (Right(timestamps), (_, Some(active: Active))) =>
+          Right(timestamps + active.createLedgerEffectiveTime)
+        case (Right(timestamps), (_, None)) => Right(timestamps)
+
+        // failure cases
+        case (acc, (cid, Some(Archived(_) | NotFound))) =>
+          acc.left.map(_ + cid).orElse(Left(Set(cid)))
+        case (acc @ Left(_), _) => acc
       }
 
     cached.map { cached =>
@@ -378,11 +384,6 @@ private[platform] object MutableCacheBackedContractStore {
   final case class ContractNotFound(contractIds: Set[ContractId])
       extends IllegalArgumentException(
         s"One or more of the following contract identifiers has not been found: ${contractIds.map(_.coid).mkString(", ")}"
-      )
-
-  final case class EmptyContractIds()
-      extends IllegalArgumentException(
-        "Cannot lookup the maximum ledger time for an empty set of contract identifiers"
       )
 
   final case class ContractReadThroughNotFound(contractId: ContractId) extends NoStackTrace {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/TranslationCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/TranslationCacheBackedContractStore.scala
@@ -43,7 +43,7 @@ class TranslationCacheBackedContractStore(
     */
   override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
       loggingContext: LoggingContext
-  ): Future[Option[Timestamp]] =
+  ): Future[Either[Set[ContractId], Option[Timestamp]]] =
     contractsReader.lookupMaximumLedgerTime(ids)
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/LedgerDaoContractsReader.scala
@@ -20,7 +20,7 @@ private[platform] trait LedgerDaoContractsReader {
     */
   def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
       loggingContext: LoggingContext
-  ): Future[Option[Timestamp]]
+  ): Future[Either[Set[ContractId], Option[Timestamp]]]
 
   /** Looks up an active or divulged contract if it is visible for the given party.
     *

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsTimestamps.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsTimestamps.scala
@@ -10,8 +10,6 @@ import java.util.TimeZone
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.Success
-
 private[backend] trait StorageBackendTestsTimestamps extends Matchers with StorageBackendSpec {
   this: AsyncFlatSpec =>
 
@@ -44,9 +42,9 @@ private[backend] trait StorageBackendTestsTimestamps extends Matchers with Stora
         withDefaultTimeZone("GMT+1")(backend.contract.maximumLedgerTime(Set(cid)))
       )
     } yield {
-      withClue("UTC") { let1 shouldBe Success(Some(let)) }
-      withClue("GMT-1") { let2 shouldBe Success(Some(let)) }
-      withClue("GMT+1") { let3 shouldBe Success(Some(let)) }
+      withClue("UTC") { let1 shouldBe Right(Some(let)) }
+      withClue("GMT-1") { let2 shouldBe Right(Some(let)) }
+      withClue("GMT+1") { let3 shouldBe Right(Some(let)) }
     }
   }
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
@@ -1,0 +1,243 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.apiserver.execution
+
+import java.time.Duration
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.error.ErrorCause
+import com.daml.error.ErrorCause.LedgerTime
+import com.daml.ledger.api.DeduplicationPeriod
+import com.daml.ledger.api.DeduplicationPeriod.DeduplicationDuration
+import com.daml.ledger.api.domain.{ApplicationId, CommandId, Commands, LedgerId}
+import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
+import com.daml.ledger.participant.state.index.v2.ContractStore
+import com.daml.ledger.participant.state.v2.{SubmitterInfo, TransactionMeta}
+import com.daml.lf.command.{Commands => LfCommands}
+import com.daml.lf.crypto.Hash
+import com.daml.lf.data.{ImmArray, Ref, Time}
+import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value.ContractId
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class LedgerTimeAwareCommandExecutorSpec
+    extends AsyncWordSpec
+    with Matchers
+    with MockitoSugar
+    with ArgumentMatchersSugar {
+
+  val submissionSeed = Hash.hashPrivateKey("a key")
+  val configuration = Configuration(
+    generation = 1,
+    timeModel = LedgerTimeModel(
+      avgTransactionLatency = Duration.ZERO,
+      minSkew = Duration.ZERO,
+      maxSkew = Duration.ZERO,
+    ).get,
+    maxDeduplicationTime = Duration.ZERO,
+  )
+
+  val cid = TransactionBuilder.newCid
+  val transaction = TransactionBuilder.justSubmitted(
+    TransactionBuilder().fetch(
+      TransactionBuilder().create(
+        cid,
+        Ref.Identifier(
+          Ref.PackageId.assertFromString("abc"),
+          Ref.QualifiedName.assertFromString("Main:Template"),
+        ),
+        Value.ValueUnit,
+        Set.empty,
+        Set.empty,
+      )
+    )
+  )
+
+  private def runExecutionTest(
+      dependsOnLedgerTime: Boolean,
+      contractStoreResults: List[Either[Set[ContractId], Option[Time.Timestamp]]],
+      finalExecutionResult: Either[ErrorCause, Time.Timestamp],
+  ) = {
+
+    def commandExecutionResult(let: Time.Timestamp) = CommandExecutionResult(
+      SubmitterInfo(
+        Nil,
+        Ref.ApplicationId.assertFromString("foobar"),
+        Ref.CommandId.assertFromString("foobar"),
+        DeduplicationDuration(Duration.ofMinutes(1)),
+        None,
+        configuration,
+      ),
+      TransactionMeta(let, None, Time.Timestamp.Epoch, submissionSeed, None, None, None),
+      transaction,
+      dependsOnLedgerTime,
+      5L,
+    )
+
+    val mockExecutor = mock[CommandExecutor]
+    when(
+      mockExecutor.execute(any[Commands], any[Hash], any[Configuration])(
+        any[ExecutionContext],
+        any[LoggingContext],
+      )
+    )
+      .thenAnswer((c: Commands) =>
+        Future.successful(Right(commandExecutionResult(c.commands.ledgerEffectiveTime)))
+      )
+
+    val mockContractStore = mock[ContractStore]
+    contractStoreResults.tail.foldLeft(
+      when(mockContractStore.lookupMaximumLedgerTime(any[Set[ContractId]])(any[LoggingContext]))
+        .thenReturn(Future.successful(contractStoreResults.head))
+    ) { case (mock, result) =>
+      mock.andThen(Future.successful(result))
+    }
+
+    val commands = Commands(
+      ledgerId = LedgerId("ledgerId"),
+      workflowId = None,
+      applicationId = ApplicationId(Ref.ApplicationId.assertFromString("applicationId")),
+      commandId = CommandId(Ref.CommandId.assertFromString("commandId")),
+      submissionId = None,
+      actAs = Set.empty,
+      readAs = Set.empty,
+      submittedAt = Time.Timestamp.Epoch,
+      deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(Duration.ZERO),
+      commands = LfCommands(
+        commands = ImmArray.Empty,
+        ledgerEffectiveTime = Time.Timestamp.Epoch,
+        commandsReference = "",
+      ),
+    )
+
+    val instance = new LedgerTimeAwareCommandExecutor(
+      mockExecutor,
+      mockContractStore,
+      3,
+      new Metrics(new MetricRegistry),
+    )
+    LoggingContext.newLoggingContext { implicit context =>
+      instance.execute(commands, submissionSeed, configuration).map { actual =>
+        val finalResult = finalExecutionResult.map(let =>
+          CommandExecutionResult(
+            SubmitterInfo(
+              Nil,
+              Ref.ApplicationId.assertFromString("foobar"),
+              Ref.CommandId.assertFromString("foobar"),
+              DeduplicationDuration(Duration.ofMinutes(1)),
+              None,
+              configuration,
+            ),
+            TransactionMeta(let, None, Time.Timestamp.Epoch, submissionSeed, None, None, None),
+            transaction,
+            dependsOnLedgerTime,
+            5L,
+          )
+        )
+
+        verify(mockExecutor, times(contractStoreResults.size)).execute(
+          any[Commands],
+          any[Hash],
+          any[Configuration],
+        )(any[ExecutionContext], any[LoggingContext])
+        verify(mockContractStore, times(contractStoreResults.size))
+          .lookupMaximumLedgerTime(Set(cid))
+
+        actual shouldEqual finalResult
+      }
+    }
+  }
+
+  val missingCid = Left(Set(cid))
+  val foundEpoch = Right(Some(Time.Timestamp.Epoch))
+  val epochPlus5: Time.Timestamp = Time.Timestamp.Epoch.add(Duration.ofSeconds(5))
+  val foundEpochPlus5 = Right(Some(epochPlus5))
+  val noLetFound = Right(None)
+
+  "LedgerTimeAwareCommandExecutor" when {
+    "the model doesn't use getTime" should {
+      "not retry if ledger effective time is found in the contract store" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(foundEpoch),
+          finalExecutionResult = Right(Time.Timestamp.Epoch),
+        )
+      }
+
+      "not retry if the contract does not have ledger effective time" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(noLetFound),
+          finalExecutionResult = Right(Time.Timestamp.Epoch),
+        )
+      }
+
+      "retry if the contract cannot be found in the contract store and fail at max retries" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(missingCid, missingCid, missingCid, missingCid),
+          finalExecutionResult = Left(LedgerTime(3)),
+        )
+      }
+
+      "succeed if the contract can be found on a retry" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(missingCid, missingCid, missingCid, foundEpoch),
+          finalExecutionResult = Right(Time.Timestamp.Epoch),
+        )
+      }
+
+      "advance the output time if the contract's LET is in the future" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(foundEpochPlus5),
+          finalExecutionResult = Right(epochPlus5),
+        )
+      }
+    }
+
+    "the model uses getTime" should {
+      "retry if the contract's LET is in the future" in {
+        runExecutionTest(
+          dependsOnLedgerTime = true,
+          contractStoreResults = List(
+            // the first lookup of +5s will cause the interpretation to be restarted,
+            // in case the usage of getTime with a different LET would result in a different transaction
+            foundEpochPlus5,
+            // The second lookup finds the same ledger time again
+            foundEpochPlus5,
+          ),
+          finalExecutionResult = Right(epochPlus5),
+        )
+      }
+
+      "retry if the contract's LET is in the future and then retry if the contract is missing" in {
+        runExecutionTest(
+          dependsOnLedgerTime = true,
+          contractStoreResults = List(
+            // the first lookup of +5s will cause the interpretation to be restarted,
+            // in case the usage of getTime with a different LET would result in a different transaction
+            foundEpochPlus5,
+            // during the second interpretation the contract was actually archived
+            // and could not be found during the maximum ledger time lookup.
+            // this causes yet another restart of the interpretation.
+            missingCid,
+            // The third lookup finds the same ledger time again
+            foundEpochPlus5,
+          ),
+          finalExecutionResult = Right(epochPlus5),
+        )
+      }
+    }
+
+  }
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
@@ -493,17 +493,11 @@ object MutableCacheBackedContractStoreSpec {
 
     override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
         loggingContext: LoggingContext
-    ): Future[Option[Timestamp]] = ids match {
+    ): Future[Either[Set[ContractId], Option[Timestamp]]] = ids match {
       case setIds if setIds == Set(cId_4) =>
-        Future.successful(Some(t4))
-      case set if set.isEmpty =>
-        Future.failed(EmptyContractIds())
+        Future.successful(Right(Some(t4)))
       case _ =>
-        Future.failed(
-          new IllegalArgumentException(
-            s"The following contracts have not been found: ${ids.map(_.coid).mkString(", ")}"
-          )
-        )
+        Future.successful(Left(ids))
     }
 
     override def lookupActiveContractAndLoadArgument(

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
@@ -32,5 +32,5 @@ trait ContractStore {
     */
   def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
       loggingContext: LoggingContext
-  ): Future[Option[Timestamp]]
+  ): Future[Either[Set[ContractId], Option[Timestamp]]]
 }


### PR DESCRIPTION
Command interpretation happens in two stages:
1) Daml interpretation
2) Determine a suitable ledger effective time

The race can happen in the following situation:
In 1) a contract key K is resolved to contract C1.
Between 1) and 2), a transaction is stored on the participant that
archives C1, but creates C2 with the same contract key K.
In 2) the ledger api server tries to lookup the ledger effective time
for all input contracts to the transaction. If it doesn't find one of
the input contracts at all, it can conclude that the transaction
wouldn't be accepted by the ledger anyway.

The behavior before this patch was to simply abort command
interpretation and return a rather cryptic error to the user.
With this patch, the ledger api server restarts the command
interpretation.
If the "missing contract" was an explicit input to the
command (e.g. as the contract for the exercise or as an argument to an
exercise), then this command will be rejected because the contract is
now archived.
If the contract ID was determined via a contract key lookup, then
restarting the interpretation will result in either a negative lookup or
a different contract ID for the new contract under this contract key.

CHANGELOG_BEGIN
[Ledger API] Retry the interpretation of a command in case of a race
with other transactions. This fix drastically reduces the likelihood of the error
"Could not find a suitable ledger time after 0 retries".
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
