### PR TITLE
Remove xxd from dev-env

### DIFF
--- a/dev-env/bin/xxd
+++ b/dev-env/bin/xxd
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-tool


### PR DESCRIPTION
The corresponding Nix attribute is missing
```
$ xxd
[dev-env] Building tools.xxd...
error: attribute 'xxd' in selection path 'tools.xxd' not found
[dev-env] Build of tools.xxd has failed!
```

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
