### PR TITLE
Make string interning available at ingestion [DPP-711]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerSubscription.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerSubscription.scala
@@ -77,10 +77,12 @@ private[platform] case class ParallelIndexerSubscription[DB_BATCH](
           metrics,
         ),
         batchingParallelism = batchingParallelism,
-        batcher = batcherExecutor.execute(batcher(ingestionStorageBackend.batch, metrics)),
+        batcher = batcherExecutor.execute(
+          batcher(ingestionStorageBackend.batch(_, stringInterningView), metrics)
+        ),
         ingestingParallelism = ingestionParallelism,
         ingester = ingester(ingestionStorageBackend.insertBatch, dbDispatcher, metrics),
-        tailer = tailer(ingestionStorageBackend.batch(Vector.empty)),
+        tailer = tailer(ingestionStorageBackend.batch(Vector.empty, stringInterningView)),
         tailingRateLimitPerSecond = tailingRateLimitPerSecond,
         ingestTail =
           ingestTail[DB_BATCH](parameterStorageBackend.updateLedgerEnd, dbDispatcher, metrics),

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/SequentialWriteDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/SequentialWriteDao.scala
@@ -125,7 +125,7 @@ private[appendonlydao] case class SequentialWriteDaoImpl[DB_BATCH](
         }
 
       dbDtosWithStringInterning
-        .pipe(ingestionStorageBackend.batch)
+        .pipe(ingestionStorageBackend.batch(_, stringInterningView))
         .pipe(ingestionStorageBackend.insertBatch(connection, _))
 
       parameterStorageBackend.updateLedgerEnd(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
@@ -4,6 +4,7 @@
 package com.daml.platform.store.backend
 
 import java.sql.Connection
+
 import com.daml.ledger.api.domain.{LedgerId, ParticipantId, PartyDetails}
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.daml.ledger.configuration.Configuration
@@ -20,9 +21,10 @@ import com.daml.platform.store.backend.EventStorageBackend.{FilterParams, RangeP
 import com.daml.platform.store.backend.postgresql.PostgresDataSourceConfig
 import com.daml.platform.store.entries.{ConfigurationEntry, PackageLedgerEntry, PartyLedgerEntry}
 import com.daml.platform.store.interfaces.LedgerDaoContractsReader.KeyState
+import com.daml.platform.store.interning.StringInterning
 import com.daml.scalautil.NeverEqualsOverride
-
 import javax.sql.DataSource
+
 import scala.annotation.unused
 import scala.util.Try
 
@@ -55,9 +57,10 @@ trait IngestionStorageBackend[DB_BATCH] {
     * This should be pure CPU logic without IO.
     *
     * @param dbDtos is a collection of DbDto from which the batch is formed
+    * @param stringInterning will be used to switch ingested strings to the internal integers
     * @return the database-specific batch DTO, which can be inserted via insertBatch
     */
-  def batch(dbDtos: Vector[DbDto]): DB_BATCH
+  def batch(dbDtos: Vector[DbDto], stringInterning: StringInterning): DB_BATCH
 
   /** Using a JDBC connection, a batch will be inserted into the database.
     * No significant CPU load, mostly blocking JDBC communication with the database backend.

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/Field.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/Field.scala
@@ -6,6 +6,8 @@ package com.daml.platform.store.backend.common
 import java.lang
 import java.sql.PreparedStatement
 
+import com.daml.platform.store.interning.StringInterning
+
 import scala.reflect.ClassTag
 
 /** @tparam FROM is an arbitrary type from which we can extract the data of interest for the particular column
@@ -19,13 +21,16 @@ import scala.reflect.ClassTag
 private[backend] abstract class Field[FROM, TO, CONVERTED](implicit
     classTag: ClassTag[CONVERTED]
 ) {
-  def extract: FROM => TO
+  def extract: StringInterning => FROM => TO
   def convert: TO => CONVERTED
   def selectFieldExpression(inputFieldName: String): String = inputFieldName
 
-  final def toArray(input: Vector[FROM]): Array[CONVERTED] =
+  final def toArray(
+      input: Vector[FROM],
+      stringInterning: StringInterning,
+  ): Array[CONVERTED] =
     input.view
-      .map(extract andThen convert)
+      .map(extract(stringInterning) andThen convert)
       .toArray(classTag)
 
   final def prepareData(preparedStatement: PreparedStatement, index: Int, value: Any): Unit =
@@ -53,51 +58,67 @@ private[backend] trait TrivialOptionalField[FROM, TO >: Null <: AnyRef]
   override def convert: Option[TO] => TO = _.orNull
 }
 
-private[backend] case class StringField[FROM](extract: FROM => String)
+private[backend] case class StringField[FROM](extract: StringInterning => FROM => String)
     extends TrivialField[FROM, String]
 
-private[backend] case class StringOptional[FROM](extract: FROM => Option[String])
+private[backend] case class StringOptional[FROM](extract: StringInterning => FROM => Option[String])
     extends TrivialOptionalField[FROM, String]
 
-private[backend] case class Bytea[FROM](extract: FROM => Array[Byte])
+private[backend] case class Bytea[FROM](extract: StringInterning => FROM => Array[Byte])
     extends TrivialField[FROM, Array[Byte]]
 
-private[backend] case class ByteaOptional[FROM](extract: FROM => Option[Array[Byte]])
-    extends TrivialOptionalField[FROM, Array[Byte]]
+private[backend] case class ByteaOptional[FROM](
+    extract: StringInterning => FROM => Option[Array[Byte]]
+) extends TrivialOptionalField[FROM, Array[Byte]]
 
-private[backend] case class Integer[FROM](extract: FROM => Int) extends TrivialField[FROM, Int]
+private[backend] case class Integer[FROM](extract: StringInterning => FROM => Int)
+    extends TrivialField[FROM, Int]
 
-private[backend] case class IntOptional[FROM](extract: FROM => Option[Int])
+private[backend] case class IntOptional[FROM](extract: StringInterning => FROM => Option[Int])
     extends Field[FROM, Option[Int], java.lang.Integer] {
   override def convert: Option[Int] => java.lang.Integer = _.map(Int.box).orNull
 }
 
-private[backend] case class Bigint[FROM](extract: FROM => Long) extends TrivialField[FROM, Long]
+private[backend] case class Bigint[FROM](extract: StringInterning => FROM => Long)
+    extends TrivialField[FROM, Long]
 
-private[backend] case class BigintOptional[FROM](extract: FROM => Option[Long])
+private[backend] case class BigintOptional[FROM](extract: StringInterning => FROM => Option[Long])
     extends Field[FROM, Option[Long], java.lang.Long] {
   override def convert: Option[Long] => java.lang.Long = _.map(Long.box).orNull
 }
 
-private[backend] case class SmallintOptional[FROM](extract: FROM => Option[Int])
+private[backend] case class SmallintOptional[FROM](extract: StringInterning => FROM => Option[Int])
     extends Field[FROM, Option[Int], java.lang.Integer] {
   override def convert: Option[Int] => java.lang.Integer = _.map(Int.box).orNull
 }
 
-private[backend] case class BooleanField[FROM](extract: FROM => Boolean)
+private[backend] case class BooleanField[FROM](extract: StringInterning => FROM => Boolean)
     extends TrivialField[FROM, Boolean]
 
-private[backend] case class BooleanOptional[FROM](extract: FROM => Option[Boolean])
-    extends Field[FROM, Option[Boolean], java.lang.Boolean] {
+private[backend] case class BooleanOptional[FROM](
+    extract: StringInterning => FROM => Option[Boolean]
+) extends Field[FROM, Option[Boolean], java.lang.Boolean] {
   override def convert: Option[Boolean] => lang.Boolean = _.map(Boolean.box).orNull
 }
 
-private[backend] case class StringArray[FROM](extract: FROM => Iterable[String])
+private[backend] case class StringArray[FROM](extract: StringInterning => FROM => Iterable[String])
     extends Field[FROM, Iterable[String], Array[String]] {
   override def convert: Iterable[String] => Array[String] = _.toArray
 }
 
-private[backend] case class StringArrayOptional[FROM](extract: FROM => Option[Iterable[String]])
-    extends Field[FROM, Option[Iterable[String]], Array[String]] {
+private[backend] case class StringArrayOptional[FROM](
+    extract: StringInterning => FROM => Option[Iterable[String]]
+) extends Field[FROM, Option[Iterable[String]], Array[String]] {
   override def convert: Option[Iterable[String]] => Array[String] = _.map(_.toArray).orNull
+}
+
+private[backend] case class IntArray[FROM](extract: StringInterning => FROM => Iterable[Int])
+    extends Field[FROM, Iterable[Int], Array[Int]] {
+  override def convert: Iterable[Int] => Array[Int] = _.toArray
+}
+
+private[backend] case class IntArrayOptional[FROM](
+    extract: StringInterning => FROM => Option[Iterable[Int]]
+) extends Field[FROM, Option[Iterable[Int]], Array[Int]] {
+  override def convert: Option[Iterable[Int]] => Array[Int] = _.map(_.toArray).orNull
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/IngestionStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/IngestionStorageBackendTemplate.scala
@@ -7,6 +7,7 @@ import java.sql.Connection
 
 import anorm.{SQL, SqlQuery}
 import com.daml.platform.store.backend.{DbDto, IngestionStorageBackend, ParameterStorageBackend}
+import com.daml.platform.store.interning.StringInterning
 
 private[backend] class IngestionStorageBackendTemplate(schema: Schema[DbDto])
     extends IngestionStorageBackend[AppendOnlySchema.Batch] {
@@ -48,6 +49,9 @@ private[backend] class IngestionStorageBackendTemplate(schema: Schema[DbDto])
   ): Unit =
     schema.executeUpdate(dbBatch, connection)
 
-  override def batch(dbDtos: Vector[DbDto]): AppendOnlySchema.Batch =
-    schema.prepareData(dbDtos)
+  override def batch(
+      dbDtos: Vector[DbDto],
+      stringInterning: StringInterning,
+  ): AppendOnlySchema.Batch =
+    schema.prepareData(dbDtos, stringInterning)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/Schema.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/Schema.scala
@@ -6,11 +6,12 @@ package com.daml.platform.store.backend.common
 import java.sql.Connection
 
 import com.daml.platform.store.backend.DbDto
+import com.daml.platform.store.interning.StringInterning
 
 import scala.reflect.ClassTag
 
 private[backend] trait Schema[FROM] {
-  def prepareData(in: Vector[FROM]): Array[Array[Array[_]]]
+  def prepareData(in: Vector[FROM], stringInterning: StringInterning): Array[Array[Array[_]]]
   def executeUpdate(data: Array[Array[Array[_]]], connection: Connection): Unit
 }
 
@@ -19,50 +20,70 @@ private[backend] object AppendOnlySchema {
   type Batch = Array[Array[Array[_]]]
 
   private[backend] trait FieldStrategy {
-    def string[FROM, _](extractor: FROM => String): Field[FROM, String, _] =
+    def string[FROM, _](extractor: StringInterning => FROM => String): Field[FROM, String, _] =
       StringField(extractor)
 
-    def stringOptional[FROM, _](extractor: FROM => Option[String]): Field[FROM, Option[String], _] =
+    def stringOptional[FROM, _](
+        extractor: StringInterning => FROM => Option[String]
+    ): Field[FROM, Option[String], _] =
       StringOptional(extractor)
 
     def stringArray[FROM, _](
-        extractor: FROM => Iterable[String]
+        extractor: StringInterning => FROM => Iterable[String]
     ): Field[FROM, Iterable[String], _] =
       StringArray(extractor)
 
     def stringArrayOptional[FROM, _](
-        extractor: FROM => Option[Iterable[String]]
+        extractor: StringInterning => FROM => Option[Iterable[String]]
     ): Field[FROM, Option[Iterable[String]], _] =
       StringArrayOptional(extractor)
 
-    def bytea[FROM, _](extractor: FROM => Array[Byte]): Field[FROM, Array[Byte], _] =
+    def intArray[FROM, _](
+        extractor: StringInterning => FROM => Iterable[Int]
+    ): Field[FROM, Iterable[Int], _] =
+      IntArray(extractor)
+
+    def intArrayOptional[FROM, _](
+        extractor: StringInterning => FROM => Option[Iterable[Int]]
+    ): Field[FROM, Option[Iterable[Int]], _] =
+      IntArrayOptional(extractor)
+
+    def bytea[FROM, _](
+        extractor: StringInterning => FROM => Array[Byte]
+    ): Field[FROM, Array[Byte], _] =
       Bytea(extractor)
 
     def byteaOptional[FROM, _](
-        extractor: FROM => Option[Array[Byte]]
+        extractor: StringInterning => FROM => Option[Array[Byte]]
     ): Field[FROM, Option[Array[Byte]], _] =
       ByteaOptional(extractor)
 
-    def bigint[FROM, _](extractor: FROM => Long): Field[FROM, Long, _] =
+    def bigint[FROM, _](extractor: StringInterning => FROM => Long): Field[FROM, Long, _] =
       Bigint(extractor)
 
-    def bigintOptional[FROM, _](extractor: FROM => Option[Long]): Field[FROM, Option[Long], _] =
+    def bigintOptional[FROM, _](
+        extractor: StringInterning => FROM => Option[Long]
+    ): Field[FROM, Option[Long], _] =
       BigintOptional(extractor)
 
-    def smallintOptional[FROM, _](extractor: FROM => Option[Int]): Field[FROM, Option[Int], _] =
+    def smallintOptional[FROM, _](
+        extractor: StringInterning => FROM => Option[Int]
+    ): Field[FROM, Option[Int], _] =
       SmallintOptional(extractor)
 
-    def int[FROM, _](extractor: FROM => Int): Field[FROM, Int, _] =
+    def int[FROM, _](extractor: StringInterning => FROM => Int): Field[FROM, Int, _] =
       Integer(extractor)
 
-    def intOptional[FROM, _](extractor: FROM => Option[Int]): Field[FROM, Option[Int], _] =
+    def intOptional[FROM, _](
+        extractor: StringInterning => FROM => Option[Int]
+    ): Field[FROM, Option[Int], _] =
       IntOptional(extractor)
 
-    def boolean[FROM, _](extractor: FROM => Boolean): Field[FROM, Boolean, _] =
+    def boolean[FROM, _](extractor: StringInterning => FROM => Boolean): Field[FROM, Boolean, _] =
       BooleanField(extractor)
 
     def booleanOptional[FROM, _](
-        extractor: FROM => Option[Boolean]
+        extractor: StringInterning => FROM => Option[Boolean]
     ): Field[FROM, Option[Boolean], _] =
       BooleanOptional(extractor)
 
@@ -76,80 +97,82 @@ private[backend] object AppendOnlySchema {
   def apply(fieldStrategy: FieldStrategy): Schema[DbDto] = {
     val eventsDivulgence: Table[DbDto.EventDivulgence] =
       fieldStrategy.insert("participant_events_divulgence")(
-        "event_offset" -> fieldStrategy.stringOptional(_.event_offset),
-        "command_id" -> fieldStrategy.stringOptional(_.command_id),
-        "workflow_id" -> fieldStrategy.stringOptional(_.workflow_id),
-        "application_id" -> fieldStrategy.stringOptional(_.application_id),
-        "submitters" -> fieldStrategy.stringArrayOptional(_.submitters),
-        "contract_id" -> fieldStrategy.string(_.contract_id),
-        "template_id" -> fieldStrategy.stringOptional(_.template_id),
-        "tree_event_witnesses" -> fieldStrategy.stringArray(_.tree_event_witnesses),
-        "create_argument" -> fieldStrategy.byteaOptional(_.create_argument),
-        "event_sequential_id" -> fieldStrategy.bigint(_.event_sequential_id),
-        "create_argument_compression" -> fieldStrategy.smallintOptional(
+        "event_offset" -> fieldStrategy.stringOptional(_ => _.event_offset),
+        "command_id" -> fieldStrategy.stringOptional(_ => _.command_id),
+        "workflow_id" -> fieldStrategy.stringOptional(_ => _.workflow_id),
+        "application_id" -> fieldStrategy.stringOptional(_ => _.application_id),
+        "submitters" -> fieldStrategy.stringArrayOptional(_ => _.submitters),
+        "contract_id" -> fieldStrategy.string(_ => _.contract_id),
+        "template_id" -> fieldStrategy.stringOptional(_ => _.template_id),
+        "tree_event_witnesses" -> fieldStrategy.stringArray(_ => _.tree_event_witnesses),
+        "create_argument" -> fieldStrategy.byteaOptional(_ => _.create_argument),
+        "event_sequential_id" -> fieldStrategy.bigint(_ => _.event_sequential_id),
+        "create_argument_compression" -> fieldStrategy.smallintOptional(_ =>
           _.create_argument_compression
         ),
       )
 
     val eventsCreate: Table[DbDto.EventCreate] =
       fieldStrategy.insert("participant_events_create")(
-        "event_offset" -> fieldStrategy.stringOptional(_.event_offset),
-        "transaction_id" -> fieldStrategy.stringOptional(_.transaction_id),
-        "ledger_effective_time" -> fieldStrategy.bigintOptional(_.ledger_effective_time),
-        "command_id" -> fieldStrategy.stringOptional(_.command_id),
-        "workflow_id" -> fieldStrategy.stringOptional(_.workflow_id),
-        "application_id" -> fieldStrategy.stringOptional(_.application_id),
-        "submitters" -> fieldStrategy.stringArrayOptional(_.submitters),
-        "node_index" -> fieldStrategy.intOptional(_.node_index),
-        "event_id" -> fieldStrategy.stringOptional(_.event_id),
-        "contract_id" -> fieldStrategy.string(_.contract_id),
-        "template_id" -> fieldStrategy.stringOptional(_.template_id),
-        "flat_event_witnesses" -> fieldStrategy.stringArray(_.flat_event_witnesses),
-        "tree_event_witnesses" -> fieldStrategy.stringArray(_.tree_event_witnesses),
-        "create_argument" -> fieldStrategy.byteaOptional(_.create_argument),
-        "create_signatories" -> fieldStrategy.stringArrayOptional(_.create_signatories),
-        "create_observers" -> fieldStrategy.stringArrayOptional(_.create_observers),
-        "create_agreement_text" -> fieldStrategy.stringOptional(_.create_agreement_text),
-        "create_key_value" -> fieldStrategy.byteaOptional(_.create_key_value),
-        "create_key_hash" -> fieldStrategy.stringOptional(_.create_key_hash),
-        "event_sequential_id" -> fieldStrategy.bigint(_.event_sequential_id),
-        "create_argument_compression" -> fieldStrategy.smallintOptional(
+        "event_offset" -> fieldStrategy.stringOptional(_ => _.event_offset),
+        "transaction_id" -> fieldStrategy.stringOptional(_ => _.transaction_id),
+        "ledger_effective_time" -> fieldStrategy.bigintOptional(_ => _.ledger_effective_time),
+        "command_id" -> fieldStrategy.stringOptional(_ => _.command_id),
+        "workflow_id" -> fieldStrategy.stringOptional(_ => _.workflow_id),
+        "application_id" -> fieldStrategy.stringOptional(_ => _.application_id),
+        "submitters" -> fieldStrategy.stringArrayOptional(_ => _.submitters),
+        "node_index" -> fieldStrategy.intOptional(_ => _.node_index),
+        "event_id" -> fieldStrategy.stringOptional(_ => _.event_id),
+        "contract_id" -> fieldStrategy.string(_ => _.contract_id),
+        "template_id" -> fieldStrategy.stringOptional(_ => _.template_id),
+        "flat_event_witnesses" -> fieldStrategy.stringArray(_ => _.flat_event_witnesses),
+        "tree_event_witnesses" -> fieldStrategy.stringArray(_ => _.tree_event_witnesses),
+        "create_argument" -> fieldStrategy.byteaOptional(_ => _.create_argument),
+        "create_signatories" -> fieldStrategy.stringArrayOptional(_ => _.create_signatories),
+        "create_observers" -> fieldStrategy.stringArrayOptional(_ => _.create_observers),
+        "create_agreement_text" -> fieldStrategy.stringOptional(_ => _.create_agreement_text),
+        "create_key_value" -> fieldStrategy.byteaOptional(_ => _.create_key_value),
+        "create_key_hash" -> fieldStrategy.stringOptional(_ => _.create_key_hash),
+        "event_sequential_id" -> fieldStrategy.bigint(_ => _.event_sequential_id),
+        "create_argument_compression" -> fieldStrategy.smallintOptional(_ =>
           _.create_argument_compression
         ),
-        "create_key_value_compression" -> fieldStrategy.smallintOptional(
+        "create_key_value_compression" -> fieldStrategy.smallintOptional(_ =>
           _.create_key_value_compression
         ),
       )
 
     val exerciseFields: Vector[(String, Field[DbDto.EventExercise, _, _])] =
       Vector[(String, Field[DbDto.EventExercise, _, _])](
-        "event_id" -> fieldStrategy.stringOptional(_.event_id),
-        "event_offset" -> fieldStrategy.stringOptional(_.event_offset),
-        "contract_id" -> fieldStrategy.string(_.contract_id),
-        "transaction_id" -> fieldStrategy.stringOptional(_.transaction_id),
-        "ledger_effective_time" -> fieldStrategy.bigintOptional(_.ledger_effective_time),
-        "node_index" -> fieldStrategy.intOptional(_.node_index),
-        "command_id" -> fieldStrategy.stringOptional(_.command_id),
-        "workflow_id" -> fieldStrategy.stringOptional(_.workflow_id),
-        "application_id" -> fieldStrategy.stringOptional(_.application_id),
-        "submitters" -> fieldStrategy.stringArrayOptional(_.submitters),
-        "create_key_value" -> fieldStrategy.byteaOptional(_.create_key_value),
-        "exercise_choice" -> fieldStrategy.stringOptional(_.exercise_choice),
-        "exercise_argument" -> fieldStrategy.byteaOptional(_.exercise_argument),
-        "exercise_result" -> fieldStrategy.byteaOptional(_.exercise_result),
-        "exercise_actors" -> fieldStrategy.stringArrayOptional(_.exercise_actors),
-        "exercise_child_event_ids" -> fieldStrategy.stringArrayOptional(_.exercise_child_event_ids),
-        "template_id" -> fieldStrategy.stringOptional(_.template_id),
-        "flat_event_witnesses" -> fieldStrategy.stringArray(_.flat_event_witnesses),
-        "tree_event_witnesses" -> fieldStrategy.stringArray(_.tree_event_witnesses),
-        "event_sequential_id" -> fieldStrategy.bigint(_.event_sequential_id),
-        "create_key_value_compression" -> fieldStrategy.smallintOptional(
+        "event_id" -> fieldStrategy.stringOptional(_ => _.event_id),
+        "event_offset" -> fieldStrategy.stringOptional(_ => _.event_offset),
+        "contract_id" -> fieldStrategy.string(_ => _.contract_id),
+        "transaction_id" -> fieldStrategy.stringOptional(_ => _.transaction_id),
+        "ledger_effective_time" -> fieldStrategy.bigintOptional(_ => _.ledger_effective_time),
+        "node_index" -> fieldStrategy.intOptional(_ => _.node_index),
+        "command_id" -> fieldStrategy.stringOptional(_ => _.command_id),
+        "workflow_id" -> fieldStrategy.stringOptional(_ => _.workflow_id),
+        "application_id" -> fieldStrategy.stringOptional(_ => _.application_id),
+        "submitters" -> fieldStrategy.stringArrayOptional(_ => _.submitters),
+        "create_key_value" -> fieldStrategy.byteaOptional(_ => _.create_key_value),
+        "exercise_choice" -> fieldStrategy.stringOptional(_ => _.exercise_choice),
+        "exercise_argument" -> fieldStrategy.byteaOptional(_ => _.exercise_argument),
+        "exercise_result" -> fieldStrategy.byteaOptional(_ => _.exercise_result),
+        "exercise_actors" -> fieldStrategy.stringArrayOptional(_ => _.exercise_actors),
+        "exercise_child_event_ids" -> fieldStrategy.stringArrayOptional(_ =>
+          _.exercise_child_event_ids
+        ),
+        "template_id" -> fieldStrategy.stringOptional(_ => _.template_id),
+        "flat_event_witnesses" -> fieldStrategy.stringArray(_ => _.flat_event_witnesses),
+        "tree_event_witnesses" -> fieldStrategy.stringArray(_ => _.tree_event_witnesses),
+        "event_sequential_id" -> fieldStrategy.bigint(_ => _.event_sequential_id),
+        "create_key_value_compression" -> fieldStrategy.smallintOptional(_ =>
           _.create_key_value_compression
         ),
-        "exercise_argument_compression" -> fieldStrategy.smallintOptional(
+        "exercise_argument_compression" -> fieldStrategy.smallintOptional(_ =>
           _.exercise_argument_compression
         ),
-        "exercise_result_compression" -> fieldStrategy.smallintOptional(
+        "exercise_result_compression" -> fieldStrategy.smallintOptional(_ =>
           _.exercise_result_compression
         ),
       )
@@ -162,21 +185,21 @@ private[backend] object AppendOnlySchema {
 
     val configurationEntries: Table[DbDto.ConfigurationEntry] =
       fieldStrategy.insert("configuration_entries")(
-        "ledger_offset" -> fieldStrategy.string(_.ledger_offset),
-        "recorded_at" -> fieldStrategy.bigint(_.recorded_at),
-        "submission_id" -> fieldStrategy.string(_.submission_id),
-        "typ" -> fieldStrategy.string(_.typ),
-        "configuration" -> fieldStrategy.bytea(_.configuration),
-        "rejection_reason" -> fieldStrategy.stringOptional(_.rejection_reason),
+        "ledger_offset" -> fieldStrategy.string(_ => _.ledger_offset),
+        "recorded_at" -> fieldStrategy.bigint(_ => _.recorded_at),
+        "submission_id" -> fieldStrategy.string(_ => _.submission_id),
+        "typ" -> fieldStrategy.string(_ => _.typ),
+        "configuration" -> fieldStrategy.bytea(_ => _.configuration),
+        "rejection_reason" -> fieldStrategy.stringOptional(_ => _.rejection_reason),
       )
 
     val packageEntries: Table[DbDto.PackageEntry] =
       fieldStrategy.insert("package_entries")(
-        "ledger_offset" -> fieldStrategy.string(_.ledger_offset),
-        "recorded_at" -> fieldStrategy.bigint(_.recorded_at),
-        "submission_id" -> fieldStrategy.stringOptional(_.submission_id),
-        "typ" -> fieldStrategy.string(_.typ),
-        "rejection_reason" -> fieldStrategy.stringOptional(_.rejection_reason),
+        "ledger_offset" -> fieldStrategy.string(_ => _.ledger_offset),
+        "recorded_at" -> fieldStrategy.bigint(_ => _.recorded_at),
+        "submission_id" -> fieldStrategy.stringOptional(_ => _.submission_id),
+        "typ" -> fieldStrategy.string(_ => _.typ),
+        "rejection_reason" -> fieldStrategy.stringOptional(_ => _.rejection_reason),
       )
 
     val packages: Table[DbDto.Package] =
@@ -184,56 +207,58 @@ private[backend] object AppendOnlySchema {
         tableName = "packages",
         keyFieldIndex = 0,
       )(
-        "package_id" -> fieldStrategy.string(_.package_id),
-        "upload_id" -> fieldStrategy.string(_.upload_id),
-        "source_description" -> fieldStrategy.stringOptional(_.source_description),
-        "package_size" -> fieldStrategy.bigint(_.package_size),
-        "known_since" -> fieldStrategy.bigint(_.known_since),
-        "ledger_offset" -> fieldStrategy.string(_.ledger_offset),
-        "package" -> fieldStrategy.bytea(_._package),
+        "package_id" -> fieldStrategy.string(_ => _.package_id),
+        "upload_id" -> fieldStrategy.string(_ => _.upload_id),
+        "source_description" -> fieldStrategy.stringOptional(_ => _.source_description),
+        "package_size" -> fieldStrategy.bigint(_ => _.package_size),
+        "known_since" -> fieldStrategy.bigint(_ => _.known_since),
+        "ledger_offset" -> fieldStrategy.string(_ => _.ledger_offset),
+        "package" -> fieldStrategy.bytea(_ => _._package),
       )
 
     val partyEntries: Table[DbDto.PartyEntry] =
       fieldStrategy.insert("party_entries")(
-        "ledger_offset" -> fieldStrategy.string(_.ledger_offset),
-        "recorded_at" -> fieldStrategy.bigint(_.recorded_at),
-        "submission_id" -> fieldStrategy.stringOptional(_.submission_id),
-        "party" -> fieldStrategy.stringOptional(_.party),
-        "display_name" -> fieldStrategy.stringOptional(_.display_name),
-        "typ" -> fieldStrategy.string(_.typ),
-        "rejection_reason" -> fieldStrategy.stringOptional(_.rejection_reason),
-        "is_local" -> fieldStrategy.booleanOptional(_.is_local),
+        "ledger_offset" -> fieldStrategy.string(_ => _.ledger_offset),
+        "recorded_at" -> fieldStrategy.bigint(_ => _.recorded_at),
+        "submission_id" -> fieldStrategy.stringOptional(_ => _.submission_id),
+        "party" -> fieldStrategy.stringOptional(_ => _.party),
+        "display_name" -> fieldStrategy.stringOptional(_ => _.display_name),
+        "typ" -> fieldStrategy.string(_ => _.typ),
+        "rejection_reason" -> fieldStrategy.stringOptional(_ => _.rejection_reason),
+        "is_local" -> fieldStrategy.booleanOptional(_ => _.is_local),
       )
 
     val commandCompletions: Table[DbDto.CommandCompletion] =
       fieldStrategy.insert("participant_command_completions")(
-        "completion_offset" -> fieldStrategy.string(_.completion_offset),
-        "record_time" -> fieldStrategy.bigint(_.record_time),
-        "application_id" -> fieldStrategy.string(_.application_id),
-        "submitters" -> fieldStrategy.stringArray(_.submitters),
-        "command_id" -> fieldStrategy.string(_.command_id),
-        "transaction_id" -> fieldStrategy.stringOptional(_.transaction_id),
-        "rejection_status_code" -> fieldStrategy.intOptional(_.rejection_status_code),
-        "rejection_status_message" -> fieldStrategy.stringOptional(_.rejection_status_message),
-        "rejection_status_details" -> fieldStrategy.byteaOptional(_.rejection_status_details),
-        "submission_id" -> fieldStrategy.stringOptional(_.submission_id),
-        "deduplication_offset" -> fieldStrategy.stringOptional(_.deduplication_offset),
-        "deduplication_duration_seconds" -> fieldStrategy.bigintOptional(
+        "completion_offset" -> fieldStrategy.string(_ => _.completion_offset),
+        "record_time" -> fieldStrategy.bigint(_ => _.record_time),
+        "application_id" -> fieldStrategy.string(_ => _.application_id),
+        "submitters" -> fieldStrategy.stringArray(_ => _.submitters),
+        "command_id" -> fieldStrategy.string(_ => _.command_id),
+        "transaction_id" -> fieldStrategy.stringOptional(_ => _.transaction_id),
+        "rejection_status_code" -> fieldStrategy.intOptional(_ => _.rejection_status_code),
+        "rejection_status_message" -> fieldStrategy.stringOptional(_ => _.rejection_status_message),
+        "rejection_status_details" -> fieldStrategy.byteaOptional(_ => _.rejection_status_details),
+        "submission_id" -> fieldStrategy.stringOptional(_ => _.submission_id),
+        "deduplication_offset" -> fieldStrategy.stringOptional(_ => _.deduplication_offset),
+        "deduplication_duration_seconds" -> fieldStrategy.bigintOptional(_ =>
           _.deduplication_duration_seconds
         ),
-        "deduplication_duration_nanos" -> fieldStrategy.intOptional(_.deduplication_duration_nanos),
-        "deduplication_start" -> fieldStrategy.bigintOptional(_.deduplication_start),
+        "deduplication_duration_nanos" -> fieldStrategy.intOptional(_ =>
+          _.deduplication_duration_nanos
+        ),
+        "deduplication_start" -> fieldStrategy.bigintOptional(_ => _.deduplication_start),
       )
 
     val commandSubmissionDeletes: Table[DbDto.CommandDeduplication] =
       fieldStrategy.delete("participant_command_submissions")(
-        "deduplication_key" -> fieldStrategy.string(_.deduplication_key)
+        "deduplication_key" -> fieldStrategy.string(_ => _.deduplication_key)
       )
 
     val stringInterningTable: Table[DbDto.StringInterningDto] =
       fieldStrategy.insert("string_interning")(
-        "internal_id" -> fieldStrategy.int(_.internalId),
-        "external_string" -> fieldStrategy.string(_.externalString),
+        "internal_id" -> fieldStrategy.int(_ => _.internalId),
+        "external_string" -> fieldStrategy.string(_ => _.externalString),
       )
 
     val executes: Seq[Array[Array[_]] => Connection => Unit] = List(
@@ -251,23 +276,28 @@ private[backend] object AppendOnlySchema {
     )
 
     new Schema[DbDto] {
-      override def prepareData(in: Vector[DbDto]): Array[Array[Array[_]]] = {
+      override def prepareData(
+          in: Vector[DbDto],
+          stringInterning: StringInterning,
+      ): Array[Array[Array[_]]] = {
         def collectWithFilter[T <: DbDto: ClassTag](filter: T => Boolean): Vector[T] =
           in.collect { case dbDto: T if filter(dbDto) => dbDto }
         def collect[T <: DbDto: ClassTag]: Vector[T] = collectWithFilter[T](_ => true)
         import DbDto._
         Array(
-          eventsDivulgence.prepareData(collect[EventDivulgence]),
-          eventsCreate.prepareData(collect[EventCreate]),
-          eventsConsumingExercise.prepareData(collectWithFilter[EventExercise](_.consuming)),
-          eventsNonConsumingExercise.prepareData(collectWithFilter[EventExercise](!_.consuming)),
-          configurationEntries.prepareData(collect[ConfigurationEntry]),
-          packageEntries.prepareData(collect[PackageEntry]),
-          packages.prepareData(collect[Package]),
-          partyEntries.prepareData(collect[PartyEntry]),
-          commandCompletions.prepareData(collect[CommandCompletion]),
-          commandSubmissionDeletes.prepareData(collect[CommandDeduplication]),
-          stringInterningTable.prepareData(collect[StringInterningDto]),
+          eventsDivulgence.prepareData(collect[EventDivulgence], stringInterning),
+          eventsCreate.prepareData(collect[EventCreate], stringInterning),
+          eventsConsumingExercise
+            .prepareData(collectWithFilter[EventExercise](_.consuming), stringInterning),
+          eventsNonConsumingExercise
+            .prepareData(collectWithFilter[EventExercise](!_.consuming), stringInterning),
+          configurationEntries.prepareData(collect[ConfigurationEntry], stringInterning),
+          packageEntries.prepareData(collect[PackageEntry], stringInterning),
+          packages.prepareData(collect[Package], stringInterning),
+          partyEntries.prepareData(collect[PartyEntry], stringInterning),
+          commandCompletions.prepareData(collect[CommandCompletion], stringInterning),
+          commandSubmissionDeletes.prepareData(collect[CommandDeduplication], stringInterning),
+          stringInterningTable.prepareData(collect[StringInterningDto], stringInterning),
         )
       }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/Table.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/Table.scala
@@ -5,15 +5,20 @@ package com.daml.platform.store.backend.common
 
 import java.sql.Connection
 
+import com.daml.platform.store.interning.StringInterning
+
 private[backend] trait Table[FROM] {
-  def prepareData(in: Vector[FROM]): Array[Array[_]]
+  def prepareData(in: Vector[FROM], stringInterning: StringInterning): Array[Array[_]]
   def executeUpdate: Array[Array[_]] => Connection => Unit
 }
 
 private[backend] abstract class BaseTable[FROM](fields: Seq[(String, Field[FROM, _, _])])
     extends Table[FROM] {
-  override def prepareData(in: Vector[FROM]): Array[Array[_]] =
-    fields.view.map(_._2.toArray(in)).toArray
+  override def prepareData(
+      in: Vector[FROM],
+      stringInterning: StringInterning,
+  ): Array[Array[_]] =
+    fields.view.map(_._2.toArray(in, stringInterning)).toArray
 }
 
 private[backend] object Table {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleField.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleField.scala
@@ -4,12 +4,15 @@
 package com.daml.platform.store.backend.oracle
 
 import java.sql.PreparedStatement
+
 import com.daml.platform.store.backend.common.Field
+import com.daml.platform.store.interning.StringInterning
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
-private[oracle] case class OracleStringArray[FROM](extract: FROM => Iterable[String])
-    extends Field[FROM, Iterable[String], String] {
+private[oracle] case class OracleStringArray[FROM](
+    extract: StringInterning => FROM => Iterable[String]
+) extends Field[FROM, Iterable[String], String] {
   override def convert: Iterable[String] => String = _.toList.toJson.compactPrint
   override def prepareDataTemplate(
       preparedStatement: PreparedStatement,
@@ -21,7 +24,7 @@ private[oracle] case class OracleStringArray[FROM](extract: FROM => Iterable[Str
 }
 
 private[oracle] case class OracleStringArrayOptional[FROM](
-    extract: FROM => Option[Iterable[String]]
+    extract: StringInterning => FROM => Option[Iterable[String]]
 ) extends Field[FROM, Option[Iterable[String]], String] {
   override def convert: Option[Iterable[String]] => String =
     _.map(_.toList.toJson.compactPrint).getOrElse("[]")

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleSchema.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleSchema.scala
@@ -6,16 +6,17 @@ package com.daml.platform.store.backend.oracle
 import com.daml.platform.store.backend.DbDto
 import com.daml.platform.store.backend.common.AppendOnlySchema.FieldStrategy
 import com.daml.platform.store.backend.common.{AppendOnlySchema, Field, Schema, Table}
+import com.daml.platform.store.interning.StringInterning
 
 private[oracle] object OracleSchema {
   private val OracleFieldStrategy = new FieldStrategy {
     override def stringArray[FROM, _](
-        extractor: FROM => Iterable[String]
+        extractor: StringInterning => FROM => Iterable[String]
     ): Field[FROM, Iterable[String], _] =
       OracleStringArray(extractor)
 
     override def stringArrayOptional[FROM, _](
-        extractor: FROM => Option[Iterable[String]]
+        extractor: StringInterning => FROM => Option[Iterable[String]]
     ): Field[FROM, Option[Iterable[String]], _] =
       OracleStringArrayOptional(extractor)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PGField.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PGField.scala
@@ -4,6 +4,7 @@
 package com.daml.platform.store.backend.postgresql
 
 import com.daml.platform.store.backend.common.Field
+import com.daml.platform.store.interning.StringInterning
 
 private[postgresql] trait PGStringArrayBase[FROM, TO] extends Field[FROM, TO, String] {
   override def selectFieldExpression(inputFieldName: String): String =
@@ -18,19 +19,21 @@ private[postgresql] trait PGStringArrayBase[FROM, TO] extends Field[FROM, TO, St
   }
 }
 
-private[postgresql] case class PGStringArray[FROM](extract: FROM => Iterable[String])
-    extends PGStringArrayBase[FROM, Iterable[String]] {
+private[postgresql] case class PGStringArray[FROM](
+    extract: StringInterning => FROM => Iterable[String]
+) extends PGStringArrayBase[FROM, Iterable[String]] {
   override def convert: Iterable[String] => String = convertBase
 }
 
 private[postgresql] case class PGStringArrayOptional[FROM](
-    extract: FROM => Option[Iterable[String]]
+    extract: StringInterning => FROM => Option[Iterable[String]]
 ) extends PGStringArrayBase[FROM, Option[Iterable[String]]] {
   override def convert: Option[Iterable[String]] => String = _.map(convertBase).orNull
 }
 
-private[postgresql] case class PGSmallintOptional[FROM](extract: FROM => Option[Int])
-    extends Field[FROM, Option[Int], java.lang.Integer] {
+private[postgresql] case class PGSmallintOptional[FROM](
+    extract: StringInterning => FROM => Option[Int]
+) extends Field[FROM, Option[Int], java.lang.Integer] {
   override def selectFieldExpression(inputFieldName: String): String =
     s"$inputFieldName::smallint"
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PGSchema.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PGSchema.scala
@@ -6,21 +6,22 @@ package com.daml.platform.store.backend.postgresql
 import com.daml.platform.store.backend.DbDto
 import com.daml.platform.store.backend.common.AppendOnlySchema.FieldStrategy
 import com.daml.platform.store.backend.common.{AppendOnlySchema, Field, Schema, Table}
+import com.daml.platform.store.interning.StringInterning
 
 private[postgresql] object PGSchema {
   private val PGFieldStrategy = new FieldStrategy {
     override def stringArray[FROM, _](
-        extractor: FROM => Iterable[String]
+        extractor: StringInterning => FROM => Iterable[String]
     ): Field[FROM, Iterable[String], _] =
       PGStringArray(extractor)
 
     override def stringArrayOptional[FROM, _](
-        extractor: FROM => Option[Iterable[String]]
+        extractor: StringInterning => FROM => Option[Iterable[String]]
     ): Field[FROM, Option[Iterable[String]], _] =
       PGStringArrayOptional(extractor)
 
     override def smallintOptional[FROM, _](
-        extractor: FROM => Option[Int]
+        extractor: StringInterning => FROM => Option[Int]
     ): Field[FROM, Option[Int], _] =
       PGSmallintOptional(extractor)
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/interning/MockStringInterning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/interning/MockStringInterning.scala
@@ -6,7 +6,10 @@ package com.daml.platform.store.interning
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.Party
 
-class InterningStringInterning extends StringInterning {
+/** This StringInterning implementation is interning in a transparent way everything it sees.
+  * This is only for test purposes.
+  */
+class MockStringInterning extends StringInterning {
   private var idToString: Map[Int, String] = Map.empty
   private var stringToId: Map[String, Int] = Map.empty
   private var lastId: Int = 0

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/SequentialWriteDaoSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/SequentialWriteDaoSpec.scala
@@ -108,7 +108,8 @@ class SequentialWriteDaoSpec extends AnyFlatSpec with Matchers {
 
     var captured: Vector[Any] = Vector.empty
 
-    override def batch(dbDtos: Vector[DbDto]): Vector[DbDto] = dbDtos
+    override def batch(dbDtos: Vector[DbDto], stringInterning: StringInterning): Vector[DbDto] =
+      dbDtos
 
     override def insertBatch(connection: Connection, batch: Vector[DbDto]): Unit = synchronized {
       connection shouldBe someConnection


### PR DESCRIPTION
We need to support mapping to internal ids at ingestion.

* Wire StringInterning to Schema
* Wire StringInterning to IngestionStorageBackend
* Fixing tests
* Renames MockStringInterning (post-review work from different PR)

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
