### PR TITLE
Add a new KV submission failure internal error [KVL-1201]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVErrors.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVErrors.scala
@@ -207,5 +207,20 @@ object KVErrors extends ErrorGroup()(ErrorGroups.rootErrorClass) {
           super.context ++ metadata // Only in logs as the category is security sensitive
       }
     }
+
+    @Explanation("An unexpected error occurred while submitting a command to the ledger.")
+    @Resolution("Contact support.")
+    object SubmissionFailed
+        extends ErrorCode(
+          id = "SUBMISSION_FAILED",
+          ErrorCategory.SystemInternalAssumptionViolated,
+        ) {
+      case class Reject(
+          details: String
+      )(implicit loggingContext: ContextualizedErrorLogger)
+          extends KVLoggingTransactionErrorImpl(
+            cause = s"Submission failure: $details"
+          )
+    }
   }
 }


### PR DESCRIPTION
It will be used by KV integrations.

Needs to be also backported to 1.18.

CHANGELOG_BEGIN
[Integration Kit] Add a new SUBMISSION_FAILED internal error
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
