### PR TITLE
Fix missing encoding of nested maps in typescript bindings

### DIFF
--- a/language-support/ts/daml-types/index.test.ts
+++ b/language-support/ts/daml-types/index.test.ts
@@ -71,6 +71,15 @@ describe('@daml/types', () => {
       expect(m2.get(k)).toEqual(makeArr(m2.values())[makeArr(m2.keys()).findIndex((l) => _.isEqual(k, l))]);
     }
   });
+  it('nested genmap', () => {
+    const {encode, decoder} = Map(Text, Map(Text, Text));
+    const decoded: Map<Text, Map<Text, Text>> =
+      emptyMap<Text, Map<Text, Text>>().set("a", emptyMap<Text, Text>().set("b", "c"));
+    const decode = (u: unknown): Map<Text, Map<Text, Text>> => decoder.runWithException(u);
+    const encoded = [["a", [["b", "c"]]]];
+    expect(encode(decoded)).toEqual(encoded);
+    expect(decode(encoded)).toEqual(decoded);
+  });
 });
 
 test('memo', () => {

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -518,5 +518,5 @@ export const emptyMap = <K, V>(): Map<K, V> => new MapImpl<K, V>([]);
  */
 export const Map = <K, V>(kd: Serializable<K>, vd: Serializable<V>): Serializable<Map<K, V>> => ({
   decoder: jtv.array(jtv.tuple([kd.decoder, vd.decoder])).map(kvs => new MapImpl(kvs)),
-  encode: (m: Map<K, V>): unknown => m.entriesArray(),
+  encode: (m: Map<K, V>): unknown => m.entriesArray().map(e => [kd.encode(e[0]), vd.encode(e[1])]),
 });


### PR DESCRIPTION
The encoder just took the keys & values as is which clearly falls
apart once those actually contain anything else that requires encoding

changelog_begin

- [Typescript Bindings] Fix an issue where nested maps did not get
  encoded properly before sent to the JSON API which caused requests
  to fail with a decoding error on the JSON API.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
