### PR TITLE
[TS-Bindings] Changes to re-enable ws multiplexing

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/jest.setup.js
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/jest.setup.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-jest.setTimeout(60000);
+jest.setTimeout(90000);
 

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -28,6 +28,8 @@ const ALICE_PARTY = 'Alice';
 const ALICE_TOKEN = computeToken(ALICE_PARTY);
 const BOB_PARTY = 'Bob';
 const BOB_TOKEN = computeToken(BOB_PARTY);
+const CHARLIE_PARTY = 'Charlie'
+const CHARLIE_TOKEN = computeToken(CHARLIE_PARTY)
 
 let sandboxPort: number | undefined = undefined;
 const SANDBOX_PORT_FILE = 'sandbox.port';
@@ -77,7 +79,7 @@ beforeAll(async () => {
     getEnv('JSON_API'),
     ['--ledger-host', 'localhost', '--ledger-port', `${sandboxPort}`,
      '--port-file', JSON_API_PORT_FILE, '--http-port', "0",
-     '--allow-insecure-tokens', '--websocket-config', '--heartBeatPer=1', '--log-level=INFO'],
+     '--allow-insecure-tokens', '--websocket-config=maxDuration=1,heartBeatPer=1', '--log-level=INFO'],
     ['-Dakka.http.server.request-timeout=60s'],
   )
   await waitOn({resources: [`file:${JSON_API_PORT_FILE}`]})
@@ -216,7 +218,7 @@ test('create + fetch & exercise', async () => {
   const personRawStream = aliceLedger.streamQuery(buildAndLint.Main.Person);
   const personStream = promisifyStream(personRawStream);
   const personStreamLive = pEvent(personRawStream, 'live');
-  expect(await personStream.next()).toEqual([[alice6Contract], [{created: alice6Contract, matchedQueries:[0]}]]);
+  expect(await personStream.next()).toEqual([[alice6Contract], [{created: alice6Contract, matchedQueries:[1]}]]);
 
   // end of non-live data, first offset
   expect(await personStreamLive).toEqual([alice6Contract]);
@@ -226,7 +228,7 @@ test('create + fetch & exercise', async () => {
   const bob4Contract = await bobLedger.create(buildAndLint.Main.Person, bob4);
   expect(bob4Contract.payload).toEqual(bob4);
   expect(bob4Contract.key).toEqual(bob4Key);
-  expect(await personStream.next()).toEqual([[alice6Contract, bob4Contract], [{created: bob4Contract, matchedQueries:[0]}]]);
+  expect(await personStream.next()).toEqual([[alice6Contract, bob4Contract], [{created: bob4Contract, matchedQueries:[1]}]]);
 
 
   // Alice changes her name.
@@ -243,7 +245,7 @@ test('create + fetch & exercise', async () => {
   expect(cooper6Contract.key).toEqual(alice6Key);
   expect(await aliceStream.next()).toEqual([[cooper6Contract], [{archived: alice6Archived}, {created: cooper6Contract, matchedQueries:[0]}]]);
   expect(await alice6KeyStream.next()).toEqual([cooper6Contract, [{archived: alice6Archived}, {created: cooper6Contract}]]);
-  expect(await personStream.next()).toEqual([[bob4Contract, cooper6Contract], [{archived: alice6Archived}, {created: cooper6Contract, matchedQueries:[0]}]]);
+  expect(await personStream.next()).toEqual([[bob4Contract, cooper6Contract], [{archived: alice6Archived}, {created: cooper6Contract, matchedQueries:[1]}]]);
 
   personContracts = await aliceLedger.query(buildAndLint.Main.Person);
   expect(personContracts).toEqual([bob4Contract, cooper6Contract]);
@@ -610,4 +612,39 @@ test('package API', async () => {
 
   const downSuc = await ledger.getPackage(buildAndLint.packageId);
   expect(downSuc.byteLength > 0).toBe(true);
+});
+
+test('reconnect on timeout, when multiplexing is enabled', async () => {
+  const charlieLedger = new Ledger({token: CHARLIE_TOKEN, httpBaseUrl: httpBaseUrl(), multiplexQueryStreams: true});
+  const charlieRawStream = charlieLedger.streamQuery(buildAndLint.Main.Person, {party: CHARLIE_PARTY});
+  const charlieStream = promisifyStream(charlieRawStream);
+  const charlieStreamLive = pEvent(charlieRawStream, 'live');
+  expect(await charlieStreamLive).toEqual([]);
+
+  const charlieRecord1: buildAndLint.Main.Person = {
+    name: 'Charlie Chaplin',
+    party: CHARLIE_PARTY,
+    age: '10',
+    friends: [],
+  };
+
+  const charlieContract1 = await charlieLedger.create(buildAndLint.Main.Person, charlieRecord1);
+  expect(await charlieStream.next()).toEqual([[charlieContract1], [{created: charlieContract1, matchedQueries: [0]}]]);
+
+  // wait 70s to trigger a disconnect on json-api which is configured to close conn after 1 minute.
+  await new Promise(resolve => setTimeout(resolve, 70000));
+
+  const charlieRecord2: buildAndLint.Main.Person = {
+    name: 'Charlie and the chocolate factory',
+    party: CHARLIE_PARTY,
+    age: '5',
+    friends: [],
+  };
+
+  // ensure that we can write and read data post reconnect.
+  const charlieContract2 = await charlieLedger.create(buildAndLint.Main.Person, charlieRecord2);
+  expect(await charlieStream.next()).toEqual([[charlieContract1, charlieContract2], [{created: charlieContract2, matchedQueries: [0]}]]);
+
+  charlieStream.close();
+
 });

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -478,18 +478,18 @@ class QueryStreamsManager {
     }
 
     private handleQueriesChange(): void {
-        if (this.queries.size > 0) {
+        //eslint-disable-next-line @typescript-eslint/no-this-alias
+        const manager = this; // stable self-reference for callbacks
 
-            if (this.ws !== undefined) {
+        if (manager.queries.size > 0) {
+
+            if (manager.ws !== undefined) {
                 //set the queries change flag to true, this should eventually get reset once the ws is closed.
-                this.wsQueriesChange = true;
-                this.wsLiveSince = undefined;
-                this.ws.close();
-                this.ws = undefined;
+                manager.wsQueriesChange = true;
+                manager.wsLiveSince = undefined;
+                manager.ws.close();
+                manager.ws = undefined;
             }
-
-            //eslint-disable-next-line @typescript-eslint/no-this-alias
-            const manager = this; // stable self-reference for callbacks
 
             const ws = new WebSocket(manager.url, manager.protocols);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -567,10 +567,10 @@ class QueryStreamsManager {
 
             const onWsOpen = (): void => {
                 // only make a new websocket request if we have registered queries
-                if(this.queries.size > 0) {
+                if(manager.queries.size > 0) {
                     let newRequests: StreamingQueryRequest[] = [];
                     let newMatchIndexLookupTable: [StreamingQuery<object, unknown, string>, number][] = [];
-                    for (const query of materialize(this.queries.values())) {
+                    for (const query of materialize(manager.queries.values())) {
 
                         const request = QueryStreamsManager.toRequest(query);
 
@@ -582,16 +582,16 @@ class QueryStreamsManager {
                         // Add entries to the lookup table for archive events
                         for (const {templateIds} of request) {
                             for (const templateId of templateIds) {
-                                this.templateIdsLookupTable[templateId] = this.templateIdsLookupTable[templateId] || new Set();
-                                this.templateIdsLookupTable[templateId].add(query);
+                                manager.templateIdsLookupTable[templateId] = manager.templateIdsLookupTable[templateId] || new Set();
+                                manager.templateIdsLookupTable[templateId].add(query);
                             }
                         }
 
                         //since we go through all queries on the manager, we should be safely able to rebuild the whole request
                         newRequests = newRequests.concat(request);
                     }
-                    this.request = newRequests;
-                    this.matchIndexLookupTable = newMatchIndexLookupTable;
+                    manager.request = newRequests;
+                    manager.matchIndexLookupTable = newMatchIndexLookupTable;
                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                     manager.ws?.send(JSON.stringify(Array.from(manager.request.values())));
                 }

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -493,8 +493,8 @@ class QueryStreamsManager {
 
             const ws = new WebSocket(manager.url, manager.protocols);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const onWsMessage = ({data}: {data: any}): void => {
-                if(manager.ws?.readyState === WsState.Open) {
+            const onWsMessage = (ws: WebSocket) => ({data}: {data: any}): void => {
+                if(ws.readyState === WsState.Open) {
                     const json: unknown = JSON.parse(data.toString());
                     if (isRecordWith('events', json)) {
                         const events: Event<object>[] = jtv.Result.withException(jtv.array(decodeEventUnknown).run(json.events));
@@ -608,7 +608,7 @@ class QueryStreamsManager {
                         manager.wsLiveSince = undefined;
                         const ws = new WebSocket(manager.url, manager.protocols);
                         ws.addEventListener('open', onWsOpen);
-                        ws.addEventListener('message', onWsMessage);
+                        ws.addEventListener('message', onWsMessage(ws));
                         ws.addEventListener('close', onWsClose);
                         manager.ws = ws;
                     } else {
@@ -627,7 +627,7 @@ class QueryStreamsManager {
             // Purposefully ignoring 'error' events; they are always followed by a 'close' event, which needs to be handled anyway
 
             ws.addEventListener('open', onWsOpen);
-            ws.addEventListener('message', onWsMessage);
+            ws.addEventListener('message', onWsMessage(ws));
             ws.addEventListener('close', onWsClose);
 
             //eslint-disable-next-line @typescript-eslint/no-this-alias

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/Config.scala
@@ -74,7 +74,7 @@ private[http] object WebsocketConfig
     extends ConfigCompanion[WebsocketConfig, DummyImplicit]("WebsocketConfig") {
 
   implicit val showInstance: Show[WebsocketConfig] = Show.shows(c =>
-    s"WebsocketConfig(maxDuration=${c.maxDuration}, heartBeatPer=${c.heartBeatPer}.seconds)"
+    s"WebsocketConfig(maxDuration=${c.maxDuration}, heartBeatPer=${c.heartBeatPer})"
   )
 
   lazy val help: String =

--- a/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/WebsocketServiceOffsetTickIntTest.scala
@@ -88,4 +88,26 @@ class WebsocketServiceOffsetTickIntTest
         }
       }
   }
+
+  "Given an offset to resume at inside the query, we should immediately start emitting ticks" in withHttpServiceAndClient {
+    (uri, _, _, client, ledgerId) =>
+      for {
+        ledgerOffset <- client.transactionClient
+          .getLedgerEnd(ledgerId)
+          .map(domain.Offset.fromLedgerApi(_))
+        _ = println(ledgerOffset)
+        msgs <- singleClientQueryStream(
+          jwt,
+          uri,
+          s"""[{"templateIds": ["Iou:Iou"], "offset": "$ledgerOffset"}]""",
+        )
+          .take(10)
+          .runWith(collectResultsAsTextMessage)
+      } yield {
+        inside(eventsBlockVector(msgs.toVector)) { case \/-(offsetTicks) =>
+          offsetTicks.forall(isAbsoluteOffsetTick) shouldBe true
+          offsetTicks should have length 10
+        }
+      }
+  }
 }


### PR DESCRIPTION
There were 2 issues here 
 - one was that on reconnect we created a new websocket connection but the `onMessage` handler still referred to the old ws object. Now the `onMessage` handler takes a websocket as an input argument.
 - the second issue was that we didn't update `wsLiveSince` parameter on the first message with offset , which indicated that the stream is live. 


CHANGELOG_BEGIN
[TS-BINDINGS] Renable ws multiplexing for stream queries after resolving the reconnect connection close bug.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
