### PR TITLE
Use absolute stack locations in SExpr1

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -178,7 +178,7 @@ private[lf] object Anf {
 
   private def convertLoc(x: source.SELoc): target.SELoc = {
     x match {
-      case source.SELocS(x) => target.SELocS(x)
+      case source.SELocS(rel, abs@_) => target.SELocS(rel) //NICK
       case source.SELocA(x) => target.SELocA(x)
       case source.SELocF(x) => target.SELocF(x)
     }
@@ -193,7 +193,7 @@ private[lf] object Anf {
   }
 
   private[this] def makeAbsoluteA(env: Env, atom: source.SExprAtomic): AbsAtom = atom match {
-    case source.SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case source.SELocS(rel, abs@_) => Right(makeAbsoluteB(env, rel)) //NICK
     case x => Left(convertAtom(x))
   }
 
@@ -206,7 +206,7 @@ private[lf] object Anf {
   private[this] type AbsLoc = Either[source.SELoc, AbsBinding]
 
   private[this] def makeAbsoluteL(env: Env, loc: source.SELoc): AbsLoc = loc match {
-    case source.SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case source.SELocS(rel, abs@_) => Right(makeAbsoluteB(env, rel)) //NICK
     case x: source.SELocA => Left(x)
     case x: source.SELocF => Left(x)
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -155,22 +155,15 @@ private[lf] object Anf {
     *    it absolute because an offset doesn't change as new bindings are pushed onto the
     *    stack.
     *
-    *    Note the contrast with the expression form `ELocS` which contains a relative offset
-    *    from the end of the stack. This relative-position is used in both the original
-    *    expression which we traverse AND the new ANF expression we are constructing. The
+    *    Happily, the source expressions use absolute stack offsets in `SELocAbsoluteS`.
+    *    In contrast to the target expressions which use relative offsets in `SELocS`. The
     *    relative-offset to a binding varies as new bindings are pushed on the stack.
     */
   private[this] case class AbsBinding(abs: DepthA)
 
-  private[this] def makeAbsoluteB(env: Env, rel: Int, abs: Int): AbsBinding = {
-    val oldAbs = env.oldDepth.incr(-rel)
-    if (DepthE(abs) != oldAbs) {
-      sys.error(
-        s"**MISMATCH in new abs calculation: abs=$abs VS oldAbs=$oldAbs [subs: rel:$rel, oldDepth:${env.oldDepth}]"
-      )
-    }
-    env.absMap.get(oldAbs) match {
-      case None => throw CompilationError(s"makeAbsoluteB(env=$env,rel=$rel)")
+  private[this] def makeAbsoluteB(env: Env, abs: Int): AbsBinding = {
+    env.absMap.get(DepthE(abs)) match {
+      case None => throw CompilationError(s"makeAbsoluteB(env=$env,abs=$abs)")
       case Some(abs) => AbsBinding(abs)
     }
   }
@@ -183,7 +176,7 @@ private[lf] object Anf {
 
   private def convertLoc(x: source.SELoc): target.SELoc = {
     x match {
-      case source.SELocS(rel @ _, abs @ _) => sys.error("Anf.convertLoc/SELocS, unreachable code")
+      case source.SELocAbsoluteS(_) => sys.error("Anf.convertLoc/SELocAbsoluteS, unreachable code")
       case source.SELocA(x) => target.SELocA(x)
       case source.SELocF(x) => target.SELocF(x)
     }
@@ -198,7 +191,7 @@ private[lf] object Anf {
   }
 
   private[this] def makeAbsoluteA(env: Env, atom: source.SExprAtomic): AbsAtom = atom match {
-    case source.SELocS(rel, abs) => Right(makeAbsoluteB(env, rel, abs))
+    case source.SELocAbsoluteS(abs) => Right(makeAbsoluteB(env, abs))
     case x => Left(convertAtom(x))
   }
 
@@ -211,13 +204,13 @@ private[lf] object Anf {
   private[this] type AbsLoc = Either[source.SELoc, AbsBinding]
 
   private[this] def makeAbsoluteL(env: Env, loc: source.SELoc): AbsLoc = loc match {
-    case source.SELocS(rel, abs) => Right(makeAbsoluteB(env, rel, abs))
+    case source.SELocAbsoluteS(abs) => Right(makeAbsoluteB(env, abs))
     case x: source.SELocA => Left(x)
     case x: source.SELocF => Left(x)
   }
 
   private[this] def makeRelativeL(depth: DepthA)(loc: AbsLoc): target.SELoc = loc match {
-    case Left(x: source.SELocS) => throw CompilationError(s"makeRelativeL: unexpected: $x")
+    case Left(x: source.SELocAbsoluteS) => throw CompilationError(s"makeRelativeL: unexpected: $x")
     case Left(loc) => convertLoc(loc)
     case Right(binding) => target.SELocS(makeRelativeB(depth, binding))
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ClosureConversion.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ClosureConversion.scala
@@ -31,18 +31,12 @@ private[speedy] object ClosureConversion {
         }
 
       def shift(n: Int): Env = {
-        def shiftLoc(loc: target.SELoc, n: Int): target.SELoc = loc match {
-          case target.SELocS(rel, abs) => target.SELocS(rel + n, abs) //NICK: abs unchanged. nice
-          case target.SELocA(_) => loc
-          case target.SELocF(_) => loc
-        }
-        // We must update both the keys of the map (the relative-indexes from the original SEVar)
-        // And also any values in the map which are stack located (SELocS), which are also indexed relatively
-        val m1 = mapping.map { case (k, loc) => (n + k, shiftLoc(loc, n)) }
+        // We just update the keys of the map (the relative-indexes from the original SEVar)
+        val m1 = mapping.map { case (k, loc) => (n + k, loc) }
         // And create mappings for the `n` new stack items
         val m2 = (1 to n).view.map { rel =>
           val abs = this.depth + n - rel
-          (rel, target.SELocS(rel, abs))
+          (rel, target.SELocAbsoluteS(abs))
         }
         Env(this.depth + n, m1 ++ m2)
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ClosureConversion.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ClosureConversion.scala
@@ -32,14 +32,16 @@ private[speedy] object ClosureConversion {
 
       def shift(n: Int): Env = {
         def shiftLoc(loc: target.SELoc, n: Int): target.SELoc = loc match {
-          case target.SELocS(i) => target.SELocS(i + n)
-          case target.SELocA(_) | target.SELocF(_) => loc
+          case target.SELocS(rel,abs) => target.SELocS(rel + n, abs) //NICK: abs unchanged. nice
+          case target.SELocA(_) => loc
+          case target.SELocF(_) => loc
         }
         // We must update both the keys of the map (the relative-indexes from the original SEVar)
         // And also any values in the map which are stack located (SELocS), which are also indexed relatively
         val m1 = mapping.map { case (k, loc) => (n + k, shiftLoc(loc, n)) }
         // And create mappings for the `n` new stack items
-        val m2 = (1 to n).view.map(i => (i, target.SELocS(i)))
+        val absDummy = 42 //NICK
+        val m2 = (1 to n).view.map(rel => (rel, target.SELocS(rel,absDummy)))
         Env(m1 ++ m2)
       }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr1.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr1.scala
@@ -51,7 +51,7 @@ private[speedy] object SExpr1 {
   sealed abstract class SELoc extends SExprAtomic
 
   // SELocS -- variable is located on the stack (SELet & binding forms of SECasePat)
-  final case class SELocS(relBad: Int, absGood: Int) extends SELoc
+  final case class SELocAbsoluteS(n: Int) extends SELoc
 
   // SELocS -- variable is located in the args array of the application
   final case class SELocA(n: Int) extends SELoc

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr1.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr1.scala
@@ -51,7 +51,7 @@ private[speedy] object SExpr1 {
   sealed abstract class SELoc extends SExprAtomic
 
   // SELocS -- variable is located on the stack (SELet & binding forms of SECasePat)
-  final case class SELocS(n: Int) extends SELoc
+  final case class SELocS(relBad: Int, absGood: Int) extends SELoc
 
   // SELocS -- variable is located in the args array of the application
   final case class SELocA(n: Int) extends SELoc


### PR DESCRIPTION
Use _absolute_ stack locations in `SExpr1`
- More convenient for the consuming phase `Anf`
- More convenient for the producing phase `ClosureConversion`

But the real payoff is that it allows us to remove the call to `shiftLoc` in `ClosureConversion` which is the major blocker to avoiding the quadratic time complexity in the `Env` management. See:  #11830 for details on the complexity issue. The change here relates to issue _(2)_ described in the issue.

