### PR TITLE
align index.rst files for HTML and PDF

### DIFF
--- a/docs/configs/pdf/index.rst
+++ b/docs/configs/pdf/index.rst
@@ -45,6 +45,9 @@ Building applications
    upgrade/index
    app-dev/authorization
    app-dev/ledger-api
+   triggers/index
+   tools/trigger-service/index
+   tools/auth-middleware/index
 
 Deploying to Daml ledgers
 -------------------------
@@ -65,6 +68,7 @@ Operating Daml
    :maxdepth: 2
 
    ops/index
+   ops/connect/index
 
 Developer Tools
 ---------------
@@ -110,11 +114,11 @@ Early Access Features
    :maxdepth: 2
 
    tools/extractor
+   tools/export/index
    daml-integration-kit/index
-   triggers/index
    tools/visual
-   tools/trigger-service
    concepts/interoperability
+   tools/non-repudiation
 
 Daml Ecosystem
 --------------


### PR DESCRIPTION
The `README.md` https://github.com/digital-asset/daml/blob/main/docs/README.md says that documentation files should be listed in both `/docs/source/index.rst` and `/docs/configs/pdf/index.rst`. This PR aligns the one for the PDF to what's in the one for HTML generation.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
