### PR TITLE
Avoid CPP in ledger API test tool daml code

### DIFF
--- a/ledger/test-common/BUILD.bazel
+++ b/ledger/test-common/BUILD.bazel
@@ -90,6 +90,9 @@ da_scala_dar_resources_library(
     add_maven_tag = True,
     daml_dir_names = test_names_with_dependencies.keys(),
     daml_root_dir = "src/main/daml",
+    exclusions = {
+        "1.8": ["**/*Exception*.daml"],
+    },
     lf_versions = lf_version_configuration_versions,
     maven_name_prefix = "test",
     visibility = ["//visibility:public"],

--- a/ledger/test-common/src/main/daml/semantic/ExceptionRaceTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/ExceptionRaceTests.daml
@@ -1,10 +1,8 @@
 -- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE CPP #-}
 module ExceptionRaceTests where
 
-#ifdef DAML_EXCEPTIONS
 import DA.Exception
 import DA.Optional (isSome)
 
@@ -108,4 +106,3 @@ template ExerciseWrapper
            throw E
           catch
             E -> pure ()
-#endif

--- a/ledger/test-common/src/main/daml/semantic/Exceptions.daml
+++ b/ledger/test-common/src/main/daml/semantic/Exceptions.daml
@@ -1,10 +1,7 @@
 -- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE CPP #-}
 module Exceptions where
-
-#ifdef DAML_EXCEPTIONS
 
 import DA.Assert
 import DA.Exception
@@ -327,4 +324,3 @@ template ExceptionTester
 
          catch
            E{} -> pure ()
-#endif

--- a/ledger/test-common/test-common.bzl
+++ b/ledger/test-common/test-common.bzl
@@ -14,6 +14,7 @@ def da_scala_dar_resources_library(
         lf_versions,
         add_maven_tag = False,
         maven_name_prefix = "",
+        exclusions = {},
         **kwargs):
     """
     Define a Scala library with dar files as resources.
@@ -24,7 +25,7 @@ def da_scala_dar_resources_library(
             daml_compile_name = "%s-tests-%s" % (daml_dir_name, lf_version)
             daml_compile_kwargs = {
                 "project_name": "%s-tests" % daml_dir_name.replace("_", "-"),
-                "srcs": native.glob(["%s/%s/*.daml" % (daml_root_dir, daml_dir_name)]),
+                "srcs": native.glob(["%s/%s/*.daml" % (daml_root_dir, daml_dir_name)], exclude = exclusions.get(lf_version, [])),
                 "target": lf_version,
             }
             daml_compile_kwargs.update(kwargs)


### PR DESCRIPTION
Apparently this works very poorly with damlc_legacy which fails to
find hpp after the latest nixpkgs upgrade. Somewhat confusingly it
only fails to find that on release builds and I don’t understand how
it ever worked but this seems more sensible anyway.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
