### PR TITLE
Add skeleton for trace-based LF evaluation tests

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -826,6 +826,7 @@ private[lf] object Speedy {
         transactionSeed: crypto.Hash,
         updateSE: SExpr,
         committer: Party,
+        traceLog: TraceLog = newTraceLog,
     ): Machine = {
       Machine(
         compiledPackages = compiledPackages,
@@ -834,6 +835,7 @@ private[lf] object Speedy {
         expr = SEApp(updateSE, Array(SEValue.Token)),
         committers = Set(committer),
         readAs = Set.empty,
+        traceLog = traceLog,
       )
     }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
@@ -6,21 +6,14 @@ package speedy
 
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{Location, Party}
-// import com.daml.lf.interpretation.{Error => IE}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{PackageInterface}
 import com.daml.lf.speedy.Compiler.FullStackTrace
-// import com.daml.lf.speedy.SResult.{SResultError, SResultFinalValue}
-// import com.daml.lf.speedy.SError.SErrorDamlException
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SResult._
-// import com.daml.lf.speedy.SValue.{SUnit, SParty}
 import com.daml.lf.testing.parser.Implicits._
-// import com.daml.lf.testing.parser.ParserParameters
 import com.daml.lf.validation.Validation
-// import com.daml.lf.value.Value.{ValueRecord, ValueText}
-import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scala.collection.mutable.ArrayBuffer
@@ -37,7 +30,7 @@ class TestTraceLog extends TraceLog {
   def getMessages: Seq[String] = messages.view.map(_._1).toSeq
 }
 
-class EvaluationOrderTest extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+class EvaluationOrderTest extends AnyWordSpec with Matchers {
 
   val pkgs: PureCompiledPackages = typeAndCompile(p"""
     module M {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.{Location, Party}
+// import com.daml.lf.interpretation.{Error => IE}
+import com.daml.lf.language.Ast._
+import com.daml.lf.language.{PackageInterface}
+import com.daml.lf.speedy.Compiler.FullStackTrace
+// import com.daml.lf.speedy.SResult.{SResultError, SResultFinalValue}
+// import com.daml.lf.speedy.SError.SErrorDamlException
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SResult._
+// import com.daml.lf.speedy.SValue.{SUnit, SParty}
+import com.daml.lf.testing.parser.Implicits._
+// import com.daml.lf.testing.parser.ParserParameters
+import com.daml.lf.validation.Validation
+// import com.daml.lf.value.Value.{ValueRecord, ValueText}
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import scala.collection.mutable.ArrayBuffer
+
+class TestTraceLog extends TraceLog {
+  private val messages: ArrayBuffer[(String, Option[Location])] = new ArrayBuffer()
+
+  override def add(message: String, optLocation: Option[Location]) = {
+    messages += ((message, optLocation))
+  }
+
+  override def iterator = messages.iterator
+
+  def getMessages: Seq[String] = messages.view.map(_._1).toSeq
+}
+
+class EvaluationOrderTest extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+
+  val pkgs: PureCompiledPackages = typeAndCompile(p"""
+    module M {
+      record @serializable T = { signatory : Party, observer : Party } ;
+      template (this : T) = {
+        precondition TRACE @Bool "precondition" True;
+        signatories TRACE @(List Party) "signatories" (Cons @Party [M:T {signatory} this] (Nil @Party));
+        observers TRACE @(List Party) "observers" (Cons @Party [M:T {observer} this] (Nil @Party));
+        agreement TRACE @Text "agreement" "";
+        key @Party
+           (TRACE @Party "key" (M:T {signatory} this))
+           (\(key : Party) -> TRACE @(List Party) "maintainers" (Cons @Party [key] (Nil @Party)));
+      };
+    }
+  """)
+
+  private val seed = crypto.Hash.hashPrivateKey("seed")
+
+  private def evalUpdateApp(
+      pkgs: CompiledPackages,
+      e: Expr,
+      args: Array[SValue],
+      party: Party,
+  ): (SResult, Seq[String]) = {
+    val se = pkgs.compiler.unsafeCompile(e)
+    val traceLog = new TestTraceLog()
+    val res = Speedy.Machine
+      .fromUpdateSExpr(pkgs, seed, SEApp(se, args.map(SEValue(_))), party, traceLog)
+      .run()
+    val msgs = traceLog.getMessages
+    (res, msgs)
+  }
+
+  private val alice = Ref.Party.assertFromString("alice")
+  private val bob = Ref.Party.assertFromString("bob")
+
+  "evaluation order" should {
+    "evaluate in correct order for successful create" in {
+      val (res, msgs) = evalUpdateApp(
+        pkgs,
+        e"\(sig : Party) (obs : Party) -> create @M:T M:T { signatory = sig, observer = obs }",
+        Array(SParty(alice), SParty(bob)),
+        alice,
+      )
+      res shouldBe a[SResultFinalValue]
+      msgs shouldBe Seq(
+        "precondition",
+        "agreement",
+        "signatories",
+        "observers",
+        "key",
+        "maintainers",
+      )
+      succeed
+    }
+  }
+
+  private def typeAndCompile(pkg: Package): PureCompiledPackages = {
+    import defaultParserParameters.defaultPackageId
+    val rawPkgs = Map(defaultPackageId -> pkg)
+    Validation.checkPackage(PackageInterface(rawPkgs), defaultPackageId, pkg)
+    val compilerConfig = Compiler.Config.Dev.copy(stacktracing = FullStackTrace)
+    PureCompiledPackages.assertBuild(rawPkgs, compilerConfig)
+  }
+}


### PR DESCRIPTION
The recent issues around wrong ordering of contract id typechecks got
me thinking about this again so I wanted to hack up a PR of how we can
test evaluation order sensibly directly at the LF level.

This is only testing a single create but I first wanted to see if we
agree that this is a sensible approach using a simple example.

If we agree that this is a sensible approach, I’d suggest to extend
those tests later in separate PRs to make them exhaustive.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
