### PR TITLE
participant-integration-api: Propagate log context through the indexer.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -38,9 +38,11 @@ object JdbcIndexer {
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslationCache.Cache,
-  )(implicit materializer: Materializer, loggingContext: LoggingContext) {
+  )(implicit materializer: Materializer) {
 
-    def initialized(resetSchema: Boolean = false): ResourceOwner[Indexer] = {
+    def initialized(
+        resetSchema: Boolean = false
+    )(implicit loggingContext: LoggingContext): ResourceOwner[Indexer] = {
       val factory = StorageBackendFactory.of(DbType.jdbcType(config.jdbcUrl))
       val dataSourceStorageBackend = factory.createDataSourceStorageBackend
       val ingestionStorageBackend = factory.createIngestionStorageBackend
@@ -110,7 +112,7 @@ object JdbcIndexer {
     private def reset(
         resetStorageBackend: ResetStorageBackend,
         dataSourceStorageBackend: DataSourceStorageBackend,
-    ): ResourceOwner[Unit] =
+    )(implicit loggingContext: LoggingContext): ResourceOwner[Unit] =
       ResourceOwner.forFuture(() =>
         Future(
           Using.resource(dataSourceStorageBackend.createDataSource(config.jdbcUrl).getConnection)(

--- a/ledger/participant-state/kvutils/app/BUILD.bazel
+++ b/ledger/participant-state/kvutils/app/BUILD.bazel
@@ -49,6 +49,7 @@ da_scala_library(
         "//ledger/participant-state-metrics",
         "//ledger/participant-state/kvutils",
         "//libs-scala/contextualized-logging",
+        "//libs-scala/logging-entries",
         "//libs-scala/ports",
         "//libs-scala/resources",
         "//libs-scala/resources-akka",

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -18,7 +18,7 @@ import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.archive.DarParser
 import com.daml.lf.data.Ref
 import com.daml.lf.engine.{Engine, EngineConfig}
-import com.daml.logging.LoggingContext.newLoggingContext
+import com.daml.logging.LoggingContext.{newLoggingContext, withEnrichedLoggingContext}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.JvmMetricSet
 import com.daml.platform.apiserver.StandaloneApiServer
@@ -102,79 +102,83 @@ final class Runner[T <: ReadWriteService, Extra](
 
         // initialize all configured participants
         _ <- Resource.sequence(config.participants.map { participantConfig =>
-          val metrics = factory.createMetrics(participantConfig, config)
-          metrics.registry.registerAll(new JvmMetricSet)
-          val lfValueTranslationCache =
-            LfValueTranslationCache.Cache.newInstrumentedInstance(
-              eventConfiguration = config.lfValueTranslationEventCache,
-              contractConfiguration = config.lfValueTranslationContractCache,
-              metrics = metrics,
-            )
-          for {
-            _ <- config.metricsReporter.fold(Resource.unit)(reporter =>
-              ResourceOwner
-                .forCloseable(() => reporter.register(metrics.registry))
-                .map(_.start(config.metricsReportingInterval.getSeconds, TimeUnit.SECONDS))
-                .acquire()
-            )
-            ledger <- factory
-              .readWriteServiceOwner(config, participantConfig, sharedEngine)
-              .acquire()
-            readService = new TimedReadService(ledger, metrics)
-            writeService = new TimedWriteService(ledger, metrics)
-            healthChecks = new HealthChecks(
-              "read" -> readService,
-              "write" -> writeService,
-            )
-            _ <- Resource.sequence(
-              config.archiveFiles.map(path =>
-                Resource.fromFuture(uploadDar(path, writeService)(resourceContext.executionContext))
+          withEnrichedLoggingContext("participantId" -> participantConfig.participantId) {
+            implicit loggingContext =>
+              val metrics = factory.createMetrics(participantConfig, config)
+              metrics.registry.registerAll(new JvmMetricSet)
+              val lfValueTranslationCache = LfValueTranslationCache.Cache.newInstrumentedInstance(
+                eventConfiguration = config.lfValueTranslationEventCache,
+                contractConfiguration = config.lfValueTranslationContractCache,
+                metrics = metrics,
               )
-            )
-            servicesExecutionContext <- ResourceOwner
-              .forExecutorService(() =>
-                new InstrumentedExecutorService(
-                  Executors.newWorkStealingPool(),
-                  metrics.registry,
-                  metrics.daml.lapi.threadpool.apiServices.toString,
+              for {
+                _ <- config.metricsReporter.fold(Resource.unit)(reporter =>
+                  ResourceOwner
+                    .forCloseable(() => reporter.register(metrics.registry))
+                    .map(_.start(config.metricsReportingInterval.getSeconds, TimeUnit.SECONDS))
+                    .acquire()
                 )
-              )
-              .map(ExecutionContext.fromExecutorService)
-              .acquire()
-            healthChecksWithIndexer <- participantConfig.mode match {
-              case ParticipantRunMode.Combined | ParticipantRunMode.Indexer =>
-                new StandaloneIndexerServer(
-                  readService = readService,
-                  config = factory.indexerConfig(participantConfig, config),
-                  servicesExecutionContext = servicesExecutionContext,
-                  metrics = metrics,
-                  lfValueTranslationCache = lfValueTranslationCache,
-                ).acquire().map(indexerHealth => healthChecks + ("indexer" -> indexerHealth))
-              case ParticipantRunMode.LedgerApiServer =>
-                Resource.successful(healthChecks)
-            }
-            _ <- participantConfig.mode match {
-              case ParticipantRunMode.Combined | ParticipantRunMode.LedgerApiServer =>
-                new StandaloneApiServer(
-                  ledgerId = config.ledgerId,
-                  config = factory.apiServerConfig(participantConfig, config),
-                  commandConfig = config.commandConfig,
-                  submissionConfig = config.submissionConfig,
-                  partyConfig = factory.partyConfig(config),
-                  optWriteService = Some(writeService),
-                  authService = factory.authService(config),
-                  healthChecks = healthChecksWithIndexer,
-                  metrics = metrics,
-                  timeServiceBackend = factory.timeServiceBackend(config),
-                  otherInterceptors = factory.interceptors(config),
-                  engine = sharedEngine,
-                  servicesExecutionContext = servicesExecutionContext,
-                  lfValueTranslationCache = lfValueTranslationCache,
-                ).acquire()
-              case ParticipantRunMode.Indexer =>
-                Resource.unit
-            }
-          } yield ()
+                ledger <- factory
+                  .readWriteServiceOwner(config, participantConfig, sharedEngine)
+                  .acquire()
+                readService = new TimedReadService(ledger, metrics)
+                writeService = new TimedWriteService(ledger, metrics)
+                healthChecks = new HealthChecks(
+                  "read" -> readService,
+                  "write" -> writeService,
+                )
+                _ <- Resource.sequence(
+                  config.archiveFiles.map(path =>
+                    Resource.fromFuture(
+                      uploadDar(path, writeService)(resourceContext.executionContext)
+                    )
+                  )
+                )
+                servicesExecutionContext <- ResourceOwner
+                  .forExecutorService(() =>
+                    new InstrumentedExecutorService(
+                      Executors.newWorkStealingPool(),
+                      metrics.registry,
+                      metrics.daml.lapi.threadpool.apiServices.toString,
+                    )
+                  )
+                  .map(ExecutionContext.fromExecutorService)
+                  .acquire()
+                healthChecksWithIndexer <- participantConfig.mode match {
+                  case ParticipantRunMode.Combined | ParticipantRunMode.Indexer =>
+                    new StandaloneIndexerServer(
+                      readService = readService,
+                      config = factory.indexerConfig(participantConfig, config),
+                      servicesExecutionContext = servicesExecutionContext,
+                      metrics = metrics,
+                      lfValueTranslationCache = lfValueTranslationCache,
+                    ).acquire().map(indexerHealth => healthChecks + ("indexer" -> indexerHealth))
+                  case ParticipantRunMode.LedgerApiServer =>
+                    Resource.successful(healthChecks)
+                }
+                _ <- participantConfig.mode match {
+                  case ParticipantRunMode.Combined | ParticipantRunMode.LedgerApiServer =>
+                    new StandaloneApiServer(
+                      ledgerId = config.ledgerId,
+                      config = factory.apiServerConfig(participantConfig, config),
+                      commandConfig = config.commandConfig,
+                      submissionConfig = config.submissionConfig,
+                      partyConfig = factory.partyConfig(config),
+                      optWriteService = Some(writeService),
+                      authService = factory.authService(config),
+                      healthChecks = healthChecksWithIndexer,
+                      metrics = metrics,
+                      timeServiceBackend = factory.timeServiceBackend(config),
+                      otherInterceptors = factory.interceptors(config),
+                      engine = sharedEngine,
+                      servicesExecutionContext = servicesExecutionContext,
+                      lfValueTranslationCache = lfValueTranslationCache,
+                    ).acquire()
+                  case ParticipantRunMode.Indexer =>
+                    Resource.unit
+                }
+              } yield ()
+          }
         })
       } yield ()
     }


### PR DESCRIPTION
And log the participant ID on startup for kvutils apps.

I suggest ignoring whitespace changes when reviewing.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
