### PR TITLE
Disable writing volatile bits in Scala statsfile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -671,7 +671,7 @@ scala_repositories(
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 
-scala_register_toolchains()
+register_toolchains("//bazel_tools/scala:toolchain")
 
 load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
 

--- a/bazel_tools/scala/BUILD.bazel
+++ b/bazel_tools/scala/BUILD.bazel
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
+
+scala_toolchain(
+    name = "toolchain_impl",
+    enable_stats_file = False,
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "toolchain",
+    toolchain = "toolchain_impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)

--- a/compatibility/WORKSPACE
+++ b/compatibility/WORKSPACE
@@ -363,4 +363,4 @@ scala_repositories(
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 
-scala_register_toolchains()
+register_toolchains("@daml//bazel_tools/scala:toolchain")

--- a/deps.bzl
+++ b/deps.bzl
@@ -30,8 +30,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-rules_scala_version = "e4560ac332e9da731c1e50a76af2579c55836a5c"
-rules_scala_sha256 = "ccf19e8f966022eaaca64da559c6140b23409829cb315f2eff5dc3e757fb6ad8"
+rules_scala_version = "17791a18aa966cdf2babb004822e6c70a7decc76"
+rules_scala_sha256 = "a8faef92f59a4f1428ed9a93c7c313a996466a66ad64c119fc49b5c7dea98c59"
 
 rules_haskell_version = "673e74aea244a6a9ee1eccec719677c80348aebf"
 rules_haskell_sha256 = "73a06dc6e0d928ceeab64e2cd3159f863eb2e263ecc64d79e3952c770cd1ee51"


### PR DESCRIPTION
Make Scala targets deterministic by disabling writing milliseconds timestamps into the statsfile.

Before (cache disabled)
```
$ n=1; bazel clean; bazel build //libs-scala/adjustable-clock --execution_log_json_file=execlog$n.json; rsync -aL bazel-bin output$n
$ n=2; bazel clean; bazel build //libs-scala/adjustable-clock --execution_log_json_file=execlog$n.json; rsync -aL bazel-bin output$n
$ diff -u execlog1.json execlog2.json
--- execlog1.json       2021-11-25 09:53:45.638891575 +0100
+++ execlog2.json       2021-11-25 10:01:52.831225558 +0100
@@ -311392,7 +311392,7 @@
   }, {
     "path": "bazel-out/k8-opt/bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/scala_version.statsfile",
     "digest": {
-      "hash": "1c535baa94812c16d33b6b3dcf2dec8e12b77e3a28cd1280ca2c9678840c4de6",
+      "hash": "a7f6f1b168649c1c5346ff92c69f0095b68781690e4b3f33321d8f35af8b3d77",
       "sizeBytes": "16",
       "hashFunctionName": "SHA-256"
     }
@@ -311705,7 +311705,7 @@
   }, {
     "path": "bazel-out/k8-opt/bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/dependency_analyzer.statsfile",
     "digest": {
-      "hash": "b3af662512a906ec56abfb222f43af189b88b00ae0449bd44c25b7e90689c4db",
+      "hash": "d6c6e2a36754efea4863593a838fbfb500a66e0150d3c3e2e2490ad65c22a2cd",
       "sizeBytes": "16",
       "hashFunctionName": "SHA-256"
     }
@@ -312025,7 +312025,7 @@
   }, {
     "path": "bazel-out/k8-opt/bin/libs-scala/adjustable-clock/adjustable-clock.statsfile",
     "digest": {
-      "hash": "4326088227e5ecf2c21e76ddb6d77c9692ef1689dd146f65ec1e75c235382251",
+      "hash": "8a6b23f3c64ce3ff171772808ca0064af52bc145a32d1b6398de124aeb813c97",
       "sizeBytes": "16",
       "hashFunctionName": "SHA-256"
     }
$ diff -r output1 output2
diff -ur output1/bazel-bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/dependency_analyzer.statsfile output2/bazel-bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/dependency_analyzer.statsfile
--- output1/bazel-bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/dependency_analyzer.statsfile      2021-11-25 09:53:41.706824833 +0100
+++ output2/bazel-bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/dependency_analyzer.statsfile      2021-11-25 10:01:49.047160467 +0100
@@ -1 +1 @@
-build_time=2507
+build_time=2522
diff -ur output1/bazel-bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/scala_version.statsfile output2/bazel-bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/scala_version.statsfile
--- output1/bazel-bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/scala_version.statsfile    2021-11-25 09:53:39.110780774 +0100
+++ output2/bazel-bin/external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/scala_version.statsfile    2021-11-25 10:01:46.427115402 +0100
@@ -1 +1 @@
-build_time=4162
+build_time=3946
diff -ur output1/bazel-bin/libs-scala/adjustable-clock/adjustable-clock.statsfile output2/bazel-bin/libs-scala/adjustable-clock/adjustable-clock.statsfile
--- output1/bazel-bin/libs-scala/adjustable-clock/adjustable-clock.statsfile    2021-11-25 09:53:45.282885532 +0100
+++ output2/bazel-bin/libs-scala/adjustable-clock/adjustable-clock.statsfile    2021-11-25 10:01:52.511220053 +0100
@@ -1 +1 @@
-build_time=3158
+build_time=3100
```

After (cache disabled)
```
$ n=3; bazel clean; bazel build //libs-scala/adjustable-clock --execution_log_json_file=execlog$n.json; rsync -aL bazel-bin output$n
$ n=4; bazel clean; bazel build //libs-scala/adjustable-clock --execution_log_json_file=execlog$n.json; rsync -aL bazel-bin output$n
$ diff -u execlog3.json execlog4.json
$ diff -ur output3 output4
```

See https://github.com/bazelbuild/rules_scala/pull/1298

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
