### PR TITLE
[TS-Bindings] Ws multiplexing for stream queries is disabled by default 

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -216,7 +216,7 @@ test('create + fetch & exercise', async () => {
   const personRawStream = aliceLedger.streamQuery(buildAndLint.Main.Person);
   const personStream = promisifyStream(personRawStream);
   const personStreamLive = pEvent(personRawStream, 'live');
-  expect(await personStream.next()).toEqual([[alice6Contract], [{created: alice6Contract, matchedQueries:[1]}]]);
+  expect(await personStream.next()).toEqual([[alice6Contract], [{created: alice6Contract, matchedQueries:[0]}]]);
 
   // end of non-live data, first offset
   expect(await personStreamLive).toEqual([alice6Contract]);
@@ -226,7 +226,7 @@ test('create + fetch & exercise', async () => {
   const bob4Contract = await bobLedger.create(buildAndLint.Main.Person, bob4);
   expect(bob4Contract.payload).toEqual(bob4);
   expect(bob4Contract.key).toEqual(bob4Key);
-  expect(await personStream.next()).toEqual([[alice6Contract, bob4Contract], [{created: bob4Contract, matchedQueries:[1]}]]);
+  expect(await personStream.next()).toEqual([[alice6Contract, bob4Contract], [{created: bob4Contract, matchedQueries:[0]}]]);
 
 
   // Alice changes her name.
@@ -243,7 +243,7 @@ test('create + fetch & exercise', async () => {
   expect(cooper6Contract.key).toEqual(alice6Key);
   expect(await aliceStream.next()).toEqual([[cooper6Contract], [{archived: alice6Archived}, {created: cooper6Contract, matchedQueries:[0]}]]);
   expect(await alice6KeyStream.next()).toEqual([cooper6Contract, [{archived: alice6Archived}, {created: cooper6Contract}]]);
-  expect(await personStream.next()).toEqual([[bob4Contract, cooper6Contract], [{archived: alice6Archived}, {created: cooper6Contract, matchedQueries:[1]}]]);
+  expect(await personStream.next()).toEqual([[bob4Contract, cooper6Contract], [{archived: alice6Archived}, {created: cooper6Contract, matchedQueries:[0]}]]);
 
   personContracts = await aliceLedger.query(buildAndLint.Main.Person);
   expect(personContracts).toEqual([bob4Contract, cooper6Contract]);

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -703,7 +703,7 @@ class Ledger {
   /**
    * Construct a new `Ledger` object. See [[LedgerOptions]] for the constructor arguments.
    */
-  constructor({token, httpBaseUrl, wsBaseUrl, reconnectThreshold = 30000, multiplexQueryStreams = true}: LedgerOptions) {
+  constructor({token, httpBaseUrl, wsBaseUrl, reconnectThreshold = 30000, multiplexQueryStreams = false}: LedgerOptions) {
     if (!httpBaseUrl) {
       httpBaseUrl = `${window.location.protocol}//${window.location.host}/`;
     }
@@ -1054,11 +1054,11 @@ class Ledger {
           }
         }
       } else if (isRecordWith('warnings', json)) {
-        console.warn(`Ledger.${callerName} warnings`, json);
+        console.warn(`${callerName} warnings`, json);
       } else if (isRecordWith('errors', json)) {
-        console.error(`Ledger.${callerName} errors`, json);
+        console.error(`${callerName} errors`, json);
       } else {
-        console.error(`Ledger.${callerName} unknown message`, json);
+        console.error(`${callerName} unknown message`, json);
       }
     };
     const closeStream = (status: { code: number; reason: string }): void => {
@@ -1242,7 +1242,7 @@ class Ledger {
       lastContractId = contract ? contract.contractId : null
       return contract;
     }
-    return this.streamSubmit("streamFetchByKey", template, 'v1/stream/fetch', request, reconnectRequest, null, change);
+    return this.streamSubmit("Ledger.streamFetchByKey", template, 'v1/stream/fetch', request, reconnectRequest, null, change);
   }
 
   /**


### PR DESCRIPTION
Ws multiplexing is disabled by default as we investigate issues with intermittent web socket closures

CHANGELOG_BEGIN
[TS-Bindings] Ws multiplexing for stream queries is disabled by default as we investigate issues
of intermittent websocket closures.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
