### PR TITLE
[Self-service error codes] Do not return error code id and definite_answer in metadata for security sensitive errors

### DIFF
--- a/ledger/error/src/main/scala/com/daml/error/ErrorCode.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorCode.scala
@@ -67,9 +67,10 @@ abstract class ErrorCode(val id: String, val category: ErrorCategory)(implicit
       getStatusInfo(err)
 
     // Provide error id and context via ErrorInfo
-    val errInfoBld = com.google.rpc.ErrorInfo.newBuilder().setReason(id)
+    val errInfoBld = com.google.rpc.ErrorInfo.newBuilder()
     if (!code.category.securitySensitive) {
       contextMap.foreach { case (k, v) => errInfoBld.putMetadata(k, v) }
+      errInfoBld.setReason(id)
     }
 
     // TODO error codes: Resolve dependency and use constant

--- a/ledger/error/src/main/scala/com/daml/error/ErrorCode.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorCode.scala
@@ -71,14 +71,15 @@ abstract class ErrorCode(val id: String, val category: ErrorCategory)(implicit
     if (!code.category.securitySensitive) {
       contextMap.foreach { case (k, v) => errInfoBld.putMetadata(k, v) }
       errInfoBld.setReason(id)
+
+      // TODO error codes: Resolve dependency and use constant
+      //    val definiteAnswerKey = com.daml.ledger.grpc.GrpcStatuses.DefiniteAnswerKey
+      val definiteAnswerKey = "definite_answer"
+      err.definiteAnswerO.foreach { definiteAnswer =>
+        errInfoBld.putMetadata(definiteAnswerKey, definiteAnswer.toString)
+      }
     }
 
-    // TODO error codes: Resolve dependency and use constant
-    //    val definiteAnswerKey = com.daml.ledger.grpc.GrpcStatuses.DefiniteAnswerKey
-    val definiteAnswerKey = "definite_answer"
-    err.definiteAnswerO.foreach { definiteAnswer =>
-      errInfoBld.putMetadata(definiteAnswerKey, definiteAnswer.toString)
-    }
     val errInfo = com.google.protobuf.Any.pack(errInfoBld.build())
 
     // Build retry info

--- a/ledger/error/src/main/scala/com/daml/error/ErrorCode.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorCode.scala
@@ -67,20 +67,20 @@ abstract class ErrorCode(val id: String, val category: ErrorCategory)(implicit
       getStatusInfo(err)
 
     // Provide error id and context via ErrorInfo
-    val errInfoBld = com.google.rpc.ErrorInfo.newBuilder()
-    if (!code.category.securitySensitive) {
-      contextMap.foreach { case (k, v) => errInfoBld.putMetadata(k, v) }
-      errInfoBld.setReason(id)
+    val maybeErrInfo =
+      if (!code.category.securitySensitive) {
+        val errInfoBld = com.google.rpc.ErrorInfo.newBuilder()
+        contextMap.foreach { case (k, v) => errInfoBld.putMetadata(k, v) }
+        errInfoBld.setReason(id)
 
-      // TODO error codes: Resolve dependency and use constant
-      //    val definiteAnswerKey = com.daml.ledger.grpc.GrpcStatuses.DefiniteAnswerKey
-      val definiteAnswerKey = "definite_answer"
-      err.definiteAnswerO.foreach { definiteAnswer =>
-        errInfoBld.putMetadata(definiteAnswerKey, definiteAnswer.toString)
-      }
-    }
-
-    val errInfo = com.google.protobuf.Any.pack(errInfoBld.build())
+        // TODO error codes: Resolve dependency and use constant
+        //    val definiteAnswerKey = com.daml.ledger.grpc.GrpcStatuses.DefiniteAnswerKey
+        val definiteAnswerKey = "definite_answer"
+        err.definiteAnswerO.foreach { definiteAnswer =>
+          errInfoBld.putMetadata(definiteAnswerKey, definiteAnswer.toString)
+        }
+        Some(com.google.protobuf.Any.pack(errInfoBld.build()))
+      } else None
 
     // Build retry info
     val retryInfo = err.retryable.map { ri =>
@@ -126,7 +126,7 @@ abstract class ErrorCode(val id: String, val category: ErrorCategory)(implicit
       .setCode(codeGrpc.value())
       .setMessage(message)
 
-    (Seq(errInfo) ++ retryInfo.toList ++ requestInfo.toList ++ resourceInfo)
+    (maybeErrInfo.toList ++ retryInfo.toList ++ requestInfo.toList ++ resourceInfo)
       .foldLeft(statusBuilder) { case (acc, item) =>
         acc.addDetails(item)
       }

--- a/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
@@ -689,7 +689,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           loggingContext: ContextualizedErrorLogger
       ) extends LoggingTransactionErrorImpl(
             cause = "A command with the given command id has already been successfully processed",
-        definiteAnswer = _definiteAnswer
+            definiteAnswer = _definiteAnswer,
           ) {
         override def context: Map[String, String] =
           super.context ++ _existingCommandSubmissionId.map("existing_submission_id" -> _).toList

--- a/ledger/error/src/main/scala/com/daml/error/utils/ErrorDetails.scala
+++ b/ledger/error/src/main/scala/com/daml/error/utils/ErrorDetails.scala
@@ -19,22 +19,23 @@ object ErrorDetails {
   final case class RetryInfoDetail(retryDelayInSeconds: Long) extends ErrorDetail
   final case class RequestInfoDetail(requestId: String) extends ErrorDetail
 
-  def from(anys: Seq[protobuf.Any]): Seq[ErrorDetail] = anys.toList.map {
+  def from(anys: Seq[protobuf.Any]): Seq[ErrorDetail] = anys.toList.flatMap {
     case any if any.is(classOf[ResourceInfo]) =>
       val v = any.unpack(classOf[ResourceInfo])
-      ResourceInfoDetail(v.getResourceType, v.getResourceName)
+      List(ResourceInfoDetail(v.getResourceType, v.getResourceName))
 
     case any if any.is(classOf[ErrorInfo]) =>
       val v = any.unpack(classOf[ErrorInfo])
-      ErrorInfoDetail(v.getReason)
+      val reason = v.getReason
+      if (reason.nonEmpty) List(ErrorInfoDetail(reason)) else Nil
 
     case any if any.is(classOf[RetryInfo]) =>
       val v = any.unpack(classOf[RetryInfo])
-      RetryInfoDetail(v.getRetryDelay.getSeconds)
+      List(RetryInfoDetail(v.getRetryDelay.getSeconds))
 
     case any if any.is(classOf[RequestInfo]) =>
       val v = any.unpack(classOf[RequestInfo])
-      RequestInfoDetail(v.getRequestId)
+      List(RequestInfoDetail(v.getRequestId))
 
     case any => throw new IllegalStateException(s"Could not unpack value of: |$any|")
   }

--- a/ledger/error/src/main/scala/com/daml/error/utils/ErrorDetails.scala
+++ b/ledger/error/src/main/scala/com/daml/error/utils/ErrorDetails.scala
@@ -3,11 +3,8 @@
 
 package com.daml.error.utils
 
-import com.daml.error.ErrorCode
 import com.google.protobuf
 import com.google.rpc.{ErrorInfo, RequestInfo, ResourceInfo, RetryInfo}
-import io.grpc.StatusRuntimeException
-import io.grpc.protobuf.StatusProto
 
 import scala.jdk.CollectionConverters._
 
@@ -38,17 +35,5 @@ object ErrorDetails {
       RequestInfoDetail(v.getRequestId)
 
     case any => throw new IllegalStateException(s"Could not unpack value of: |$any|")
-  }
-
-  def isErrorCode(exception: StatusRuntimeException)(errorCode: ErrorCode): Boolean = {
-    val rpcStatus =
-      StatusProto.fromStatusAndTrailers(exception.getStatus, exception.getTrailers)
-
-    ErrorDetails
-      .from(rpcStatus.getDetailsList.asScala.toSeq)
-      .exists {
-        case ErrorInfoDetail(reason, _) => reason == errorCode.id
-        case _ => false
-      }
   }
 }

--- a/ledger/error/src/main/scala/com/daml/error/utils/ErrorDetails.scala
+++ b/ledger/error/src/main/scala/com/daml/error/utils/ErrorDetails.scala
@@ -15,30 +15,27 @@ object ErrorDetails {
   sealed trait ErrorDetail extends Product with Serializable
 
   final case class ResourceInfoDetail(name: String, typ: String) extends ErrorDetail
-  final case class ErrorInfoDetail(reason: String, metadata: Map[String, String] = Map.empty)
+  final case class ErrorInfoDetail(reason: String, metadata: Map[String, String])
       extends ErrorDetail
   final case class RetryInfoDetail(retryDelayInSeconds: Long) extends ErrorDetail
   final case class RequestInfoDetail(requestId: String) extends ErrorDetail
 
-  def from(anys: Seq[protobuf.Any]): Seq[ErrorDetail] = anys.toList.flatMap {
+  def from(anys: Seq[protobuf.Any]): Seq[ErrorDetail] = anys.toList.map {
     case any if any.is(classOf[ResourceInfo]) =>
       val v = any.unpack(classOf[ResourceInfo])
-      List(ResourceInfoDetail(v.getResourceType, v.getResourceName))
+      ResourceInfoDetail(v.getResourceType, v.getResourceName)
 
     case any if any.is(classOf[ErrorInfo]) =>
       val v = any.unpack(classOf[ErrorInfo])
-      val reason = v.getReason
-      if (reason.nonEmpty || v.getMetadataCount > 0)
-        List(ErrorInfoDetail(reason, v.getMetadataMap.asScala.toMap))
-      else Nil
+      ErrorInfoDetail(v.getReason, v.getMetadataMap.asScala.toMap)
 
     case any if any.is(classOf[RetryInfo]) =>
       val v = any.unpack(classOf[RetryInfo])
-      List(RetryInfoDetail(v.getRetryDelay.getSeconds))
+      RetryInfoDetail(v.getRetryDelay.getSeconds)
 
     case any if any.is(classOf[RequestInfo]) =>
       val v = any.unpack(classOf[RequestInfo])
-      List(RequestInfoDetail(v.getRequestId))
+      RequestInfoDetail(v.getRequestId)
 
     case any => throw new IllegalStateException(s"Could not unpack value of: |$any|")
   }

--- a/ledger/error/src/test/suite/scala/com/daml/error/ErrorCodeSpec.scala
+++ b/ledger/error/src/test/suite/scala/com/daml/error/ErrorCodeSpec.scala
@@ -60,7 +60,8 @@ class ErrorCodeSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
   }
 
   s"$className.asGrpcErrorFromContext" should "output a GRPC error with correct status, message and metadata" in {
-    val error = NotSoSeriousError.Error("some error cause")
+    val contextMetadata = Map("some key" -> "some value", "another key" -> "another value")
+    val error = NotSoSeriousError.Error("some error cause", contextMetadata)
     val correlationId = "12345678"
 
     val actualGrpcError = error.asGrpcErrorFromContext(errorLoggingContext(Some(correlationId)))
@@ -78,7 +79,10 @@ class ErrorCodeSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
     actualGrpcError.getMessage shouldBe expectedErrorMessage
 
     errorDetails should contain theSameElementsAs Seq(
-      ErrorDetails.ErrorInfoDetail(NotSoSeriousError.id),
+      ErrorDetails.ErrorInfoDetail(
+        NotSoSeriousError.id,
+        Map("category" -> "1") ++ contextMetadata ++ Map("definite_answer" -> "true"),
+      ),
       ErrorDetails.RetryInfoDetail(TransientServerFailure.retryable.get.duration.toSeconds),
       ErrorDetails.RequestInfoDetail(correlationId),
       ErrorDetails.ResourceInfoDetail(error.resources.head._1.asString, error.resources.head._2),
@@ -104,9 +108,7 @@ class ErrorCodeSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
     actualStatus.getCode shouldBe io.grpc.Status.Code.INTERNAL
     actualGrpcError.getStatus.getDescription shouldBe expectedErrorMessage
 
-    errorDetails should contain theSameElementsAs Seq(
-      ErrorDetails.RequestInfoDetail(correlationId)
-    )
+    errorDetails should contain theSameElementsAs Seq(ErrorDetails.RequestInfoDetail(correlationId))
   }
 
   private def logSeriousError(

--- a/ledger/error/src/test/utils/scala/com/daml/error/utils/testpackage/SeriousError.scala
+++ b/ledger/error/src/test/utils/scala/com/daml/error/utils/testpackage/SeriousError.scala
@@ -13,7 +13,11 @@ case object SeriousError
     extends ErrorCode("BLUE_SCREEN", ErrorCategory.SystemInternalAssumptionViolated)(
       ErrorClass.root()
     ) {
-  case class Error(cause: String, override val context: Map[String, String] = Map.empty)(implicit
+  case class Error(
+      cause: String,
+      override val context: Map[String, String] = Map.empty,
+      override val definiteAnswerO: Option[Boolean] = Some(true),
+  )(implicit
       val loggingContext: LoggingContext
   ) extends BaseError {
 

--- a/ledger/error/src/test/utils/scala/com/daml/error/utils/testpackage/SeriousError.scala
+++ b/ledger/error/src/test/utils/scala/com/daml/error/utils/testpackage/SeriousError.scala
@@ -13,7 +13,9 @@ case object SeriousError
     extends ErrorCode("BLUE_SCREEN", ErrorCategory.SystemInternalAssumptionViolated)(
       ErrorClass.root()
     ) {
-  case class Error(cause: String)(implicit val loggingContext: LoggingContext) extends BaseError {
+  case class Error(cause: String, override val context: Map[String, String] = Map.empty)(implicit
+      val loggingContext: LoggingContext
+  ) extends BaseError {
 
     /** The error code, usually passed in as implicit where the error class is defined */
     override def code: ErrorCode = SeriousError.code

--- a/ledger/error/src/test/utils/scala/com/daml/error/utils/testpackage/subpackage/MildErrors.scala
+++ b/ledger/error/src/test/utils/scala/com/daml/error/utils/testpackage/subpackage/MildErrors.scala
@@ -19,7 +19,11 @@ object MildErrors
         "TEST_ROUTINE_FAILURE_PLEASE_IGNORE",
         ErrorCategory.TransientServerFailure,
       ) {
-    case class Error(someErrArg: String)(implicit val loggingContext: LoggingContext)
+    case class Error(
+        someErrArg: String,
+        override val context: Map[String, String],
+        override val definiteAnswerO: Option[Boolean] = Some(true),
+    )(implicit val loggingContext: LoggingContext)
         extends BaseError {
 
       override def code: ErrorCode = NotSoSeriousError.code

--- a/ledger/ledger-api-auth/src/test/suite/scala/com/digitalasset/ledger/api/auth/AuthorizationInterceptorSpec.scala
+++ b/ledger/ledger-api-auth/src/test/suite/scala/com/digitalasset/ledger/api/auth/AuthorizationInterceptorSpec.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.api.auth
 
 import com.daml.error.ErrorCodesVersionSwitcher
 import com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor
-import com.google.rpc.ErrorInfo
 import io.grpc.protobuf.StatusProto
 import io.grpc.{Metadata, ServerCall, Status}
 import org.mockito.captor.ArgCaptor
@@ -42,9 +41,7 @@ class AuthorizationInterceptorSpec
       actualStatus.getDescription shouldBe "An error occurred. Please contact the operator and inquire about the request <no-correlation-id>"
 
       val actualRpcStatus = StatusProto.fromStatusAndTrailers(actualStatus, actualMetadata)
-      actualRpcStatus.getDetailsList.size() shouldBe 1
-      val errorInfo = actualRpcStatus.getDetailsList.get(0).unpack(classOf[ErrorInfo])
-      errorInfo.getReason shouldBe "INTERNAL_AUTHORIZATION_ERROR"
+      actualRpcStatus.getDetailsList.size() shouldBe 0
     }
   }
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
@@ -76,7 +76,7 @@ class ErrorFactories private (errorCodesVersionSwitcher: ErrorCodesVersionSwitch
         v2 = LedgerApiErrors.RequestTimeOut
           .Reject(
             "Timed out while awaiting for a completion corresponding to a command submission.",
-            definiteAnswer = false,
+            _definiteAnswer = false,
           )
           .asGrpcStatusFromContext,
       )
@@ -149,7 +149,7 @@ class ErrorFactories private (errorCodesVersionSwitcher: ErrorCodesVersionSwitch
     errorCodesVersionSwitcher.choose(
       v1 = io.grpc.Status.NOT_FOUND.asRuntimeException(),
       v2 = LedgerApiErrors.RequestValidation.NotFound.Package
-        .Reject(packageId = packageId)
+        .Reject(_packageId = packageId)
         .asGrpcError,
     )
 
@@ -309,9 +309,9 @@ class ErrorFactories private (errorCodesVersionSwitcher: ErrorCodesVersionSwitch
       v1 = invalidArgumentV1(definiteAnswer, message),
       v2 = LedgerApiErrors.RequestValidation.NonHexOffset
         .Error(
-          fieldName = fieldName,
-          offsetValue = offsetValue,
-          message = message,
+          _fieldName = fieldName,
+          _offsetValue = offsetValue,
+          _message = message,
         )
         .asGrpcError,
     )
@@ -385,11 +385,7 @@ class ErrorFactories private (errorCodesVersionSwitcher: ErrorCodesVersionSwitch
     errorCodesVersionSwitcher.choose(
       v1 = aborted(message, definiteAnswer),
       v2 = LedgerApiErrors.RequestTimeOut
-        .Reject(
-          message,
-          // TODO error codes: How to handle None definiteAnswer?
-          definiteAnswer.getOrElse(false),
-        )
+        .Reject(message, definiteAnswer.getOrElse(false))
         .asGrpcError,
     )
   }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
@@ -184,7 +184,7 @@ class ErrorFactories private (errorCodesVersionSwitcher: ErrorCodesVersionSwitch
         exception
       },
       v2 = LedgerApiErrors.ConsistencyErrors.DuplicateCommand
-        .Reject(existingCommandSubmissionId = existingSubmissionId)
+        .Reject(_existingCommandSubmissionId = existingSubmissionId)
         .asGrpcError,
     )
 

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
@@ -73,10 +73,7 @@ class ErrorFactoriesSpec
         expectedCode = Code.INTERNAL,
         expectedMessage =
           s"An error occurred. Please contact the operator and inquire about the request $originalCorrelationId",
-        expectedDetails = Seq[ErrorDetails.ErrorDetail](
-          ErrorDetails.ErrorInfoDetail("INDEX_DB_SQL_NON_TRANSIENT_ERROR"),
-          expectedCorrelationIdRequestInfo,
-        ),
+        expectedDetails = Seq[ErrorDetails.ErrorDetail](expectedCorrelationIdRequestInfo),
       )
     }
 
@@ -100,10 +97,7 @@ class ErrorFactoriesSpec
           v2_code = Code.INTERNAL,
           v2_message =
             s"An error occurred. Please contact the operator and inquire about the request $originalCorrelationId",
-          v2_details = Seq[ErrorDetails.ErrorDetail](
-            ErrorDetails.ErrorInfoDetail("LEDGER_API_INTERNAL_ERROR"),
-            expectedCorrelationIdRequestInfo,
-          ),
+          v2_details = Seq[ErrorDetails.ErrorDetail](expectedCorrelationIdRequestInfo),
         )
       }
 
@@ -176,10 +170,7 @@ class ErrorFactoriesSpec
           v2_code = Code.INTERNAL,
           v2_message =
             s"An error occurred. Please contact the operator and inquire about the request cor-id-12345679",
-          v2_details = Seq[ErrorDetails.ErrorDetail](
-            ErrorDetails.ErrorInfoDetail("LEDGER_API_INTERNAL_ERROR"),
-            expectedCorrelationIdRequestInfo,
-          ),
+          v2_details = Seq[ErrorDetails.ErrorDetail](expectedCorrelationIdRequestInfo),
         )
 
       }
@@ -209,10 +200,7 @@ class ErrorFactoriesSpec
         v2_code = Code.INTERNAL,
         v2_message =
           s"An error occurred. Please contact the operator and inquire about the request $originalCorrelationId",
-        v2_details = Seq[ErrorDetails.ErrorDetail](
-          ErrorDetails.ErrorInfoDetail("LEDGER_API_INTERNAL_ERROR"),
-          expectedCorrelationIdRequestInfo,
-        ),
+        v2_details = Seq[ErrorDetails.ErrorDetail](expectedCorrelationIdRequestInfo),
       )
     }
 
@@ -269,10 +257,7 @@ class ErrorFactoriesSpec
         v2_code = Code.PERMISSION_DENIED,
         v2_message =
           s"An error occurred. Please contact the operator and inquire about the request $originalCorrelationId",
-        v2_details = Seq[ErrorDetails.ErrorDetail](
-          ErrorDetails.ErrorInfoDetail("PERMISSION_DENIED"),
-          expectedCorrelationIdRequestInfo,
-        ),
+        v2_details = Seq[ErrorDetails.ErrorDetail](expectedCorrelationIdRequestInfo),
       )
     }
 
@@ -351,10 +336,7 @@ class ErrorFactoriesSpec
         v2_code = Code.UNAUTHENTICATED,
         v2_message =
           s"An error occurred. Please contact the operator and inquire about the request $originalCorrelationId",
-        v2_details = Seq[ErrorDetails.ErrorDetail](
-          ErrorDetails.ErrorInfoDetail("UNAUTHENTICATED"),
-          expectedCorrelationIdRequestInfo,
-        ),
+        v2_details = Seq[ErrorDetails.ErrorDetail](expectedCorrelationIdRequestInfo),
       )
     }
 
@@ -368,10 +350,7 @@ class ErrorFactoriesSpec
         v2_code = Code.INTERNAL,
         v2_message =
           s"An error occurred. Please contact the operator and inquire about the request $originalCorrelationId",
-        v2_details = Seq[ErrorDetails.ErrorDetail](
-          ErrorDetails.ErrorInfoDetail("INTERNAL_AUTHORIZATION_ERROR"),
-          expectedCorrelationIdRequestInfo,
-        ),
+        v2_details = Seq[ErrorDetails.ErrorDetail](expectedCorrelationIdRequestInfo),
       )
     }
 
@@ -513,10 +492,7 @@ class ErrorFactoriesSpec
         v2_code = Code.INTERNAL,
         v2_message =
           s"An error occurred. Please contact the operator and inquire about the request $originalCorrelationId",
-        v2_details = Seq[ErrorDetails.ErrorDetail](
-          ErrorDetails.ErrorInfoDetail("LEDGER_API_INTERNAL_ERROR"),
-          expectedCorrelationIdRequestInfo,
-        ),
+        v2_details = Seq[ErrorDetails.ErrorDetail](expectedCorrelationIdRequestInfo),
       )
     }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -7,7 +7,7 @@ import akka.Done
 import akka.actor.Cancellable
 import akka.stream._
 import akka.stream.scaladsl.{Keep, Sink, Source}
-import com.daml.error.definitions.IndexErrors
+import com.daml.error.definitions.IndexErrors.IndexDbException
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.offset.Offset
@@ -147,12 +147,11 @@ private[platform] object ReadOnlySqlLedger {
         executionContext: ExecutionContext,
         loggingContext: LoggingContext,
     ): Future[LedgerId] = {
+      // If the index database is not yet fully initialized,
+      // querying for the ledger ID will throw different errors,
+      // depending on the database, and how far the initialization is.
       val isRetryable: PartialFunction[Throwable, Boolean] = {
-        // If the index database is not yet fully initialized,
-        // querying for the ledger ID will throw different errors,
-        // depending on the database, and how far the initialization is.
-        case IndexErrors.DatabaseErrors.SqlTransientError(_) => true
-        case IndexErrors.DatabaseErrors.SqlNonTransientError(_) => true
+        case _: IndexDbException => true
         case _: LedgerIdNotFoundException => true
         case _: MismatchException.LedgerId => false
         case _ => false

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/ConversionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/ConversionsSpec.scala
@@ -132,7 +132,7 @@ class ConversionsSpec extends AsyncWordSpec with Matchers {
         v1expectedCode = Status.Code.ABORTED.value(),
         v1expectedMessage = "Invalid ledger time: Too late.",
         v2expectedCode = Status.Code.FAILED_PRECONDITION.value(),
-        v2expectedMessage = "INVALID_LEDGER_TIME(9,0): Invalid ledger time: Too late.",
+        v2expectedMessage = "INVALID_LEDGER_TIME(9,0): Too late.",
       )
     }
   }

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/stores/ledger/RejectionSpec.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/stores/ledger/RejectionSpec.scala
@@ -59,7 +59,6 @@ class RejectionSpec extends AnyWordSpec with Matchers {
       errorInfo shouldBe com.google.rpc.error_details.ErrorInfo(
         reason = "LEDGER_CONFIGURATION_NOT_FOUND",
         metadata = Map(
-          "message" -> "Cannot validate ledger time",
           "category" -> "11",
           "definite_answer" -> "false",
         ),
@@ -104,7 +103,7 @@ class RejectionSpec extends AnyWordSpec with Matchers {
         Rejection.InvalidLedgerTime(outOfRange).toStateRejectionReason(errorFactoriesV2)
 
       actualRejectionReason.code shouldBe Status.Code.FAILED_PRECONDITION.value()
-      actualRejectionReason.message shouldBe "INVALID_LEDGER_TIME(9,12345678): Invalid ledger time: Ledger time 2021-07-20T09:30:00Z outside of range [2021-07-20T09:00:00Z, 2021-07-20T09:10:00Z]"
+      actualRejectionReason.message shouldBe "INVALID_LEDGER_TIME(9,12345678): Ledger time 2021-07-20T09:30:00Z outside of range [2021-07-20T09:00:00Z, 2021-07-20T09:10:00Z]"
 
       val (errorInfo, requestInfo) = extractDetails(actualRejectionReason.status.details)
 
@@ -115,7 +114,6 @@ class RejectionSpec extends AnyWordSpec with Matchers {
           "ledger_time_lower_bound" -> "2021-07-20T09:00:00Z",
           "ledger_time_upper_bound" -> "2021-07-20T09:10:00Z",
           "category" -> "9",
-          "message" -> "Ledger time 2021-07-20T09:30:00Z outside of range [2021-07-20T09:00:00Z, 2021-07-20T09:10:00Z]",
           "definite_answer" -> "false",
         ),
       )

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -383,7 +383,7 @@ final class SqlLedgerSpec
           case Seq(Completion(`commandId1`, Some(status), _, _, _, _, _)) =>
             status.code should be(Status.Code.FAILED_PRECONDITION.value)
             status.message should be(
-              s"INVALID_LEDGER_TIME(9,$submissionId): Invalid ledger time: Ledger time 2021-09-01T18:05:00Z outside of range [2021-09-01T17:59:50Z, 2021-09-01T18:00:30Z]"
+              s"INVALID_LEDGER_TIME(9,$submissionId): Ledger time 2021-09-01T18:05:00Z outside of range [2021-09-01T17:59:50Z, 2021-09-01T18:00:30Z]"
             )
         }
       }


### PR DESCRIPTION
This PR fixes the current situation where the error code id and definite_answer are returned in the gRPC metadata even for security sensitive error categories. A specific test is written for this in `ErrorCodeSpec`

Additionally, this PR enforces the test assertions (by asserting the metadata in `ErrorFactoriesSpec`) and removes some redundant information for the error contexts

- Hint: see fields renames with `_` prefix 

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
