### PR TITLE
[participant-integration-api] - Split StandaloneIndexerServer  [kvl-1172]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerServer.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.indexer
+
+import akka.stream.Materializer
+import com.daml.ledger.api.health.{Healthy, ReportsHealth}
+import com.daml.ledger.participant.state.{v2 => state}
+import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.metrics.Metrics
+import com.daml.platform.store.LfValueTranslationCache
+
+import scala.concurrent.ExecutionContext
+
+final class IndexerServer(
+    readService: state.ReadService,
+    config: IndexerConfig,
+    servicesExecutionContext: ExecutionContext,
+    metrics: Metrics,
+    lfValueTranslationCache: LfValueTranslationCache.Cache,
+)(implicit materializer: Materializer, loggingContext: LoggingContext)
+    extends ResourceOwner[ReportsHealth] {
+
+  private val logger = ContextualizedLogger.get(this.getClass)
+
+  override def acquire()(implicit context: ResourceContext): Resource[ReportsHealth] = {
+    val indexerFactory = new JdbcIndexer.Factory(
+      config,
+      readService,
+      servicesExecutionContext,
+      metrics,
+      lfValueTranslationCache,
+    )
+    val indexer = RecoveringIndexer(
+      materializer.system.scheduler,
+      materializer.executionContext,
+      config.restartDelay,
+    )
+
+    def startIndexer(
+        initializedDebugLogMessage: String = "Waiting for the indexer to initialize the database.",
+        resetSchema: Boolean = false,
+    ): Resource[ReportsHealth] =
+      indexerFactory
+        .initialized(resetSchema)
+        .acquire()
+        .flatMap(indexer.start)
+        .map { case (healthReporter, _) =>
+          logger.debug(initializedDebugLogMessage)
+          healthReporter
+        }
+
+    config.startupMode match {
+      case IndexerStartupMode.MigrateAndStart =>
+        startIndexer()
+
+      case IndexerStartupMode.ResetAndStart =>
+        startIndexer(resetSchema = true)
+
+      case IndexerStartupMode.ValidateAndStart =>
+        startIndexer()
+
+      case IndexerStartupMode.ValidateAndWaitOnly =>
+        Resource
+          .successful(
+            {
+              logger.debug("Waiting for the indexer to validate the schema migrations.")
+              () => Healthy
+            }
+          )
+
+      case IndexerStartupMode.MigrateOnEmptySchemaAndStart =>
+        startIndexer(
+          initializedDebugLogMessage =
+            "Waiting for the indexer to initialize the empty or up-to-date database."
+        )
+    }
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerServerMigrations.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerServerMigrations.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.indexer
+
+import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
+import com.daml.logging.LoggingContext
+import com.daml.platform.store.FlywayMigrations
+
+import scala.concurrent.Future
+
+final class IndexerServerMigrations(
+    config: IndexerConfig,
+    additionalMigrationPaths: Seq[String] = Seq.empty,
+)(implicit loggingContext: LoggingContext)
+    extends ResourceOwner[Unit] {
+
+  override def acquire()(implicit context: ResourceContext): Resource[Unit] = {
+    val flywayMigrations =
+      new FlywayMigrations(
+        config.jdbcUrl,
+        additionalMigrationPaths,
+      )
+
+    val migrationRun = config.startupMode match {
+      case IndexerStartupMode.MigrateAndStart =>
+        flywayMigrations.migrate(config.allowExistingSchema)
+
+      case IndexerStartupMode.ResetAndStart =>
+        Future.unit
+
+      case IndexerStartupMode.ValidateAndStart =>
+        flywayMigrations.validate()
+
+      case IndexerStartupMode.ValidateAndWaitOnly =>
+        flywayMigrations.validateAndWaitOnly(
+          config.schemaMigrationAttempts,
+          config.schemaMigrationAttemptBackoff,
+        )
+
+      case IndexerStartupMode.MigrateOnEmptySchemaAndStart =>
+        flywayMigrations.migrateOnEmptySchema()
+    }
+    Resource.fromFuture(migrationRun)
+  }
+}

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -269,6 +269,7 @@ client_server_build(
         "localhost:%PORT%",
         "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
         "--exclude=HealthServiceIT",  # Does not make sense to run it for the export
+        "--additional=KVCommandDeduplicationIT",
     ],
     output_env = "KVUTILS_LEDGER_EXPORT",
     server = "//ledger/ledger-on-memory:app",


### PR DESCRIPTION
- required for https://github.com/digital-asset/daml/pull/11916 to initialize the JdbcIndexer before the StandaloneIndexerServer (migrations are required)
- Split StandaloneIndexerServer into IndexerServer and IndexerServerMigrations to allow us to run them in a separate order, so we can first run migrations and then instantiate other services which depend on the migrations (JdbcIndexer)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
