### PR TITLE
Error when fetching the wrong template id (via fetch by interface).

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
@@ -274,18 +274,14 @@ class InterfacesTest
       val command = FetchByInterfaceCommand(idI2, idT2, cid1)
       run(command) shouldBe a[Left[_, _]]
     }
-    // TODO https://github.com/digital-asset/daml/issues/11703
-    //   Enable these tests.
-    /*
-      "be unable to fetch T1 (disguised as T2) via interface I1" in {
-        val command = FetchByInterfaceCommand(idI1, idT2, cid1)
-        run(command) shouldBe a[Left[_, _]]
-      }
-      "be unable to fetch T2 (disguised as T1) via interface I1" in {
-        val command = FetchByInterfaceCommand(idI1, idT1, cid2)
-        run(command) shouldBe a[Left[_, _]]
-      }
-     */
+    "be unable to fetch T1 (disguised as T2) via interface I1" in {
+      val command = FetchByInterfaceCommand(idI1, idT2, cid1)
+      run(command) shouldBe a[Left[_, _]]
+    }
+    "be unable to fetch T2 (disguised as T1) via interface I1" in {
+      val command = FetchByInterfaceCommand(idI1, idT1, cid2)
+      run(command) shouldBe a[Left[_, _]]
+    }
     "be unable to fetch T2 (disguised as T1) by interface I2 (stopped in preprocessor)" in {
       val command = FetchByInterfaceCommand(idI2, idT1, cid2)
       preprocess(command) shouldBe a[Left[_, _]]

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
@@ -19,6 +19,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.EitherValues
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import interpretation.{Error => IE}
 
 import scala.language.implicitConversions
 
@@ -220,7 +221,7 @@ class InterfacesTest
         ExerciseByInterfaceCommand(idI2, idT2, cid2, "C2", ValueRecord(None, ImmArray.empty))
       run(command) shouldBe a[Right[_, _]]
     }
-    "be unable to exercise T1 by interface I2   (stopped in preprocessor)" in {
+    "be unable to exercise T1 by interface I2 via 'exercise by interface' (stopped in preprocessor)" in {
       val command =
         ExerciseByInterfaceCommand(idI2, idT1, cid1, "C2", ValueRecord(None, ImmArray.empty))
       preprocess(command) shouldBe a[Left[_, _]]
@@ -229,12 +230,22 @@ class InterfacesTest
     "be unable to exercise T1 (disguised as T2) by interface I1 via 'exercise by interface'" in {
       val command =
         ExerciseByInterfaceCommand(idI1, idT2, cid1, "C1", ValueRecord(None, ImmArray.empty))
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid1, idT2, idT1))
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
     "be unable to exercise T2 (disguised as T1) by interface I1 via 'exercise by interface'" in {
       val command =
         ExerciseByInterfaceCommand(idI1, idT1, cid2, "C1", ValueRecord(None, ImmArray.empty))
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid2, idT1, idT2))
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
     "be unable to exercise T2 (disguised as T1) by interface I2 via 'exercise by interface' (stopped in preprocessor)" in {
       val command =
@@ -276,11 +287,21 @@ class InterfacesTest
     }
     "be unable to fetch T1 (disguised as T2) via interface I1" in {
       val command = FetchByInterfaceCommand(idI1, idT2, cid1)
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid1, idT2, idT1))
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
     "be unable to fetch T2 (disguised as T1) via interface I1" in {
       val command = FetchByInterfaceCommand(idI1, idT1, cid2)
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid2, idT1, idT2))
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
     "be unable to fetch T2 (disguised as T1) by interface I2 (stopped in preprocessor)" in {
       val command = FetchByInterfaceCommand(idI2, idT1, cid2)


### PR DESCRIPTION
When doing a "fetch by interface" command with a known template id,
error out with a WronglyTypedContract if the fetched contract has
a different template id. This doesn't affect daml, only affects
replays, so it's rather minor. I also enabled the engine test that
caught this.

Part of #11703, follow up to #11836.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
