### PR TITLE
Allow encoded server key files to be in base64 [DPP-761] (#11796)

### DIFF
--- a/ledger/test-common/test-certificates/BUILD.bazel
+++ b/ledger/test-common/test-certificates/BUILD.bazel
@@ -80,7 +80,7 @@ chmod 444 $(location server.crt)
 
 # Encrypt server's key and dump encryption parameters to a JSON file.
 # NOTE: Encryption details used to encrypt the private must be kept in sync with `ledger/test-common/files/server-pem-decryption-parameters.json`
-$(location @openssl_dev_env//:openssl) enc -aes-128-cbc \
+$(location @openssl_dev_env//:openssl) enc -aes-128-cbc -base64 \
     -in $(location server.pem) \
     -out $(location server.pem.enc) \
     -K 0034567890abcdef1234567890abcdef \


### PR DESCRIPTION
* Allow encoded server key files to be in base64

CHANGELOG_BEGIN
CHANGELOG_END

* format

* dry tests

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
