### PR TITLE
Migrate matches-docs tests to sandbox on postgres

### DIFF
--- a/daml-script/export/integration-tests/matches-docs/BUILD.bazel
+++ b/daml-script/export/integration-tests/matches-docs/BUILD.bazel
@@ -49,7 +49,7 @@ client_server_build(
     client_files = ["//daml-script/test:script-test.dar"],
     data = ["//daml-script/test:script-test.dar"],
     output_env = "EXPORT_OUT",
-    server = "//ledger/sandbox:sandbox-binary",
+    server = "//ledger/sandbox:sandbox-ephemeral-postgresql",
     server_args = [
         "--port=0",
         "--port-file=%PORT_FILE%",

--- a/daml-script/export/integration-tests/matches-docs/BUILD.bazel
+++ b/daml-script/export/integration-tests/matches-docs/BUILD.bazel
@@ -55,7 +55,8 @@ client_server_build(
         "--port-file=%PORT_FILE%",
     ],
     server_files = ["//daml-script/test:script-test.dar"],
-)
+) if not is_windows else None
+# Disabled on Windows since postgres gets unhappy in client_server_build.
 
 # Compare the generated Daml ledger export to the example export used in the
 # documentation. This functions as both a golden test on ledger exports and to

--- a/daml-script/export/integration-tests/matches-docs/BUILD.bazel
+++ b/daml-script/export/integration-tests/matches-docs/BUILD.bazel
@@ -107,4 +107,4 @@ $(POSIX_DIFF) -Naur --strip-trailing-cr <($(POSIX_SED) '1,3d;s/[0-9a-f]\\{{64\\}
         "//docs:source/tools/export/output-root/daml.yaml",
     ],
     toolchains = ["@rules_sh//sh/posix:make_variables"],
-)
+) if not is_windows else None

--- a/daml-script/export/integration-tests/matches-docs/BUILD.bazel
+++ b/daml-script/export/integration-tests/matches-docs/BUILD.bazel
@@ -14,6 +14,7 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
 )
+load("@os_info//:os_info.bzl", "is_windows")
 
 da_scala_binary(
     name = "example-export-client",

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -32,7 +32,7 @@ let shared = rec {
 
     postgresql_9_6 = if pkgs.buildPlatform.libc == "glibc"
       then pkgs.runCommand "postgresql_9_6_wrapper" { buildInputs = [ pkgs.makeWrapper ]; } ''
-      mkdir -p $out/bin $out/include $out/lib $out/share
+      mkdir -p $out/bin
       for tool in ${pkgs.postgresql_9_6}/bin/*; do
         makeWrapper $tool $out/bin/$(basename $tool) --set LOCALE_ARCHIVE ${pkgs.glibcLocales}/lib/locale/locale-archive
       done

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -30,7 +30,8 @@ let shared = rec {
     zip
   ;
 
-    postgresql_9_6 = pkgs.runCommand "postgresql_9_6_wrapper" { buildInputs = [ pkgs.makeWrapper ]; } ''
+    postgresql_9_6 = if pkgs.buildPlatform.libc == "glibc"
+      then pkgs.runCommand "postgresql_9_6_wrapper" { buildInputs = [ pkgs.makeWrapper ]; } ''
       mkdir -p $out/bin $out/include $out/lib $out/share
       for tool in ${pkgs.postgresql_9_6}/bin/*; do
         makeWrapper $tool $out/bin/$(basename $tool) --set LOCALE_ARCHIVE ${pkgs.glibcLocales}/lib/locale/locale-archive
@@ -38,7 +39,7 @@ let shared = rec {
       ln -s ${pkgs.postgresql_9_6}/include $out/include
       ln -s ${pkgs.postgresql_9_6}/lib $out/lib
       ln -s ${pkgs.postgresql_9_6}/share $out/share
-    '';
+    '' else pkgs.postgresql_9_6;
 
 
     scala_2_12 = (pkgs.scala_2_12.override { }).overrideAttrs (attrs: {

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -24,12 +24,22 @@ let shared = rec {
     openssl
     gnupatch
     patchelf
-    postgresql_9_6
     protobuf3_8
     python3
     toxiproxy
     zip
-    ;
+  ;
+
+    postgresql_9_6 = pkgs.runCommand "postgresql_9_6_wrapper" { buildInputs = [ pkgs.makeWrapper ]; } ''
+      mkdir -p $out/bin $out/include $out/lib $out/share
+      for tool in ${pkgs.postgresql_9_6}/bin/*; do
+        makeWrapper $tool $out/bin/$(basename $tool) --set LOCALE_ARCHIVE ${pkgs.glibcLocales}/lib/locale/locale-archive
+      done
+      ln -s ${pkgs.postgresql_9_6}/include $out/include
+      ln -s ${pkgs.postgresql_9_6}/lib $out/lib
+      ln -s ${pkgs.postgresql_9_6}/share $out/share
+    '';
+
 
     scala_2_12 = (pkgs.scala_2_12.override { }).overrideAttrs (attrs: {
       # Something appears to be broken in nixpkgs' fixpoint which results in the


### PR DESCRIPTION
We’ve seen timeouts on party allocation which are likely caused by the
h2 issues that keep popping up. Switching to postgres should hopefully
solve that.

We need to wrap postgres to set LOCALE_ARCHIVE for this to work in
builds. We already pass it through in tests which is why it works fine there.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
