### PR TITLE
Include module names in LF type errors

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -224,13 +224,13 @@ object Ast {
         case TSynApp(syn, args) =>
           maybeParens(
             prec > precTApp,
-            syn.qualifiedName.name.toString + " " +
+            syn.qualifiedName.toString + " " +
               args
                 .map(t => prettyType(t, precTApp + 1))
                 .toSeq
                 .mkString(" "),
           )
-        case TTyCon(con) => con.qualifiedName.name.toString
+        case TTyCon(con) => con.qualifiedName.toString
         case TBuiltin(BTArrow) => "(->)"
         case TBuiltin(bt) => bt.toString.stripPrefix("BT")
         case TApp(TApp(TBuiltin(BTArrow), param), result) =>


### PR DESCRIPTION
After staring at a type mismatch between `Nested` and `Nested` this
seemed like a sensible change. We could also include the package
ids. I don’t have strong feelings about this but this seems like a
clear uncontroversial improvement.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
