### PR TITLE
Add `cpu:2` tag to extractor tests

### DIFF
--- a/extractor/extractor.bzl
+++ b/extractor/extractor.bzl
@@ -12,6 +12,7 @@ def extractor_test(name, srcs, flaky):
         name = name,
         flaky = flaky,
         size = "medium",
+        tags = ["cpu:2"],
         srcs = srcs,
         data = [
             "//daml-lf/encoder:testing-dar-latest",


### PR DESCRIPTION
This will limit the parallelism of extractor integration tests.

Each test runs now a bit faster although overall all tests seem
to run a bit slower. This seems a good compromise as it should
limit the contention over system resources between various
integration tests, each running a PostgreSQL instance and sharing
various system resources.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
