### PR TITLE
kvutils - Backwards looking command deduplication [KVL-1174]

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -538,9 +538,7 @@ excluded_test_tool_tests = [
                 "end": "1.18.0-snapshot.20211026.8179.0.e474b2d1",
                 "exclusions": [
                     # Exclude dedup tests due to large number of changes (removed participant deduplication, switch to append-only schema, changes in deduplication duration)
-                    "KVCommandDeduplicationIT:KVCommandDeduplicationSimpleDeduplicationMixedClients",
-                    "KVCommandDeduplicationIT:KVCommandDeduplicationDeduplicateSubmitterBasic",
-                    "KVCommandDeduplicationIT:KVCommandDeduplicationSimpleDeduplicationBasic",
+                    "KVCommandDeduplicationIT",
                     "CommandDeduplicationIT",  # Latest version of the test is dependent on having the submission id populated
                 ],
             },

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -535,7 +535,7 @@ excluded_test_tool_tests = [
         "start": "1.18.0-snapshot.20211026.8179.0.e474b2d1",
         "platform_ranges": [
             {
-                "end": "1.18.0-snapshot.20211026.8179.0.e474b2d1",
+                "end": "1.18.0-snapshot.20211102.8257.1",
                 "exclusions": [
                     # Exclude dedup tests due to large number of changes (removed participant deduplication, switch to append-only schema, changes in deduplication duration)
                     "KVCommandDeduplicationIT",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
@@ -492,6 +492,7 @@ object CommandDeduplicationBase {
       */
     protected def delayBy(duration: Duration): Future[Unit]
   }
+
   class TimeDelayMechanism(val deduplicationDuration: Duration, val extraWait: Duration)(implicit
       ec: ExecutionContext
   ) extends DelayMechanism {
@@ -508,9 +509,9 @@ object CommandDeduplicationBase {
     override protected def delayBy(duration: Duration): Future[Unit] =
       ledger
         .time()
-        .flatMap(currentTime => {
+        .flatMap { currentTime =>
           ledger.setTime(currentTime, currentTime.plusMillis(duration.toMillis))
-        })
+        }
   }
 
   /** @param participantDeduplication If participant deduplication is enabled then we will receive synchronous rejections

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
@@ -473,23 +473,20 @@ object CommandDeduplicationBase {
 
     /** Delay by the guaranteed full deduplication period. After calling this method any duplicate calls should succeed
       */
-    def delayForEntireDeduplicationPeriod(): Future[Unit] = delayBy(
-      deduplicationDuration + extraWait
-    )
+    def delayForEntireDeduplicationPeriod(): Future[Unit] =
+      delayBy(deduplicationDuration + extraWait)
 
     /** Delay by [[deduplicationDuration]] - [[delta]]. Delta should be a value big enough to account for the latency required to process a transaction.
       * By using this delay we can validate that the minimum deduplication period [[deduplicationDuration]] is respected
       */
-    def delayToEndOfMinimumDeduplicationPeriod(delta: Duration): Future[Unit] = delayBy(
-      deduplicationDuration - delta
-    )
+    def delayToEndOfMinimumDeduplicationPeriod(delta: Duration): Future[Unit] =
+      delayBy(deduplicationDuration - delta)
 
     /** Delay by [[delta]] + [[extraWait]]. By using [[delayToEndOfMinimumDeduplicationPeriod]] and [[delayFromEndOfMinimumDeduplicationPeriod]]
       * with the same [[delta]] value, it mimics the behavior of [[delayForEntireDeduplicationPeriod]]
       */
-    def delayFromEndOfMinimumDeduplicationPeriod(delta: Duration): Future[Unit] = delayBy(
-      delta + extraWait
-    )
+    def delayFromEndOfMinimumDeduplicationPeriod(delta: Duration): Future[Unit] =
+      delayBy(delta + extraWait)
 
     /** Delay with [[duration]]
       */

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
@@ -64,19 +64,14 @@ private[testtool] abstract class CommandDeduplicationBase(
             DeduplicationPeriod.DeduplicationTime(deduplicationDuration.asProtobuf)
         )
       runWithDeduplicationDelay(configuredParticipants) { delay =>
-        val deltaForTransactionLatency =
-          300.millis // account for 3 requests, first accepted and the following 2 rejected
         for {
           // Submit command (first deduplication window)
           // Note: the second submit() in this block is deduplicated and thus rejected by the ledger API server,
           // only one submission is therefore sent to the ledger.
           completion1 <- submitRequestAndAssertCompletionAccepted(ledger)(request, party)
           _ <- submitRequestAndAssertDeduplication(ledger)(request, party)
-          // Delay close to the end of the minimum guaranteed deduplication
-          _ <- delay.delayToEndOfMinimumDeduplicationPeriod(deltaForTransactionLatency)
-          _ <- submitRequestAndAssertDeduplication(ledger)(request, party)
           // Wait until the end of first deduplication window
-          _ <- delay.delayFromEndOfMinimumDeduplicationPeriod(deltaForTransactionLatency)
+          _ <- delay.delayForEntireDeduplicationPeriod()
 
           // Submit command (second deduplication window)
           // Note: the deduplication window is guaranteed to have passed on both

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
@@ -476,18 +476,6 @@ object CommandDeduplicationBase {
     def delayForEntireDeduplicationPeriod(): Future[Unit] =
       delayBy(deduplicationDuration + extraWait)
 
-    /** Delay by [[deduplicationDuration]] - [[delta]]. Delta should be a value big enough to account for the latency required to process a transaction.
-      * By using this delay we can validate that the minimum deduplication period [[deduplicationDuration]] is respected
-      */
-    def delayToEndOfMinimumDeduplicationPeriod(delta: Duration): Future[Unit] =
-      delayBy(deduplicationDuration - delta)
-
-    /** Delay by [[delta]] + [[extraWait]]. By using [[delayToEndOfMinimumDeduplicationPeriod]] and [[delayFromEndOfMinimumDeduplicationPeriod]]
-      * with the same [[delta]] value, it mimics the behavior of [[delayForEntireDeduplicationPeriod]]
-      */
-    def delayFromEndOfMinimumDeduplicationPeriod(delta: Duration): Future[Unit] =
-      delayBy(delta + extraWait)
-
     /** Delay with [[duration]]
       */
     protected def delayBy(duration: Duration): Future[Unit]

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/deduplication/CommandDeduplicationBase.scala
@@ -5,8 +5,8 @@ package com.daml.ledger.api.testtool.infrastructure.deduplication
 
 import com.daml.error.ErrorCode
 import com.daml.error.definitions.LedgerApiErrors
-
 import java.util.UUID
+
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -21,6 +21,7 @@ import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.client.binding.Primitive.Party
 import com.daml.ledger.test.model.DA.Types.Tuple2
 import com.daml.ledger.test.model.Test.{Dummy, DummyWithAnnotation, TextKey, TextKeyOperations}
+import com.daml.timer.Delayed
 import io.grpc.Status.Code
 
 import scala.annotation.nowarn
@@ -69,8 +70,11 @@ private[testtool] abstract class CommandDeduplicationBase(
           // only one submission is therefore sent to the ledger.
           completion1 <- submitRequestAndAssertCompletionAccepted(ledger)(request, party)
           _ <- submitRequestAndAssertDeduplication(ledger)(request, party)
+          // Delay close to the end of the minimum guaranteed deduplication
+          _ <- delay.delayToEndOfMinimumDeduplicationPeriod(100.millis)
+          _ <- submitRequestAndAssertDeduplication(ledger)(request, party)
           // Wait until the end of first deduplication window
-          _ <- delay()
+          _ <- delay.delayFromEndOfMinimumDeduplicationPeriod(100.millis)
 
           // Submit command (second deduplication window)
           // Note: the deduplication window is guaranteed to have passed on both
@@ -184,7 +188,7 @@ private[testtool] abstract class CommandDeduplicationBase(
           _ <- submitAndWaitRequestAndAssertDeduplication(ledger)(request)
 
           // Wait until the end of first deduplication window
-          _ <- delay()
+          _ <- delay.delayForEntireDeduplicationPeriod()
 
           // Submit command (second deduplication window)
           _ <- ledger.submitAndWait(request)
@@ -253,7 +257,7 @@ private[testtool] abstract class CommandDeduplicationBase(
                     _ <- submitAndAssertDeduplicated(secondCall)
 
                     // Wait until the end of first deduplication window
-                    _ <- delay()
+                    _ <- delay.delayForEntireDeduplicationPeriod()
 
                     // Submit command (second deduplication window)
                     _ <- submitAndAssertAccepted(thirdCall)
@@ -467,7 +471,52 @@ private[testtool] abstract class CommandDeduplicationBase(
 
 object CommandDeduplicationBase {
   trait DelayMechanism {
-    def apply(): Future[Unit]
+    val deduplicationDuration: Duration
+    val extraWait: Duration
+
+    /** Delay by the guaranteed full deduplication period. After calling this method any duplicate calls should succeed
+      */
+    def delayForEntireDeduplicationPeriod(): Future[Unit] = delayBy(
+      deduplicationDuration + extraWait
+    )
+
+    /** Delay by [[deduplicationDuration]] - [[delta]]. Delta should be a value big enough to account for the latency required to process a transaction.
+      * By using this delay we can validate that the minimum deduplication period [[deduplicationDuration]] is respected
+      */
+    def delayToEndOfMinimumDeduplicationPeriod(delta: Duration): Future[Unit] = delayBy(
+      deduplicationDuration - delta
+    )
+
+    /** Delay by [[delta]] + [[extraWait]]. By using [[delayToEndOfMinimumDeduplicationPeriod]] and [[delayFromEndOfMinimumDeduplicationPeriod]]
+      * with the same [[delta]] value, it mimics the behavior of [[delayForEntireDeduplicationPeriod]]
+      */
+    def delayFromEndOfMinimumDeduplicationPeriod(delta: Duration): Future[Unit] = delayBy(
+      delta + extraWait
+    )
+
+    /** Delay with [[duration]]
+      */
+    protected def delayBy(duration: Duration): Future[Unit]
+  }
+  class TimeDelayMechanism(val deduplicationDuration: Duration, val extraWait: Duration)(implicit
+      ec: ExecutionContext
+  ) extends DelayMechanism {
+
+    override protected def delayBy(duration: Duration): Future[Unit] = Delayed.by(duration)(())
+  }
+
+  class StaticTimeDelayMechanism(
+      ledger: ParticipantTestContext,
+      val deduplicationDuration: Duration,
+      val extraWait: Duration,
+  )(implicit ec: ExecutionContext)
+      extends DelayMechanism {
+    override protected def delayBy(duration: Duration): Future[Unit] =
+      ledger
+        .time()
+        .flatMap(currentTime => {
+          ledger.setTime(currentTime, currentTime.plusMillis(duration.toMillis))
+        })
   }
 
   /** @param participantDeduplication If participant deduplication is enabled then we will receive synchronous rejections

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
@@ -7,9 +7,9 @@ import com.daml.ledger.api.testtool.infrastructure.deduplication.CommandDeduplic
 import com.daml.ledger.api.testtool.infrastructure.deduplication.CommandDeduplicationBase.{
   DeduplicationFeatures,
   DelayMechanism,
+  TimeDelayMechanism,
 }
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
-import com.daml.timer.Delayed
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
@@ -28,7 +28,7 @@ final class CommandDeduplicationIT(
   )(
       testWithDelayMechanism: DelayMechanism => Future[Unit]
   )(implicit ec: ExecutionContext): Future[Unit] =
-    testWithDelayMechanism(() => Delayed.by(defaultDeduplicationWindowWait)(()))
+    testWithDelayMechanism(new TimeDelayMechanism(deduplicationDuration, ledgerWaitInterval))
 
   override def testNamingPrefix: String = "ParticipantCommandDeduplication"
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
@@ -59,9 +59,13 @@ message DamlCommandDedupValue {
     // deduplication key will be rejected due to a duplicate submission.
     google.protobuf.Timestamp deduplicated_until = 2;
     google.protobuf.Timestamp record_time = 3;
-    // record_time is not available during pre-execution
-    google.protobuf.Timestamp max_record_time = 4;
+    PreExecutionDeduplicationBounds record_time_bounds = 4;
   }
+}
+message PreExecutionDeduplicationBounds {
+  // record_time is not available during pre-execution
+  google.protobuf.Timestamp max_record_time = 1;
+  google.protobuf.Timestamp min_record_time = 2;
 }
 
 message DamlSubmissionDedupKey {

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
@@ -54,12 +54,14 @@ message DamlCommandDedupKey {
 
 message DamlCommandDedupValue {
   reserved 1; // was record_time
-  // The time until when future commands with the same
-  // deduplication key will be rejected due to a duplicate submission.
-  google.protobuf.Timestamp deduplicated_until = 2;
-  // The submission time of the initial command.
-  // We use submission time because record time is not available during pre-execution.
-  google.protobuf.Timestamp submission_time = 3;
+  oneof time {
+    // The time until when future commands with the same
+    // deduplication key will be rejected due to a duplicate submission.
+    google.protobuf.Timestamp deduplicated_until = 2;
+    google.protobuf.Timestamp record_time = 3;
+    // record_time is not available during pre-execution
+    google.protobuf.Timestamp max_record_time = 4;
+  }
 }
 
 message DamlSubmissionDedupKey {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
@@ -3,90 +3,140 @@
 
 package com.daml.ledger.participant.state.kvutils.committer.transaction
 
-import java.time.Instant
-
-import com.daml.ledger.configuration.Configuration
-import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
 import com.daml.ledger.participant.state.kvutils.Conversions.{
-  buildDuration,
   commandDedupKey,
   parseDuration,
   parseTimestamp,
 }
-import com.daml.ledger.participant.state.kvutils.committer.Committer.getCurrentConfiguration
 import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepResult}
-import com.daml.ledger.participant.state.kvutils.store.{DamlCommandDedupValue, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.store.DamlCommandDedupValue.TimeCase
 import com.daml.ledger.participant.state.kvutils.store.events.{
   DamlTransactionRejectionEntry,
   Duplicate,
 }
+import com.daml.ledger.participant.state.kvutils.store.{
+  DamlCommandDedupValue,
+  DamlLogEntry,
+  DamlStateValue,
+}
+import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
 import com.daml.logging.LoggingContext
 
 private[transaction] object CommandDeduplication {
 
-  def overwriteDeduplicationPeriodWithMaxDurationStep(
-      defaultConfig: Configuration
-  ): Step = new Step {
-    override def apply(context: CommitContext, input: DamlTransactionEntrySummary)(implicit
-        loggingContext: LoggingContext
-    ): StepResult[DamlTransactionEntrySummary] = {
-      val (_, currentConfig) = getCurrentConfiguration(defaultConfig, context)
-      val submission = input.submission.toBuilder
-      submission.getSubmitterInfoBuilder.setDeduplicationDuration(
-        buildDuration(currentConfig.maxDeduplicationTime)
-      )
-      StepContinue(input.copyPreservingDecodedTransaction(submission.build()))
-    }
-  }
-
   /** Reject duplicate commands
     */
-  def deduplicateCommandStep(rejections: Rejections): Step = new Step {
-    def apply(
-        commitContext: CommitContext,
-        transactionEntry: DamlTransactionEntrySummary,
-    )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
-      commitContext.recordTime
-        .map { recordTime =>
-          val dedupKey = commandDedupKey(transactionEntry.submitterInfo)
-          val dedupEntry = commitContext.get(dedupKey)
-          if (dedupEntry.forall(isAfterDeduplicationTime(recordTime.toInstant, _))) {
-            StepContinue(transactionEntry)
-          } else {
-            rejections.reject(
-              DamlTransactionRejectionEntry.newBuilder
-                .setSubmitterInfo(transactionEntry.submitterInfo)
-                // No duplicate rejection is a definite answer as the deduplication entry will eventually expire.
-                .setDefiniteAnswer(false)
-                .setDuplicateCommand(Duplicate.newBuilder.setDetails("")),
-              "the command is a duplicate",
-              commitContext.recordTime,
+  def deduplicateCommandStep(rejections: Rejections): Step =
+    new Step {
+      def apply(
+          commitContext: CommitContext,
+          transactionEntry: DamlTransactionEntrySummary,
+      )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
+        val commandDeduplicationDuration =
+          if (transactionEntry.submitterInfo.hasDeduplicationDuration)
+            parseDuration(transactionEntry.submitterInfo.getDeduplicationDuration)
+          else
+            throw Err.InternalError(
+              "Deduplication period not supported, only durations are supported"
             )
-          }
+        val dedupKey = commandDedupKey(transactionEntry.submitterInfo)
+        val dedupEntry = commitContext.get(dedupKey)
+        val maybeDedupValue = dedupEntry
+          .filter(_.hasCommandDedup)
+          .map(_.getCommandDedup)
+        val recordTimeOrMinimumRecordTime = commitContext.recordTime match {
+          case Some(recordTime) =>
+            // During the normal execution, in the deduplication state value we stored the record time
+            // This allows us to compare the record times directly
+            recordTime.toInstant
+          case None =>
+            // We select minimum record time for pre-execution
+            // During pre-execution in the deduplication state value we stored the maximum record time
+            // To guarantee the deduplication duration, we basically compare the maximum record time of the previous transaction
+            // with the minimum record time of the current transaction. This gives us the smallest possible interval between two transactions.
+            commitContext.minimumRecordTime match {
+              case Some(minimumRecordTime) => minimumRecordTime.toInstant
+              case None =>
+                throw Err.InternalError("Minimum record time is not set for pre-execution")
+            }
         }
-        .getOrElse(StepContinue(transactionEntry))
-    }
-  }
+        val isDuplicate = maybeDedupValue
+          .flatMap(commandDeduplication =>
+            commandDeduplication.getTimeCase match {
+              // Backward-compatibility, will not  be set for new entries
+              case TimeCase.DEDUPLICATED_UNTIL =>
+                Some(parseTimestamp(commandDeduplication.getDeduplicatedUntil).toInstant)
+              // Set during normal execution, no time skews are added
+              case TimeCase.RECORD_TIME =>
+                val storedDuplicateRecordTime =
+                  parseTimestamp(commandDeduplication.getRecordTime).toInstant
+                Some(
+                  storedDuplicateRecordTime
+                    .plus(commandDeduplicationDuration)
+                )
+              // Set during pre-execution, time skews are already accounted for
+              case TimeCase.MAX_RECORD_TIME =>
+                val maxRecordTime =
+                  parseTimestamp(commandDeduplication.getMaxRecordTime).toInstant
+                Some(
+                  maxRecordTime
+                    .plus(commandDeduplicationDuration)
+                )
+              case TimeCase.TIME_NOT_SET =>
+                None
+            }
+          )
+          .forall(deduplicatedUntil => recordTimeOrMinimumRecordTime.isAfter(deduplicatedUntil))
+        if (isDuplicate) {
+          StepContinue(transactionEntry)
+        } else {
+          if (commitContext.preExecute) {
+            // The out of time bounds entry is required in the committer, so we set it to the default value as we stop the steps here with the duplicate rejection
+            commitContext.outOfTimeBoundsLogEntry = Some(DamlLogEntry.getDefaultInstance)
+          }
+          duplicateRejection(commitContext, transactionEntry)
+        }
+      }
 
-  def setDeduplicationEntryStep(defaultConfig: Configuration): Step =
+      private def duplicateRejection(
+          commitContext: CommitContext,
+          transactionEntry: DamlTransactionEntrySummary,
+      )(implicit loggingContext: LoggingContext) = {
+        rejections.reject(
+          DamlTransactionRejectionEntry.newBuilder
+            .setSubmitterInfo(transactionEntry.submitterInfo)
+            // No duplicate rejection is a definite answer as the deduplication entry will eventually expire.
+            .setDefiniteAnswer(false)
+            .setDuplicateCommand(Duplicate.newBuilder.setDetails("")),
+          "the command is a duplicate",
+          commitContext.recordTime,
+        )
+      }
+    }
+
+  def setDeduplicationEntryStep(): Step =
     new Step {
       def apply(commitContext: CommitContext, transactionEntry: DamlTransactionEntrySummary)(
           implicit loggingContext: LoggingContext
       ): StepResult[DamlTransactionEntrySummary] = {
-        val (_, config) = getCurrentConfiguration(defaultConfig, commitContext)
-        // Deduplication duration must be explicitly overwritten in a previous step
-        //  (see [[TransactionCommitter.overwriteDeduplicationPeriodWithMaxDuration]]) and set to ``config.maxDeduplicationTime``.
         if (!transactionEntry.submitterInfo.hasDeduplicationDuration) {
           throw Err.InvalidSubmission("Deduplication duration is not set.")
         }
-        val deduplicateUntil = Conversions.buildTimestamp(
-          transactionEntry.submissionTime
-            .add(parseDuration(transactionEntry.submitterInfo.getDeduplicationDuration))
-            .add(config.timeModel.minSkew)
-        )
         val commandDedupBuilder = DamlCommandDedupValue.newBuilder
-          .setDeduplicatedUntil(deduplicateUntil)
-          .setSubmissionTime(Conversions.buildTimestamp(transactionEntry.submissionTime))
+        commitContext.recordTime
+          .map(Conversions.buildTimestamp) match {
+          case Some(recordTime) =>
+            commandDedupBuilder.setRecordTime(recordTime)
+          case None =>
+            commandDedupBuilder.setMaxRecordTime(
+              commitContext.maximumRecordTime
+                .map(Conversions.buildTimestamp)
+                .getOrElse(
+                  throw Err.InternalError("Maximum record time is not set for pre-execution")
+                )
+            )
+        }
+
         // Set a deduplication entry.
         commitContext.set(
           commandDedupKey(transactionEntry.submitterInfo),
@@ -99,19 +149,4 @@ private[transaction] object CommandDeduplication {
         StepContinue(transactionEntry)
       }
     }
-
-  // Checks that the submission time of the command is after the
-  // deduplicationTime represented by stateValue
-  private def isAfterDeduplicationTime(
-      submissionTime: Instant,
-      stateValue: DamlStateValue,
-  ): Boolean = {
-    val cmdDedup = stateValue.getCommandDedup
-    if (stateValue.hasCommandDedup && cmdDedup.hasDeduplicatedUntil) {
-      val dedupTime = parseTimestamp(cmdDedup.getDeduplicatedUntil).toInstant
-      dedupTime.isBefore(submissionTime)
-    } else {
-      false
-    }
-  }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -69,14 +69,12 @@ private[kvutils] class TransactionCommitter(
   override protected val steps: Steps[DamlTransactionEntrySummary] = Iterable(
     "authorize_submitter" -> authorizeSubmitters,
     "check_informee_parties_allocation" -> checkInformeePartiesAllocation,
-    "overwrite_deduplication_period" -> CommandDeduplication
-      .overwriteDeduplicationPeriodWithMaxDurationStep(defaultConfig),
-    "deduplicate" -> CommandDeduplication.deduplicateCommandStep(rejections),
     "set_time_bounds" -> TimeBoundBindingStep.setTimeBoundsInContextStep(defaultConfig),
+    "deduplicate" -> CommandDeduplication.deduplicateCommandStep(rejections),
     "validate_ledger_time" -> ledgerTimeValidator.createValidationStep(rejections),
     "validate_model_conformance" -> modelConformanceValidator.createValidationStep(rejections),
     "validate_consistency" -> TransactionConsistencyValidator.createValidationStep(rejections),
-    "set_deduplication_entry" -> CommandDeduplication.setDeduplicationEntryStep(defaultConfig),
+    "set_deduplication_entry" -> CommandDeduplication.setDeduplicationEntryStep(),
     "blind" -> blind,
     "trim_unnecessary_nodes" -> trimUnnecessaryNodes,
     "build_final_log_entry" -> buildFinalLogEntry,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -544,7 +544,7 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
       }
     }
 
-    "use max deduplication duration as deduplication period" in KVTest.runTestWithSimplePackage(
+    "return the provided deduplication period" in KVTest.runTestWithSimplePackage(
       alice,
       bob,
       eve,
@@ -560,15 +560,16 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
           )
         })
         transaction <- runSimpleCommand(alice, seed, command)
+        deduplicationDuration = Duration.ofHours(1)
         preExecutionResult <- preExecuteTransaction(
           submitter = alice,
           transaction = transaction,
           submissionSeed = seed,
-          deduplicationDuration = Duration.ofHours(1),
+          deduplicationDuration = deduplicationDuration,
         ).map(_._2)
       } yield {
         preExecutionResult.successfulLogEntry.getTransactionEntry.getSubmitterInfo.getDeduplicationDuration shouldBe Conversions
-          .buildDuration(maxDeduplicationDuration)
+          .buildDuration(deduplicationDuration)
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -560,16 +560,16 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
           )
         })
         transaction <- runSimpleCommand(alice, seed, command)
-        deduplicationDuration = Duration.ofHours(1)
+        expectedDeduplicationDuration = Duration.ofHours(1)
         preExecutionResult <- preExecuteTransaction(
           submitter = alice,
           transaction = transaction,
           submissionSeed = seed,
-          deduplicationDuration = deduplicationDuration,
+          deduplicationDuration = expectedDeduplicationDuration,
         ).map(_._2)
       } yield {
         preExecutionResult.successfulLogEntry.getTransactionEntry.getSubmitterInfo.getDeduplicationDuration shouldBe Conversions
-          .buildDuration(deduplicationDuration)
+          .buildDuration(expectedDeduplicationDuration)
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -4,10 +4,15 @@
 package com.daml.ledger.participant.state.kvutils.committer.transaction
 
 import java.time
+import java.time.Duration
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.Configuration
-import com.daml.ledger.participant.state.kvutils.Conversions.{buildDuration, buildTimestamp}
+import com.daml.ledger.participant.state.kvutils.Conversions.{
+  buildDuration,
+  buildTimestamp,
+  parseTimestamp,
+}
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
 import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepStop}
 import com.daml.ledger.participant.state.kvutils.store.events.{
@@ -21,14 +26,12 @@ import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.google.protobuf
 import org.mockito.MockitoSugar
-import org.scalatest.Inside.inside
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.annotation.nowarn
-import scala.util.Random
 
 @nowarn("msg=deprecated")
 class CommandDeduplicationSpec
@@ -44,165 +47,264 @@ class CommandDeduplicationSpec
   private val rejections = new Rejections(metrics)
   private val deduplicateCommandStep = CommandDeduplication.deduplicateCommandStep(rejections)
   private val setDeduplicationEntryStep =
-    CommandDeduplication.setDeduplicationEntryStep(theDefaultConfig)
+    CommandDeduplication.setDeduplicationEntryStep()
 
   "deduplicateCommand" should {
-    "continue if record time is not available" in {
-      val context = createCommitContext(recordTime = None)
+    Map(
+      "pre-execution" -> ((dedupValueBuilder: Timestamp => Option[DamlStateValue]) => {
+        val timestamp = Timestamp.now()
+        val dedupValue = dedupValueBuilder(timestamp)
+        val commitContext = createCommitContext(None, Map(aDedupKey -> dedupValue))
+        commitContext.minimumRecordTime = Some(timestamp)
+        timestamp -> commitContext
+      }),
+      "normal-execution" -> ((dedupValueBuilder: Timestamp => Option[DamlStateValue]) => {
+        val timestamp = Timestamp.now()
+        val dedupValue = dedupValueBuilder(timestamp)
+        val commitContext = createCommitContext(Some(timestamp), Map(aDedupKey -> dedupValue))
+        timestamp -> commitContext
+      }),
+    ).foreach { case (key, contextBuilder) =>
+      key should {
+        "continue if no deduplication entry could be found" in {
+          val (_, context) = contextBuilder(_ => None)
 
-      val actual =
-        deduplicateCommandStep(context, aTransactionEntrySummary)
-
-      actual match {
-        case StepContinue(_) => succeed
-        case StepStop(_) => fail()
-      }
-    }
-
-    "continue if record time is available but no deduplication entry could be found" in {
-      val inputs = Map(aDedupKey -> None)
-      val context =
-        createCommitContext(recordTime = Some(aRecordTime), inputs = inputs)
-
-      val actual = deduplicateCommandStep(context, aTransactionEntrySummary)
-
-      actual match {
-        case StepContinue(_) => succeed
-        case StepStop(_) => fail()
-      }
-    }
-
-    "continue if record time is after deduplication time in case a deduplication entry is found" in {
-      val dedupValue = newDedupValue(aRecordTime)
-      val inputs = Map(aDedupKey -> Some(dedupValue))
-      val context =
-        createCommitContext(recordTime = Some(aRecordTime.addMicros(1)), inputs = inputs)
-
-      val actual = deduplicateCommandStep(context, aTransactionEntrySummary)
-
-      actual match {
-        case StepContinue(_) => succeed
-        case StepStop(_) => fail()
-      }
-    }
-
-    "produce rejection log entry in case record time is on or before deduplication time" in {
-      for (
-        (recordTime, deduplicationTime) <- Iterable(
-          (aRecordTime, aRecordTime),
-          (aRecordTime, aRecordTime.addMicros(1)),
-        )
-      ) {
-        val dedupValue = newDedupValue(deduplicationTime)
-        val inputs = Map(aDedupKey -> Some(dedupValue))
-        val context =
-          createCommitContext(recordTime = Some(recordTime), inputs = inputs)
-
-        val actual = deduplicateCommandStep(context, aTransactionEntrySummary)
-
-        actual match {
-          case StepContinue(_) => fail()
-          case StepStop(actualLogEntry) =>
-            actualLogEntry.hasTransactionRejectionEntry shouldBe true
+          deduplicationStepContinues(context)
         }
-      }
-    }
 
-    "setting dedup context" should {
-      val deduplicateUntil = protobuf.Timestamp.newBuilder().setSeconds(30).build()
-      val submissionTime = protobuf.Timestamp.newBuilder().setSeconds(60).build()
-      val deduplicationDuration = time.Duration.ofSeconds(3)
+        "continue if deduplication entry has no value set" in {
+          val (_, context) = contextBuilder(_ => Some(newDedupValue(identity)))
 
-      "calculate deduplicate until based on deduplication duration" in {
-        val (context, transactionEntrySummary) =
-          buildContextAndTransaction(
-            submissionTime,
-            _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration)),
-          )
-        setDeduplicationEntryStep(context, transactionEntrySummary)
-        contextDeduplicateUntil(
-          context,
-          transactionEntrySummary,
-        ).value shouldBe protobuf.Timestamp
-          .newBuilder()
-          .setSeconds(
-            submissionTime.getSeconds + deduplicationDuration.getSeconds + theDefaultConfig.timeModel.minSkew.getSeconds
-          )
-          .build()
-      }
+          deduplicationStepContinues(context)
+        }
 
-      "set the submission time in the committer context" in {
-        val (context, transactionEntrySummary) =
-          buildContextAndTransaction(
-            submissionTime,
-            _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration)),
-          )
-        setDeduplicationEntryStep(context, transactionEntrySummary)
-        context
-          .get(Conversions.commandDedupKey(transactionEntrySummary.submitterInfo))
-          .map(
-            _.getCommandDedup.getSubmissionTime
-          )
-          .value shouldBe submissionTime
-      }
+        "using deduplicate until" should {
 
-      "throw an error for unsupported deduplication periods" in {
-        forAll(
-          Table[DamlSubmitterInfo.Builder => DamlSubmitterInfo.Builder](
-            "deduplication setter",
-            _.clearDeduplicationPeriod(),
-            _.setDeduplicationOffset("offset"),
-            _.setDeduplicateUntil(deduplicateUntil),
-          )
-        ) { deduplicationSetter =>
-          {
-            val (context, transactionEntrySummary) =
-              buildContextAndTransaction(submissionTime, deduplicationSetter)
-            a[Err.InvalidSubmission] shouldBe thrownBy(
-              setDeduplicationEntryStep(context, transactionEntrySummary)
+          "continue if record time is after deduplication time in case a deduplication entry is found" in {
+            val (_, context) = contextBuilder(timestamp =>
+              Some(
+                newDedupValue(
+                  _.setDeduplicatedUntil(buildTimestamp(timestamp.subtract(Duration.ofSeconds(1))))
+                )
+              )
             )
+
+            deduplicationStepContinues(context)
+          }
+
+          "produce rejection log entry in case record time is on or before deduplication time" in {
+            for (
+              durationToAdd <- Iterable(
+                Duration.ZERO,
+                Duration.ofSeconds(1),
+              )
+            ) {
+              val (_, context) = contextBuilder(timestamp =>
+                Some(
+                  newDedupValue(
+                    _.setDeduplicatedUntil(buildTimestamp(timestamp.add(durationToAdd)))
+                  )
+                )
+              )
+              deduplicateStepHasTransactionRejectionEntry(context)
+            }
           }
         }
+
+        "using deduplication duration" should {
+          forAll(
+            Table[
+              String,
+              Timestamp => DamlCommandDedupValue.Builder => DamlCommandDedupValue.Builder,
+            ](
+              "identifier" -> "time setter",
+              "record time" -> ((timestamp: Timestamp) =>
+                (builder: DamlCommandDedupValue.Builder) =>
+                  builder.setRecordTime(buildTimestamp(timestamp))
+              ),
+              "max record time" -> ((timestamp: Timestamp) =>
+                (builder: DamlCommandDedupValue.Builder) =>
+                  builder.setMaxRecordTime(buildTimestamp(timestamp))
+              ),
+            )
+          )(
+            (
+                identifier: String,
+                timeSetter: Timestamp => DamlCommandDedupValue.Builder => DamlCommandDedupValue.Builder,
+            ) => {
+              identifier should {
+                "continue if record time is after deduplication time in case a deduplication entry is found" in {
+                  val (_, context) = contextBuilder(timestamp =>
+                    Some(
+                      newDedupValue(
+                        timeSetter(timestamp.subtract(deduplicationDuration.plusMillis(1)))
+                      )
+                    )
+                  )
+
+                  deduplicationStepContinues(context)
+                }
+
+                "produce rejection log entry in case transaction timestamp is on or before deduplication time" in {
+                  for (
+                    durationToSubstractFromDeduplicationDuration <- Iterable(
+                      Duration.ZERO,
+                      Duration.ofSeconds(1),
+                    )
+                  ) {
+                    val (_, context) = contextBuilder(timestamp =>
+                      Some(
+                        newDedupValue(
+                          timeSetter(
+                            timestamp.subtract(
+                              deduplicationDuration.minus(
+                                durationToSubstractFromDeduplicationDuration
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                    deduplicateStepHasTransactionRejectionEntry(context)
+                  }
+                }
+              }
+            }
+          )
+        }
       }
     }
 
-    "overwriteDeduplicationPeriodWithMaxDuration" should {
-      "set max deduplication duration as deduplication period" in {
-        val maxDeduplicationDuration = time.Duration.ofSeconds(Random.nextLong())
-        val config = theDefaultConfig.copy(maxDeduplicationTime = maxDeduplicationDuration)
-        val commitContext = createCommitContext(
-          None,
-          Map(
-            Conversions.configurationStateKey -> None
-          ),
+    "using pre-execution" should {
+
+      "produce rejection log entry when there's an overlap between previous transaction max-record-time and current transaction min-record-time" in {
+        val timestamp = Timestamp.now()
+        val dedupValue = newDedupValue(_.setMaxRecordTime(buildTimestamp(timestamp)))
+        val commitContext = createCommitContext(None, Map(aDedupKey -> Some(dedupValue)))
+        commitContext.minimumRecordTime = Some(timestamp.subtract(Duration.ofMillis(1)))
+
+        deduplicateStepHasTransactionRejectionEntry(commitContext)
+      }
+
+      "set the out of time bounds log entry during rejections" in {
+        val timestamp = Timestamp.now()
+        val dedupValue = newDedupValue(_.setMaxRecordTime(buildTimestamp(timestamp)))
+        val commitContext = createCommitContext(None, Map(aDedupKey -> Some(dedupValue)))
+        commitContext.minimumRecordTime = Some(timestamp)
+
+        deduplicateStepHasTransactionRejectionEntry(commitContext)
+        commitContext.outOfTimeBoundsLogEntry shouldBe 'defined
+      }
+
+    }
+  }
+
+  "setting dedup context" should {
+    val deduplicateUntil = protobuf.Timestamp.newBuilder().setSeconds(30).build()
+    val submissionTime = protobuf.Timestamp.newBuilder().setSeconds(60).build()
+    val deduplicationDuration = time.Duration.ofSeconds(3)
+
+    "set the maximum record time in the committer context values" in {
+      val (context, transactionEntrySummary) =
+        buildContextAndTransaction(
+          submissionTime,
+          _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration)),
         )
-        val result =
-          CommandDeduplication.overwriteDeduplicationPeriodWithMaxDurationStep(config)(
-            commitContext,
-            aTransactionEntrySummary,
+      val maximumRecordTime = Timestamp.now()
+      context.maximumRecordTime = Some(maximumRecordTime)
+      setDeduplicationEntryStep(context, transactionEntrySummary)
+      parseTimestamp(
+        deduplicateValueStoredInContext(context, transactionEntrySummary)
+          .map(
+            _.getMaxRecordTime
           )
-        inside(result) { case StepContinue(entry) =>
-          entry.submitterInfo.getDeduplicationDuration shouldBe buildDuration(
-            maxDeduplicationDuration
+          .value
+      ) shouldBe maximumRecordTime
+    }
+
+    "set the record time in the committer context values" in {
+      val recordTime = Timestamp.now()
+      val (context, transactionEntrySummary) =
+        buildContextAndTransaction(
+          submissionTime,
+          _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration)),
+          Some(recordTime),
+        )
+      context.maximumRecordTime = Some(recordTime)
+      setDeduplicationEntryStep(context, transactionEntrySummary)
+      parseTimestamp(
+        deduplicateValueStoredInContext(context, transactionEntrySummary)
+          .map(
+            _.getRecordTime
+          )
+          .value
+      ) shouldBe recordTime
+    }
+
+    "throw an error for missing max record time" in {
+      val (context, transactionEntrySummary) =
+        buildContextAndTransaction(
+          submissionTime,
+          _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration)),
+        )
+      a[Err.InternalError] shouldBe thrownBy(
+        setDeduplicationEntryStep(context, transactionEntrySummary)
+      )
+    }
+
+    "throw an error for unsupported deduplication periods" in {
+      forAll(
+        Table[DamlSubmitterInfo.Builder => DamlSubmitterInfo.Builder](
+          "deduplication setter",
+          _.clearDeduplicationPeriod(),
+          _.setDeduplicationOffset("offset"),
+          _.setDeduplicateUntil(deduplicateUntil),
+        )
+      ) { deduplicationSetter =>
+        {
+          val (context, transactionEntrySummary) =
+            buildContextAndTransaction(submissionTime, deduplicationSetter)
+          a[Err.InvalidSubmission] shouldBe thrownBy(
+            setDeduplicationEntryStep(context, transactionEntrySummary)
           )
         }
       }
     }
   }
 
-  private def newDedupValue(deduplicationTime: Timestamp): DamlStateValue =
-    DamlStateValue.newBuilder
-      .setCommandDedup(
-        DamlCommandDedupValue.newBuilder.setDeduplicatedUntil(buildTimestamp(deduplicationTime))
-      )
-      .build
+  private def deduplicateStepHasTransactionRejectionEntry(context: CommitContext) = {
+    val actual = deduplicateCommandStep(context, aTransactionEntrySummary)
+
+    actual match {
+      case StepContinue(_) => fail()
+      case StepStop(actualLogEntry) =>
+        actualLogEntry.hasTransactionRejectionEntry shouldBe true
+    }
+  }
+
+  private def deduplicationStepContinues(context: CommitContext) = {
+    val actual = deduplicateCommandStep(context, aTransactionEntrySummary)
+
+    actual match {
+      case StepContinue(_) => succeed
+      case StepStop(_) => fail()
+    }
+  }
 }
 
 object CommandDeduplicationSpec {
 
   private val aDamlTransactionEntry = createEmptyTransactionEntry(List("aSubmitter"))
-  private val aTransactionEntrySummary = DamlTransactionEntrySummary(aDamlTransactionEntry)
-  private val aRecordTime = Timestamp(100)
+  private val deduplicationDuration = Duration.ofSeconds(3)
+  private val aTransactionEntrySummary = DamlTransactionEntrySummary(
+    aDamlTransactionEntry.toBuilder
+      .setSubmitterInfo(
+        DamlSubmitterInfo
+          .newBuilder()
+          .setDeduplicationDuration(buildDuration(deduplicationDuration))
+      )
+      .build()
+  )
   private val aDedupKey = Conversions
     .commandDedupKey(aTransactionEntrySummary.submitterInfo)
   private val aDamlConfigurationStateValue = DamlStateValue.newBuilder
@@ -215,8 +317,9 @@ object CommandDeduplicationSpec {
   private def buildContextAndTransaction(
       submissionTime: protobuf.Timestamp,
       submitterInfoAugmenter: DamlSubmitterInfo.Builder => DamlSubmitterInfo.Builder,
+      recordTime: Option[Timestamp] = None,
   ) = {
-    val context = createCommitContext(None)
+    val context = createCommitContext(recordTime)
     context.set(Conversions.configurationStateKey, aDamlConfigurationStateValue)
     val transactionEntrySummary = DamlTransactionEntrySummary(
       aDamlTransactionEntry.toBuilder
@@ -232,12 +335,21 @@ object CommandDeduplicationSpec {
     context -> transactionEntrySummary
   }
 
-  private def contextDeduplicateUntil(
+  private def deduplicateValueStoredInContext(
       context: CommitContext,
       transactionEntrySummary: DamlTransactionEntrySummary,
   ) = context
     .get(Conversions.commandDedupKey(transactionEntrySummary.submitterInfo))
     .map(
-      _.getCommandDedup.getDeduplicatedUntil
+      _.getCommandDedup
     )
+
+  private def newDedupValue(
+      valueBuilder: DamlCommandDedupValue.Builder => DamlCommandDedupValue.Builder
+  ): DamlStateValue =
+    DamlStateValue.newBuilder
+      .setCommandDedup(
+        valueBuilder(DamlCommandDedupValue.newBuilder)
+      )
+      .build
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -127,7 +127,10 @@ class CommandDeduplicationSpec
               "record time bounds" -> ((timestamp: Timestamp) =>
                 (builder: DamlCommandDedupValue.Builder) =>
                   builder.setRecordTimeBounds(
-                    buildPreExecutionDeduplicationBounds(timestamp, timestamp)
+                    buildPreExecutionDeduplicationBounds(
+                      timestamp.subtract(deduplicationDuration),
+                      timestamp,
+                    )
                   )
               ),
             )


### PR DESCRIPTION
Points to watch:
- pre-execution uses previous command max record time and current command to calculate the period between commands
- normal execution uses previous command record time and current command record time to calculate the period between commands
- the duplicate rejection is produced as the 'successfulWriteSet' in the committer, and is no longer part of the 'outoftimeboundsWriteSet'

This points are open for discussion if anyone has different thoughts about any of them

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
