### PR TITLE
Make lookupTemplateChoice return only choices defined in the template.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -85,17 +85,16 @@ final class ValueEnricher(
       choiceName: Name,
       value: Value,
   ): Result[Value] =
-    handleLookup(interface.lookupTemplateChoice(tyCon, choiceName))
-      .flatMap(choice => enrichValue(choice.argBinder._2, value))
+    handleLookup(interface.lookupChoice(tyCon, choiceName))
+      .flatMap(choiceInfo => enrichValue(choiceInfo.choice.argBinder._2, value))
 
   def enrichChoiceResult(
       tyCon: Identifier,
       choiceName: Name,
       value: Value,
   ): Result[Value] =
-    handleLookup(interface.lookupTemplateChoice(tyCon, choiceName)).flatMap(choice =>
-      enrichValue(choice.returnType, value)
-    )
+    handleLookup(interface.lookupChoice(tyCon, choiceName))
+      .flatMap(choiceInfo => enrichValue(choiceInfo.choice.returnType, value))
 
   def enrichContractKey(tyCon: Identifier, value: Value): Result[Value] =
     handleLookup(interface.lookupTemplateKey(tyCon))

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
@@ -192,14 +192,10 @@ class InterfacesTest
       val command = ExerciseTemplateCommand(idI1, cid1, "C1", ValueRecord(None, ImmArray.empty))
       preprocess(command) shouldBe a[Left[_, _]]
     }
-    // TODO https://github.com/digital-asset/daml/issues/11558
-    //   Fix lookupTemplateChoice to not return inherited choices.
-    /*
-      "be unable to exercise T1 inherited choice via exercise template (stopped in preprocessor)" in {
-        val command = ExerciseTemplateCommand(idT1, cid1, "C1", ValueRecord(None, ImmArray.empty))
-        preprocess(command) shouldBe a[Left[_, _]]
-      }
-     */
+    "be unable to exercise T1 inherited choice via exercise template (stopped in preprocessor)" in {
+      val command = ExerciseTemplateCommand(idT1, cid1, "C1", ValueRecord(None, ImmArray.empty))
+      preprocess(command) shouldBe a[Left[_, _]]
+    }
     "be able to exercise T1 own choice via exercise template" in {
       val command =
         ExerciseTemplateCommand(idT1, cid1, "OwnChoice", ValueRecord(None, ImmArray.empty))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -76,7 +76,7 @@ object ScriptF {
         _clients.copy(party_participants = _clients.party_participants + (party -> participant))
     }
     def lookupChoice(id: Identifier, choice: Name): Either[String, Ast.TemplateChoiceSignature] =
-      compiledPackages.interface.lookupTemplateChoice(id, choice).left.map(_.pretty)
+      compiledPackages.interface.lookupChoice(id, choice).map(_.choice).left.map(_.pretty)
 
     def lookupKeyTy(id: Identifier): Either[String, Ast.Type] =
       compiledPackages.interface.lookupTemplateKey(id) match {


### PR DESCRIPTION
This fixes a bug in the typechecker (#11558) and the command
preprocessor, since those were written with this behavior of
lookupTemplateChoice in mind. Enables the engine test that
caught this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
