### PR TITLE
DPP-752 refactor event strategy

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CompletionStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CompletionStorageBackendTemplate.scala
@@ -38,7 +38,12 @@ class CompletionStorageBackendTemplate(
     import com.daml.platform.store.Conversions.OffsetToStatement
     import com.daml.platform.store.Conversions.ledgerStringToStatement
     import ComposableQuery._
-    SQL"""
+    val internedParties =
+      parties.view.map(stringInterning.party.tryInternalize).flatMap(_.toList).toSet
+    if (internedParties.isEmpty) {
+      List.empty
+    } else {
+      SQL"""
         SELECT
           completion_offset,
           record_time,
@@ -59,9 +64,10 @@ class CompletionStorageBackendTemplate(
           ($startExclusive is null or completion_offset > $startExclusive) AND
           completion_offset <= $endInclusive AND
           application_id = $applicationId AND
-          ${queryStrategy.arrayIntersectionNonEmptyClause("submitters", parties, stringInterning)}
+          ${queryStrategy.arrayIntersectionNonEmptyClause("submitters", internedParties)}
         ORDER BY completion_offset ASC"""
-      .as(completionParser.*)(connection)
+        .as(completionParser.*)(connection)
+    }
   }
 
   private val sharedColumns: RowParser[Offset ~ Timestamp ~ String ~ String ~ Option[String]] =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ComposableQuery.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ComposableQuery.scala
@@ -82,8 +82,5 @@ object ComposableQuery {
           stringParts = start :: List.fill(composits.size - 1)(sep) ::: List(end),
           valueParts = composits.toSeq,
         )
-
-    def mkComposite(sep: String): CompositeSql = mkComposite("", sep, "")
-    def mkComposite: CompositeSql = mkComposite("", "", "")
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ComposableQuery.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ComposableQuery.scala
@@ -71,16 +71,12 @@ object ComposableQuery {
   }
 
   implicit class CompositConcatenationOps(val composits: Iterable[CompositeSql]) extends AnyVal {
-    def mkComposite(start: String, sep: String, end: String): CompositeSql =
-      if (composits.isEmpty)
-        CompositeSql(
-          stringParts = s"$start$end" :: Nil,
-          valueParts = Nil,
-        )
-      else
-        CompositeSql(
-          stringParts = start :: List.fill(composits.size - 1)(sep) ::: List(end),
-          valueParts = composits.toSeq,
-        )
+    def mkComposite(start: String, sep: String, end: String): CompositeSql = {
+      require(composits.nonEmpty, "composits must be non-empty")
+      CompositeSql(
+        stringParts = start :: List.fill(composits.size - 1)(sep) ::: List(end),
+        valueParts = composits.toSeq,
+      )
+    }
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -349,7 +349,7 @@ abstract class EventStorageBackendTemplate(
         .toList
 
     val internedAllParties: Set[Int] =
-      internedWildcardParties.concat(internedPartiesAndTemplates.flatMap(_._1))
+      internedWildcardParties.concat(internedPartiesAndTemplates.view.flatMap(_._1))
 
     if (internedAllParties.isEmpty) {
       Vector.empty

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -738,34 +738,6 @@ abstract class EventStorageBackendTemplate(
 trait EventStrategy {
 
   /** This populates the following part of the query:
-    *   SELECT ..., [THIS PART] as event_witnesses
-    * Should boil down to an intersection between the set of the witnesses-column and the parties.
-    *
-    * @param witnessesColumnName name of the witnesses column in the query
-    * @param parties which is all the parties we are interested in in the resul
-    * @return the composable SQL
-    */
-  def filteredEventWitnessesClause(
-      witnessesColumnName: String,
-      parties: Set[Ref.Party],
-      stringInterning: StringInterning,
-  ): CompositeSql
-
-  /** This populates the following part of the query:
-    *   SELECT ...,case when [THIS PART] then command_id else "" end as command_id
-    * Should boil down to a do-intersect? query between the submittersColumName column and the parties
-    *
-    * @param submittersColumnName name of the Array column holding submitters
-    * @param parties which is all the parties we are interested in in the resul
-    * @return the composable SQL
-    */
-  def submittersArePartiesClause(
-      submittersColumnName: String,
-      parties: Set[Ref.Party],
-      stringInterning: StringInterning,
-  ): CompositeSql
-
-  /** This populates the following part of the query:
     *   SELECT ... WHERE ... AND [THIS PART]
     * This strategy is responsible to generate appropriate SQL cod based on the filterParams, so that results match the criteria
     *

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -332,24 +332,54 @@ abstract class EventStorageBackendTemplate(
       fetchSizeHint: Option[Int],
       filterParams: FilterParams,
   )(connection: Connection): Vector[T] = {
-    val parties =
-      filterParams.wildCardParties.iterator
-        .++(filterParams.partiesAndTemplates.iterator.flatMap(_._1.iterator))
-        .map(stringInterning.party.tryInternalize)
-        .flatMap(_.iterator)
-        .toSet
-    SQL"""
+    val internedWildcardParties: Set[Int] = filterParams.wildCardParties.view
+      .flatMap(party => stringInterning.party.tryInternalize(party).toList)
+      .toSet
+
+    val internedPartiesAndTemplates: List[(Set[Int], Set[Int])] =
+      filterParams.partiesAndTemplates.iterator
+        .map { case (parties, templateIds) =>
+          (
+            parties.flatMap(s => stringInterning.party.tryInternalize(s).toList),
+            templateIds.flatMap(s => stringInterning.templateId.tryInternalize(s).toList),
+          )
+        }
+        .filterNot(_._1.isEmpty)
+        .filterNot(_._2.isEmpty)
+        .toList
+
+    val internedAllParties: Set[Int] =
+      internedWildcardParties.concat(internedPartiesAndTemplates.flatMap(_._1))
+
+    if (internedAllParties.isEmpty) {
+      Vector.empty
+    } else {
+      val wildcardPartiesClause = if (internedWildcardParties.isEmpty) {
+        Nil
+      } else {
+        eventStrategy.wildcardPartiesClause(witnessesColumn, internedWildcardParties) :: Nil
+      }
+      val filterPartiesClauses = if (internedPartiesAndTemplates.isEmpty) {
+        Nil
+      } else {
+        eventStrategy.filterPartiesClause(witnessesColumn, internedPartiesAndTemplates)
+      }
+      val witnessesWhereClause =
+        (wildcardPartiesClause ::: filterPartiesClauses).mkComposite("(", " or ", ")")
+
+      SQL"""
         SELECT
           #$selectColumns, #$witnessesColumn as event_witnesses, command_id
         FROM
           participant_events #$columnPrefix $joinClause
         WHERE
-        $additionalAndClause
-          ${eventStrategy.witnessesWhereClause(witnessesColumn, filterParams, stringInterning)}
+          $additionalAndClause
+          $witnessesWhereClause
         ORDER BY event_sequential_id
         ${queryStrategy.limitClause(limit)}"""
-      .withFetchSize(fetchSizeHint)
-      .asVectorOf(rowParser(parties))(connection)
+        .withFetchSize(fetchSizeHint)
+        .asVectorOf(rowParser(internedAllParties))(connection)
+    }
   }
 
   override def transactionEvents(
@@ -737,19 +767,31 @@ abstract class EventStorageBackendTemplate(
   */
 trait EventStrategy {
 
-  /** This populates the following part of the query:
-    *   SELECT ... WHERE ... AND [THIS PART]
-    * This strategy is responsible to generate appropriate SQL cod based on the filterParams, so that results match the criteria
+  /** Generates a clause that checks whether any of the given wildcard parties is a witness
     *
     * @param witnessesColumnName name of the Array column holding witnesses
-    * @param filterParams the filtering criteria
+    * @param internedWildcardParties List of all wildcard parties (their interned names).
+    *                                Guaranteed to be non-empty.
     * @return the composable SQL
     */
-  def witnessesWhereClause(
+  def wildcardPartiesClause(
       witnessesColumnName: String,
-      filterParams: FilterParams,
-      stringInterning: StringInterning,
+      internedWildcardParties: Set[Int],
   ): CompositeSql
+
+  /** Generates a clause that checks whether any of the given filters matches the contract,
+    *  i.e., whether the template id matches AND any of the parties is a witness
+    *
+    * @param witnessesColumnName Name of the Array column holding witnesses
+    * @param internedPartiesTemplates List of all filters. For each filter, the list contains one element with
+    *                                 the list of interned party names and the list of interned template ids.
+    *                                 All sets of interned names are guaranteed to be non-empty.
+    * @return one composable SQL for each filter
+    */
+  def filterPartiesClause(
+      witnessesColumnName: String,
+      internedPartiesTemplates: List[(Set[Int], Set[Int])],
+  ): List[CompositeSql]
 
   /** Pruning participant_events_create_filter entries.
     *

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
@@ -42,6 +42,14 @@ trait QueryStrategy {
       stringInterning: StringInterning,
   ): CompositeSql
 
+  /** A version of [[arrayIntersectionNonEmptyClause]] where all parties have already been interned.
+    * The set of interned parties must be non-empty.
+    */
+  def arrayIntersectionNonEmptyClause(
+      columnName: String,
+      internedParties: Set[Int],
+  ): CompositeSql
+
   /** Would be used in column selectors in GROUP BY situations to see whether a boolean column had true
     * Example: getting all groups and see wheter they have someone who had covid:
     *   SELECT group_name, booleanOrAggregationFunction(has_covid) GROUP BY group_name;

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
@@ -3,9 +3,7 @@
 
 package com.daml.platform.store.backend.common
 
-import com.daml.lf.data.Ref
 import com.daml.platform.store.backend.common.ComposableQuery.{CompositeSql, SqlStringInterpolation}
-import com.daml.platform.store.interning.StringInterning
 
 trait QueryStrategy {
 
@@ -33,17 +31,8 @@ trait QueryStrategy {
     * have at least one element in common (eg their intersection is non empty).
     *
     * @param columnName the SQL table definition which holds the set of parties
-    * @param parties set of parties
+    * @param internedParties set of parties (their interned names)
     * @return the composable SQL
-    */
-  def arrayIntersectionNonEmptyClause(
-      columnName: String,
-      parties: Set[Ref.Party],
-      stringInterning: StringInterning,
-  ): CompositeSql
-
-  /** A version of [[arrayIntersectionNonEmptyClause]] where all parties have already been interned.
-    * The set of interned parties must be non-empty.
     */
   def arrayIntersectionNonEmptyClause(
       columnName: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2EventStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2EventStrategy.scala
@@ -5,34 +5,12 @@ package com.daml.platform.store.backend.h2
 
 import anorm.{Row, SimpleSql}
 import com.daml.ledger.offset.Offset
-import com.daml.lf.data.Ref
 import com.daml.platform.store.backend.EventStorageBackend.FilterParams
 import com.daml.platform.store.backend.common.ComposableQuery.{CompositeSql, SqlStringInterpolation}
 import com.daml.platform.store.backend.common.EventStrategy
 import com.daml.platform.store.interning.StringInterning
 
 object H2EventStrategy extends EventStrategy {
-  override def filteredEventWitnessesClause(
-      witnessesColumnName: String,
-      parties: Set[Ref.Party],
-      stringInterning: StringInterning,
-  ): CompositeSql = {
-    val partiesArray: Array[java.lang.Integer] =
-      parties.view.map(stringInterning.party.tryInternalize).flatMap(_.toList).map(Int.box).toArray
-    if (partiesArray.isEmpty) cSQL"false"
-    else cSQL"array_intersection(#$witnessesColumnName, $partiesArray)"
-  }
-
-  override def submittersArePartiesClause(
-      submittersColumnName: String,
-      parties: Set[Ref.Party],
-      stringInterning: StringInterning,
-  ): CompositeSql =
-    H2QueryStrategy.arrayIntersectionNonEmptyClause(
-      columnName = submittersColumnName,
-      parties = parties,
-      stringInterning = stringInterning,
-    )
 
   override def witnessesWhereClause(
       witnessesColumnName: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2EventStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2EventStrategy.scala
@@ -17,22 +17,20 @@ object H2EventStrategy extends EventStrategy {
     cSQL"(${H2QueryStrategy.arrayIntersectionNonEmptyClause(witnessesColumnName, internedWildcardParties)})"
   }
 
-  override def filterPartiesClause(
+  override def partiesAndTemplatesClause(
       witnessesColumnName: String,
-      internedPartiesTemplates: List[(Set[Int], Set[Int])],
-  ): List[CompositeSql] = {
-    internedPartiesTemplates
-      .map { case (parties, templateIds) =>
-        val clause =
-          H2QueryStrategy.arrayIntersectionNonEmptyClause(
-            witnessesColumnName,
-            parties,
-          )
-        // anorm does not like primitive arrays, so we need to box it
-        val templateIdsArray = templateIds.map(Int.box).toArray
+      internedParties: Set[Int],
+      internedTemplates: Set[Int],
+  ): CompositeSql = {
+    val clause =
+      H2QueryStrategy.arrayIntersectionNonEmptyClause(
+        witnessesColumnName,
+        internedParties,
+      )
+    // anorm does not like primitive arrays, so we need to box it
+    val templateIdsArray = internedTemplates.map(Int.box).toArray
 
-        cSQL"( ($clause) AND (template_id = ANY($templateIdsArray)) )"
-      }
+    cSQL"( ($clause) AND (template_id = ANY($templateIdsArray)) )"
   }
 
   override def pruneCreateFilters(pruneUpToInclusive: Offset): SimpleSql[Row] = {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2QueryStrategy.scala
@@ -27,6 +27,15 @@ object H2QueryStrategy extends QueryStrategy {
         .mkComposite("(", " or ", ")")
   }
 
+  override def arrayIntersectionNonEmptyClause(
+      columnName: String,
+      internedParties: Set[Int],
+  ): CompositeSql = {
+    internedParties
+      .map(p => cSQL"array_contains(#$columnName, $p)")
+      .mkComposite("(", " or ", ")")
+  }
+
   override def arrayContains(arrayColumnName: String, elementColumnName: String): String =
     s"array_contains($arrayColumnName, $elementColumnName)"
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2QueryStrategy.scala
@@ -3,29 +3,10 @@
 
 package com.daml.platform.store.backend.h2
 
-import com.daml.lf.data.Ref
 import com.daml.platform.store.backend.common.ComposableQuery.{CompositeSql, SqlStringInterpolation}
 import com.daml.platform.store.backend.common.QueryStrategy
-import com.daml.platform.store.interning.StringInterning
 
 object H2QueryStrategy extends QueryStrategy {
-
-  override def arrayIntersectionNonEmptyClause(
-      columnName: String,
-      parties: Set[Ref.Party],
-      stringInterning: StringInterning,
-  ): CompositeSql = {
-    val internedParties = parties.view
-      .map(stringInterning.party.tryInternalize)
-      .flatMap(_.toList)
-      .map(p => cSQL"array_contains(#$columnName, $p)")
-      .toList
-    if (internedParties.isEmpty)
-      cSQL"false"
-    else
-      internedParties
-        .mkComposite("(", " or ", ")")
-  }
 
   override def arrayIntersectionNonEmptyClause(
       columnName: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2QueryStrategy.scala
@@ -12,6 +12,7 @@ object H2QueryStrategy extends QueryStrategy {
       columnName: String,
       internedParties: Set[Int],
   ): CompositeSql = {
+    require(internedParties.nonEmpty, "internedParties must be non-empty")
     internedParties
       .map(p => cSQL"array_contains(#$columnName, $p)")
       .mkComposite("(", " or ", ")")

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleEventStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleEventStrategy.scala
@@ -17,21 +17,17 @@ object OracleEventStrategy extends EventStrategy {
     cSQL"(${OracleQueryStrategy.arrayIntersectionNonEmptyClause(witnessesColumnName, internedWildcardParties)})"
   }
 
-  override def filterPartiesClause(
+  override def partiesAndTemplatesClause(
       witnessesColumnName: String,
-      internedPartiesTemplates: List[(Set[Int], Set[Int])],
-  ): List[CompositeSql] = {
-    internedPartiesTemplates
-      .map { case (parties, templateIds) =>
-        val clause =
-          OracleQueryStrategy.arrayIntersectionNonEmptyClause(
-            witnessesColumnName,
-            parties,
-          )
-        // TODO: Postgres and H2 use Array[Integer], Oracle uses Set[Int] to send the template Ids.
-        // Does it make a difference?
-        cSQL"( ($clause) AND (template_id IN ($templateIds)) )"
-      }
+      internedParties: Set[Int],
+      internedTemplates: Set[Int],
+  ): CompositeSql = {
+    val clause =
+      OracleQueryStrategy.arrayIntersectionNonEmptyClause(
+        witnessesColumnName,
+        internedParties,
+      )
+    cSQL"( ($clause) AND (template_id IN ($internedTemplates)) )"
   }
 
   override def pruneCreateFilters(pruneUpToInclusive: Offset): SimpleSql[Row] = {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleQueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleQueryStrategy.scala
@@ -3,24 +3,10 @@
 
 package com.daml.platform.store.backend.oracle
 
-import com.daml.lf.data.Ref
 import com.daml.platform.store.backend.common.ComposableQuery.{CompositeSql, SqlStringInterpolation}
 import com.daml.platform.store.backend.common.QueryStrategy
-import com.daml.platform.store.interning.StringInterning
 
 object OracleQueryStrategy extends QueryStrategy {
-
-  override def arrayIntersectionNonEmptyClause(
-      columnName: String,
-      parties: Set[Ref.Party],
-      stringInterning: StringInterning,
-  ): CompositeSql = {
-    val internedParties =
-      parties.view.map(stringInterning.party.tryInternalize).flatMap(_.toList).toSet
-    if (internedParties.isEmpty) cSQL"1 = 0"
-    else
-      arrayIntersectionNonEmptyClause(columnName, internedParties)
-  }
 
   override def arrayIntersectionNonEmptyClause(
       columnName: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleQueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleQueryStrategy.scala
@@ -19,7 +19,14 @@ object OracleQueryStrategy extends QueryStrategy {
       parties.view.map(stringInterning.party.tryInternalize).flatMap(_.toList).toSet
     if (internedParties.isEmpty) cSQL"1 = 0"
     else
-      cSQL"(EXISTS (SELECT 1 FROM JSON_TABLE(#$columnName, '$$[*]' columns (value NUMBER PATH '$$')) WHERE value IN ($internedParties)))"
+      arrayIntersectionNonEmptyClause(columnName, internedParties)
+  }
+
+  override def arrayIntersectionNonEmptyClause(
+      columnName: String,
+      internedParties: Set[Int],
+  ): CompositeSql = {
+    cSQL"(EXISTS (SELECT 1 FROM JSON_TABLE(#$columnName, '$$[*]' columns (value NUMBER PATH '$$')) WHERE value IN ($internedParties)))"
   }
 
   override def columnEqualityBoolean(column: String, value: String): String =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleQueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleQueryStrategy.scala
@@ -12,6 +12,7 @@ object OracleQueryStrategy extends QueryStrategy {
       columnName: String,
       internedParties: Set[Int],
   ): CompositeSql = {
+    require(internedParties.nonEmpty, "internedParties must be non-empty")
     cSQL"(EXISTS (SELECT 1 FROM JSON_TABLE(#$columnName, '$$[*]' columns (value NUMBER PATH '$$')) WHERE value IN ($internedParties)))"
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresEventStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresEventStrategy.scala
@@ -5,37 +5,12 @@ package com.daml.platform.store.backend.postgresql
 
 import anorm.{Row, SimpleSql}
 import com.daml.ledger.offset.Offset
-import com.daml.platform.store.appendonlydao.events.Party
 import com.daml.platform.store.backend.EventStorageBackend.FilterParams
 import com.daml.platform.store.backend.common.ComposableQuery.{CompositeSql, SqlStringInterpolation}
 import com.daml.platform.store.backend.common.EventStrategy
 import com.daml.platform.store.interning.StringInterning
 
 object PostgresEventStrategy extends EventStrategy {
-  override def filteredEventWitnessesClause(
-      witnessesColumnName: String,
-      parties: Set[Party],
-      stringInterning: StringInterning,
-  ): CompositeSql = {
-    val internedParties: Array[java.lang.Integer] = parties.view
-      .flatMap(party => stringInterning.party.tryInternalize(party).map(Int.box).toList)
-      .toArray
-    if (internedParties.length == 1)
-      cSQL"array[${internedParties.head}]::integer[]"
-    else
-      cSQL"array(select unnest(#$witnessesColumnName) intersect select unnest($internedParties::integer[]))"
-  }
-
-  override def submittersArePartiesClause(
-      submittersColumnName: String,
-      parties: Set[Party],
-      stringInterning: StringInterning,
-  ): CompositeSql = {
-    val partiesArray: Array[java.lang.Integer] = parties.view
-      .flatMap(party => stringInterning.party.tryInternalize(party).map(Int.box).toList)
-      .toArray
-    cSQL"(#$submittersColumnName::integer[] && $partiesArray::integer[])"
-  }
 
   override def witnessesWhereClause(
       witnessesColumnName: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresEventStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresEventStrategy.scala
@@ -19,17 +19,15 @@ object PostgresEventStrategy extends EventStrategy {
     cSQL"(#$witnessesColumnName::integer[] && $internedWildcardPartiesArray::integer[])"
   }
 
-  override def filterPartiesClause(
+  override def partiesAndTemplatesClause(
       witnessesColumnName: String,
-      internedPartiesTemplates: List[(Set[Int], Set[Int])],
-  ): List[CompositeSql] = {
-    internedPartiesTemplates
-      .map { case (parties, templates) =>
-        // anorm does not like primitive arrays, so we need to box it
-        val partiesArray = parties.map(Int.box).toArray
-        val templateIdsArray = templates.map(Int.box).toArray
-        cSQL"( (#$witnessesColumnName::integer[] && $partiesArray::integer[]) AND (template_id = ANY($templateIdsArray::integer[])) )"
-      }
+      internedParties: Set[Int],
+      internedTemplates: Set[Int],
+  ): CompositeSql = {
+    // anorm does not like primitive arrays, so we need to box it
+    val partiesArray = internedParties.map(Int.box).toArray
+    val templateIdsArray = internedTemplates.map(Int.box).toArray
+    cSQL"( (#$witnessesColumnName::integer[] && $partiesArray::integer[]) AND (template_id = ANY($templateIdsArray::integer[])) )"
   }
 
   override def pruneCreateFilters(pruneUpToInclusive: Offset): SimpleSql[Row] = {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresQueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresQueryStrategy.scala
@@ -13,6 +13,7 @@ object PostgresQueryStrategy extends QueryStrategy {
       columnName: String,
       internedParties: Set[Int],
   ): CompositeSql = {
+    require(internedParties.nonEmpty, "internedParties must be non-empty")
     // anorm does not like primitive arrays, so we need to box it
     val partiesArray: Array[java.lang.Integer] = internedParties.map(Int.box).toArray
     cSQL"#$columnName::int[] && $partiesArray::int[]"

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresQueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresQueryStrategy.scala
@@ -3,25 +3,11 @@
 
 package com.daml.platform.store.backend.postgresql
 
-import com.daml.lf.data.Ref
 import com.daml.platform.store.backend.common.ComposableQuery.CompositeSql
 import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
 import com.daml.platform.store.backend.common.QueryStrategy
-import com.daml.platform.store.interning.StringInterning
 
 object PostgresQueryStrategy extends QueryStrategy {
-
-  override def arrayIntersectionNonEmptyClause(
-      columnName: String,
-      parties: Set[Ref.Party],
-      stringInterning: StringInterning,
-  ): CompositeSql = {
-    val partiesArray: Array[java.lang.Integer] =
-      parties
-        .flatMap(party => stringInterning.party.tryInternalize(party).map(Int.box).toList)
-        .toArray
-    cSQL"#$columnName::int[] && $partiesArray::int[]"
-  }
 
   override def arrayIntersectionNonEmptyClause(
       columnName: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresQueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresQueryStrategy.scala
@@ -23,6 +23,15 @@ object PostgresQueryStrategy extends QueryStrategy {
     cSQL"#$columnName::int[] && $partiesArray::int[]"
   }
 
+  override def arrayIntersectionNonEmptyClause(
+      columnName: String,
+      internedParties: Set[Int],
+  ): CompositeSql = {
+    // anorm does not like primitive arrays, so we need to box it
+    val partiesArray: Array[java.lang.Integer] = internedParties.map(Int.box).toArray
+    cSQL"#$columnName::int[] && $partiesArray::int[]"
+  }
+
   override def arrayContains(arrayColumnName: String, elementColumnName: String): String =
     s"$elementColumnName = any($arrayColumnName)"
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendProvider.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendProvider.scala
@@ -11,7 +11,7 @@ import com.daml.platform.store.backend.h2.H2StorageBackendFactory
 import com.daml.platform.store.backend.oracle.OracleStorageBackendFactory
 import com.daml.platform.store.backend.postgresql.PostgresStorageBackendFactory
 import com.daml.platform.store.cache.MutableLedgerEndCache
-import com.daml.platform.store.interning.{MockStringInterning, StringInterning}
+import com.daml.platform.store.interning.MockStringInterning
 import com.daml.testing.oracle.OracleAroundAll
 import com.daml.testing.postgresql.PostgresAroundAll
 import org.scalatest.Suite
@@ -89,7 +89,7 @@ case class TestBackend(
     reset: ResetStorageBackend,
     stringInterning: StringInterningStorageBackend,
     ledgerEndCache: MutableLedgerEndCache,
-    stringInterningSupport: StringInterning,
+    stringInterningSupport: MockStringInterning,
 )
 
 object TestBackend {

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSpec.scala
@@ -85,6 +85,7 @@ private[backend] trait StorageBackendSpec
       executeSql { c =>
         backend.reset.resetAll(c)
         updateLedgerEndCache(c)
+        backend.stringInterningSupport.reset()
       },
       60.seconds,
     )

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSpec.scala
@@ -85,6 +85,11 @@ private[backend] trait StorageBackendSpec
       executeSql { c =>
         backend.reset.resetAll(c)
         updateLedgerEndCache(c)
+        // Note: here we reset the MockStringInterning object to make sure each test starts with empty interning state.
+        // This is not strictly necessary, as tryInternalize() always succeeds in MockStringInterning - we don't have
+        // a problem where the interning would be affected by data left over by previous tests.
+        // To write tests that are sensitive to interning unknown data, we would have to use a custom storage backend
+        // implementation.
         backend.stringInterningSupport.reset()
       },
       60.seconds,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
@@ -9,6 +9,7 @@ trait StorageBackendSuite
     extends StorageBackendTestsInitialization
     with StorageBackendTestsInitializeIngestion
     with StorageBackendTestsIngestion
+    with StorageBackendTestsEvents
     with StorageBackendTestsCompletions
     with StorageBackendTestsReset
     with StorageBackendTestsPruning

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestValues.scala
@@ -238,6 +238,20 @@ private[backend] object StorageBackendTestValues {
       deduplication_start = deduplicationStart.map(_.micros),
     )
 
+  def dtoCreateFilter(
+      event_sequential_id: Long,
+      template_id: Ref.Identifier,
+      party_id: String,
+  ): DbDto.CreateFilter = DbDto.CreateFilter(event_sequential_id, template_id.toString, party_id)
+
+  def dtoInterning(
+      internal: Int,
+      external: String,
+  ): DbDto.StringInterningDto = DbDto.StringInterningDto(
+    internalId = internal,
+    externalString = external,
+  )
+
   def dtoTransactionId(dto: DbDto): Ref.TransactionId = {
     dto match {
       case e: DbDto.EventCreate => Ref.TransactionId.assertFromString(e.transaction_id.get)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsEvents.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsEvents.scala
@@ -1,0 +1,299 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.backend
+
+import com.daml.lf.data.Ref
+import org.scalatest.Inside
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+private[backend] trait StorageBackendTestsEvents
+    extends Matchers
+    with Inside
+    with StorageBackendSpec {
+  this: AsyncFlatSpec =>
+
+  behavior of "StorageBackend (events)"
+
+  import StorageBackendTestValues._
+
+  it should "find contracts by party" in {
+    val partySignatory = Ref.Party.assertFromString("signatory")
+    val partyObserver1 = Ref.Party.assertFromString("observer1")
+    val partyObserver2 = Ref.Party.assertFromString("observer2")
+
+    val dtos = Vector(
+      dtoCreate(offset(1), 1L, "#1", signatory = partySignatory, observer = partyObserver1),
+      dtoCreateFilter(1L, someTemplateId, partySignatory),
+      dtoCreateFilter(1L, someTemplateId, partyObserver1),
+      dtoCreate(offset(2), 2L, "#2", signatory = partySignatory, observer = partyObserver2),
+      dtoCreateFilter(2L, someTemplateId, partySignatory),
+      dtoCreateFilter(2L, someTemplateId, partyObserver2),
+    )
+
+    for {
+      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
+      _ <- executeSql(ingest(dtos, _))
+      _ <- executeSql(
+        updateLedgerEnd(offset(2), 2L)
+      )
+      resultSignatory <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partySignatory,
+          templateIdFilter = None,
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+      resultObserver1 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partyObserver1,
+          templateIdFilter = None,
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+      resultObserver2 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partyObserver2,
+          templateIdFilter = None,
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+    } yield {
+      resultSignatory should contain theSameElementsAs Vector(1L, 2L)
+      resultObserver1 should contain theSameElementsAs Vector(1L)
+      resultObserver2 should contain theSameElementsAs Vector(2L)
+    }
+  }
+
+  it should "find contracts by party and template" in {
+    val partySignatory = Ref.Party.assertFromString("signatory")
+    val partyObserver1 = Ref.Party.assertFromString("observer1")
+    val partyObserver2 = Ref.Party.assertFromString("observer2")
+
+    val dtos = Vector(
+      dtoCreate(offset(1), 1L, "#1", signatory = partySignatory, observer = partyObserver1),
+      dtoCreateFilter(1L, someTemplateId, partySignatory),
+      dtoCreateFilter(1L, someTemplateId, partyObserver1),
+      dtoCreate(offset(2), 2L, "#2", signatory = partySignatory, observer = partyObserver2),
+      dtoCreateFilter(2L, someTemplateId, partySignatory),
+      dtoCreateFilter(2L, someTemplateId, partyObserver2),
+    )
+
+    for {
+      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
+      _ <- executeSql(ingest(dtos, _))
+      _ <- executeSql(
+        updateLedgerEnd(offset(2), 2L)
+      )
+      resultSignatory <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partySignatory,
+          templateIdFilter = Some(someTemplateId),
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+      resultObserver1 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partyObserver1,
+          templateIdFilter = Some(someTemplateId),
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+      resultObserver2 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partyObserver2,
+          templateIdFilter = Some(someTemplateId),
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+    } yield {
+      resultSignatory should contain theSameElementsAs Vector(1L, 2L)
+      resultObserver1 should contain theSameElementsAs Vector(1L)
+      resultObserver2 should contain theSameElementsAs Vector(2L)
+    }
+  }
+
+  it should "not find contracts when the template doesn't match" in {
+    val partySignatory = Ref.Party.assertFromString("signatory")
+    val partyObserver1 = Ref.Party.assertFromString("observer1")
+    val partyObserver2 = Ref.Party.assertFromString("observer2")
+    val otherTemplate = Ref.Identifier.assertFromString("pkg:Mod:Template2")
+
+    val dtos = Vector(
+      dtoCreate(offset(1), 1L, "#1", signatory = partySignatory, observer = partyObserver1),
+      dtoCreateFilter(1L, someTemplateId, partySignatory),
+      dtoCreateFilter(1L, someTemplateId, partyObserver1),
+      dtoCreate(offset(2), 2L, "#2", signatory = partySignatory, observer = partyObserver2),
+      dtoCreateFilter(2L, someTemplateId, partySignatory),
+      dtoCreateFilter(2L, someTemplateId, partyObserver2),
+    )
+
+    for {
+      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
+      _ <- executeSql(ingest(dtos, _))
+      _ <- executeSql(
+        updateLedgerEnd(offset(2), 2L)
+      )
+      resultSignatory <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partySignatory,
+          templateIdFilter = Some(otherTemplate),
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+      resultObserver1 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partyObserver1,
+          templateIdFilter = Some(otherTemplate),
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+      resultObserver2 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partyObserver2,
+          templateIdFilter = Some(otherTemplate),
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+    } yield {
+      resultSignatory shouldBe empty
+      resultObserver1 shouldBe empty
+      resultObserver2 shouldBe empty
+    }
+  }
+
+  it should "not find contracts when unknown names are used" in {
+    val partySignatory = Ref.Party.assertFromString("signatory")
+    val partyObserver = Ref.Party.assertFromString("observer")
+    val partyUnknown = Ref.Party.assertFromString("unknown")
+    val unknownTemplate = Ref.Identifier.assertFromString("unknown:unknown:unknown")
+
+    val dtos = Vector(
+      dtoCreate(offset(1), 1L, "#1", signatory = partySignatory, observer = partyObserver),
+      dtoCreateFilter(1L, someTemplateId, partySignatory),
+      dtoCreateFilter(1L, someTemplateId, partyObserver),
+    )
+
+    for {
+      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
+      _ <- executeSql(ingest(dtos, _))
+      _ <- executeSql(
+        updateLedgerEnd(offset(1), 1L)
+      )
+      resultUnknownParty <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partyUnknown,
+          templateIdFilter = None,
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+      resultUnknownTemplate <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partySignatory,
+          templateIdFilter = Some(unknownTemplate),
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+      resultUnknownPartyAndTemplate <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partyUnknown,
+          templateIdFilter = Some(unknownTemplate),
+          startExclusive = 0L,
+          endInclusive = 10L,
+          limit = 10,
+        )
+      )
+    } yield {
+      resultUnknownParty shouldBe empty
+      resultUnknownTemplate shouldBe empty
+      resultUnknownPartyAndTemplate shouldBe empty
+    }
+  }
+
+  it should "respect bounds and limits" in {
+    val partySignatory = Ref.Party.assertFromString("signatory")
+    val partyObserver1 = Ref.Party.assertFromString("observer1")
+    val partyObserver2 = Ref.Party.assertFromString("observer2")
+
+    val dtos = Vector(
+      dtoCreate(offset(1), 1L, "#1", signatory = partySignatory, observer = partyObserver1),
+      dtoCreateFilter(1L, someTemplateId, partySignatory),
+      dtoCreateFilter(1L, someTemplateId, partyObserver1),
+      dtoCreate(offset(2), 2L, "#2", signatory = partySignatory, observer = partyObserver2),
+      dtoCreateFilter(2L, someTemplateId, partySignatory),
+      dtoCreateFilter(2L, someTemplateId, partyObserver2),
+    )
+
+    for {
+      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
+      _ <- executeSql(ingest(dtos, _))
+      _ <- executeSql(
+        updateLedgerEnd(offset(2), 2L)
+      )
+      result01L2 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partySignatory,
+          templateIdFilter = None,
+          startExclusive = 0L,
+          endInclusive = 1L,
+          limit = 2,
+        )
+      )
+      result12L2 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partySignatory,
+          templateIdFilter = None,
+          startExclusive = 1L,
+          endInclusive = 2L,
+          limit = 2,
+        )
+      )
+      result02L1 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partySignatory,
+          templateIdFilter = None,
+          startExclusive = 0L,
+          endInclusive = 2L,
+          limit = 1,
+        )
+      )
+      result02L2 <- executeSql(
+        backend.event.activeContractEventIds(
+          partyFilter = partySignatory,
+          templateIdFilter = None,
+          startExclusive = 0L,
+          endInclusive = 2L,
+          limit = 2,
+        )
+      )
+    } yield {
+      result01L2 should contain theSameElementsAs Vector(1L)
+      result12L2 should contain theSameElementsAs Vector(2L)
+      result02L1 should contain theSameElementsAs Vector(1L)
+      result02L2 should contain theSameElementsAs Vector(1L, 2L)
+    }
+  }
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/interning/MockStringInterning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/interning/MockStringInterning.scala
@@ -64,4 +64,10 @@ class MockStringInterning extends StringInterning {
       override def tryExternalize(id: Int): Option[Party] =
         rawStringInterning.tryExternalize(id).map(Party.assertFromString)
     }
+
+  private[store] def reset(): Unit = synchronized {
+    idToString = Map.empty
+    stringToId = Map.empty
+    lastId = 0
+  }
 }


### PR DESCRIPTION
This PR:
- Moves common code from `EventStrategy` to `EventStorageBackendTemplate`.
- Adds an optimization where we don't execute any query against the database if the result is known to be empty.
- Adds more ACS test on LedgerDao and StorageBackend levels