### PR TITLE
Add `isSubsetOf` and some more predicates in DA.Set

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Set.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Set.daml
@@ -44,6 +44,7 @@ module DA.Set
   , toMap
   , fromMap
   , member
+  , notMember
   , null
   , insert
   , filter
@@ -52,6 +53,8 @@ module DA.Set
   , union
   , intersection
   , difference
+  , isSubsetOf
+  , isProperSubsetOf
   ) where
 
 import qualified DA.Foldable as Foldable
@@ -87,6 +90,11 @@ fromMap = Set
 -- | Is the element in the set?
 member : Ord k => k -> Set k -> Bool
 member k (Set m) = M.member k m
+
+-- | Is the element not in the set?
+-- `notMember k s` is equivalent to `not (member k s)`.
+notMember : Ord k => k -> Set k -> Bool
+notMember k s = not (member k s)
 
 -- | Is this the empty set?
 null : Set k -> Bool
@@ -125,6 +133,16 @@ intersection s1 s2 = filter (`member` s2) s1
 difference : Ord k => Set k -> Set k -> Set k
 difference s1 s2 = filter (\x -> not (x `member` s2)) s1
 
+-- | `isSubsetOf a b` returns true if `a` is a subset of `b`,
+-- that is, if every element of `a` is in `b`.
+isSubsetOf : Ord k => Set k -> Set k -> Bool
+isSubsetOf a b = all (`member` b) (toList a)
+
+-- | `isProperSubsetOf a b` returns true if `a` is a proper subset of `b`.
+-- That is, if `a` is a subset of `b` but not equal to `b`.
+isProperSubsetOf : Ord k => Set k -> Set k -> Bool
+isProperSubsetOf a b = (a /= b) && isSubsetOf a b
+
 deriving instance Ord k => Eq (Set k)
 deriving instance Ord k => Ord (Set k)
 
@@ -143,7 +161,6 @@ instance Ord k => Monoid (Set k) where
 instance DA.Internal.Record.HasField "map" (Set k) (Map k ()) where
   getField (Set m) = m
   setField m _ = Set m
-
 
 instance Foldable.Foldable Set where
   toList = DA.Set.toList

--- a/compiler/damlc/tests/daml-test-files/Set.daml
+++ b/compiler/damlc/tests/daml-test-files/Set.daml
@@ -30,6 +30,11 @@ testMember = scenario do
   True === member "" (fromList ["", "b", "c"])
   False === member 2 (fromList [])
 
+testNotMember = scenario do
+  True === notMember "a" (fromList ["", "b", "c"])
+  False === notMember "" (fromList ["", "b", "c"])
+  True === notMember 2 (fromList [])
+
 testNull = scenario do
   True === S.null S.empty
   False === S.null (insert 5 S.empty)
@@ -66,6 +71,28 @@ testDifference = scenario do
   [] === toList (difference S.empty (fromList [4, 2]))
   [1, 3, 5] === toList (difference (fromList [1, 5, 3]) S.empty)
   [] === toList (difference S.empty (fromList ([] : [Int])))
+
+testIsSubsetOf = scenario do
+  True === isSubsetOf (fromList [1,2]) (fromList [1,2,3])
+  True === isSubsetOf (fromList [1,2]) (fromList [1,2])
+  False === isSubsetOf (fromList [1,2,3]) (fromList [1,2])
+  True === isSubsetOf (fromList @Text []) (fromList [])
+  True === isSubsetOf (fromList []) (fromList ["hello"])
+  True === isSubsetOf (fromList ["hello"]) (fromList ["hello"])
+  False === isSubsetOf (fromList ["hello!"]) (fromList ["hello"])
+  False === isSubsetOf (fromList ["hello"]) (fromList ["hello!"])
+  False === isSubsetOf (fromList ["hello"]) (fromList [])
+
+testIsProperSubsetOf = scenario do
+  True === isProperSubsetOf (fromList [1,2]) (fromList [1,2,3])
+  False === isProperSubsetOf (fromList [1,2]) (fromList [1,2])
+  False === isProperSubsetOf (fromList [1,2,3]) (fromList [1,2])
+  False === isProperSubsetOf (fromList @Text []) (fromList [])
+  True === isProperSubsetOf (fromList []) (fromList ["hello"])
+  False === isProperSubsetOf (fromList ["hello"]) (fromList ["hello"])
+  False === isProperSubsetOf (fromList ["hello!"]) (fromList ["hello"])
+  False === isProperSubsetOf (fromList ["hello"]) (fromList ["hello!"])
+  False === isProperSubsetOf (fromList ["hello"]) (fromList [])
 
 testFoldable = scenario do
   Foldable.toList (S.fromList [1,2,3,4]) === [1,2,3,4]


### PR DESCRIPTION
I noticed we didn't have a "subset" function in DA.Set when Oliver
showed me some daml test code that had to define it manually. So I
decided to add it, and a couple more predicates.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
