### PR TITLE
 LF: Simplify transaction versionning for interface

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/VersionRange.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/VersionRange.scala
@@ -21,13 +21,7 @@ final case class VersionRange[V](
 
   require(min <= max)
 
-  def intersect(that: VersionRange[V]): VersionRange[V] =
-    VersionRange(
-      min = this.min max that.min,
-      max = this.max min that.max,
-    )
-
-  def map[W](f: V => W)(implicit ordering: Ordering[W]) =
+  private[lf] def map[W](f: V => W)(implicit ordering: Ordering[W]) =
     VersionRange(f(min), f(max))
 
   def contains(v: V): Boolean =

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -4,7 +4,7 @@
 package com.daml.lf
 package speedy
 
-import com.daml.lf.data._
+import com.daml.lf.data.ImmArray
 import com.daml.lf.ledger.Authorize
 import com.daml.lf.speedy.PartialTransaction._
 import com.daml.lf.speedy.SValue.{SValue => _, _}
@@ -17,23 +17,16 @@ import org.scalatest.wordspec.AnyWordSpec
 class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
   private[this] val transactionSeed = crypto.Hash.hashPrivateKey("PartialTransactionSpec")
-
-  private val templates: Map[TransactionVersion, Ref.Identifier] =
-    TransactionVersion.All.view
-      .map(v => v -> Ref.Identifier.assertFromString(s"pkg${v.protoValue}:Mod:Template"))
-      .toMap
-  private[this] val templateId = templates(TransactionVersion.StableVersions.max)
-  private[this] val choiceId = Ref.Name.assertFromString("choice")
+  private[this] val templateId = data.Ref.Identifier.assertFromString("pkg:Mod:Template")
+  private[this] val choiceId = data.Ref.Name.assertFromString("choice")
   private[this] val cid = Value.ContractId.V1(crypto.Hash.hashPrivateKey("My contract"))
-  private[this] val party = Ref.Party.assertFromString("Alice")
-  private[this] val committers: Set[Ref.Party] = Set.empty
-
-  private[this] val pkg2TxVersion = templates.map { case (version, id) => id.packageId -> version }
+  private[this] val party = data.Ref.Party.assertFromString("Alice")
+  private[this] val committers: Set[data.Ref.Party] = Set.empty
 
   private[this] val initialState = PartialTransaction.initial(
-    pkg2TxVersion,
+    _ => TransactionVersion.maxVersion,
     ContractKeyUniquenessMode.On,
-    Time.Timestamp.Epoch,
+    data.Time.Timestamp.Epoch,
     InitialSeeding.TransactionSeed(transactionSeed),
     committers,
   )
@@ -49,7 +42,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
   private[this] implicit class PartialTransactionExtra(val ptx: PartialTransaction) {
 
-    def insertCreate_(templateId: Ref.Identifier = templateId): PartialTransaction =
+    def insertCreate_ : PartialTransaction =
       ptx
         .insertCreate(
           Authorize(Set(party)),
@@ -64,7 +57,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
         )
         ._2
 
-    def beginExercises_(templateId: Ref.Identifier = templateId): PartialTransaction =
+    def beginExercises_ : PartialTransaction =
       ptx.beginExercises(
         Authorize(Set(party)),
         targetId = cid,
@@ -94,13 +87,13 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   private[this] val outputCids =
     contractIdsInOrder(
       initialState //
-        .insertCreate_() // create the contract cid_0
-        .beginExercises_() // open an exercise context
-        .insertCreate_() // create the contract cid_1_0
-        .insertCreate_() // create the contract cid_1_2
-        .insertCreate_() // create the contract cid_1_3
+        .insertCreate_ // create the contract cid_0
+        .beginExercises_ // open an exercise context
+        .insertCreate_ // create the contract cid_1_0
+        .insertCreate_ // create the contract cid_1_2
+        .insertCreate_ // create the contract cid_1_3
         .endExercises_ // close the exercise context normally
-        .insertCreate_() // create the contract cid_2
+        .insertCreate_ // create the contract cid_2
     )
 
   val Seq(cid_0, cid_1_0, cid_1_1, cid_1_2, cid_2) = outputCids
@@ -109,29 +102,29 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
     "be without effect when closed without exception" in {
       def run1 = contractIdsInOrder(
         initialState //
-          .insertCreate_() // create the contract cid_0
-          .beginExercises_() // open an exercise context
-          .insertCreate_() // create the contract cid_1_0
+          .insertCreate_ // create the contract cid_0
+          .beginExercises_ // open an exercise context
+          .insertCreate_ // create the contract cid_1_0
           .beginTry // open a try context
-          .insertCreate_() // create the contract cid_1_1
+          .insertCreate_ // create the contract cid_1_1
           .endTry // close the try context
-          .insertCreate_() // create the contract cid_1_2
+          .insertCreate_ // create the contract cid_1_2
           .endExercises_ // close the exercise context normally
-          .insertCreate_() // create the contract cid_2
+          .insertCreate_ // create the contract cid_2
       )
 
       def run2 = contractIdsInOrder(
         // the double slashes below tricks scalafmt
         initialState //
-          .insertCreate_() // create the contract cid_0
+          .insertCreate_ // create the contract cid_0
           .beginTry // open a try context
-          .beginExercises_() // open an exercise context
-          .insertCreate_() // create the contract cid_1_0
-          .insertCreate_() // create the contract cid_1_2
-          .insertCreate_() // create the contract cid_1_3
+          .beginExercises_ // open an exercise context
+          .insertCreate_ // create the contract cid_1_0
+          .insertCreate_ // create the contract cid_1_2
+          .insertCreate_ // create the contract cid_1_3
           .endExercises_ // close the exercise context normally
           .endTry // close the try context
-          .insertCreate_() // create the contract cid_2
+          .insertCreate_ // create the contract cid_2
       )
 
       run1 shouldBe outputCids
@@ -143,106 +136,51 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
       def run1 = contractIdsInOrder(
         // the double slashes below tricks scalafmt
         initialState //
-          .insertCreate_() // create the contract cid_0
+          .insertCreate_ // create the contract cid_0
           .beginTry // open a first try context
-          .beginExercises_() // open an exercise context
-          .insertCreate_() // create the contract cid_1_0
-          .insertCreate_() // create the contract cid_1_1
-          .insertCreate_() // create the contract cid_1_2
+          .beginExercises_ // open an exercise context
+          .insertCreate_ // create the contract cid_1_0
+          .insertCreate_ // create the contract cid_1_1
+          .insertCreate_ // create the contract cid_1_2
           // an exception is thrown
           .abortExercises // close abruptly the exercise due to an uncaught exception
           .rollbackTry_ // the try context handles the exception
-          .insertCreate_() // create the contract cid_2
+          .insertCreate_ // create the contract cid_2
       )
 
       def run2 = contractIdsInOrder(
         initialState //
-          .insertCreate_() // create the contract cid_0
+          .insertCreate_ // create the contract cid_0
           .beginTry // open a first try context
-          .beginExercises_() // open an exercise context
-          .insertCreate_() // create the contract cid_1_0
-          .insertCreate_() // create the contract cid_1_1
+          .beginExercises_ // open an exercise context
+          .insertCreate_ // create the contract cid_1_0
+          .insertCreate_ // create the contract cid_1_1
           .beginTry // open a second try context
-          .insertCreate_() // create the contract cid_1_2
+          .insertCreate_ // create the contract cid_1_2
           // an exception is thrown
           .abortTry // the second try context does not handle the exception
           .abortExercises // close abruptly the exercise due to an uncaught exception
           .rollbackTry_ // the first try context does handle the exception
-          .insertCreate_() // create the contract cid_2
+          .insertCreate_ // create the contract cid_2
       )
 
       def run3 = contractIdsInOrder(
         // the double slashes below tricks scalafmt
         initialState //
-          .insertCreate_() // create the contract cid_0
-          .beginExercises_() // open an exercise context
-          .insertCreate_() // create the contract cid_1_0
+          .insertCreate_ // create the contract cid_0
+          .beginExercises_ // open an exercise context
+          .insertCreate_ // create the contract cid_1_0
           .beginTry // open a try context
-          .insertCreate_() // create the contract cid_1_2
+          .insertCreate_ // create the contract cid_1_2
           .rollbackTry_ // the try  context does handle the exception
-          .insertCreate_() // create the contract cid_1_3
+          .insertCreate_ // create the contract cid_1_3
           .endExercises_ // close the exercise context normally
-          .insertCreate_() // create the contract cid_2
+          .insertCreate_ // create the contract cid_2
       )
 
       run1 shouldBe Seq(cid_0, cid_1_0, cid_1_1, cid_1_2, cid_2)
       run2 shouldBe Seq(cid_0, cid_1_0, cid_1_1, cid_1_2, cid_2)
       run3 shouldBe Seq(cid_0, cid_1_0, cid_1_1, cid_1_2, cid_2)
-    }
-  }
-
-  "infers version as" should {
-
-    "be the max of the version of the children nodes" in {
-
-      import TransactionVersion._
-
-      def versionsInOrder(ptx: PartialTransaction) =
-        inside(ptx.finish) { case CompleteTransaction(tx, _, _) =>
-          tx.version -> tx.fold(Vector.empty[Option[TransactionVersion]])(_ :+ _._2.optVersion)
-        }
-
-      versionsInOrder(
-        initialState
-          .insertCreate_(templates(V14))
-      ) shouldBe (V14 -> Seq(Some(V14)))
-
-      versionsInOrder(
-        initialState
-          .insertCreate_(templates(V12))
-          .insertCreate_(templates(V13))
-      ) shouldBe (V13 -> Seq(Some(V12), Some(V13)))
-
-      versionsInOrder(
-        initialState
-          .beginExercises_(templates(V14))
-          .insertCreate_(templates(V12))
-          .insertCreate_(templates(V13))
-          .endExercises_
-      ) shouldBe (V14 -> Seq(Some(V14), Some(V12), Some(V13)))
-
-      versionsInOrder(
-        initialState
-          .beginExercises_(templates(V11))
-          .insertCreate_(templates(V12))
-          .insertCreate_(templates(V13))
-          .endExercises_
-      ) shouldBe (V13 -> Seq(Some(V13), Some(V12), Some(V13)))
-
-      versionsInOrder(
-        initialState.beginTry
-          .insertCreate_(templates(VDev))
-          .insertCreate_(templates(V14))
-          .endTry
-      ) shouldBe (VDev -> Seq(Some(VDev), Some(V14)))
-
-      versionsInOrder(
-        initialState.beginTry
-          .insertCreate_(templates(V14))
-          .insertCreate_(templates(VDev))
-          .rollbackTry_
-      ) shouldBe (VDev -> Seq(None, Some(V14), Some(VDev)))
-
     }
   }
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -67,7 +67,7 @@ object LanguageVersion {
 
   // All versions compatible with legacy contract ID scheme.
   val LegacyVersions: VersionRange[LanguageVersion] =
-    VersionRange(StableVersions.min, max = v1_8)
+    StableVersions.copy(max = v1_8)
 
   // All the stable and preview versions
   // Equals `Stable` if no preview version is available
@@ -76,7 +76,7 @@ object LanguageVersion {
 
   // All the versions
   val DevVersions: VersionRange[LanguageVersion] =
-    VersionRange(StableVersions.min, v1_dev)
+    StableVersions.copy(max = v1_dev)
 
   val defaultV1: LanguageVersion = StableVersions.max
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -26,8 +26,6 @@ object TransactionVersion {
   private[daml] implicit val Ordering: scala.Ordering[TransactionVersion] =
     scala.Ordering.by(_.index)
 
-  private[lf] val NoVersions: VersionRange[TransactionVersion] = VersionRange.slowEmpty(All)
-
   private[this] val stringMapping = All.iterator.map(v => v.protoValue -> v).toMap
 
   def fromString(vs: String): Either[String, TransactionVersion] =


### PR DESCRIPTION

We revert #11626, and just change the way transaction version is
computed:
    
- As before, Node version is calculated from the
  package of the template ID action.
    
- Transaction version is the max of the version of all the nodes,
   instead of the root nodes.
    
CHANGELOG_BEGIN
CHANGELOG_END



### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
