### PR TITLE
[BACKPORT] No task fix releasing resources on inititlization failure

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/InitHookDataSourceProxy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/InitHookDataSourceProxy.scala
@@ -38,6 +38,11 @@ private[backend] case class InitHookDataSourceProxy(
     } catch {
       case t: Throwable =>
         logger.warn(s"Init hook execution failed", t)
+        try {
+          connection.close() // releasing resources in case of initialisation issues
+        } catch {
+          case _: Throwable => () // catching all resource-releasing exceptions
+        }
         throw t
     }
     logger.info(s"Init hook execution finished successfully, connection ready")


### PR DESCRIPTION
…on failed (#11915)

Previously InitHookDataSourceProxy was not closing the connection if initialization failed,
which causing worker-locks to stuck on PostgreSQL side, preventing subsequent HA initialization.
This PR fixes by closing explicitly the connection, if initialization failed.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
