### PR TITLE
switch dev images to Temurin

### DIFF
--- a/ci/docker/daml-sdk/Dockerfile
+++ b/ci/docker/daml-sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jdk-hotspot
+FROM eclipse-temurin:11
 ARG VERSION
 # This is needed to get the DNS requests
 # from Haskell binaries to succeed.


### PR DESCRIPTION
The AdoptOpenJDK project has been renamed to Adoptium so they renamed
the adoptopenjdk images to Temurin.

CHANGELOG_BEGIN
CHANGELOG_END