### PR TITLE
Log execution context throwables as error

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/AsyncSupport.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/AsyncSupport.scala
@@ -31,7 +31,7 @@ object AsyncSupport {
       size: Int,
       namePrefix: String,
       withMetric: Option[(MetricName, MetricRegistry)] = None,
-  ): ResourceOwner[Executor] =
+  )(implicit loggingContext: LoggingContext): ResourceOwner[Executor] =
     ResourceOwner
       .forExecutorService(() =>
         ExecutionContext.fromExecutorService(
@@ -54,11 +54,9 @@ object AsyncSupport {
             }
           },
           throwable =>
-            LoggingContext.newLoggingContext { implicit loggingContext =>
-              ContextualizedLogger
-                .get(this.getClass)
-                .error(s"ExecutionContext ${namePrefix} has failed with an exception", throwable)
-            },
+            ContextualizedLogger
+              .get(this.getClass)
+              .error(s"ExecutionContext ${namePrefix} has failed with an exception", throwable),
         )
       )
       .map(Executor.forExecutionContext)

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -70,14 +70,12 @@ object ParallelIndexerFactory {
                     new ThreadFactoryBuilder().setNameFormat(s"ha-coordinator-%d").build,
                   ),
                   throwable =>
-                    LoggingContext.newLoggingContext { implicit loggingContext =>
-                      ContextualizedLogger
-                        .get(this.getClass)
-                        .error(
-                          s"ExecutionContext ${jdbcUrl} has failed with an exception",
-                          throwable,
-                        )
-                    },
+                    ContextualizedLogger
+                      .get(this.getClass)
+                      .error(
+                        s"ExecutionContext has failed with an exception",
+                        throwable,
+                      ),
                 )
               )
             timer <- ResourceOwner.forTimer(() => new Timer)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/DbDispatcher.scala
@@ -25,15 +25,13 @@ private[platform] final class DbDispatcher private (
     executor: Executor,
     overallWaitTimer: Timer,
     overallExecutionTimer: Timer,
-) extends ReportsHealth {
+)(implicit loggingContext: LoggingContext)
+    extends ReportsHealth {
 
   private val logger = ContextualizedLogger.get(this.getClass)
   private val executionContext = ExecutionContext.fromExecutor(
     executor,
-    throwable =>
-      LoggingContext.newLoggingContext { implicit loggingContext =>
-        logger.error("ExecutionContext has failed with an exception", throwable)
-      },
+    throwable => logger.error("ExecutionContext has failed with an exception", throwable),
   )
 
   override def currentHealth(): HealthStatus =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/DbDispatcher.scala
@@ -28,7 +28,13 @@ private[platform] final class DbDispatcher private (
 ) extends ReportsHealth {
 
   private val logger = ContextualizedLogger.get(this.getClass)
-  private val executionContext = ExecutionContext.fromExecutor(executor)
+  private val executionContext = ExecutionContext.fromExecutor(
+    executor,
+    throwable =>
+      LoggingContext.newLoggingContext { implicit loggingContext =>
+        logger.error("ExecutionContext has failed with an exception", throwable)
+      },
+  )
 
   override def currentHealth(): HealthStatus =
     connectionProvider.currentHealth()


### PR DESCRIPTION
In canton we are observing `RejectionExecutionException` shutdown errors that we have not been able to isolate. @daravep found that this may be because without providing a `reporter: Throwable => Unit`, the root cause failures go to stderr instead.

Could you take a look at the attached code and help us "make it real", so that we can track down the root cause?

changelog_begin
changelog_end

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
