### PR TITLE
Use explicit party specifications in Daml Script over JSON API

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -223,20 +223,20 @@ class JsonLedgerClient(
       mat: Materializer,
   ): Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = {
     for {
-      optPartySets <- validateSubmitParties(actAs, readAs)
+      partySets <- validateSubmitParties(actAs, readAs)
 
       result <- commands match {
         case Nil => Future { Right(List()) }
         case cmd :: Nil =>
           cmd match {
             case command.CreateCommand(tplId, argument) =>
-              create(tplId, argument, optPartySets)
+              create(tplId, argument, partySets)
             case command.ExerciseCommand(tplId, cid, choice, argument) =>
-              exercise(tplId, cid, choice, argument, optPartySets)
+              exercise(tplId, cid, choice, argument, partySets)
             case command.ExerciseByKeyCommand(tplId, key, choice, argument) =>
-              exerciseByKey(tplId, key, choice, argument, optPartySets)
+              exerciseByKey(tplId, key, choice, argument, partySets)
             case command.CreateAndExerciseCommand(tplId, template, choice, argument) =>
-              createAndExercise(tplId, template, choice, argument, optPartySets)
+              createAndExercise(tplId, template, choice, argument, partySets)
           }
         case _ =>
           Future.failed(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -329,7 +329,11 @@ class JsonLedgerClient(
           s"Tried to $what as ${parties.toList.mkString(" ")} but token contains no parties."
         )
       )
-    } else if (missingParties.isEmpty) {
+    } else if (missingParties.nonEmpty) {
+      Future.failed(new RuntimeException(s"Tried to $what as [${parties.toList
+        .mkString(", ")}] but token provides claims for [${tokenParties
+        .mkString(", ")}]. Missing claims: [${missingParties.mkString(", ")}]"))
+    } else {
       import scalaz.std.string._
       if (partiesSet === tokenParties) {
         // For backwards-compatibility we only set the party set flags when needed
@@ -337,10 +341,6 @@ class JsonLedgerClient(
       } else {
         Future.successful(Some(QueryParties(parties)))
       }
-    } else {
-      Future.failed(new RuntimeException(s"Tried to $what as [${parties.toList
-        .mkString(", ")}] but token provides claims for [${tokenParties
-        .mkString(", ")}]. Missing claims: [${missingParties.mkString(", ")}]"))
     }
   }
 

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -350,6 +350,8 @@ template MultiPartyContract
         actualContract <- fetch cid
         return ()
 
+deriving instance Ord MultiPartyContract
+
 multiPartySubmission : Script ()
 multiPartySubmission = do
   p1 <- allocateParty "p1"
@@ -409,3 +411,31 @@ jsonMultiPartySubmissionCreate (p1, p2) = do
 jsonMultiPartySubmissionExercise : (Party, Party, ContractId MultiPartyContract, ContractId MultiPartyContract) -> Script ()
 jsonMultiPartySubmissionExercise (p1, p2, cid, cidFetch) = do
   submitMulti [p2] [p1] (exerciseCmd cid (MPFetchOther cidFetch p2))
+
+-- Run a test with a token with actAs = [p1, p2], readAs = []
+jsonMultiPartyPartySets : (Party, Party) -> Script ()
+jsonMultiPartyPartySets (p1, p2) = do
+  -- We can use authority from both parties
+  submitMulti [p1, p2] [] $ createCmd (T p1 p2)
+  -- Despite having a multi-party token we can still do single-party submissions
+  submitMulti [p1] [] $ createCmd (T p1 p1)
+  submitMulti [p2] [] $ createCmd (T p2 p2)
+  -- A single party submission that requires authority from both fails
+  submitMultiMustFail [p1] [] $ createCmd (T p1 p2)
+  submitMultiMustFail [p2] [] $ createCmd (T p1 p2)
+  -- We can also use the parties as readAs since actAs implies readAs
+  cid <- submitMulti [p1, p2] [] $ createCmd (MultiPartyContract [p1, p2])
+  ownedByP1 <- submitMulti [p1] [] $ createCmd (MultiPartyContract [p1])
+  submitMultiMustFail [p2] [] $ exerciseCmd cid (MPFetchOther ownedByP1 p2)
+  submitMulti [p2] [p1] $ exerciseCmd cid (MPFetchOther ownedByP1 p2)
+  -- Query works for both parties
+  rs <- query @MultiPartyContract [p1, p2]
+  sort (map snd rs) === [MultiPartyContract [p1], MultiPartyContract [p1, p2]]
+  -- Query works for a single party
+  rs <- query @MultiPartyContract p2
+  sort (map snd rs) === [MultiPartyContract [p1, p2]]
+  r <- queryContractId p1 ownedByP1
+  r === Some (MultiPartyContract [p1])
+  r <- queryContractId p2 ownedByP1
+  r === None
+  pure ()

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -304,7 +304,7 @@ final class JsonApiIt
         )
       } yield {
         assert(
-          exception.getCause.getMessage === "Tried to submit a command with actAs = [Bob] but token provides claims for actAs = [Alice]"
+          exception.getCause.getMessage === "Tried to submit a command with actAs = [Bob] but token provides claims for actAs = [Alice]. Missing claims: [Bob]"
         )
       }
     }
@@ -338,7 +338,7 @@ final class JsonApiIt
         )
       } yield {
         assert(
-          exception.getCause.getMessage === "Tried to query as Bob but token provides claims for Alice"
+          exception.getCause.getMessage === "Tried to query as [Bob] but token provides claims for [Alice]. Missing claims: [Bob]"
         )
       }
     }
@@ -491,6 +491,20 @@ final class JsonApiIt
         )
       } yield {
         assert(r == SUnit)
+      }
+    }
+    "party-set arguments" in {
+      val party1 = "partySetArguments1"
+      val party2 = "partySetArguments2"
+      for {
+        clients <- getMultiPartyClients(List(party1, party2))
+        r <- run(
+          clients,
+          QualifiedName.assertFromString("ScriptTest:jsonMultiPartyPartySets"),
+          inputValue = Some(JsArray(JsString(party1), JsString(party2))),
+        )
+      } yield {
+        r shouldBe SUnit
       }
     }
     "invalid response" in {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonPartyValidation.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonPartyValidation.scala
@@ -34,7 +34,7 @@ final class JsonPartyValidation extends AnyWordSpec with Matchers {
         OneAnd(alice, Set.empty),
         Set.empty,
         token(List(alice), List()),
-      ) shouldBe Right(())
+      ) shouldBe Right(None)
     }
     "fail for no actAs party" in {
       validateSubmitParties(OneAnd(alice, Set.empty), Set.empty, token(List(), List())) shouldBe a[
@@ -46,14 +46,14 @@ final class JsonPartyValidation extends AnyWordSpec with Matchers {
         OneAnd(alice, Set.empty),
         Set.empty,
         token(List(alice, alice), List()),
-      ) shouldBe Right(())
+      ) shouldBe Right(None)
     }
     "handle duplicate actAs in submit" in {
       validateSubmitParties(
         OneAnd(alice, Set(alice)),
         Set.empty,
         token(List(alice), List()),
-      ) shouldBe Right(())
+      ) shouldBe Right(None)
     }
     "fail for missing readAs party" in {
       validateSubmitParties(
@@ -67,21 +67,21 @@ final class JsonPartyValidation extends AnyWordSpec with Matchers {
         OneAnd(alice, Set.empty),
         Set(bob),
         token(List(alice), List(bob)),
-      ) shouldBe Right(())
+      ) shouldBe Right(None)
     }
     "ignore party that is in readAs and actAs in token" in {
       validateSubmitParties(
         OneAnd(alice, Set.empty),
         Set(),
         token(List(alice), List(alice)),
-      ) shouldBe Right(())
+      ) shouldBe Right(None)
     }
     "ignore party that is in readAs and actAs in submit" in {
       validateSubmitParties(
         OneAnd(alice, Set.empty),
         Set(alice),
         token(List(alice), List()),
-      ) shouldBe Right(())
+      ) shouldBe Right(None)
     }
     "fail if party is in actAs in submit but only in readAs in token" in {
       validateSubmitParties(OneAnd(alice, Set.empty), Set(), token(List(), List(alice))) shouldBe a[
@@ -93,14 +93,28 @@ final class JsonPartyValidation extends AnyWordSpec with Matchers {
         OneAnd(alice, Set.empty),
         Set(bob),
         token(List(alice), List(bob, bob)),
-      ) shouldBe Right(())
+      ) shouldBe Right(None)
     }
     "handle duplicate readAs in submit" in {
       validateSubmitParties(
         OneAnd(alice, Set.empty),
         Set(bob, bob),
         token(List(alice), List(bob)),
-      ) shouldBe Right(())
+      ) shouldBe Right(None)
+    }
+    "return explicit party specification for constrained actAs" in {
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set.empty,
+        token(List(alice, bob), List()),
+      ) shouldBe Right(Some(SubmitParties(OneAnd(alice, Set.empty), Set.empty)))
+    }
+    "return explicit party specification for constrained readAs" in {
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set.empty,
+        token(List(alice), List(bob)),
+      ) shouldBe Right(Some(SubmitParties(OneAnd(alice, Set.empty), Set.empty)))
     }
   }
 }

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -403,7 +403,7 @@ abstract class AbstractFuncIT
           end,
         )
         e.cmd.stackTrace shouldBe StackTrace(
-          Vector(loc("submit", (390, 18), (390, 31)), loc("mySubmit", (395, 2), (395, 12)))
+          Vector(loc("submit", (392, 18), (392, 31)), loc("mySubmit", (397, 2), (397, 12)))
         )
       }
     }


### PR DESCRIPTION
This uses the new party set arguments from #11454 to allow Daml Script
over the JSON API to `submit p` even if we have a token with more
claims.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
