### PR TITLE
iface: support for fixed choices in TS codegen

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -337,12 +337,12 @@ test('create + fetch & exercise', async () => {
 
 });
 
+
 // TODO https://github.com/digital-asset/daml/issues/10810
-// Reenable test
-/*
+// Reenable full test when JSON API can handle interface contract IDs.
 test("interfaces", async () => {
   const aliceLedger = new Ledger({token: ALICE_TOKEN, httpBaseUrl: httpBaseUrl()});
-  const bobLedger = new Ledger({token: BOB_TOKEN, httpBaseUrl: httpBaseUrl()});
+  // const bobLedger = new Ledger({token: BOB_TOKEN, httpBaseUrl: httpBaseUrl()});
 
   const assetPayload = {
     issuer: ALICE_PARTY,
@@ -350,24 +350,30 @@ test("interfaces", async () => {
   }
   const ifaceContract = await aliceLedger.create(buildAndLint.Main.Asset, assetPayload);
   expect(ifaceContract.payload).toEqual(assetPayload);
-  const [ifaceContract1, events1] = await aliceLedger.exercise(buildAndLint.Main.Asset.Transfer, ifaceContract.contractId, {newOwner: BOB_PARTY});
-  expect(events1).toMatchObject(
-    [ {archived: {templateId: buildAndLint.Main.Asset.templateId}},
-      {created: {templateId: buildAndLint.Main.Asset.templateId,
-       signatories: [ALICE_PARTY],
-       payload: {issuer: ALICE_PARTY, owner: BOB_PARTY}}}
-    ]
-  )
-  const [,events2] = await bobLedger.exercise(buildAndLint.Main.Asset.Transfer, ifaceContract1 as unknown as ContractId<buildAndLint.Main.Asset>, {newOwner: ALICE_PARTY});
-  expect(events2).toMatchObject(
-    [ {archived: {templateId: buildAndLint.Main.Asset.templateId}},
-      {created: {templateId: buildAndLint.Main.Asset.templateId,
-       signatories: [ALICE_PARTY],
-       payload: {issuer: ALICE_PARTY, owner: ALICE_PARTY}}}
-    ]
-  )
+  try {
+  const [, ] = await aliceLedger.exercise(buildAndLint.Main.Asset.Transfer, ifaceContract.contractId, {newOwner: BOB_PARTY});
+  } catch (ex) {
+      expect([400]).toContain(ex.status);
+      // currently the JSON API can't handle interface contract IDs in the response and returns a
+      // 400 error.
+      expect(ex.errors.length).toBe(1);
+  }
+  // expect(events1).toMatchObject(
+  //   [ {archived: {templateId: buildAndLint.Main.Asset.templateId}},
+  //     {created: {templateId: buildAndLint.Main.Asset.templateId,
+  //      signatories: [ALICE_PARTY],
+  //      payload: {issuer: ALICE_PARTY, owner: BOB_PARTY}}}
+  //   ]
+  // )
+  // const [,events2] = await bobLedger.exercise(buildAndLint.Main.Token.Transfer, ifaceContract1, {newOwner: ALICE_PARTY});
+  // expect(events2).toMatchObject(
+  //   [ {archived: {templateId: buildAndLint.Main.Asset.templateId}},
+  //     {created: {templateId: buildAndLint.Main.Asset.templateId,
+  //      signatories: [ALICE_PARTY],
+  //      payload: {issuer: ALICE_PARTY, owner: ALICE_PARTY}}}
+  //   ]
+  // )
 });
-*/
 
 test("createAndExercise", async () => {
   const ledger = new Ledger({token: ALICE_TOKEN, httpBaseUrl: httpBaseUrl()});


### PR DESCRIPTION
This adds support for fixed choices to the TS codegen. However,
currently this fails because the JSON API does not accept interface
template ID's when exercising a choice.

Part of #11608.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
