### PR TITLE
self-service compat: set branch name to not main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,5 +217,5 @@ jobs:
   - bash: |
       set -euo pipefail
       source $(bash-lib)
-      trigger_azure $(System.AccessToken) --branch $(branch) PRs
-      trigger_azure $(System.AccessToken) --branch $(branch) digital-asset.daml-daily-compat
+      trigger_azure $(System.AccessToken) PRs --branch $(branch)
+      trigger_azure $(System.AccessToken) digital-asset.daml-daily-compat --branch $(branch)

--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -160,18 +160,18 @@ steps:
     }
     trigger_azure() (
       token=$1
-      option=$2
-      target=$3
-      build=$4
+      shift
+      build=$1
+      shift
       az extension add --name azure-devops
       trap 'az devops logout' EXIT
       echo $token \
         | az devops login --org "https://dev.azure.com/digitalasset"
       az pipelines build queue \
-        $option $target \
         --definition-name $build \
         --org "https://dev.azure.com/digitalasset" \
-        --project daml
+        --project daml \
+        $@
     )
 
     END

--- a/ci/prs.yml
+++ b/ci/prs.yml
@@ -186,7 +186,8 @@ jobs:
       COMMIT=$(git rev-parse HEAD^2)
       REQUEST=$(git log -n1 --format="%(trailers:key=run-full-compat,valueonly)" $COMMIT)
       if [ $REQUEST == true ]; then
-        trigger_azure $AZURE_TOKEN --commit-id $COMMIT digital-asset.daml-daily-compat
+        # Unfortunately recovering the actual branch name is tricky
+        trigger_azure $AZURE_TOKEN digital-asset.daml-daily-compat --commit-id $COMMIT --branch not-main
       fi
     env:
       AZURE_TOKEN: $(System.AccessToken)


### PR DESCRIPTION
The "tell slack about failures" step is conditional on the branch name being main; for whatever reason if we don't supply a branch name Azure sets it to `main`, regardless of the fact that the commit is not in that branch at all.

CHANGELOG_BEGIN
CHANGELOG_END