### PR TITLE
Update protobuf docs template to handle oneOf

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -63,14 +63,12 @@ message Commands {
   oneof deduplication_period {
     // Specifies the length of the deduplication period.
     // Same semantics apply as for `deduplication_duration`.
-    //
     // Must be non-negative. Must not exceed the maximum deduplication time (see
     // ``ledger_configuration_service.proto``).
     google.protobuf.Duration deduplication_time = 9 [deprecated = true];
 
     // Specifies the length of the deduplication period.
     // It is interpreted relative to the local clock at some point during the submission's processing.
-    //
     // Must be non-negative. Must not exceed the maximum deduplication time (see
     // ``ledger_configuration_service.proto``).
     google.protobuf.Duration deduplication_duration = 15;

--- a/ledger-api/grpc-definitions/rst_mmd.tmpl
+++ b/ledger-api/grpc-definitions/rst_mmd.tmpl
@@ -26,7 +26,7 @@ Ledger API Reference
    {{range .Fields -}}
    * - .. _{{$full_name}}.{{.Name}}: 
 
-       {{.Name}}
+       {{if .IsOneof}}`oneof <https://developers.google.com/protocol-buffers/docs/proto3#oneof>`_ {{.OneofDecl}}.{{end}}{{.Name}}
      - :ref:`{{.LongType}} <{{.FullType}}>`
      - {{.Label}}
      - {{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}}


### PR DESCRIPTION
Builds upon #1180 to render the oneof fields a bit nicer.

Note that we also need to kill newlines in the descriptions. That’s
not an issue in the plugin but in how rst renders tables.

See https://github.com/digital-asset/daml/issues/11761 for the old rendering.

New rendering:
![Screenshot 2021-11-25 at 19-46-29 Ledger API Reference — Daml SDK 0 0 0 documentation](https://user-images.githubusercontent.com/1313584/143491379-30bb0514-211d-4988-920a-b472ad598380.png)

I roughly followed how this is handled in the example in the plugin https://github.com/pseudomuto/protoc-gen-doc/blob/2dde01902b28e8b2201d935467bc4308ec912255/examples/templates/grpc-md.tmpl#L49. if someone has a better idea, I’m happy to change it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
