### PR TITLE
fix Nix install on macOS nodes

### DIFF
--- a/infra/macos/2-common-box/init.sh
+++ b/infra/macos/2-common-box/init.sh
@@ -114,10 +114,14 @@ echo "created cache partitions"
 
 # Note: installing Nix in single-user mode with /nix already existing and
 # writeable does not require sudoer access
+# Single-user install is no longer available in the 2.4+ installer, so we pin
+# _the installer_ to 2.3.16 then upgrade to nix 2.4.x.
 su -l vsts <<'END'
 set -euo pipefail
 export PATH="/usr/local/bin:/usr/sbin:$PATH"
-bash <(curl -sSfL https://nixos.org/nix/install)
+bash <(curl -sSfL https://releases.nixos.org/nix/nix-2.3.16/install)
+export PATH="$HOME/.nix-profile/bin:$PATH"
+nix-channel --update && nix-env -iA nixpkgs.nix_2_4
 echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
 END
 


### PR DESCRIPTION
As part of the 2.4 release, the Nix installer has been changed to take care of the volume setup (which we don't want it to do here). Because that requires root access, they've decided to make multi-user install the default, and to disable single-user install.

We could do an in-depth review of the difference and adapt our setup to use a multi-user setup (we do use the multi-user setup on Linux, so there's precedent), but as an immediate fix, we can keep our single-user setup _and_ get the latest Nix by using the 2.3.16 installer and then upgrading from within Nix itself. This _should_ keep working at least for a while, as Linux still defaults to single-user.

CHANGELOG_BEGIN
CHANGELOG_END