### PR TITLE
kvutils - Deprecate deduplicate_until [kvl-1174]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/log_entry.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/log_entry.proto
@@ -81,7 +81,8 @@ message DamlLogEntryId {
 message DamlOutOfTimeBoundsEntry {
   // We don't expect entry.recordTime to be present.
   DamlLogEntry entry = 1;
-  google.protobuf.Timestamp duplicate_until = 2;
+  // Read-only for backwards compatibility, will not be set for new entries
+  google.protobuf.Timestamp duplicate_until = 2 [deprecated = true];
   google.protobuf.Timestamp too_early_until = 3;
   google.protobuf.Timestamp too_late_from = 4;
 }

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
@@ -57,7 +57,8 @@ message DamlCommandDedupValue {
   oneof time {
     // The time until when future commands with the same
     // deduplication key will be rejected due to a duplicate submission.
-    google.protobuf.Timestamp deduplicated_until = 2;
+    // Read-only for backwards compatibility
+    google.protobuf.Timestamp deduplicated_until = 2 [deprecated = true];
     google.protobuf.Timestamp record_time = 3;
     PreExecutionDeduplicationBounds record_time_bounds = 4;
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -28,10 +28,10 @@ import com.daml.lf.data.Ref.LedgerString
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.transaction.CommittedTransaction
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
-
 import com.google.common.io.BaseEncoding
 import com.google.protobuf.ByteString
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 /** Utilities for producing [[Update]] events from [[DamlLogEntry]]'s committed to a
@@ -426,6 +426,7 @@ object KeyValueConsumption {
       Some(correlationId(rejectionEntry.getSubmitterInfo)),
     )
 
+  @nowarn("msg=deprecated")
   private def parseTimeBounds(outOfTimeBoundsEntry: DamlOutOfTimeBoundsEntry): TimeBounds = {
     val duplicateUntilMaybe = parseOptionalTimestamp(
       outOfTimeBoundsEntry.hasDuplicateUntil,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -333,12 +333,16 @@ object KeyValueConsumption {
       List.empty
     }
 
+  @nowarn("msg=deprecated")
   private[kvutils] case class TimeBounds(
       tooEarlyUntil: Option[Timestamp] = None,
       tooLateFrom: Option[Timestamp] = None,
+      @deprecated("Read-only for backwards compatibility.")
       deduplicateUntil: Option[Timestamp] = None,
   )
 
+  // Ignore deprecation warnings caused by deduplicate until, which is read-only for backwards compatibility
+  @nowarn("msg=deprecated")
   private[kvutils] def outOfTimeBoundsEntryToUpdate(
       recordTime: Timestamp,
       outOfTimeBoundsEntry: DamlOutOfTimeBoundsEntry,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -32,7 +32,6 @@ private[kvutils] case class CommitContext(
 
   var minimumRecordTime: Option[Timestamp] = None
   var maximumRecordTime: Option[Timestamp] = None
-  var deduplicateUntil: Option[Timestamp] = None
 
   // Rejection log entry used for generating an out-of-time-bounds log entry in case of
   // pre-execution.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -128,9 +128,6 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
         commitContext.maximumRecordTime.foreach { timestamp =>
           builder.setTooLateFrom(buildTimestamp(timestamp))
         }
-        commitContext.deduplicateUntil.foreach { timestamp =>
-          builder.setDuplicateUntil(buildTimestamp(timestamp))
-        }
         DamlLogEntry.newBuilder
           .setOutOfTimeBoundsEntry(builder)
           .build

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
@@ -28,10 +28,13 @@ import com.daml.ledger.participant.state.kvutils.store.{
 import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
 import com.daml.logging.LoggingContext
 
+import scala.annotation.nowarn
+
 private[transaction] object CommandDeduplication {
 
   /** Reject duplicate commands
     */
+  @nowarn("msg=deprecated")
   def deduplicateCommandStep(rejections: Rejections): Step =
     new Step {
       def apply(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
@@ -499,7 +499,6 @@ class KeyValueConsumptionSpec extends AnyWordSpec with Matchers {
     val builder = DamlOutOfTimeBoundsEntry.newBuilder
     timeBounds.tooEarlyUntil.foreach(value => builder.setTooEarlyUntil(buildTimestamp(value)))
     timeBounds.tooLateFrom.foreach(value => builder.setTooLateFrom(buildTimestamp(value)))
-    timeBounds.deduplicateUntil.foreach(value => builder.setDuplicateUntil(buildTimestamp(value)))
     builder.setEntry(buildLogEntry(logEntryType, definiteAnswer))
     builder.build
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
@@ -39,8 +39,9 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
 import org.scalatest.prop.{TableFor1, TableFor4, TableFor5}
 import org.scalatest.wordspec.AnyWordSpec
-
 import java.time.Instant
+
+import scala.annotation.nowarn
 
 class KeyValueConsumptionSpec extends AnyWordSpec with Matchers {
   private val aLogEntryIdString = "test"
@@ -491,6 +492,7 @@ class KeyValueConsumptionSpec extends AnyWordSpec with Matchers {
     )
   }
 
+  @nowarn("msg=deprecated")
   private def buildOutOfTimeBoundsEntry(
       timeBounds: TimeBounds,
       logEntryType: DamlLogEntry.PayloadCase,
@@ -499,6 +501,7 @@ class KeyValueConsumptionSpec extends AnyWordSpec with Matchers {
     val builder = DamlOutOfTimeBoundsEntry.newBuilder
     timeBounds.tooEarlyUntil.foreach(value => builder.setTooEarlyUntil(buildTimestamp(value)))
     timeBounds.tooLateFrom.foreach(value => builder.setTooLateFrom(buildTimestamp(value)))
+    timeBounds.deduplicateUntil.foreach(value => builder.setDuplicateUntil(buildTimestamp(value)))
     builder.setEntry(buildLogEntry(logEntryType, definiteAnswer))
     builder.build
   }


### PR DESCRIPTION
- deduplicate_until is no longer used by backwards looking command deduplication, therefore we deprecate the field in the proto files (keep it there for backwards compatibility) and remove references to it from the committer context

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
