### PR TITLE
parameterize QueryBenchmark by a tableSize instead of a batchSize

### DIFF
--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/ContractDaoBenchmark.scala
@@ -94,11 +94,16 @@ abstract class ContractDaoBenchmark extends OracleAround {
         val n = offset + i
         contract(n, signatory, tpid, payload)
       }.toList
-    val inserted = dao
-      .transact(queries.insertContracts[List, JsValue, JsValue](contracts))
-      .unsafeRunSync()
+    val inserted = insertContracts(contracts)
     assert(inserted == batchSize)
   }
+
+  protected def insertContracts[F[_]: cats.Foldable: scalaz.Functor](
+      contracts: F[DBContract[SurrogateTpId, JsValue, JsValue, Seq[String]]]
+  ) =
+    dao
+      .transact(queries.insertContracts[F, JsValue, JsValue](contracts))
+      .unsafeRunSync()
 }
 
 trait BenchmarkDbConnection {

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
@@ -19,6 +19,7 @@ import scala.collection.compat._
 
 trait QueryPayloadBenchmark extends ContractDaoBenchmark {
   self: BenchmarkDbConnection =>
+  import QueryPayloadBenchmark._
 
   @Param(Array("1", "10", "100"))
   var extraParties: Int = _
@@ -29,28 +30,6 @@ trait QueryPayloadBenchmark extends ContractDaoBenchmark {
   private val tpid = TemplateId("-pkg-", "M", "T")
   private var surrogateTpid: SurrogateTpId = _
   val party = "Alice"
-
-  private[this] val dummyPackageId = Ref.PackageId.assertFromString("dummy-package-id")
-  private[this] val dummyId = Ref.Identifier(
-    dummyPackageId,
-    Ref.QualifiedName.assertFromString("Foo:Bar"),
-  )
-  private[this] val dummyTypeCon = iface.TypeCon(iface.TypeConName(dummyId), ImmArraySeq.empty)
-
-  val predicate = ValuePredicate.fromJsObject(
-    Map("v" -> JsNumber(0)),
-    dummyTypeCon,
-    Map(
-      dummyId -> iface.DefDataType(
-        ImmArraySeq.empty,
-        iface.Record(
-          ImmArraySeq(
-            (Ref.Name.assertFromString("v"), iface.TypePrim(iface.PrimType.Int64, ImmArraySeq()))
-          )
-        ),
-      )
-    ).lift,
-  )
 
   def whereClause = predicate.toSqlWhereClause(dao.jdbcDriver)
 
@@ -84,6 +63,30 @@ trait QueryPayloadBenchmark extends ContractDaoBenchmark {
   }
 
   discard(IterableOnce) // only needed for scala 2.12
+}
+
+object QueryPayloadBenchmark {
+  private[this] val dummyPackageId = Ref.PackageId.assertFromString("dummy-package-id")
+  private[this] val dummyId = Ref.Identifier(
+    dummyPackageId,
+    Ref.QualifiedName.assertFromString("Foo:Bar"),
+  )
+  private[this] val dummyTypeCon = iface.TypeCon(iface.TypeConName(dummyId), ImmArraySeq.empty)
+
+  val predicate = ValuePredicate.fromJsObject(
+    Map("v" -> JsNumber(0)),
+    dummyTypeCon,
+    Map(
+      dummyId -> iface.DefDataType(
+        ImmArraySeq.empty,
+        iface.Record(
+          ImmArraySeq(
+            (Ref.Name.assertFromString("v"), iface.TypePrim(iface.PrimType.Int64, ImmArraySeq()))
+          )
+        ),
+      )
+    ).lift,
+  )
 }
 
 class QueryPayloadBenchmarkOracle extends QueryPayloadBenchmark with OracleBenchmarkDbConn


### PR DESCRIPTION
A tool incidentally made as part of #11683.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
