### PR TITLE
different types for different speedy phases

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
@@ -13,7 +13,7 @@ import com.daml.lf.engine.script._
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{Ast, LanguageVersion, Util => AstUtil}
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.{Compiler, SDefinition, SError, SExpr, SValue}
+import com.daml.lf.speedy.{Compiler, SDefinition, SError, SValue}
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.tls.{TlsConfiguration, TlsConfigurationCli}

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -8,7 +8,8 @@ import com.daml.lf.command._
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.{PackageId, ParticipantId, Party}
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.{InitialSeeding, PartialTransaction, Pretty, SError, SExpr}
+import com.daml.lf.speedy.{InitialSeeding, PartialTransaction, Pretty, SError}
+import com.daml.lf.speedy.SExpr.{SExpr, SEApp, SEValue}
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{SubmittedTransaction, VersionedTransaction, Transaction => Tx}
@@ -309,7 +310,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
         compiledPackages = compiledPackages,
         submissionTime = submissionTime,
         initialSeeding = seeding,
-        expr = SExpr.SEApp(sexpr, Array(SExpr.SEValue.Token)),
+        expr = SEApp(sexpr, Array(SEValue.Token)),
         committers = submitters,
         readAs = readAs,
         validating = validating,

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -6,7 +6,7 @@ package speedy
 package explore
 
 import com.daml.lf.language.PackageInterface
-import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.SExpr0._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SBuiltin._
@@ -35,7 +35,7 @@ object PlaySpeedy {
     names.foreach { name =>
       val (expected, expr) = examples(name)
       val converted = compiler.unsafeClosureConvert(expr)
-      val machine = Speedy.Machine.fromPureSExpr(PureCompiledPackages.Empty, converted)
+      val machine = Machine.fromPureSExpr(PureCompiledPackages.Empty, converted)
       runMachine(name, machine, expected)
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -21,10 +21,17 @@ package com.daml.lf.speedy
   *  crashing at runtime if one is encountered. In particular we must ensure that the
   *  expression forms: SEAppGeneral and SECase are removed, and replaced by the simpler
   *  SEAppAtomic and SECaseAtomic (plus SELet as required).
+  *
+  *  This compilation phase transforms from SExpr0 to SExpr.
+  *    SExpr contains only the expression forms which execute on the speedy machine.
+  *    SExpr0 contains expression forms which exist during the speedy compilation pipeline.
+  *
+  *  We use "s." and "t." (source/target) for lightweight discrimination
   */
 
 import com.daml.lf.data.Trampoline.{Bounce, Land, Trampoline}
-import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.{SExpr0 => s}
+import com.daml.lf.speedy.{SExpr => t}
 import com.daml.lf.speedy.Compiler.CompilationError
 
 import scala.annotation.tailrec
@@ -34,17 +41,17 @@ private[lf] object Anf {
   /** * Entry point for the ANF transformation phase
     */
   @throws[CompilationError]
-  def flattenToAnf(exp: SExpr): SExpr = {
+  def flattenToAnf(exp: s.SExpr): t.SExpr = {
     flattenToAnfInternal(exp).wrapped
   }
 
   /** `AExpr` tracks when an expression has been transformed. It is
     * private to this file.
     */
-  private final case class AExpr(wrapped: SExpr) extends Serializable
+  private final case class AExpr(wrapped: t.SExpr) extends Serializable
 
   @throws[CompilationError]
-  private def flattenToAnfInternal(exp: SExpr): AExpr = {
+  private def flattenToAnfInternal(exp: s.SExpr): AExpr = {
     val depth = DepthA(0)
     val env = initEnv
     flattenExp(depth, env, exp) { anf =>
@@ -167,34 +174,52 @@ private[lf] object Anf {
     (depth.n - binding.abs.n)
   }
 
-  private[this] type AbsAtom = Either[SExprAtomic, AbsBinding]
+  private[this] type AbsAtom = Either[t.SExprAtomic, AbsBinding]
 
-  private[this] def makeAbsoluteA(env: Env, atom: SExprAtomic): AbsAtom = atom match {
-    case SELocS(rel) => Right(makeAbsoluteB(env, rel))
-    case x => Left(x)
+  private def convertLoc(x: s.SELoc): t.SELoc = {
+    x match {
+      case s.SELocS(x) => t.SELocS(x)
+      case s.SELocA(x) => t.SELocA(x)
+      case s.SELocF(x) => t.SELocF(x)
+    }
   }
 
-  private[this] def makeRelativeA(depth: DepthA)(atom: AbsAtom): SExprAtomic = atom match {
-    case Left(x: SELocS) => throw CompilationError(s"makeRelativeA: unexpected: $x")
+  private def convertAtom(x: s.SExprAtomic): t.SExprAtomic = {
+    x match {
+      case loc: s.SELoc => convertLoc(loc)
+      case s.SEValue(x) => t.SEValue(x)
+      case s.SEBuiltin(x) => t.SEBuiltin(x)
+      case s.SEBuiltinRecursiveDefinition(x) => t.SEBuiltinRecursiveDefinition(x)
+      case _: s.SEVar => sys.error(s"Anf1.convertAtom, unexpected: $x")
+    }
+  }
+
+  private[this] def makeAbsoluteA(env: Env, atom: s.SExprAtomic): AbsAtom = atom match {
+    case s.SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case x => Left(convertAtom(x))
+  }
+
+  private[this] def makeRelativeA(depth: DepthA)(atom: AbsAtom): t.SExprAtomic = atom match {
+    case Left(x: t.SELocS) => throw CompilationError(s"makeRelativeA: unexpected: $x")
     case Left(atom) => atom
-    case Right(binding) => SELocS(makeRelativeB(depth, binding))
+    case Right(binding) => t.SELocS(makeRelativeB(depth, binding))
   }
 
-  private[this] type AbsLoc = Either[SELoc, AbsBinding]
+  private[this] type AbsLoc = Either[s.SELoc, AbsBinding]
 
-  private[this] def makeAbsoluteL(env: Env, loc: SELoc): AbsLoc = loc match {
-    case SELocS(rel) => Right(makeAbsoluteB(env, rel))
-    case x: SELocA => Left(x)
-    case x: SELocF => Left(x)
+  private[this] def makeAbsoluteL(env: Env, loc: s.SELoc): AbsLoc = loc match {
+    case s.SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case x: s.SELocA => Left(x)
+    case x: s.SELocF => Left(x)
   }
 
-  private[this] def makeRelativeL(depth: DepthA)(loc: AbsLoc): SELoc = loc match {
-    case Left(x: SELocS) => throw CompilationError(s"makeRelativeL: unexpected: $x")
-    case Left(loc) => loc
-    case Right(binding) => SELocS(makeRelativeB(depth, binding))
+  private[this] def makeRelativeL(depth: DepthA)(loc: AbsLoc): t.SELoc = loc match {
+    case Left(x: s.SELocS) => throw CompilationError(s"makeRelativeL: unexpected: $x")
+    case Left(loc) => convertLoc(loc)
+    case Right(binding) => t.SELocS(makeRelativeB(depth, binding))
   }
 
-  private[this] def flattenExp[A](depth: DepthA, env: Env, exp: SExpr)(
+  private[this] def flattenExp[A](depth: DepthA, env: Env, exp: s.SExpr)(
       k: K[AExpr, A]
   ): Trampoline[A] = {
     Bounce(() =>
@@ -207,10 +232,10 @@ private[lf] object Anf {
   private[this] def transformLet1[A](
       depth: DepthA,
       env: Env,
-      rhs: SExpr,
-      body: SExpr,
+      rhs: s.SExpr,
+      body: s.SExpr,
       k: K[AExpr, A],
-      transform: Tx[SExpr, A],
+      transform: Tx[t.SExpr, A],
   ): Trampoline[A] = {
     Bounce(() =>
       transformExp(depth, env, rhs, k) { (depth, rhs, txK) =>
@@ -222,7 +247,7 @@ private[lf] object Anf {
             env1,
             body,
             { body1 =>
-              Bounce(() => txK(AExpr(SELet1(rhs, body1.wrapped))))
+              Bounce(() => txK(AExpr(t.SELet1(rhs, body1.wrapped))))
             },
           )(transform)
         )
@@ -230,27 +255,27 @@ private[lf] object Anf {
     )
   }
 
-  private[this] def flattenAlts[A](depth: DepthA, env: Env, alts: Array[SCaseAlt])(
-      k: K[Array[SCaseAlt], A]
+  private[this] def flattenAlts[A](depth: DepthA, env: Env, alts: Array[s.SCaseAlt])(
+      k: K[Array[t.SCaseAlt], A]
   ): Trampoline[A] = {
     // Note: this could be made properly CPS and thus constant stack through
     // trampoline by implementing a CPS version of map. However, map on an
     // array is implemented as a loop so this should be fine.
     Bounce(() =>
-      k(alts.map { case SCaseAlt(pat, body0) =>
+      k(alts.map { case s.SCaseAlt(pat, body0) =>
         val n = patternNArgs(pat)
         val env1 = trackBindings(depth, env, n)
         flattenExp(depth.incr(n), env1, body0)(body => {
-          Land(SCaseAlt(pat, body.wrapped))
+          Land(t.SCaseAlt(pat, body.wrapped))
         }).bounce
       })
     )
   }
 
-  private[this] def patternNArgs(pat: SCasePat): Int = pat match {
-    case _: SCPEnum | _: SCPPrimCon | SCPNil | SCPDefault | SCPNone => 0
-    case _: SCPVariant | SCPSome => 1
-    case SCPCons => 2
+  private[this] def patternNArgs(pat: t.SCasePat): Int = pat match {
+    case _: t.SCPEnum | _: t.SCPPrimCon | t.SCPNil | t.SCPDefault | t.SCPNone => 0
+    case _: t.SCPVariant | t.SCPSome => 1
+    case t.SCPCons => 2
   }
 
   /** `transformExp` is the function at the heart of the ANF transformation.
@@ -266,23 +291,23 @@ private[lf] object Anf {
     *  Note: this wrapping is the reason why we need a "second" CPS transform to
     *  achieve constant stack through trampoline.
     */
-  private[this] def transformExp[A](depth: DepthA, env: Env, exp: SExpr, k: K[AExpr, A])(
-      transform: Tx[SExpr, A]
+  private[this] def transformExp[A](depth: DepthA, env: Env, exp: s.SExpr, k: K[AExpr, A])(
+      transform: Tx[t.SExpr, A]
   ): Trampoline[A] =
     exp match {
-      case atom0: SExprAtomic =>
+      case atom0: s.SExprAtomic =>
         val atom = makeRelativeA(depth)(makeAbsoluteA(env, atom0))
         Bounce(() => transform(depth, atom, k))
 
-      case x: SEVal => Bounce(() => transform(depth, x, k))
-      case x: SEImportValue => Bounce(() => transform(depth, x, k))
+      case s.SEVal(x) => Bounce(() => transform(depth, t.SEVal(x), k))
+      case s.SEImportValue(ty, v) => Bounce(() => transform(depth, t.SEImportValue(ty, v), k))
 
-      case SEAppGeneral(func, args) =>
+      case s.SEAppGeneral(func, args) =>
         // It's safe to perform ANF if the func-expression has no effects when evaluated.
         val safeFunc =
           func match {
             // we know that trivially in these two cases
-            case SEBuiltin(b) => (args.size <= b.arity)
+            case s.SEBuiltin(b) => (args.size <= b.arity)
             case _ => false
           }
         // It's also safe to perform ANF for applications of a single argument.
@@ -292,68 +317,66 @@ private[lf] object Anf {
           transformMultiAppSafely[A](depth, env, func, args, k)(transform)
         }
 
-      case SEMakeClo(fvs0, arity, body0) =>
+      case s.SEMakeClo(fvs0, arity, body0) =>
         val fvs = fvs0.map((loc) => makeRelativeL(depth)(makeAbsoluteL(env, loc)))
         val body = flattenToAnfInternal(body0).wrapped
-        Bounce(() => transform(depth, SEMakeClo(fvs, arity, body), k))
+        Bounce(() => transform(depth, t.SEMakeClo(fvs, arity, body), k))
 
-      case SECase(scrut, alts0) => {
+      case s.SECase(scrut, alts0) => {
         Bounce(() =>
           atomizeExp(depth, env, scrut, k) { (depth, scrut, txK) =>
             val scrut1 = makeRelativeA(depth)(scrut)
             Bounce(() =>
               flattenAlts(depth, env, alts0) { alts =>
-                Bounce(() => transform(depth, SECaseAtomic(scrut1, alts), txK))
+                Bounce(() => transform(depth, t.SECaseAtomic(scrut1, alts), txK))
               }
             )
           }
         )
       }
 
-      case SELet(rhss, body) =>
+      case s.SELet(rhss, body) =>
         val expanded = expandMultiLet(rhss, body)
         Bounce(() => transformExp(depth, env, expanded, k)(transform))
 
-      case SELet1General(rhs, body) =>
+      case s.SELet1General(rhs, body) =>
         Bounce(() => transformLet1(depth, env, rhs, body, k, transform))
 
-      case SELocation(loc, body) => {
+      case s.SELocation(loc, body) => {
         Bounce(() =>
           transformExp(depth, env, body, k) { (depth, body, txK) =>
-            Bounce(() => transform(depth, SELocation(loc, body), txK))
+            Bounce(() => transform(depth, t.SELocation(loc, body), txK))
           }
         )
       }
 
-      case SELabelClosure(label, exp) => {
+      case s.SELabelClosure(label, exp) => {
         Bounce(() =>
           transformExp(depth, env, exp, k) { (depth, exp, txK) =>
-            Bounce(() => transform(depth, SELabelClosure(label, exp), txK))
+            Bounce(() => transform(depth, t.SELabelClosure(label, exp), txK))
           }
         )
       }
 
-      case SETryCatch(body0, handler0) =>
+      case s.SETryCatch(body0, handler0) =>
         // we must not lift applications from either the body or the handler outside of
         // the try-catch block, so we flatten each separately:
-        val body: SExpr = flattenExp(depth, env, body0)(anf => Land(anf.wrapped)).bounce
-        val handler: SExpr =
+        val body: t.SExpr = flattenExp(depth, env, body0)(anf => Land(anf.wrapped)).bounce
+        val handler: t.SExpr =
           flattenExp(depth.incr(1), trackBindings(depth, env, 1), handler0)(anf =>
             Land(anf.wrapped)
           ).bounce
-        Bounce(() => transform(depth, SETryCatch(body, handler), k))
+        Bounce(() => transform(depth, t.SETryCatch(body, handler), k))
 
-      case SEScopeExercise(body0) =>
-        val body: SExpr = flattenExp(depth, env, body0)(anf => Land(anf.wrapped)).bounce
-        Bounce(() => transform(depth, SEScopeExercise(body), k))
+      case s.SEScopeExercise(body0) =>
+        val body: t.SExpr = flattenExp(depth, env, body0)(anf => Land(anf.wrapped)).bounce
+        Bounce(() => transform(depth, t.SEScopeExercise(body), k))
 
-      case _: SEAbs | _: SEDamlException | _: SEAppAtomicFun | _: SEAppAtomicGeneral |
-          _: SEAppAtomicSaturatedBuiltin | _: SELet1Builtin | _: SELet1BuiltinArithmetic |
-          _: SECaseAtomic =>
+      case _: s.SEAbs | _: s.SEDamlException =>
         throw CompilationError(s"flatten: unexpected: $exp")
     }
 
-  private[this] def atomizeExps[A](depth: DepthA, env: Env, exps: List[SExpr], k: K[AExpr, A])(
+  private[this] def atomizeExps[A](depth: DepthA, env: Env, exps: List[s.SExpr], k: K[AExpr, A])(
       transform: Tx[List[AbsAtom], A]
   ): Trampoline[A] =
     exps match {
@@ -370,11 +393,11 @@ private[lf] object Anf {
         )
     }
 
-  private[this] def atomizeExp[A](depth: DepthA, env: Env, exp: SExpr, k: K[AExpr, A])(
+  private[this] def atomizeExp[A](depth: DepthA, env: Env, exp: s.SExpr, k: K[AExpr, A])(
       transform: Tx[AbsAtom, A]
   ): Trampoline[A] = {
     exp match {
-      case ea: SExprAtomic => Bounce(() => transform(depth, makeAbsoluteA(env, ea), k))
+      case ea: s.SExprAtomic => Bounce(() => transform(depth, makeAbsoluteA(env, ea), k))
       case _ => {
         Bounce(() =>
           transformExp(depth, env, exp, k) { (depth, anf, txK) =>
@@ -384,7 +407,7 @@ private[lf] object Anf {
                 depth.incr(1),
                 atom,
                 { body =>
-                  Bounce(() => txK(AExpr(SELet1(anf, body.wrapped))))
+                  Bounce(() => txK(AExpr(t.SELet1(anf, body.wrapped))))
                 },
               )
             )
@@ -394,13 +417,13 @@ private[lf] object Anf {
     }
   }
 
-  private[this] def expandMultiLet(rhss: List[SExpr], body: SExpr): SExpr = {
+  private[this] def expandMultiLet(rhss: List[s.SExpr], body: s.SExpr): s.SExpr = {
     //loop over rhss in reverse order
     @tailrec
-    def loop(acc: SExpr, xs: List[SExpr]): SExpr = {
+    def loop(acc: s.SExpr, xs: List[s.SExpr]): s.SExpr = {
       xs match {
         case Nil => acc
-        case rhs :: xs => loop(SELet1General(rhs, acc), xs)
+        case rhs :: xs => loop(s.SELet1General(rhs, acc), xs)
       }
     }
     loop(body, rhss.reverse)
@@ -412,17 +435,17 @@ private[lf] object Anf {
   private[this] def transformMultiApp[A](
       depth: DepthA,
       env: Env,
-      func: SExpr,
-      args: Array[SExpr],
+      func: s.SExpr,
+      args: Array[s.SExpr],
       k: K[AExpr, A],
-  )(transform: Tx[SExpr, A]): Trampoline[A] = {
+  )(transform: Tx[t.SExpr, A]): Trampoline[A] = {
     Bounce(() =>
       atomizeExp(depth, env, func, k) { (depth, func, txK1) =>
         Bounce(() =>
           atomizeExps(depth, env, args.toList, txK1) { (depth, args, txK) =>
             val func1 = makeRelativeA(depth)(func)
             val args1 = args.map(makeRelativeA(depth))
-            Bounce(() => transform(depth, SEAppAtomic(func1, args1.toArray), txK))
+            Bounce(() => transform(depth, t.SEAppAtomic(func1, args1.toArray), txK))
           }
         )
       }
@@ -436,10 +459,10 @@ private[lf] object Anf {
   private[this] def transformMultiAppSafely[A](
       depth: DepthA,
       env: Env,
-      func: SExpr,
-      args: Array[SExpr],
+      func: s.SExpr,
+      args: Array[s.SExpr],
       k: K[AExpr, A],
-  )(transform: Tx[SExpr, A]): Trampoline[A] = {
+  )(transform: Tx[t.SExpr, A]): Trampoline[A] = {
 
     Bounce(() =>
       atomizeExp(depth, env, func, k) { (depth, func, txK) =>
@@ -448,7 +471,7 @@ private[lf] object Anf {
         val args1 = args.map(arg => flattenExp(depth, env, arg)(anf => Land(anf)).bounce.wrapped)
         Bounce(() =>
           // we build a non-atomic application here (only the function is atomic)
-          transform(depth, SEAppAtomicFun(func1, args1.toArray), txK)
+          transform(depth, t.SEAppAtomicFun(func1, args1.toArray), txK)
         )
       }
     )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -1537,7 +1537,6 @@ private[lf] final class Compiler(
       ifaceId: Identifier,
   ): (t.SDefinitionRef, SDefinition) =
     t.ImplementsDefRef(tmplId, ifaceId) ->
-      //SDefinition(flattenToAnf(unsafeClosureConvert(SEAbs.identity)))// NIC, was bug, 2x flattenToAnf!
       SDefinition(unsafeClosureConvert(s.SEAbs.identity))
 
   // Compile the implementation of an interface method.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -12,8 +12,9 @@ import com.daml.lf.language.{LanguageVersion, LookupError, PackageInterface, Sta
 import com.daml.lf.speedy.Anf.flattenToAnf
 import com.daml.lf.speedy.Profile.LabelModule
 import com.daml.lf.speedy.SBuiltin._
-import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.{SExpr0 => s}
+import com.daml.lf.speedy.{SExpr => t}
 import com.daml.lf.validation.{EUnknownDefinition, Validation, ValidationError}
 import com.daml.scalautil.Statement.discard
 import com.daml.nameof.NameOf
@@ -85,20 +86,20 @@ private[lf] object Compiler {
     )
   }
 
-  private val SEGetTime = SEBuiltin(SBGetTime)
+  private val SEGetTime = s.SEBuiltin(SBGetTime)
 
   private def SBCompareNumeric(b: SBuiltinPure) =
-    SEAbs(3, SEApp(SEBuiltin(b), Array(SEVar(2), SEVar(1))))
+    s.SEAbs(3, s.SEApp(s.SEBuiltin(b), Array(s.SEVar(2), s.SEVar(1))))
   private val SBLessNumeric = SBCompareNumeric(SBLess)
   private val SBLessEqNumeric = SBCompareNumeric(SBLessEq)
   private val SBGreaterNumeric = SBCompareNumeric(SBGreater)
   private val SBGreaterEqNumeric = SBCompareNumeric(SBGreaterEq)
   private val SBEqualNumeric = SBCompareNumeric(SBEqual)
 
-  private val SBEToTextNumeric = SEAbs(1, SEBuiltin(SBToText))
+  private val SBEToTextNumeric = s.SEAbs(1, s.SEBuiltin(SBToText))
 
-  private val SENat: Numeric.Scale => Some[SEValue] =
-    Numeric.Scale.values.map(n => Some(SEValue(STNat(n))))
+  private val SENat: Numeric.Scale => Some[s.SEValue] =
+    Numeric.Scale.values.map(n => Some(s.SEValue(STNat(n))))
 
   /** Validates and Compiles all the definitions in the packages provided. Returns them in a Map.
     *
@@ -109,11 +110,12 @@ private[lf] object Compiler {
       interface: PackageInterface,
       packages: Map[PackageId, Package],
       compilerConfig: Compiler.Config,
-  ): Either[String, Map[SDefinitionRef, SDefinition]] = {
+  ): Either[String, Map[t.SDefinitionRef, SDefinition]] = {
     val compiler = new Compiler(interface, compilerConfig)
     try {
-      Right(packages.foldLeft(Map.empty[SDefinitionRef, SDefinition]) { case (acc, (pkgId, pkg)) =>
-        acc ++ compiler.unsafeCompilePackage(pkgId, pkg)
+      Right(packages.foldLeft(Map.empty[t.SDefinitionRef, SDefinition]) {
+        case (acc, (pkgId, pkg)) =>
+          acc ++ compiler.unsafeCompilePackage(pkgId, pkg)
       })
     } catch {
       case CompilationError(msg) => Left(s"Compilation Error: $msg")
@@ -152,10 +154,10 @@ private[lf] final class Compiler(
     }
 
   // Stack-trace support is disabled by avoiding the construction of SELocation nodes.
-  private[this] def maybeSELocation(loc: Location, sexp: SExpr): SExpr = {
+  private[this] def maybeSELocation(loc: Location, sexp: s.SExpr): s.SExpr = {
     config.stacktracing match {
       case NoStackTrace => sexp
-      case FullStackTrace => SELocation(loc, sexp)
+      case FullStackTrace => s.SELocation(loc, sexp)
     }
   }
 
@@ -178,7 +180,7 @@ private[lf] final class Compiler(
       varIndices: Map[VarRef, Position],
   ) {
 
-    def toSEVar(p: Position): SEVar = SEVar(position - p.idx)
+    def toSEVar(p: Position): s.SEVar = s.SEVar(position - p.idx)
 
     def nextPosition = Position(position)
 
@@ -210,70 +212,85 @@ private[lf] final class Compiler(
 
     private[this] def vars: List[VarRef] = varIndices.keys.toList
 
-    private[this] def lookupVar(varRef: VarRef): Option[SEVar] =
+    private[this] def lookupVar(varRef: VarRef): Option[s.SEVar] =
       varIndices.get(varRef).map(toSEVar)
 
-    def lookupExprVar(name: ExprVarName): SEVar =
+    def lookupExprVar(name: ExprVarName): s.SEVar =
       lookupVar(EVarRef(name))
         .getOrElse(throw CompilationError(s"Unknown variable: $name. Known: ${vars.mkString(",")}"))
 
-    def lookupTypeVar(name: TypeVarName): Option[SEVar] =
+    def lookupTypeVar(name: TypeVarName): Option[s.SEVar] =
       lookupVar(TVarRef(name))
 
   }
 
-  private[this] val withLabel: (Profile.Label, SExpr) => SExpr =
+  // We add labels before and after flattenning
+
+  private[this] val withLabelS: (Profile.Label, s.SExpr) => s.SExpr =
     config.profiling match {
       case NoProfile => { (_, expr) =>
         expr
       }
       case FullProfile => { (label, expr) =>
         expr match {
-          case SELabelClosure(_, expr1) => SELabelClosure(label, expr1)
-          case _ => SELabelClosure(label, expr)
+          case s.SELabelClosure(_, expr1) => s.SELabelClosure(label, expr1)
+          case _ => s.SELabelClosure(label, expr)
         }
       }
     }
 
-  private[this] def withOptLabel[L: Profile.LabelModule.Allowed](
+  private[this] val withLabelT: (Profile.Label, t.SExpr) => t.SExpr =
+    config.profiling match {
+      case NoProfile => { (_, expr) =>
+        expr
+      }
+      case FullProfile => { (label, expr) =>
+        expr match {
+          case t.SELabelClosure(_, expr1) => t.SELabelClosure(label, expr1)
+          case _ => t.SELabelClosure(label, expr)
+        }
+      }
+    }
+
+  private[this] def withOptLabelS[L: Profile.LabelModule.Allowed](
       optLabel: Option[L with AnyRef],
-      expr: SExpr,
-  ): SExpr =
+      expr: s.SExpr,
+  ): s.SExpr =
     optLabel match {
-      case Some(label) => withLabel(label, expr)
+      case Some(label) => withLabelS(label, expr)
       case None => expr
     }
 
-  private[this] def app(f: SExpr, a: SExpr) = SEApp(f, Array(a))
+  private[this] def app(f: s.SExpr, a: s.SExpr) = s.SEApp(f, Array(a))
 
-  private[this] def let(env: Env, bound: SExpr)(f: (Position, Env) => SExpr): SELet =
+  private[this] def let(env: Env, bound: s.SExpr)(f: (Position, Env) => s.SExpr): s.SELet =
     f(env.nextPosition, env.pushVar) match {
-      case SELet(bounds, body) =>
-        SELet(bound :: bounds, body)
+      case s.SELet(bounds, body) =>
+        s.SELet(bound :: bounds, body)
       case otherwise =>
-        SELet(List(bound), otherwise)
+        s.SELet(List(bound), otherwise)
     }
 
-  private[this] def unaryFunction(env: Env)(f: (Position, Env) => SExpr): SEAbs =
+  private[this] def unaryFunction(env: Env)(f: (Position, Env) => s.SExpr): s.SEAbs =
     f(env.nextPosition, env.pushVar) match {
-      case SEAbs(n, body) => SEAbs(n + 1, body)
-      case otherwise => SEAbs(1, otherwise)
+      case s.SEAbs(n, body) => s.SEAbs(n + 1, body)
+      case otherwise => s.SEAbs(1, otherwise)
     }
 
   private[this] def labeledUnaryFunction[L: Profile.LabelModule.Allowed](
       label: L with AnyRef,
       env: Env,
   )(
-      body: (Position, Env) => SExpr
-  ): SExpr =
-    unaryFunction(env)((positions, env) => withLabel(label, body(positions, env)))
+      body: (Position, Env) => s.SExpr
+  ): s.SExpr =
+    unaryFunction(env)((positions, env) => withLabelS(label, body(positions, env)))
 
-  private[this] def topLevelFunction[SDefRef <: SDefinitionRef: LabelModule.Allowed](
+  private[this] def topLevelFunction[SDefRef <: t.SDefinitionRef: LabelModule.Allowed](
       ref: SDefRef
   )(
-      body: SExpr
+      body: s.SExpr
   ): (SDefRef, SDefinition) =
-    ref -> SDefinition(unsafeClosureConvert(withLabel(ref, body)))
+    ref -> SDefinition(unsafeClosureConvert(withLabelS(ref, body)))
 
   private val Position1 = Env.Empty.nextPosition
   private val Env1 = Env.Empty.pushVar
@@ -282,45 +299,51 @@ private[lf] final class Compiler(
   private val Position3 = Env2.nextPosition
   private val Env3 = Env2.pushVar
 
-  private[this] def topLevelFunction1[SDefRef <: SDefinitionRef: LabelModule.Allowed](ref: SDefRef)(
-      body: (Position, Env) => SExpr
+  private[this] def topLevelFunction1[SDefRef <: t.SDefinitionRef: LabelModule.Allowed](
+      ref: SDefRef
+  )(
+      body: (Position, Env) => s.SExpr
   ): (SDefRef, SDefinition) =
-    topLevelFunction(ref)(SEAbs(1, body(Position1, Env1)))
+    topLevelFunction(ref)(s.SEAbs(1, body(Position1, Env1)))
 
-  private[this] def topLevelFunction2[SDefRef <: SDefinitionRef: LabelModule.Allowed](ref: SDefRef)(
-      body: (Position, Position, Env) => SExpr
+  private[this] def topLevelFunction2[SDefRef <: t.SDefinitionRef: LabelModule.Allowed](
+      ref: SDefRef
+  )(
+      body: (Position, Position, Env) => s.SExpr
   ): (SDefRef, SDefinition) =
-    topLevelFunction(ref)(SEAbs(2, body(Position1, Position2, Env2)))
+    topLevelFunction(ref)(s.SEAbs(2, body(Position1, Position2, Env2)))
 
-  private[this] def topLevelFunction3[SDefRef <: SDefinitionRef: LabelModule.Allowed](ref: SDefRef)(
-      body: (Position, Position, Position, Env) => SExpr
+  private[this] def topLevelFunction3[SDefRef <: t.SDefinitionRef: LabelModule.Allowed](
+      ref: SDefRef
+  )(
+      body: (Position, Position, Position, Env) => s.SExpr
   ): (SDefRef, SDefinition) =
-    topLevelFunction(ref)(SEAbs(3, body(Position1, Position2, Position3, Env3)))
+    topLevelFunction(ref)(s.SEAbs(3, body(Position1, Position2, Position3, Env3)))
 
   @throws[PackageNotFound]
   @throws[CompilationError]
-  def unsafeCompile(cmds: ImmArray[Command]): SExpr =
+  def unsafeCompile(cmds: ImmArray[Command]): t.SExpr =
     validate(compilationPipeline(compileCommands(cmds)))
 
   @throws[PackageNotFound]
   @throws[CompilationError]
-  def unsafeCompileForReinterpretation(cmd: Command): SExpr =
+  def unsafeCompileForReinterpretation(cmd: Command): t.SExpr =
     validate(compilationPipeline(compileCommandForReinterpretation(cmd)))
 
   @throws[PackageNotFound]
   @throws[CompilationError]
-  def unsafeCompile(expr: Expr): SExpr =
+  def unsafeCompile(expr: Expr): t.SExpr =
     validate(compilationPipeline(compile(Env.Empty, expr)))
 
   @throws[PackageNotFound]
   @throws[CompilationError]
-  def unsafeClosureConvert(sexpr: SExpr): SExpr =
+  def unsafeClosureConvert(sexpr: s.SExpr): t.SExpr =
     validate(compilationPipeline(sexpr))
 
   // Run the compilation pipeline phases:
   // (1) closure conversion
   // (2) transform to ANF
-  private[this] def compilationPipeline(sexpr: SExpr): SExpr =
+  private[this] def compilationPipeline(sexpr: s.SExpr): t.SExpr =
     flattenToAnf(closureConvert(Map.empty, sexpr))
 
   @throws[PackageNotFound]
@@ -328,19 +351,19 @@ private[lf] final class Compiler(
   def unsafeCompileModule(
       pkgId: PackageId,
       module: Module,
-  ): Iterable[(SDefinitionRef, SDefinition)] = {
-    val builder = Iterable.newBuilder[(SDefinitionRef, SDefinition)]
-    def addDef(binding: (SDefinitionRef, SDefinition)) = discard(builder += binding)
+  ): Iterable[(t.SDefinitionRef, SDefinition)] = {
+    val builder = Iterable.newBuilder[(t.SDefinitionRef, SDefinition)]
+    def addDef(binding: (t.SDefinitionRef, SDefinition)) = discard(builder += binding)
 
     module.exceptions.foreach { case (defName, GenDefException(message)) =>
-      val ref = ExceptionMessageDefRef(Identifier(pkgId, QualifiedName(module.name, defName)))
-      builder += (ref -> SDefinition(withLabel(ref, unsafeCompile(message))))
+      val ref = t.ExceptionMessageDefRef(Identifier(pkgId, QualifiedName(module.name, defName)))
+      builder += (ref -> SDefinition(withLabelT(ref, unsafeCompile(message))))
     }
 
     module.definitions.foreach {
       case (defName, DValue(_, _, body, _)) =>
-        val ref = LfDefRef(Identifier(pkgId, QualifiedName(module.name, defName)))
-        builder += (ref -> SDefinition(withLabel(ref, unsafeCompile(body))))
+        val ref = t.LfDefRef(Identifier(pkgId, QualifiedName(module.name, defName)))
+        builder += (ref -> SDefinition(withLabelT(ref, unsafeCompile(body))))
       case _ =>
     }
 
@@ -391,7 +414,7 @@ private[lf] final class Compiler(
   def unsafeCompilePackage(
       pkgId: PackageId,
       pkg: Package,
-  ): Iterable[(SDefinitionRef, SDefinition)] = {
+  ): Iterable[(t.SDefinitionRef, SDefinition)] = {
     logger.trace(s"compilePackage: Compiling $pkgId...")
 
     val t0 = Time.Timestamp.now()
@@ -428,18 +451,18 @@ private[lf] final class Compiler(
     result
   }
 
-  private[this] def patternNArgs(pat: SCasePat): Int = pat match {
-    case _: SCPEnum | _: SCPPrimCon | SCPNil | SCPDefault | SCPNone => 0
-    case _: SCPVariant | SCPSome => 1
-    case SCPCons => 2
+  private[this] def patternNArgs(pat: t.SCasePat): Int = pat match {
+    case _: t.SCPEnum | _: t.SCPPrimCon | t.SCPNil | t.SCPDefault | t.SCPNone => 0
+    case _: t.SCPVariant | t.SCPSome => 1
+    case t.SCPCons => 2
   }
 
-  private[this] def compile(env: Env, expr0: Expr): SExpr =
+  private[this] def compile(env: Env, expr0: Expr): s.SExpr =
     expr0 match {
       case EVar(name) =>
         env.lookupExprVar(name)
       case EVal(ref) =>
-        SEVal(LfDefRef(ref))
+        s.SEVal(t.LfDefRef(ref))
       case EBuiltin(bf) =>
         compileBuiltin(bf)
       case EPrimCon(con) =>
@@ -465,8 +488,8 @@ private[lf] final class Compiler(
       case EStructCon(fields) =>
         val fieldsInputOrder =
           Struct.assertFromSeq(fields.iterator.map(_._1).zipWithIndex.toSeq)
-        SEApp(
-          SEBuiltin(SBStructCon(fieldsInputOrder)),
+        s.SEApp(
+          s.SEBuiltin(SBStructCon(fieldsInputOrder)),
           mapToArray(fields) { case (_, e) => compile(env, e) },
         )
       case structProj: EStructProj =>
@@ -487,18 +510,18 @@ private[lf] final class Compiler(
       case ECase(scrut, alts) =>
         compileECase(env, scrut, alts)
       case ENil(_) =>
-        SEValue.EmptyList
+        s.SEValue.EmptyList
       case ECons(_, front, tail) =>
         // TODO(JM): Consider emitting SEValue(SList(...)) for
         // constant lists?
         val args = (front.iterator.map(compile(env, _)) ++ Seq(compile(env, tail))).toArray
         if (front.length == 1) {
-          SEApp(SEBuiltin(SBCons), args)
+          s.SEApp(s.SEBuiltin(SBCons), args)
         } else {
-          SEApp(SEBuiltin(SBConsMany(front.length)), args)
+          s.SEApp(s.SEBuiltin(SBConsMany(front.length)), args)
         }
       case ENone(_) =>
-        SEValue.None
+        s.SEValue.None
       case ESome(_, body) =>
         SBSome(compile(env, body))
       case EEnumCon(tyCon, consName) =>
@@ -506,7 +529,7 @@ private[lf] final class Compiler(
           NameOf.qualifiedNameOfCurrentFunc,
           interface.lookupEnumConstructor(tyCon, consName),
         )
-        SEValue(SEnum(tyCon, consName, rank))
+        s.SEValue(SEnum(tyCon, consName, rank))
       case EVariantCon(tapp, variant, arg) =>
         val rank = handleLookup(
           NameOf.qualifiedNameOfCurrentFunc,
@@ -528,7 +551,7 @@ private[lf] final class Compiler(
       case EFromAny(ty, e) =>
         SBFromAny(ty)(compile(env, e))
       case ETypeRep(typ) =>
-        SEValue(STypeRep(typ))
+        s.SEValue(STypeRep(typ))
       case EToAnyException(ty, e) =>
         SBToAny(ty)(compile(env, e))
       case EFromAnyException(ty, e) =>
@@ -547,12 +570,15 @@ private[lf] final class Compiler(
     }
 
   @inline
-  private[this] def compileBuiltin(bf: BuiltinFunction): SExpr =
+  private[this] def compileBuiltin(bf: BuiltinFunction): s.SExpr =
     bf match {
       case BEqualList =>
-        val ref = SEBuiltinRecursiveDefinition.EqualList
-        withLabel(ref.ref, ref)
-      case BCoerceContractId => SEAbs.identity
+        val ref: t.SEBuiltinRecursiveDefinition.Reference =
+          t.SEBuiltinRecursiveDefinition.Reference.EqualList
+        val exp: s.SExpr = s.SEBuiltinRecursiveDefinition(ref)
+        withLabelS(ref, exp)
+
+      case BCoerceContractId => s.SEAbs.identity
       // Numeric Comparisons
       case BLessNumeric => SBLessNumeric
       case BLessEqNumeric => SBLessEqNumeric
@@ -561,10 +587,10 @@ private[lf] final class Compiler(
       case BEqualNumeric => SBEqualNumeric
       case BNumericToText => SBEToTextNumeric
 
-      case BTextMapEmpty => SEValue.EmptyTextMap
-      case BGenMapEmpty => SEValue.EmptyGenMap
+      case BTextMapEmpty => s.SEValue.EmptyTextMap
+      case BGenMapEmpty => s.SEValue.EmptyGenMap
       case _ =>
-        SEBuiltin(bf match {
+        s.SEBuiltin(bf match {
           case BTrace => SBTrace
 
           // Decimal arithmetic
@@ -676,16 +702,16 @@ private[lf] final class Compiler(
     }
 
   @inline
-  private[this] def compilePrimCon(con: PrimCon): SExpr =
+  private[this] def compilePrimCon(con: PrimCon): s.SExpr =
     con match {
-      case PCTrue => SEValue.True
-      case PCFalse => SEValue.False
-      case PCUnit => SEValue.Unit
+      case PCTrue => s.SEValue.True
+      case PCFalse => s.SEValue.False
+      case PCUnit => s.SEValue.Unit
     }
 
   @inline
-  private[this] def compilePrimLit(lit: PrimLit): SExpr =
-    SEValue(lit match {
+  private[this] def compilePrimLit(lit: PrimLit): s.SExpr =
+    s.SEValue(lit match {
       case PLInt64(i) => SInt64(i)
       case PLNumeric(d) => SNumeric(d)
       case PLText(t) => SText(t)
@@ -716,16 +742,16 @@ private[lf] final class Compiler(
       env: Env,
       tApp: TypeConApp,
       fields: ImmArray[(FieldName, Expr)],
-  ): SExpr =
+  ): s.SExpr =
     if (fields.isEmpty)
-      SEValue(SRecord(tApp.tycon, ImmArray.Empty, noArgs))
+      s.SEValue(SRecord(tApp.tycon, ImmArray.Empty, noArgs))
     else
-      SEApp(
-        SEBuiltin(SBRecCon(tApp.tycon, fields.map(_._1))),
+      s.SEApp(
+        s.SEBuiltin(SBRecCon(tApp.tycon, fields.map(_._1))),
         fields.iterator.map(f => compile(env, f._2)).toArray,
       )
 
-  private[this] def compileERecUpd(env: Env, erecupd: ERecUpd): SExpr = {
+  private[this] def compileERecUpd(env: Env, erecupd: ERecUpd): s.SExpr = {
     val tapp = erecupd.tycon
     val (record, fields, updates) = collectRecUpds(erecupd)
     if (fields.length == 1) {
@@ -746,8 +772,8 @@ private[lf] final class Compiler(
     }
   }
 
-  private[this] def compileECase(env: Env, scrut: Expr, alts: ImmArray[CaseAlt]): SExpr =
-    SECase(
+  private[this] def compileECase(env: Env, scrut: Expr, alts: ImmArray[CaseAlt]): s.SExpr =
+    s.SECase(
       compile(env, scrut),
       mapToArray(alts) { case CaseAlt(pat, expr) =>
         pat match {
@@ -756,32 +782,32 @@ private[lf] final class Compiler(
               NameOf.qualifiedNameOfCurrentFunc,
               interface.lookupVariantConstructor(tycon, variant),
             ).rank
-            SCaseAlt(SCPVariant(tycon, variant, rank), compile(env.pushExprVar(binder), expr))
+            s.SCaseAlt(t.SCPVariant(tycon, variant, rank), compile(env.pushExprVar(binder), expr))
 
           case CPEnum(tycon, constructor) =>
             val rank = handleLookup(
               NameOf.qualifiedNameOfCurrentFunc,
               interface.lookupEnumConstructor(tycon, constructor),
             )
-            SCaseAlt(SCPEnum(tycon, constructor, rank), compile(env, expr))
+            s.SCaseAlt(t.SCPEnum(tycon, constructor, rank), compile(env, expr))
 
           case CPNil =>
-            SCaseAlt(SCPNil, compile(env, expr))
+            s.SCaseAlt(t.SCPNil, compile(env, expr))
 
           case CPCons(head, tail) =>
-            SCaseAlt(SCPCons, compile(env.pushExprVar(head).pushExprVar(tail), expr))
+            s.SCaseAlt(t.SCPCons, compile(env.pushExprVar(head).pushExprVar(tail), expr))
 
           case CPPrimCon(pc) =>
-            SCaseAlt(SCPPrimCon(pc), compile(env, expr))
+            s.SCaseAlt(t.SCPPrimCon(pc), compile(env, expr))
 
           case CPNone =>
-            SCaseAlt(SCPNone, compile(env, expr))
+            s.SCaseAlt(t.SCPNone, compile(env, expr))
 
           case CPSome(body) =>
-            SCaseAlt(SCPSome, compile(env.pushExprVar(body), expr))
+            s.SCaseAlt(t.SCPSome, compile(env.pushExprVar(body), expr))
 
           case CPDefault =>
-            SCaseAlt(SCPDefault, compile(env, expr))
+            s.SCaseAlt(t.SCPDefault, compile(env, expr))
         }
       },
     )
@@ -791,55 +817,55 @@ private[lf] final class Compiler(
   private[this] def compileELet(
       env0: Env,
       eLet0: ELet,
-      bounds0: List[SExpr] = List.empty,
-  ): SELet = {
+      bounds0: List[s.SExpr] = List.empty,
+  ): s.SELet = {
     val binding = eLet0.binding
-    val bounds = withOptLabel(binding.binder, compile(env0, binding.bound)) :: bounds0
+    val bounds = withOptLabelS(binding.binder, compile(env0, binding.bound)) :: bounds0
     val env1 = env0.pushExprVar(binding.binder)
     eLet0.body match {
       case eLet1: ELet =>
         compileELet(env1, eLet1, bounds)
       case body0 =>
         compile(env1, body0) match {
-          case SELet(bounds1, body1) =>
-            SELet(bounds.foldLeft(bounds1)((acc, b) => b :: acc), body1)
+          case s.SELet(bounds1, body1) =>
+            s.SELet(bounds.foldLeft(bounds1)((acc, b) => b :: acc), body1)
           case otherwise =>
-            SELet(bounds.reverse, otherwise)
+            s.SELet(bounds.reverse, otherwise)
         }
     }
   }
 
   @inline
-  private[this] def compileEUpdate(env: Env, update: Update): SExpr =
+  private[this] def compileEUpdate(env: Env, update: Update): s.SExpr =
     update match {
       case UpdatePure(_, e) =>
         compilePure(env, e)
       case UpdateBlock(bindings, body) =>
         compileBlock(env, bindings, body)
       case UpdateFetch(tmplId, coidE) =>
-        FetchDefRef(tmplId)(compile(env, coidE))
+        t.FetchDefRef(tmplId)(compile(env, coidE))
       case UpdateFetchInterface(ifaceId, coidE) =>
-        FetchDefRef(ifaceId)(compile(env, coidE))
+        t.FetchDefRef(ifaceId)(compile(env, coidE))
       case UpdateEmbedExpr(_, e) =>
         compileEmbedExpr(env, e)
       case UpdateCreate(tmplId, arg) =>
-        CreateDefRef(tmplId)(compile(env, arg))
+        t.CreateDefRef(tmplId)(compile(env, arg))
       case UpdateExercise(tmplId, chId, cidE, argE) =>
-        ChoiceDefRef(tmplId, chId)(compile(env, cidE), compile(env, argE))
+        t.ChoiceDefRef(tmplId, chId)(compile(env, cidE), compile(env, argE))
       case UpdateExerciseInterface(ifaceId, chId, cidE, argE) =>
-        ChoiceDefRef(ifaceId, chId)(compile(env, cidE), compile(env, argE))
+        t.ChoiceDefRef(ifaceId, chId)(compile(env, cidE), compile(env, argE))
       case UpdateExerciseByKey(tmplId, chId, keyE, argE) =>
-        ChoiceByKeyDefRef(tmplId, chId)(compile(env, keyE), compile(env, argE))
+        t.ChoiceByKeyDefRef(tmplId, chId)(compile(env, keyE), compile(env, argE))
       case UpdateGetTime =>
         SEGetTime
       case UpdateLookupByKey(RetrieveByKey(templateId, key)) =>
-        LookupByKeyDefRef(templateId)(compile(env, key))
+        t.LookupByKeyDefRef(templateId)(compile(env, key))
       case UpdateFetchByKey(RetrieveByKey(templateId, key)) =>
-        FetchByKeyDefRef(templateId)(compile(env, key))
+        t.FetchByKeyDefRef(templateId)(compile(env, key))
 
       case UpdateTryCatch(_, body, binder, handler) =>
         unaryFunction(env) { (tokenPos, env0) =>
-          SETryCatch(
+          s.SETryCatch(
             app(compile(env0, body), env0.toSEVar(tokenPos)), {
               val env1 = env0.pushExprVar(binder)
               SBTryHandler(
@@ -853,7 +879,7 @@ private[lf] final class Compiler(
     }
 
   @tailrec
-  private[this] def compileAbss(env: Env, expr0: Expr, arity: Int = 0): SExpr =
+  private[this] def compileAbss(env: Env, expr0: Expr, arity: Int = 0): s.SExpr =
     expr0 match {
       case EAbs((binder, typ @ _), body, ref @ _) =>
         compileAbss(env.pushExprVar(binder), body, arity + 1)
@@ -864,11 +890,11 @@ private[lf] final class Compiler(
       case _ if arity == 0 =>
         compile(env, expr0)
       case _ =>
-        withLabel(AnonymousClosure, SEAbs(arity, compile(env, expr0)))
+        withLabelS(t.AnonymousClosure, s.SEAbs(arity, compile(env, expr0)))
     }
 
   @tailrec
-  private[this] def compileApps(env: Env, expr0: Expr, args: List[SExpr] = List.empty): SExpr =
+  private[this] def compileApps(env: Env, expr0: Expr, args: List[s.SExpr] = List.empty): s.SExpr =
     expr0 match {
       case EApp(fun, arg) =>
         compileApps(env, fun, compile(env, arg) :: args)
@@ -877,17 +903,17 @@ private[lf] final class Compiler(
       case _ if args.isEmpty =>
         compile(env, expr0)
       case _ =>
-        SEApp(compile(env, expr0), args.toArray)
+        s.SEApp(compile(env, expr0), args.toArray)
     }
 
-  private[this] def translateType(env: Env, typ: Type): Option[SExpr] =
+  private[this] def translateType(env: Env, typ: Type): Option[s.SExpr] =
     typ match {
       case TNat(n) => SENat(n)
       case TVar(name) => env.lookupTypeVar(name)
       case _ => None
     }
 
-  private[this] def compileScenario(env: Env, scen: Scenario, optLoc: Option[Location]): SExpr =
+  private[this] def compileScenario(env: Env, scen: Scenario, optLoc: Option[Location]): s.SExpr =
     scen match {
       case ScenarioPure(_, e) =>
         compilePure(env, e)
@@ -914,7 +940,7 @@ private[lf] final class Compiler(
       updateE: Expr,
       optLoc: Option[Location],
       mustFail: Boolean,
-  ): SExpr =
+  ): s.SExpr =
     // let party = <partyE>
     //     update = <updateE>
     // in $submit(mustFail)(party, update)
@@ -925,19 +951,19 @@ private[lf] final class Compiler(
     }
 
   @inline
-  private[this] def compileGetParty(env: Env, expr: Expr): SExpr =
+  private[this] def compileGetParty(env: Env, expr: Expr): s.SExpr =
     labeledUnaryFunction(Profile.GetPartyLabel, env) { (tokenPos, env) =>
       SBSGetParty(compile(env, expr), env.toSEVar(tokenPos))
     }
 
   @inline
-  private[this] def compilePass(env: Env, time: Expr): SExpr =
+  private[this] def compilePass(env: Env, time: Expr): s.SExpr =
     labeledUnaryFunction(Profile.PassLabel, env) { (tokenPos, env) =>
       SBSPass(compile(env, time), env.toSEVar(tokenPos))
     }
 
   @inline
-  private[this] def compileEmbedExpr(env: Env, expr: Expr): SExpr =
+  private[this] def compileEmbedExpr(env: Env, expr: Expr): s.SExpr =
     // EmbedExpr's get wrapped into an extra layer of abstraction
     // to delay evaluation.
     // e.g.
@@ -946,7 +972,7 @@ private[lf] final class Compiler(
       app(compile(env, expr), env.toSEVar(tokenPos))
     }
 
-  private[this] def compilePure(env: Env, body: Expr): SExpr =
+  private[this] def compilePure(env: Env, body: Expr): s.SExpr =
     // pure <E>
     // =>
     // ((\x token -> x) <E>)
@@ -956,7 +982,7 @@ private[lf] final class Compiler(
       }
     }
 
-  private[this] def compileBlock(env: Env, bindings: ImmArray[Binding], body: Expr): SExpr =
+  private[this] def compileBlock(env: Env, bindings: ImmArray[Binding], body: Expr): s.SExpr =
     // do
     //   x <- f
     //   y <- g x
@@ -972,7 +998,7 @@ private[lf] final class Compiler(
         let(env, app(env.toSEVar(firstPos), env.toSEVar(tokenPos))) { (firstBoundPos, _env) =>
           val env = bindings.head.binder.fold(_env)(_env.bindExprVar(_, firstBoundPos))
 
-          def loop(env: Env, list: List[Binding]): SExpr = list match {
+          def loop(env: Env, list: List[Binding]): s.SExpr = list match {
             case Binding(binder, _, bound) :: tail =>
               let(env, app(compile(env, bound), env.toSEVar(tokenPos))) { (boundPos, _env) =>
                 val env = binder.fold(_env)(_env.bindExprVar(_, boundPos))
@@ -994,15 +1020,18 @@ private[lf] final class Compiler(
       env: Env,
       keyPos: Position,
       tmplKey: TemplateKey,
-  ): SExpr =
+  ): s.SExpr =
     KeyWithMaintainersStruct(
       env.toSEVar(keyPos),
       app(compile(env, tmplKey.maintainers), env.toSEVar(keyPos)),
     )
 
-  private[this] def compileKeyWithMaintainers(env: Env, maybeTmplKey: Option[TemplateKey]): SExpr =
+  private[this] def compileKeyWithMaintainers(
+      env: Env,
+      maybeTmplKey: Option[TemplateKey],
+  ): s.SExpr =
     maybeTmplKey match {
-      case None => SEValue.None
+      case None => s.SEValue.None
       case Some(tmplKey) =>
         let(env, compile(env, tmplKey.body)) { (keyPos, env) =>
           SBSome(encodeKeyWithMaintainers(env, keyPos, tmplKey))
@@ -1024,7 +1053,7 @@ private[lf] final class Compiler(
       env,
       SBUFetch(
         tmplId
-      )(env.toSEVar(cidPos), mbKey.fold(SEValue.None: SExpr)(pos => SBSome(env.toSEVar(pos)))),
+      )(env.toSEVar(cidPos), mbKey.fold(s.SEValue.None: s.SExpr)(pos => SBSome(env.toSEVar(pos)))),
     ) { (tmplArgPos, _env) =>
       val env =
         _env.bindExprVar(tmpl.param, tmplArgPos).bindExprVar(choice.argBinder._1, choiceArgPos)
@@ -1042,12 +1071,12 @@ private[lf] final class Compiler(
           compile(env, choice.controllers),
           choice.choiceObservers match {
             case Some(observers) => compile(env, observers)
-            case None => SEValue.EmptyList
+            case None => s.SEValue.EmptyList
           },
         ),
       ) { (_, _env) =>
         val env = _env.bindExprVar(choice.selfBinder, cidPos)
-        SEScopeExercise(
+        s.SEScopeExercise(
           app(compile(env, choice.update), env.toSEVar(tokenPos))
         )
       }
@@ -1076,12 +1105,12 @@ private[lf] final class Compiler(
           compile(env, choice.controllers),
           choice.choiceObservers match {
             case Some(observers) => compile(env, observers)
-            case None => SEValue.EmptyList
+            case None => s.SEValue.EmptyList
           },
         ),
       ) { (_, _env) =>
         val env = _env.bindExprVar(choice.selfBinder, cidPos)
-        SEScopeExercise(app(compile(env, choice.update), env.toSEVar(tokenPos)))
+        s.SEScopeExercise(app(compile(env, choice.update), env.toSEVar(tokenPos)))
       }
     }
 
@@ -1089,20 +1118,21 @@ private[lf] final class Compiler(
       ifaceId: TypeConName,
       param: ExprVarName,
       choice: TemplateChoice,
-  ): (SDefinitionRef, SDefinition) =
-    topLevelFunction3(ChoiceDefRef(ifaceId, choice.name)) { (cidPos, choiceArgPos, tokenPos, env) =>
-      compileFixedChoiceBody(env, ifaceId, param, choice)(
-        choiceArgPos,
-        cidPos,
-        tokenPos,
-      )
+  ): (t.SDefinitionRef, SDefinition) =
+    topLevelFunction3(t.ChoiceDefRef(ifaceId, choice.name)) {
+      (cidPos, choiceArgPos, tokenPos, env) =>
+        compileFixedChoiceBody(env, ifaceId, param, choice)(
+          choiceArgPos,
+          cidPos,
+          tokenPos,
+        )
     }
 
   private[this] def compileChoice(
       tmplId: TypeConName,
       tmpl: Template,
       choice: TemplateChoice,
-  ): (SDefinitionRef, SDefinition) =
+  ): (t.SDefinitionRef, SDefinition) =
     // Compiles a choice into:
     // ChoiceDefRef(SomeTemplate, SomeChoice) = \<actors> <cid> <choiceArg> <token> ->
     //   let targ = fetch(tmplId) <cid>
@@ -1110,13 +1140,14 @@ private[lf] final class Compiler(
     //       <retValue> = [update] <token>
     //       _ = $endExercise[tmplId] <retValue>
     //   in <retValue>
-    topLevelFunction3(ChoiceDefRef(tmplId, choice.name)) { (cidPos, choiceArgPos, tokenPos, env) =>
-      compileChoiceBody(env, tmplId, tmpl, choice)(
-        choiceArgPos,
-        cidPos,
-        None,
-        tokenPos,
-      )
+    topLevelFunction3(t.ChoiceDefRef(tmplId, choice.name)) {
+      (cidPos, choiceArgPos, tokenPos, env) =>
+        compileChoiceBody(env, tmplId, tmpl, choice)(
+          choiceArgPos,
+          cidPos,
+          None,
+          tokenPos,
+        )
     }
 
   /** Compile a choice into a top-level function for exercising that choice */
@@ -1125,7 +1156,7 @@ private[lf] final class Compiler(
       tmpl: Template,
       tmplKey: TemplateKey,
       choice: TemplateChoice,
-  ): (SDefinitionRef, SDefinition) =
+  ): (t.SDefinitionRef, SDefinition) =
     // Compiles a choice into:
     // ChoiceByKeyDefRef(SomeTemplate, SomeChoice) = \ <actors> <key> <choiceArg> <token> ->
     //    let <keyWithM> = { key = <key> ; maintainers = [tmpl.maintainers] <key> }
@@ -1135,7 +1166,7 @@ private[lf] final class Compiler(
     //       <retValue> = <updateE> <token>
     //       _ = $endExercise[tmplId] <retValue>
     //   in  <retValue>
-    topLevelFunction3(ChoiceByKeyDefRef(tmplId, choice.name)) {
+    topLevelFunction3(t.ChoiceByKeyDefRef(tmplId, choice.name)) {
       (keyPos, choiceArgPos, tokenPos, env) =>
         let(env, encodeKeyWithMaintainers(env, keyPos, tmplKey)) { (keyWithMPos, env) =>
           let(env, SBUFetchKey(tmplId)(env.toSEVar(keyWithMPos))) { (cidPos, env) =>
@@ -1177,88 +1208,81 @@ private[lf] final class Compiler(
     *       SELocF(0) ..            [reference the first let-bound variable via the closure]
     *       SELocA(0))              [reference the first function arg]
     */
-  private[this] def closureConvert(remaps: Map[Int, SELoc], expr: SExpr): SExpr = {
+  private[this] def closureConvert(remaps: Map[Int, s.SELoc], expr: s.SExpr): s.SExpr = {
     // remaps is a function which maps the relative offset from variables (SEVar) to their runtime location
     // The Map must contain a binding for every variable referenced.
     // The Map is consulted when translating variable references (SEVar) and free variables of an abstraction (SEAbs)
-    def remap(i: Int): SELoc =
+    def remap(i: Int): s.SELoc =
       remaps.get(i) match {
         case Some(loc) => loc
         case None =>
           throw CompilationError(s"remap($i),remaps=$remaps")
       }
     expr match {
-      case SEVar(i) => remap(i)
-      case v: SEVal => v
-      case be: SEBuiltin => be
-      case pl: SEValue => pl
-      case f: SEBuiltinRecursiveDefinition => f
-      case SELocation(loc, body) =>
-        SELocation(loc, closureConvert(remaps, body))
+      case s.SEVar(i) => remap(i)
+      case v: s.SEVal => v
+      case be: s.SEBuiltin => be
+      case pl: s.SEValue => pl
+      case f: s.SEBuiltinRecursiveDefinition => f
+      case s.SELocation(loc, body) =>
+        s.SELocation(loc, closureConvert(remaps, body))
 
-      case SEAbs(0, _) =>
+      case s.SEAbs(0, _) =>
         throw CompilationError("empty SEAbs")
 
-      case SEAbs(arity, body) =>
+      case s.SEAbs(arity, body) =>
         val fvs = freeVars(body, arity).toList.sorted
-        val newRemapsF: Map[Int, SELoc] = fvs.zipWithIndex.map { case (orig, i) =>
-          (orig + arity) -> SELocF(i)
+        val newRemapsF: Map[Int, s.SELoc] = fvs.zipWithIndex.map { case (orig, i) =>
+          (orig + arity) -> s.SELocF(i)
         }.toMap
         val newRemapsA = (1 to arity).map { case i =>
-          i -> SELocA(arity - i)
+          i -> s.SELocA(arity - i)
         }
         // The keys in newRemapsF and newRemapsA are disjoint
         val newBody = closureConvert(newRemapsF ++ newRemapsA, body)
-        SEMakeClo(fvs.map(remap).toArray, arity, newBody)
+        s.SEMakeClo(fvs.map(remap).toArray, arity, newBody)
 
-      case SEAppGeneral(fun, args) =>
+      case s.SEAppGeneral(fun, args) =>
         val newFun = closureConvert(remaps, fun)
         val newArgs = args.map(closureConvert(remaps, _))
-        SEApp(newFun, newArgs)
+        s.SEApp(newFun, newArgs)
 
-      case SEAppAtomicFun(fun, args) =>
-        val newFun = closureConvert(remaps, fun)
-        val newArgs = args.map(closureConvert(remaps, _))
-        SEApp(newFun, newArgs)
-
-      case SECase(scrut, alts) =>
-        SECase(
+      case s.SECase(scrut, alts) =>
+        s.SECase(
           closureConvert(remaps, scrut),
-          alts.map { case SCaseAlt(pat, body) =>
+          alts.map { case s.SCaseAlt(pat, body) =>
             val n = patternNArgs(pat)
-            SCaseAlt(
+            s.SCaseAlt(
               pat,
               closureConvert(shift(remaps, n), body),
             )
           },
         )
 
-      case SELet(bounds, body) =>
-        SELet(
+      case s.SELet(bounds, body) =>
+        s.SELet(
           bounds.zipWithIndex.map { case (b, i) =>
             closureConvert(shift(remaps, i), b)
           },
           closureConvert(shift(remaps, bounds.length), body),
         )
 
-      case SETryCatch(body, handler) =>
-        SETryCatch(
+      case s.SETryCatch(body, handler) =>
+        s.SETryCatch(
           closureConvert(remaps, body),
           closureConvert(shift(remaps, 1), handler),
         )
 
-      case SEScopeExercise(body) =>
-        SEScopeExercise(closureConvert(remaps, body))
+      case s.SEScopeExercise(body) =>
+        s.SEScopeExercise(closureConvert(remaps, body))
 
-      case SELabelClosure(label, expr) =>
-        SELabelClosure(label, closureConvert(remaps, expr))
+      case s.SELabelClosure(label, expr) =>
+        s.SELabelClosure(label, closureConvert(remaps, expr))
 
-      case SELet1General(bound, body) =>
-        SELet1General(closureConvert(remaps, bound), closureConvert(shift(remaps, 1), body))
+      case s.SELet1General(bound, body) =>
+        s.SELet1General(closureConvert(remaps, bound), closureConvert(shift(remaps, 1), body))
 
-      case _: SELoc | _: SEMakeClo | _: SELet1Builtin | _: SELet1BuiltinArithmetic |
-          _: SEDamlException | _: SEImportValue | _: SEAppAtomicGeneral |
-          _: SEAppAtomicSaturatedBuiltin | _: SECaseAtomic =>
+      case _: s.SELoc | _: s.SEMakeClo | _: s.SEDamlException | _: s.SEImportValue =>
         throw CompilationError(s"closureConvert: unexpected $expr")
     }
   }
@@ -1269,62 +1293,59 @@ private[lf] final class Compiler(
   // We must modify `remaps` because it is keyed by indexes relative to the end of the stack.
   // And any values in the map which are of the form SELocS must also be _shifted_
   // because SELocS indexes are also relative to the end of the stack.
-  private[this] def shift(remaps: Map[Int, SELoc], n: Int): Map[Int, SELoc] = {
+  private[this] def shift(remaps: Map[Int, s.SELoc], n: Int): Map[Int, s.SELoc] = {
 
     // We must update both the keys of the map (the relative-indexes from the original SEVar)
     // And also any values in the map which are stack located (SELocS), which are also indexed relatively
     val m1 = remaps.map { case (k, loc) => (n + k, shiftLoc(loc, n)) }
 
     // And create mappings for the `n` new stack items
-    val m2 = (1 to n).map(i => (i, SELocS(i)))
+    val m2 = (1 to n).map(i => (i, s.SELocS(i)))
 
     m1 ++ m2
   }
 
-  private[this] def shiftLoc(loc: SELoc, n: Int): SELoc = loc match {
-    case SELocS(i) => SELocS(i + n)
-    case SELocA(_) | SELocF(_) => loc
+  private[this] def shiftLoc(loc: s.SELoc, n: Int): s.SELoc = loc match {
+    case s.SELocS(i) => s.SELocS(i + n)
+    case s.SELocA(_) | s.SELocF(_) => loc
   }
 
   /** Compute the free variables in a speedy expression.
     * The returned free variables are de bruijn indices
     * adjusted to the stack of the caller.
     */
-  private[this] def freeVars(expr: SExpr, initiallyBound: Int): Set[Int] = {
-    def go(expr: SExpr, bound: Int, free: Set[Int]): Set[Int] =
+  private[this] def freeVars(expr: s.SExpr, initiallyBound: Int): Set[Int] = {
+    def go(expr: s.SExpr, bound: Int, free: Set[Int]): Set[Int] =
       expr match {
-        case SEVar(i) =>
+        case s.SEVar(i) =>
           if (i > bound) free + (i - bound) else free /* adjust to caller's environment */
-        case _: SEVal => free
-        case _: SEBuiltin => free
-        case _: SEValue => free
-        case _: SEBuiltinRecursiveDefinition => free
-        case SELocation(_, body) =>
+        case _: s.SEVal => free
+        case _: s.SEBuiltin => free
+        case _: s.SEValue => free
+        case _: s.SEBuiltinRecursiveDefinition => free
+        case s.SELocation(_, body) =>
           go(body, bound, free)
-        case SEAppGeneral(fun, args) =>
+        case s.SEAppGeneral(fun, args) =>
           args.foldLeft(go(fun, bound, free))((acc, arg) => go(arg, bound, acc))
-        case SEAppAtomicFun(fun, args) =>
-          args.foldLeft(go(fun, bound, free))((acc, arg) => go(arg, bound, acc))
-        case SEAbs(n, body) =>
+        case s.SEAbs(n, body) =>
           go(body, bound + n, free)
-        case SECase(scrut, alts) =>
-          alts.foldLeft(go(scrut, bound, free)) { case (acc, SCaseAlt(pat, body)) =>
+        case s.SECase(scrut, alts) =>
+          alts.foldLeft(go(scrut, bound, free)) { case (acc, s.SCaseAlt(pat, body)) =>
             go(body, bound + patternNArgs(pat), acc)
           }
-        case SELet(bounds, body) =>
+        case s.SELet(bounds, body) =>
           bounds.zipWithIndex.foldLeft(go(body, bound + bounds.length, free)) {
             case (acc, (expr, idx)) => go(expr, bound + idx, acc)
           }
-        case SELabelClosure(_, expr) =>
+        case s.SELabelClosure(_, expr) =>
           go(expr, bound, free)
-        case SETryCatch(body, handler) =>
+        case s.SETryCatch(body, handler) =>
           go(body, bound, go(handler, 1 + bound, free))
-        case SEScopeExercise(body) =>
+        case s.SEScopeExercise(body) =>
           go(body, bound, free)
 
-        case _: SELoc | _: SEMakeClo | _: SEDamlException | _: SEImportValue |
-            _: SEAppAtomicGeneral | _: SEAppAtomicSaturatedBuiltin | _: SELet1General |
-            _: SELet1Builtin | _: SELet1BuiltinArithmetic | _: SECaseAtomic =>
+        case _: s.SELoc | _: s.SEMakeClo | _: s.SEDamlException | _: s.SEImportValue |
+            _: s.SELet1General =>
           throw CompilationError(s"freeVars: unexpected $expr")
       }
 
@@ -1334,7 +1355,7 @@ private[lf] final class Compiler(
   /** Validate variable references in a speedy expression */
   // validate that we correctly captured all free-variables, and so reference to them is
   // via the surrounding closure, instead of just finding them higher up on the stack
-  private[this] def validate(expr0: SExpr): SExpr = {
+  private[this] def validate(expr0: t.SExpr): t.SExpr = {
 
     def goV(v: SValue): Unit =
       v match {
@@ -1351,82 +1372,76 @@ private[lf] final class Compiler(
         case SEnum(_, _, _) => ()
         case SAny(_, v) => goV(v)
         case _: SPAP | SToken | SStruct(_, _) =>
-          throw CompilationError("validate: unexpected SEValue")
+          throw CompilationError("validate: unexpected s.SEValue")
       }
 
-    def goBody(maxS: Int, maxA: Int, maxF: Int): SExpr => Unit = {
+    def goBody(maxS: Int, maxA: Int, maxF: Int): t.SExpr => Unit = {
 
-      def goLoc(loc: SELoc) = loc match {
-        case SELocS(i) =>
+      def goLoc(loc: t.SELoc) = loc match {
+        case t.SELocS(i) =>
           if (i < 1 || i > maxS)
             throw CompilationError(s"validate: SELocS: index $i out of range ($maxS..1)")
-        case SELocA(i) =>
+        case t.SELocA(i) =>
           if (i < 0 || i >= maxA)
             throw CompilationError(s"validate: SELocA: index $i out of range (0..$maxA-1)")
-        case SELocF(i) =>
+        case t.SELocF(i) =>
           if (i < 0 || i >= maxF)
             throw CompilationError(s"validate: SELocF: index $i out of range (0..$maxF-1)")
       }
 
-      def go(expr: SExpr): Unit = expr match {
-        case loc: SELoc => goLoc(loc)
-        case _: SEVal => ()
-        case _: SEBuiltin => ()
-        case _: SEBuiltinRecursiveDefinition => ()
-        case SEValue(v) => goV(v)
-        case SEAppAtomicGeneral(fun, args) =>
+      def go(expr: t.SExpr): Unit = expr match {
+        case loc: t.SELoc => goLoc(loc)
+        case _: t.SEVal => ()
+        case _: t.SEBuiltin => ()
+        case _: t.SEBuiltinRecursiveDefinition => ()
+        case t.SEValue(v) => goV(v)
+        case t.SEAppAtomicGeneral(fun, args) =>
           go(fun)
           args.foreach(go)
-        case SEAppAtomicSaturatedBuiltin(_, args) =>
+        case t.SEAppAtomicSaturatedBuiltin(_, args) =>
           args.foreach(go)
-        case SEAppGeneral(fun, args) =>
+        case t.SEAppGeneral(fun, args) =>
           go(fun)
           args.foreach(go)
-        case SEAppAtomicFun(fun, args) =>
+        case t.SEAppAtomicFun(fun, args) =>
           go(fun)
           args.foreach(go)
-        case SEMakeClo(fvs, n, body) =>
+        case t.SEMakeClo(fvs, n, body) =>
           fvs.foreach(goLoc)
           goBody(0, n, fvs.length)(body)
-        case SECaseAtomic(scrut, alts) => go(SECase(scrut, alts))
-        case SECase(scrut, alts) =>
+        case t.SECaseAtomic(scrut, alts) =>
           go(scrut)
-          alts.foreach { case SCaseAlt(pat, body) =>
+          alts.foreach { case t.SCaseAlt(pat, body) =>
             val n = patternNArgs(pat)
             goBody(maxS + n, maxA, maxF)(body)
           }
-        case SELet(bounds, body) =>
-          bounds.zipWithIndex.foreach { case (rhs, i) =>
-            goBody(maxS + i, maxA, maxF)(rhs)
-          }
-          goBody(maxS + bounds.length, maxA, maxF)(body)
-        case _: SELet1General => goLets(maxS)(expr)
-        case _: SELet1Builtin => goLets(maxS)(expr)
-        case _: SELet1BuiltinArithmetic => goLets(maxS)(expr)
-        case SELocation(_, body) =>
+        case _: t.SELet1General => goLets(maxS)(expr)
+        case _: t.SELet1Builtin => goLets(maxS)(expr)
+        case _: t.SELet1BuiltinArithmetic => goLets(maxS)(expr)
+        case t.SELocation(_, body) =>
           go(body)
-        case SELabelClosure(_, expr) =>
+        case t.SELabelClosure(_, expr) =>
           go(expr)
-        case SETryCatch(body, handler) =>
+        case t.SETryCatch(body, handler) =>
           go(body)
           goBody(maxS + 1, maxA, maxF)(handler)
-        case SEScopeExercise(body) =>
+        case t.SEScopeExercise(body) =>
           go(body)
 
-        case _: SEVar | _: SEAbs | _: SEDamlException | _: SEImportValue =>
+        case _: t.SEDamlException | _: t.SEImportValue =>
           throw CompilationError(s"validate: unexpected $expr")
       }
       @tailrec
-      def goLets(maxS: Int)(expr: SExpr): Unit = {
+      def goLets(maxS: Int)(expr: t.SExpr): Unit = {
         def go = goBody(maxS, maxA, maxF)
         expr match {
-          case SELet1General(rhs, body) =>
+          case t.SELet1General(rhs, body) =>
             go(rhs)
             goLets(maxS + 1)(body)
-          case SELet1Builtin(_, args, body) =>
+          case t.SELet1Builtin(_, args, body) =>
             args.foreach(go)
             goLets(maxS + 1)(body)
-          case SELet1BuiltinArithmetic(_, args, body) =>
+          case t.SELet1BuiltinArithmetic(_, args, body) =>
             args.foreach(go)
             goLets(maxS + 1)(body)
           case expr =>
@@ -1449,7 +1464,7 @@ private[lf] final class Compiler(
       env,
       SBUFetch(
         tmplId
-      )(env.toSEVar(cidPos), mbKey.fold(SEValue.None: SExpr)(pos => SBSome(env.toSEVar(pos)))),
+      )(env.toSEVar(cidPos), mbKey.fold(s.SEValue.None: s.SExpr)(pos => SBSome(env.toSEVar(pos)))),
     ) { (tmplArgPos, _env) =>
       val env = _env.bindExprVar(tmpl.param, tmplArgPos)
       let(
@@ -1463,13 +1478,13 @@ private[lf] final class Compiler(
   private[this] def compileFetch(
       tmplId: Identifier,
       tmpl: Template,
-  ): (SDefinitionRef, SDefinition) =
+  ): (t.SDefinitionRef, SDefinition) =
     // compile a template to
     // FetchDefRef(tmplId) = \ <coid> <token> ->
     //   let <tmplArg> = $fetch(tmplId) <coid>
     //       _ = $insertFetch(tmplId, false) coid [tmpl.signatories] [tmpl.observers] [tmpl.key]
     //   in <tmplArg>
-    topLevelFunction2(FetchDefRef(tmplId)) { (cidPos, tokenPos, env) =>
+    topLevelFunction2(t.FetchDefRef(tmplId)) { (cidPos, tokenPos, env) =>
       compileFetchBody(env, tmplId, tmpl)(cidPos, None, tokenPos)
     }
 
@@ -1477,8 +1492,8 @@ private[lf] final class Compiler(
   //  Here we fetch twice, once by interface Id once by template Id. Try to bypass the second fetch.
   private[this] def compileFetchInterface(
       ifaceId: Identifier
-  ): (SDefinitionRef, SDefinition) =
-    topLevelFunction2(FetchDefRef(ifaceId)) { (cidPos, _, env) =>
+  ): (t.SDefinitionRef, SDefinition) =
+    topLevelFunction2(t.FetchDefRef(ifaceId)) { (cidPos, _, env) =>
       let(env, SBUFetchInterface(ifaceId)(env.toSEVar(cidPos))) { (payloadPos, env) =>
         let(
           env,
@@ -1492,24 +1507,24 @@ private[lf] final class Compiler(
   private[this] def compileKey(
       tmplId: Identifier,
       tmpl: Template,
-  ): (SDefinitionRef, SDefinition) =
-    topLevelFunction1(KeyDefRef(tmplId)) { (tmplArgPos, env) =>
+  ): (t.SDefinitionRef, SDefinition) =
+    topLevelFunction1(t.KeyDefRef(tmplId)) { (tmplArgPos, env) =>
       compileKeyWithMaintainers(env.bindExprVar(tmpl.param, tmplArgPos), tmpl.key)
     }
 
   private[this] def compileSignatories(
       tmplId: Identifier,
       tmpl: Template,
-  ): (SDefinitionRef, SDefinition) =
-    topLevelFunction1(SignatoriesDefRef(tmplId)) { (tmplArgPos, env) =>
+  ): (t.SDefinitionRef, SDefinition) =
+    topLevelFunction1(t.SignatoriesDefRef(tmplId)) { (tmplArgPos, env) =>
       compile(env.bindExprVar(tmpl.param, tmplArgPos), tmpl.signatories)
     }
 
   private[this] def compileObservers(
       tmplId: Identifier,
       tmpl: Template,
-  ): (SDefinitionRef, SDefinition) =
-    topLevelFunction1(ObserversDefRef(tmplId)) { (tmplArgPos, env) =>
+  ): (t.SDefinitionRef, SDefinition) =
+    topLevelFunction1(t.ObserversDefRef(tmplId)) { (tmplArgPos, env) =>
       compile(env.bindExprVar(tmpl.param, tmplArgPos), tmpl.observers)
     }
 
@@ -1520,24 +1535,25 @@ private[lf] final class Compiler(
   private[this] def compileImplements(
       tmplId: Identifier,
       ifaceId: Identifier,
-  ): (SDefinitionRef, SDefinition) =
-    ImplementsDefRef(tmplId, ifaceId) ->
-      SDefinition(flattenToAnf(unsafeClosureConvert(SEAbs.identity)))
+  ): (t.SDefinitionRef, SDefinition) =
+    t.ImplementsDefRef(tmplId, ifaceId) ->
+      //SDefinition(flattenToAnf(unsafeClosureConvert(SEAbs.identity)))// NIC, was bug, 2x flattenToAnf!
+      SDefinition(unsafeClosureConvert(s.SEAbs.identity))
 
   // Compile the implementation of an interface method.
   private[this] def compileImplementsMethod(
       tmplId: Identifier,
       ifaceId: Identifier,
       method: TemplateImplementsMethod,
-  ): (SDefinitionRef, SDefinition) = {
-    val ref = ImplementsMethodDefRef(tmplId, ifaceId, method.name)
-    ref -> SDefinition(withLabel(ref, unsafeCompile(method.value)))
+  ): (t.SDefinitionRef, SDefinition) = {
+    val ref = t.ImplementsMethodDefRef(tmplId, ifaceId, method.name)
+    ref -> SDefinition(withLabelT(ref, unsafeCompile(method.value)))
   }
 
   private[this] def compileCreate(
       tmplId: Identifier,
       tmpl: Template,
-  ): (SDefinitionRef, SDefinition) = {
+  ): (t.SDefinitionRef, SDefinition) = {
     val precondsArray =
       (Iterator(tmpl.precond) ++ (tmpl.implements.iterator.map(impl => impl._2.precond)))
         .to(ImmArray)
@@ -1546,7 +1562,7 @@ private[lf] final class Compiler(
     // CreateDefRef(tmplId) = \ <tmplArg> <token> ->
     //   let _ = $checkPrecond(tmplId)(<tmplArg> [tmpl.precond ++ [precond | precond <- tmpl.implements]]
     //   in $create <tmplArg> [tmpl.agreementText] [tmpl.signatories] [tmpl.observers] [tmpl.key]
-    topLevelFunction2(CreateDefRef(tmplId)) { (tmplArgPos, _, _env) =>
+    topLevelFunction2(t.CreateDefRef(tmplId)) { (tmplArgPos, _, _env) =>
       val env = _env.bindExprVar(tmpl.param, tmplArgPos)
       // We check precondition in a separated builtin to prevent
       // further evaluation of agreement, signatories, observers and key
@@ -1569,29 +1585,30 @@ private[lf] final class Compiler(
       createArg: SValue,
       choiceId: ChoiceName,
       choiceArg: SValue,
-  ): SExpr =
+  ): s.SExpr =
     labeledUnaryFunction(Profile.CreateAndExerciseLabel(tmplId, choiceId), Env.Empty) {
       (tokenPos, env) =>
-        let(env, CreateDefRef(tmplId)(SEValue(createArg), env.toSEVar(tokenPos))) { (cidPos, env) =>
-          ChoiceDefRef(tmplId, choiceId)(
-            env.toSEVar(cidPos),
-            SEValue(choiceArg),
-            env.toSEVar(tokenPos),
-          )
+        let(env, t.CreateDefRef(tmplId)(s.SEValue(createArg), env.toSEVar(tokenPos))) {
+          (cidPos, env) =>
+            t.ChoiceDefRef(tmplId, choiceId)(
+              env.toSEVar(cidPos),
+              s.SEValue(choiceArg),
+              env.toSEVar(tokenPos),
+            )
         }
     }
 
   private[this] def compileLookupByKey(
       tmplId: Identifier,
       tmplKey: TemplateKey,
-  ): (SDefinitionRef, SDefinition) =
+  ): (t.SDefinitionRef, SDefinition) =
     // compile a template with key into
     // LookupByKeyDefRef(tmplId) = \ <key> <token> ->
     //    let <keyWithM> = { key = <key> ; maintainers = [tmplKey.maintainers] <key> }
     //        <mbCid> = $lookupKey(tmplId) <keyWithM>
     //        _ = $insertLookup(tmplId> <keyWithM> <mbCid>
     //    in <mbCid>
-    topLevelFunction2(LookupByKeyDefRef(tmplId)) { (keyPos, _, env) =>
+    topLevelFunction2(t.LookupByKeyDefRef(tmplId)) { (keyPos, _, env) =>
       let(env, encodeKeyWithMaintainers(env, keyPos, tmplKey)) { (keyWithMPos, env) =>
         let(env, SBULookupKey(tmplId)(env.toSEVar(keyWithMPos))) { (maybeCidPos, env) =>
           let(
@@ -1612,7 +1629,7 @@ private[lf] final class Compiler(
       tmplId: TypeConName,
       tmpl: Template,
       tmplKey: TemplateKey,
-  ): (SDefinitionRef, SDefinition) =
+  ): (t.SDefinitionRef, SDefinition) =
     // compile a template with key into
     // FetchByKeyDefRef(tmplId) = \ <key> <token> ->
     //    let <keyWithM> = { key = <key> ; maintainers = [tmpl.maintainers] <key> }
@@ -1620,7 +1637,7 @@ private[lf] final class Compiler(
     //        <contract> = $fetch(tmplId) <coid>
     //        _ = $insertFetch <coid> <signatories> <observers> (Some <keyWithM> )
     //    in { contractId: ContractId Foo, contract: Foo }
-    topLevelFunction2(FetchByKeyDefRef(tmplId)) { (keyPos, tokenPos, env) =>
+    topLevelFunction2(t.FetchByKeyDefRef(tmplId)) { (keyPos, tokenPos, env) =>
       let(env, encodeKeyWithMaintainers(env, keyPos, tmplKey)) { (keyWithMPos, env) =>
         let(env, SBUFetchKey(tmplId)(env.toSEVar(keyWithMPos))) { (cidPos, env) =>
           let(env, compileFetchBody(env, tmplId, tmpl)(cidPos, Some(keyWithMPos), tokenPos)) {
@@ -1631,17 +1648,17 @@ private[lf] final class Compiler(
       }
     }
 
-  private[this] def compileCommand(cmd: Command): SExpr = cmd match {
+  private[this] def compileCommand(cmd: Command): s.SExpr = cmd match {
     case Command.Create(templateId, argument) =>
-      CreateDefRef(templateId)(SEValue(argument))
+      t.CreateDefRef(templateId)(s.SEValue(argument))
     case Command.Exercise(templateId, contractId, choiceId, argument) =>
-      ChoiceDefRef(templateId, choiceId)(SEValue(contractId), SEValue(argument))
+      t.ChoiceDefRef(templateId, choiceId)(s.SEValue(contractId), s.SEValue(argument))
     case Command.ExerciseByKey(templateId, contractKey, choiceId, argument) =>
-      ChoiceByKeyDefRef(templateId, choiceId)(SEValue(contractKey), SEValue(argument))
+      t.ChoiceByKeyDefRef(templateId, choiceId)(s.SEValue(contractKey), s.SEValue(argument))
     case Command.Fetch(templateId, coid) =>
-      FetchDefRef(templateId)(SEValue(coid))
+      t.FetchDefRef(templateId)(s.SEValue(coid))
     case Command.FetchByKey(templateId, key) =>
-      FetchByKeyDefRef(templateId)(SEValue(key))
+      t.FetchByKeyDefRef(templateId)(s.SEValue(key))
     case Command.CreateAndExercise(templateId, createArg, choice, choiceArg) =>
       compileCreateAndExercise(
         templateId,
@@ -1650,16 +1667,16 @@ private[lf] final class Compiler(
         choiceArg,
       )
     case Command.LookupByKey(templateId, contractKey) =>
-      LookupByKeyDefRef(templateId)(SEValue(contractKey))
+      t.LookupByKeyDefRef(templateId)(s.SEValue(contractKey))
   }
 
-  private val SEUpdatePureUnit = unaryFunction(Env.Empty)((_, _) => SEValue.Unit)
+  private val SEUpdatePureUnit = unaryFunction(Env.Empty)((_, _) => s.SEValue.Unit)
 
-  private[this] val handleEverything: SExpr = SBSome(SEUpdatePureUnit)
+  private[this] val handleEverything: s.SExpr = SBSome(SEUpdatePureUnit)
 
-  private[this] def catchEverything(e: SExpr): SExpr =
+  private[this] def catchEverything(e: s.SExpr): s.SExpr =
     unaryFunction(Env.Empty) { (tokenPos, env0) =>
-      SETryCatch(
+      s.SETryCatch(
         app(e, env0.toSEVar(tokenPos)), {
           val binderPos = env0.nextPosition
           val env1 = env0.pushVar
@@ -1668,10 +1685,10 @@ private[lf] final class Compiler(
       )
     }
 
-  private[this] def compileCommandForReinterpretation(cmd: Command): SExpr =
+  private[this] def compileCommandForReinterpretation(cmd: Command): s.SExpr =
     catchEverything(compileCommand(cmd))
 
-  private[this] def compileCommands(bindings: ImmArray[Command]): SExpr =
+  private[this] def compileCommands(bindings: ImmArray[Command]): s.SExpr =
     // commands are compile similarly as update block
     // see compileBlock
     bindings.toList match {
@@ -1688,7 +1705,7 @@ private[lf] final class Compiler(
                 env = env.pushVar
                 expr
               }
-              SELet(exprs, SEValue.Unit)
+              s.SELet(exprs, s.SEValue.Unit)
             }
           }
         }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -46,7 +46,6 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
 
   def pp(e: SExpr): String = e match {
     case SEValue(v) => s"(VALUE)${pp(v)}"
-    case SEVar(n) => s"D#$n" //dont expect these at runtime
     case loc: SELoc => pp(loc)
     case SEAppGeneral(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicFun(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
@@ -56,12 +55,10 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     case SEBuiltin(b) => s"(BUILTIN)$b"
     case SEVal(ref) => s"(DEF)${pp(ref)}"
     case SELocation(_, exp) => s"LOC(${pp(exp)})"
-    case SELet(rhss, body) => s"letG (${commas(rhss.map(pp))}) in ${pp(body)}"
     case SELet1General(rhs, body) => s"let ${pp(rhs)} in ${pp(body)}"
     case SELet1Builtin(builtin, args, body) =>
       s"letB (${pp(SEBuiltin(builtin))},${commas(args.map(pp))}) in ${pp(body)}"
     case SECaseAtomic(scrut, _) => s"case(atomic) ${pp(scrut)} of..."
-    case SECase(scrut, _) => s"case ${pp(scrut)} of..."
     case _ => "<" + e.getClass.getSimpleName + "...>"
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -15,8 +15,8 @@ import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.Speedy._
-import com.daml.lf.speedy.{SExpr0 => s}
-import com.daml.lf.speedy.{SExpr => t}
+import com.daml.lf.speedy.{SExpr0 => compileTime}
+import com.daml.lf.speedy.{SExpr => runTime}
 import com.daml.lf.speedy.SValue.{SValue => _, _}
 import com.daml.lf.speedy.SValue.{SValue => SV}
 import com.daml.lf.transaction.{
@@ -49,11 +49,14 @@ private[speedy] sealed abstract class SBuiltin(val arity: Int) {
 
   // Helper for constructing expressions applying this builtin.
   // E.g. SBCons(SEVar(1), SEVar(2))
-  private[lf] def apply(args: s.SExpr*): s.SExpr = //expressions built at compile-time
-    s.SEApp(s.SEBuiltin(this), args.toArray)
 
-  private[lf] def apply(args: t.SExpr*): t.SExpr = //expressions built at runtime
-    t.SEApp(t.SEBuiltin(this), args.toArray)
+  // TODO: move this into the speedy compiler code
+  private[lf] def apply(args: compileTime.SExpr*): compileTime.SExpr =
+    compileTime.SEApp(compileTime.SEBuiltin(this), args.toArray)
+
+  // TODO: avoid constructing application expression at run time
+  private[lf] def apply(args: runTime.SExpr*): runTime.SExpr =
+    runTime.SEApp(runTime.SEBuiltin(this), args.toArray)
 
   /** Execute the builtin with 'arity' number of arguments in 'args'.
     * Updates the machine state accordingly.
@@ -1712,17 +1715,21 @@ private[lf] object SBuiltin {
       }
     }
 
-    private val mapping: Map[String, s.SExpr] =
+    //TODO: move this into the speedy compiler code
+    private val mapping: Map[String, compileTime.SExpr] =
       List(
         "ANSWER" -> SBExperimentalAnswer,
         "TO_TYPE_REP" -> SBExperimentalToTypeRep,
         "RESOLVE_VIRTUAL_CREATE" -> new SBResolveVirtual(CreateDefRef),
         "RESOLVE_VIRTUAL_SIGNATORY" -> new SBResolveVirtual(SignatoriesDefRef),
         "RESOLVE_VIRTUAL_OBSERVER" -> new SBResolveVirtual(ObserversDefRef),
-      ).view.map { case (name, builtin) => name -> s.SEBuiltin(builtin) }.toMap
+      ).view.map { case (name, builtin) => name -> compileTime.SEBuiltin(builtin) }.toMap
 
-    def apply(name: String): s.SExpr =
-      mapping.getOrElse(name, SBError(s.SEValue(SText(s"experimental $name not supported."))))
+    def apply(name: String): compileTime.SExpr =
+      mapping.getOrElse(
+        name,
+        SBError(compileTime.SEValue(SText(s"experimental $name not supported."))),
+      )
 
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1206,7 +1206,8 @@ private[lf] object SBuiltin {
   ) extends SBuiltin(1) {
     override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val record = getSRecord(args, 0)
-      machine.ctrl = ImplementsMethodDefRef(record.id, ifaceId, methodName)(SEValue(record))
+      machine.ctrl =
+        SEApp(SEVal(ImplementsMethodDefRef(record.id, ifaceId, methodName)), Array(SEValue(record)))
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SDefinition.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SDefinition.scala
@@ -4,6 +4,7 @@
 package com.daml.lf.speedy
 
 import com.daml.lf.data.Ref.Location
+import com.daml.lf.speedy.SExpr.SExpr
 
 /** Top-level speedy definition.
   *

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -24,7 +24,7 @@ import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SBuiltin._
-import com.daml.lf.speedy.{SExpr0 => s}
+import com.daml.lf.speedy.{SExpr0 => compileTime}
 import com.daml.scalautil.Statement.discard
 
 /** The speedy expression:
@@ -393,9 +393,9 @@ object SExpr {
     def ref: DefinitionRef
     def packageId: PackageId = ref.packageId
     def modName: ModuleName = ref.qualifiedName.module
-    private[this] val eval = s.SEVal(this)
-    def apply(args: s.SExpr*) = s.SEApp(eval, args.toArray) // build at compile-time
-    def apply(args: SExpr*) = SEApp(SEVal(this), args.toArray) // build at runtime
+    // TODO: move this into the speedy compiler code
+    private[this] val eval = compileTime.SEVal(this)
+    def apply(args: compileTime.SExpr*) = compileTime.SEApp(eval, args.toArray)
   }
 
   // references to definitions that come from the archive

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -452,6 +452,7 @@ object SExpr {
 
   }
 
+  // TODO: simplify here: There is only kind of SEBuiltinRecursiveDefinition! - EqualList
   final object SEBuiltinRecursiveDefinition {
 
     sealed abstract class Reference

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -8,6 +8,11 @@ package speedy
   *
   * This reduces the number of binding forms by moving update and scenario
   * expressions into builtins.
+  *
+  * These are the expression forms which remain at the end of the speedy-compiler
+  * pipeline. (after ANF).
+  *
+  * These are the expressions forms which execute on the Speedy machine.
   */
 import java.util
 
@@ -19,44 +24,31 @@ import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SBuiltin._
-import com.daml.nameof.NameOf
+import com.daml.lf.speedy.{SExpr0 => s}
 import com.daml.scalautil.Statement.discard
 
 /** The speedy expression:
-  * - de Bruijn indexed.
+  * - variables represented by their runtime location
   * - closure converted.
   * - multi-argument applications and abstractions.
   * - all update and scenario operations converted to builtin functions.
   */
-sealed abstract class SExpr extends Product with Serializable {
-  def execute(machine: Machine): Unit
-  @SuppressWarnings(Array("org.wartremover.warts.Any"))
-  override def toString: String =
-    productPrefix + productIterator.map(SExpr.prettyPrint).mkString("(", ",", ")")
-}
+
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 object SExpr {
+
+  sealed abstract class SExpr extends Product with Serializable {
+    def execute(machine: Machine): Unit
+    @SuppressWarnings(Array("org.wartremover.warts.Any"))
+    override def toString: String =
+      productPrefix + productIterator.map(prettyPrint).mkString("(", ",", ")")
+  }
 
   sealed abstract class SExprAtomic extends SExpr {
     def lookupValue(machine: Machine): SValue
 
     final def execute(machine: Machine): Unit = {
       machine.returnValue = lookupValue(machine)
-    }
-  }
-
-  /** Reference to a variable. 'index' is the 1-based de Bruijn index,
-    * that is, SEVar(1) points to the nearest enclosing variable binder.
-    * which could be an SELam, SELet, or a binding variant of SECasePat.
-    * https://en.wikipedia.org/wiki/De_Bruijn_index
-    * This expression form is only allowed prior to closure conversion
-    */
-  final case class SEVar(index: Int) extends SExprAtomic {
-    def lookupValue(machine: Machine): SValue = {
-      throw SErrorCrash(
-        NameOf.qualifiedNameOfCurrentFunc,
-        "unexpected SEVar, expected SELoc(S/A/F)",
-      )
     }
   }
 
@@ -112,6 +104,8 @@ object SExpr {
 
   /** Function application:
     *    General case: 'fun' and 'args' are any kind of expression
+    *    This case *ought* not to exist post-ANF.
+    *    Sadly, we have many code paths where this case is constructed.
     */
   final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
@@ -169,7 +163,7 @@ object SExpr {
   }
 
   object SEAppAtomic {
-    // smart constructor: detect special case of saturated builtin application
+    // smart constructor (used in Anf.scala): detect special case of saturated builtin application
     def apply(func: SExprAtomic, args: Array[SExprAtomic]): SExpr = {
       func match {
         case SEBuiltin(builtin) if builtin.arity == args.length =>
@@ -178,23 +172,6 @@ object SExpr {
           SEAppAtomicGeneral(func, args) // general case
       }
     }
-  }
-
-  /** Lambda abstraction. Transformed into SEMakeClo in lambda lifting.
-    * NOTE(JM): Compilation done in two passes so that closure conversion
-    * can be written against this simplified expression type.
-    */
-  final case class SEAbs(arity: Int, body: SExpr) extends SExpr {
-    def execute(machine: Machine): Unit =
-      throw SErrorCrash(NameOf.qualifiedNameOfCurrentFunc, "unexpected SEAbs, expected SEMakeClo")
-  }
-
-  object SEAbs {
-    // Helper for constructing abstraction expressions:
-    // SEAbs(1) { ... }
-    def apply(arity: Int)(body: SExpr): SExpr = SEAbs(arity, body)
-
-    val identity: SEAbs = SEAbs(1, SEVar(1))
   }
 
   /** Closure creation. Create a new closure object storing the free variables
@@ -244,30 +221,7 @@ object SExpr {
     }
   }
 
-  /** Pattern match. */
-  final case class SECase(scrut: SExpr, alts: Array[SCaseAlt]) extends SExpr with SomeArrayEquals {
-    def execute(machine: Machine): Unit = {
-      machine.pushKont(KMatch(machine, alts))
-      machine.ctrl = scrut
-    }
-
-    override def toString: String = s"SECase($scrut, ${alts.mkString("[", ",", "]")})"
-  }
-
-  object SECase {
-
-    // Helper for constructing case expressions:
-    // SECase(scrut) of(
-    //   SECaseAlt(SCPNil ,...),
-    //   SECaseAlt(SCPDefault, ...),
-    // )
-    case class PartialSECase(scrut: SExpr) {
-      def of(alts: SCaseAlt*): SExpr = SECase(scrut, alts.toArray)
-    }
-
-    def apply(scrut: SExpr) = PartialSECase(scrut)
-  }
-
+  /** (Atomic) Pattern match. */
   final case class SECaseAtomic(scrut: SExprAtomic, alts: Array[SCaseAlt])
       extends SExpr
       with SomeArrayEquals {
@@ -333,6 +287,7 @@ object SExpr {
   }
 
   object SELet1 {
+    // smart constructor (used in Anf.scala)
     def apply(rhs: SExpr, body: SExpr): SExpr = {
       rhs match {
         case SEAppAtomicSaturatedBuiltin(builtin: SBuiltinPure, args) =>
@@ -342,16 +297,6 @@ object SExpr {
         case _ => SELet1General(rhs, body)
       }
     }
-  }
-
-  /** A non-recursive, non-parallel let block.
-    * It is used as an intermediary data structure by the compiler to
-    * mitigate stack overflow issues, but are later exploded into
-    * [[SELet1General]] and [[SELet1Builtin]] by the ANF transformation.
-    */
-  final case class SELet(bounds: List[SExpr], body: SExpr) extends SExpr {
-    def execute(machine: Machine): Unit =
-      throw SErrorCrash(NameOf.qualifiedNameOfCurrentFunc, "not implemented")
   }
 
   /** Location annotation. When encountered the location is stored in the 'lastLocation'
@@ -448,8 +393,9 @@ object SExpr {
     def ref: DefinitionRef
     def packageId: PackageId = ref.packageId
     def modName: ModuleName = ref.qualifiedName.module
-    private[this] val eval = SEVal(this)
-    def apply(args: SExpr*) = SEApp(eval, args.toArray)
+    private[this] val eval = s.SEVal(this)
+    def apply(args: s.SExpr*) = s.SEApp(eval, args.toArray) // build at compile-time
+    def apply(args: SExpr*) = SEApp(SEVal(this), args.toArray) // build at runtime
   }
 
   // references to definitions that come from the archive
@@ -514,7 +460,9 @@ object SExpr {
       final case object EqualList extends Reference
     }
 
-    val EqualList: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.EqualList)
+    private val EqualList: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(
+      Reference.EqualList
+    )
 
     // The body of an expanded recursive-builtin will always be in ANF form.
     // The comments show where variables are to be found at runtime.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -31,7 +31,7 @@ import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.{SExpr => t}
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-object SExpr0 {
+private[speedy] object SExpr0 {
 
   sealed abstract class SExpr extends Product with Serializable
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -28,7 +28,8 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.language.Ast
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.speedy.SValue._
-import com.daml.lf.speedy.{SExpr => t}
+import com.daml.lf.speedy.SExpr.{SDefinitionRef, SCasePat}
+import com.daml.lf.speedy.{SExpr => runTime}
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 private[speedy] object SExpr0 {
@@ -48,7 +49,7 @@ private[speedy] object SExpr0 {
   /** Reference to a value. On first lookup the evaluated expression is
     * stored in 'cached'.
     */
-  final case class SEVal(ref: t.SDefinitionRef) extends SExpr
+  final case class SEVal(ref: SDefinitionRef) extends SExpr
 
   /** Reference to a builtin function */
   final case class SEBuiltin(b: SBuiltin) extends SExprAtomic
@@ -154,14 +155,15 @@ private[speedy] object SExpr0 {
   /** Case alternative. If the 'pattern' matches, then the environment is accordingly
     * extended and 'body' is evaluated.
     */
-  final case class SCaseAlt(pattern: t.SCasePat, body: SExpr)
+  final case class SCaseAlt(pattern: SCasePat, body: SExpr)
 
   //
   // List builtins (equalList) are implemented as recursive
   // definition to save java stack
   //
 
-  final case class SEBuiltinRecursiveDefinition(ref: t.SEBuiltinRecursiveDefinition.Reference)
+  // TODO: simplify here: There is only kind of SEBuiltinRecursiveDefinition! - EqualList
+  final case class SEBuiltinRecursiveDefinition(ref: runTime.SEBuiltinRecursiveDefinition.Reference)
       extends SExprAtomic
 
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -22,6 +22,17 @@ package speedy
   * Stages 1 and 2 are in Compiler.scala; stage 3 in Anf.scala.
   * During Stage3 (ANF transformation), we move from this type (SExpr0) to SExpr,
   * and so have the expression form suitable for execution on a speedy machine.
+  *
+  * Here is a summary of the differences between SExp0 and SExpr:
+  *
+  * - Constructors in both: SEAppGeneral, SEBuiltin, SEBuiltinRecursiveDefinition,
+  *   SEDamlException, SEImportValue, SELabelClosure, SELet1General, SELocA, SELocF,
+  *   SELocS, SELocation, SEMakeClo, SEScopeExercise, SETryCatch, SEVal, SEValue,
+  *
+  * - Only in SExpr0: SEAbs, SECase, SELet, SEVar
+  *
+  * - Only in SExpr: SEAppAtomicFun, SEAppAtomicGeneral, SEAppAtomicSaturatedBuiltin,
+  *   SECaseAtomic, SELet1Builtin, SELet1BuiltinArithmetic
   */
 
 import com.daml.lf.data.Ref._

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -1,0 +1,167 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+/** SExpr0 -- AST for the speedy compiler pipeline.
+  *
+  * These are *not* the expression forms which run on the speedy machine. See SExpr.
+  *
+  * These are the expression forms which exist during the speedy compiler pipeline:
+  * The pipeline stages are:
+  *
+  * 1: convert from LF
+  *     - reducing binding forms (update & scenario becoming builtins)
+  *     - moving to de Bruijn indexing for variable
+  *     - moving to multi-argument applications and abstractions.
+  *
+  * 2: closure conversion
+  * 3: transform to ANF
+  *
+  * Stages 1 and 2 are in Compiler.scala; stage 3 in Anf.scala.
+  * During Stage3 (ANF transformation), we move from this type (SExpr0) to SExpr,
+  * and so have the expression form suitable for execution on a speedy machine.
+  */
+
+import com.daml.lf.data.Ref._
+import com.daml.lf.language.Ast
+import com.daml.lf.value.{Value => V}
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.{SExpr => t}
+
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
+object SExpr0 {
+
+  sealed abstract class SExpr extends Product with Serializable
+
+  sealed abstract class SExprAtomic extends SExpr
+
+  /** Reference to a variable. 'index' is the 1-based de Bruijn index,
+    * that is, SEVar(1) points to the nearest enclosing variable binder.
+    * which could be an SELam, SELet, or a binding variant of SECasePat.
+    * https://en.wikipedia.org/wiki/De_Bruijn_index
+    * This expression form is only allowed prior to closure conversion
+    */
+  final case class SEVar(index: Int) extends SExprAtomic
+
+  /** Reference to a value. On first lookup the evaluated expression is
+    * stored in 'cached'.
+    */
+  final case class SEVal(ref: t.SDefinitionRef) extends SExpr
+
+  /** Reference to a builtin function */
+  final case class SEBuiltin(b: SBuiltin) extends SExprAtomic
+
+  /** A pre-computed value, usually primitive literal, e.g. integer, text, boolean etc. */
+  final case class SEValue(v: SValue) extends SExprAtomic
+
+  object SEValue extends SValueContainer[SEValue]
+
+  /** Function application:
+    *    General case: 'fun' and 'args' are any kind of expression
+    */
+  final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals
+
+  object SEApp {
+    def apply(fun: SExpr, args: Array[SExpr]): SExpr = {
+      SEAppGeneral(fun, args)
+    }
+  }
+
+  /** Lambda abstraction. Transformed into SEMakeClo in lambda lifting.
+    * NOTE(JM): Compilation done in two passes so that closure conversion
+    * can be written against this simplified expression type.
+    */
+  final case class SEAbs(arity: Int, body: SExpr) extends SExpr
+
+  object SEAbs {
+    // Helper for constructing abstraction expressions:
+    // SEAbs(1) { ... }
+    def apply(arity: Int)(body: SExpr): SExpr = SEAbs(arity, body)
+
+    val identity: SEAbs = SEAbs(1, SEVar(1))
+  }
+
+  /** Closure creation. Create a new closure object storing the free variables
+    * in 'body'.
+    */
+  final case class SEMakeClo(fvs: Array[SELoc], arity: Int, body: SExpr)
+      extends SExpr
+      with SomeArrayEquals
+
+  /** SELoc -- Reference to the runtime location of a variable.
+    *
+    *    This is the closure-converted form of SEVar. There are three sub-forms, with sufffix:
+    *    S/A/F, indicating [S]tack, [A]argument, or [F]ree variable captured by a closure.
+    */
+  sealed abstract class SELoc extends SExprAtomic
+
+  // SELocS -- variable is located on the stack (SELet & binding forms of SECasePat)
+  final case class SELocS(n: Int) extends SELoc
+
+  // SELocS -- variable is located in the args array of the application
+  final case class SELocA(n: Int) extends SELoc
+
+  // SELocF -- variable is located in the free-vars array of the closure being applied
+  final case class SELocF(n: Int) extends SELoc
+
+  /** Pattern match. */
+  final case class SECase(scrut: SExpr, alts: Array[SCaseAlt]) extends SExpr with SomeArrayEquals
+
+  /** A let-expression with a single RHS
+    * This form only exists *during* the ANF transformation, but not when the ANF
+    * transformation is finished.
+    */
+  final case class SELet1General(rhs: SExpr, body: SExpr) extends SExpr with SomeArrayEquals
+
+  /** A non-recursive, non-parallel let block.
+    * It is used as an intermediary data structure by the compiler to
+    * mitigate stack overflow issues, but are later exploded into
+    * [[SELet1General]] and [[SELet1Builtin]] by the ANF transformation.
+    */
+  final case class SELet(bounds: List[SExpr], body: SExpr) extends SExpr
+
+  /** Location annotation. When encountered the location is stored in the 'lastLocation'
+    * variable of the machine. When commit is begun the location is stored in 'commitLocation'.
+    */
+  final case class SELocation(loc: Location, expr: SExpr) extends SExpr
+
+  /** This is used only during profiling. When a package is compiled with
+    * profiling enabled, the right hand sides of top-level and let bindings,
+    * lambdas and some builtins are wrapped into [[SELabelClosure]]. During
+    * runtime, if the value resulting from evaluating [[expr]] is a
+    * (partially applied) closure, the label of the closure is set to the
+    * [[label]] given here.
+    * See [[com.daml.lf.speedy.Profile]] for an explanation why we use
+    * [[AnyRef]] for the label.
+    */
+  final case class SELabelClosure(label: Profile.Label, expr: SExpr) extends SExpr
+
+  /** We cannot crash in the engine call back.
+    * Rather, we set the control to this expression and then crash when executing.
+    */
+  final case class SEDamlException(error: interpretation.Error) extends SExpr
+
+  final case class SEImportValue(typ: Ast.Type, value: V) extends SExpr
+
+  /** Exception handler */
+  final case class SETryCatch(body: SExpr, handler: SExpr) extends SExpr
+
+  /** Exercise scope (begin..end) */
+  final case class SEScopeExercise(body: SExpr) extends SExpr
+
+  /** Case alternative. If the 'pattern' matches, then the environment is accordingly
+    * extended and 'body' is evaluated.
+    */
+  final case class SCaseAlt(pattern: t.SCasePat, body: SExpr)
+
+  //
+  // List builtins (equalList) are implemented as recursive
+  // definition to save java stack
+  //
+
+  final case class SEBuiltinRecursiveDefinition(ref: t.SEBuiltinRecursiveDefinition.Reference)
+      extends SExprAtomic
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -9,6 +9,7 @@ import java.util
 import com.daml.lf.data._
 import com.daml.lf.data.Ref._
 import com.daml.lf.language.Ast._
+import com.daml.lf.speedy.SExpr.SExpr
 import com.daml.lf.transaction.TransactionVersion
 import com.daml.lf.value.Value.ValueArithmeticError
 import com.daml.lf.value.{Value => V}
@@ -121,7 +122,7 @@ sealed trait SValue {
         val prim2 = prim match {
           case PClosure(label, expr, vars) =>
             PClosure(label, expr, vars.map(_.mapContractId(f)))
-          case other => other
+          case _: PBuiltin => prim
         }
         val args2 = mapArrayList(args, _.mapContractId(f))
         SPAP(prim2, args2, arity)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -4,6 +4,7 @@
 package com.daml.lf.speedy.iterable
 
 import com.daml.lf.speedy.{SExpr, SValue}
+import com.daml.lf.speedy.SExpr.SExpr
 import scala.jdk.CollectionConverters._
 
 // Iterates only over immediate children similar to Haskell’s
@@ -16,14 +17,11 @@ private[speedy] object SExprIterable {
     case SExpr.SEAppAtomicFun(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicGeneral(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicSaturatedBuiltin(_, args) => args.iterator
-    case SExpr.SEAbs(_, body) => Iterator(body)
     case SExpr.SEMakeClo(_, _, body) => Iterator(body)
-    case SExpr.SECase(scrut, alts) => Iterator(scrut) ++ alts.iterator.map(_.body)
     case SExpr.SECaseAtomic(scrut, alts) => Iterator(scrut) ++ alts.iterator.map(_.body)
     case SExpr.SELet1General(rhs, body) => Iterator(rhs, body)
     case SExpr.SELet1Builtin(_, args, body) => args.iterator ++ Iterator(body)
     case SExpr.SELet1BuiltinArithmetic(_, args, body) => args.iterator ++ Iterator(body)
-    case SExpr.SELet(bounds, body) => bounds.iterator ++ Iterator(body)
     case SExpr.SELocation(_, expr) => Iterator(expr)
     case SExpr.SELabelClosure(_, expr) => Iterator(expr)
     case SExpr.SEDamlException(_) => Iterator.empty
@@ -36,7 +34,6 @@ private[speedy] object SExprIterable {
     case SExpr.SELocS(_) => Iterator.empty
     case SExpr.SEValue(v) => iterator(v)
     case SExpr.SELocF(_) => Iterator.empty
-    case SExpr.SEVar(_) => Iterator.empty
   }
   private def iterator(v: SValue): Iterator[SExpr] = v match {
     case SValue.SPAP(prim, actuals, _) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
@@ -7,7 +7,8 @@ import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.{SExpr0 => s}
+import com.daml.lf.speedy.{SExpr => t}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.Anf.flattenToAnf
@@ -18,15 +19,15 @@ class AnfTest extends AnyWordSpec with Matchers {
 
   "identity: [\\x. x]" should {
     "be transformed to ANF as expected" in {
-      val original = lam(1, arg0)
-      val expected = original
+      val original = slam(1, sarg0)
+      val expected = lam(1, arg0)
       testTransform(original, expected)
     }
   }
 
   "twice: [\\f x. f (f x)]" should {
     "be transformed to ANF as expected" in {
-      val original = lam(2, app(arg0, app(arg0, arg1)))
+      val original = slam(2, sapp(sarg0, sapp(sarg0, sarg1)))
       val expected = lam(2, let1(appa(arg0, arg1), appa(arg0, stack1)))
       testTransform(original, expected)
     }
@@ -34,7 +35,7 @@ class AnfTest extends AnyWordSpec with Matchers {
 
   "thrice: [\\f x. f (f (f x))]" should {
     "be transformed to ANF as expected" in {
-      val original = lam(2, app(arg0, app(arg0, app(arg0, arg1))))
+      val original = slam(2, sapp(sarg0, sapp(sarg0, sapp(sarg0, sarg1))))
       val expected =
         lam(2, let1(appa(arg0, arg1), let1(appa(arg0, stack1), appa(arg0, stack1))))
       testTransform(original, expected)
@@ -43,7 +44,7 @@ class AnfTest extends AnyWordSpec with Matchers {
 
   "arithmetic non-atomic: [\\f x. f (x+1)]" should {
     "be transformed to ANF as expected" in {
-      val original = lam(2, app(arg0, binop(SBAddInt64, arg1, num1)))
+      val original = slam(2, sapp(sarg0, sbinop(SBAddInt64, sarg1, snum1)))
       val expected = lam(2, let1b2(SBAddInt64, arg1, num1, appa(arg0, stack1)))
       testTransform(original, expected)
     }
@@ -52,12 +53,12 @@ class AnfTest extends AnyWordSpec with Matchers {
   "nested (4x non-atomic): [\\f x. f(x+1) - f(x+2)]" should {
     "be transformed to ANF as expected" in {
       val original =
-        lam(
+        slam(
           2,
-          binop(
+          sbinop(
             SBSubInt64,
-            app(arg0, binop(SBAddInt64, arg1, num1)),
-            app(arg0, binop(SBAddInt64, arg1, num2)),
+            sapp(sarg0, sbinop(SBAddInt64, sarg1, snum1)),
+            sapp(sarg0, sbinop(SBAddInt64, sarg1, snum2)),
           ),
         )
       val expected =
@@ -85,7 +86,7 @@ class AnfTest extends AnyWordSpec with Matchers {
   "builtin multi-arg fun: [\\g. (g 1) - (g 2)]" should {
     "be transformed to ANF as expected" in {
       val original =
-        lam(1, binop(SBSubInt64, app(arg1, num1), app(arg1, num2)))
+        slam(1, sbinop(SBSubInt64, sapp(sarg1, snum1), sapp(sarg1, snum2)))
       val expected =
         lam(1, let1(appa(arg1, num1), let1(appa(arg1, num2), binopa(SBSubInt64, stack2, stack1))))
       testTransform(original, expected)
@@ -95,7 +96,7 @@ class AnfTest extends AnyWordSpec with Matchers {
   "unknown multi-arg fun: [\\f g. f (g 1) (g 2)]" should {
     "be transformed to ANF as expected (safely)" in {
       val original =
-        lam(2, app2(arg0, app(arg1, num1), app(arg1, num2)))
+        slam(2, sapp2(sarg0, sapp(sarg1, snum1), sapp(sarg1, snum2)))
       val expected =
         lam(2, app2n(arg0, appa(arg1, num1), appa(arg1, num2)))
       testTransform(original, expected)
@@ -105,12 +106,12 @@ class AnfTest extends AnyWordSpec with Matchers {
   "known apps nested in unknown: [\\f g x. f (g (x+1)) (g (x+2))]" should {
     "be transformed to ANF as expected (safely)" in {
       val original =
-        lam(
+        slam(
           2,
-          app2(
-            arg0,
-            app(arg1, binop(SBSubInt64, arg3, num1)),
-            app(arg1, binop(SBSubInt64, arg3, num2)),
+          sapp2(
+            sarg0,
+            sapp(sarg1, sbinop(SBSubInt64, sarg3, snum1)),
+            sapp(sarg1, sbinop(SBSubInt64, sarg3, snum2)),
           ),
         )
       val expected =
@@ -128,23 +129,23 @@ class AnfTest extends AnyWordSpec with Matchers {
 
   "error applied to 1 arg" should {
     "be transformed to ANF as expected" in {
-      val original = lam(1, SEApp(SEBuiltin(SBError), Array(arg0)))
-      val expected = lam(1, SEAppAtomicSaturatedBuiltin(SBError, Array(arg0)))
+      val original = slam(1, s.SEApp(s.SEBuiltin(SBError), Array(sarg0)))
+      val expected = lam(1, t.SEAppAtomicSaturatedBuiltin(SBError, Array(arg0)))
       testTransform(original, expected)
     }
   }
 
   "error (over) applied to 2 arg" should {
     "be transformed to ANF as expected" in {
-      val original = lam(2, SEApp(SEBuiltin(SBError), Array(arg0, arg1)))
-      val expected = lam(2, SEAppAtomicFun(SEBuiltin(SBError), Array(arg0, arg1)))
+      val original = slam(2, s.SEApp(s.SEBuiltin(SBError), Array(sarg0, sarg1)))
+      val expected = lam(2, t.SEAppAtomicFun(t.SEBuiltin(SBError), Array(arg0, arg1)))
       testTransform(original, expected)
     }
   }
 
   "case expression: [\\a b c. if a then b else c]" should {
     "be transformed to ANF as expected" in {
-      val original = lam(3, ite(arg0, arg1, arg2))
+      val original = slam(3, site(sarg0, sarg1, sarg2))
       val expected = lam(3, itea(arg0, arg1, arg2))
       testTransform(original, expected)
     }
@@ -153,7 +154,10 @@ class AnfTest extends AnyWordSpec with Matchers {
   "non-atomic in branch: [\\f x. if x==0 then 1 else f (div(1,x))]" should {
     "be transformed to ANF as expected" in {
       val original =
-        lam(2, ite(binop(SBEqual, arg1, num0), num1, app(arg0, binop(SBDivInt64, num1, arg1))))
+        slam(
+          2,
+          site(sbinop(SBEqual, sarg1, snum0), snum1, sapp(sarg0, sbinop(SBDivInt64, snum1, sarg1))),
+        )
       val expected =
         lam(
           2,
@@ -171,7 +175,7 @@ class AnfTest extends AnyWordSpec with Matchers {
   "nested lambda: [\\f g. g (\\y. f (f y))]" should {
     "be transformed to ANF as expected" in {
       val original =
-        lam(2, app(arg1, clo1(arg0, 1, app(free0, app(free0, arg0)))))
+        slam(2, sapp(sarg1, sclo1(sarg0, 1, sapp(sfree0, sapp(sfree0, sarg0)))))
       val expected =
         lam(
           2,
@@ -183,90 +187,113 @@ class AnfTest extends AnyWordSpec with Matchers {
 
   "issue 6535: [\\x. x + x]" should {
     "be transformed to ANF as expected (with no redundant lets)" in {
-      val original = lam(1, binop(SBAddInt64, arg1, arg1))
+      val original = slam(1, sbinop(SBAddInt64, sarg1, sarg1))
       val expected = lam(1, binopa(SBAddInt64, arg1, arg1))
       testTransform(original, expected)
     }
   }
 
   // expression builders
-  private def lam(n: Int, body: SExpr): SExpr = SEMakeClo(Array(), n, body)
-  private def clo1(fv: SELoc, n: Int, body: SExpr): SExpr = SEMakeClo(Array(fv), n, body)
+  private def lam(n: Int, body: t.SExpr): t.SExpr = t.SEMakeClo(Array(), n, body)
+  private def clo1(fv: t.SELoc, n: Int, body: t.SExpr): t.SExpr = t.SEMakeClo(Array(fv), n, body)
 
-  private def app(func: SExpr, arg: SExpr): SExpr = SEAppGeneral(func, Array(arg))
-
-  private def app2(func: SExpr, arg1: SExpr, arg2: SExpr): SExpr =
-    SEAppGeneral(func, Array(arg1, arg2))
-
-  private def app2n(func: SExprAtomic, arg1: SExpr, arg2: SExpr): SExpr =
-    SEAppAtomicFun(func, Array(arg1, arg2))
-
-  private def binop(op: SBuiltinPure, x: SExpr, y: SExpr): SExpr = SEApp(SEBuiltin(op), Array(x, y))
-
-  private def binop(op: SBuiltinArithmetic, x: SExpr, y: SExpr): SExpr =
-    SEApp(SEBuiltin(op), Array(x, y))
-
-  private def ite(i: SExpr, t: SExpr, e: SExpr): SExpr =
-    SECase(i, Array(SCaseAlt(patTrue, t), SCaseAlt(patFalse, e)))
+  private def app2n(func: t.SExprAtomic, arg1: t.SExpr, arg2: t.SExpr): t.SExpr =
+    t.SEAppAtomicFun(func, Array(arg1, arg2))
 
   // anf builders
-  private def let1(rhs: SExpr, body: SExpr): SExpr =
-    SELet1General(rhs, body)
+  private def let1(rhs: t.SExpr, body: t.SExpr): t.SExpr =
+    t.SELet1General(rhs, body)
 
-  private def let1b2(op: SBuiltinPure, arg1: SExprAtomic, arg2: SExprAtomic, body: SExpr): SExpr =
-    SELet1Builtin(op, Array(arg1, arg2), body)
+  private def let1b2(
+      op: SBuiltinPure,
+      arg1: t.SExprAtomic,
+      arg2: t.SExprAtomic,
+      body: t.SExpr,
+  ): t.SExpr =
+    t.SELet1Builtin(op, Array(arg1, arg2), body)
 
   private def let1b2(
       op: SBuiltinArithmetic,
-      arg1: SExprAtomic,
-      arg2: SExprAtomic,
-      body: SExpr,
-  ): SExpr =
-    SELet1BuiltinArithmetic(op, Array(arg1, arg2), body)
+      arg1: t.SExprAtomic,
+      arg2: t.SExprAtomic,
+      body: t.SExpr,
+  ): t.SExpr =
+    t.SELet1BuiltinArithmetic(op, Array(arg1, arg2), body)
 
-  private def appa(func: SExprAtomic, arg: SExprAtomic): SExpr =
-    SEAppAtomicGeneral(func, Array(arg))
+  private def appa(func: t.SExprAtomic, arg: t.SExprAtomic): t.SExpr =
+    t.SEAppAtomicGeneral(func, Array(arg))
 
-  private def binopa(op: SBuiltinArithmetic, x: SExprAtomic, y: SExprAtomic): SExpr =
-    SEAppAtomicSaturatedBuiltin(op, Array(x, y))
+  private def binopa(op: SBuiltinArithmetic, x: t.SExprAtomic, y: t.SExprAtomic): t.SExpr =
+    t.SEAppAtomicSaturatedBuiltin(op, Array(x, y))
 
-  private def itea(i: SExprAtomic, t: SExpr, e: SExpr): SExpr =
-    SECaseAtomic(i, Array(SCaseAlt(patTrue, t), SCaseAlt(patFalse, e)))
+  private def itea(i: t.SExprAtomic, th: t.SExpr, e: t.SExpr): t.SExpr =
+    t.SECaseAtomic(i, Array(t.SCaseAlt(patTrue, th), t.SCaseAlt(patFalse, e)))
 
   // true/false case-patterns
-  private def patTrue: SCasePat =
-    SCPVariant(Identifier.assertFromString("P:M:bool"), IdString.Name.assertFromString("True"), 1)
+  private def patTrue: t.SCasePat =
+    t.SCPVariant(Identifier.assertFromString("P:M:bool"), IdString.Name.assertFromString("True"), 1)
 
-  private def patFalse: SCasePat =
-    SCPVariant(Identifier.assertFromString("P:M:bool"), IdString.Name.assertFromString("False"), 2)
+  private def patFalse: t.SCasePat =
+    t.SCPVariant(
+      Identifier.assertFromString("P:M:bool"),
+      IdString.Name.assertFromString("False"),
+      2,
+    )
 
   // atoms
 
-  private def arg0 = SELocA(0)
-  private def arg1 = SELocA(1)
-  private def arg2 = SELocA(2)
-  private def arg3 = SELocA(3)
-  private def free0 = SELocF(0)
-  private def stack1 = SELocS(1)
-  private def stack2 = SELocS(2)
-  private def stack3 = SELocS(3)
+  private def arg0 = t.SELocA(0)
+  private def arg1 = t.SELocA(1)
+  private def arg2 = t.SELocA(2)
+  private def arg3 = t.SELocA(3)
+  private def free0 = t.SELocF(0)
+  private def stack1 = t.SELocS(1)
+  private def stack2 = t.SELocS(2)
+  private def stack3 = t.SELocS(3)
   private def num0 = num(0)
   private def num1 = num(1)
   private def num2 = num(2)
-  private def num(n: Long): SExprAtomic = SEValue(SInt64(n))
+  private def num(n: Long): t.SExprAtomic = t.SEValue(SInt64(n))
+
+  // We have different expression types before/after the ANF transform, so we different constructors.
+  // Use "s" (for "source") as a prefix to distinguish.
+  private def slam(n: Int, body: s.SExpr): s.SExpr = s.SEMakeClo(Array(), n, body)
+  private def sclo1(fv: s.SELoc, n: Int, body: s.SExpr): s.SExpr = s.SEMakeClo(Array(fv), n, body)
+  private def sapp(func: s.SExpr, arg: s.SExpr): s.SExpr = s.SEAppGeneral(func, Array(arg))
+  private def sbinop(op: SBuiltinPure, x: s.SExpr, y: s.SExpr): s.SExpr =
+    s.SEApp(s.SEBuiltin(op), Array(x, y))
+  private def sbinop(op: SBuiltinArithmetic, x: s.SExpr, y: s.SExpr): s.SExpr =
+    s.SEApp(s.SEBuiltin(op), Array(x, y))
+  private def sapp2(func: s.SExpr, arg1: s.SExpr, arg2: s.SExpr): s.SExpr =
+    s.SEAppGeneral(func, Array(arg1, arg2))
+  private def site(i: s.SExpr, t: s.SExpr, e: s.SExpr): s.SExpr =
+    s.SECase(i, Array(s.SCaseAlt(patTrue, t), s.SCaseAlt(patFalse, e)))
+  private def sarg0 = s.SELocA(0)
+  private def sarg1 = s.SELocA(1)
+  private def sarg2 = s.SELocA(2)
+  private def sarg3 = s.SELocA(3)
+  private def sfree0 = s.SELocF(0)
+  private def snum0 = snum(0)
+  private def snum1 = snum(1)
+  private def snum2 = snum(2)
+  private def snum(n: Long): s.SExprAtomic = s.SEValue(SInt64(n))
 
   // run a test...
-  private def testTransform(original: SExpr, expected: SExpr, show: Boolean = false): Assertion = {
+  private def testTransform(
+      original: s.SExpr,
+      expected: t.SExpr,
+      show: Boolean = false,
+  ): Assertion = {
     val transformed = flattenToAnf(original)
     if (show || transformed != expected) {
-      println(s"**original:\n${pp(original)}\n")
+      //println(s"**original:\n${pp(original)}\n")
       println(s"**transformed:\n${pp(transformed)}\n")
       println(s"**expected:\n${pp(expected)}\n")
     }
     transformed shouldBe (expected)
   }
 
-  private def pp(e: SExpr): String = {
+  private def pp(e: t.SExpr): String = {
     prettySExpr(0)(e).render(80)
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
@@ -286,7 +286,7 @@ class AnfTest extends AnyWordSpec with Matchers {
   ): Assertion = {
     val transformed = flattenToAnf(original)
     if (show || transformed != expected) {
-      //println(s"**original:\n${pp(original)}\n")
+      println(s"**original:\n${original}\n")
       println(s"**transformed:\n${pp(transformed)}\n")
       println(s"**expected:\n${pp(expected)}\n")
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ComparisonSBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ComparisonSBuiltinTest.scala
@@ -6,6 +6,7 @@ package speedy
 
 import com.daml.lf.data.{ImmArray, Ref, Struct}
 import com.daml.lf.language.Ast
+import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SError.SError
 import com.daml.lf.speedy.SResult.SResultError
 import com.daml.lf.testing.parser.ParserParameters
@@ -633,7 +634,7 @@ class ComparisonSBuiltinTest extends AnyWordSpec with Matchers with TableDrivenP
       ContractId.V1.assertFromString("00" * 32 + "0000"),
       ContractId.V1.assertFromString("00" * 32 + "0001"),
       ContractId.V1.assertFromString("00" + "ff" * 32),
-    ).map(cid => SExpr.SEValue(SValue.SContractId(cid)): SExpr)
+    ).map(cid => SEValue(SValue.SContractId(cid)): SExpr)
 
   private[this] def eval(bi: Ast.BuiltinFunction, t: Ast.Type, x: Ast.Expr, y: Ast.Expr) = {
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
@@ -649,7 +650,7 @@ class ComparisonSBuiltinTest extends AnyWordSpec with Matchers with TableDrivenP
       )
     )
     val machine =
-      Speedy.Machine.fromPureSExpr(compiledPackages, SExpr.SEApp(sexpr, contractIds))
+      Speedy.Machine.fromPureSExpr(compiledPackages, SEApp(sexpr, contractIds))
     try {
       machine.run() match {
         case SResult.SResultFinalValue(v) => Right(v)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/CompilerTest.scala
@@ -7,6 +7,7 @@ package speedy
 import java.util
 import com.daml.lf.data._
 import com.daml.lf.language.Ast._
+import com.daml.lf.speedy.SExpr.SExpr
 import com.daml.lf.testing.parser.Implicits._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -12,6 +12,7 @@ import com.daml.lf.language.{Ast, LookupError}
 import com.daml.lf.transaction.{GlobalKey, NodeId, SubmittedTransaction}
 import com.daml.lf.value.Value.{ContractId, VersionedContractInstance}
 import com.daml.lf.speedy._
+import com.daml.lf.speedy.SExpr.{SExpr, SEValue, SEApp}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.IncompleteTransaction
 import com.daml.lf.value.Value
@@ -88,7 +89,7 @@ final class ScenarioRunner(
             ScenarioLedgerApi(ledger),
             committers,
             Set.empty,
-            SExpr.SEValue(commands),
+            SEValue(commands),
             location,
             nextSeed(),
             machine.traceLog,
@@ -428,7 +429,7 @@ object ScenarioRunner {
       compiledPackages = compiledPackages,
       submissionTime = Time.Timestamp.MinValue,
       initialSeeding = InitialSeeding.TransactionSeed(seed),
-      expr = SExpr.SEApp(commands, Array(SExpr.SEValue(SValue.SToken))),
+      expr = SEApp(commands, Array(SEValue(SValue.SToken))),
       committers = committers,
       readAs = readAs,
       traceLog = traceLog,

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -10,6 +10,7 @@ import com.daml.lf.archive.UniversalArchiveDecoder
 import com.daml.lf.data.Ref.{Identifier, Location, Party, QualifiedName}
 import com.daml.lf.data.Time
 import com.daml.lf.language.Ast.EVal
+import com.daml.lf.speedy.SExpr.{SExpr, SEValue}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{NodeId, GlobalKey, SubmittedTransaction}
 import com.daml.lf.value.Value
@@ -85,7 +86,7 @@ class CollectAuthorityState {
             api,
             committers,
             Set.empty,
-            SExpr.SEValue(commands),
+            SEValue(commands),
             location,
             crypto.Hash.hashPrivateKey(step.toString),
             doEnrichment = false,
@@ -128,7 +129,7 @@ class CollectAuthorityState {
             api,
             committers,
             Set.empty,
-            SExpr.SEValue(commands),
+            SEValue(commands),
             location,
             crypto.Hash.hashPrivateKey(step.toString),
           ) match {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -19,7 +19,8 @@ import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
-import com.daml.lf.speedy.{Pretty, SExpr, SValue, Speedy}
+import com.daml.lf.speedy.{Pretty, SValue, Speedy}
+import com.daml.lf.speedy.SExpr.SExpr
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.platform.participant.util.LfEngineToApi.toApiIdentifier

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -41,7 +41,6 @@ import com.daml.lf.speedy.{
   Pretty,
   SDefinition,
   SError,
-  SExpr,
   SValue,
   Speedy,
   TraceLog,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -16,7 +16,8 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.script.ledgerinteraction.{ScriptLedgerClient, ScriptTimeMode}
 import com.daml.lf.language.Ast
 import com.daml.lf.speedy.SExpr.{SEApp, SEValue}
-import com.daml.lf.speedy.{SError, SExpr, SValue}
+import com.daml.lf.speedy.{SError, SValue}
+import com.daml.lf.speedy.SExpr.SExpr
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.value.Value

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -30,7 +30,7 @@ import com.daml.lf.language.Util._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
-import com.daml.lf.speedy.{Compiler, Pretty, SExpr, SValue, Speedy}
+import com.daml.lf.speedy.{Compiler, Pretty, SValue, Speedy}
 import com.daml.lf.{CompiledPackages, PureCompiledPackages}
 import com.daml.logging.LoggingContextOf.{label, newLoggingContext}
 import com.daml.logging.entries.{LoggingEntry, LoggingValue}


### PR DESCRIPTION
Use different expression types for pre/post ANF transformation
- `SExpr` is the type executed on a speedy machine; clients of speedy use this type.
- `SExpr0` is the type used during the speedy compilation pipeline; the type is purely internal to the speedy compiler pipeline
- The ANF compilation phase transforms from `SExp0` to `SExpr`
- The two types contains only the variant forms required.

The intention is that this refactoring (and others) will help with the more substantive issue: https://github.com/digital-asset/daml/issues/11561, by reducing the cases we have to consider when making the various speedy compilation phases stack-safe
