### PR TITLE
Disable ofInterestRule by default

### DIFF
--- a/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
@@ -147,7 +147,7 @@ pattern EventVirtualResourceNoteSet vr note <-
 runShakeTest :: Maybe SS.Handle -> ShakeTest () -> IO (Either ShakeTestError ShakeTestResults)
 runShakeTest mbScenarioService (ShakeTest m) = do
     dlintDataDir <-locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
-    let options = (defaultOptions Nothing) { optDlintUsage = DlintEnabled dlintDataDir False }
+    let options = (defaultOptions Nothing) { optDlintUsage = DlintEnabled dlintDataDir False, optEnableOfInterestRule = True }
     virtualResources <- newTVarIO Map.empty
     virtualResourcesNotes <- newTVarIO Map.empty
     let eventLogger :: forall (m :: Method 'FromServer 'Notification). SMethod m -> MessageParams m -> IO ()

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -202,7 +202,7 @@ defaultOptions mbVersion =
         , optCppPath = Nothing
         , optIncrementalBuild = IncrementalBuild False
         , optIgnorePackageMetadata = IgnorePackageMetadata False
-        , optEnableOfInterestRule = True
+        , optEnableOfInterestRule = False
         , optAccessTokenPath = Nothing
         }
 

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -485,6 +485,7 @@ execIde telemetry (Debug debug) enableScenarioService options =
           dlintDataDir <- locateRunfiles $ mainWorkspace </> "compiler/damlc/daml-ide-core"
           options <- pure options
               { optScenarioService = enableScenarioService
+              , optEnableOfInterestRule = True
               , optSkipScenarioValidation = SkipScenarioValidation True
               -- TODO(MH): The `optionsParser` does not provide a way to skip
               -- individual options. As a stopgap we ignore the argument to

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -261,8 +261,6 @@ exec Damldoc{..} = do
         { do_compileOptions = cOptions
             { optHaddock = Haddock True
             , optScenarioService = EnableScenarioService False
-            , optEnableOfInterestRule = False
-            -- No need to generate core in the background, so we disable it.
             }
         , do_diagsLogger = diagnosticsLogger
         , do_outputPath = cOutputPath

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -290,7 +290,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = do
     let optHaddock = Haddock False
     let optIncrementalBuild = IncrementalBuild False
     let optIgnorePackageMetadata = IgnorePackageMetadata False
-    let optEnableOfInterestRule = True
+    let optEnableOfInterestRule = False
     optCppPath <- optCppPath
     optEnableScripts <- enableScriptsOpt
 

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -979,7 +979,6 @@ options :: Options
 options =
   (defaultOptions (Just lfVersion))
     { optDlintUsage = DlintDisabled,
-      optEnableOfInterestRule = False,
       optEnableScripts = EnableScripts True
     }
 


### PR DESCRIPTION
This seems like a more sensible default. There are really only very
few places where it makes sense to do things automagically (mainly the
IDE). For everything else we might just end up wasting time by
compiling stuff we don’t need.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
