### PR TITLE
Add a Canton sandbox to the SDK

### DIFF
--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -111,3 +111,6 @@ commands:
   path: damlc/damlc
   args: ["repl"]
   desc: "Launch the Daml REPL"
+- name: canton-sandbox
+  path: daml-helper/daml-helper
+  args: ["canton-sandbox"]

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -27,6 +27,7 @@ inputs = {
     "templates": "//templates:templates-tarball.tar.gz",
     "trigger_dars": "//triggers/daml:daml-trigger-dars",
     "script_dars": "//daml-script/daml:daml-script-dars",
+    "canton": "@canton//:lib",
     "sdk_deploy_jar": {
         "ce": "//daml-assistant/daml-sdk:sdk_deploy.jar",
         "ee": "//daml-assistant/daml-sdk:sdk_ee_deploy.jar",
@@ -81,6 +82,9 @@ def sdk_tarball(name, version, config):
 
           mkdir -p $$OUT/studio
           cp $(location {daml_extension}) $$OUT/studio/daml-bundled.vsix
+
+          mkdir -p $$OUT/canton
+          cp $(location {canton}) $$OUT/canton/canton.jar
 
           mkdir -p $$OUT/templates
           tar xf $(location {templates}) --strip-components=1 -C $$OUT/templates


### PR DESCRIPTION
This is only the first step so we have something to use in tests,
eventually `daml sandbox` should map to this Sandbox.

part of #11831

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
