### PR TITLE
participant-state - Add an implicit logging context to the write service [kvl-1072]

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiConfigManagementServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiConfigManagementServiceSpec.scala
@@ -336,7 +336,10 @@ object ApiConfigManagementServiceSpec {
         maxRecordTime: Time.Timestamp,
         submissionId: Ref.SubmissionId,
         config: Configuration,
-    )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] = {
+    )(implicit
+        loggingContext: LoggingContext,
+        telemetryContext: TelemetryContext,
+    ): CompletionStage[state.SubmissionResult] = {
       telemetryContext.setAttribute(
         anApplicationIdSpanAttribute._1,
         anApplicationIdSpanAttribute._2,
@@ -389,7 +392,10 @@ object ApiConfigManagementServiceSpec {
           maxRecordTime: Time.Timestamp,
           submissionId: SubmissionId,
           configuration: Configuration,
-      )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
+      )(implicit
+          loggingContext: LoggingContext,
+          telemetryContext: TelemetryContext,
+      ): CompletionStage[SubmissionResult] = {
         configurationQueue.offer((currentOffset.getAndIncrement(), submissionId, configuration))
         completedFuture(state.SubmissionResult.Acknowledged)
       }

--- a/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPackageManagementServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPackageManagementServiceSpec.scala
@@ -132,7 +132,10 @@ object ApiPackageManagementServiceSpec {
         submissionId: Ref.SubmissionId,
         archives: List[DamlLf.Archive],
         sourceDescription: Option[String],
-    )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] = {
+    )(implicit
+        loggingContext: LoggingContext,
+        telemetryContext: TelemetryContext,
+    ): CompletionStage[state.SubmissionResult] = {
       telemetryContext.setAttribute(
         anApplicationIdSpanAttribute._1,
         anApplicationIdSpanAttribute._2,

--- a/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPartyManagementServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/db/migration/translation/apiserver/services/admin/ApiPartyManagementServiceSpec.scala
@@ -89,7 +89,10 @@ object ApiPartyManagementServiceSpec {
         hint: Option[Ref.Party],
         displayName: Option[String],
         submissionId: Ref.SubmissionId,
-    )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] = {
+    )(implicit
+        loggingContext: LoggingContext,
+        telemetryContext: TelemetryContext,
+    ): CompletionStage[state.SubmissionResult] = {
       telemetryContext.setAttribute(
         anApplicationIdSpanAttribute._1,
         anApplicationIdSpanAttribute._2,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigurationProvisionerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/configuration/LedgerConfigurationProvisionerSpec.scala
@@ -73,7 +73,7 @@ final class LedgerConfigurationProvisionerSpec
             any[Timestamp],
             any[Ref.SubmissionId],
             any[Configuration],
-          )(any[TelemetryContext])
+          )(any[LoggingContext], any[TelemetryContext])
 
           scheduler.timePasses(100.millis)
           eventually {
@@ -81,7 +81,7 @@ final class LedgerConfigurationProvisionerSpec
               eqTo(Timestamp.assertFromInstant(timeProvider.getCurrentTime.plusSeconds(60))),
               eqTo(submissionId),
               eqTo(configurationToSubmit),
-            )(any[TelemetryContext])
+            )(any[LoggingContext], any[TelemetryContext])
           }
           succeed
         }
@@ -115,7 +115,7 @@ final class LedgerConfigurationProvisionerSpec
             any[Timestamp],
             any[Ref.SubmissionId],
             any[Configuration],
-          )(any[TelemetryContext])
+          )(any[LoggingContext], any[TelemetryContext])
           succeed
         }
     }
@@ -158,7 +158,7 @@ final class LedgerConfigurationProvisionerSpec
           any[Timestamp],
           any[Ref.SubmissionId],
           any[Configuration],
-        )(any[TelemetryContext])
+        )(any[LoggingContext], any[TelemetryContext])
         succeed
       }
   }
@@ -192,7 +192,7 @@ final class LedgerConfigurationProvisionerSpec
           any[Timestamp],
           any[Ref.SubmissionId],
           any[Configuration],
-        )(any[TelemetryContext])
+        )(any[LoggingContext], any[TelemetryContext])
         succeed
       }
   }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
@@ -102,7 +102,7 @@ class ApiSubmissionServiceSpec
         any[Option[Ref.Party]],
         any[Option[Ref.Party]],
         any[Ref.SubmissionId],
-      )(any[TelemetryContext])
+      )(any[LoggingContext], any[TelemetryContext])
     ).thenReturn(completedFuture(state.SubmissionResult.Acknowledged))
 
     val service =
@@ -118,7 +118,7 @@ class ApiSubmissionServiceSpec
           eqTo(Some(Ref.Party.assertFromString(party))),
           eqTo(Some(party)),
           any[Ref.SubmissionId],
-        )(any[TelemetryContext])
+        )(any[LoggingContext], any[TelemetryContext])
       }
       verifyNoMoreInteractions(writeService)
       succeed
@@ -137,7 +137,7 @@ class ApiSubmissionServiceSpec
         any[Option[Ref.Party]],
         any[Option[Ref.Party]],
         any[Ref.SubmissionId],
-      )(any[TelemetryContext])
+      )(any[LoggingContext], any[TelemetryContext])
     ).thenReturn(completedFuture(state.SubmissionResult.Acknowledged))
 
     val service =
@@ -151,7 +151,7 @@ class ApiSubmissionServiceSpec
         any[Option[Ref.Party]],
         any[Option[String]],
         any[Ref.SubmissionId],
-      )(any[TelemetryContext])
+      )(any[LoggingContext], any[TelemetryContext])
       succeed
     }
   }
@@ -173,7 +173,7 @@ class ApiSubmissionServiceSpec
         any[Option[Ref.Party]],
         any[Option[String]],
         any[Ref.SubmissionId],
-      )(any[TelemetryContext])
+      )(any[LoggingContext], any[TelemetryContext])
       succeed
     }
   }
@@ -192,7 +192,7 @@ class ApiSubmissionServiceSpec
         eqTo(Some(typedParty)),
         eqTo(Some(party)),
         any[Ref.SubmissionId],
-      )(any[TelemetryContext])
+      )(any[LoggingContext], any[TelemetryContext])
     ).thenReturn(completedFuture(submissionFailure))
     when(partyManagementService.getParties(Seq(typedParty)))
       .thenReturn(Future(List.empty[PartyDetails]))

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
@@ -30,8 +30,8 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
   )(implicit
-      telemetryContext: TelemetryContext,
       loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
   ): CompletionStage[SubmissionResult] =
     Timed.timedAndTrackedCompletionStage(
       metrics.daml.services.write.submitTransaction,

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
@@ -48,7 +48,10 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       submissionId: Ref.SubmissionId,
       archives: List[DamlLf.Archive],
       sourceDescription: Option[String],
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] =
     Timed.completionStage(
       metrics.daml.services.write.uploadPackages,
       delegate.uploadPackages(submissionId, archives, sourceDescription),
@@ -58,7 +61,10 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       hint: Option[Ref.Party],
       displayName: Option[String],
       submissionId: Ref.SubmissionId,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] =
     Timed.completionStage(
       metrics.daml.services.write.allocateParty,
       delegate.allocateParty(hint, displayName, submissionId),
@@ -68,7 +74,10 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       maxRecordTime: Time.Timestamp,
       submissionId: Ref.SubmissionId,
       config: Configuration,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] =
     Timed.completionStage(
       metrics.daml.services.write.submitConfiguration,
       delegate.submitConfiguration(maxRecordTime, submissionId, config),

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
@@ -18,6 +18,7 @@ import com.daml.ledger.participant.state.v2.{
 }
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.SubmittedTransaction
+import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.telemetry.TelemetryContext
 
@@ -28,7 +29,10 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      telemetryContext: TelemetryContext,
+      loggingContext: LoggingContext,
+  ): CompletionStage[SubmissionResult] =
     Timed.timedAndTrackedCompletionStage(
       metrics.daml.services.write.submitTransaction,
       metrics.daml.services.write.submitTransactionRunning,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -134,7 +134,10 @@ final class Runner[T <: ReadWriteService, Extra](
                 _ <- Resource.sequence(
                   config.archiveFiles.map(path =>
                     Resource.fromFuture(
-                      uploadDar(path, writeService)(resourceContext.executionContext)
+                      uploadDar(path, writeService)(
+                        loggingContext,
+                        resourceContext.executionContext,
+                      )
                     )
                   )
                 )
@@ -198,7 +201,8 @@ final class Runner[T <: ReadWriteService, Extra](
   }
 
   private def uploadDar(from: Path, to: WritePackagesService)(implicit
-      executionContext: ExecutionContext
+      loggingContext: LoggingContext,
+      executionContext: ExecutionContext,
   ): Future[Unit] = DefaultTelemetry.runFutureInSpan(SpanName.RunnerUploadDar, SpanKind.Internal) {
     implicit telemetryContext =>
       val submissionId = Ref.SubmissionId.assertFromString(UUID.randomUUID().toString)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
@@ -68,8 +68,8 @@ class KeyValueParticipantState(
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
   )(implicit
-      telemetryContext: TelemetryContext,
       loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
   ): CompletionStage[SubmissionResult] =
     writerAdapter.submitTransaction(
       submitterInfo,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
@@ -67,7 +67,10 @@ class KeyValueParticipantState(
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      telemetryContext: TelemetryContext,
+      loggingContext: LoggingContext,
+  ): CompletionStage[SubmissionResult] =
     writerAdapter.submitTransaction(
       submitterInfo,
       transactionMeta,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
@@ -82,21 +82,30 @@ class KeyValueParticipantState(
       maxRecordTime: Time.Timestamp,
       submissionId: Ref.SubmissionId,
       config: Configuration,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] =
     writerAdapter.submitConfiguration(maxRecordTime, submissionId, config)
 
   override def uploadPackages(
       submissionId: Ref.SubmissionId,
       archives: List[DamlLf.Archive],
       sourceDescription: Option[String],
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] =
     writerAdapter.uploadPackages(submissionId, archives, sourceDescription)
 
   override def allocateParty(
       hint: Option[Ref.Party],
       displayName: Option[String],
       submissionId: Ref.SubmissionId,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] =
     writerAdapter.allocateParty(hint, displayName, submissionId)
 
   override def prune(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -69,7 +69,10 @@ class KeyValueParticipantStateWriter(
       submissionId: Ref.SubmissionId,
       archives: List[DamlLf.Archive],
       sourceDescription: Option[String],
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] = {
     val submission = keyValueSubmission
       .archivesToSubmission(
         submissionId,
@@ -84,7 +87,10 @@ class KeyValueParticipantStateWriter(
       maxRecordTime: Time.Timestamp,
       submissionId: Ref.SubmissionId,
       config: Configuration,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] = {
     val submission =
       keyValueSubmission
         .configurationToSubmission(maxRecordTime, submissionId, writer.participantId, config)
@@ -95,7 +101,10 @@ class KeyValueParticipantStateWriter(
       hint: Option[Ref.Party],
       displayName: Option[String],
       submissionId: Ref.SubmissionId,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] = {
     val party = hint.getOrElse(generateRandomParty())
     val submission =
       keyValueSubmission.partyToSubmission(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueSubmission}
 import com.daml.ledger.participant.state.v2._
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.SubmittedTransaction
-import com.daml.logging.LoggingContext.newLoggingContextWith
+import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.telemetry.TelemetryContext
@@ -38,8 +38,8 @@ class KeyValueParticipantStateWriter(
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
   )(implicit
-      telemetryContext: TelemetryContext,
       loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
   ): CompletionStage[SubmissionResult] = {
     val submission =
       keyValueSubmission.transactionToSubmission(
@@ -49,7 +49,7 @@ class KeyValueParticipantStateWriter(
       )
     val metadata = CommitMetadata(submission, Some(estimatedInterpretationCost))
     val submissionId = submitterInfo.submissionId.getOrElse {
-      newLoggingContextWith(
+      withEnrichedLoggingContext(
         "commandId" -> submitterInfo.commandId,
         "applicationId" -> submitterInfo.applicationId,
       ) { implicit loggingContext =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.participant.state.kvutils.api
 
 import java.util.UUID
 import java.util.concurrent.{CompletableFuture, CompletionStage}
+
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.configuration.Configuration
@@ -14,8 +15,8 @@ import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueSubmission}
 import com.daml.ledger.participant.state.v2._
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.SubmittedTransaction
-import com.daml.logging.ContextualizedLogger
 import com.daml.logging.LoggingContext.newLoggingContextWith
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.telemetry.TelemetryContext
 
@@ -36,7 +37,10 @@ class KeyValueParticipantStateWriter(
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] = {
+  )(implicit
+      telemetryContext: TelemetryContext,
+      loggingContext: LoggingContext,
+  ): CompletionStage[SubmissionResult] = {
     val submission =
       keyValueSubmission.transactionToSubmission(
         submitterInfo,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -37,6 +37,7 @@ class KeyValueParticipantStateWriterSpec
     with ArgumentMatchersSugar {
 
   import KeyValueParticipantStateWriterSpec._
+  private implicit val loggingContext = com.daml.logging.LoggingContext.ForTesting
 
   "participant state writer" should {
     "submit a transaction" in {

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteConfigService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteConfigService.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletionStage
 import com.daml.ledger.configuration.Configuration
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
+import com.daml.logging.LoggingContext
 import com.daml.telemetry.TelemetryContext
 
 trait WriteConfigService {
@@ -26,12 +27,14 @@ trait WriteConfigService {
     * @param maxRecordTime: The maximum record time after which the request is rejected.
     * @param submissionId: Client picked submission identifier for matching the responses with the request.
     * @param config: The new ledger configuration.
-    * @param telemetryContext: An implicit context for tracing.
     * @return an async result of a SubmissionResult
     */
   def submitConfiguration(
       maxRecordTime: Timestamp,
       submissionId: Ref.SubmissionId,
       config: Configuration,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult]
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult]
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WritePackagesService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WritePackagesService.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionStage
 
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.lf.data.Ref
+import com.daml.logging.LoggingContext
 import com.daml.telemetry.TelemetryContext
 
 /** An interface for uploading packages via a participant. */
@@ -37,7 +38,6 @@ trait WritePackagesService {
     * @param archives           Daml-LF archives to be uploaded to the ledger.
     *    All archives must be valid, i.e., they must successfully decode and pass
     *    Daml engine validation.
-    * @param telemetryContext   An implicit context for tracing.
     *
     * @return an async result of a [[SubmissionResult]]
     */
@@ -45,5 +45,8 @@ trait WritePackagesService {
       submissionId: Ref.SubmissionId,
       archives: List[Archive],
       sourceDescription: Option[String],
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult]
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult]
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WritePartyService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WritePartyService.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.participant.state.v2
 import java.util.concurrent.CompletionStage
 
 import com.daml.lf.data.Ref
+import com.daml.logging.LoggingContext
 import com.daml.telemetry.TelemetryContext
 
 /** An interface for on-boarding parties via a participant. */
@@ -28,7 +29,6 @@ trait WritePartyService {
     * @param hint             A party identifier suggestion
     * @param displayName      A human readable name of the new party
     * @param submissionId     Client picked submission identifier for matching the responses with the request.
-    * @param telemetryContext An implicit context for tracing.
     *
     * @return an async result of a SubmissionResult
     */
@@ -36,5 +36,8 @@ trait WritePartyService {
       hint: Option[Ref.Party],
       displayName: Option[String],
       submissionId: Ref.SubmissionId,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult]
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult]
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteService.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionStage
 
 import com.daml.ledger.api.health.ReportsHealth
 import com.daml.lf.transaction.SubmittedTransaction
+import com.daml.logging.LoggingContext
 import com.daml.telemetry.TelemetryContext
 
 /** An interface to change a ledger via a participant.
@@ -95,13 +96,17 @@ trait WriteService
     * @param estimatedInterpretationCost Estimated cost of interpretation that may be used for
     *                                    handling submitted transactions differently.
     * @param telemetryContext            Implicit context for tracing.
+    * @param loggingContext            Implicit context for logging.
     */
   def submitTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult]
+  )(implicit
+      telemetryContext: TelemetryContext,
+      loggingContext: LoggingContext,
+  ): CompletionStage[SubmissionResult]
 
   /** Indicates whether command deduplication should be enabled when using this [[WriteService]]
     * This is temporary until we fully transition from [[com.daml.ledger.participant.state.v1.WriteService]] to [[WriteService]]

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteService.scala
@@ -95,8 +95,6 @@ trait WriteService
     *                                    daml-lf/spec/contract-id.rst.
     * @param estimatedInterpretationCost Estimated cost of interpretation that may be used for
     *                                    handling submitted transactions differently.
-    * @param telemetryContext            Implicit context for tracing.
-    * @param loggingContext            Implicit context for logging.
     */
   def submitTransaction(
       submitterInfo: SubmitterInfo,
@@ -104,8 +102,8 @@ trait WriteService
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
   )(implicit
-      telemetryContext: TelemetryContext,
       loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
   ): CompletionStage[SubmissionResult]
 
   /** Indicates whether command deduplication should be enabled when using this [[WriteService]]

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -36,7 +36,7 @@ private[stores] final class LedgerBackedWriteService(
       transactionMeta: state.TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] =
+  )(implicit telemetryContext: TelemetryContext, loggingContext: LoggingContext): CompletionStage[state.SubmissionResult] =
     withEnrichedLoggingContext(
       "actAs" -> submitterInfo.actAs,
       "applicationId" -> submitterInfo.applicationId,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -36,7 +36,10 @@ private[stores] final class LedgerBackedWriteService(
       transactionMeta: state.TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
-  )(implicit telemetryContext: TelemetryContext, loggingContext: LoggingContext): CompletionStage[state.SubmissionResult] =
+  )(implicit
+      telemetryContext: TelemetryContext,
+      loggingContext: LoggingContext,
+  ): CompletionStage[state.SubmissionResult] =
     withEnrichedLoggingContext(
       "actAs" -> submitterInfo.actAs,
       "applicationId" -> submitterInfo.applicationId,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -37,8 +37,8 @@ private[stores] final class LedgerBackedWriteService(
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
   )(implicit
-      telemetryContext: TelemetryContext,
       loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
   ): CompletionStage[state.SubmissionResult] =
     withEnrichedLoggingContext(
       "actAs" -> submitterInfo.actAs,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/LedgerBackedWriteService.scala
@@ -25,8 +25,6 @@ private[stores] final class LedgerBackedWriteService(
     ledger: Ledger,
     timeProvider: TimeProvider,
     enablePruning: Boolean,
-)(implicit
-    loggingContext: LoggingContext
 ) extends state.WriteService {
 
   override def currentHealth(): HealthStatus = ledger.currentHealth()
@@ -58,7 +56,10 @@ private[stores] final class LedgerBackedWriteService(
       hint: Option[Ref.Party],
       displayName: Option[String],
       submissionId: Ref.SubmissionId,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] = {
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[state.SubmissionResult] = {
     val party = hint.getOrElse(PartyIdGenerator.generateRandomId())
     withEnrichedLoggingContext(
       "party" -> party,
@@ -73,7 +74,10 @@ private[stores] final class LedgerBackedWriteService(
       submissionId: Ref.SubmissionId,
       payload: List[DamlLf.Archive],
       sourceDescription: Option[String],
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[state.SubmissionResult] =
     withEnrichedLoggingContext(
       "submissionId" -> submissionId,
       "description" -> sourceDescription,
@@ -94,7 +98,10 @@ private[stores] final class LedgerBackedWriteService(
       maxRecordTime: Time.Timestamp,
       submissionId: Ref.SubmissionId,
       config: Configuration,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[state.SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[state.SubmissionResult] =
     withEnrichedLoggingContext(
       "maxRecordTime" -> maxRecordTime.toInstant,
       "submissionId" -> submissionId,

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
@@ -73,7 +73,10 @@ case class ReadWriteServiceBridge(
       maxRecordTime: Time.Timestamp,
       submissionId: Ref.SubmissionId,
       config: Configuration,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] =
     submit(
       Submission.Config(
         maxRecordTime = maxRecordTime,
@@ -88,7 +91,10 @@ case class ReadWriteServiceBridge(
       hint: Option[Ref.Party],
       displayName: Option[String],
       submissionId: Ref.SubmissionId,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] =
     submit(
       Submission.AllocateParty(
         hint = hint,
@@ -101,7 +107,10 @@ case class ReadWriteServiceBridge(
       submissionId: Ref.SubmissionId,
       archives: List[Archive],
       sourceDescription: Option[String],
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
+  ): CompletionStage[SubmissionResult] =
     submit(
       Submission.UploadPackages(
         submissionId = submissionId,

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
@@ -57,8 +57,8 @@ case class ReadWriteServiceBridge(
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
   )(implicit
-      telemetryContext: TelemetryContext,
       loggingContext: LoggingContext,
+      telemetryContext: TelemetryContext,
   ): CompletionStage[SubmissionResult] =
     submit(
       Submission.Transaction(

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
@@ -56,7 +56,10 @@ case class ReadWriteServiceBridge(
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
-  )(implicit telemetryContext: TelemetryContext): CompletionStage[SubmissionResult] =
+  )(implicit
+      telemetryContext: TelemetryContext,
+      loggingContext: LoggingContext,
+  ): CompletionStage[SubmissionResult] =
     submit(
       Submission.Transaction(
         submitterInfo = submitterInfo,

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -7,6 +7,7 @@ import java.io.File
 import java.time.{Clock, Instant}
 import java.util.UUID
 import java.util.concurrent.Executors
+
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.daml.api.util.TimeProvider
@@ -32,7 +33,7 @@ import com.daml.lf.archive.DarParser
 import com.daml.lf.data.Ref
 import com.daml.lf.engine.{Engine, EngineConfig}
 import com.daml.lf.language.LanguageVersion
-import com.daml.logging.ContextualizedLogger
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.MetricsReporting
 import com.daml.platform.apiserver._
@@ -325,7 +326,8 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
     }
 
   private def uploadDar(from: File, to: WritePackagesService)(implicit
-      executionContext: ExecutionContext
+      executionContext: ExecutionContext,
+      loggingContext: LoggingContext,
   ): Future[Unit] = DefaultTelemetry.runFutureInSpan(SpanName.RunnerUploadDar, SpanKind.Internal) {
     implicit telemetryContext =>
       val submissionId = Ref.SubmissionId.assertFromString(UUID.randomUUID().toString)


### PR DESCRIPTION
propagate the logging context through the write service
In a subsequent PR the context is used to log errors from deduplication period conversions and validations.

changelog_begin
participant-state - WriteService submit transaction now requires an implicit LoggingContext
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
