### PR TITLE
[Docs] Add labels to error codes to support references to them

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -106,8 +106,14 @@ genrule(
     cmd = """
         cp -rL docs/source source
 
-        cp -L -- $(location //docs:generate-docs-error-codes-inventory-into-rst-file)      source/app-dev/grpc/error-codes-inventory.rst
-        cp -L -- $(location //docs:generate-docs-error-categories-inventory-into-rst-file) source/app-dev/grpc/error-categories-inventory.rst
+        # Copy in error inventories
+        #
+        # These files are meant to be only included into other .rst files and so
+        # in order to prevent Sphinx from recognizing them as source files
+        # we append an '.inc' suffix. (See `source_suffix` in `conf.py`.)
+        cp -L -- $(location //docs:generate-docs-error-codes-inventory-into-rst-file)      source/app-dev/grpc/error-codes-inventory.rst.inc
+        cp -L -- $(location //docs:generate-docs-error-categories-inventory-into-rst-file) source/app-dev/grpc/error-categories-inventory.rst.inc
+
         # Copy in Stdlib
         mkdir -p source/daml/stdlib
         tar xf $(location //compiler/damlc:daml-base-rst.tar.gz) \\

--- a/docs/scripts/live-preview.sh
+++ b/docs/scripts/live-preview.sh
@@ -21,8 +21,8 @@ cleanup()
   rm -rf ../source/getting-started/code
   rm -rf ../source/daml/stdlib
   rm -f ../source/app-dev/grpc/proto-docs.rst
-  rm -f ../source/app-dev/grpc/error-codes-inventory.rst
-  rm -f ../source/app-dev/grpc/error-categories-inventory.rst
+  rm -f ../source/app-dev/grpc/error-codes-inventory.rst.inc
+  rm -f ../source/app-dev/grpc/error-categories-inventory.rst.inc
   rm -f ../source/LICENSE
   rm -f ../source/NOTICES
   echo "Done cleanup ... quitting."
@@ -69,9 +69,9 @@ do
 
         # Error codes and error categories
         bazel build //docs:generate-docs-error-codes-inventory-into-rst-file
-        cp -L ../../bazel-bin/docs/error-codes-inventory.rst $BUILD_DIR/source/app-dev/grpc/error-codes-inventory.rst
+        cp -L ../../bazel-bin/docs/error-codes-inventory.rst $BUILD_DIR/source/app-dev/grpc/error-codes-inventory.rst.inc
         bazel build //docs:generate-docs-error-categories-inventory-into-rst-file
-        cp -L ../../bazel-bin/docs/error-categories-inventory.rst $BUILD_DIR/source/app-dev/grpc/error-categories-inventory.rst
+        cp -L ../../bazel-bin/docs/error-categories-inventory.rst $BUILD_DIR/source/app-dev/grpc/error-categories-inventory.rst.inc
 
         # Hoogle
         bazel build //compiler/damlc:daml-base-hoogle.txt

--- a/docs/source/app-dev/grpc/error-codes.rst
+++ b/docs/source/app-dev/grpc/error-codes.rst
@@ -89,7 +89,7 @@ in a sensible way to automatically deal with errors and decide whether to retry
 a request or escalate to the operator.
 
 .. This file is generated:
-.. include:: error-categories-inventory.rst
+.. include:: error-categories-inventory.rst.inc
 
 
 Anatomy of an Error
@@ -162,7 +162,7 @@ Error Codes Inventory
 
 
 .. This file is generated:
-.. include:: error-codes-inventory.rst
+.. include:: error-codes-inventory.rst.inc
 
 
 Error Codes Migration Guide

--- a/ledger/error/generator/app/src/main/scala/com/daml/error/generator/app/ErrorCodeInventoryDocsGenApp.scala
+++ b/ledger/error/generator/app/src/main/scala/com/daml/error/generator/app/ErrorCodeInventoryDocsGenApp.scala
@@ -190,7 +190,7 @@ object ErrorGroupTree {
          |    """.stripMargin)
     val errorCodeReferenceName = s"error_code_${e.code}"
     s"""
-       |.. _${errorCodeReferenceName}:
+       |.. _$errorCodeReferenceName:
        |
        |${e.code}
        |---------------------------------------------------------------------------------------------------------------------------------------

--- a/ledger/error/generator/app/src/main/scala/com/daml/error/generator/app/ErrorCodeInventoryDocsGenApp.scala
+++ b/ledger/error/generator/app/src/main/scala/com/daml/error/generator/app/ErrorCodeInventoryDocsGenApp.scala
@@ -188,7 +188,11 @@ object ErrorGroupTree {
     val deprecationText = e.deprecationO.fold("")(d => s"""
          |    **Deprecation**: ${d}
          |    """.stripMargin)
-    s"""${e.code}
+    val errorCodeReferenceName = s"error_code_${e.code}"
+    s"""
+       |.. _${errorCodeReferenceName}:
+       |
+       |${e.code}
        |---------------------------------------------------------------------------------------------------------------------------------------
        |    $deprecationText
        |    **Explanation**: ${e.explanation}


### PR DESCRIPTION
You can now reference error codes like this:
```
:ref:`error_code_<ERROR_CODE_ID>`
```

### reST references

For a reference defined for a section:
```
.. _my_ref:

My section
=============
```
you can refer to this section like this:
```
See this :ref:`my_ref`
```

https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref