### PR TITLE
LF: Drop typeparameter from KeyWithMaintainers

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -547,12 +547,12 @@ final class Conversions(
   }
 
   def convertKeyWithMaintainers(
-      key: Node.KeyWithMaintainers[V.VersionedValue]
+      key: Node.VersionedKeyWithMaintainers
   ): proto.KeyWithMaintainers = {
     proto.KeyWithMaintainers
       .newBuilder()
-      .setKey(convertVersionedValue(key.key))
-      .addAllMaintainers(key.maintainers.map(convertParty).asJava)
+      .setKey(convertVersionedValue(key.map(_.key)))
+      .addAllMaintainers(key.unversioned.maintainers.map(convertParty).asJava)
       .build()
   }
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Event.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Event.scala
@@ -33,7 +33,7 @@ sealed trait Event extends Product with Serializable {
 final case class CreateEvent(
     contractId: ContractId,
     templateId: Identifier,
-    contractKey: Option[KeyWithMaintainers[Value]],
+    contractKey: Option[KeyWithMaintainers],
     argument: Value,
     agreementText: String,
     signatories: Set[Party],

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -101,25 +101,18 @@ final class ValueEnricher(
     handleLookup(interface.lookupTemplateKey(tyCon))
       .flatMap(key => enrichValue(key.typ, value))
 
-  def enrichVersionedContractKey(
-      tyCon: Identifier,
-      value: VersionedValue,
-  ): Result[VersionedValue] =
-    handleLookup(interface.lookupTemplateKey(tyCon))
-      .flatMap(key => enrichVersionedValue(key.typ, value))
-
   private val ResultNone = ResultDone(None)
 
   def enrichContractKey(
       tyCon: Identifier,
-      key: Node.KeyWithMaintainers[Value],
-  ): Result[Node.KeyWithMaintainers[Value]] =
+      key: Node.KeyWithMaintainers,
+  ): Result[Node.KeyWithMaintainers] =
     enrichContractKey(tyCon, key.key).map(normalizedKey => key.copy(key = normalizedKey))
 
   def enrichContractKey(
       tyCon: Identifier,
-      key: Option[Node.KeyWithMaintainers[Value]],
-  ): Result[Option[Node.KeyWithMaintainers[Value]]] =
+      key: Option[Node.KeyWithMaintainers],
+  ): Result[Option[Node.KeyWithMaintainers]] =
     key match {
       case Some(k) =>
         enrichContractKey(tyCon, k).map(Some(_))
@@ -129,14 +122,14 @@ final class ValueEnricher(
 
   def enrichVersionedContractKey(
       tyCon: Identifier,
-      key: Node.KeyWithMaintainers[VersionedValue],
-  ): Result[Node.KeyWithMaintainers[VersionedValue]] =
-    enrichVersionedContractKey(tyCon, key.key).map(normalizedKey => key.copy(key = normalizedKey))
+      key: Node.VersionedKeyWithMaintainers,
+  ): Result[Node.VersionedKeyWithMaintainers] =
+    enrichContractKey(tyCon, key.unversioned).map(normalizedValue => key.map(_ => normalizedValue))
 
   def enrichVersionedContractKey(
       tyCon: Identifier,
-      key: Option[Node.KeyWithMaintainers[VersionedValue]],
-  ): Result[Option[Node.KeyWithMaintainers[VersionedValue]]] =
+      key: Option[Node.VersionedKeyWithMaintainers],
+  ): Result[Option[Node.VersionedKeyWithMaintainers]] =
     key match {
       case Some(k) =>
         enrichVersionedContractKey(tyCon, k).map(Some(_))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -189,13 +189,13 @@ private[lf] object Pretty {
           prettyLoc(amf.optLocation)
     }
 
-  def prettyKeyWithMaintainers(key: Node.KeyWithMaintainers[Value]): Doc =
+  def prettyKeyWithMaintainers(key: Node.KeyWithMaintainers): Doc =
     // the maintainers are induced from the key -- so don't clutter
     prettyValue(false)(key.key)
 
-  def prettyVersionedKeyWithMaintainers(key: Node.KeyWithMaintainers[VersionedValue]): Doc =
+  def prettyVersionedKeyWithMaintainers(key: Node.VersionedKeyWithMaintainers): Doc =
     // the maintainers are induced from the key -- so don't clutter
-    prettyValue(false)(key.key.unversioned)
+    prettyKeyWithMaintainers(key.unversioned)
 
   def prettyEventInfo(l: ScenarioLedger, txId: TransactionId)(nodeId: NodeId): Doc = {
     def arrowRight(d: Doc) = text("└─>") & d

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1765,7 +1765,7 @@ private[lf] object SBuiltin {
       templateId: TypeConName,
       location: String,
       v: SValue,
-  ): Node.KeyWithMaintainers[V] =
+  ): Node.KeyWithMaintainers =
     v match {
       case SStruct(_, vals) =>
         val key = onLedger.ptx.normValue(templateId, vals.get(keyIdx))
@@ -1782,7 +1782,7 @@ private[lf] object SBuiltin {
       templateId: TypeConName,
       where: String,
       optKey: SValue,
-  ): Option[Node.KeyWithMaintainers[V]] =
+  ): Option[Node.KeyWithMaintainers] =
     optKey match {
       case SOptional(mbKey) => mbKey.map(extractKeyWithMaintainers(onLedger, templateId, where, _))
       case v => throw SErrorCrash(where, s"Expected optional key with maintainers, got: $v")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -104,7 +104,7 @@ private[lf] object Speedy {
       value: SValue,
       signatories: Set[Party],
       observers: Set[Party],
-      key: Option[Node.KeyWithMaintainers[V]],
+      key: Option[Node.KeyWithMaintainers],
   ) {
     private[lf] val stakeholders: Set[Party] = signatories union observers;
   }
@@ -355,7 +355,7 @@ private[lf] object Speedy {
         arg: SValue,
         signatories: Set[Party],
         observers: Set[Party],
-        key: Option[Node.KeyWithMaintainers[V]],
+        key: Option[Node.KeyWithMaintainers],
     ) =
       withOnLedger("addLocalContract") { onLedger =>
         onLedger.cachedContracts = onLedger.cachedContracts.updated(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -141,7 +141,7 @@ private[lf] object PartialTransaction {
   final case class ExercisesContextInfo(
       targetId: Value.ContractId,
       templateId: TypeConName,
-      contractKey: Option[Node.KeyWithMaintainers[Value]],
+      contractKey: Option[Node.KeyWithMaintainers],
       choiceId: ChoiceName,
       consuming: Boolean,
       actingParties: Set[Party],
@@ -407,7 +407,7 @@ private[speedy] case class PartialTransaction(
       optLocation: Option[Location],
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[Node.KeyWithMaintainers[Value]],
+      key: Option[Node.KeyWithMaintainers],
       byInterface: Option[TypeConName],
   ): (Value.ContractId, PartialTransaction) = {
     val actionNodeSeed = context.nextActionChildSeed
@@ -500,7 +500,7 @@ private[speedy] case class PartialTransaction(
       actingParties: Set[Party],
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[Node.KeyWithMaintainers[Value]],
+      key: Option[Node.KeyWithMaintainers],
       byKey: Boolean,
       byInterface: Option[TypeConName],
   ): PartialTransaction = {
@@ -528,7 +528,7 @@ private[speedy] case class PartialTransaction(
       auth: Authorize,
       templateId: TypeConName,
       optLocation: Option[Location],
-      key: Node.KeyWithMaintainers[Value],
+      key: Node.KeyWithMaintainers,
       result: Option[Value.ContractId],
   ): PartialTransaction = {
     val nid = NodeId(nextNodeIdx)
@@ -557,7 +557,7 @@ private[speedy] case class PartialTransaction(
       signatories: Set[Party],
       stakeholders: Set[Party],
       choiceObservers: Set[Party],
-      mbKey: Option[Node.KeyWithMaintainers[Value]],
+      mbKey: Option[Node.KeyWithMaintainers],
       byKey: Boolean,
       chosenValue: Value,
       byInterface: Option[TypeConName],

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -187,8 +187,8 @@ object TransactionBuilder {
 
   type TxValue = value.Value.VersionedValue
 
-  type KeyWithMaintainers = Node.KeyWithMaintainers[Value]
-  type TxKeyWithMaintainers = Node.KeyWithMaintainers[TxValue]
+  type KeyWithMaintainers = Node.KeyWithMaintainers
+  type TxKeyWithMaintainers = Node.VersionedKeyWithMaintainers
 
   def apply(
       pkgLangVersion: Ref.PackageId => LanguageVersion = _ => LanguageVersion.StableVersions.max

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -274,7 +274,7 @@ object ValueGenerators {
       agreement <- Arbitrary.arbitrary[String]
     } yield arg.map(Value.ContractInstance(template, _, agreement))
 
-  val keyWithMaintainersGen: Gen[Node.KeyWithMaintainers[Value]] = {
+  val keyWithMaintainersGen: Gen[Node.KeyWithMaintainers] = {
     for {
       key <- valueGen
       maintainers <- genNonEmptyParties

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
@@ -28,7 +28,7 @@ class Normalization {
     * longer need this separate normalization pass.
     */
 
-  private type KWM = Node.KeyWithMaintainers[Val]
+  private type KWM = Node.KeyWithMaintainers
   private type VTX = VersionedTransaction
 
   def normalizeTx(vtx: VTX): VTX = {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -502,7 +502,7 @@ sealed abstract class HasTxNodes {
       def assertKeyMapping(
           templateId: Identifier,
           cid: Value.ContractId,
-          optKey: Option[Node.KeyWithMaintainers[Value]],
+          optKey: Option[Node.KeyWithMaintainers],
       ): Either[KeyInputError, State] =
         optKey.fold[Either[KeyInputError, State]](Right(this)) { key =>
           val gk = GlobalKey.assertBuild(templateId, key.key)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -184,7 +184,7 @@ object TransactionCoder {
   private[this] def encodeKeyWithMaintainers(
       encodeCid: ValueCoder.EncodeCid,
       version: TransactionVersion,
-      key: Node.KeyWithMaintainers[Value],
+      key: Node.KeyWithMaintainers,
   ): Either[EncodeError, TransactionOuterClass.KeyWithMaintainers] = {
     val builder =
       TransactionOuterClass.KeyWithMaintainers
@@ -204,7 +204,7 @@ object TransactionCoder {
   private[this] def encodeAndSetContractKey(
       encodeCid: ValueCoder.EncodeCid,
       version: TransactionVersion,
-      key: Option[Node.KeyWithMaintainers[Value]],
+      key: Option[Node.KeyWithMaintainers],
       setKey: TransactionOuterClass.KeyWithMaintainers => GeneratedMessageV3.Builder[_],
   ) = {
     key match {
@@ -420,7 +420,7 @@ object TransactionCoder {
       decodeCid: ValueCoder.DecodeCid,
       version: TransactionVersion,
       keyWithMaintainers: TransactionOuterClass.KeyWithMaintainers,
-  ): Either[DecodeError, Node.KeyWithMaintainers[Value]] = {
+  ): Either[DecodeError, Node.KeyWithMaintainers] = {
     for {
       maintainers <- toPartySet(keyWithMaintainers.getMaintainersList)
       key <- decodeValue(
@@ -438,7 +438,7 @@ object TransactionCoder {
       decodeCid: ValueCoder.DecodeCid,
       version: TransactionVersion,
       keyWithMaintainers: TransactionOuterClass.KeyWithMaintainers,
-  ): Either[DecodeError, Option[Node.KeyWithMaintainers[Value]]] = {
+  ): Either[DecodeError, Option[Node.KeyWithMaintainers]] = {
     if (keyWithMaintainers == TransactionOuterClass.KeyWithMaintainers.getDefaultInstance) {
       RightNone
     } else {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Util.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Util.scala
@@ -88,15 +88,15 @@ object Util {
       .map(normalized => contract.map(_.copy(arg = normalized)))
 
   def normalizeKey(
-      key: Node.KeyWithMaintainers[Value],
+      key: Node.KeyWithMaintainers,
       version: TransactionVersion,
-  ): Either[String, Node.KeyWithMaintainers[Value]] =
+  ): Either[String, Node.KeyWithMaintainers] =
     normalizeValue(key.key, version).map(normalized => key.copy(key = normalized))
 
   def normalizeOptKey(
-      key: Option[Node.KeyWithMaintainers[Value]],
+      key: Option[Node.KeyWithMaintainers],
       version: TransactionVersion,
-  ): Either[String, Option[Node.KeyWithMaintainers[Value]]] =
+  ): Either[String, Option[Node.KeyWithMaintainers]] =
     key match {
       case Some(value) => normalizeKey(value, version).map(Some(_))
       case None => Right(None)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -941,7 +941,7 @@ class TransactionCoderSpec
     )
 
   private[this] def normalizeKey(
-      key: Node.KeyWithMaintainers[Value],
+      key: Node.KeyWithMaintainers,
       version: TransactionVersion,
   ) = {
     key.copy(key = normalize(key.key, version))

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/validation/ValidationSpec.scala
@@ -44,7 +44,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers with TableDrivenPropertyC
   //--[types]--
 
   private type Val = V
-  private type KWM = Node.KeyWithMaintainers[Val]
+  private type KWM = Node.KeyWithMaintainers
   private type OKWM = Option[KWM]
   private type Exe = Node.Exercise
   private type VTX = VersionedTransaction

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
@@ -173,13 +173,13 @@ object LfEngineToApi {
 
   def lfContractKeyToApiValue(
       verbose: Boolean,
-      lf: Node.KeyWithMaintainers[LfValue],
+      lf: Node.KeyWithMaintainers,
   ): Either[String, api.Value] =
     lfValueToApiValue(verbose, lf.key)
 
   def lfContractKeyToApiValue(
       verbose: Boolean,
-      lf: Option[Node.KeyWithMaintainers[LfValue]],
+      lf: Option[Node.KeyWithMaintainers],
   ): Either[String, Option[api.Value]] =
     lf.fold[Either[String, Option[api.Value]]](Right(None))(
       lfContractKeyToApiValue(verbose, _).map(Some(_))

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -148,7 +148,10 @@ private[migration] class V2_1__Rebuild_Acs extends BaseJavaMigration {
             "key" -> c.key
               .map(k =>
                 valueSerializer
-                  .serializeValue(k.key, s"Failed to serialize key for contract ${c.id.coid}")
+                  .serializeValue(
+                    k.map(_.key),
+                    s"Failed to serialize key for contract ${c.id.coid}",
+                  )
               ),
           )
         )
@@ -230,7 +233,7 @@ private[migration] class V2_1__Rebuild_Acs extends BaseJavaMigration {
         .flatMap(c =>
           c.key
             .map(k =>
-              k.maintainers.map(p =>
+              k.unversioned.maintainers.map(p =>
                 Seq[NamedParameter](
                   "contract_id" -> c.id.coid,
                   "maintainer" -> p,

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v25_backfill_participant_events/V25EventsTableInsert.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v25_backfill_participant_events/V25EventsTableInsert.scala
@@ -28,7 +28,7 @@ private[v25_backfill_participant_events] object V25EventsTableInsert {
   private def serializeNullableKeyOrThrow(node: Create): Option[Array[Byte]] =
     node.versionedKey.map(k =>
       serialize(
-        value = k.key,
+        value = k.map(_.key),
         errorContext = cantSerialize(attribute = "key", forContract = node.coid),
       )
     )

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v29_fix_participant_events/V29EventsTableInsert.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/v29_fix_participant_events/V29EventsTableInsert.scala
@@ -28,7 +28,7 @@ private[v29_fix_participant_events] object V29EventsTableInsert {
   private def serializeNullableKeyOrThrow(node: Create): Option[Array[Byte]] =
     node.versionedKey.map(k =>
       serialize(
-        value = k.key,
+        value = k.map(_.key),
         errorContext = cantSerialize(attribute = "key", forContract = node.coid),
       )
     )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
@@ -174,7 +174,7 @@ private[platform] class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](
                   )
                 case Some(key) =>
                   val gk =
-                    GlobalKey(activeContract.contract.unversioned.template, key.key.unversioned)
+                    GlobalKey(activeContract.contract.unversioned.template, key.unversioned.key)
                   if (als.lookupContractByKey(gk).isDefined) {
                     state.copy(
                       currentState = state.currentState.copy(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/Contract.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/Contract.scala
@@ -6,10 +6,10 @@ package com.daml.platform.store
 import java.time.Instant
 
 import com.daml.lf.data.Ref
-import com.daml.lf.transaction.Node.KeyWithMaintainers
+import com.daml.lf.transaction.Node.VersionedKeyWithMaintainers
 import com.daml.lf.transaction.NodeId
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.{ContractId, VersionedContractInstance, VersionedValue}
+import com.daml.lf.value.Value.{ContractId, VersionedContractInstance}
 
 /** A contract that is part of the [[ActiveLedgerState]].
   * Depending on where the contract came from, other metadata may be available.
@@ -57,7 +57,7 @@ private[platform] object Contract {
         Ref.Party,
         Ref.TransactionId,
       ], // for each party, the transaction id at which the contract was divulged
-      key: Option[KeyWithMaintainers[VersionedValue]],
+      key: Option[VersionedKeyWithMaintainers],
       signatories: Set[Ref.Party],
       observers: Set[Ref.Party],
       agreementText: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/LfValueTranslation.scala
@@ -103,7 +103,7 @@ final class LfValueTranslation(
   private def serializeNullableKeyOrThrow(c: Create): Option[Array[Byte]] =
     c.versionedKey.map(k =>
       ValueSerializer.serializeValue(
-        value = k.key,
+        value = k.map(_.key),
         errorContext = cantSerialize(attribute = "key", forContract = c.coid),
       )
     )
@@ -111,7 +111,7 @@ final class LfValueTranslation(
   private def serializeNullableKeyOrThrow(e: Exercise): Option[Array[Byte]] = {
     e.versionedKey.map(k =>
       ValueSerializer.serializeValue(
-        value = k.key,
+        value = k.map(_.key),
         errorContext = cantSerialize(attribute = "key", forContract = e.targetCoid),
       )
     )
@@ -146,7 +146,7 @@ final class LfValueTranslation(
     cache.events.put(
       key = LfValueTranslationCache.EventCache.Key(eventId),
       value = LfValueTranslationCache.EventCache.Value
-        .Create(create.versionedArg, create.versionedKey.map(_.key)),
+        .Create(create.versionedArg, create.versionedKey.map(_.map(_.key))),
     )
     cache.contracts.put(
       key = LfValueTranslationCache.ContractCache.Key(create.coid),

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/PostCommitValidation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/PostCommitValidation.scala
@@ -153,11 +153,11 @@ private[appendonlydao] object PostCommitValidation {
     )(implicit connection: Connection): Result =
       node match {
         case c: Create =>
-          state.validateCreate(c.versionedKey.map(convert(c.templateId, _)), c.coid)
+          state.validateCreate(c.key.map(convert(c.templateId, _)), c.coid)
         case l: LookupByKey =>
-          state.validateLookupByKey(convert(l.templateId, l.versionedKey), l.result)
+          state.validateLookupByKey(convert(l.templateId, l.key), l.result)
         case e: Exercise if e.consuming =>
-          state.removeKeyIfDefined(e.versionedKey.map(convert(e.templateId, _)))
+          state.removeKeyIfDefined(e.key.map(convert(e.templateId, _)))
         case _ =>
           // fetch and non-consuming exercise nodes don't need to validate
           // anything with regards to contract keys and do not alter the

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/package.scala
@@ -88,12 +88,12 @@ package object events {
       .fold(Vector.empty[A])(_ :+ _)
       .concatSubstreams
 
-  def convert(template: Identifier, key: lftx.Node.KeyWithMaintainers[Value]): Key =
-    Key.assertBuild(template, key.key.unversioned)
+  def convert(template: Identifier, key: lftx.Node.KeyWithMaintainers): Key =
+    Key.assertBuild(template, key.key)
 
   def convertLfValueKey(
       template: Identifier,
-      key: KeyWithMaintainers[lfval],
+      key: KeyWithMaintainers,
   ) =
     Key.assertBuild(template, key.key)
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -195,7 +195,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
       absCid: ContractId,
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[Node.KeyWithMaintainers[LfValue]] = None,
+      key: Option[Node.KeyWithMaintainers] = None,
       templateId: Identifier = someTemplateId,
       contractArgument: LfValue = someContractArgument,
   ): Node.Create =
@@ -213,7 +213,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
 
   protected final def exerciseNode(
       targetCid: ContractId,
-      key: Option[Node.KeyWithMaintainers[LfValue]] = None,
+      key: Option[Node.KeyWithMaintainers] = None,
   ): Node.Exercise =
     Node.Exercise(
       targetCoid = targetCid,
@@ -328,7 +328,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
 
   protected final def createTestKey(
       maintainers: Set[Party]
-  ): (Node.KeyWithMaintainers[ValueText], GlobalKey) = {
+  ): (Node.KeyWithMaintainers, GlobalKey) = {
     val aTextValue = ValueText(scala.util.Random.nextString(10))
     val keyWithMaintainers = Node.KeyWithMaintainers(aTextValue, maintainers)
     val globalKey = GlobalKey.assertBuild(someTemplateId, aTextValue)
@@ -339,7 +339,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
       submittingParties: Set[Party],
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[Node.KeyWithMaintainers[LfValue]],
+      key: Option[Node.KeyWithMaintainers],
       contractArgument: LfValue = someContractArgument,
   ): Future[(Offset, LedgerEntry.Transaction)] =
     store(
@@ -422,7 +422,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
 
   protected def singleExercise(
       targetCid: ContractId,
-      key: Option[Node.KeyWithMaintainers[LfValue]] = None,
+      key: Option[Node.KeyWithMaintainers] = None,
   ): (Offset, LedgerEntry.Transaction) = {
     val txBuilder = newBuilder()
     val nid = txBuilder.add(exerciseNode(targetCid, key))

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
@@ -58,8 +58,8 @@ private[replay] final class Adapter(
 
   // drop value version
   private[this] def adapt(
-      k: Node.KeyWithMaintainers[Value]
-  ): Node.KeyWithMaintainers[Value] =
+      k: Node.KeyWithMaintainers
+  ): Node.KeyWithMaintainers =
     k.copy(adapt(k.key))
 
   def adapt(coinst: Value.VersionedContractInstance): Value.VersionedContractInstance =

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -275,7 +275,7 @@ private[sandbox] final class InMemoryLedger(
               contract.contract.unversioned
             }
           val contractKey = contract.key.map { key =>
-            val unversionedKey = key.map(_.unversioned)
+            val unversionedKey = key.unversioned
             if (verbose) {
               consumeEnricherResult(
                 enricher.enrichContractKey(contract.contract.unversioned.template, unversionedKey)


### PR DESCRIPTION
Following up #10827 and #10921, we drop type parameter to
KeyWithMaintainers, and use the `Versioned` wrapper introduced in

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
