### PR TITLE
LF: Introduce configurable limits on produced transactions

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -184,8 +184,16 @@ final class Conversions(
                 builder.setCrash(s"Contract Id comparability Error")
               case NonComparableValues =>
                 builder.setComparableValueError(proto.Empty.newBuilder)
-              case ValueExceedsMaxNesting =>
-                builder.setValueExceedsMaxNesting(proto.Empty.newBuilder)
+              case Limit(limitError) =>
+                limitError match {
+                  case Limit.ValueNesting(_) =>
+                    builder.setValueExceedsMaxNesting(proto.Empty.newBuilder)
+                  // TODO https://github.com/digital-asset/daml/issues/11691
+                  //   Handle the other cases properly.
+                  case _ =>
+                    builder.setCrash(s"A limit was overpass when building the transaction")
+                }
+
               case _: ChoiceGuardFailed =>
                 // TODO https://github.com/digital-asset/daml/issues/11703
                 //   Implement this.

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -314,6 +314,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
         readAs = readAs,
         validating = validating,
         contractKeyUniqueness = config.contractKeyUniqueness,
+        limits = config.limits,
       )
       interpretLoop(machine, ledgerTime)
     }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -35,6 +35,7 @@ final case class EngineConfig(
     contractKeyUniqueness: ContractKeyUniquenessMode = ContractKeyUniquenessMode.On,
     forbidV0ContractId: Boolean = false,
     requireSuffixedGlobalContractId: Boolean = false,
+    limits: interpretation.Limits = interpretation.Limits.Lenient,
 ) {
 
   private[lf] def getCompilerConfig: speedy.Compiler.Config =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -107,8 +107,44 @@ private[lf] object Pretty {
       case ContractIdInContractKey(key) =>
         text("Contract IDs are not supported in contract keys:") &
           prettyContractId(key.cids.head)
-      case ValueExceedsMaxNesting =>
-        text(s"Value exceeds maximum nesting value of 100")
+      case Limit(error) =>
+        error match {
+          case Limit.ValueNesting(limit) =>
+            text(s"Value exceeds maximum nesting value of $limit")
+          case Limit.ContractSignatories(cid @ _, templateId, arg @ _, signatories, limit) =>
+            text(
+              s"Create Fetch or exercise a Contract of type $templateId with ${signatories.size} signatories but the limit is $limit"
+            )
+          case Limit.ContractObservers(cid @ _, templateId, arg @ _, observers, limit) =>
+            text(
+              s"Create Fetch or exercise a Contract of type $templateId  ${observers.size} observes but the limit is $limit"
+            )
+          case Limit.ChoiceControllers(
+                cid @ _,
+                templateId,
+                choiceName,
+                arg @ _,
+                controllers,
+                limit,
+              ) =>
+            text(
+              s"Exercise the choice $templateId:$choiceName with ${controllers.size} controllers but the limit is $limit"
+            )
+          case Limit.ChoiceObservers(
+                cid @ _,
+                templateId,
+                choiceName,
+                arg @ _,
+                observers,
+                limit,
+              ) =>
+            text(
+              s"Exercise the choice $templateId:$choiceName with ${observers.size} observers but the limit is $limit"
+            )
+          case Limit.TransactionInputContracts(limit) =>
+            text(s"Transaction exceeds maximum input contract number of $limit")
+        }
+
       case ChoiceGuardFailed(cid, templateId, choiceName, byInterface) => (
         text(s"Choice guard failed for") & prettyTypeConName(templateId) &
           text(s"contract") & prettyContractId(cid) &

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -961,7 +961,7 @@ private[lf] object SBuiltin {
           byInterface = byInterface,
         )
 
-      machine.addLocalContract(coid, templateId, createArg, sigs, obs, mbKey)
+      onLedger.addLocalContract(coid, templateId, createArg, sigs, obs, mbKey)
       onLedger.ptx = newPtx
       checkAborted(onLedger.ptx)
       machine.returnValue = SContractId(coid)
@@ -1002,8 +1002,9 @@ private[lf] object SBuiltin {
       val sigs = cached.signatories
       val templateObservers = cached.observers
       val ctrls = extractParties(NameOf.qualifiedNameOfCurrentFunc, args.get(2))
-      val choiceObservers = extractParties(NameOf.qualifiedNameOfCurrentFunc, args.get(3))
-
+      onLedger.enforceChoiceControllersLimit(ctrls, coid, templateId, choiceId, chosenValue)
+      val obsrs = extractParties(NameOf.qualifiedNameOfCurrentFunc, args.get(3))
+      onLedger.enforceChoiceObserversLimit(obsrs, coid, templateId, choiceId, chosenValue)
       val mbKey = cached.key
       val auth = machine.auth
 
@@ -1018,7 +1019,7 @@ private[lf] object SBuiltin {
           actingParties = ctrls,
           signatories = sigs,
           stakeholders = sigs union templateObservers,
-          choiceObservers = choiceObservers,
+          choiceObservers = obsrs,
           mbKey = mbKey,
           byKey = byKey,
           chosenValue = chosenValue,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -60,7 +60,9 @@ sealed trait SValue {
 
     def go(v: SValue, maxNesting: Int = V.MAXIMUM_NESTING): V = {
       if (maxNesting < 0)
-        throw SError.SErrorDamlException(interpretation.Error.ValueExceedsMaxNesting)
+        throw SError.SErrorDamlException(
+          interpretation.Error.Limit(interpretation.Error.Limit.ValueNesting(V.MAXIMUM_NESTING))
+        )
       val nextMaxNesting = maxNesting - 1
       v match {
         case SInt64(x) => V.ValueInt64(x)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -8,6 +8,7 @@ import java.util
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
+import com.daml.lf.interpretation.{Error => IError}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{LookupError, Util => AstUtil}
 import com.daml.lf.ledger.Authorize
@@ -109,6 +110,10 @@ private[lf] object Speedy {
     private[lf] val stakeholders: Set[Party] = signatories union observers;
   }
 
+  private[this] def enforceLimit(actual: Int, limit: Int, error: Int => IError.Limit.Error) =
+    if (actual > limit)
+      throw SError.SErrorDamlException(IError.Limit(error(limit)))
+
   private[lf] final case class OnLedger(
       val validating: Boolean,
       val contractKeyUniqueness: ContractKeyUniquenessMode,
@@ -124,6 +129,8 @@ private[lf] object Speedy {
       var dependsOnTime: Boolean,
       // global contract discriminators, that are discriminators from contract created in previous transactions
       var cachedContracts: Map[V.ContractId, CachedContract],
+      var numInputContracts: Int,
+      val limits: interpretation.Limits,
   ) extends LedgerMode {
     private[lf] val visibleToStakeholders: Set[Party] => SVisibleToStakeholders =
       if (validating) { _ => SVisibleToStakeholders.Visible }
@@ -133,6 +140,83 @@ private[lf] object Speedy {
     private[lf] def finish: PartialTransaction.Result = ptx.finish
     private[lf] def ptxInternal: PartialTransaction = ptx //deprecated
     private[lf] def incompleteTransaction: IncompleteTransaction = ptx.finishIncomplete
+
+    private[this] def updateCachedContracts(coid: V.ContractId, contract: CachedContract): Unit = {
+      enforceLimit(
+        contract.signatories.size,
+        limits.contractSignatories,
+        IError.Limit
+          .ContractSignatories(
+            coid,
+            contract.templateId,
+            contract.value.toUnnormalizedValue,
+            contract.signatories,
+            _,
+          ),
+      )
+      enforceLimit(
+        contract.observers.size,
+        limits.contractObservers,
+        IError.Limit
+          .ContractObservers(
+            coid,
+            contract.templateId,
+            contract.value.toUnnormalizedValue,
+            contract.observers,
+            _,
+          ),
+      )
+      cachedContracts = cachedContracts.updated(coid, contract)
+    }
+
+    private[speedy] def addLocalContract(
+        coid: V.ContractId,
+        templateId: Ref.TypeConName,
+        value: SValue,
+        signatories: Set[Party],
+        observers: Set[Party],
+        key: Option[Node.KeyWithMaintainers],
+    ): Unit =
+      updateCachedContracts(
+        coid,
+        CachedContract(templateId, value, signatories, observers, key),
+      )
+
+    private[speedy] def addGlobalContract(coid: V.ContractId, contract: CachedContract): Unit = {
+      numInputContracts += 1
+      enforceLimit(
+        numInputContracts,
+        limits.transactionInputContracts,
+        IError.Limit.TransactionInputContracts,
+      )
+      updateCachedContracts(coid, contract)
+    }
+
+    private[speedy] def enforceChoiceControllersLimit(
+        controllers: Set[Party],
+        cid: V.ContractId,
+        templateId: TypeConName,
+        choiceName: ChoiceName,
+        arg: V,
+    ): Unit =
+      enforceLimit(
+        controllers.size,
+        limits.choiceControllers,
+        IError.Limit.ChoiceControllers(cid, templateId, choiceName, arg, controllers, _),
+      )
+
+    private[speedy] def enforceChoiceObserversLimit(
+        observers: Set[Party],
+        cid: V.ContractId,
+        templateId: TypeConName,
+        choiceName: ChoiceName,
+        arg: V,
+    ): Unit =
+      enforceLimit(
+        observers.size,
+        limits.choiceObservers,
+        IError.Limit.ChoiceObservers(cid, templateId, choiceName, arg, observers, _),
+      )
 
   }
 
@@ -348,21 +432,6 @@ private[lf] object Speedy {
       }
 
     private[lf] def auth: Authorize = Authorize(this.contextActors)
-
-    def addLocalContract(
-        coid: V.ContractId,
-        templateId: Ref.TypeConName,
-        arg: SValue,
-        signatories: Set[Party],
-        observers: Set[Party],
-        key: Option[Node.KeyWithMaintainers],
-    ) =
-      withOnLedger("addLocalContract") { onLedger =>
-        onLedger.cachedContracts = onLedger.cachedContracts.updated(
-          coid,
-          CachedContract(templateId, arg, signatories, observers, key),
-        )
-      }
 
     /** Reuse an existing speedy machine to evaluate a new expression.
       *      Do not use if the machine is partway though an existing evaluation.
@@ -765,6 +834,7 @@ private[lf] object Speedy {
         warningLog: WarningLog = newWarningLog,
         contractKeyUniqueness: ContractKeyUniquenessMode = ContractKeyUniquenessMode.On,
         commitLocation: Option[Location] = None,
+        limits: interpretation.Limits = interpretation.Limits.Lenient,
     ): Machine = {
       val pkg2TxVersion =
         compiledPackages.interface.packageLanguageVersion.andThen(
@@ -794,7 +864,9 @@ private[lf] object Speedy {
           commitLocation = commitLocation,
           dependsOnTime = false,
           cachedContracts = Map.empty,
+          numInputContracts = 0,
           contractKeyUniqueness = contractKeyUniqueness,
+          limits = limits,
         ),
         traceLog = traceLog,
         warningLog = warningLog,
@@ -812,10 +884,11 @@ private[lf] object Speedy {
         compiledPackages: CompiledPackages,
         transactionSeed: crypto.Hash,
         updateE: Expr,
-        committer: Party,
+        committers: Set[Party],
+        limits: interpretation.Limits = interpretation.Limits.Lenient,
     ): Machine = {
       val updateSE: SExpr = compiledPackages.compiler.unsafeCompile(updateE)
-      fromUpdateSExpr(compiledPackages, transactionSeed, updateSE, committer)
+      fromUpdateSExpr(compiledPackages, transactionSeed, updateSE, committers, limits)
     }
 
     @throws[PackageNotFound]
@@ -825,7 +898,8 @@ private[lf] object Speedy {
         compiledPackages: CompiledPackages,
         transactionSeed: crypto.Hash,
         updateSE: SExpr,
-        committer: Party,
+        committers: Set[Party],
+        limits: interpretation.Limits = interpretation.Limits.Lenient,
         traceLog: TraceLog = newTraceLog,
     ): Machine = {
       Machine(
@@ -833,8 +907,9 @@ private[lf] object Speedy {
         submissionTime = Time.Timestamp.MinValue,
         initialSeeding = InitialSeeding.TransactionSeed(transactionSeed),
         expr = SEApp(updateSE, Array(SEValue.Token)),
-        committers = Set(committer),
+        committers = committers,
         readAs = Set.empty,
+        limits = limits,
         traceLog = traceLog,
       )
     }
@@ -1283,7 +1358,7 @@ private[lf] object Speedy {
       machine.withOnLedger("KCacheContract") { onLedger =>
         val cached = SBuiltin.extractCachedContract(onLedger, templateId, sv)
         machine.checkContractVisibility(onLedger, cid, cached);
-        onLedger.cachedContracts = onLedger.cachedContracts.updated(cid, cached)
+        onLedger.addGlobalContract(cid, cached)
         machine.returnValue = cached.value
       }
     }
@@ -1342,14 +1417,7 @@ private[lf] object Speedy {
       byInterface: Option[TypeConName],
   ) extends Kont {
     def abort[E](): E =
-      throw SErrorDamlException(
-        interpretation.Error.ChoiceGuardFailed(
-          coid,
-          templateId,
-          choiceName,
-          byInterface,
-        )
-      )
+      throw SErrorDamlException(IError.ChoiceGuardFailed(coid, templateId, choiceName, byInterface))
 
     def execute(v: SValue) = {
       v match {
@@ -1408,7 +1476,7 @@ private[lf] object Speedy {
         machine.env.clear()
         machine.envBase = 0
         throw SErrorDamlException(
-          interpretation.Error.UnhandledException(excep.ty, excep.value.toUnnormalizedValue)
+          IError.UnhandledException(excep.ty, excep.value.toUnnormalizedValue)
         )
     }
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
@@ -58,7 +58,7 @@ class EvaluationOrderTest extends AnyWordSpec with Matchers {
     val se = pkgs.compiler.unsafeCompile(e)
     val traceLog = new TestTraceLog()
     val res = Speedy.Machine
-      .fromUpdateSExpr(pkgs, seed, SEApp(se, args.map(SEValue(_))), party, traceLog)
+      .fromUpdateSExpr(pkgs, seed, SEApp(se, args.map(SEValue(_))), Set(party), traceLog = traceLog)
       .run()
     val msgs = traceLog.getMessages
     (res, msgs)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -476,7 +476,7 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
     "works as expected for a contract version POST-dating exceptions" in {
       val pkgs = mkPackagesAtVersion(LanguageVersion.v1_dev)
       val res = Speedy.Machine
-        .fromUpdateSExpr(pkgs, transactionSeed, applyToParty(pkgs, example, party), party)
+        .fromUpdateSExpr(pkgs, transactionSeed, applyToParty(pkgs, example, party), Set(party))
         .run()
       res shouldBe SResultFinalValue(SUnit)
     }
@@ -491,7 +491,7 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
       val pkgs = mkPackagesAtVersion(LanguageVersion.v1_11)
       val res = Speedy.Machine
-        .fromUpdateSExpr(pkgs, transactionSeed, applyToParty(pkgs, example, party), party)
+        .fromUpdateSExpr(pkgs, transactionSeed, applyToParty(pkgs, example, party), Set(party))
         .run()
       res shouldBe SResultError(SErrorDamlException(anException))
     }
@@ -557,7 +557,7 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
   private def runUpdateExpr(pkgs1: PureCompiledPackages)(e: Expr): SResult = {
     def transactionSeed: crypto.Hash = crypto.Hash.hashPrivateKey("ExceptionTest.scala")
-    Speedy.Machine.fromUpdateExpr(pkgs1, transactionSeed, e, party).run()
+    Speedy.Machine.fromUpdateExpr(pkgs1, transactionSeed, e, Set(party)).run()
   }
 
   "rollback of creates (mixed versions)" should {
@@ -698,18 +698,20 @@ class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyCh
     val causeUncatchable2: SExpr = applyToParty(pkgs, e"NewM:causeUncatchable2", party)
 
     "create rollback when old contacts are not within try-catch context" in {
-      val res = Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, causeRollback, party).run()
+      val res =
+        Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, causeRollback, Set(party)).run()
       res shouldBe SResultFinalValue(SUnit)
     }
 
     "causes uncatchable exception when an old contract is within a new-exercise within a try-catch" in {
-      val res = Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, causeUncatchable, party).run()
+      val res =
+        Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, causeUncatchable, Set(party)).run()
       res shouldBe SResultError(SErrorDamlException(anException))
     }
 
     "causes uncatchable exception when an old contract is within a new-exercise which aborts" in {
       val res =
-        Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, causeUncatchable2, party).run()
+        Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, causeUncatchable2, Set(party)).run()
       res shouldBe SResultError(SErrorDamlException(anException))
     }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/LimitsSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/LimitsSpec.scala
@@ -1,0 +1,433 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import com.daml.lf.data.{FrontStack, ImmArray, Ref}
+import com.daml.lf.interpretation.{Error => IE}
+import com.daml.lf.language.{Ast, PackageInterface}
+import com.daml.lf.testing.parser.Implicits._
+import com.daml.lf.transaction.{SubmittedTransaction, TransactionVersion, Versioned}
+import com.daml.lf.validation.Validation
+import com.daml.lf.value.Value
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+
+class LimitsSpec extends AnyWordSpec with Matchers with Inside with TableDrivenPropertyChecks {
+
+  private[this] val pkgs = typeAndCompile(
+    p"""
+      module Mod {
+        
+        record @serializable T = { 
+          signatories: List Party,
+          observers: List Party
+        };
+        
+        record @serializable NoOpArg = { controllers: List Party, observers: List Party };
+        
+        val fetches: List (ContractId Mod:T) -> Update (List Mod:T) = 
+          \(cids: List (ContractId Mod:T)) -> 
+            case cids of 
+              Cons h t -> 
+                ubind 
+                  first: Mod:T <- fetch @Mod:T h;
+                  rest: List Mod:T <- Mod:fetches t
+                in 
+                  upure @(List Mod:T) Cons @Mod:T [first] rest
+            | Nil -> 
+                upure @(List Mod:T) Nil @Mod:T;
+        
+        template (this : T) =  {
+          precondition True;
+          signatories Mod:T {signatories} this;
+          observers Mod:T {observers} this;
+          agreement "Agreement";
+          choice @nonConsuming NoOp (self) (arg: Mod:NoOpArg): Unit,
+            controllers Mod:NoOpArg {controllers} arg,
+            observers Mod:NoOpArg {observers} arg
+            to
+              upure @Unit ();
+         };
+      }
+    """
+  )
+
+  "Machine" should {
+
+    val committers = (0 to 100).view.map(i => Ref.Party.assertFromString(s"Parties$i")).toSet
+    val limit = 10
+    val testCases =
+      Table("size" -> "success", 1 -> true, limit -> true, limit + 1 -> false, 5 * limit -> false)
+
+    "refuse to create a contract with too many signatories" in {
+      val limits = interpretation.Limits.Lenient.copy(contractSignatories = limit)
+
+      val e =
+        e"""\(signatories: List Party) (observers: List Party) -> 
+             create @Mod:T Mod:T { signatories = signatories, observers = observers }
+         """
+      forEvery(testCases) { (i, succeed) =>
+        val (signatories, observers) = committers.splitAt(i)
+        val result =
+          eval(limits, Map.empty, committers, e, asSParties(signatories), asSParties(observers))
+
+        if (succeed)
+          result shouldBe a[Right[_, _]]
+        else
+          inside(result) {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.Limit(IE.Limit.ContractSignatories(_, templateId, _, parties, reportedlimit))
+                  )
+                ) =>
+              templateId shouldBe T
+              parties shouldBe signatories
+              reportedlimit shouldBe limit
+          }
+      }
+    }
+
+    "refuse to fetch a contract with too many signatories" in {
+      val limits = interpretation.Limits.Lenient.copy(contractSignatories = limit)
+      val e = e"""\(cid: ContractId Mod:T) -> fetch @Mod:T cid"""
+
+      forEvery(testCases) { (i, succeed) =>
+        val (signatories, observers) = committers.splitAt(i)
+        val contract = mkContract(signatories, observers)
+        val result = eval(limits, Map(aCid -> contract), signatories, e, SValue.SContractId(aCid))
+        if (succeed)
+          result shouldBe a[Right[_, _]]
+        else
+          inside(result) {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.Limit(IE.Limit.ContractSignatories(_, templateId, _, parties, reportedlimit))
+                  )
+                ) =>
+              templateId shouldBe T
+              parties shouldBe signatories
+              reportedlimit shouldBe limit
+          }
+      }
+    }
+
+    "refuse to exercise a contract with too many signatories" in {
+      val limits = interpretation.Limits.Lenient.copy(contractSignatories = limit)
+      val e =
+        e"""\(cid: ContractId Mod:T) (controllers: List Party) -> 
+           exercise @Mod:T NoOp cid Mod:NoOpArg {controllers = controllers, observers = Nil @Party }"""
+
+      forEvery(testCases) { (i, succeed) =>
+        val (signatories, observers) = committers.splitAt(i)
+        val contract = mkContract(signatories, observers)
+        val result = eval(
+          limits,
+          Map(aCid -> contract),
+          signatories,
+          e,
+          SValue.SContractId(aCid),
+          asSParties(signatories),
+        )
+
+        if (succeed)
+          result shouldBe a[Right[_, _]]
+        else
+          inside(result) {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.Limit(IE.Limit.ContractSignatories(_, templateId, _, parties, reportedlimit))
+                  )
+                ) =>
+              templateId shouldBe T
+              parties shouldBe signatories
+              reportedlimit shouldBe limit
+          }
+      }
+    }
+
+    "refuse to create a contract with too many observers" in {
+      val limits = interpretation.Limits.Lenient.copy(contractObservers = limit)
+
+      val e =
+        e"""\(signatories: List Party) (observers: List Party) -> 
+             create @Mod:T Mod:T { signatories = signatories, observers = observers }
+         """
+
+      forEvery(testCases) { (i, succeed) =>
+        val (observers, signatories) = committers.splitAt(i)
+        val result =
+          eval(limits, Map.empty, signatories, e, asSParties(signatories), asSParties(observers))
+
+        if (succeed)
+          result shouldBe a[Right[_, _]]
+        else
+          inside(result) {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.Limit(IE.Limit.ContractObservers(_, templateId, _, parties, reportedlimit))
+                  )
+                ) =>
+              templateId shouldBe T
+              parties shouldBe observers
+              reportedlimit shouldBe limit
+          }
+      }
+    }
+
+    "refuse to fetch a contract with too many observers" in {
+      val limits = interpretation.Limits.Lenient.copy(contractObservers = limit)
+      val e = e"""\(cid: ContractId Mod:T) -> fetch @Mod:T cid"""
+
+      forEvery(testCases) { (i, succeed) =>
+        val (observers, signatories) = committers.splitAt(i)
+        val contract = mkContract(signatories, observers)
+        val result = eval(limits, Map(aCid -> contract), signatories, e, SValue.SContractId(aCid))
+
+        if (succeed)
+          result shouldBe a[Right[_, _]]
+        else
+          inside(result) {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.Limit(IE.Limit.ContractObservers(_, templateId, _, parties, reportedlimit))
+                  )
+                ) =>
+              templateId shouldBe T
+              parties shouldBe observers
+              reportedlimit shouldBe limit
+          }
+      }
+    }
+
+    "refuse to exercise a contract with too many observers" in {
+      val limits = interpretation.Limits.Lenient.copy(contractObservers = limit)
+      val e =
+        e"""\(cid: ContractId Mod:T) (controllers: List Party) ->
+           exercise @Mod:T NoOp cid Mod:NoOpArg {controllers = controllers, observers = Nil @Party }"""
+
+      forEvery(testCases) { (i, succeed) =>
+        val (observers, signatories) = committers.splitAt(i)
+        val contract = mkContract(signatories, observers)
+        val result = eval(
+          limits,
+          Map(aCid -> contract),
+          signatories,
+          e,
+          SValue.SContractId(aCid),
+          asSParties(signatories),
+        )
+
+        if (succeed)
+          result shouldBe a[Right[_, _]]
+        else
+          inside(result) {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.Limit(IE.Limit.ContractObservers(_, templateId, _, parties, reportedlimit))
+                  )
+                ) =>
+              templateId shouldBe T
+              parties shouldBe observers
+              reportedlimit shouldBe limit
+          }
+      }
+    }
+
+    "refuse to exercise a choice with too many controllers" in {
+      val limits = interpretation.Limits.Lenient.copy(choiceControllers = limit)
+      val e =
+        e"""\(signatories: List Party) (controllers: List Party) -> 
+            ubind 
+               cid: ContractId Mod:T <- create @Mod:T Mod:T { 
+                 signatories = signatories, 
+                 observers = Nil @Party 
+               }
+            in exercise @Mod:T NoOp cid Mod:NoOpArg {controllers = controllers, observers = Nil @Party } 
+         """
+
+      forEvery(testCases) { (i, succeed) =>
+        val (controllers, signatories) = committers.splitAt(i)
+        val result =
+          eval(limits, Map.empty, committers, e, asSParties(signatories), asSParties(controllers))
+
+        if (succeed)
+          result shouldBe a[Right[_, _]]
+        else
+          inside(result) {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.Limit(
+                      IE.Limit.ChoiceControllers(
+                        _,
+                        templateId,
+                        choiceName,
+                        _,
+                        parties,
+                        reportedlimit,
+                      )
+                    )
+                  )
+                ) =>
+              templateId shouldBe T
+              choiceName shouldBe "NoOp"
+              parties shouldBe controllers
+              reportedlimit shouldBe limit
+          }
+      }
+    }
+
+    "refuse to exercise a choice with too many observers" in {
+      val limits = interpretation.Limits.Lenient.copy(choiceObservers = limit)
+      val committers = (0 to 99).view.map(i => Ref.Party.assertFromString(s"Party$i")).toSet
+      val e =
+        e"""\(signatories: List Party) (controllers: List Party) (observers: List Party) ->
+            ubind
+               cid: ContractId Mod:T <- create @Mod:T Mod:T {
+                 signatories = signatories,
+                 observers = Nil @Party
+               }
+            in exercise @Mod:T NoOp cid Mod:NoOpArg {controllers = controllers, observers = observers}
+         """
+
+      forEvery(testCases) { (i, succeed) =>
+        val (observers, signatories) = committers.splitAt(i)
+        val result = eval(
+          limits,
+          Map.empty,
+          committers,
+          e,
+          asSParties(signatories),
+          asSParties(signatories),
+          asSParties(observers),
+        )
+        if (succeed)
+          result shouldBe a[Right[_, _]]
+        else
+          inside(result) {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.Limit(
+                      IE.Limit.ChoiceObservers(_, templateId, choiceName, _, parties, reportedlimit)
+                    )
+                  )
+                ) =>
+              templateId shouldBe T
+              choiceName shouldBe "NoOp"
+              parties shouldBe observers
+              reportedlimit shouldBe limit
+              false
+          }
+      }
+    }
+
+    "refuse to build a transaction with too many input contracts" in {
+      val limits = interpretation.Limits.Lenient.copy(transactionInputContracts = limit)
+
+      val signatories = committers.take(1)
+      val contract = mkContract(signatories, Set.empty)
+      val contracts = (_: Value.ContractId) => contract
+      val cids = (1 to 99).map(i => Value.ContractId.V1(crypto.Hash.hashPrivateKey(s"contract$i")))
+      val e = e"Mod:fetches"
+
+      forEvery(testCases) { (i, succeed) =>
+        val result = eval(limits, contracts, committers, e, asSCids(cids.take(i)))
+        if (succeed)
+          result shouldBe a[Right[_, _]]
+        else
+          inside(result) {
+            case Left(
+                  SError.SErrorDamlException(
+                    IE.Limit(IE.Limit.TransactionInputContracts(reportedlimit))
+                  )
+                ) =>
+              reportedlimit shouldBe limit
+              false
+          }
+      }
+    }
+
+  }
+
+  private def asSParties(parties: Iterable[Ref.Party]) =
+    SValue.SList(parties.map(SValue.SParty).to(FrontStack))
+
+  private def asSCids(cids: Iterable[Value.ContractId]) =
+    SValue.SList(cids.map(SValue.SContractId).to(FrontStack))
+
+  private val txSeed = crypto.Hash.hashPrivateKey(this.getClass.getCanonicalName)
+
+  private def typeAndCompile(pkg: Ast.Package): PureCompiledPackages = {
+    import defaultParserParameters.defaultPackageId
+    val rawPkgs = Map(defaultPackageId -> pkg)
+    Validation.checkPackage(PackageInterface(rawPkgs), defaultPackageId, pkg)
+    val compilerConfig = Compiler.Config.Dev
+    PureCompiledPackages.assertBuild(rawPkgs, compilerConfig)
+  }
+
+  private[this] val T = { val Ast.TTyCon(t) = t"Mod:T"; t }
+
+  private[this] val aCid = Value.ContractId.V1(crypto.Hash.hashPrivateKey("a contract ID"))
+  private[this] def mkContract(signatories: Iterable[Ref.Party], observers: Iterable[Ref.Party]) = {
+
+    Versioned(
+      TransactionVersion.StableVersions.max,
+      Value.ContractInstance(
+        T,
+        Value.ValueRecord(
+          None,
+          ImmArray(
+            None -> Value.ValueList(signatories.view.map(Value.ValueParty).to(FrontStack)),
+            None -> Value.ValueList(observers.view.map(Value.ValueParty).to(FrontStack)),
+          ),
+        ),
+        "Agreement",
+      ),
+    )
+  }
+
+  private[this] def eval(
+      limits: interpretation.Limits,
+      contracts: Value.ContractId => Versioned[Value.ContractInstance],
+      committers: Set[Ref.Party],
+      e: Ast.Expr,
+      agrs: SValue*
+  ): Either[SError.SError, SubmittedTransaction] = {
+    val machine = Speedy.Machine.fromUpdateSExpr(
+      compiledPackages = pkgs,
+      transactionSeed = txSeed,
+      updateSE =
+        SExpr.SEApp(pkgs.compiler.unsafeCompile(e), agrs.view.map(SExpr.SEValue(_)).toArray),
+      committers = committers,
+      limits = limits,
+    )
+    final case class Goodbye(e: SError.SError) extends RuntimeException("", null, false, false)
+    try {
+      var result = Option.empty[SubmittedTransaction]
+      while (result.isEmpty) {
+        machine.run() match {
+          case SResult.SResultFinalValue(_) =>
+            machine.withOnLedger("LimitsSpec")(_.ptx.finish match {
+              case PartialTransaction.CompleteTransaction(tx, _, _) =>
+                result = Some(tx)
+              case PartialTransaction.IncompleteTransaction(ptx) =>
+                throw new RuntimeException(s"Got unexpected incomplete transaction $ptx")
+            })
+          case SResult.SResultNeedContract(contractId, _, _, callback) =>
+            callback(contracts(contractId))
+          case SResult.SResultError(err) =>
+            throw Goodbye(err)
+          case res =>
+            throw new RuntimeException(s"Got unexpected interpretation result $res")
+        }
+      }
+      Right(result.get)
+    } catch {
+      case Goodbye(err) => Left(err)
+    }
+  }
+
+}

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
@@ -69,7 +69,8 @@ class ProfilerTest extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
     val party = Ref.Party.assertFromString("Alice")
     val se = compiledPackages.compiler.unsafeCompile(e)
     val example: SExpr = SEApp(se, Array(SEValue(SParty(party))))
-    val machine = Speedy.Machine.fromUpdateSExpr(compiledPackages, transactionSeed, example, party)
+    val machine =
+      Speedy.Machine.fromUpdateSExpr(compiledPackages, transactionSeed, example, Set(party))
     val res = machine.run()
     res match {
       case _: SResultFinalValue =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/RollbackTest.scala
@@ -51,7 +51,7 @@ class RollbackTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     def transactionSeed: crypto.Hash = crypto.Hash.hashPrivateKey("RollbackTest.scala")
     val se = pkgs1.compiler.unsafeCompile(e)
     val example = SEApp(se, Array(SEValue(SParty(party))))
-    val machine = Speedy.Machine.fromUpdateSExpr(pkgs1, transactionSeed, example, party)
+    val machine = Speedy.Machine.fromUpdateSExpr(pkgs1, transactionSeed, example, Set(party))
     val res = machine.run()
     res match {
       case _: SResultFinalValue =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1631,6 +1631,8 @@ object SBuiltinTest {
     evalSExpr(SEApp(compiledPackages.compiler.unsafeCompile(e), args.map(SEValue(_))), onLedger)
   }
 
+  private[this] val committers = Set(Ref.Party.assertFromString("Alice"))
+
   private def evalSExpr(e: SExpr, onLedger: Boolean): Either[SError, SValue] = {
     val machine = if (onLedger) {
       val seed = crypto.Hash.hashPrivateKey("SBuiltinTest")
@@ -1638,7 +1640,7 @@ object SBuiltinTest {
         compiledPackages,
         transactionSeed = seed,
         updateSE = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(e)),
-        committer = Ref.Party.assertFromString("Alice"),
+        committers = committers,
       )
     } else {
       Speedy.Machine.fromPureSExpr(compiledPackages, e)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SValueTest.scala
@@ -26,10 +26,15 @@ class SValueTest extends AnyWordSpec with Matchers {
       else toNat(i - 1, SValue.SVariant(Nat, S, 1, acc))
 
     "rejects excessive nesting" in {
+      import interpretation.{Error => IError}
+
       // Because Z has a nesting of 1, toNat(Value.MAXIMUM_NESTING) has a nesting of
       // Value.MAXIMUM_NESTING + 1
-      Try(toNat(Value.MAXIMUM_NESTING).toUnnormalizedValue) shouldBe
-        Failure(SError.SErrorDamlException(interpretation.Error.ValueExceedsMaxNesting))
+      val x = Try(toNat(Value.MAXIMUM_NESTING).toUnnormalizedValue)
+      x shouldBe
+        Failure(
+          SError.SErrorDamlException(IError.Limit(IError.Limit.ValueNesting(Value.MAXIMUM_NESTING)))
+        )
     }
 
     "accepts just right nesting" in {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -180,13 +180,16 @@ class OrderingSpec
     }
   }
 
+  private[this] val txSeed = crypto.Hash.hashPrivateKey("OrderingSpec")
+  private[this] val committers = Set(Ref.Party.assertFromString("Alice"))
+
   private def translatePrimValue(typ: iface.Type, v: Value) = {
-    val seed = crypto.Hash.hashPrivateKey("OrderingSpec")
+
     val machine = Speedy.Machine.fromUpdateSExpr(
       PureCompiledPackages.Empty,
-      transactionSeed = seed,
+      transactionSeed = txSeed,
       updateSE = SEApp(SEMakeClo(Array(), 2, SELocA(0)), Array(SEImportValue(toAstType(typ), v))),
-      committer = Ref.Party.assertFromString("Alice"),
+      committers = committers,
     )
 
     machine.run() match {

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -435,6 +435,7 @@ object ScenarioRunner {
       traceLog = traceLog,
       warningLog = warningLog,
       commitLocation = location,
+      limits = interpretation.Limits.Lenient,
     )
     val onLedger = ledgerMachine.withOnLedger(NameOf.qualifiedNameOfCurrentFunc)(identity)
     val enricher = if (doEnrichment) new EnricherImpl(compiledPackages) else NoEnricher

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -4,7 +4,7 @@
 package com.daml.lf
 package interpretation
 
-import com.daml.lf.data.Ref.{Location, Party, TypeConName, ChoiceName}
+import com.daml.lf.data.Ref.{ChoiceName, Location, Party, TypeConName}
 import com.daml.lf.transaction.{GlobalKey, NodeId}
 import com.daml.lf.language.Ast
 import com.daml.lf.value.Value
@@ -116,7 +116,8 @@ object Error {
 
   final case class ContractIdInContractKey(key: Value) extends Error
 
-  final case object ValueExceedsMaxNesting extends Error
+  @deprecated("use Limit.ValueNesting", since = "2.0.0")
+  val ValueExceedsMaxNesting: Limit.ValueNesting.type = Limit.ValueNesting
 
   /** A choice guard returned false, invalidating some expectation. */
   final case class ChoiceGuardFailed(
@@ -125,5 +126,51 @@ object Error {
       choiceName: ChoiceName,
       byInterface: Option[TypeConName],
   ) extends Error
+
+  final case class Limit(error: Limit.Error) extends Error
+
+  object Limit {
+
+    sealed abstract class Error extends Serializable with Product
+
+    final case class ValueNesting(limit: Int) extends Error
+
+    final case class ContractSignatories(
+        coid: Value.ContractId,
+        templateId: TypeConName,
+        arg: Value,
+        signatories: Set[Party],
+        limit: Int,
+    ) extends Error
+
+    final case class ContractObservers(
+        coid: Value.ContractId,
+        templateId: TypeConName,
+        arg: Value,
+        observers: Set[Party],
+        limit: Int,
+    ) extends Error
+
+    final case class ChoiceControllers(
+        cid: Value.ContractId,
+        templateId: TypeConName,
+        choiceName: ChoiceName,
+        arg: Value,
+        controllers: Set[Party],
+        limit: Int,
+    ) extends Error
+
+    final case class ChoiceObservers(
+        cid: Value.ContractId,
+        templateId: TypeConName,
+        choiceName: ChoiceName,
+        arg: Value,
+        observers: Set[Party],
+        limit: Int,
+    ) extends Error
+
+    final case class TransactionInputContracts(limit: Int) extends Error
+
+  }
 
 }

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Limits.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Limits.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package interpretation
+
+case class Limits(
+    contractSignatories: Int = Int.MaxValue,
+    contractObservers: Int = Int.MaxValue,
+    choiceControllers: Int = Int.MaxValue,
+    choiceObservers: Int = Int.MaxValue,
+    transactionInputContracts: Int = Int.MaxValue,
+)
+
+object Limits {
+  val Lenient = Limits()
+}

--- a/ledger/error/src/main/scala/com/daml/error/definitions/RejectionGenerators.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/RejectionGenerators.scala
@@ -145,7 +145,7 @@ class RejectionGenerators(conformanceMode: Boolean) {
             .Error(
               renderedMessage
             )
-        case LfInterpretationError.ValueExceedsMaxNesting =>
+        case LfInterpretationError.Limit(_) =>
           LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError
             .Error(
               renderedMessage


### PR DESCRIPTION
This is part of #11691

This PR allows to limits:
- the number of signatories,
- the number of observers,
- the number of controllers,
- the number of inputContracts,

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
