### PR TITLE
Fix call to experimental interface signatory builtin

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -422,7 +422,7 @@ convertPrim version "EToAnyContractKey"
 
 convertPrim _ "ESignatoryInterface" (TCon interface :-> TList TParty) =
     ETmLam (mkVar "this", TCon interface) $
-    EExperimental "RESOLVE_VIRTUAL_SIGNATORIES"
+    EExperimental "RESOLVE_VIRTUAL_SIGNATORY"
         (TCon interface :-> TCon interface :-> TList TParty)
         `ETmApp` EVar (mkVar "this") `ETmApp` EVar (mkVar "this")
 

--- a/compiler/damlc/tests/daml-test-files/Interface.daml
+++ b/compiler/damlc/tests/daml-test-files/Interface.daml
@@ -90,6 +90,8 @@ main = scenario do
     _ <- exercise cidToken1 (Noop ())
     (cidToken2, cidToken3) <- exercise cidToken1 (Split 10)
     token2 <- fetch cidToken2
+    -- Party is duplicated because p is both observer & issuer
+    signatory token2 === [p, p]
     getAmount token2 === 10
     case fromInterface @_ @Token token2 of
       None -> abort "expected Asset"


### PR DESCRIPTION
Turns out if you mistype the name it doesn’t work, who would have
thought.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
