### PR TITLE
Bump extractor init timeout to 60s

### DIFF
--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
@@ -121,7 +121,7 @@ trait ExtractorFixture extends SandboxParticipantFixture with PostgresAroundSuit
         try {
           val (dar, _) = readDar(darFile)
           val result = participantClients().flatMap(run(_, init, dar = dar)(ec))(ec)
-          val _ = Await.result(result, atMost = 30.seconds)
+          val _ = Await.result(result, atMost = 60.seconds)
         } finally {
           ec.shutdown()
         }


### PR DESCRIPTION
I’ve seen this timeout at 30s on CI under load.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
