### PR TITLE
Refactoring for Canton compatibility on PackageServiceErrors

### DIFF
--- a/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
@@ -15,8 +15,7 @@ trait ErrorResource {
 
 object ErrorResource {
 
-  private lazy val all =
-    Seq(ContractId, ContractKey, DalfPackage, LedgerId, CommandId, TransactionId, Party)
+  val all = Seq(ContractId, ContractKey, DalfPackage, LedgerId, CommandId, TransactionId, Party)
 
   def fromString(str: String): Option[ErrorResource] = all.find(_.asString == str)
 

--- a/ledger/error/src/main/scala/com/daml/error/definitions/LoggingPackageServiceError.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/LoggingPackageServiceError.scala
@@ -10,15 +10,18 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.Error
 import com.daml.lf.{VersionRange, language, validation}
 
-abstract class PackageServiceError(
+trait PackageServiceError extends BaseError
+
+abstract class LoggingPackageServiceError(
     override val cause: String,
     override val throwableO: Option[Throwable] = None,
 )(implicit override val code: ErrorCode)
-    extends BaseError.Impl(cause, throwableO) {
+    extends BaseError.Impl(cause, throwableO)
+    with PackageServiceError {
   final override def logOnCreation: Boolean = true
 }
 
-object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
+object LoggingPackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
   object Reading extends ErrorGroup {
     @Explanation(
       """This error indicates that the supplied dar file name did not meet the requirements to be stored in the persistence store."""
@@ -31,7 +34,7 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
         ) {
       final case class Error(reason: String)(implicit
           val loggingContext: ContextualizedErrorLogger
-      ) extends PackageServiceError(
+      ) extends LoggingPackageServiceError(
             cause = "Dar file name is invalid"
           )
     }
@@ -42,7 +45,7 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
         extends ErrorCode(id = "INVALID_DAR", ErrorCategory.InvalidIndependentOfSystemState) {
       final case class Error(entries: Seq[String], throwable: Throwable)(implicit
           val loggingContext: ContextualizedErrorLogger
-      ) extends PackageServiceError(
+      ) extends LoggingPackageServiceError(
             cause = "Dar file is corrupt",
             throwableO = Some(throwable),
           )
@@ -53,7 +56,7 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
         extends ErrorCode(id = "INVALID_ZIP_ENTRY", ErrorCategory.InvalidIndependentOfSystemState) {
       final case class Error(name: String, entries: Seq[String])(implicit
           val loggingContext: ContextualizedErrorLogger
-      ) extends PackageServiceError(
+      ) extends LoggingPackageServiceError(
             cause = "Dar zip file is corrupt"
           )
     }
@@ -69,7 +72,7 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
         ) {
       final case class Error(entries: Seq[String])(implicit
           val loggingContext: ContextualizedErrorLogger
-      ) extends PackageServiceError(
+      ) extends LoggingPackageServiceError(
             cause = "Unsupported legacy Dar zip file"
           )
     }
@@ -80,7 +83,7 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
         extends ErrorCode(id = "ZIP_BOMB", ErrorCategory.InvalidIndependentOfSystemState) {
       final case class Error(msg: String)(implicit
           val loggingContext: ContextualizedErrorLogger
-      ) extends PackageServiceError(
+      ) extends LoggingPackageServiceError(
             cause = "Dar zip file seems to be a zip bomb."
           )
     }
@@ -93,7 +96,7 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
         extends ErrorCode(id = "DAR_PARSE_ERROR", ErrorCategory.InvalidIndependentOfSystemState) {
       final case class Error(reason: String)(implicit
           val loggingContext: ContextualizedErrorLogger
-      ) extends PackageServiceError(
+      ) extends LoggingPackageServiceError(
             cause = "Failed to parse the dar file content."
           )
     }
@@ -109,22 +112,22 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
       ) {
     final case class Validation(nameOfFunc: String, msg: String, detailMsg: String = "")(implicit
         val loggingContext: ContextualizedErrorLogger
-    ) extends PackageServiceError(
+    ) extends LoggingPackageServiceError(
           cause = "Internal package validation error."
         )
     final case class Error(missing: Set[PackageId])(implicit
         val loggingContext: ContextualizedErrorLogger
-    ) extends PackageServiceError(
+    ) extends LoggingPackageServiceError(
           cause = "Failed to resolve package ids locally."
         )
     final case class Generic(reason: String)(implicit
         val loggingContext: ContextualizedErrorLogger
-    ) extends PackageServiceError(
+    ) extends LoggingPackageServiceError(
           cause = "Generic error (please check the reason string)."
         )
     final case class Unhandled(throwable: Throwable)(implicit
         val loggingContext: ContextualizedErrorLogger
-    ) extends PackageServiceError(
+    ) extends LoggingPackageServiceError(
           cause = "Failed with an unknown error cause",
           throwableO = Some(throwable),
         )
@@ -133,33 +136,33 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
   object Validation {
     def handleLfArchiveError(
         lfArchiveError: LfArchiveError
-    )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): PackageServiceError =
+    )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): LoggingPackageServiceError =
       lfArchiveError match {
         case LfArchiveError.InvalidDar(entries, cause) =>
-          PackageServiceError.Reading.InvalidDar
+          LoggingPackageServiceError.Reading.InvalidDar
             .Error(entries.entries.keys.toSeq, cause)
         case LfArchiveError.InvalidZipEntry(name, entries) =>
-          PackageServiceError.Reading.InvalidZipEntry
+          LoggingPackageServiceError.Reading.InvalidZipEntry
             .Error(name, entries.entries.keys.toSeq)
         case LfArchiveError.InvalidLegacyDar(entries) =>
-          PackageServiceError.Reading.InvalidLegacyDar.Error(entries.entries.keys.toSeq)
+          LoggingPackageServiceError.Reading.InvalidLegacyDar.Error(entries.entries.keys.toSeq)
         case LfArchiveError.ZipBomb =>
-          PackageServiceError.Reading.ZipBomb.Error(LfArchiveError.ZipBomb.getMessage)
+          LoggingPackageServiceError.Reading.ZipBomb.Error(LfArchiveError.ZipBomb.getMessage)
         case e: LfArchiveError =>
-          PackageServiceError.Reading.ParseError.Error(e.msg)
+          LoggingPackageServiceError.Reading.ParseError.Error(e.msg)
         case e =>
-          PackageServiceError.InternalError.Unhandled(e)
+          LoggingPackageServiceError.InternalError.Unhandled(e)
       }
 
     def handleLfEnginePackageError(err: Error.Package.Error)(implicit
         loggingContext: ContextualizedErrorLogger
-    ): PackageServiceError = err match {
+    ): LoggingPackageServiceError = err match {
       case Error.Package.Internal(nameOfFunc, msg) =>
-        PackageServiceError.InternalError.Validation(nameOfFunc, msg)
+        LoggingPackageServiceError.InternalError.Validation(nameOfFunc, msg)
       case Error.Package.Validation(validationError) =>
         ValidationError.Error(validationError)
       case Error.Package.MissingPackage(packageId, _) =>
-        PackageServiceError.InternalError.Error(Set(packageId))
+        LoggingPackageServiceError.InternalError.Error(Set(packageId))
       case Error.Package
             .AllowedLanguageVersion(packageId, languageVersion, allowedLanguageVersions) =>
         AllowedLanguageMismatchError(
@@ -180,7 +183,7 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
         ) {
       final case class Error(validationError: validation.ValidationError)(implicit
           val loggingContext: ContextualizedErrorLogger
-      ) extends PackageServiceError(
+      ) extends LoggingPackageServiceError(
             cause = "Package validation failed."
           )
     }
@@ -191,7 +194,7 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
         allowedLanguageVersions: VersionRange[language.LanguageVersion],
     )(implicit
         val loggingContext: ContextualizedErrorLogger
-    ) extends PackageServiceError(
+    ) extends LoggingPackageServiceError(
           cause = LedgerApiErrors.CommandExecution.Package.AllowedLanguageVersions
             .buildCause(packageId, languageVersion, allowedLanguageVersions)
         )(
@@ -212,7 +215,7 @@ object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
           missingDependencies: Set[Ref.PackageId],
       )(implicit
           val loggingContext: ContextualizedErrorLogger
-      ) extends PackageServiceError(
+      ) extends LoggingPackageServiceError(
             cause =
               "The set of packages in the dar is not self-consistent and is missing dependencies"
           )

--- a/ledger/error/src/main/scala/com/daml/error/definitions/LoggingPackageServiceError.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/LoggingPackageServiceError.scala
@@ -21,7 +21,7 @@ abstract class LoggingPackageServiceError(
   final override def logOnCreation: Boolean = true
 }
 
-object LoggingPackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
+object PackageServiceError extends LedgerApiErrors.PackageServiceErrorGroup {
   object Reading extends ErrorGroup {
     @Explanation(
       """This error indicates that the supplied dar file name did not meet the requirements to be stored in the persistence store."""
@@ -139,30 +139,30 @@ object LoggingPackageServiceError extends LedgerApiErrors.PackageServiceErrorGro
     )(implicit contextualizedErrorLogger: ContextualizedErrorLogger): LoggingPackageServiceError =
       lfArchiveError match {
         case LfArchiveError.InvalidDar(entries, cause) =>
-          LoggingPackageServiceError.Reading.InvalidDar
+          PackageServiceError.Reading.InvalidDar
             .Error(entries.entries.keys.toSeq, cause)
         case LfArchiveError.InvalidZipEntry(name, entries) =>
-          LoggingPackageServiceError.Reading.InvalidZipEntry
+          PackageServiceError.Reading.InvalidZipEntry
             .Error(name, entries.entries.keys.toSeq)
         case LfArchiveError.InvalidLegacyDar(entries) =>
-          LoggingPackageServiceError.Reading.InvalidLegacyDar.Error(entries.entries.keys.toSeq)
+          PackageServiceError.Reading.InvalidLegacyDar.Error(entries.entries.keys.toSeq)
         case LfArchiveError.ZipBomb =>
-          LoggingPackageServiceError.Reading.ZipBomb.Error(LfArchiveError.ZipBomb.getMessage)
+          PackageServiceError.Reading.ZipBomb.Error(LfArchiveError.ZipBomb.getMessage)
         case e: LfArchiveError =>
-          LoggingPackageServiceError.Reading.ParseError.Error(e.msg)
+          PackageServiceError.Reading.ParseError.Error(e.msg)
         case e =>
-          LoggingPackageServiceError.InternalError.Unhandled(e)
+          PackageServiceError.InternalError.Unhandled(e)
       }
 
     def handleLfEnginePackageError(err: Error.Package.Error)(implicit
         loggingContext: ContextualizedErrorLogger
     ): LoggingPackageServiceError = err match {
       case Error.Package.Internal(nameOfFunc, msg) =>
-        LoggingPackageServiceError.InternalError.Validation(nameOfFunc, msg)
+        PackageServiceError.InternalError.Validation(nameOfFunc, msg)
       case Error.Package.Validation(validationError) =>
         ValidationError.Error(validationError)
       case Error.Package.MissingPackage(packageId, _) =>
-        LoggingPackageServiceError.InternalError.Error(Set(packageId))
+        PackageServiceError.InternalError.Error(Set(packageId))
       case Error.Package
             .AllowedLanguageVersion(packageId, languageVersion, allowedLanguageVersions) =>
         AllowedLanguageMismatchError(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
-import com.daml.error.definitions.PackageServiceError
+import com.daml.error.definitions.LoggingPackageServiceError
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -43,7 +43,7 @@ final class PackageManagementServiceIT extends LedgerTestSuite {
         ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
-        PackageServiceError.Reading.InvalidDar,
+        LoggingPackageServiceError.Reading.InvalidDar,
         Some(Pattern.compile("Invalid DAR: package-upload|Dar file is corrupt")),
       )
     }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
-import com.daml.error.definitions.LoggingPackageServiceError
+import com.daml.error.definitions.PackageServiceError
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -43,7 +43,7 @@ final class PackageManagementServiceIT extends LedgerTestSuite {
         ledger,
         failure,
         Status.Code.INVALID_ARGUMENT,
-        LoggingPackageServiceError.Reading.InvalidDar,
+        PackageServiceError.Reading.InvalidDar,
         Some(Pattern.compile("Invalid DAR: package-upload|Dar file is corrupt")),
       )
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -9,8 +9,8 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.daml.api.util.TimestampConversion
 import com.daml.daml_lf_dev.DamlLf.Archive
-import com.daml.error.definitions.PackageServiceError
-import com.daml.error.definitions.PackageServiceError.Validation
+import com.daml.error.definitions.LoggingPackageServiceError
+import com.daml.error.definitions.LoggingPackageServiceError.Validation
 import com.daml.error.{
   ContextualizedErrorLogger,
   DamlContextualizedErrorLogger,
@@ -145,7 +145,7 @@ private[apiserver] final class ApiPackageManagementService private (
     }
 
   private implicit class ErrorValidations[E, R](result: Either[E, R]) {
-    def handleError(toSelfServiceErrorCode: E => PackageServiceError): Try[R] =
+    def handleError(toSelfServiceErrorCode: E => LoggingPackageServiceError): Try[R] =
       result.left.map { err =>
         toSelfServiceErrorCode(err).asGrpcError
       }.toTry

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -10,7 +10,7 @@ import akka.stream.scaladsl.Source
 import com.daml.api.util.TimestampConversion
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.error.definitions.LoggingPackageServiceError
-import com.daml.error.definitions.LoggingPackageServiceError.Validation
+import com.daml.error.definitions.PackageServiceError.Validation
 import com.daml.error.{
   ContextualizedErrorLogger,
   DamlContextualizedErrorLogger,


### PR DESCRIPTION
* ErrorResource.all is public for accessibility from Canton

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
