### PR TITLE
Add gRPC definitions for participant user management service

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
@@ -1,0 +1,161 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package com.daml.ledger.api.v1.admin;
+
+option java_outer_classname = "UserManagementServiceOuterClass";
+option java_package = "com.daml.ledger.api.v1.admin";
+option csharp_namespace = "Com.Daml.Ledger.Api.V1.Admin";
+
+import "google/protobuf/empty.proto";
+
+
+// Manage users and their rights for interacting with the Ledger API served by a participant node.
+//
+// The API roughly follows the Google API style guidelines for resource-oriented design
+// (https://cloud.google.com/apis/design/resources) with the following simplifications to
+// ease its implementation:
+//
+// 1. List methods do not (yet) support pagination,
+//    as we expect to have fewer than 10k users and 1k rights per user.
+//
+// 2. Resources are not named as per the Google API style guide,
+//    as this would be in contrast with the other Ledger API services.
+//
+// Authorization rules for the services RPCs are specified on the `RpcNameRequest`
+// messages as boolean expressions over these facts:
+// - ``HasRight(r)``: true iff the authenticated user has right `r`
+// - ``IsAuthenticatedUser(u)``: true iff ``u`` is equal to the name of the authenticated user
+//
+service UserManagementService {
+
+    // Create a new user, failing if it already exists.
+    rpc CreateUser (CreateUserRequest) returns (User);
+
+    // Get the user data of a specific user or the authenticated user.
+    rpc GetUser (GetUserRequest) returns (User);
+
+    // Delete an existing user and all its rights.
+    rpc DeleteUser (DeleteUserRequest) returns (google.protobuf.Empty);
+
+    // List the all existing users.
+    rpc ListUsers (ListUsersRequest) returns (ListUsersResponse);
+
+    // Grant a right to a user. Idempotent if the user already has the right.
+    rpc CreateUserRight (CreateUserRightRequest) returns (Right);
+
+    // Revoke a right from a user. Fails if the user does not have the right.
+    rpc DeleteUserRight (DeleteUserRightRequest) returns (google.protobuf.Empty);
+
+    // List the set of all rights granted to a user.
+    rpc ListUserRights (ListUserRightsRequest) returns (ListUserRightsResponse);
+}
+
+
+// Users and rights
+///////////////////
+
+// Users are are used to manage the rights given to authenticated Ledger API clients.
+// They are stored and managed per participant node.
+//
+// TLS client certificates authenticate the user specified by the certificates common name.
+// JWT tokens authenticate the user specified by the JWT tokens 'sub' (subject) claim.
+message User {
+    // The user identifier, which must be a non-empty string of at most 64
+    // characters matching the regexp [a-z0-9-_.], i.e. lower-case characters, digits,
+    // dashes or dots. Double-dots, double-dashes, and double-underscores are not allowed.
+    string id = 1;
+
+    // The primary party as which this user reads and acts by default on the ledger
+    // provided it has the corresponding ``CanReadAs(primary_party)`` or 
+    // ``CanActAs(primary_party)`` rights.
+    string primary_party = 2;
+}
+
+// A right granted to a user.
+message Right {
+    // The user is allowed to administrate the participant node.
+    message ParticipantAdmin {}
+
+    // The user can authorize commands for the given party.
+    message CanActAs {
+        string party = 1;
+    }
+
+    // The user can read ledger data visible to the given party.
+    message CanReadAs {
+        string party = 1;
+    }
+
+    oneof kind {
+        ParticipantAdmin participant_admin = 1;
+        CanActAs can_act_as = 2;
+        CanReadAs can_read_as = 3;
+    }
+}
+
+
+// RPC requests and responses
+/////////////////////////////
+
+// Required authorization: ``HasRight(ParticipantAdmin)``
+message CreateUserRequest {
+    // The user to create, which is granted exactly
+    // the ``CanActAs(user.primary_party)`` right upon creation.
+    User user = 1;
+}
+
+// Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedUser(user_id)``
+message GetUserRequest {
+    // The user whose data we want to retrieve.
+    // If set to empty string (the default), then the data for the authenticated user will be retrieved.
+    string user_id = 1;
+}
+
+// Required authorization: ``HasRight(ParticipantAdmin)``
+message DeleteUserRequest {
+    string user_id = 1;
+}
+
+// Required authorization: ``HasRight(ParticipantAdmin)``
+message ListUsersRequest {
+    // TODO: add pagination, cf. https://cloud.google.com/apis/design/design_patterns#list_pagination
+}
+
+message ListUsersResponse {
+    repeated User users = 1;
+}
+
+// Add the right to the set of rights given to the user.
+// Idempotent if the user already has the right.
+//
+// Required authorization: ``HasRight(ParticipantAdmin)``
+message CreateUserRightRequest {
+    string user_id = 1;
+    Right right = 2;
+}
+
+// Remove the right from the set of rights granted to the user.
+// Fails if the user does not have the right.
+//
+// Required authorization: ``HasRight(ParticipantAdmin)``
+message DeleteUserRightRequest {
+    string user_id = 1;
+    Right right = 2;
+}
+
+// Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedUser(user_id)``
+message ListUserRightsRequest {
+    // The user for which to list the rights.
+    // If set to empty string (the default), then the rights for the authenticated user will be shown.
+    string user_id = 1;
+
+    // TODO: add pagination, cf. https://cloud.google.com/apis/design/design_patterns#list_pagination
+}
+
+message ListUserRightsResponse {
+    repeated Right rights = 1;
+}
+

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
@@ -12,7 +12,8 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1.Admin";
 import "google/protobuf/empty.proto";
 
 
-// Manage users and their rights for interacting with the Ledger API served by a participant node.
+// Experimental API to manage users and their rights for interacting with the Ledger API
+// served by a participant node.
 //
 // The API roughly follows the Google API style guidelines for resource-oriented design
 // (https://cloud.google.com/apis/design/resources) with the following simplifications to
@@ -43,11 +44,11 @@ service UserManagementService {
     // List the all existing users.
     rpc ListUsers (ListUsersRequest) returns (ListUsersResponse);
 
-    // Grant a right to a user. Idempotent if the user already has the right.
-    rpc CreateUserRight (CreateUserRightRequest) returns (Right);
+    // Grant rights to a user.
+    rpc GrantUserRights (GrantUserRightsRequest) returns (GrantUserRightsResponse);
 
-    // Revoke a right from a user. Fails if the user does not have the right.
-    rpc DeleteUserRight (DeleteUserRightRequest) returns (google.protobuf.Empty);
+    // Revoke rights from a user.
+    rpc RevokeUserRights (RevokeUserRightsRequest) returns (RevokeUserRightsResponse);
 
     // List the set of all rights granted to a user.
     rpc ListUserRights (ListUserRightsRequest) returns (ListUserRightsResponse);
@@ -69,7 +70,7 @@ message User {
     string id = 1;
 
     // The primary party as which this user reads and acts by default on the ledger
-    // provided it has the corresponding ``CanReadAs(primary_party)`` or 
+    // _provided_ it has the corresponding ``CanReadAs(primary_party)`` or 
     // ``CanActAs(primary_party)`` rights.
     string primary_party = 2;
 }
@@ -102,9 +103,12 @@ message Right {
 
 // Required authorization: ``HasRight(ParticipantAdmin)``
 message CreateUserRequest {
-    // The user to create, which is granted exactly
-    // the ``CanActAs(user.primary_party)`` right upon creation.
+    // The user to create.
     User user = 1;
+
+    // The rights to be assigned to the user upon creation,
+    // which SHOULD include appropriate rights for the ``user.primary_party``.
+    repeated Right rights = 2;
 }
 
 // Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedUser(user_id)``
@@ -128,28 +132,38 @@ message ListUsersResponse {
     repeated User users = 1;
 }
 
-// Add the right to the set of rights given to the user.
-// Idempotent if the user already has the right.
+// Add the rights to the set of rights granted to the user.
 //
 // Required authorization: ``HasRight(ParticipantAdmin)``
-message CreateUserRightRequest {
+message GrantUserRightsRequest {
     string user_id = 1;
-    Right right = 2;
+
+    repeated Right rights = 2;
 }
 
-// Remove the right from the set of rights granted to the user.
-// Fails if the user does not have the right.
+message GrantUserRightsResponse {
+    // The rights that were newly granted by the request.
+    repeated Right newly_granted_rights = 1;
+}
+
+// Remove the rights from the set of rights granted to the user.
 //
 // Required authorization: ``HasRight(ParticipantAdmin)``
-message DeleteUserRightRequest {
+message RevokeUserRightsRequest {
     string user_id = 1;
-    Right right = 2;
+
+    repeated Right rights = 2;
+}
+
+message RevokeUserRightsResponse {
+    // The rights that were actually revoked by the request.
+    repeated Right newly_revoked_rights = 1;
 }
 
 // Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedUser(user_id)``
 message ListUserRightsRequest {
     // The user for which to list the rights.
-    // If set to empty string (the default), then the rights for the authenticated user will be shown.
+    // If set to empty string (the default), then the rights for the authenticated user will be listed.
     string user_id = 1;
 
     // TODO: add pagination, cf. https://cloud.google.com/apis/design/design_patterns#list_pagination


### PR DESCRIPTION
This PR introduces the gRPC definitions for an experimental user management service to manage users and their rights for interacting with the Ledger API served by a participant node. The PR does not change the set of actually exposed services of a Ledger API server. 

I expect to implement the user management service in a later PR behind a feature flag such that we can start a PoC phase to evaluate whether all the Daml SDK tools can be made to work well (or hopefully better) building on this user management service. I expect that we'll iterate further on the service's gRPC definitions as part of this PoC phase.

@bame-da @cocreature @stefanobaghino-da could I ask one of you to approve the PR so we can start the PoC implementation work?

FYI: @da-tanabe @adriaanm-da @gerolf-da and others, feel free to review the code directly on this PR and add comments here. I will then take care of addressing the comments on a new PR in case this one is already merged.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description
- [x] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
