### PR TITLE
ledger-api-bench-tool: Allocate observers indexed from 0 [DPP-669]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/CommandSubmitter.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/CommandSubmitter.scala
@@ -71,7 +71,7 @@ case class CommandSubmitter(services: LedgerApiServices) {
   private def allocateParties(number: Int, name: Int => String)(implicit
       ec: ExecutionContext
   ): Future[List[Primitive.Party]] =
-    (1 to number).foldLeft(Future.successful(List.empty[Primitive.Party])) { (allocated, i) =>
+    (0 until number).foldLeft(Future.successful(List.empty[Primitive.Party])) { (allocated, i) =>
       allocated.flatMap { parties =>
         services.partyManagementService.allocateParty(name(i)).map(party => parties :+ party)
       }


### PR DESCRIPTION
ledger-api-bench-tool: Index observers in the submission starting from 0 until the total number.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
