### PR TITLE
LF: Reintroduce TransactionVersion.asVersionedTransaction

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2302,10 +2302,8 @@ object EngineTest {
 
     finalState.map(state =>
       (
-        VersionedTransaction(
-          state.nodes.values.map(_.optVersion.getOrElse(TxVersions.minVersion)).max,
-          state.nodes,
-          state.roots.toImmArray,
+        TxVersions.asVersionedTransaction(
+          Tx(state.nodes, state.roots.toImmArray)
         ),
         Tx.Metadata(
           submissionSeed = None,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -73,7 +73,7 @@ object TransactionVersion {
       tx: Transaction
   ): VersionedTransaction = tx match {
     case Transaction(nodes, roots) =>
-      val txVersion = roots.iterator.foldLeft(minVersion)((acc, nodeId) =>
+      val txVersion = roots.foldLeft(minVersion)((acc, nodeId) =>
         nodes(nodeId) match {
           case action: Node.Action => acc max action.version
           case _: Node.Rollback => acc max minExceptions

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -6,8 +6,6 @@ package transaction
 
 import com.daml.lf.language.LanguageVersion
 
-import scala.Ordering.Implicits.infixOrderingOps
-
 sealed abstract class TransactionVersion private (val protoValue: String, private val index: Int)
     extends Product
     with Serializable
@@ -73,13 +71,13 @@ object TransactionVersion {
       tx: Transaction
   ): VersionedTransaction = tx match {
     case Transaction(nodes, roots) =>
-      val txVersion = roots.foldLeft(minVersion)((acc, nodeId) =>
+      val rootVersions = roots.iterator.map(nodeId =>
         nodes(nodeId) match {
-          case action: Node.Action => acc max action.version
-          case _: Node.Rollback => acc max minExceptions
+          case action: Node.Action => action.version
+          case _: Node.Rollback => minExceptions
         }
       )
-      VersionedTransaction(txVersion, nodes, roots)
+      VersionedTransaction(rootVersions.max, nodes, roots)
   }
 
   val StableVersions: VersionRange[TransactionVersion] =


### PR DESCRIPTION
This have been drop in #11626, but canton is using it.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
