### PR TITLE
Expose submissionId via the Java bindings

### DIFF
--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -120,6 +120,9 @@ da_scala_test_suite(
         "@maven//:org_scalatestplus_scalacheck_1_15",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
+    scalacopts = [
+        "-P:silencer:globalFilters=deprecated",  # tests need to check the behavior of deprecated fields
+    ],
     deps = [
         ":bindings-java",
         ":bindings-java-tests-lib",

--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -121,7 +121,8 @@ da_scala_test_suite(
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = [
-        "-P:silencer:globalFilters=deprecated",  # tests need to check the behavior of deprecated fields
+        "-P:silencer:globalFilters=DeduplicationTime.*deprecated",  # deprecated field that needs to be tested
+        "-P:silencer:globalFilters=DEDUPLICATION_TIME.*deprecated",  # deprecated field that needs to be tested
     ],
     deps = [
         ":bindings-java",

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitAndWaitRequest.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitAndWaitRequest.java
@@ -42,6 +42,33 @@ public class SubmitAndWaitRequest {
       @NonNull String workflowId,
       @NonNull String applicationId,
       @NonNull String commandId,
+      @NonNull String submissionId,
+      @NonNull String party,
+      @NonNull Optional<Instant> minLedgerTimeAbsolute,
+      @NonNull Optional<Duration> minLedgerTimeRelative,
+      @NonNull Optional<Duration> deduplicationTime,
+      @NonNull List<@NonNull Command> commands) {
+    return CommandServiceOuterClass.SubmitAndWaitRequest.newBuilder()
+        .setCommands(
+            SubmitCommandsRequest.toProto(
+                ledgerId,
+                workflowId,
+                applicationId,
+                commandId,
+                submissionId,
+                party,
+                minLedgerTimeAbsolute,
+                minLedgerTimeRelative,
+                deduplicationTime,
+                commands))
+        .build();
+  }
+
+  public static CommandServiceOuterClass.SubmitAndWaitRequest toProto(
+      @NonNull String ledgerId,
+      @NonNull String workflowId,
+      @NonNull String applicationId,
+      @NonNull String commandId,
       @NonNull List<@NonNull String> actAs,
       @NonNull List<@NonNull String> readAs,
       @NonNull Optional<Instant> minLedgerTimeAbsolute,
@@ -55,6 +82,35 @@ public class SubmitAndWaitRequest {
                 workflowId,
                 applicationId,
                 commandId,
+                actAs,
+                readAs,
+                minLedgerTimeAbsolute,
+                minLedgerTimeRelative,
+                deduplicationTime,
+                commands))
+        .build();
+  }
+
+  public static CommandServiceOuterClass.SubmitAndWaitRequest toProto(
+      @NonNull String ledgerId,
+      @NonNull String workflowId,
+      @NonNull String applicationId,
+      @NonNull String commandId,
+      @NonNull String submissionId,
+      @NonNull List<@NonNull String> actAs,
+      @NonNull List<@NonNull String> readAs,
+      @NonNull Optional<Instant> minLedgerTimeAbsolute,
+      @NonNull Optional<Duration> minLedgerTimeRelative,
+      @NonNull Optional<Duration> deduplicationTime,
+      @NonNull List<@NonNull Command> commands) {
+    return CommandServiceOuterClass.SubmitAndWaitRequest.newBuilder()
+        .setCommands(
+            SubmitCommandsRequest.toProto(
+                ledgerId,
+                workflowId,
+                applicationId,
+                commandId,
+                submissionId,
                 actAs,
                 readAs,
                 minLedgerTimeAbsolute,

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitRequest.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/SubmitRequest.java
@@ -63,4 +63,60 @@ public class SubmitRequest {
                 commands))
         .build();
   }
+
+  public static CommandSubmissionServiceOuterClass.SubmitRequest toProto(
+      @NonNull String ledgerId,
+      @NonNull String workflowId,
+      @NonNull String applicationId,
+      @NonNull String commandId,
+      @NonNull String submissionId,
+      @NonNull String party,
+      @NonNull Optional<Instant> minLedgerTimeAbs,
+      @NonNull Optional<Duration> minLedgerTimeRel,
+      @NonNull Optional<Duration> deduplicationTime,
+      @NonNull List<@NonNull Command> commands) {
+    return CommandSubmissionServiceOuterClass.SubmitRequest.newBuilder()
+        .setCommands(
+            SubmitCommandsRequest.toProto(
+                ledgerId,
+                workflowId,
+                applicationId,
+                commandId,
+                submissionId,
+                party,
+                minLedgerTimeAbs,
+                minLedgerTimeRel,
+                deduplicationTime,
+                commands))
+        .build();
+  }
+
+  public static CommandSubmissionServiceOuterClass.SubmitRequest toProto(
+      @NonNull String ledgerId,
+      @NonNull String workflowId,
+      @NonNull String applicationId,
+      @NonNull String commandId,
+      @NonNull String submissionId,
+      @NonNull List<@NonNull String> actAs,
+      @NonNull List<@NonNull String> readAs,
+      @NonNull Optional<Instant> minLedgerTimeAbs,
+      @NonNull Optional<Duration> minLedgerTimeRel,
+      @NonNull Optional<Duration> deduplicationTime,
+      @NonNull List<@NonNull Command> commands) {
+    return CommandSubmissionServiceOuterClass.SubmitRequest.newBuilder()
+        .setCommands(
+            SubmitCommandsRequest.toProto(
+                ledgerId,
+                workflowId,
+                applicationId,
+                commandId,
+                submissionId,
+                actAs,
+                readAs,
+                minLedgerTimeAbs,
+                minLedgerTimeRel,
+                deduplicationTime,
+                commands))
+        .build();
+  }
 }

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/SubmitCommandsRequestSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/SubmitCommandsRequestSpec.scala
@@ -1,0 +1,383 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data
+
+import java.time.Duration
+import java.util.Optional
+
+import com.daml.ledger.api.v1.CommandsOuterClass
+import com.daml.ledger.api.v1.CommandsOuterClass.Commands.DeduplicationPeriodCase
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
+
+final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "SubmitCommandsRequest.toProto/fromProto"
+
+  it should "return the expected submissionId in different overloads" in {
+
+    withClue("(String, String, String, String, String, Optional, Optional, Optional, List)") {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          "Alice",
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          List.empty.asJava,
+        )
+
+      proto.getSubmissionId shouldBe ""
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getSubmissionId shouldEqual Optional.empty()
+    }
+
+    withClue(
+      "(String, String, String, String, String, String, Optional, Optional, Optional, List)"
+    ) {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          "submissionId",
+          "Alice",
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          List.empty.asJava,
+        )
+
+      proto.getSubmissionId shouldBe "submissionId"
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getSubmissionId shouldEqual Optional.of("submissionId")
+    }
+
+    withClue("(String, String, String, String, List, List, Optional, Optional, Optional, List)") {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          List("Alice").asJava,
+          List.empty[String].asJava,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          List.empty[Command].asJava,
+        )
+
+      proto.getSubmissionId shouldBe ""
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getSubmissionId shouldEqual Optional.empty()
+    }
+
+    withClue(
+      "(String, String, String, String, String, List, List, Optional, Optional, Optional, List)"
+    ) {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          "submissionId",
+          List("Alice").asJava,
+          List.empty.asJava,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          List.empty.asJava,
+        )
+
+      proto.getSubmissionId shouldBe "submissionId"
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getSubmissionId shouldEqual Optional.of("submissionId")
+
+    }
+
+  }
+
+  it should "return the expected deduplicationTime/deduplicationDuration in different overloads (set)" in {
+
+    val duration = Duration.ofSeconds(42, 47)
+
+    withClue("(String, String, String, String, String, Optional, Optional, Optional, List)") {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          "Alice",
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(duration),
+          List.empty.asJava,
+        )
+
+      // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
+      proto.getDeduplicationPeriodCase shouldBe DeduplicationPeriodCase.DEDUPLICATION_TIME
+      proto.hasDeduplicationTime shouldBe true
+      proto.getDeduplicationTime.getSeconds shouldBe 42
+      proto.getDeduplicationTime.getNanos shouldBe 47
+
+      proto.hasDeduplicationDuration shouldBe false
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getDeduplicationTime shouldEqual Optional.of(duration)
+    }
+
+    withClue(
+      "(String, String, String, String, String, String, Optional, Optional, Optional, List)"
+    ) {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          "submissionId",
+          "Alice",
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(duration),
+          List.empty.asJava,
+        )
+
+      // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
+      proto.getDeduplicationPeriodCase shouldBe DeduplicationPeriodCase.DEDUPLICATION_TIME
+      proto.hasDeduplicationTime shouldBe true
+      proto.getDeduplicationTime.getSeconds shouldBe 42
+      proto.getDeduplicationTime.getNanos shouldBe 47
+
+      proto.hasDeduplicationDuration shouldBe false
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getDeduplicationTime shouldEqual Optional.of(duration)
+    }
+
+    withClue("(String, String, String, String, List, List, Optional, Optional, Optional, List)") {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          List("Alice").asJava,
+          List.empty[String].asJava,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(duration),
+          List.empty[Command].asJava,
+        )
+
+      // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
+      proto.getDeduplicationPeriodCase shouldBe DeduplicationPeriodCase.DEDUPLICATION_TIME
+      proto.hasDeduplicationTime shouldBe true
+      proto.getDeduplicationTime.getSeconds shouldBe 42
+      proto.getDeduplicationTime.getNanos shouldBe 47
+
+      proto.hasDeduplicationDuration shouldBe false
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getDeduplicationTime shouldEqual Optional.of(duration)
+    }
+
+    withClue(
+      "(String, String, String, String, String, List, List, Optional, Optional, Optional, List)"
+    ) {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          "submissionId",
+          List("Alice").asJava,
+          List.empty.asJava,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(duration),
+          List.empty.asJava,
+        )
+
+      // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
+      proto.getDeduplicationPeriodCase shouldBe DeduplicationPeriodCase.DEDUPLICATION_TIME
+      proto.hasDeduplicationTime shouldBe true
+      proto.getDeduplicationTime.getSeconds shouldBe 42
+      proto.getDeduplicationTime.getNanos shouldBe 47
+
+      proto.hasDeduplicationDuration shouldBe false
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getDeduplicationTime shouldEqual Optional.of(duration)
+
+    }
+
+  }
+
+  it should "return the expected deduplicationTime/deduplicationDuration in different overloads (unset)" in {
+
+    withClue("(String, String, String, String, String, Optional, Optional, Optional, List)") {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          "Alice",
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          List.empty.asJava,
+        )
+
+      // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
+      proto.getDeduplicationPeriodCase shouldBe DeduplicationPeriodCase.DEDUPLICATIONPERIOD_NOT_SET
+      proto.hasDeduplicationTime shouldBe false
+
+      proto.hasDeduplicationDuration shouldBe false
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getDeduplicationTime shouldEqual Optional.empty()
+    }
+
+    withClue(
+      "(String, String, String, String, String, String, Optional, Optional, Optional, List)"
+    ) {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          "submissionId",
+          "Alice",
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          List.empty.asJava,
+        )
+
+      // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
+      proto.getDeduplicationPeriodCase shouldBe DeduplicationPeriodCase.DEDUPLICATIONPERIOD_NOT_SET
+      proto.hasDeduplicationTime shouldBe false
+
+      proto.hasDeduplicationDuration shouldBe false
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getDeduplicationTime shouldEqual Optional.empty()
+    }
+
+    withClue("(String, String, String, String, List, List, Optional, Optional, Optional, List)") {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          List("Alice").asJava,
+          List.empty[String].asJava,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          List.empty.asJava,
+        )
+
+      // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
+      proto.getDeduplicationPeriodCase shouldBe DeduplicationPeriodCase.DEDUPLICATIONPERIOD_NOT_SET
+      proto.hasDeduplicationTime shouldBe false
+
+      proto.hasDeduplicationDuration shouldBe false
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getDeduplicationTime shouldEqual Optional.empty()
+    }
+
+    withClue(
+      "(String, String, String, String, String, List, List, Optional, Optional, Optional, List)"
+    ) {
+      val proto =
+        SubmitCommandsRequest.toProto(
+          "ledgerId",
+          "workflowId",
+          "applicationId",
+          "commandId",
+          "submissionId",
+          List("Alice").asJava,
+          List.empty.asJava,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          List.empty.asJava,
+        )
+
+      // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
+      proto.getDeduplicationPeriodCase shouldBe DeduplicationPeriodCase.DEDUPLICATIONPERIOD_NOT_SET
+      proto.hasDeduplicationTime shouldBe false
+
+      proto.hasDeduplicationDuration shouldBe false
+
+      val request = SubmitCommandsRequest.fromProto(proto)
+
+      request.getDeduplicationTime shouldEqual Optional.empty()
+
+    }
+
+  }
+
+  behavior of "SubmitCommandsRequest.fromProto"
+
+  it should "set the deduplicationTime field even when only deduplicationDuration is set" in {
+
+    val proto =
+      CommandsOuterClass.Commands
+        .newBuilder(
+          SubmitCommandsRequest.toProto(
+            "ledgerId",
+            "workflowId",
+            "applicationId",
+            "commandId",
+            "Alice",
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            List.empty.asJava,
+          )
+        )
+        .setDeduplicationDuration(
+          com.google.protobuf.Duration.newBuilder().setSeconds(42).setNanos(47).build()
+        )
+        .build()
+
+    val request = SubmitCommandsRequest.fromProto(proto)
+
+    request.getDeduplicationTime shouldEqual Optional.of(Duration.ofSeconds(42, 47))
+
+  }
+
+}

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/SubmitCommandsRequestSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/SubmitCommandsRequestSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.javaapi.data
 
-import java.time.Duration
+import java.time.{Duration, Instant}
 import java.util.Optional
 
 import com.daml.ledger.api.v1.CommandsOuterClass
@@ -27,10 +27,10 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "applicationId",
           "commandId",
           "Alice",
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
-          List.empty.asJava,
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
+          Optional.empty[Duration](),
+          List.empty[Command].asJava,
         )
 
       proto.getSubmissionId shouldBe ""
@@ -51,10 +51,10 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "commandId",
           "submissionId",
           "Alice",
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
-          List.empty.asJava,
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
+          Optional.empty[Duration](),
+          List.empty[Command].asJava,
         )
 
       proto.getSubmissionId shouldBe "submissionId"
@@ -73,9 +73,9 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "commandId",
           List("Alice").asJava,
           List.empty[String].asJava,
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
+          Optional.empty[Duration](),
           List.empty[Command].asJava,
         )
 
@@ -97,11 +97,11 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "commandId",
           "submissionId",
           List("Alice").asJava,
-          List.empty.asJava,
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
-          List.empty.asJava,
+          List.empty[String].asJava,
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
+          Optional.empty[Duration](),
+          List.empty[Command].asJava,
         )
 
       proto.getSubmissionId shouldBe "submissionId"
@@ -126,10 +126,10 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "applicationId",
           "commandId",
           "Alice",
-          Optional.empty(),
-          Optional.empty(),
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
           Optional.of(duration),
-          List.empty.asJava,
+          List.empty[Command].asJava,
         )
 
       // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
@@ -156,10 +156,10 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "commandId",
           "submissionId",
           "Alice",
-          Optional.empty(),
-          Optional.empty(),
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
           Optional.of(duration),
-          List.empty.asJava,
+          List.empty[Command].asJava,
         )
 
       // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
@@ -184,8 +184,8 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "commandId",
           List("Alice").asJava,
           List.empty[String].asJava,
-          Optional.empty(),
-          Optional.empty(),
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
           Optional.of(duration),
           List.empty[Command].asJava,
         )
@@ -214,11 +214,11 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "commandId",
           "submissionId",
           List("Alice").asJava,
-          List.empty.asJava,
-          Optional.empty(),
-          Optional.empty(),
+          List.empty[String].asJava,
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
           Optional.of(duration),
-          List.empty.asJava,
+          List.empty[Command].asJava,
         )
 
       // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
@@ -247,10 +247,10 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "applicationId",
           "commandId",
           "Alice",
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
-          List.empty.asJava,
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
+          Optional.empty[Duration](),
+          List.empty[Command].asJava,
         )
 
       // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
@@ -275,10 +275,10 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "commandId",
           "submissionId",
           "Alice",
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
-          List.empty.asJava,
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
+          Optional.empty[Duration](),
+          List.empty[Command].asJava,
         )
 
       // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
@@ -301,10 +301,10 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "commandId",
           List("Alice").asJava,
           List.empty[String].asJava,
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
-          List.empty.asJava,
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
+          Optional.empty[Duration](),
+          List.empty[Command].asJava,
         )
 
       // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
@@ -329,11 +329,11 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
           "commandId",
           "submissionId",
           List("Alice").asJava,
-          List.empty.asJava,
-          Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
-          List.empty.asJava,
+          List.empty[String].asJava,
+          Optional.empty[Instant](),
+          Optional.empty[Duration](),
+          Optional.empty[Duration](),
+          List.empty[Command].asJava,
         )
 
       // We are sticking on the now deprecated deduplicationTime on purpose for backward compatibility
@@ -363,10 +363,10 @@ final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
             "applicationId",
             "commandId",
             "Alice",
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            List.empty.asJava,
+            Optional.empty[Instant](),
+            Optional.empty[Duration](),
+            Optional.empty[Duration](),
+            List.empty[Command].asJava,
           )
         )
         .setDeduplicationDuration(


### PR DESCRIPTION
Closes #11705

Will need to be forward-ported to `main` once merged.

changelog_begin
[Java Bindings] submissionId is now exposed via the bindings, see issue #11705
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
