### PR TITLE
Backport: Restart the submission interpretation in case of a race [DPP-737]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
@@ -71,13 +71,13 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
                 if (maxUsedTime.forall(_ <= commands.commands.ledgerEffectiveTime)) {
                   Future.successful(Right(cer))
                 } else if (!cer.dependsOnLedgerTime) {
-                  logger.debug(
+                  logger.info(
                     s"Advancing ledger effective time for the output from ${commands.commands.ledgerEffectiveTime} to $maxUsedTime"
                   )
                   Future.successful(Right(advanceOutputTime(cer, maxUsedTime)))
                 } else if (retriesLeft > 0) {
                   metrics.daml.execution.retry.mark()
-                  logger.debug(
+                  logger.info(
                     s"Restarting the computation with new ledger effective time $maxUsedTime"
                   )
                   val advancedCommands = advanceInputTime(commands, maxUsedTime)
@@ -98,7 +98,7 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
                     loop(commands, submissionSeed, ledgerConfiguration, retriesLeft - 1)
                   } else {
                     logger.info(
-                      s"Lookup of maximum ledger time failed after ${maxRetries - retriesLeft}. Used contracts: ${usedContractIds
+                      s"Lookup of maximum ledger time failed after ${maxRetries - retriesLeft} retries. Missing contracts: ${contracts
                         .mkString("[", ", ", "]")}."
                     )
                     Future.successful(Left(ErrorCause.LedgerTime(maxRetries)))

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -27,10 +27,13 @@ import com.daml.platform.store.interfaces.LedgerDaoContractsReader.{
 
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
+
+import com.daml.platform.apiserver.execution.MissingContracts
+
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 private[platform] class MutableCacheBackedContractStore(
     metrics: Metrics,
@@ -73,41 +76,46 @@ private[platform] class MutableCacheBackedContractStore(
   override def lookupMaximumLedgerTime(ids: Set[ContractId])(implicit
       loggingContext: LoggingContext
   ): Future[Option[Instant]] =
-    if (ids.isEmpty)
-      Future.failed(EmptyContractIds())
-    else {
-      Future
-        .fromTry(partitionCached(ids))
-        .flatMap {
-          case (cached, toBeFetched) if toBeFetched.isEmpty =>
-            Future.successful(Some(cached.max))
-          case (cached, toBeFetched) =>
-            contractsReader
-              .lookupMaximumLedgerTime(toBeFetched)
-              .map(_.map(m => (cached + m).max))
-        }
-    }
+    Future
+      .fromTry(partitionCached(ids))
+      .flatMap {
+        case (cached, toBeFetched) if toBeFetched.isEmpty =>
+          Future.successful(Some(cached.max))
+        case (cached, toBeFetched) =>
+          contractsReader
+            .lookupMaximumLedgerTime(toBeFetched)
+            .map(_.map(m => (cached + m).max))
+      }
 
   private def partitionCached(
       ids: Set[ContractId]
-  )(implicit loggingContext: LoggingContext) = {
+  )(implicit
+      loggingContext: LoggingContext
+  ): Try[(Set[Instant], Set[ContractId])] = {
     val cacheQueried = ids.map(id => id -> contractsCache.get(id))
 
     val cached = cacheQueried.view
-      .map(_._2)
-      .foldLeft(Try(Set.empty[Instant])) {
-        case (Success(timestamps), Some(active: Active)) =>
-          Success(timestamps + active.createLedgerEffectiveTime)
-        case (Success(_), Some(Archived(_))) => Failure(ContractNotFound(ids))
-        case (Success(_), Some(NotFound)) => Failure(ContractNotFound(ids))
-        case (Success(timestamps), None) => Success(timestamps)
-        case (failure, _) => failure
+      .foldLeft[Either[Set[ContractId], Set[Instant]]](Right(Set.empty[Instant])) {
+        // successful lookups
+        case (Right(timestamps), (_, Some(active: Active))) =>
+          Right(timestamps + active.createLedgerEffectiveTime)
+        case (Right(timestamps), (_, None)) => Right(timestamps)
+
+        // failure cases
+        case (acc, (cid, Some(Archived(_) | NotFound))) =>
+          val missingContracts = acc.left.getOrElse(Set.empty) + cid
+          Left(missingContracts)
+        case (acc @ Left(_), _) => acc
       }
 
-    cached.map { cached =>
-      val missing = cacheQueried.collect { case (id, None) => id }
-      (cached, missing)
-    }
+    cached
+      .map { cached =>
+        val missing = cacheQueried.collect { case (id, None) => id }
+        (cached, missing)
+      }
+      .left
+      .map(MissingContracts)
+      .toTry
   }
 
   private def readThroughContractsCache(contractId: ContractId)(implicit
@@ -377,16 +385,6 @@ private[platform] object MutableCacheBackedContractStore {
           contractStateUpdateDone.map(_ => ())(context.executionContext)
       }.map(_ => contractStore)
   }
-
-  final case class ContractNotFound(contractIds: Set[ContractId])
-      extends IllegalArgumentException(
-        s"One or more of the following contract identifiers has not been found: ${contractIds.map(_.coid).mkString(", ")}"
-      )
-
-  final case class EmptyContractIds()
-      extends IllegalArgumentException(
-        "Cannot lookup the maximum ledger time for an empty set of contract identifiers"
-      )
 
   final case class ContractReadThroughNotFound(contractId: ContractId) extends NoStackTrace {
     override def getMessage: String =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTable.scala
@@ -9,6 +9,7 @@ import java.time.Instant
 import anorm.SqlParser.int
 import anorm.{BatchSql, NamedParameter, SqlStringInterpolation, ~}
 import com.daml.ledger.api.domain.PartyDetails
+import com.daml.platform.apiserver.execution.MissingContracts
 import com.daml.platform.store.Conversions._
 import com.daml.platform.store.DbType
 import com.daml.platform.store.dao.JdbcLedgerDao
@@ -114,9 +115,6 @@ private[events] object ContractsTable {
       "Cannot lookup the maximum ledger time for an empty set of contract identifiers"
     )
 
-  private def notFound(contractIds: Set[ContractId]): Throwable =
-    new IllegalArgumentException(
-      s"One or more of the following contract identifiers has not been found: ${contractIds.map(_.coid).mkString(", ")}"
-    )
+  private def notFound(contractIds: Set[ContractId]): Throwable = MissingContracts(contractIds)
 
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
@@ -1,0 +1,244 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.apiserver.execution
+
+import java.time.{Duration, Instant}
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.api.DeduplicationPeriod
+import com.daml.ledger.api.DeduplicationPeriod.DeduplicationDuration
+import com.daml.ledger.api.domain.{ApplicationId, CommandId, Commands, LedgerId, SubmissionId}
+import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
+import com.daml.ledger.participant.state.index.v2.ContractStore
+import com.daml.ledger.participant.state.v2.{SubmitterInfo, TransactionMeta}
+import com.daml.lf.command.{Commands => LfCommands}
+import com.daml.lf.crypto.Hash
+import com.daml.lf.data.{ImmArray, Ref, Time}
+import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value.ContractId
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.store.ErrorCause
+import com.daml.platform.store.ErrorCause.LedgerTime
+import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+class LedgerTimeAwareCommandExecutorSpec
+    extends AsyncWordSpec
+    with Matchers
+    with MockitoSugar
+    with ArgumentMatchersSugar {
+
+  val submissionSeed = Hash.hashPrivateKey("a key")
+  val configuration = Configuration(
+    generation = 1,
+    timeModel = LedgerTimeModel(
+      avgTransactionLatency = Duration.ZERO,
+      minSkew = Duration.ZERO,
+      maxSkew = Duration.ZERO,
+    ).get,
+    maxDeduplicationTime = Duration.ZERO,
+  )
+
+  val cid = TransactionBuilder.newCid
+  val transaction = TransactionBuilder.justSubmitted(
+    TransactionBuilder().fetch(
+      TransactionBuilder().create(
+        cid,
+        Ref.Identifier(
+          Ref.PackageId.assertFromString("abc"),
+          Ref.QualifiedName.assertFromString("Main:Template"),
+        ),
+        Value.ValueUnit,
+        Set.empty,
+        Set.empty,
+      )
+    )
+  )
+
+  private def runExecutionTest(
+      dependsOnLedgerTime: Boolean,
+      contractStoreResults: List[Try[Option[Instant]]],
+      finalExecutionResult: Either[ErrorCause, Time.Timestamp],
+  ) = {
+
+    def commandExecutionResult(let: Time.Timestamp) = CommandExecutionResult(
+      SubmitterInfo(
+        Nil,
+        Ref.ApplicationId.assertFromString("foobar"),
+        Ref.CommandId.assertFromString("foobar"),
+        DeduplicationDuration(Duration.ofMinutes(1)),
+        Ref.SubmissionId.assertFromString("foobar"),
+        configuration,
+      ),
+      TransactionMeta(let, None, Time.Timestamp.Epoch, submissionSeed, None, None, None),
+      transaction,
+      dependsOnLedgerTime,
+      5L,
+    )
+
+    val mockExecutor = mock[CommandExecutor]
+    when(
+      mockExecutor.execute(any[Commands], any[Hash], any[Configuration])(
+        any[ExecutionContext],
+        any[LoggingContext],
+      )
+    )
+      .thenAnswer((c: Commands) =>
+        Future.successful(Right(commandExecutionResult(c.commands.ledgerEffectiveTime)))
+      )
+
+    val mockContractStore = mock[ContractStore]
+    contractStoreResults.tail.foldLeft(
+      when(mockContractStore.lookupMaximumLedgerTime(any[Set[ContractId]])(any[LoggingContext]))
+        .thenReturn(Future.fromTry(contractStoreResults.head))
+    ) { case (mock, result) =>
+      mock.andThen(Future.fromTry(result))
+    }
+
+    val commands = Commands(
+      ledgerId = LedgerId("ledgerId"),
+      workflowId = None,
+      applicationId = ApplicationId(Ref.ApplicationId.assertFromString("applicationId")),
+      commandId = CommandId(Ref.CommandId.assertFromString("commandId")),
+      submissionId = SubmissionId(Ref.SubmissionId.assertFromString("submissionId")),
+      actAs = Set.empty,
+      readAs = Set.empty,
+      submittedAt = Instant.EPOCH,
+      deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(Duration.ZERO),
+      commands = LfCommands(
+        commands = ImmArray.Empty,
+        ledgerEffectiveTime = Time.Timestamp.Epoch,
+        commandsReference = "",
+      ),
+    )
+
+    val instance = new LedgerTimeAwareCommandExecutor(
+      mockExecutor,
+      mockContractStore,
+      3,
+      new Metrics(new MetricRegistry),
+    )
+    LoggingContext.newLoggingContext { implicit context =>
+      instance.execute(commands, submissionSeed, configuration).map { actual =>
+        val expectedResult = finalExecutionResult.map(let =>
+          CommandExecutionResult(
+            SubmitterInfo(
+              Nil,
+              Ref.ApplicationId.assertFromString("foobar"),
+              Ref.CommandId.assertFromString("foobar"),
+              DeduplicationDuration(Duration.ofMinutes(1)),
+              Ref.SubmissionId.assertFromString("foobar"),
+              configuration,
+            ),
+            TransactionMeta(let, None, Time.Timestamp.Epoch, submissionSeed, None, None, None),
+            transaction,
+            dependsOnLedgerTime,
+            5L,
+          )
+        )
+
+        verify(mockExecutor, times(contractStoreResults.size)).execute(
+          any[Commands],
+          any[Hash],
+          any[Configuration],
+        )(any[ExecutionContext], any[LoggingContext])
+        verify(mockContractStore, times(contractStoreResults.size))
+          .lookupMaximumLedgerTime(Set(cid))
+
+        actual shouldEqual expectedResult
+      }
+    }
+  }
+
+  val missingCid = Failure(MissingContracts(Set(cid)))
+  val foundEpoch = Success(Some(Instant.EPOCH))
+  val epochPlus5: Time.Timestamp = Time.Timestamp.Epoch.add(Duration.ofSeconds(5))
+  val foundEpochPlus5 = Success(Some(epochPlus5.toInstant))
+  val noLetFound = Success(None)
+
+  "LedgerTimeAwareCommandExecutor" when {
+    "the model doesn't use getTime" should {
+      "not retry if ledger effective time is found in the contract store" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(foundEpoch),
+          finalExecutionResult = Right(Time.Timestamp.Epoch),
+        )
+      }
+
+      "not retry if the contract does not have ledger effective time" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(noLetFound),
+          finalExecutionResult = Right(Time.Timestamp.Epoch),
+        )
+      }
+
+      "retry if the contract cannot be found in the contract store and fail at max retries" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(missingCid, missingCid, missingCid, missingCid),
+          finalExecutionResult = Left(LedgerTime(3)),
+        )
+      }
+
+      "succeed if the contract can be found on a retry" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(missingCid, missingCid, missingCid, foundEpoch),
+          finalExecutionResult = Right(Time.Timestamp.Epoch),
+        )
+      }
+
+      "advance the output time if the contract's LET is in the future" in {
+        runExecutionTest(
+          dependsOnLedgerTime = false,
+          contractStoreResults = List(foundEpochPlus5),
+          finalExecutionResult = Right(epochPlus5),
+        )
+      }
+    }
+
+    "the model uses getTime" should {
+      "retry if the contract's LET is in the future" in {
+        runExecutionTest(
+          dependsOnLedgerTime = true,
+          contractStoreResults = List(
+            // the first lookup of +5s will cause the interpretation to be restarted,
+            // in case the usage of getTime with a different LET would result in a different transaction
+            foundEpochPlus5,
+            // The second lookup finds the same ledger time again
+            foundEpochPlus5,
+          ),
+          finalExecutionResult = Right(epochPlus5),
+        )
+      }
+
+      "retry if the contract's LET is in the future and then retry if the contract is missing" in {
+        runExecutionTest(
+          dependsOnLedgerTime = true,
+          contractStoreResults = List(
+            // the first lookup of +5s will cause the interpretation to be restarted,
+            // in case the usage of getTime with a different LET would result in a different transaction
+            foundEpochPlus5,
+            // during the second interpretation the contract was actually archived
+            // and could not be found during the maximum ledger time lookup.
+            // this causes yet another restart of the interpretation.
+            missingCid,
+            // The third lookup finds the same ledger time again
+            foundEpochPlus5,
+          ),
+          finalExecutionResult = Right(epochPlus5),
+        )
+      }
+    }
+
+  }
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
@@ -14,6 +14,8 @@ import com.daml.lf.value.Value.ValueText
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import com.daml.platform.apiserver.execution.MissingContracts
+
 import scala.util.{Failure, Success, Try}
 
 final class PostCommitValidationSpec extends AnyWordSpec with Matchers {
@@ -545,9 +547,7 @@ object PostCommitValidationSpec {
     l.fold(r)(left => r.fold(l)(right => if (left.isAfter(right)) l else r))
 
   private def notFound(contractIds: Set[ContractId]): Throwable =
-    new IllegalArgumentException(
-      s"One or more of the following contract identifiers has not been found: ${contractIds.map(_.coid).mkString(", ")}"
-    )
+    MissingContracts(contractIds)
 
   private def noCommittedContract(parties: List[PartyDetails]): ContractStoreFixture =
     ContractStoreFixture(

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -48,6 +48,7 @@ import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction, TransactionComm
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.platform.apiserver.execution.MissingContracts
 import com.daml.platform.index.TransactionConversion
 import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.participant.util.LfEngineToApi
@@ -329,25 +330,18 @@ private[sandbox] final class InMemoryLedger(
   override def lookupMaximumLedgerTime(contractIds: Set[ContractId])(implicit
       loggingContext: LoggingContext
   ): Future[Option[Instant]] =
-    if (contractIds.isEmpty) {
-      Future.failed(
-        new IllegalArgumentException(
-          "Cannot lookup the maximum ledger time for an empty set of contract identifiers"
-        )
-      )
-    } else {
-      Future.fromTry(Try(this.synchronized {
-        contractIds.foldLeft[Option[Instant]](Some(Instant.MIN))((acc, id) => {
+    Future.fromTry(Try(this.synchronized {
+      contractIds
+        .foldLeft[Option[Instant]](None)((acc, id) => {
           val let = acs.activeContracts
             .getOrElse(
               id,
-              sys.error(s"Contract $id not found while looking for maximum ledger time"),
+              throw MissingContracts(Set(id)),
             )
             .let
           acc.map(acc => if (let.isAfter(acc)) let else acc)
         })
-      }))
-    }
+    }))
 
   override def publishTransaction(
       submitterInfo: state.SubmitterInfo,


### PR DESCRIPTION
Command interpretation happens in two stages:
1. Daml interpretation
2. Determine a suitable ledger effective time

The race can happen in the following situation:
In 1) a contract key K is resolved to contract C1.
Between 1) and 2), a transaction is stored on the participant that
archives C1, but creates C2 with the same contract key K.
In 2) the ledger api server tries to lookup the ledger effective time
for all input contracts to the transaction. If it doesn't find one of
the input contracts at all, it can conclude that the transaction
wouldn't be accepted by the ledger anyway.

The behavior before this patch was to simply abort command
interpretation and return a rather cryptic error to the user.
With this patch, the ledger api server restarts the command
interpretation.
If the "missing contract" was an explicit input to the
command (e.g. as the contract for the exercise or as an argument to an
exercise), then this command will be rejected because the contract is
now archived.
If the contract ID was determined via a contract key lookup, then
restarting the interpretation will result in either a negative lookup or
a different contract ID for the new contract under this contract key.

CHANGELOG_BEGIN
[Ledger API] Retry the interpretation of a command in case of a race
with other transactions. This fix drastically reduces the likelihood of the error
"Could not find a suitable ledger time after 0 retries".
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
