### PR TITLE
All packages must be valid

### DIFF
--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WritePackagesService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WritePackagesService.scala
@@ -35,6 +35,8 @@ trait WritePackagesService {
     *   describing where it got the package from, e.g., when, where, or by whom
     *   the packages were uploaded.
     * @param archives           Daml-LF archives to be uploaded to the ledger.
+    *    All archives must be valid, i.e., they must successfully decode and pass
+    *    Daml engine validation.
     * @param telemetryContext   An implicit context for tracing.
     *
     * @return an async result of a [[SubmissionResult]]


### PR DESCRIPTION
The package management service already [validates all uploaded packages](https://github.com/digital-asset/daml/blob/main/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala#L101), so let's add it to the `WriteService` contract.