### PR TITLE
Set scalafmt dialect explicitly

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,6 +5,7 @@ project.git = true
 align.preset = none # never align to make the fmt more diff friendly
 maxColumn = 100
 runner.fatalWarnings = true
+runner.dialect = scala213
 trailingCommas = multiple
 # Disable scala doc wrapping (behavior changed in v3.0.0).
 docstrings.wrap = no


### PR DESCRIPTION
Scalafmt started issuing warnings because we don’t do this since our
latest nixpkgs upgrade which included a scalafmt upgrade.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
