### PR TITLE
port #11798 documentation changes to json-api HTTP codes documentation

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -220,9 +220,9 @@ The **JSON API** can return one of the following HTTP status codes:
 - 403 - Forbidden, insufficient permissions
 - 404 - Not Found
 - 409 - Conflict, contract ID or key missing or duplicated
-- 429 - Too Many Requests, ledger server has hit configured limit of in-flight commands
 - 500 - Internal Server Error
 - 503 - Service Unavailable, ledger server is not running yet or has been shut down
+- 504 - Gateway Timeout, transaction failed to receive its completion within the predefined timeout
 
 When the Ledger API returns an error code, the JSON API maps it to one of the above codes according to `the official gRPC to HTTP code mapping <https://cloud.google.com/apis/design/errors#generating_errors>`_.
 
@@ -231,7 +231,7 @@ If a client's HTTP GET or POST request reaches an API endpoint, the correspondin
 .. code-block:: none
 
     {
-        "status": <400 | 401 | 403 | 404 | 409 | 429 | 500 | 503>,
+        "status": <400 | 401 | 403 | 404 | 409 | 500 | 503 | 504>,
         "errors": <JSON array of strings>, | "result": <JSON object or array>,
         ["warnings": <JSON object> ]
     }


### PR DESCRIPTION
#11798 documents some error code changes from the ledger API; we also document those for json-api users.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
