### PR TITLE
Backport signing tool changes

### DIFF
--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -13,12 +13,13 @@ mv "bazel-bin/release/windows-installer/daml-sdk-installer.exe" "$INSTALLER"
 chmod +wx "$INSTALLER"
 
 if ! [ -f /C/Users/u/.dotnet/tools/azuresigntool.exe ]; then
-    "/C/Program Files/dotnet/dotnet.exe" tool install --global AzureSignTool
+    "/C/Program Files/dotnet/dotnet.exe" tool install --global AzureSignTool --version 3.0.0
 fi
 
 /C/Users/u/.dotnet/tools/azuresigntool.exe sign \
   --azure-key-vault-url "$AZURE_KEY_VAULT_URL" \
   --azure-key-vault-client-id "$AZURE_CLIENT_ID" \
+  --azure-key-vault-tenant-id "$AZURE_TENANT_ID" \
   --azure-key-vault-client-secret "$AZURE_CLIENT_SECRET" \
   --azure-key-vault-certificate "$AZURE_KEY_VAULT_CERTIFICATE" \
   --description "Daml SDK installer" \


### PR DESCRIPTION
(Partial) backport from #10979

This bumps dotnet to the version required by the latest azuresigntool,
and pins azuresigntool for the future.

As usual for live CI upgrades, this will be rolled out using the
blue/green approach. I'll keep each deployed commit in this PR.

For future reference, this is PR [#10979].

[#10979]: https://github.com/digital-asset/daml/pull/10979

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
