### PR TITLE
Fix package version validation in damlc

### DIFF
--- a/compiler/damlc/daml-package-config/BUILD.bazel
+++ b/compiler/damlc/daml-package-config/BUILD.bazel
@@ -4,6 +4,7 @@
 load(
     "//bazel_tools:haskell.bzl",
     "da_haskell_library",
+    "da_haskell_test",
 )
 
 da_haskell_library(
@@ -25,5 +26,24 @@ da_haskell_library(
         "//:sdk-version-hs-lib",
         "//compiler/daml-lf-ast",
         "//daml-assistant:daml-project-config",
+    ],
+)
+
+da_haskell_test(
+    name = "tests",
+    srcs = glob(["test/**/*.hs"]),
+    hackage_deps = [
+        "base",
+        "containers",
+        "tasty",
+        "tasty-hunit",
+        "text",
+    ],
+    main_function = "DA.Daml.Package.ConfigTest.main",
+    src_strip_prefix = "src",
+    deps = [
+        ":daml-package-config",
+        "//compiler/daml-lf-ast",
+        "//libs-haskell/test-utils",
     ],
 )

--- a/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
+++ b/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
@@ -87,7 +87,7 @@ checkPkgConfig PackageConfigFields {pName, pVersion} =
       , "use them as dependencies in other projects. Unsupported package names or versions may"
       , "start causing compilation errors without warning."
       ]
-    versionRegex = "^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?)?$" :: T.Text
+    versionRegex = "^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*$" :: T.Text
     packageNameRegex = "^[A-Za-z][A-Za-z0-9]*(\\-[A-Za-z][A-Za-z0-9]*)*$" :: T.Text
 
 overrideSdkVersion :: PackageConfigFields -> IO PackageConfigFields

--- a/compiler/damlc/daml-package-config/test/DA/Daml/Package/ConfigTest.hs
+++ b/compiler/damlc/daml-package-config/test/DA/Daml/Package/ConfigTest.hs
@@ -1,0 +1,41 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Daml.Package.ConfigTest (main) where
+
+import qualified DA.Daml.LF.Ast as LF
+import DA.Daml.Package.Config
+import DA.Test.Util
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = defaultMain $
+  testGroup "package-config"
+    [ checkPkgConfigTests
+    ]
+
+checkPkgConfigTests :: TestTree
+checkPkgConfigTests = testGroup "checkPkgConfig"
+  [ testCase "accepts stable version" $ do
+      checkPkgConfig (config (LF.PackageName "foobar") (LF.PackageVersion "1.1.1")) @?= []
+  , testCase "accepts GHC snapshot version" $ do
+      checkPkgConfig (config (LF.PackageName "foobar") (LF.PackageVersion "2.0.0.20211130.8536.0")) @?= []
+  , testCase "rejects semver snapshot version" $ do
+      [err] <- pure $ checkPkgConfig (config (LF.PackageName "foobar") (LF.PackageVersion "2.0.0-snapshot.20211130.8536.0.683ab871"))
+      assertInfixOf "Invalid package version" (T.unpack err)
+  ]
+  where
+    config name version = PackageConfigFields
+      { pName = name
+      , pSrc = "src"
+      , pExposedModules = Nothing
+      , pVersion = Just version
+      , pDependencies = []
+      , pDataDependencies = []
+      , pModulePrefixes = Map.empty
+      , pSdkVersion = PackageSdkVersion "0.0.0"
+      }
+


### PR DESCRIPTION
Currently the validation only allows for 3-component version
names. However even our own releases don’t respect that for snapshots
so instead we relax the validation to allow an arbitrary number of
numeric components which matches what ghc-pkg allows.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
