### PR TITLE
Limit the number of parallel Bazel actions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,14 @@ build --experimental_strict_action_env
 # in us getting a certificate for githubassets.com instead.
 startup --host_jvm_args=-Xms2g --host_jvm_args=-Xmx2g --host_jvm_args=-Djdk.tls.client.protocols=TLSv1.2
 
+# Limit the number of parallel actions spawned by Bazel to the number of
+# physical CPUs. (Assuming a CPU with hyperthreading enabled)
+build --loading_phase_threads="HOST_CPUS*.5"
+fetch --loading_phase_threads="HOST_CPUS*.5"
+query --loading_phase_threads="HOST_CPUS*.5"
+sync --loading_phase_threads="HOST_CPUS*.5"
+build --local_cpu_resources="HOST_CPUS*.5"
+
 # Enable sandboxing and caching for exclusive tests
 build --incompatible_exclusive_test_sandboxed
 

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -33,6 +33,14 @@ build --experimental_strict_action_env
 # in us getting a certificate for githubassets.com instead.
 startup --host_jvm_args=-Xms2g --host_jvm_args=-Xmx2g --host_jvm_args=-Djdk.tls.client.protocols=TLSv1.2
 
+# Limit the number of parallel actions spawned by Bazel to the number of
+# physical CPUs. (Assuming a CPU with hyperthreading enabled)
+build --loading_phase_threads="HOST_CPUS*.5"
+fetch --loading_phase_threads="HOST_CPUS*.5"
+query --loading_phase_threads="HOST_CPUS*.5"
+sync --loading_phase_threads="HOST_CPUS*.5"
+build --local_cpu_resources="HOST_CPUS*.5"
+
 # Enable sandboxing and caching for exclusive tests
 build --incompatible_exclusive_test_sandboxed
 


### PR DESCRIPTION
Limit the number of parallel actions spawned by Bazel to the number of physical CPUs. (Assuming a CPU with hyperthreading enabled)

I've run tests on a Linux ad-hoc machine to compare test run-time and flakiness at different values of `--local_cpu_resources`.
The ad-hoc machine had 4 physical (8 virtual) cores. Bazel views this as `HOST_CPUS=8` and spawns as many actions in parallel.

The test runs were more reliable (less flaky) and barely slower when limiting the number of CPUs to the number of physical cores.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
