### PR TITLE
[JSON-API] Backport of connection pool for 1.11.x , configurable db options needs forward porting

### DIFF
--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -155,7 +155,7 @@ trait JsonApiFixture
                 )
                 .flatMap({
                   case -\/(e) => Future.failed(new IllegalStateException(e.toString))
-                  case \/-(a) => Future.successful(a)
+                  case \/-(a) => Future.successful(a._1)
                 })
             }((binding: ServerBinding) => binding.unbind().map(_ => ()))
           }

--- a/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceOracleInt.scala
+++ b/ledger-service/http-json-oracle/src/it/scala/http/HttpServiceOracleInt.scala
@@ -3,6 +3,7 @@
 
 package com.daml.http
 
+import com.daml.http.dbbackend.ConnectionPool
 import org.scalatest.Inside
 import org.scalatest.AsyncTestSuite
 import org.scalatest.matchers.should.Matchers
@@ -22,6 +23,7 @@ trait HttpServiceOracleInt extends AbstractHttpServiceIntegrationTestFuns {
     url = s"jdbc:oracle:thin:@//localhost:$oraclePort/XEPDB1",
     user = oracleUsername,
     password = oraclePwd,
+    poolSize = ConnectionPool.PoolSize.Integration,
     createSchema = true,
   )
 }

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
@@ -4,12 +4,12 @@
 package com.daml.http.perf
 
 import java.io.File
-
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.daml.gatling.stats.{SimulationLog, SimulationLogSyntax}
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
-import com.daml.http.HttpServiceTestFixture.{withLedger, withHttpService}
+import com.daml.http.HttpServiceTestFixture.{withHttpService, withLedger}
+import com.daml.http.dbbackend.ConnectionPool
 import com.daml.http.domain.{JwtPayload, LedgerId}
 import com.daml.http.perf.scenario.SimulationConfig
 import com.daml.http.util.FutureUtil._
@@ -162,6 +162,7 @@ object Main extends StrictLogging {
       url = c.url,
       user = "test",
       password = "",
+      poolSize = ConnectionPool.PoolSize.Integration,
       createSchema = true,
     )
 

--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -5,7 +5,6 @@ package com.daml.http
 
 import java.io.File
 import java.time.Instant
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
@@ -79,7 +78,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
 
     val contractDaoF: Future[Option[ContractDao]] = jdbcConfig.map(c => initializeDb(c)).sequence
 
-    val httpServiceF: Future[ServerBinding] = for {
+    val httpServiceF: Future[(ServerBinding, Option[ContractDao])] = for {
       contractDao <- contractDaoF
       config = Config(
         ledgerHost = "localhost",
@@ -116,7 +115,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
     } yield codecs
 
     val fa: Future[A] = for {
-      httpService <- httpServiceF
+      (httpService, _) <- httpServiceF
       address = httpService.localAddress
       uri = Uri.from(scheme = "http", host = address.getHostName, port = address.getPort)
       (encoder, decoder) <- codecsF
@@ -125,12 +124,13 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
     } yield a
 
     fa.transformWith { ta =>
-      Future
-        .sequence(
-          Seq(
-            httpServiceF.flatMap(_.unbind())
-          ) map (_ fallbackTo Future.unit)
-        )
+      httpServiceF
+        .flatMap { case (serv, dao) =>
+          logger.info("Shutting down http service")
+          dao.foreach(_.close())
+          serv.unbind()
+        }
+        .fallbackTo(Future.unit)
         .transform(_ => ta)
     }
   }
@@ -222,8 +222,8 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
   }
 
   private def stripLeft(
-      fa: Future[HttpService.Error \/ ServerBinding]
-  )(implicit ec: ExecutionContext): Future[ServerBinding] =
+      fa: Future[HttpService.Error \/ (ServerBinding, Option[ContractDao])]
+  )(implicit ec: ExecutionContext): Future[(ServerBinding, Option[ContractDao])] =
     fa.flatMap {
       case -\/(e) =>
         Future.failed(new IllegalStateException(s"Cannot start HTTP Service: ${e.message}"))
@@ -233,7 +233,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
 
   private def initializeDb(c: JdbcConfig)(implicit ec: ExecutionContext): Future[ContractDao] =
     for {
-      dao <- Future(ContractDao(c.driver, c.url, c.user, c.password))
+      dao <- Future(ContractDao(c))
       _ <- {
         import dao.{logHandler, jdbcDriver}
         dao.transact(ContractDao.initialize).unsafeToFuture(): Future[Unit]

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -67,6 +67,7 @@ da_scala_library(
         "//libs-scala/doobie-slf4j",
         "//libs-scala/ports",
         "//libs-scala/scala-utils",
+        "@maven//:com_zaxxer_HikariCP",
     ],
 )
 

--- a/ledger-service/http-json/src/failure/scala/http/HttpTestFixture.scala
+++ b/ledger-service/http-json/src/failure/scala/http/HttpTestFixture.scala
@@ -5,10 +5,12 @@ package com.daml.http
 
 import akka.http.scaladsl.model.Uri
 import com.daml.bazeltools.BazelRunfiles
+import com.daml.http.dbbackend.ConnectionPool
 import com.daml.http.json.{DomainJsonDecoder, DomainJsonEncoder}
 import com.daml.ledger.client.LedgerClient
 import com.daml.ports.LockedFreePort
 import com.daml.testing.postgresql.PostgresAroundAll
+
 import java.net.InetAddress
 import org.scalatest.Suite
 
@@ -38,6 +40,7 @@ trait HttpFailureTestFixture extends ToxicSandboxFixture with PostgresAroundAll 
         s"jdbc:postgresql://${postgresDatabase.hostName}:$dbProxyPort/${postgresDatabase.databaseName}?user=${postgresDatabase.userName}&password=${postgresDatabase.password}",
       user = "test",
       password = "",
+      poolSize = ConnectionPool.PoolSize.Integration,
       createSchema = true,
     )
 

--- a/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
@@ -3,6 +3,7 @@
 
 package com.daml.http
 
+import com.daml.http.dbbackend.ConnectionPool
 import com.daml.testing.postgresql.PostgresAroundAll
 import org.scalatest.Inside
 import org.scalatest.AsyncTestSuite
@@ -22,6 +23,7 @@ trait HttpServicePostgresInt extends AbstractHttpServiceIntegrationTestFuns with
     url = postgresDatabase.url,
     user = "test",
     password = "",
+    poolSize = ConnectionPool.PoolSize.Integration,
     createSchema = true,
   )
 

--- a/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServicePostgresInt.scala
@@ -13,6 +13,9 @@ trait HttpServicePostgresInt extends AbstractHttpServiceIntegrationTestFuns with
 
   override final def jdbcConfig: Option[JdbcConfig] = Some(jdbcConfig_)
 
+  // has to be lazy because jdbcConfig_ is NOT initialized yet
+  protected lazy val dao = dbbackend.ContractDao(jdbcConfig_)
+
   // has to be lazy because postgresFixture is NOT initialized yet
   protected[this] lazy val jdbcConfig_ = JdbcConfig(
     driver = "org.postgresql.Driver",
@@ -21,4 +24,9 @@ trait HttpServicePostgresInt extends AbstractHttpServiceIntegrationTestFuns with
     password = "",
     createSchema = true,
   )
+
+  override protected def afterAll(): Unit = {
+    dao.close()
+    super.afterAll()
+  }
 }

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceWithPostgresIntTest.scala
@@ -18,14 +18,6 @@ class HttpServiceWithPostgresIntTest
 
   override def wsConfig: Option[WebsocketConfig] = None
 
-  // has to be lazy because jdbcConfig_ is NOT initialized yet
-  private lazy val dao = dbbackend.ContractDao(
-    jdbcDriver = jdbcConfig_.driver,
-    jdbcUrl = jdbcConfig_.url,
-    username = jdbcConfig_.user,
-    password = jdbcConfig_.password,
-  )
-
   "query persists all active contracts" in withHttpService { (uri, encoder, _) =>
     searchExpectOk(
       searchDataSet,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -63,7 +63,7 @@ object Main extends StrictLogging {
 
     def terminate(): Unit = discard { Await.result(asys.terminate(), 10.seconds) }
 
-    val contractDao = config.jdbcConfig.map(c => ContractDao(c.driver, c.url, c.user, c.password))
+    val contractDao = config.jdbcConfig.map(c => ContractDao(c))
 
     (contractDao, config.jdbcConfig) match {
       case (Some(dao), Some(c)) if c.createSchema =>
@@ -82,7 +82,7 @@ object Main extends StrictLogging {
       case _ =>
     }
 
-    val serviceF: Future[HttpService.Error \/ ServerBinding] =
+    val serviceF: Future[HttpService.Error \/ (ServerBinding, Option[ContractDao])] =
       HttpService.start(
         startSettings = config,
         contractDao = contractDao,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -18,6 +18,7 @@ import scalaz.{NonEmptyList, OneAnd}
 import scalaz.syntax.tag._
 import spray.json.{JsNull, JsValue}
 import cats.effect.{Blocker, ContextShift, IO}
+import com.daml.scalautil.Statement.discard
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import doobie._
 
@@ -44,11 +45,10 @@ class ContractDao private (
   def isValid(timeoutSeconds: Int): IO[Boolean] =
     fconn.isValid(timeoutSeconds).transact(xa)
 
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def shutdown(): Try[Unit] = {
     Try {
       dbAccessPool.shutdown()
-      dbAccessPool.awaitTermination(10, TimeUnit.SECONDS)
+      discard(dbAccessPool.awaitTermination(10, TimeUnit.SECONDS))
       ds.close()
     }
   }
@@ -305,9 +305,6 @@ object ContractDao {
   }
 }
 
-/*
-  TODO below values are hardcoded for now, refactor to be picked up as cli flags/ props later.
- */
 object ConnectionPool {
 
   type PoolSize = Int

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -7,6 +7,7 @@ import cats.effect._
 import cats.syntax.apply._
 import com.daml.doobie.logging.Slf4jLogHandler
 import com.daml.http.domain
+import com.daml.http.JdbcConfig
 import com.daml.http.json.JsonProtocol.LfValueDatabaseCodec
 import doobie.LogHandler
 import doobie.free.connection.ConnectionIO
@@ -16,10 +17,24 @@ import doobie.util.log
 import scalaz.{NonEmptyList, OneAnd}
 import scalaz.syntax.tag._
 import spray.json.{JsNull, JsValue}
+import cats.effect.{Blocker, ContextShift, IO}
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import doobie._
 
+import java.io.{Closeable, IOException}
+import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
+import java.util.concurrent.Executors.newWorkStealingPool
+import javax.sql.DataSource
 import scala.concurrent.ExecutionContext
+import scala.language.existentials
+import scala.util.Try
 
-class ContractDao private (xa: Connection.T)(implicit val jdbcDriver: SupportedJdbcDriver) {
+class ContractDao private (
+    ds: DataSource with Closeable,
+    xa: ConnectionPool.T,
+    dbAccessPool: ExecutorService,
+)(implicit val jdbcDriver: SupportedJdbcDriver)
+    extends Closeable {
 
   implicit val logHandler: log.LogHandler = Slf4jLogHandler(classOf[ContractDao])
 
@@ -28,6 +43,26 @@ class ContractDao private (xa: Connection.T)(implicit val jdbcDriver: SupportedJ
 
   def isValid(timeoutSeconds: Int): IO[Boolean] =
     fconn.isValid(timeoutSeconds).transact(xa)
+
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  def shutdown(): Try[Unit] = {
+    Try {
+      dbAccessPool.shutdown()
+      dbAccessPool.awaitTermination(10, TimeUnit.SECONDS)
+      ds.close()
+    }
+  }
+
+  @throws[IOException]
+  override def close(): Unit = {
+    shutdown().fold(
+      {
+        case e: IOException => throw e
+        case e => throw new IOException(e)
+      },
+      identity,
+    )
+  }
 }
 
 object ContractDao {
@@ -40,17 +75,20 @@ object ContractDao {
     scala.util.Try(Class forName d).isSuccess
   }
 
-  def apply(jdbcDriver: String, jdbcUrl: String, username: String, password: String)(implicit
+  def apply(cfg: JdbcConfig)(implicit
       ec: ExecutionContext
   ): ContractDao = {
     val cs: ContextShift[IO] = IO.contextShift(ec)
     implicit val sjd: SupportedJdbcDriver = supportedJdbcDrivers.getOrElse(
-      jdbcDriver,
+      cfg.driver,
       throw new IllegalArgumentException(
-        s"JDBC driver $jdbcDriver is not one of ${supportedJdbcDrivers.keySet}"
+        s"JDBC driver ${cfg.driver} is not one of ${supportedJdbcDrivers.keySet}"
       ),
     )
-    new ContractDao(Connection.connect(jdbcDriver, jdbcUrl, username, password)(cs))
+    //pool for connections awaiting database access
+    val es = Executors.newWorkStealingPool(cfg.poolSize)
+    val (ds, conn) = ConnectionPool.connect(cfg)(ExecutionContext.fromExecutor(es), cs)
+    new ContractDao(ds, conn, es)
   }
 
   def initialize(implicit log: LogHandler, sjd: SupportedJdbcDriver): ConnectionIO[Unit] =
@@ -264,5 +302,48 @@ object ContractDao {
 
   object StaleOffsetException {
     val SqlState = "STALE_OFFSET_EXCEPTION"
+  }
+}
+
+/*
+  TODO below values are hardcoded for now, refactor to be picked up as cli flags/ props later.
+ */
+object ConnectionPool {
+
+  type PoolSize = Int
+  object PoolSize {
+    val Integration = 2
+    val Production = 8
+  }
+
+  type T = Transactor.Aux[IO, _ <: DataSource with Closeable]
+
+  def connect(c: JdbcConfig)(implicit
+      ec: ExecutionContext,
+      cs: ContextShift[IO],
+  ): (DataSource with Closeable, T) = {
+    val ds = dataSource(c)
+    (
+      ds,
+      Transactor
+        .fromDataSource[IO](
+          ds,
+          connectEC = ec,
+          blocker = Blocker liftExecutorService newWorkStealingPool(c.poolSize),
+        )(IO.ioConcurrentEffect(cs), cs),
+    )
+  }
+
+  private[this] def dataSource(jc: JdbcConfig) = {
+    import jc._
+    val c = new HikariConfig
+    c.setJdbcUrl(url)
+    c.setUsername(user)
+    c.setPassword(password)
+    c.setMinimumIdle(jc.minIdle)
+    c.setConnectionTimeout(jc.connectionTimeout)
+    c.setMaximumPoolSize(poolSize)
+    c.setIdleTimeout(jc.idleTimeout)
+    new HikariDataSource(c)
   }
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -3,7 +3,6 @@
 
 package com.daml.http.dbbackend
 
-import cats.effect._
 import cats.syntax.apply._
 import com.daml.doobie.logging.Slf4jLogHandler
 import com.daml.http.domain

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
@@ -19,10 +19,10 @@ final class CliSpec extends AnyFreeSpec with Matchers {
     "jdbc:postgresql://localhost:5432/test?&ssl=true",
     "postgres",
     "password",
-    false,
+    poolSize = 10,
   )
   val jdbcConfigString =
-    "driver=org.postgresql.Driver,url=jdbc:postgresql://localhost:5432/test?&ssl=true,user=postgres,password=password,createSchema=false"
+    "driver=org.postgresql.Driver,url=jdbc:postgresql://localhost:5432/test?&ssl=true,user=postgres,password=password,createSchema=false,poolSize=10"
 
   val sharedOptions =
     Seq("--ledger-host", "localhost", "--ledger-port", "6865", "--http-port", "7500")

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
@@ -20,9 +20,13 @@ final class CliSpec extends AnyFreeSpec with Matchers {
     "postgres",
     "password",
     poolSize = 10,
+    minIdle = 4,
+    connectionTimeout = 5000,
+    idleTimeout = 1000,
   )
   val jdbcConfigString =
-    "driver=org.postgresql.Driver,url=jdbc:postgresql://localhost:5432/test?&ssl=true,user=postgres,password=password,createSchema=false,poolSize=10"
+    "driver=org.postgresql.Driver,url=jdbc:postgresql://localhost:5432/test?&ssl=true,user=postgres,password=password," +
+      "createSchema=false,poolSize=10,minIdle=4,connectionTimeout=5000,idleTimeout=1000"
 
   val sharedOptions =
     Seq("--ledger-host", "localhost", "--ledger-port", "6865", "--http-port", "7500")


### PR DESCRIPTION
Backport of Hikari connection pool for 1.11.x plus addition of a configurable pool size parameter to jdbcConfig.

Forward porting of configurable db options for `main` is on [#11621](https://github.com/digital-asset/daml/pull/11621)

CHANGELOG_BEGIN
[JSON-API] Backport of Hikari connection pool for 1.11.x plus addition of a configurable pool size parameter to jdbcConfig.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
