### PR TITLE
Remove the use of nesting with `size` approach as suggested by scalacheck.

### DIFF
--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -82,10 +82,15 @@ object ValueGenerators {
       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$".toVector
     val mainChars =
       firstChars ++ "1234567890"
+    val suffixLengthGen = Gen.frequency(
+      90 -> Gen.choose(0, 9),
+      8 -> Gen.choose(0, 99),
+      2 -> Gen.choose(0, 999),
+    )
     for {
       h <- Gen.oneOf(firstChars)
-      suffixLength <- Gen.choose(0, 999)
-      t <- Gen.listOfN(suffixLength, Gen.oneOf(mainChars)) //Name is max 999 characters
+      suffixLength <- suffixLengthGen
+      t <- Gen.listOfN(suffixLength, Gen.oneOf(mainChars))
     } yield Name.assertFromString((h :: t).mkString)
   }
 


### PR DESCRIPTION
This is an attempt to solve #11497 

On my local workstation the test in the main branch was running for 6 seconds and with the new approach it takes 20 sec. It can be improved by redistributing flat generators and recursive ones with `Gen.frequency`. Please suggest what would you prefer. 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.