### PR TITLE
Only run self-service compat job on PRs

### DIFF
--- a/ci/prs.yml
+++ b/ci/prs.yml
@@ -174,6 +174,7 @@ jobs:
 - job: self_service_compat_test
   pool:
     vmImage: ubuntu-20.04
+  condition: eq(variables['Build.Reason'], 'PullRequest')
   steps:
   - checkout: self
   - template: bash-lib.yml


### PR DESCRIPTION
This is currently failing for the notice file update PR. While we
could try to hack around the git commands to do something sensible, I
don’t really see the point. We really only need this for PRs.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
