### PR TITLE
Set symlink_node_modules = False

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,5 @@
 workspace(
     name = "com_github_digital_asset_daml",
-    managed_directories = {
-        "@npm": ["node_modules"],
-        "@daml_extension_deps": ["compiler/daml-extension/node_modules"],
-        "@navigator_frontend_deps": ["navigator/frontend/node_modules"],
-        "@language_support_ts_deps": ["language-support/ts/packages/node_modules"],
-    },
 )
 
 # NOTE(JM): Load external dependencies from deps.bzl.
@@ -755,6 +749,7 @@ yarn_install(
     name = "npm",
     args = ["--frozen-lockfile"],
     package_json = "//:package.json",
+    symlink_node_modules = False,
     yarn_lock = "//:yarn.lock",
 )
 
@@ -763,6 +758,7 @@ yarn_install(
     name = "daml_extension_deps",
     args = ["--frozen-lockfile"],
     package_json = "//compiler/daml-extension:package.json",
+    symlink_node_modules = False,
     yarn_lock = "//compiler/daml-extension:yarn.lock",
 )
 
@@ -771,6 +767,7 @@ yarn_install(
     name = "navigator_frontend_deps",
     args = ["--frozen-lockfile"],
     package_json = "//navigator/frontend:package.json",
+    symlink_node_modules = False,
     yarn_lock = "//navigator/frontend:yarn.lock",
 )
 
@@ -784,6 +781,7 @@ yarn_install(
     name = "language_support_ts_deps",
     args = ["--frozen-lockfile"],
     package_json = "//language-support/ts/packages:package.json",
+    symlink_node_modules = False,
     yarn_lock = "//language-support/ts/packages:yarn.lock",
 ) if not is_windows else create_workspace(
     name = "language_support_ts_deps",


### PR DESCRIPTION
By default `yarn_install` will install `node_modules` in the repository.
The advantage is that editor tooling and the like can use this
`node_modules` tree without needing to duplicate it between Bazel and
tooling. The downside is that Bazel has less strict control over this
tree. In particular, on refetch it can happen that old files remain in
the tree and confuse the build going forward.

For example, we have occasionally observed errors of the form
```
warning Cannot find a suitable global folder. Tried these: "/usr/local, /does-not-exist/.yarn"
 ERROR  The following files have the same case insensitive path, which isn't supported by the VSIX format:
  - extension/node_modules/form-data/Readme.md
  - extension/node_modules/form-data/README.md
```

Setting this flag to `False` means that `node_modules` will instead be
installed under Bazel's output base and Bazel can make sure to clear the
tree before a refetch.

See [docs](https://github.com/bazelbuild/rules_nodejs/blob/9f8a18505f839f1c5c9bb7e69040d695aac677d5/internal/npm_install/npm_install.bzl#L330)

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
