### PR TITLE
[ledger-api] - Rename the error metadata key for invalid deduplication duration

### DIFF
--- a/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
@@ -542,6 +542,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           id = "INVALID_DEDUPLICATION_PERIOD",
           ErrorCategory.InvalidGivenCurrentSystemStateOther,
         ) {
+      val ValidMaxDeduplicationFieldKey = "longest_duration"
       case class Reject(
           _reason: String,
           _maxDeduplicationDuration: Option[Duration],
@@ -550,10 +551,11 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       ) extends LoggingTransactionErrorImpl(
             cause = s"The submitted command had an invalid deduplication period: ${_reason}"
           ) {
-        override def context: Map[String, String] =
+        override def context: Map[String, String] = {
           super.context ++ _maxDeduplicationDuration
-            .map("max_deduplication_duration" -> _.toString)
+            .map(ValidMaxDeduplicationFieldKey -> _.toString)
             .toList
+        }
       }
     }
 

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -26,6 +26,8 @@ import org.scalatest.wordspec.AnyWordSpec
 import scalaz.syntax.tag._
 import java.time.{Instant, Duration => JDuration}
 
+import com.daml.error.definitions.LedgerApiErrors.RequestValidation.InvalidDeduplicationPeriodField.ValidMaxDeduplicationFieldKey
+
 import scala.annotation.nowarn
 
 @nowarn("msg=deprecated")
@@ -419,7 +421,7 @@ class SubmitRequestValidatorTest
             expectedDescriptionV2 = s"INVALID_DEDUPLICATION_PERIOD(9,0): The submitted command had an invalid deduplication period: The given deduplication duration of ${java.time.Duration
               .ofSeconds(durationSecondsExceedingMax)} exceeds the maximum deduplication time of ${internal.maxDeduplicationDuration}",
             metadataV2 = Map(
-              "max_deduplication_duration" -> internal.maxDeduplicationDuration.toString
+              ValidMaxDeduplicationFieldKey -> internal.maxDeduplicationDuration.toString
             ),
           )
         }

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
@@ -6,6 +6,7 @@ package com.daml
 import java.sql.{SQLNonTransientException, SQLTransientException}
 import java.time.Duration
 
+import com.daml.error.definitions.LedgerApiErrors.RequestValidation.InvalidDeduplicationPeriodField.ValidMaxDeduplicationFieldKey
 import com.daml.error.utils.ErrorDetails
 import com.daml.error.{
   ContextualizedErrorLogger,
@@ -463,7 +464,7 @@ class ErrorFactoriesSpec
             Map(
               "category" -> "9",
               "definite_answer" -> "false",
-              "max_deduplication_duration" -> maxDeduplicationDuration.toString,
+              ValidMaxDeduplicationFieldKey -> maxDeduplicationDuration.toString,
             ),
           ),
           expectedCorrelationIdRequestInfo,


### PR DESCRIPTION
Rename to longest_duration so that we are in sync with the design doc and canton

changelog_begin
[ledger-api] - Rename the error metadata key max_deduplication_duration to longest_duration
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
