### PR TITLE
Introduce explicit TLS 1.2 version tests [DPP-788]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TLSOnePointThreeIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TLSOnePointThreeIT.scala
@@ -27,6 +27,10 @@ import scala.util.{Failure, Success, Try}
   */
 final class TLSOnePointThreeIT
     extends TlsIT(shortIdentifierPrefix = "ServerOnTLSv13ConnectionFromClientOn") {
+  testTlsConnection(
+    clientTlsVersions = Seq[TlsVersion](TlsVersion.V1_2, TlsVersion.V1_3),
+    assertConnectionOk = true,
+  )
   testTlsConnection(clientTlsVersion = TlsVersion.V1_3, assertConnectionOk = true)
   testTlsConnection(clientTlsVersion = TlsVersion.V1_2, assertConnectionOk = false)
   testTlsConnection(clientTlsVersion = TlsVersion.V1_1, assertConnectionOk = false)
@@ -43,6 +47,8 @@ final class TLSAtLeastOnePointTwoIT
     clientTlsVersions = Seq[TlsVersion](TlsVersion.V1_2, TlsVersion.V1_3),
     assertConnectionOk = true,
   )
+  testTlsConnection(clientTlsVersion = TlsVersion.V1_3, assertConnectionOk = true)
+  testTlsConnection(clientTlsVersion = TlsVersion.V1_2, assertConnectionOk = true)
   testTlsConnection(clientTlsVersion = TlsVersion.V1_1, assertConnectionOk = false)
   testTlsConnection(clientTlsVersion = TlsVersion.V1, assertConnectionOk = false)
 }


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

<p data-pm-slice="1 1 []">The existing <span class="code" spellcheck="false">TLSAtLeastOnePointTwoIT</span> test creates a client that supports a list of TLS 1.2 and 1.3. In a handshake with a server locked to 1.3 it agrees to use the common 1.3 protocol.</p><p>We do not have a test that makes sure that an old client supporting only 1.2 can connect to a 1.2+1.3 ledger. For what we know we might inadvertently break support for such clients without noticing.</p><p>Following table summarizes the status quo</p>

  | ServerTLS 1.2+1.3 | ServerTLS 1.3
-- | -- | --
Client 1.2 | success not tested; but should be in TLSAtLeastOnePointTwoIT | failure tested in TLSOnePointThreeIT
Client 1.3 | success tested in TLSOnePointThreeIT; but should also be in TLSAtLeastOnePointTwoIT | success tested in TLSOnePointThreeIT
Client 1.2+1.3 | success tested in TLSAtLeastOnePointTwoIT | success tested in TLSAtLeastOnePointTwoIT; but should also be in TLSOnePointThreeIT

<p></p>
