### PR TITLE
[kvutils] - Rename expire_at to prunable_from for clarity [KVL-1199]

### DIFF
--- a/ci/check-protobuf-stability.sh
+++ b/ci/check-protobuf-stability.sh
@@ -119,7 +119,7 @@ USAGE
   # The files are always split for versions > 1.17, and there is no way of opening a PR against a target <= 1.17 which includes this check
   BUF_CONFIG_UPDATED=true
   BUF_GIT_TARGET_TO_CHECK=".git#branch=origin/${TARGET}"
-  # The target check can be skipped by including the following trailer `Breaks-Proto: true` into the commit message
+  # The target check can be skipped by including the following trailer `Breaks-Protobuf: true` into the commit message
   if is_check_skipped; then
     echo "Skipping check for protobuf compatibility"
   else

--- a/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/com/daml/ledger/participant/state/kvutils/store/state.proto
@@ -62,7 +62,7 @@ message DamlCommandDedupValue {
     PreExecutionDeduplicationBounds record_time_bounds = 4;
   }
   string submission_id = 5;
-  google.protobuf.Timestamp expire_at = 6;
+  google.protobuf.Timestamp prunable_from = 6;
 }
 
 message PreExecutionDeduplicationBounds {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
@@ -215,14 +215,14 @@ private[transaction] object CommandDeduplication {
             val minRecordTime = commitContext.minimumRecordTime.getOrElse(
               throw Err.InternalError("Minimum record time is not set for pre-execution")
             )
-            val expireAt = maxRecordTime.add(pruningInterval)
+            val prunableFrom = maxRecordTime.add(pruningInterval)
             commandDedupBuilder
               .setRecordTimeBounds(
                 PreExecutionDeduplicationBounds.newBuilder
                   .setMaxRecordTime(Conversions.buildTimestamp(maxRecordTime))
                   .setMinRecordTime(Conversions.buildTimestamp(minRecordTime))
               )
-              .setPrunableFrom(Conversions.buildTimestamp(expireAt))
+              .setPrunableFrom(Conversions.buildTimestamp(prunableFrom))
         }
 
         // Set a deduplication entry.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
@@ -200,14 +200,14 @@ private[transaction] object CommandDeduplication {
         val (_, config) = getCurrentConfiguration(defaultConfig, commitContext)
         // build the maximum interval for which we might use the deduplication entry
         // we account for both time skews even if it means that the expiry time would be slightly longer than required
-        val expireInterval =
+        val pruningInterval =
           config.maxDeduplicationTime.plus(config.timeModel.maxSkew).plus(config.timeModel.minSkew)
         commitContext.recordTime match {
           case Some(recordTime) =>
-            val expireAt = recordTime.add(expireInterval)
+            val prunableFrom = recordTime.add(pruningInterval)
             commandDedupBuilder
               .setRecordTime(Conversions.buildTimestamp(recordTime))
-              .setExpireAt(Conversions.buildTimestamp(expireAt))
+              .setPrunableFrom(Conversions.buildTimestamp(prunableFrom))
           case None =>
             val maxRecordTime = commitContext.maximumRecordTime.getOrElse(
               throw Err.InternalError("Maximum record time is not set for pre-execution")
@@ -215,14 +215,14 @@ private[transaction] object CommandDeduplication {
             val minRecordTime = commitContext.minimumRecordTime.getOrElse(
               throw Err.InternalError("Minimum record time is not set for pre-execution")
             )
-            val expireAt = maxRecordTime.add(expireInterval)
+            val expireAt = maxRecordTime.add(pruningInterval)
             commandDedupBuilder
               .setRecordTimeBounds(
                 PreExecutionDeduplicationBounds.newBuilder
                   .setMaxRecordTime(Conversions.buildTimestamp(maxRecordTime))
                   .setMinRecordTime(Conversions.buildTimestamp(minRecordTime))
               )
-              .setExpireAt(Conversions.buildTimestamp(expireAt))
+              .setPrunableFrom(Conversions.buildTimestamp(expireAt))
         }
 
         // Set a deduplication entry.

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -280,7 +280,7 @@ class CommandDeduplicationSpec
           .build()
       }
 
-      "set expire time based on max record time" in {
+      "set pruning time based on max record time" in {
         val (context, transactionEntrySummary) =
           buildContextAndTransaction(
             submissionTime,
@@ -294,7 +294,7 @@ class CommandDeduplicationSpec
         parseTimestamp(
           deduplicateValueStoredInContext(context, transactionEntrySummary)
             .map(
-              _.getExpireAt
+              _.getPrunableFrom
             )
             .value
         ) shouldBe maximumRecordTime
@@ -341,7 +341,7 @@ class CommandDeduplicationSpec
         ) shouldBe recordTime
       }
 
-      "set expire time based on record time" in {
+      "set pruning time based on record time" in {
         val recordTime = timestamp
         val (context, transactionEntrySummary) =
           buildContextAndTransaction(
@@ -353,7 +353,7 @@ class CommandDeduplicationSpec
         parseTimestamp(
           deduplicateValueStoredInContext(context, transactionEntrySummary)
             .map(
-              _.getExpireAt
+              _.getPrunableFrom
             )
             .value
         ) shouldBe recordTime


### PR DESCRIPTION
changelog_begin
changelog_end

Breaks-protobuf: true

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
