### PR TITLE
LF: drop forgotten deprecated Node aliases.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -12,8 +12,7 @@ import com.daml.lf.speedy.{InitialSeeding, PartialTransaction, Pretty, SError}
 import com.daml.lf.speedy.SExpr.{SExpr, SEApp, SEValue}
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.speedy.SResult._
-import com.daml.lf.transaction.{SubmittedTransaction, VersionedTransaction, Transaction => Tx}
-import com.daml.lf.transaction.Node._
+import com.daml.lf.transaction.{Node, SubmittedTransaction, VersionedTransaction, Transaction => Tx}
 import java.nio.file.Files
 
 import com.daml.lf.language.{PackageInterface, LanguageVersion, LookupError, StablePackages}
@@ -490,12 +489,12 @@ object Engine {
       val makeDesc = (kind: String, tmpl: Ref.Identifier, extra: Option[String]) =>
         s"$kind:${tmpl.qualifiedName.name}${extra.map(extra => s":$extra").getOrElse("")}"
       tx.nodes.get(tx.roots(0)).toList.head match {
-        case _: NodeRollback => "rollback"
-        case create: NodeCreate => makeDesc("create", create.templateId, None)
-        case exercise: NodeExercises =>
+        case _: Node.Rollback => "rollback"
+        case create: Node.Create => makeDesc("create", create.templateId, None)
+        case exercise: Node.Exercise =>
           makeDesc("exercise", exercise.templateId, Some(exercise.choiceId))
-        case fetch: NodeFetch => makeDesc("fetch", fetch.templateId, None)
-        case lookup: NodeLookupByKey => makeDesc("lookup", lookup.templateId, None)
+        case fetch: Node.Fetch => makeDesc("fetch", fetch.templateId, None)
+        case lookup: Node.LookupByKey => makeDesc("lookup", lookup.templateId, None)
       }
     } else {
       s"compound:${tx.roots.length}"

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ReinterpretTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ReinterpretTest.scala
@@ -11,8 +11,13 @@ import com.daml.bazeltools.BazelRunfiles
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
 import com.daml.lf.language.Ast._
-import com.daml.lf.transaction.{GlobalKeyWithMaintainers, NodeId, Transaction, SubmittedTransaction}
-import com.daml.lf.transaction.Node.{NodeRollback, NodeExercises, NodeCreate}
+import com.daml.lf.transaction.{
+  GlobalKeyWithMaintainers,
+  Node,
+  NodeId,
+  Transaction,
+  SubmittedTransaction,
+}
 import com.daml.lf.value.Value._
 import com.daml.lf.command._
 import com.daml.lf.transaction.test.TransactionBuilder.{assertAsVersionedContract}
@@ -191,9 +196,9 @@ object ReinterpretTest {
     def ofTransaction(tx: Transaction): Top = {
       def ofNid(nid: NodeId): Shape = {
         tx.nodes(nid) match {
-          case node: NodeExercises => Exercise(node.children.toList.map(ofNid))
-          case node: NodeRollback => Rollback(node.children.toList.map(ofNid))
-          case _: NodeCreate => Create()
+          case node: Node.Exercise => Exercise(node.children.toList.map(ofNid))
+          case node: Node.Rollback => Rollback(node.children.toList.map(ofNid))
+          case _: Node.Create => Create()
           case _ => sys.error(s"Shape.ofTransaction, unexpected tx node")
         }
       }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Normalization.scala
@@ -17,7 +17,7 @@ class Normalization {
     * - field names are dropped from Records
     * - values are normalized recursively
     * - all values embedded in transaction nodes are normalized
-    * - version-specific normalization is applied to the 'byKey' fields of 'NodeFetch' and 'NodeExercises'
+    * - version-specific normalization is applied to the 'byKey' fields of 'Node.Fetch' and 'Node.Exercises'
     *
     * We do not normalize the node-ids in the transaction here, but rather assume that
     * aspect of normalization has already been performed (by the engine, or by

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -13,14 +13,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.scenario.{ScenarioLedger, ScenarioRunner}
 import com.daml.lf.speedy.{SValue, TraceLog, WarningLog}
-import com.daml.lf.transaction.Node.{
-  NodeRollback,
-  NodeCreate,
-  NodeExercises,
-  NodeFetch,
-  NodeLookupByKey,
-}
-import com.daml.lf.transaction.{GlobalKey, NodeId, Versioned}
+import com.daml.lf.transaction.{GlobalKey, Node, NodeId, Versioned}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.script.converter.ConverterException
@@ -176,14 +169,14 @@ class IdeLedgerClient(
             throw new IllegalArgumentException(s"Unknown root node id $id"),
           )
           node match {
-            case create: NodeCreate => ScriptLedgerClient.CreateResult(create.coid)
-            case exercise: NodeExercises =>
+            case create: Node.Create => ScriptLedgerClient.CreateResult(create.coid)
+            case exercise: Node.Exercise =>
               ScriptLedgerClient.ExerciseResult(
                 exercise.templateId,
                 exercise.choiceId,
                 exercise.exerciseResult.get,
               )
-            case _: NodeFetch | _: NodeLookupByKey | _: NodeRollback =>
+            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback =>
               throw new IllegalArgumentException(s"Invalid root node: $node")
           }
         }
@@ -227,9 +220,9 @@ class IdeLedgerClient(
         val transaction = result.richTransaction.transaction
         def convEvent(id: NodeId): Option[ScriptLedgerClient.TreeEvent] =
           transaction.nodes(id) match {
-            case create: NodeCreate =>
+            case create: Node.Create =>
               Some(ScriptLedgerClient.Created(create.templateId, create.coid, create.arg))
-            case exercise: NodeExercises =>
+            case exercise: Node.Exercise =>
               Some(
                 ScriptLedgerClient.Exercised(
                   exercise.templateId,
@@ -239,7 +232,7 @@ class IdeLedgerClient(
                   exercise.children.collect(Function.unlift(convEvent(_))).toList,
                 )
               )
-            case _: NodeFetch | _: NodeLookupByKey | _: NodeRollback => None
+            case _: Node.Fetch | _: Node.LookupByKey | _: Node.Rollback => None
           }
         ScriptLedgerClient.TransactionTree(
           transaction.roots.collect(Function.unlift(convEvent(_))).toList

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V4_1__Collect_Parties.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V4_1__Collect_Parties.scala
@@ -9,14 +9,7 @@ import java.sql.{Connection, ResultSet}
 
 import anorm.{BatchSql, NamedParameter}
 import com.daml.lf.data.Ref
-import com.daml.lf.transaction.VersionedTransaction
-import com.daml.lf.transaction.Node.{
-  NodeRollback,
-  NodeCreate,
-  NodeExercises,
-  NodeFetch,
-  NodeLookupByKey,
-}
+import com.daml.lf.transaction.{Node, VersionedTransaction}
 import com.daml.platform.store.Conversions._
 import com.daml.platform.db.migration.translation.TransactionSerializer
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
@@ -106,22 +99,22 @@ private[migration] class V4_1__Collect_Parties extends BaseJavaMigration {
     transaction
       .fold[Set[Ref.Party]](Set.empty) { case (parties, (_, node)) =>
         node match {
-          case _: NodeRollback => Set.empty
-          case nf: NodeFetch =>
+          case _: Node.Rollback => Set.empty
+          case nf: Node.Fetch =>
             parties
               .union(nf.signatories)
               .union(nf.stakeholders)
               .union(nf.actingParties)
-          case nc: NodeCreate =>
+          case nc: Node.Create =>
             parties
               .union(nc.signatories)
               .union(nc.stakeholders)
-          case ne: NodeExercises =>
+          case ne: Node.Exercise =>
             parties
               .union(ne.signatories)
               .union(ne.stakeholders)
               .union(ne.actingParties)
-          case _: NodeLookupByKey =>
+          case _: Node.LookupByKey =>
             parties
         }
       }


### PR DESCRIPTION
Because of a bug in the scala compiler, deprecated pattern matchings are
not detected (See https://github.com/scala/bug/issues/12493).
Hence some deprecated usage of Node aliases have been forgotten in #11469

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
