### PR TITLE
ci: self-service compat test start

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,9 +211,11 @@ jobs:
     branch: $[ dependencies.compat_versions_pr.outputs['out.branch'] ]
   steps:
   - checkout: none
+  - template: bash-lib.yml
+    parameters:
+      var_name: bash-lib
   - bash: |
       set -euo pipefail
-      az extension add --name azure-devops
-      echo "$(System.AccessToken)" | az devops login --org "https://dev.azure.com/digitalasset"
-      az pipelines build queue --branch $(branch) --definition-name "digital-asset.daml-daily-compat" --org "https://dev.azure.com/digitalasset" --project daml
-      az pipelines build queue --branch $(branch) --definition-name "PRs" --org "https://dev.azure.com/digitalasset" --project daml
+      source $(bash-lib)
+      trigger_azure $(System.AccessToken) --branch $(branch) PRs
+      trigger_azure $(System.AccessToken) --branch $(branch) digital-asset.daml-daily-compat

--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -158,6 +158,21 @@ steps:
     next_in_rotation_github() {
       next_in_rotation | awk '{print $2}'
     }
+    trigger_azure() (
+      token=$1
+      option=$2
+      target=$3
+      build=$4
+      az extension add --name azure-devops
+      trap 'az devops logout' EXIT
+      echo $token \
+        | az devops login --org "https://dev.azure.com/digitalasset"
+      az pipelines build queue \
+        $option $target \
+        --definition-name $build \
+        --org "https://dev.azure.com/digitalasset" \
+        --project daml
+    )
 
     END
     echo "##vso[task.setvariable variable=${{parameters.var_name}}]$TMP"

--- a/ci/prs.yml
+++ b/ci/prs.yml
@@ -170,3 +170,22 @@ jobs:
             tell_slack "<@${user}> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for <https://github.com/digital-asset/daml/pull/$(pr.num)|PR $(pr.num)> has completed with status $(build_status) (changelog: $(changelog_status))." \
                        "$(Slack.team-daml-ci)"
         fi
+
+- job: self_service_compat_test
+  pool:
+    vmImage: ubuntu-20.04
+  steps:
+  - checkout: self
+  - template: bash-lib.yml
+    parameters:
+      var_name: bash-lib
+  - bash: |
+      set -euo pipefail
+      source $(bash-lib)
+      COMMIT=$(git rev-parse HEAD^2)
+      REQUEST=$(git log -n1 --format="%(trailers:key=run-full-compat,valueonly)" $COMMIT)
+      if [ $REQUEST == true ]; then
+        trigger_azure $AZURE_TOKEN --commit-id $COMMIT digital-asset.daml-daily-compat
+      fi
+    env:
+      AZURE_TOKEN: $(System.AccessToken)


### PR DESCRIPTION
It should now be possible for anyone to trigger the daily compat build by adding a `run-full-compat: true` trailer to their commit message.

```
CHANGELOG_BEGIN
CHANGELOG_END
```

run-full-compat: true