### PR TITLE
kvutils - Add expire_at for command deduplication state values [KVL-1199]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
@@ -62,7 +62,9 @@ message DamlCommandDedupValue {
     PreExecutionDeduplicationBounds record_time_bounds = 4;
   }
   string submission_id = 5;
+  google.protobuf.Timestamp expire_at = 6;
 }
+
 message PreExecutionDeduplicationBounds {
   // record_time is not available during pre-execution
   google.protobuf.Timestamp max_record_time = 1;

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.participant.state.kvutils.committer.transaction
 
 import java.time.Duration
 
+import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions.{
   buildDuration,
   commandDedupKey,
@@ -12,6 +13,7 @@ import com.daml.ledger.participant.state.kvutils.Conversions.{
   parseInstant,
   parseTimestamp,
 }
+import com.daml.ledger.participant.state.kvutils.committer.Committer.getCurrentConfiguration
 import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepContinue, StepResult}
 import com.daml.ledger.participant.state.kvutils.store.DamlCommandDedupValue.TimeCase
 import com.daml.ledger.participant.state.kvutils.store.events.{
@@ -184,7 +186,7 @@ private[transaction] object CommandDeduplication {
       }
     }
 
-  def setDeduplicationEntryStep(): Step =
+  def setDeduplicationEntryStep(defaultConfig: Configuration): Step =
     new Step {
       def apply(commitContext: CommitContext, transactionEntry: DamlTransactionEntrySummary)(
           implicit loggingContext: LoggingContext
@@ -195,10 +197,17 @@ private[transaction] object CommandDeduplication {
         val commandDedupBuilder = DamlCommandDedupValue.newBuilder.setSubmissionId(
           transactionEntry.submitterInfo.getSubmissionId
         )
-        commitContext.recordTime
-          .map(Conversions.buildTimestamp) match {
+        val (_, config) = getCurrentConfiguration(defaultConfig, commitContext)
+        // build the maximum interval for which we might use the deduplication entry
+        // we account for both time skews even if it means that the expiry time would be slightly longer than required
+        val expireInterval =
+          config.maxDeduplicationTime.plus(config.timeModel.maxSkew).plus(config.timeModel.minSkew)
+        commitContext.recordTime match {
           case Some(recordTime) =>
-            commandDedupBuilder.setRecordTime(recordTime)
+            val expireAt = recordTime.add(expireInterval)
+            commandDedupBuilder
+              .setRecordTime(Conversions.buildTimestamp(recordTime))
+              .setExpireAt(Conversions.buildTimestamp(expireAt))
           case None =>
             val maxRecordTime = commitContext.maximumRecordTime.getOrElse(
               throw Err.InternalError("Maximum record time is not set for pre-execution")
@@ -206,11 +215,14 @@ private[transaction] object CommandDeduplication {
             val minRecordTime = commitContext.minimumRecordTime.getOrElse(
               throw Err.InternalError("Minimum record time is not set for pre-execution")
             )
-            commandDedupBuilder.setRecordTimeBounds(
-              PreExecutionDeduplicationBounds.newBuilder
-                .setMaxRecordTime(Conversions.buildTimestamp(maxRecordTime))
-                .setMinRecordTime(Conversions.buildTimestamp(minRecordTime))
-            )
+            val expireAt = maxRecordTime.add(expireInterval)
+            commandDedupBuilder
+              .setRecordTimeBounds(
+                PreExecutionDeduplicationBounds.newBuilder
+                  .setMaxRecordTime(Conversions.buildTimestamp(maxRecordTime))
+                  .setMinRecordTime(Conversions.buildTimestamp(minRecordTime))
+              )
+              .setExpireAt(Conversions.buildTimestamp(expireAt))
         }
 
         // Set a deduplication entry.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -74,7 +74,7 @@ private[kvutils] class TransactionCommitter(
     "validate_ledger_time" -> ledgerTimeValidator.createValidationStep(rejections),
     "validate_model_conformance" -> modelConformanceValidator.createValidationStep(rejections),
     "validate_consistency" -> TransactionConsistencyValidator.createValidationStep(rejections),
-    "set_deduplication_entry" -> CommandDeduplication.setDeduplicationEntryStep(),
+    "set_deduplication_entry" -> CommandDeduplication.setDeduplicationEntryStep(defaultConfig),
     "blind" -> blind,
     "trim_unnecessary_nodes" -> trimUnnecessaryNodes,
     "build_final_log_entry" -> buildFinalLogEntry,


### PR DESCRIPTION
changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
