### PR TITLE
LF: Rename GenTransaction to Transaction

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -6,7 +6,7 @@ package com.daml.lf.engine
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.transaction.Node
-import com.daml.lf.transaction.{BlindingInfo, GenTransaction, NodeId, VersionedTransaction}
+import com.daml.lf.transaction.{BlindingInfo, Transaction, NodeId, VersionedTransaction}
 import com.daml.lf.ledger._
 import com.daml.lf.data.Relation.Relation
 
@@ -43,8 +43,8 @@ object Blinding {
   def divulgedTransaction(
       divulgences: Relation[NodeId, Party],
       party: Party,
-      tx: GenTransaction,
-  ): GenTransaction = {
+      tx: Transaction,
+  ): Transaction = {
     val partyDivulgences = Relation.invert(divulgences)(party)
     // Note that this relies on the local divulgence to be well-formed:
     // if an exercise node is divulged to A but some of its descendants
@@ -74,7 +74,7 @@ object Blinding {
       }
     }
 
-    GenTransaction(
+    Transaction(
       roots = go(BackStack.empty, tx.roots.toFrontStack),
       nodes = filteredNodes,
     )

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -8,7 +8,7 @@ import com.daml.lf.data.Ref.{Identifier, Name, PackageId}
 import com.daml.lf.language.{Ast, LookupError}
 import com.daml.lf.transaction.{
   IncompleteTransaction,
-  GenTransaction,
+  Transaction,
   Node,
   NodeId,
   VersionedTransaction,
@@ -174,7 +174,7 @@ final class ValueEnricher(
         } yield exe.copy(chosenValue = choiceArg, exerciseResult = result, key = key)
     }
 
-  def enrichTransaction(tx: GenTransaction): Result[GenTransaction] =
+  def enrichTransaction(tx: Transaction): Result[Transaction] =
     for {
       normalizedNodes <-
         tx.nodes.foldLeft[Result[Map[NodeId, Node]]](ResultDone(Map.empty)) {
@@ -184,14 +184,14 @@ final class ValueEnricher(
               normalizedNode <- enrichNode(node)
             } yield nodes.updated(nid, normalizedNode)
         }
-    } yield GenTransaction(
+    } yield Transaction(
       nodes = normalizedNodes,
       roots = tx.roots,
     )
 
   def enrichVersionedTransaction(versionedTx: VersionedTransaction): Result[VersionedTransaction] =
-    enrichTransaction(GenTransaction(versionedTx.nodes, versionedTx.roots)).map {
-      case GenTransaction(nodes, roots) =>
+    enrichTransaction(Transaction(versionedTx.nodes, versionedTx.roots)).map {
+      case Transaction(nodes, roots) =>
         VersionedTransaction(versionedTx.version, nodes, roots)
     }
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -19,7 +19,6 @@ import com.daml.lf.transaction.{
   NodeId,
   SubmittedTransaction,
   VersionedTransaction,
-  Transaction => GenTx,
   Transaction => Tx,
   TransactionVersion => TxVersions,
 }
@@ -1196,7 +1195,7 @@ class EngineTest
       }
     }
 
-    def txFetchActors(tx: GenTx): Set[Party] =
+    def txFetchActors(tx: Tx): Set[Party] =
       tx.fold(Set[Party]()) { case (actors, (_, n)) =>
         actors union actFetchActors(n)
       }
@@ -1369,9 +1368,7 @@ class EngineTest
       lookerUpCid -> lookerUpInst,
     )
 
-    def firstLookupNode(
-        tx: GenTx
-    ): Option[(NodeId, Node.LookupByKey)] =
+    def firstLookupNode(tx: Tx): Option[(NodeId, Node.LookupByKey)] =
       tx.nodes.collectFirst { case (nid, nl @ Node.LookupByKey(_, _, _, _)) =>
         nid -> nl
       }
@@ -2213,7 +2210,7 @@ object EngineTest {
       dependsOnTime: Boolean = false,
       nodeSeeds: BackStack[(NodeId, crypto.Hash)] = BackStack.empty,
   ) {
-    def commit(tr: GenTx, meta: Tx.Metadata) = {
+    def commit(tr: Tx, meta: Tx.Metadata) = {
       val (newContracts, newKeys) = tr.fold((contracts, keys)) {
         case ((contracts, keys), (_, exe: Node.Exercise)) =>
           (contracts - exe.targetCoid, keys)
@@ -2306,10 +2303,7 @@ object EngineTest {
     finalState.map(state =>
       (
         TxVersions.asVersionedTransaction(
-          GenTx(
-            state.nodes,
-            state.roots.toImmArray,
-          )
+          Tx(state.nodes, state.roots.toImmArray)
         ),
         Tx.Metadata(
           submissionSeed = None,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -19,7 +19,7 @@ import com.daml.lf.transaction.{
   NodeId,
   SubmittedTransaction,
   VersionedTransaction,
-  GenTransaction => GenTx,
+  Transaction => GenTx,
   Transaction => Tx,
   TransactionVersion => TxVersions,
 }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ReinterpretTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ReinterpretTest.scala
@@ -11,12 +11,7 @@ import com.daml.bazeltools.BazelRunfiles
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
 import com.daml.lf.language.Ast._
-import com.daml.lf.transaction.{
-  GlobalKeyWithMaintainers,
-  NodeId,
-  GenTransaction,
-  SubmittedTransaction,
-}
+import com.daml.lf.transaction.{GlobalKeyWithMaintainers, NodeId, Transaction, SubmittedTransaction}
 import com.daml.lf.transaction.Node.{NodeRollback, NodeExercises, NodeCreate}
 import com.daml.lf.value.Value._
 import com.daml.lf.command._
@@ -193,7 +188,7 @@ object ReinterpretTest {
     final case class Rollback(x: List[Shape]) extends Shape
     final case class Create() extends Shape
 
-    def ofTransaction(tx: GenTransaction): Top = {
+    def ofTransaction(tx: Transaction): Top = {
       def ofNid(nid: NodeId): Shape = {
         tx.nodes(nid) match {
           case node: NodeExercises => Exercise(node.children.toList.map(ofNid))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/NormalizeRollbacks.scala
@@ -4,14 +4,14 @@
 package com.daml.lf
 package speedy
 
-import com.daml.lf.transaction.{NodeId, GenTransaction}
+import com.daml.lf.transaction.{NodeId, Transaction}
 import com.daml.lf.transaction.Node
 import com.daml.lf.data.{BackStack, ImmArray}
 import com.daml.lf.data.Trampoline.{Bounce, Land, Trampoline}
 
 private[lf] object NormalizeRollbacks {
 
-  private[this] type TX = GenTransaction
+  private[this] type TX = Transaction
 
   // Normalize a transaction so rollback nodes satisfy the normalization rules.
   // see `makeRoll` below
@@ -30,7 +30,7 @@ private[lf] object NormalizeRollbacks {
     // (1) drop nodes; (2) combine nodes (3) lift nodes from a lower level to a higher level.
 
     txOriginal match {
-      case GenTransaction(nodesOriginal, rootsOriginal) =>
+      case Transaction(nodesOriginal, rootsOriginal) =>
         def traverseNodeIds[R](
             xs: List[NodeId]
         )(k: Vector[Norm] => Trampoline[R]): Trampoline[R] = {
@@ -74,7 +74,7 @@ private[lf] object NormalizeRollbacks {
           pushNorms(initialState, norms.toList) { (finalState, roots) =>
             Land(
               (
-                GenTransaction(finalState.nodeMap, roots.to(ImmArray)),
+                Transaction(finalState.nodeMap, roots.to(ImmArray)),
                 finalState.seedIds.toImmArray,
               )
             )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -9,7 +9,6 @@ import com.daml.lf.data.{BackStack, ImmArray, Ref, Time}
 import com.daml.lf.ledger.{Authorize, FailedAuthorization}
 import com.daml.lf.transaction.{
   ContractKeyUniquenessMode,
-  Transaction,
   GlobalKey,
   Node,
   NodeId,
@@ -325,7 +324,7 @@ private[speedy] case class PartialTransaction(
 
         nodes.keySet diff allChildNodeIds
       }
-      val tx = Transaction(nodes, rootNodes.to(ImmArray))
+      val tx = Tx(nodes, rootNodes.to(ImmArray))
 
       tx.foreach { (nid, node) =>
         val rootPrefix = if (rootNodes.contains(nid)) "root " else ""
@@ -370,7 +369,7 @@ private[speedy] case class PartialTransaction(
     context.info match {
       case _: RootContextInfo if aborted.isEmpty =>
         val roots = context.children.toImmArray
-        val tx0 = Transaction(nodes, roots)
+        val tx0 = Tx(nodes, roots)
         val (tx, seeds) = NormalizeRollbacks.normalizeTx(tx0)
         CompleteTransaction(
           SubmittedTransaction(
@@ -389,7 +388,7 @@ private[speedy] case class PartialTransaction(
     val ptx = unwind()
 
     transaction.IncompleteTransaction(
-      Transaction(
+      Tx(
         ptx.nodes,
         ptx.context.children.toImmArray.toSeq.sortBy(_.index).toImmArray,
       ),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -9,7 +9,7 @@ import com.daml.lf.data.{BackStack, ImmArray, Ref, Time}
 import com.daml.lf.ledger.{Authorize, FailedAuthorization}
 import com.daml.lf.transaction.{
   ContractKeyUniquenessMode,
-  GenTransaction,
+  Transaction,
   GlobalKey,
   Node,
   NodeId,
@@ -325,7 +325,7 @@ private[speedy] case class PartialTransaction(
 
         nodes.keySet diff allChildNodeIds
       }
-      val tx = GenTransaction(nodes, rootNodes.to(ImmArray))
+      val tx = Transaction(nodes, rootNodes.to(ImmArray))
 
       tx.foreach { (nid, node) =>
         val rootPrefix = if (rootNodes.contains(nid)) "root " else ""
@@ -370,7 +370,7 @@ private[speedy] case class PartialTransaction(
     context.info match {
       case _: RootContextInfo if aborted.isEmpty =>
         val roots = context.children.toImmArray
-        val tx0 = GenTransaction(nodes, roots)
+        val tx0 = Transaction(nodes, roots)
         val (tx, seeds) = NormalizeRollbacks.normalizeTx(tx0)
         CompleteTransaction(
           SubmittedTransaction(
@@ -389,7 +389,7 @@ private[speedy] case class PartialTransaction(
     val ptx = unwind()
 
     transaction.IncompleteTransaction(
-      GenTransaction(
+      Transaction(
         ptx.nodes,
         ptx.context.children.toImmArray.toSeq.sortBy(_.index).toImmArray,
       ),

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/NormalizeRollbacksSpec.scala
@@ -13,7 +13,7 @@ import com.daml.lf.data.Ref
 import com.daml.lf.transaction.Node
 import com.daml.lf.transaction.Transaction.LeafNode
 import com.daml.lf.transaction.TransactionVersion
-import com.daml.lf.transaction.{NodeId, GenTransaction}
+import com.daml.lf.transaction.{NodeId, Transaction}
 import com.daml.lf.value.{Value => V}
 
 class NormalizeRollbacksSpec extends AnyWordSpec with Matchers with Inside {
@@ -172,7 +172,7 @@ class NormalizeRollbacksSpec extends AnyWordSpec with Matchers with Inside {
 object NormalizeRollbackSpec {
 
   type Cid = V.ContractId
-  type TX = GenTransaction
+  type TX = Transaction
 
   def preOrderNidsOfTxIsIncreasingFromZero(tx: TX): Boolean = {
     def check(x1: Int, xs: List[Int]): Boolean = {
@@ -221,7 +221,7 @@ object NormalizeRollbackSpec {
 
   def isNormalized(tx: TX): Boolean = {
     tx match {
-      case GenTransaction(nodes, _) =>
+      case Transaction(nodes, _) =>
         def isRB(node: Node): Boolean = {
           node match {
             case _: Node.Rollback => true
@@ -269,7 +269,7 @@ object NormalizeRollbackSpec {
         }
       }
       val roots: List[NodeId] = top.xs.map(toNid)
-      GenTransaction(nodes, roots.to(ImmArray))
+      Transaction(nodes, roots.to(ImmArray))
     }
 
     def ofTransaction(tx: TX): Top = {

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -7,13 +7,7 @@ package test
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
-import com.daml.lf.transaction.{
-  GenTransaction,
-  Node,
-  NodeId,
-  TransactionVersion,
-  VersionedTransaction,
-}
+import com.daml.lf.transaction.{Transaction, Node, NodeId, TransactionVersion, VersionedTransaction}
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.value.Value._
 import org.scalacheck.{Arbitrary, Gen}
@@ -485,11 +479,11 @@ object ValueGenerators {
     *
     * This list is complete as of transaction version 5. -SC
     */
-  val malformedGenTransaction: Gen[GenTransaction] = {
+  val malformedGenTransaction: Gen[Transaction] = {
     for {
       nodes <- Gen.listOf(danglingRefGenNode)
       roots <- Gen.listOf(Arbitrary.arbInt.arbitrary.map(NodeId(_)))
-    } yield GenTransaction(nodes.toMap, roots.to(ImmArray))
+    } yield Transaction(nodes.toMap, roots.to(ImmArray))
   }
 
   /*
@@ -503,7 +497,7 @@ object ValueGenerators {
    *
    */
 
-  val noDanglingRefGenTransaction: Gen[GenTransaction] = {
+  val noDanglingRefGenTransaction: Gen[Transaction] = {
 
     def nonDanglingRefNodeGen(
         maxDepth: Int,
@@ -557,7 +551,7 @@ object ValueGenerators {
     }
 
     nonDanglingRefNodeGen(3, NodeId(0)).map { case (nodeIds, nodes) =>
-      GenTransaction(nodes, nodeIds)
+      Transaction(nodes, nodeIds)
     }
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/IncompleteTransaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/IncompleteTransaction.scala
@@ -7,6 +7,6 @@ package transaction
 import com.daml.lf.data.Ref.Location
 
 final case class IncompleteTransaction(
-    transaction: GenTransaction,
+    transaction: Transaction,
     locationInfo: Map[NodeId, Location],
 )

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -779,9 +779,6 @@ object Transaction {
     }.duplicates
   }
 
-  @deprecated("use com.daml.value.Value.VersionedValue directly", since = "1.18.0")
-  type Value = Value.VersionedValue
-
   @deprecated("use com.daml.value.Value.VersionedContractInstance", since = "1.18.0")
   type ContractInstance = Value.VersionedContractInstance
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -38,8 +38,8 @@ final case class VersionedTransaction private[lf] (
     )
 
   // O(1)
-  def transaction: GenTransaction =
-    GenTransaction(nodes, roots)
+  def transaction: Transaction =
+    Transaction(nodes, roots)
 
 }
 
@@ -54,18 +54,18 @@ final case class VersionedTransaction private[lf] (
   * For performance reasons, users are not required to call `isWellFormed`.
   * Therefore, it is '''forbidden''' to create ill-formed instances, i.e., instances with `!isWellFormed.isEmpty`.
   */
-final case class GenTransaction(
+final case class Transaction(
     nodes: Map[NodeId, Node],
     roots: ImmArray[NodeId],
 ) extends HasTxNodes
-    with value.CidContainer[GenTransaction] {
+    with value.CidContainer[Transaction] {
 
-  import GenTransaction._
+  import Transaction._
 
   override protected def self: this.type = this
-  override def mapCid(f: ContractId => ContractId): GenTransaction =
+  override def mapCid(f: ContractId => ContractId): Transaction =
     copy(nodes = nodes.map { case (nodeId, node) => nodeId -> node.mapCid(f) })
-  def mapNodeId(f: NodeId => NodeId): GenTransaction =
+  def mapNodeId(f: NodeId => NodeId): Transaction =
     copy(
       nodes = nodes.map { case (nodeId, node) => f(nodeId) -> node.mapNodeId(f) },
       roots = roots.map(f),
@@ -134,13 +134,13 @@ final case class GenTransaction(
   /** Compares two Transactions up to renaming of Nids. You most likely want to use this rather than ==, since the
     * Nid is irrelevant to the content of the transaction.
     */
-  def equalForest(other: GenTransaction): Boolean =
+  def equalForest(other: Transaction): Boolean =
     compareForest(other)(_ == _)
 
   /** Compares two Transactions up to renaming of Nids. with the specified comparision of nodes
     * Nid is irrelevant to the content of the transaction.
     */
-  def compareForest(other: GenTransaction)(
+  def compareForest(other: Transaction)(
       compare: (Node, Node) => Boolean
   ): Boolean = {
     @tailrec
@@ -731,14 +731,14 @@ sealed abstract class HasTxNodes {
 
 }
 
-object GenTransaction {
+object Transaction {
 
   @deprecated("use com.daml.transaction.GenTransaction directly", since = "1.18.0")
-  type WithTxValue = GenTransaction
+  type WithTxValue = Transaction
 
-  private[this] val Empty = GenTransaction(HashMap.empty, ImmArray.Empty)
+  private[this] val Empty = Transaction(HashMap.empty, ImmArray.Empty)
 
-  private[lf] def empty: GenTransaction = Empty
+  private[lf] def empty: Transaction = Empty
 
   private[lf] case class NotWellFormedError(nid: NodeId, reason: NotWellFormedErrorReason)
   private[lf] sealed trait NotWellFormedErrorReason
@@ -778,9 +778,6 @@ object GenTransaction {
       }
     }.duplicates
   }
-}
-
-object Transaction {
 
   @deprecated("use com.daml.value.Value.VersionedValue directly", since = "1.18.0")
   type Value = Value.VersionedValue
@@ -792,11 +789,6 @@ object Transaction {
   type ActionNode = Node.Action
   @deprecated("use com.daml.transaction.Node.LeafOnlyAction directly", since = "1.18.0")
   type LeafNode = Node.LeafOnlyAction
-
-  @deprecated("use com.daml.transaction.VersionedTransaction", since = "1.18.0")
-  type Transaction = VersionedTransaction
-  @deprecated("use com.daml.transaction.VersionedTransaction", since = "1.18.0")
-  val Transaction: VersionedTransaction.type = VersionedTransaction
 
   /** Transaction meta data
     *
@@ -901,4 +893,5 @@ object Transaction {
     * was inconsistent with earlier nodes (in execution order).
     */
   final case class InconsistentKeys(key: GlobalKey) extends KeyInputError
+
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -677,7 +677,7 @@ object TransactionCoder {
       .map(_.toImmArray)
   }
 
-  /** Encode a [[GenTransaction[Nid]]] to protobuf using [[TransactionVersion]] provided by the libary.
+  /** Encode a [[Transaction[Nid]]] to protobuf using [[TransactionVersion]] provided by the libary.
     *
     * @param tx        the transaction to be encoded
     * @param encodeNid node id encoding function
@@ -787,7 +787,7 @@ object TransactionCoder {
       )
     } yield tx
 
-  /** Reads a [[GenTransaction[Nid]]] from protobuf. Does not check if
+  /** Reads a [[Transaction[Nid]]] from protobuf. Does not check if
     * [[TransactionVersion]] passed in the protobuf is currently supported, if you need this check use
     * [[TransactionCoder.decodeTransaction]].
     *

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -66,12 +66,12 @@ object TransactionVersion {
   }
 
   private[lf] def asVersionedTransaction(
-      tx: GenTransaction
+      tx: Transaction
   ): VersionedTransaction = {
     import scala.Ordering.Implicits.infixOrderingOps
 
     tx match {
-      case GenTransaction(nodes, roots) =>
+      case Transaction(nodes, roots) =>
         val txVersion = roots.iterator.foldLeft(TransactionVersion.minVersion)((acc, nodeId) =>
           nodes(nodeId).optVersion match {
             case Some(version) => acc max version

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -860,7 +860,7 @@ class TransactionCoderSpec
       case _ => gn
     }
 
-  def hasChoiceObserves(tx: GenTransaction): Boolean =
+  def hasChoiceObserves(tx: Transaction): Boolean =
     tx.nodes.values.exists {
       case ne: Node.Exercise => ne.choiceObservers.nonEmpty
       case _ => false

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -5,7 +5,7 @@ package com.daml.lf
 package transaction
 
 import com.daml.lf.data.{Bytes, ImmArray, Ref}
-import com.daml.lf.transaction.GenTransaction.{
+import com.daml.lf.transaction.Transaction.{
   AliasedNode,
   DanglingNodeId,
   NotWellFormedError,
@@ -647,11 +647,11 @@ object TransactionSpec {
 
   import TransactionBuilder.Implicits._
 
-  type Transaction = GenTransaction
+  type Transaction = Transaction
   def mkTransaction(
       nodes: HashMap[NodeId, Node],
       roots: ImmArray[NodeId],
-  ): Transaction = GenTransaction(nodes, roots)
+  ): Transaction = Transaction(nodes, roots)
 
   def dummyRollbackNode(
       children: ImmArray[NodeId]

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -647,7 +647,6 @@ object TransactionSpec {
 
   import TransactionBuilder.Implicits._
 
-  type Transaction = Transaction
   def mkTransaction(
       nodes: HashMap[NodeId, Node],
       roots: ImmArray[NodeId],

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
@@ -423,7 +423,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   private def tweakTxNodes(tweakNode: Tweak[Node]) = Tweak[VTX] { vtx =>
     // tweak any node in a transaction
     vtx.transaction match {
-      case GenTransaction(nodeMapA, roots) =>
+      case Transaction(nodeMapA, roots) =>
         for {
           nid <- nodeMapA.keys.toList
           nodeB <- tweakNode.run(nodeMapA(nid))


### PR DESCRIPTION
Following up #10827 and #10921 that drop type parameters from GenNode,
we rename GenTransaction to Transaction.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
