### PR TITLE
Only run migration tests for stable versions on each PR

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -129,6 +129,7 @@ first_post_7587_trigger_version = "1.7.0-snapshot.20201012.5405.0.af92198d"
 migration_test(
     name = "migration-stable",
     timeout = "eternal",
+    quick_tags = ["head-quick"],
     # Exclusive due to hardcoded postgres ports.
     tags = [
         "exclusive",
@@ -145,6 +146,7 @@ migration_test(
 
 migration_test(
     name = "meta-migration-test",
+    quick_tags = [],
     tags = [
         "exclusive",
         "manual",
@@ -158,6 +160,7 @@ migration_test(
 migration_test(
     name = "migration-all",
     timeout = "eternal",
+    quick_tags = [],
     # Exclusive due to hardcoded postgres ports.
     tags = ["exclusive"],
     versions = [

--- a/compatibility/sandbox-migration/util.bzl
+++ b/compatibility/sandbox-migration/util.bzl
@@ -14,7 +14,7 @@ def migration_test(name, versions, tags, quick_tags, **kwargs):
             "//sandbox-migration:migration-step",
         ] + ["@daml-sdk-{}//:daml".format(ver) for ver in versions],
         args = versions,
-        tags = tags + ["head-quick"],
+        tags = tags + quick_tags,
         **kwargs
     )
 

--- a/compatibility/sandbox-migration/util.bzl
+++ b/compatibility/sandbox-migration/util.bzl
@@ -3,7 +3,7 @@
 
 load("@os_info//:os_info.bzl", "is_linux")
 
-def migration_test(name, versions, tags, **kwargs):
+def migration_test(name, versions, tags, quick_tags, **kwargs):
     native.sh_test(
         name = name,
         srcs = ["//sandbox-migration:test.sh"],


### PR DESCRIPTION
The ones that also go through snapshots are still there but only run
on the daily run.

The reason for this PR is that we’ve actually gotten damlc tests
pretty fast now to the point where I’m waiting for the compat tests to
finish on PRs that don’t force conformance test reruns.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
