### PR TITLE
Use DeBruijn levels in SExpr0.

### DIFF
--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -90,20 +90,21 @@ object PlaySpeedy {
   def examples: Map[String, (Int, SExpr)] = {
 
     def num(n: Long): SExpr = SEValue(SInt64(n))
+    def mkVar(level: Int) = SEVarLevel(level)
 
-    // The trailing numeral is the number of args at the scala level
+    // The trailing numeral is the number of args at the scala mkVar
 
     def decrement1(x: SExpr): SExpr = SEApp(SEBuiltin(SBSubInt64), List(x, SEValue(SInt64(1))))
-    val decrement = SEAbs(1, decrement1(SEVar(1)))
+    val decrement = SEAbs(1, decrement1(mkVar(0)))
 
     def subtract2(x: SExpr, y: SExpr): SExpr = SEApp(SEBuiltin(SBSubInt64), List(x, y))
-    val subtract = SEAbs(2, subtract2(SEVar(2), SEVar(1)))
+    val subtract = SEAbs(2, subtract2(mkVar(0), mkVar(1)))
 
     def twice2(f: SExpr, x: SExpr): SExpr = SEApp(f, List(SEApp(f, List(x))))
-    val twice = SEAbs(2, twice2(SEVar(2), SEVar(1)))
+    val twice = SEAbs(2, twice2(mkVar(3), mkVar(4)))
 
     def thrice2(f: SExpr, x: SExpr): SExpr = SEApp(f, List(SEApp(f, List(SEApp(f, List(x))))))
-    val thrice = SEAbs(2, thrice2(SEVar(2), SEVar(1)))
+    val thrice = SEAbs(2, thrice2(mkVar(0), mkVar(1)))
 
     val examples = List(
       (
@@ -142,7 +143,10 @@ object PlaySpeedy {
               List(num(21)),
               SEApp(
                 twice,
-                List(SEAbs(1, subtract2(SEVar(1), subtract2(SEVar(4), SEVar(2)))), SEVar(2)),
+                List(
+                  SEAbs(1, subtract2(mkVar(3), subtract2(mkVar(0), mkVar(2)))),
+                  mkVar(1),
+                ),
               ),
             ), //100
           ),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -13,7 +13,7 @@ package speedy
   *
   * 1: convert from LF
   *     - reducing binding forms (update & scenario becoming builtins)
-  *     - moving to de Bruijn indexing for variable
+  *     - convert named variables to de Bruijn levels
   *     - moving to multi-argument applications and abstractions.
   *
   * 2: closure conversion
@@ -54,13 +54,11 @@ private[speedy] object SExpr0 {
 
   sealed abstract class SExpr extends Product with Serializable
 
-  /** Reference to a variable. 'index' is the 1-based de Bruijn index,
-    * that is, SEVar(1) points to the nearest enclosing variable binder.
-    * which could be an SELam, SELet, or a binding variant of SECasePat.
+  /** Reference to a variable. 'level' is the 0-based de Bruijn LEVEL (not INDEX)
     * https://en.wikipedia.org/wiki/De_Bruijn_index
     * This expression form is only allowed prior to closure conversion
     */
-  final case class SEVar(index: Int) extends SExpr
+  final case class SEVarLevel(level: Int) extends SExpr
 
   /** Reference to a value. On first lookup the evaluated expression is
     * stored in 'cached'.
@@ -80,14 +78,6 @@ private[speedy] object SExpr0 {
 
   /** Lambda abstraction. Transformed to SEMakeClo during closure conversion */
   final case class SEAbs(arity: Int, body: SExpr) extends SExpr
-
-  object SEAbs {
-    // Helper for constructing abstraction expressions:
-    // SEAbs(1) { ... }
-    def apply(arity: Int)(body: SExpr): SExpr = SEAbs(arity, body)
-
-    val identity: SEAbs = SEAbs(1, SEVar(1))
-  }
 
   /** Pattern match. */
   final case class SECase(scrut: SExpr, alts: List[SCaseAlt]) extends SExpr


### PR DESCRIPTION
Move to using DB-levels (not DB-indexes) in `SExpr0`. 
- `ClosureConversion`  code to compute `freeVars` is much simpler.
-  adapt `Compiler.scala`

(During the dev for this change, I ran with both _index_ and _level_ numbers, and ensure behaviour is unchanged.)

This PR is waiting for the fix in: #12047

This PR is part of work to cleanup the speedy compiler: #11669
