### PR TITLE
Use CanAbort instead of ActionFail in DA.*.Total

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/List/Total.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/List/Total.daml
@@ -23,66 +23,66 @@ import DA.List hiding (foldBalanced1, head, tail, init, last, foldl1, foldr1,
 
 import qualified DA.List
 
-head : ActionFail m => [a] -> m a
+head : CanAbort m => [a] -> m a
 head (x::_) = pure x
-head [] = fail "head: empty list"
+head [] = abort "head: empty list"
 
-tail : ActionFail m => [a] -> m [a]
+tail : CanAbort m => [a] -> m [a]
 tail (_::xs) = pure xs
-tail [] = fail "tail: empty list"
+tail [] = abort "tail: empty list"
 
-last : ActionFail m => [a] -> m a
+last : CanAbort m => [a] -> m a
 last = foldl1 (flip const)
 
-init : ActionFail m => [a] -> m [a]
+init : CanAbort m => [a] -> m [a]
 init [_]     = pure []
 init (x::xs) = do i <- init xs; pure (x :: i)
-init []      = fail "init: empty list"
+init []      = abort "init: empty list"
 
 infixl 9 !!
-(!!) : ActionFail m => [a] -> Int -> m a
-_ !! i | i < 0 = fail "(!!): negative index"
-[] !! _ = fail "(!!): index too large"
+(!!) : CanAbort m => [a] -> Int -> m a
+_ !! i | i < 0 = abort "(!!): negative index"
+[] !! _ = abort "(!!): index too large"
 (x::_) !! 0 = pure x
 (_::xs) !! i = xs !! (i-1)
 
-foldl1 : ActionFail m => (a -> a -> a) -> [a] -> m a
+foldl1 : CanAbort m => (a -> a -> a) -> [a] -> m a
 foldl1 f (x::xs) = pure (foldl f x xs)
-foldl1 _  [] = fail "foldl1: empty list"
+foldl1 _  [] = abort "foldl1: empty list"
 
-foldr1 : ActionFail m => (a -> a -> a) -> [a] -> m a
-foldr1 f [] = fail "foldr1: empty list"
+foldr1 : CanAbort m => (a -> a -> a) -> [a] -> m a
+foldr1 f [] = abort "foldr1: empty list"
 foldr1 f xs = foldl1 (flip f) (reverse xs)
 
-foldBalanced1 : ActionFail m => (a -> a -> a) -> [a] -> m a
-foldBalanced1 _ [] = fail "foldBalanced1: empty list"
+foldBalanced1 : CanAbort m => (a -> a -> a) -> [a] -> m a
+foldBalanced1 _ [] = abort "foldBalanced1: empty list"
 foldBalanced1 _ [x] = pure x
 foldBalanced1 f xs = foldBalanced1 f (combinePairs f xs)
 
 -- | `minimumBy f xs` returns the first element `x` of `xs` for which `f x y`
 -- is either `LT` or `EQ` for all other `y` in `xs`. The result is
 -- wrapped in a monadic context, with a failure if `xs` is empty.
-minimumBy : (ActionFail m) => (a -> a -> Ordering) -> [a] -> m a
-minimumBy _ [] = fail "minimumBy: empty list"
+minimumBy : (CanAbort m) => (a -> a -> Ordering) -> [a] -> m a
+minimumBy _ [] = abort "minimumBy: empty list"
 minimumBy f xs = pure $ DA.List.minimumBy f xs
 
 -- | `maximumBy f xs` returns the first element `x` of `xs` for which `f x y`
 -- is either `GT` or `EQ` for all other `y` in `xs`. The result is
 -- wrapped in a monadic context, with a failure if `xs` is empty.
-maximumBy : (ActionFail m) => (a -> a -> Ordering) -> [a] -> m a
-maximumBy _ [] = fail "maximumBy: empty list"
+maximumBy : (CanAbort m) => (a -> a -> Ordering) -> [a] -> m a
+maximumBy _ [] = abort "maximumBy: empty list"
 maximumBy f xs = pure $ DA.List.maximumBy f xs
 
 -- | `minimumOn f xs` returns the first element `x` of `xs` for which `f x`
 -- is smaller than or equal to any other `f y` for `y` in `xs`. The result is
 -- wrapped in a monadic context, with a failure if `xs` is empty.
-minimumOn : (ActionFail m, Ord k) => (a -> k) -> [a] -> m a
-minimumOn _ [] = fail "minimumOn: empty list"
+minimumOn : (CanAbort m, Ord k) => (a -> k) -> [a] -> m a
+minimumOn _ [] = abort "minimumOn: empty list"
 minimumOn f xs = pure $ DA.List.minimumOn f xs
 
 -- | `maximumOn f xs` returns the first element `x` of `xs` for which `f x`
 -- is greater than or equal to any other `f y` for `y` in `xs`. The result is
 -- wrapped in a monadic context, with a failure if `xs` is empty.
-maximumOn : (ActionFail m, Ord k) => (a -> k) -> [a] -> m a
-maximumOn _ [] = fail "maximumOn: empty list"
+maximumOn : (CanAbort m, Ord k) => (a -> k) -> [a] -> m a
+maximumOn _ [] = abort "maximumOn: empty list"
 maximumOn f xs = pure $ DA.List.maximumOn f xs

--- a/compiler/damlc/daml-stdlib-src/DA/Maybe/Total.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Maybe/Total.daml
@@ -12,9 +12,9 @@ import DA.Maybe hiding (fromJust, fromJustNote)
 import DA.Optional.Total
 
 {-# DEPRECATED fromJust "Daml 1.2 compatibility helper, use 'fromSome' from 'DA.Optional.Total' instead of 'fromJust'" #-}
-fromJust : ActionFail m => Optional a -> m a
+fromJust : CanAbort m => Optional a -> m a
 fromJust = fromSome
 
 {-# DEPRECATED fromJustNote "Daml 1.2 compatibility helper, use 'fromSomeNote' from 'DA.Optional.Total' instead of 'fromJustNote'" #-}
-fromJustNote : ActionFail m => Text -> Optional a -> m a
+fromJustNote : CanAbort m => Text -> Optional a -> m a
 fromJustNote = fromSomeNote

--- a/compiler/damlc/daml-stdlib-src/DA/Optional/Total.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Optional/Total.daml
@@ -9,9 +9,9 @@ where
 
 import DA.Optional hiding (fromSome, fromSomeNote)
 
-fromSome : ActionFail m => Optional a -> m a
+fromSome : CanAbort m => Optional a -> m a
 fromSome = fromSomeNote "fromSome: None"
 
-fromSomeNote : ActionFail m => Text -> Optional a -> m a
+fromSomeNote : CanAbort m => Text -> Optional a -> m a
 fromSomeNote _ (Some x) = pure x
-fromSomeNote n None = fail n
+fromSomeNote n None = abort n

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -637,8 +637,9 @@ fromTreeGo (CreatedIndex index) events =
   case mapOptional fromCreated events of
     [] -> error "No created events for the requested template id found"
     contractIds ->
-      let msg = "CreatedIndex out of bound" in
-      fromSomeNote msg $ contractIds !! index.offset
+      case contractIds !! index.offset of
+        Left _ -> error "CreatedIndex out of bound"
+        Right cid -> cid
   where
     fromCreated : Template t => TreeEvent -> Optional (ContractId t)
     fromCreated (CreatedEvent created) = fromAnyContractId created.contractId
@@ -647,9 +648,9 @@ fromTreeGo (ExercisedIndex index) events =
   case mapOptional fromExercised events of
     [] -> error $ "No exercised events for choice " <> index.choice <> " found"
     childEventsList ->
-      let msg = "ExercisedIndex on choice " <> index.choice <> " out of bound"
-          childEvents = fromSomeNote msg $ childEventsList !! index.offset in
-      fromTreeGo index.child childEvents
+      case childEventsList !! index.offset of
+        Left _ -> error ("ExercisedIndex on choice " <> index.choice <> " out of bound")
+        Right childEvents -> fromTreeGo index.child childEvents
   where
     fromExercised : TreeEvent -> Optional [TreeEvent]
     fromExercised (CreatedEvent _) = None


### PR DESCRIPTION
Fixes #11709

changelog_begin

- [Daml Standard Library] DA.List.Total and DA.Optional.Total now
  use a CanAbort constraint instead of an ActionFail constraint.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
