### PR TITLE
[ledger-api-client] - Do not account for deduplication_time as timeout [KVL-1172]

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -3,10 +3,12 @@
 
 package com.daml.ledger.client.services.commands.tracker
 
+import java.time.{Duration, Instant}
+
 import akka.stream.stage._
 import akka.stream.{Attributes, Inlet, Outlet}
 import com.daml.grpc.{GrpcException, GrpcStatus}
-import com.daml.ledger.api.v1.commands.Commands
+import com.daml.ledger.api.v1.command_completion_service.Checkpoint
 import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.client.services.commands.tracker.CommandTracker._
@@ -24,9 +26,6 @@ import com.google.protobuf.empty.Empty
 import com.google.rpc.status.{Status => StatusProto}
 import io.grpc.Status
 import org.slf4j.LoggerFactory
-import java.time.{Duration, Instant}
-
-import com.daml.ledger.api.v1.command_completion_service.Checkpoint
 
 import scala.annotation.nowarn
 import scala.collection.compat._

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -255,22 +255,8 @@ private[commands] class CommandTracker[Context](
           ) with NoStackTrace
         }
         val commandTimeout = submission.value.timeout match {
-          // The command submission timeout takes precedence.
           case Some(timeout) => durationOrdering.min(timeout, maximumCommandTimeout)
-          case None =>
-            commands.deduplicationPeriod match {
-              // We keep supporting the `deduplication_time` field as the command timeout,
-              // for historical reasons.
-              case Commands.DeduplicationPeriod.DeduplicationTime(deduplicationTimeProto) =>
-                val deduplicationTime = Duration.ofSeconds(
-                  deduplicationTimeProto.seconds,
-                  deduplicationTimeProto.nanos.toLong,
-                )
-                durationOrdering.min(deduplicationTime, maximumCommandTimeout)
-              // All other deduplication periods do not influence the command timeout.
-              case _ =>
-                maximumCommandTimeout
-            }
+          case None => maximumCommandTimeout
         }
         val trackingData = TrackingData(
           commandId = commandId,

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -29,7 +29,6 @@ import com.daml.ledger.client.services.commands.tracker.CompletionResponse.{
 }
 import com.daml.ledger.client.services.commands.tracker.{CompletionResponse, TrackedCommandKey}
 import com.daml.util.Ctx
-import com.google.protobuf.duration.{Duration => DurationProto}
 import com.google.protobuf.empty.Empty
 import com.google.protobuf.timestamp.Timestamp
 import com.google.rpc.code._

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -329,31 +329,6 @@ class CommandTrackerFlowTest
         succeed
       }
 
-      "use the command deduplication time, if provided" in {
-        val Handle(submissions, results, _, _) = runCommandTrackingFlow(allSubmissionsSuccessful)
-
-        val deduplicationTime = DurationProto.of(0, 200000000) // 200ms
-        submissions.sendNext(
-          Ctx(
-            context,
-            CommandSubmission(
-              Commands(
-                commandId = commandId,
-                submissionId = submissionId,
-                deduplicationPeriod =
-                  Commands.DeduplicationPeriod.DeduplicationTime(deduplicationTime),
-              )
-            ),
-          )
-        )
-
-        results.expectNext(
-          500.milliseconds,
-          Ctx(context, Left(CompletionResponse.TimeoutResponse(commandId))),
-        )
-        succeed
-      }
-
       "cap the timeout at the maximum command timeout" in {
         val Handle(submissions, results, _, _) = runCommandTrackingFlow(
           allSubmissionsSuccessful,


### PR DESCRIPTION
- Fully decouple the command timeout from the deduplication period
- This is required so that the tracker no longer need the deduplication period and we can decouple the tracker input from the commands

changelog_begin
ledger-api-client - The default command tracking timeout is no longer influenced by the deprecated `deduplication_time` as a deduplication period. Previously if no timeout was being set in the command and `deduplication_time` was set as the deduplication period then the command tracking timeout was the minimum between the deduplication_time and max tracking timeout.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
