### PR TITLE
kvutils - For duplicate command rejections, add the submission id as metadata [KVL-1175]

### DIFF
--- a/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
@@ -650,11 +650,17 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           ErrorCategory.InvalidGivenCurrentSystemStateResourceExists,
         ) {
 
-      case class Reject(override val definiteAnswer: Boolean = false)(implicit
+      case class Reject(
+          override val definiteAnswer: Boolean = false,
+          existingCommandSubmissionId: Option[String],
+      )(implicit
           loggingContext: ContextualizedErrorLogger
       ) extends LoggingTransactionErrorImpl(
             cause = "A command with the given command id has already been successfully processed"
-          )
+          ) {
+        override def context: Map[String, String] =
+          super.context ++ existingCommandSubmissionId.map("existing_submission_id" -> _).toList
+      }
     }
 
     @Explanation("An input contract has been archived by a concurrent transaction submission.")

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
@@ -167,7 +167,7 @@ class ErrorFactories private (errorCodesVersionSwitcher: ErrorCodesVersionSwitch
       v2 = LedgerApiErrors.InternalError.VersionService(message).asGrpcError,
     )
 
-  def duplicateCommandException(implicit
+  def duplicateCommandException(existingSubmissionId: Option[String])(implicit
       contextualizedErrorLogger: ContextualizedErrorLogger
   ): StatusRuntimeException =
     errorCodesVersionSwitcher.choose(
@@ -183,7 +183,9 @@ class ErrorFactories private (errorCodesVersionSwitcher: ErrorCodesVersionSwitch
         contextualizedErrorLogger.info(exception.getMessage)
         exception
       },
-      v2 = LedgerApiErrors.ConsistencyErrors.DuplicateCommand.Reject().asGrpcError,
+      v2 = LedgerApiErrors.ConsistencyErrors.DuplicateCommand
+        .Reject(existingCommandSubmissionId = existingSubmissionId)
+        .asGrpcError,
     )
 
   /** @param expected Expected ledger id.

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
@@ -247,7 +247,7 @@ class ErrorFactoriesSpec
     }
 
     "return the DuplicateCommandException" in {
-      assertVersionedError(_.duplicateCommandException)(
+      assertVersionedError(_.duplicateCommandException(None))(
         v1_code = Code.ALREADY_EXISTS,
         v1_message = "Duplicate command",
         v1_details = Seq(definiteAnswers(false)),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -186,7 +186,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
         case _: CommandDeduplicationDuplicate =>
           metrics.daml.commands.deduplicatedCommands.mark()
           Future.failed(
-            errorFactories.duplicateCommandException
+            errorFactories.duplicateCommandException(None)
           )
       }
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/events/rejection_reason.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/events/rejection_reason.proto
@@ -47,6 +47,7 @@ message InvalidLedgerTime {
 // key during its implementation specific deduplication window.
 message Duplicate {
   string details = 1;
+  string submission_id = 2;
 }
 
 // A party mentioned as a stakeholder or actor has not been on-boarded on

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
@@ -62,6 +62,7 @@ message DamlCommandDedupValue {
     google.protobuf.Timestamp record_time = 3;
     PreExecutionDeduplicationBounds record_time_bounds = 4;
   }
+  string submission_id = 5;
 }
 message PreExecutionDeduplicationBounds {
   // record_time is not available during pre-execution

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -363,6 +363,7 @@ object KeyValueConsumption {
             recordTime,
             rejectionEntry,
             errorVersionSwitch,
+            None, // Not available for historical entries
           )(contextualizedErrorLogger(loggingContext, rejectionEntry))
         )
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -445,9 +445,9 @@ class ConversionsSpec extends AnyWordSpec with Matchers with OptionValues {
                 Map.empty,
               ),
               (
-                _.setDuplicateCommand(Duplicate.newBuilder()),
+                _.setDuplicateCommand(Duplicate.newBuilder().setSubmissionId("not_used")),
                 Code.ALREADY_EXISTS,
-                Map.empty,
+                Map(),
               ),
               (
                 _.setSubmitterCannotActViaParticipant(
@@ -494,6 +494,23 @@ class ConversionsSpec extends AnyWordSpec with Matchers with OptionValues {
           }
         }
       }
+    }
+
+    "decode duplicate command v2" in {
+      val finalReason = Conversions
+        .decodeTransactionRejectionEntry(
+          DamlTransactionRejectionEntry
+            .newBuilder()
+            .setDuplicateCommand(Duplicate.newBuilder().setSubmissionId("submissionId"))
+            .build(),
+          v2ErrorSwitch,
+        )
+      finalReason.code shouldBe Code.ALREADY_EXISTS.value()
+      finalReason.definiteAnswer shouldBe false
+      val actualDetails = finalReasonDetails(finalReason)
+      actualDetails should contain allElementsOf Map(
+        "existing_submission_id" -> "submissionId"
+      )
     }
 
     "decode completion info" should {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -171,6 +171,20 @@ class CommandDeduplicationSpec
                   deduplicateStepHasTransactionRejectionEntry(context)
                 }
               }
+
+              "include the submission id in the rejection" in {
+                val submissionId = "submissionId"
+                val (_, context) = contextBuilder(timestamp =>
+                  Some(
+                    newDedupValue(builder =>
+                      timeSetter(timestamp)(builder.setSubmissionId(submissionId))
+                    )
+                  )
+                )
+                val rejection = deduplicateStepHasTransactionRejectionEntry(context)
+                rejection.getDuplicateCommand.getSubmissionId shouldBe submissionId
+              }
+
             }
           }
         }
@@ -281,6 +295,23 @@ class CommandDeduplicationSpec
           )
           .value
       ) shouldBe recordTime
+    }
+
+    "set the submission id in the dedup value" in {
+      val submissionId = "submissionId"
+      val (context, transactionEntrySummary) =
+        buildContextAndTransaction(
+          submissionTime,
+          _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration))
+            .setSubmissionId(submissionId),
+          Some(timestamp),
+        )
+      setDeduplicationEntryStep(context, transactionEntrySummary)
+      deduplicateValueStoredInContext(context, transactionEntrySummary)
+        .map(
+          _.getSubmissionId
+        )
+        .value shouldBe submissionId
     }
 
     "throw an error for missing record time bounds" in {


### PR DESCRIPTION
- include the metadata key existing_submission_id, which is populated with the value of the previously accepted command for duplicate commands

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
