### PR TITLE
[participant-integration-api] - Use internal CommandCompletionService [KVL-1172]

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.client.services.commands.tracker
 
-import java.time.{Duration, Instant}
-
 import akka.stream.stage._
 import akka.stream.{Attributes, Inlet, Outlet}
 import com.daml.grpc.{GrpcException, GrpcStatus}
@@ -27,6 +25,7 @@ import com.google.rpc.status.{Status => StatusProto}
 import io.grpc.Status
 import org.slf4j.LoggerFactory
 
+import java.time.{Duration, Instant}
 import scala.annotation.nowarn
 import scala.collection.compat._
 import scala.collection.{immutable, mutable}

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.client.services.commands.tracker
 
+import java.time.{Duration, Instant}
+
 import akka.stream.stage._
 import akka.stream.{Attributes, Inlet, Outlet}
 import com.daml.grpc.{GrpcException, GrpcStatus}
@@ -25,7 +27,6 @@ import com.google.rpc.status.{Status => StatusProto}
 import io.grpc.Status
 import org.slf4j.LoggerFactory
 
-import java.time.{Duration, Instant}
 import scala.annotation.nowarn
 import scala.collection.compat._
 import scala.collection.{immutable, mutable}

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
@@ -7,10 +7,6 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.daml.error.DamlContextualizedErrorLogger
 import com.daml.grpc.adapter.ExecutionSequencerFactory
-import com.daml.ledger.api.domain
-import com.daml.ledger.api.messages.command.completion.{
-  CompletionStreamRequest => ValidatedCompletionStreamRequest
-}
 import com.daml.ledger.api.v1.command_completion_service._
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.validation.CompletionServiceRequestValidator
@@ -19,21 +15,6 @@ import com.daml.platform.server.api.ValidationLogger
 import com.daml.platform.server.api.services.domain.CommandCompletionService
 
 import scala.concurrent.{ExecutionContext, Future}
-
-object GrpcCommandCompletionService {
-
-  private[this] val completionStreamDefaultOffset = Some(domain.LedgerOffset.LedgerEnd)
-
-  private def fillInWithDefaults(
-      request: ValidatedCompletionStreamRequest
-  ): ValidatedCompletionStreamRequest =
-    if (request.offset.isDefined) {
-      request
-    } else {
-      request.copy(offset = completionStreamDefaultOffset)
-    }
-
-}
 
 class GrpcCommandCompletionService(
     service: CommandCompletionService,
@@ -56,7 +37,7 @@ class GrpcCommandCompletionService(
       .validateGrpcCompletionStreamRequest(request)
       .fold(
         t => Source.failed[CompletionStreamResponse](ValidationLogger.logFailure(request, t)),
-        GrpcCommandCompletionService.fillInWithDefaults _ andThen service.completionStreamSource,
+        service.completionStreamSource,
       )
   }
 

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidatorTest.scala
@@ -127,7 +127,7 @@ class CompletionServiceRequestValidatorTest
       "return the correct error on missing party" in {
         fixture.testRequestFailure(
           testedRequest = _.validateCompletionStreamRequest(
-            completionReq.copy(parties = Set()),
+            completionReq.copy(parties = Set.empty),
             ledgerEnd,
           ),
           expectedCodeV1 = INVALID_ARGUMENT,

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidatorTest.scala
@@ -54,7 +54,7 @@ class CompletionServiceRequestValidatorTest
 
   "CompletionRequestValidation" when {
 
-    "validating grpc completion requests" should {
+    "validating gRPC completion requests" should {
 
       "reject requests with empty ledger ID" in {
         fixture.testRequestFailure(
@@ -108,7 +108,7 @@ class CompletionServiceRequestValidatorTest
       }
     }
 
-    "validate domain completions requests" should {
+    "validate domain completion requests" should {
 
       "reject requests with empty ledger ID" in {
         fixture.testRequestFailure(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -4,16 +4,17 @@
 package com.daml.platform.apiserver.services
 
 import java.util.concurrent.atomic.AtomicLong
+
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import com.daml.error.ErrorCodesVersionSwitcher
+import com.daml.error.{DamlContextualizedErrorLogger, ErrorCodesVersionSwitcher}
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.domain.{LedgerId, LedgerOffset}
 import com.daml.ledger.api.messages.command.completion.CompletionStreamRequest
 import com.daml.ledger.api.v1.command_completion_service._
-import com.daml.ledger.api.validation.PartyNameChecker
+import com.daml.ledger.api.validation.{CompletionServiceRequestValidator, PartyNameChecker}
 import com.daml.ledger.participant.state.index.v2.IndexCompletionsService
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.entries.{LoggingEntries, LoggingValue}
@@ -21,6 +22,7 @@ import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.apiserver.services.ApiCommandCompletionService._
+import com.daml.platform.server.api.ValidationLogger
 import com.daml.platform.server.api.services.domain.CommandCompletionService
 import com.daml.platform.server.api.services.grpc.GrpcCommandCompletionService
 import io.grpc.ServerServiceDefinition
@@ -29,6 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 private[apiserver] final class ApiCommandCompletionService private (
     completionsService: IndexCompletionsService,
+    validator: CompletionServiceRequestValidator,
     metrics: Metrics,
 )(implicit
     protected val materializer: Materializer,
@@ -39,30 +42,42 @@ private[apiserver] final class ApiCommandCompletionService private (
 
   import Logging._
 
-  private val logger = ContextualizedLogger.get(this.getClass)
+  private implicit val logger: ContextualizedLogger = ContextualizedLogger.get(this.getClass)
+  private implicit val contextualizedErrorLogger: DamlContextualizedErrorLogger =
+    new DamlContextualizedErrorLogger(logger, loggingContext, None)
 
   private val subscriptionIdCounter = new AtomicLong()
 
   override def completionStreamSource(
       request: CompletionStreamRequest
   ): Source[CompletionStreamResponse, NotUsed] =
-    withEnrichedLoggingContext(logging.parties(request.parties), logging.offset(request.offset)) {
-      implicit loggingContext =>
-        val subscriptionId = subscriptionIdCounter.getAndIncrement().toString
-        logger.info(s"Received request for completion subscription $subscriptionId: $request")
+    Source.future(getLedgerEnd(request.ledgerId)).flatMapConcat { ledgerEnd =>
+      validator
+        .validateCompletionStreamRequest(request, ledgerEnd)
+        .fold(
+          t => Source.failed[CompletionStreamResponse](ValidationLogger.logFailure(request, t)),
+          request =>
+            withEnrichedLoggingContext(
+              logging.parties(request.parties),
+              logging.offset(request.offset),
+            ) { implicit loggingContext =>
+              val subscriptionId = subscriptionIdCounter.getAndIncrement().toString
+              logger.info(s"Received request for completion subscription $subscriptionId: $request")
 
-        val offset = request.offset.getOrElse(LedgerOffset.LedgerEnd)
+              val offset = request.offset.getOrElse(LedgerOffset.LedgerEnd)
 
-        completionsService
-          .getCompletions(offset, request.applicationId, request.parties)
-          .via(
-            logger.enrichedDebugStream(
-              "Responding with completions.",
-              response => LoggingEntries("response" -> responseToLoggingValue(response)),
-            )
-          )
-          .via(logger.logErrorsOnStream)
-          .via(StreamMetrics.countElements(metrics.daml.lapi.streams.completions))
+              completionsService
+                .getCompletions(offset, request.applicationId, request.parties)
+                .via(
+                  logger.enrichedDebugStream(
+                    "Responding with completions.",
+                    response => LoggingEntries("response" -> responseToLoggingValue(response)),
+                  )
+                )
+                .via(logger.logErrorsOnStream)
+                .via(StreamMetrics.countElements(metrics.daml.lapi.streams.completions))
+            },
+        )
     }
 
   override def getLedgerEnd(ledgerId: domain.LedgerId): Future[LedgerOffset.Absolute] =
@@ -81,15 +96,18 @@ private[apiserver] object ApiCommandCompletionService {
       esf: ExecutionSequencerFactory,
       executionContext: ExecutionContext,
       loggingContext: LoggingContext,
-  ): GrpcCommandCompletionService with GrpcApiService = {
-    val impl: CommandCompletionService =
-      new ApiCommandCompletionService(completionsService, metrics)
-
-    new GrpcCommandCompletionService(
+  ): (CommandCompletionService, GrpcCommandCompletionService with GrpcApiService) = {
+    val validator = new CompletionServiceRequestValidator(
       ledgerId,
-      impl,
       PartyNameChecker.AllowAllParties,
       errorCodesVersionSwitcher,
+    )
+    val impl: CommandCompletionService =
+      new ApiCommandCompletionService(completionsService, validator, metrics)
+
+    impl -> new GrpcCommandCompletionService(
+      impl,
+      validator,
     ) with GrpcApiService {
       override def bindService(): ServerServiceDefinition =
         CommandCompletionServiceGrpc.bindService(this, executionContext)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -248,7 +248,8 @@ private[apiserver] object ApiCommandService {
   private object Tracking {
     final case class Key(applicationId: Ref.ApplicationId, parties: Set[Ref.Party])
 
-    private implicit val logger: ContextualizedLogger = ContextualizedLogger.get(this.getClass)
+    private val logger: ContextualizedLogger = ContextualizedLogger.get(this.getClass)
+
     def getTrackerKey(commands: Commands): Tracking.Key = {
       val parties = CommandsValidator.effectiveActAs(commands)
       // Safe to convert the applicationId and the parties as the command should've been already validated


### PR DESCRIPTION
- Fully decouple the usage of the gRPC CommandCompletionService vs the internally defined CommandCompletionService
- This allows the two interfaces to diverge and does not force us to expose all the methods that we want to add to the internal CommandCompletionService
- The validation had to be split into 2 steps, one in the gRPC service which handle the type validation and another one in the internal service which does the "data" validation

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
