### PR TITLE
Make the `InstrumentedSource.queue` use the `BoundedSourceQueue` [KVL-1177]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
@@ -52,10 +52,10 @@ private[services] final class QueueBackedTracker(
         trackedPromise.future.map(
           _.left.map(completionFailure => QueueCompletionFailure(completionFailure))
         )
-      case Success(QueueOfferResult.Failure(t)) =>
+      case Success(QueueOfferResult.Failure(throwable)) =>
         toQueueSubmitFailure(
           errorFactories.SubmissionQueueErrors
-            .failedToEnqueueCommandSubmission("Failed to enqueue")(t)
+            .failedToEnqueueCommandSubmission("Failed to enqueue")(throwable)
         )
       case Success(QueueOfferResult.Dropped) =>
         toQueueSubmitFailure(errorFactories.bufferFull("The submission ingress buffer is full"))
@@ -63,9 +63,11 @@ private[services] final class QueueBackedTracker(
         toQueueSubmitFailure(
           errorFactories.SubmissionQueueErrors.queueClosed("Command service queue")
         )
-      case Failure(t) =>
+      case Failure(throwable) =>
         toQueueSubmitFailure(
-          errorFactories.SubmissionQueueErrors.failedToEnqueueCommandSubmission("Failed")(t)
+          errorFactories.SubmissionQueueErrors.failedToEnqueueCommandSubmission(
+            "Unexpected `BoundedSourceQueue.offer` exception"
+          )(throwable)
         )
     }
   }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/QueueBackedTrackerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/QueueBackedTrackerSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatest.{BeforeAndAfterEach, Inside}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 class QueueBackedTrackerSpec
     extends AsyncWordSpec
@@ -48,7 +49,8 @@ class QueueBackedTrackerSpec
 
   override protected def afterEach(): Unit = {
     consumer.cancel()
-    queue.complete()
+    Try(queue.complete())
+    ()
   }
 
   "Tracker Implementation" when {


### PR DESCRIPTION
We never use other `OverflowStrategy`(ies) than `dropNew`. Therefore, we can drop the `overflowStrategy` param and create `BoundedSourceQueue`s that drop new elements by default. It simplifies the code and may improve performance, as the `offer` method no longer returns a `Future`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
