### PR TITLE
Add additional rights and clarifications to user management API

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
@@ -87,12 +87,6 @@ message Right {
     // The user is allowed to administrate the participant node.
     message ParticipantAdmin {}
 
-    // The user can authorize commands for any party hosted on this participant node.
-    message CanActAsAnyParty {}
-
-    // The user can all read ledger data visible to some party on this participant node.
-    message CanReadAsAnyParty {}
-
     // The user can authorize commands for the given party.
     message CanActAs {
         string party = 1;
@@ -105,9 +99,8 @@ message Right {
 
     oneof kind {
         ParticipantAdmin participant_admin = 1;
-        CanActAsAnyParty can_act_as_any_party = 2;
-        CanActAs can_act_as = 3;
-        CanReadAs can_read_as = 4;
+        CanActAs can_act_as = 2;
+        CanReadAs can_read_as = 3;
     }
 }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
@@ -39,7 +39,7 @@ service UserManagementService {
     rpc GetUser (GetUserRequest) returns (User);
 
     // Delete an existing user and all its rights.
-    rpc DeleteUser (DeleteUserRequest) returns (google.protobuf.Empty);
+    rpc DeleteUser (DeleteUserRequest) returns (DeleteUserResponse);
 
     // List the all existing users.
     rpc ListUsers (ListUsersRequest) returns (ListUsersResponse);
@@ -72,13 +72,26 @@ message User {
     // The primary party as which this user reads and acts by default on the ledger
     // _provided_ it has the corresponding ``CanReadAs(primary_party)`` or 
     // ``CanActAs(primary_party)`` rights.
+    //
+    // Ledger API clients SHOULD set this field to a non-empty value for all users to
+    // enable the users to act on the ledger using their own Daml party.
+    // Ledger API clients MAY set this field to empty for special users; e.g., a user
+    // that is granted ``CanReadAsAnyParty`` so that it can export the data for all parties
+    // hosted on the participant node.
     string primary_party = 2;
 }
+
 
 // A right granted to a user.
 message Right {
     // The user is allowed to administrate the participant node.
     message ParticipantAdmin {}
+
+    // The user can authorize commands for any party hosted on this participant node.
+    message CanActAsAnyParty {}
+
+    // The user can all read ledger data visible to some party on this participant node.
+    message CanReadAsAnyParty {}
 
     // The user can authorize commands for the given party.
     message CanActAs {
@@ -92,8 +105,9 @@ message Right {
 
     oneof kind {
         ParticipantAdmin participant_admin = 1;
-        CanActAs can_act_as = 2;
-        CanReadAs can_read_as = 3;
+        CanActAsAnyParty can_act_as_any_party = 2;
+        CanActAs can_act_as = 3;
+        CanReadAs can_read_as = 4;
     }
 }
 
@@ -121,6 +135,9 @@ message GetUserRequest {
 // Required authorization: ``HasRight(ParticipantAdmin)``
 message DeleteUserRequest {
     string user_id = 1;
+}
+
+message DeleteUserResponse {
 }
 
 // Required authorization: ``HasRight(ParticipantAdmin)``


### PR DESCRIPTION
Addresses: learning from design doc and review comments from https://github.com/digital-asset/daml/pull/11818/ that were added after merging; concretely
- add `CanActAsAnyParty` and `CanReadAsAnyParty` rights
- make `primary_party` optional for special users
- add `DeleteUserResponse`

FYI: @da-tanabe @bame-da @cocreature @gerolf-da @stefanobaghino-da @adriaanm-da @nmarton-da 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description
- [x] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
