### PR TITLE
Change daml script’s sleep to sleep for a minimum amount of time

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -394,10 +394,22 @@ object ScriptF {
         mat: Materializer,
         esf: ExecutionSequencerFactory,
     ): Future[SExpr] = Future {
-      val sleepMillis = micros / 1000
-      val sleepNanos = (micros % 1000) * 1000
-      Thread.sleep(sleepMillis, sleepNanos.toInt)
+      sleepAtLeast(micros * 1000)
       SEApp(SEValue(continue), Array(SEValue(SUnit)))
+    }
+
+    private def sleepAtLeast(totalNanos: Long) = {
+      // Thread.sleep can wake up earlier so we loop it to guarantee a minimum
+      // sleep time
+      val t0 = System.nanoTime
+      var nanosLeft = totalNanos
+      while (nanosLeft > 0) {
+        val milis = nanosLeft / 1000000
+        val nanos = (nanosLeft % 1000000).toInt
+        Thread.sleep(milis, nanos);
+        val t1 = System.nanoTime
+        nanosLeft = totalNanos - (t1 - t0)
+      }
     }
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -404,9 +404,7 @@ object ScriptF {
       val t0 = System.nanoTime
       var nanosLeft = totalNanos
       while (nanosLeft > 0) {
-        val milis = nanosLeft / 1000000
-        val nanos = (nanosLeft % 1000000).toInt
-        Thread.sleep(milis, nanos);
+        java.util.concurrent.TimeUnit.NANOSECONDS.sleep(nanosLeft)
         val t1 = System.nanoTime
         nanosLeft = totalNanos - (t1 - t0)
       }


### PR DESCRIPTION
We’ve seen a few flaky test failures where we slept for less than the
expected amount of time which isn’t what we want. We definitely cannot
guarantee an exact sleep time but at least a minimum.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
