### PR TITLE
libs-scala: Move `SourceQueueResourceOwner` from the Integration Kit

### DIFF
--- a/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/AkkaResourceOwnerFactories.scala
+++ b/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/AkkaResourceOwnerFactories.scala
@@ -5,6 +5,7 @@ package com.daml.resources.akka
 
 import akka.actor.{ActorSystem, Cancellable}
 import akka.stream.Materializer
+import akka.stream.scaladsl.{RunnableGraph, SourceQueue, SourceQueueWithComplete}
 import com.daml.resources.{AbstractResourceOwner, HasExecutionContext}
 
 trait AkkaResourceOwnerFactories[Context] {
@@ -26,4 +27,9 @@ trait AkkaResourceOwnerFactories[Context] {
 
   def forCancellable[C <: Cancellable](acquire: () => C): AbstractResourceOwner[Context, C] =
     new CancellableResourceOwner(acquire)
+
+  def forSourceQueue[T](
+      queueGraph: RunnableGraph[SourceQueueWithComplete[T]]
+  )(implicit materializer: Materializer): AbstractResourceOwner[Context, SourceQueue[T]] =
+    new SourceQueueResourceOwner[T, Context](queueGraph)
 }

--- a/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/SourceQueueResourceOwner.scala
+++ b/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/SourceQueueResourceOwner.scala
@@ -15,10 +15,8 @@ class SourceQueueResourceOwner[T, Context: HasExecutionContext](
     materializer: Materializer
 ) extends AbstractResourceOwner[Context, SourceQueue[T]] {
   override def acquire()(implicit context: Context): Resource[Context, SourceQueue[T]] =
-    ReleasableResource(Future(queueGraph.run()))(queue =>
-      {
-        queue.complete()
-        queue.watchCompletion()
-      }.map(_ => ())
-    )
+    ReleasableResource(Future(queueGraph.run())) { queue =>
+      queue.complete()
+      queue.watchCompletion().map(_ => ())
+    }
 }

--- a/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/SourceQueueResourceOwner.scala
+++ b/libs-scala/resources-akka/src/main/scala/com/digitalasset/resources/akka/SourceQueueResourceOwner.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.resources.akka
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.{RunnableGraph, SourceQueue, SourceQueueWithComplete}
+import com.daml.resources.{AbstractResourceOwner, HasExecutionContext, ReleasableResource, Resource}
+
+import scala.concurrent.Future
+
+class SourceQueueResourceOwner[T, Context: HasExecutionContext](
+    queueGraph: RunnableGraph[SourceQueueWithComplete[T]]
+)(implicit
+    materializer: Materializer
+) extends AbstractResourceOwner[Context, SourceQueue[T]] {
+  override def acquire()(implicit context: Context): Resource[Context, SourceQueue[T]] =
+    ReleasableResource(Future(queueGraph.run()))(queue =>
+      {
+        queue.complete()
+        queue.watchCompletion()
+      }.map(_ => ())
+    )
+}

--- a/libs-scala/resources-akka/src/test/suite/scala/com/digitalasset/resources/akka/AkkaResourceOwnerSpec.scala
+++ b/libs-scala/resources-akka/src/test/suite/scala/com/digitalasset/resources/akka/AkkaResourceOwnerSpec.scala
@@ -4,6 +4,7 @@
 package com.daml.resources.akka
 
 import java.util.concurrent.atomic.AtomicBoolean
+
 import akka.actor.{Actor, ActorSystem, Cancellable, Props}
 import akka.stream.{Materializer, OverflowStrategy, QueueOfferResult}
 import akka.stream.scaladsl.{Keep, Sink, Source}


### PR DESCRIPTION
Not one-to-one tho, so please check if these changes make sense.
I also checked current usages of `Source.queue` and none of them would be reasonable to migrate.
It is going to be used solely by the Integration Kit, at least for now.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
