### PR TITLE
Fix PreemptableSequence merge function

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/ha/PreemptableSequence.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/ha/PreemptableSequence.scala
@@ -162,11 +162,13 @@ object PreemptableSequence {
             handle.killSwitch.abort(ex)
           case _ => ()
         }
-        val result = handle.completed
-        // not strictly needed for this use case, but in theory multiple preemptable stages are possible after each other
-        // this is needed to remove the delegation of the killSwitch after stage is complete
-        result.onComplete(_ => killSwitchCaptor.setDelegate(None))
-        result
+        handle.completed
+          .transform { r =>
+            // not strictly needed for this use case, but in theory multiple preemptable stages are possible after each other
+            // this is needed to remove the delegation of the killSwitch after stage is complete
+            killSwitchCaptor.setDelegate(None)
+            r
+          }
       }
 
       override def handle: Handle = resultHandle


### PR DESCRIPTION
By switching to transform from onComplete, to force execution before the future is completed.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
