### PR TITLE
Add ContractDoesNotImplementInterface error.

### DIFF
--- a/compiler/damlc/tests/daml-test-files/InterfaceErrors.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceErrors.daml
@@ -17,7 +17,7 @@ template MyTemplate
     where
         signatory p
 
--- @ERROR range=21:1-21:17; Attempt to fetch or exercise a wrongly typed contract.
+-- @ERROR range=21:1-21:17; CRASH: ContractDoesNotImplementInterface unhandled in scenario service
 fetchBadContract = scenario do
     p <- getParty "Alice"
     p `submit` do
@@ -25,7 +25,7 @@ fetchBadContract = scenario do
         let cid' : ContractId MyInterface = coerceContractId cid
         fetch cid'
 
--- @ERROR range=29:1-29:20; Attempt to fetch or exercise a wrongly typed contract
+-- @ERROR range=29:1-29:20; CRASH: ContractDoesNotImplementInterface unhandled in scenario service
 exerciseBadContract = scenario do
     p <- getParty "Alice"
     p `submit` do

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -164,6 +164,10 @@ final class Conversions(
                     .setContractRef(mkContractRef(coid, actual))
                     .setExpected(convertIdentifier(expected))
                 )
+              case _: ContractDoesntImplementInterface =>
+                // TODO https://github.com/digital-asset/daml/issues/10810
+                //   Implement this.
+                builder.setCrash(s"ContractDoesntImplementInterface unhandled in scenario service")
               case FailedAuthorization(nid, fa) =>
                 builder.setScenarioCommitError(
                   proto.CommitError.newBuilder

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -164,10 +164,10 @@ final class Conversions(
                     .setContractRef(mkContractRef(coid, actual))
                     .setExpected(convertIdentifier(expected))
                 )
-              case _: ContractDoesntImplementInterface =>
+              case _: ContractDoesNotImplementInterface =>
                 // TODO https://github.com/digital-asset/daml/issues/10810
                 //   Implement this.
-                builder.setCrash(s"ContractDoesntImplementInterface unhandled in scenario service")
+                builder.setCrash(s"ContractDoesNotImplementInterface unhandled in scenario service")
               case FailedAuthorization(nid, fa) =>
                 builder.setScenarioCommitError(
                   proto.CommitError.newBuilder

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
@@ -17,6 +17,7 @@ import com.daml.lf.command._
 import com.daml.lf.transaction.test.TransactionBuilder.assertAsVersionedContract
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.EitherValues
+import org.scalatest.Inside._
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import interpretation.{Error => IE}
@@ -147,13 +148,10 @@ class InterfacesTest
     }
     "be unable to exercise interface I2 on a T1 contract" in {
       val command = ExerciseCommand(idI2, cid1, "C2", ValueRecord(None, ImmArray.empty))
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          err shouldBe Error.Interpretation.DamlException(
-            IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
-          )
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe Error.Interpretation.DamlException(
+          IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+        )
       }
     }
 
@@ -176,20 +174,14 @@ class InterfacesTest
 
     "be unable to exercise T1 (disguised as T2) by interface I1" in {
       val command = ExerciseCommand(idT2, cid1, "C1", ValueRecord(None, ImmArray.empty))
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid1, idT2, idT1))
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid1, idT2, idT1))
       }
     }
     "be unable to exercise T2 (disguised as T1) by interface I1" in {
       val command = ExerciseCommand(idT1, cid2, "C1", ValueRecord(None, ImmArray.empty))
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid2, idT1, idT2))
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid2, idT1, idT2))
       }
     }
     "be unable to exercise T2 (disguised as T1) by interface I2 (stopped in preprocessor)" in {
@@ -198,15 +190,12 @@ class InterfacesTest
     }
     "be unable to exercise T1 (disguised as T2) by interface I2 " in {
       val command = ExerciseCommand(idT2, cid1, "C2", ValueRecord(None, ImmArray.empty))
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          // TODO https://github.com/digital-asset/daml/issues/11703
-          //   This should really be a WronglyTypedContract error.
-          err shouldBe Error.Interpretation.DamlException(
-            IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
-          )
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        // TODO https://github.com/digital-asset/daml/issues/11703
+        //   This should really be a WronglyTypedContract error.
+        err shouldBe Error.Interpretation.DamlException(
+          IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+        )
       }
     }
 
@@ -256,21 +245,15 @@ class InterfacesTest
     "be unable to exercise T1 (disguised as T2) by interface I1 via 'exercise by interface'" in {
       val command =
         ExerciseByInterfaceCommand(idI1, idT2, cid1, "C1", ValueRecord(None, ImmArray.empty))
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid1, idT2, idT1))
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid1, idT2, idT1))
       }
     }
     "be unable to exercise T2 (disguised as T1) by interface I1 via 'exercise by interface'" in {
       val command =
         ExerciseByInterfaceCommand(idI1, idT1, cid2, "C1", ValueRecord(None, ImmArray.empty))
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid2, idT1, idT2))
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid2, idT1, idT2))
       }
     }
     "be unable to exercise T2 (disguised as T1) by interface I2 via 'exercise by interface' (stopped in preprocessor)" in {
@@ -281,15 +264,12 @@ class InterfacesTest
     "be unable to exercise T1 (disguised as T2) by interface I2 via 'exercise by interface'" in {
       val command =
         ExerciseByInterfaceCommand(idI2, idT2, cid1, "C2", ValueRecord(None, ImmArray.empty))
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          // TODO https://github.com/digital-asset/daml/issues/11703
-          //   This should really be a WronglyTypedContract error.
-          err shouldBe Error.Interpretation.DamlException(
-            IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
-          )
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        // TODO https://github.com/digital-asset/daml/issues/11703
+        //   This should really be a WronglyTypedContract error.
+        err shouldBe Error.Interpretation.DamlException(
+          IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+        )
       }
     }
 
@@ -318,33 +298,24 @@ class InterfacesTest
     }
     "be unable to fetch T1 (disguised as T2) via interface I2" in {
       val command = FetchByInterfaceCommand(idI2, idT2, cid1)
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          // TODO https://github.com/digital-asset/daml/issues/11703
-          //   This should really be a WronglyTypedContract error.
-          err shouldBe Error.Interpretation.DamlException(
-            IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
-          )
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        // TODO https://github.com/digital-asset/daml/issues/11703
+        //   This should really be a WronglyTypedContract error.
+        err shouldBe Error.Interpretation.DamlException(
+          IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+        )
       }
     }
     "be unable to fetch T1 (disguised as T2) via interface I1" in {
       val command = FetchByInterfaceCommand(idI1, idT2, cid1)
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid1, idT2, idT1))
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid1, idT2, idT1))
       }
     }
     "be unable to fetch T2 (disguised as T1) via interface I1" in {
       val command = FetchByInterfaceCommand(idI1, idT1, cid2)
-      run(command) match {
-        case Left(Error.Interpretation(err, _)) =>
-          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid2, idT1, idT2))
-        case result =>
-          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
+        err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid2, idT1, idT2))
       }
     }
     "be unable to fetch T2 (disguised as T1) by interface I2 (stopped in preprocessor)" in {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
@@ -147,7 +147,14 @@ class InterfacesTest
     }
     "be unable to exercise interface I2 on a T1 contract" in {
       val command = ExerciseCommand(idI2, cid1, "C2", ValueRecord(None, ImmArray.empty))
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          err shouldBe Error.Interpretation.DamlException(
+            IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+          )
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
 
     "be able to exercise T1 by interface I1" in {
@@ -169,11 +176,21 @@ class InterfacesTest
 
     "be unable to exercise T1 (disguised as T2) by interface I1" in {
       val command = ExerciseCommand(idT2, cid1, "C1", ValueRecord(None, ImmArray.empty))
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid1, idT2, idT1))
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
     "be unable to exercise T2 (disguised as T1) by interface I1" in {
       val command = ExerciseCommand(idT1, cid2, "C1", ValueRecord(None, ImmArray.empty))
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          err shouldBe Error.Interpretation.DamlException(IE.WronglyTypedContract(cid2, idT1, idT2))
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
     "be unable to exercise T2 (disguised as T1) by interface I2 (stopped in preprocessor)" in {
       val command = ExerciseCommand(idT1, cid2, "C2", ValueRecord(None, ImmArray.empty))
@@ -181,7 +198,16 @@ class InterfacesTest
     }
     "be unable to exercise T1 (disguised as T2) by interface I2 " in {
       val command = ExerciseCommand(idT2, cid1, "C2", ValueRecord(None, ImmArray.empty))
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          // TODO https://github.com/digital-asset/daml/issues/11703
+          //   This should really be a WronglyTypedContract error.
+          err shouldBe Error.Interpretation.DamlException(
+            IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+          )
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
 
     /* exercise template tests */
@@ -255,7 +281,16 @@ class InterfacesTest
     "be unable to exercise T1 (disguised as T2) by interface I2 via 'exercise by interface'" in {
       val command =
         ExerciseByInterfaceCommand(idI2, idT2, cid1, "C2", ValueRecord(None, ImmArray.empty))
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          // TODO https://github.com/digital-asset/daml/issues/11703
+          //   This should really be a WronglyTypedContract error.
+          err shouldBe Error.Interpretation.DamlException(
+            IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+          )
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
 
     "be unable to exercise T2 choice by the wrong interface (stopped in preprocessor)" in {
@@ -283,7 +318,16 @@ class InterfacesTest
     }
     "be unable to fetch T1 (disguised as T2) via interface I2" in {
       val command = FetchByInterfaceCommand(idI2, idT2, cid1)
-      run(command) shouldBe a[Left[_, _]]
+      run(command) match {
+        case Left(Error.Interpretation(err, _)) =>
+          // TODO https://github.com/digital-asset/daml/issues/11703
+          //   This should really be a WronglyTypedContract error.
+          err shouldBe Error.Interpretation.DamlException(
+            IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+          )
+        case result =>
+          fail(s"Expected Left(Error.Interpretation(err, _)), not $result")
+      }
     }
     "be unable to fetch T1 (disguised as T2) via interface I1" in {
       val command = FetchByInterfaceCommand(idI1, idT2, cid1)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InterfacesTest.scala
@@ -150,7 +150,7 @@ class InterfacesTest
       val command = ExerciseCommand(idI2, cid1, "C2", ValueRecord(None, ImmArray.empty))
       inside(run(command)) { case Left(Error.Interpretation(err, _)) =>
         err shouldBe Error.Interpretation.DamlException(
-          IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+          IE.ContractDoesNotImplementInterface(idI2, cid1, idT1)
         )
       }
     }
@@ -194,7 +194,7 @@ class InterfacesTest
         // TODO https://github.com/digital-asset/daml/issues/11703
         //   This should really be a WronglyTypedContract error.
         err shouldBe Error.Interpretation.DamlException(
-          IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+          IE.ContractDoesNotImplementInterface(idI2, cid1, idT1)
         )
       }
     }
@@ -268,7 +268,7 @@ class InterfacesTest
         // TODO https://github.com/digital-asset/daml/issues/11703
         //   This should really be a WronglyTypedContract error.
         err shouldBe Error.Interpretation.DamlException(
-          IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+          IE.ContractDoesNotImplementInterface(idI2, cid1, idT1)
         )
       }
     }
@@ -302,7 +302,7 @@ class InterfacesTest
         // TODO https://github.com/digital-asset/daml/issues/11703
         //   This should really be a WronglyTypedContract error.
         err shouldBe Error.Interpretation.DamlException(
-          IE.ContractDoesntImplementInterface(idI2, cid1, idT1)
+          IE.ContractDoesNotImplementInterface(idI2, cid1, idT1)
         )
       }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -81,6 +81,12 @@ private[lf] object Pretty {
           ) & prettyTypeConName(
             actual
           )
+      case ContractDoesntImplementInterface(interfaceId, coid, templateId) =>
+        text("Update failed due to contract") & prettyContractId(coid) & text(
+          "not implementing an interface"
+        ) /
+          text("Expected contract to implement interface") & prettyTypeConName(interfaceId) &
+          text("but contract has type") & prettyTypeConName(templateId)
       case CreateEmptyContractKeyMaintainers(tid, arg, key) =>
         text("Update failed due to a contract key with an empty sey of maintainers when creating") &
           prettyTypeConName(tid) & text("with") & prettyValue(true)(arg) /

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -81,7 +81,7 @@ private[lf] object Pretty {
           ) & prettyTypeConName(
             actual
           )
-      case ContractDoesntImplementInterface(interfaceId, coid, templateId) =>
+      case ContractDoesNotImplementInterface(interfaceId, coid, templateId) =>
         text("Update failed due to contract") & prettyContractId(coid) & text(
           "not implementing an interface"
         ) /

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1113,7 +1113,7 @@ private[lf] object SBuiltin {
               machine.returnValue = cached.value
             case None =>
               machine.ctrl = SEDamlException(
-                IE.ContractDoesntImplementInterface(
+                IE.ContractDoesNotImplementInterface(
                   interfaceId = ifaceId,
                   coid = coid,
                   templateId = cached.templateId,
@@ -1143,7 +1143,7 @@ private[lf] object SBuiltin {
                     )
                   case None =>
                     machine.ctrl = SEDamlException(
-                      IE.ContractDoesntImplementInterface(
+                      IE.ContractDoesNotImplementInterface(
                         interfaceId = ifaceId,
                         coid = coid,
                         templateId = actualTmplId,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1113,9 +1113,11 @@ private[lf] object SBuiltin {
               machine.returnValue = cached.value
             case None =>
               machine.ctrl = SEDamlException(
-                // TODO https://github.com/digital-asset/daml/issues/10810:
-                //   Create a more specific exception.
-                IE.WronglyTypedContract(coid, ifaceId, cached.templateId)
+                IE.ContractDoesntImplementInterface(
+                  interfaceId = ifaceId,
+                  coid = coid,
+                  templateId = cached.templateId,
+                )
               )
           }
         case None =>
@@ -1140,10 +1142,13 @@ private[lf] object SBuiltin {
                       ),
                     )
                   case None =>
-                    machine.ctrl =
-                      // TODO https://github.com/digital-asset/daml/issues/10810:
-                      //   Create a more specific exception.
-                      SEDamlException(IE.WronglyTypedContract(coid, ifaceId, actualTmplId))
+                    machine.ctrl = SEDamlException(
+                      IE.ContractDoesntImplementInterface(
+                        interfaceId = ifaceId,
+                        coid = coid,
+                        templateId = actualTmplId,
+                      )
+                    )
                 }
               },
             )

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -89,6 +89,15 @@ object Error {
       actual: TypeConName,
   ) extends Error
 
+  /** We tried to fetch / exercise a contract by interface, but
+    * the contract does not implement this interface.
+    */
+  final case class ContractDoesntImplementInterface(
+      interfaceId: TypeConName,
+      coid: ContractId,
+      templateId: TypeConName,
+  ) extends Error
+
   /** There was an authorization failure during execution. */
   final case class FailedAuthorization(
       nid: NodeId,

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -92,7 +92,7 @@ object Error {
   /** We tried to fetch / exercise a contract by interface, but
     * the contract does not implement this interface.
     */
-  final case class ContractDoesntImplementInterface(
+  final case class ContractDoesNotImplementInterface(
       interfaceId: TypeConName,
       coid: ContractId,
       templateId: TypeConName,

--- a/ledger/error/src/main/scala/com/daml/error/definitions/RejectionGenerators.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/RejectionGenerators.scala
@@ -130,6 +130,11 @@ class RejectionGenerators(conformanceMode: Boolean) {
             .Error(
               renderedMessage
             )
+        case _: LfInterpretationError.ContractDoesntImplementInterface =>
+          LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError
+            .Error(
+              renderedMessage
+            )
         case LfInterpretationError.NonComparableValues =>
           LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError
             .Error(

--- a/ledger/error/src/main/scala/com/daml/error/definitions/RejectionGenerators.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/RejectionGenerators.scala
@@ -130,7 +130,7 @@ class RejectionGenerators(conformanceMode: Boolean) {
             .Error(
               renderedMessage
             )
-        case _: LfInterpretationError.ContractDoesntImplementInterface =>
+        case _: LfInterpretationError.ContractDoesNotImplementInterface =>
           LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError
             .Error(
               renderedMessage


### PR DESCRIPTION
For when fetching or exercising by interface generically, and the fetched contract doesn't implement the interface. Right now this takes precedence over type errors, but it shouldn't.

Part of #10810 and #11703.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
