### PR TITLE
Remove SEDamlException & SEImportValue from SExpr{0,1}

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -301,8 +301,6 @@ private[lf] object Anf {
         Bounce(() => transform(depth, atom, k))
 
       case source.SEVal(x) => Bounce(() => transform(depth, target.SEVal(x), k))
-      case source.SEImportValue(ty, v) =>
-        Bounce(() => transform(depth, target.SEImportValue(ty, v), k))
 
       case source.SEAppGeneral(func, args) =>
         // It's safe to perform ANF if the func-expression has no effects when evaluated.
@@ -373,9 +371,6 @@ private[lf] object Anf {
       case source.SEScopeExercise(body0) =>
         val body: target.SExpr = flattenExp(depth, env, body0)(anf => Land(anf.wrapped)).bounce
         Bounce(() => transform(depth, target.SEScopeExercise(body), k))
-
-      case _: source.SEDamlException =>
-        throw CompilationError(s"flatten: unexpected: $exp")
     }
 
   private[this] def atomizeExps[A](

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ClosureConversion.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ClosureConversion.scala
@@ -120,9 +120,6 @@ private[speedy] object ClosureConversion {
 
       case source.SELet1General(bound, body) =>
         target.SELet1General(closureConvert(remaps, bound), closureConvert(shift(remaps, 1), body))
-
-      case _: source.SEDamlException | _: source.SEImportValue =>
-        throw CompilationError(s"closureConvert: unexpected $expr")
     }
   }
 
@@ -184,7 +181,7 @@ private[speedy] object ClosureConversion {
         case source.SEScopeExercise(body) =>
           go(body, bound, free)
 
-        case _: source.SEDamlException | _: source.SEImportValue | _: source.SELet1General =>
+        case _: source.SELet1General =>
           throw CompilationError(s"freeVars: unexpected $expr")
       }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -327,6 +327,9 @@ object SExpr {
 
   /** We cannot crash in the engine call back.
     * Rather, we set the control to this expression and then crash when executing.
+    *
+    * The SEDamlException form is never constructed when compiling user LF.
+    * It is only constructed at runtime by certain builtin-ops.
     */
   final case class SEDamlException(error: interpretation.Error) extends SExpr {
     def execute(machine: Machine): Unit = {
@@ -334,6 +337,9 @@ object SExpr {
     }
   }
 
+  /** The SEImportValue form is never constructed when compiling user LF.
+    * It is only constructed at runtime by certain builtin-ops.
+    */
   final case class SEImportValue(typ: Ast.Type, value: V) extends SExpr {
     def execute(machine: Machine): Unit = {
       machine.importValue(typ, value)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -31,7 +31,7 @@ package speedy
   * Summary of which constructors are contained by: SExp0, SExpr1 and SExpr:
   *
   * - In SExpr{0,1,} (everywhere): SEAppGeneral, SEBuiltin, SEBuiltinRecursiveDefinition,
-  *   SEDamlException, SEImportValue, SELabelClosure, SELet1General, SELocation,
+  *   SELabelClosure, SELet1General, SELocation,
   *   SEScopeExercise, SETryCatch, SEVal, SEValue,
   *
   * - In SExpr0: SEAbs, SEVar
@@ -42,11 +42,11 @@ package speedy
   *
   * - In SExpr: SEAppAtomicFun, SEAppAtomicGeneral, SEAppAtomicSaturatedBuiltin,
   *   SECaseAtomic, SELet1Builtin, SELet1BuiltinArithmetic
+  *
+  * - In SExpr (runtime only, i.e. rejected by validate): SEDamlException, SEImportValue
   */
 
 import com.daml.lf.data.Ref._
-import com.daml.lf.language.Ast
-import com.daml.lf.value.{Value => V}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SExpr.{SDefinitionRef, SCasePat}
 import com.daml.lf.speedy.{SExpr => runTime}
@@ -128,13 +128,6 @@ private[speedy] object SExpr0 {
     * [[AnyRef]] for the label.
     */
   final case class SELabelClosure(label: Profile.Label, expr: SExpr) extends SExpr
-
-  /** We cannot crash in the engine call back.
-    * Rather, we set the control to this expression and then crash when executing.
-    */
-  final case class SEDamlException(error: interpretation.Error) extends SExpr
-
-  final case class SEImportValue(typ: Ast.Type, value: V) extends SExpr
 
   /** Exception handler */
   final case class SETryCatch(body: SExpr, handler: SExpr) extends SExpr

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr1.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr1.scala
@@ -10,8 +10,6 @@ package speedy
   */
 
 import com.daml.lf.data.Ref._
-import com.daml.lf.language.Ast
-import com.daml.lf.value.{Value => V}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SExpr.{SDefinitionRef, SCasePat}
 import com.daml.lf.speedy.{SExpr => runTime}
@@ -100,13 +98,6 @@ private[speedy] object SExpr1 {
     * [[AnyRef]] for the label.
     */
   final case class SELabelClosure(label: Profile.Label, expr: SExpr) extends SExpr
-
-  /** We cannot crash in the engine call back.
-    * Rather, we set the control to this expression and then crash when executing.
-    */
-  final case class SEDamlException(error: interpretation.Error) extends SExpr
-
-  final case class SEImportValue(typ: Ast.Type, value: V) extends SExpr
 
   /** Exception handler */
   final case class SETryCatch(body: SExpr, handler: SExpr) extends SExpr


### PR DESCRIPTION
Remove unnecessary constructors: `SEDamlException`, `SEImportValue`, from `SExpr{0,1}`

Actually they probably shouldn't even be a part of `SExpr` either. Instead we should implement the functionality using new continuation variants. But that's a refactoring step for another day.

Part of: #11669