### PR TITLE
Add the Daml API for exposing user management in Daml Script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -51,6 +51,17 @@ module Daml.Script
   , exercisedN
   , AnyContractId
   , fromAnyContractId
+
+  , User(..)
+  , UserRight(..)
+  , createUser
+  , getUser
+  , deleteUser
+  , listUsers
+  , grantUserRights
+  , revokeUserRights
+  , listUserRights
+  , submitUser
   ) where
 
 #ifdef DAML_EXCEPTIONS
@@ -108,6 +119,13 @@ data ScriptF a
   | GetTime (GetTimePayload a)
   | SetTime (SetTimePayload a)
   | Sleep (SleepRec a)
+  | CreateUser (CreateUserPayload a)
+  | GetUser (GetUserPayload a)
+  | DeleteUser (DeleteUserPayload a)
+  | ListUsers (ListUsersPayload a)
+  | GrantUserRights (GrantUserRightsPayload a)
+  | RevokeUserRights (RevokeUserRightsPayload a)
+  | ListUserRights (ListUserRightsPayload a)
 #ifndef DAML_EXCEPTIONS
   deriving Functor
 #else
@@ -731,3 +749,127 @@ submitTreeMulti actAs readAs cmds =
     commands = void cmds
     locations = getCallStack callStack
     continue = identity
+
+-- | HIDE User as used in the user management service
+data User = User
+  with
+    id : Text
+    primaryParty : Optional Party
+  deriving (Show, Eq)
+
+-- | HIDE The rights of a user
+data UserRight
+  = ParticipantAdmin
+  | CanActAs Party
+  | CanReadAs Party
+  deriving (Show, Eq)
+
+-- | HIDE Create a user with the given rights
+createUser : HasCallStack => User -> [UserRight] -> Script User
+createUser user rights = lift $ Free $ CreateUser CreateUserPayload with
+  continue = pure
+  locations = getCallStack callStack
+  user
+  rights
+
+-- | HIDE Fetch a user by user id
+getUser : HasCallStack => Text -> Script (Optional User)
+getUser userId = lift $ Free $ GetUser GetUserPayload with
+  continue = pure
+  locations = getCallStack callStack
+  userId
+
+-- | HIDE List all users on the participant
+listUsers : Script [User]
+listUsers = lift $ Free $ ListUsers ListUsersPayload with
+  continue = pure
+  locations = getCallStack callStack
+
+-- | HIDE Grant the user the given rights. Returns the rights that have been newly granted.
+grantUserRights : HasCallStack => Text -> [UserRight] -> Script [UserRight]
+grantUserRights userId rights = lift $ Free $ GrantUserRights GrantUserRightsPayload with
+  continue = pure
+  locations = getCallStack callStack
+  userId
+  rights
+
+-- | HIDE Revoke the rights of the given user. Returns the revoked rights.
+revokeUserRights : HasCallStack => Text -> [UserRight] -> Script [UserRight]
+revokeUserRights userId rights = lift $ Free $ RevokeUserRights RevokeUserRightsPayload with
+  continue = pure
+  locations = getCallStack callStack
+  userId
+  rights
+
+-- | HIDE Delete the given user. Fails if the user does not exist.
+deleteUser : HasCallStack => Text -> Script ()
+deleteUser userId = lift $ Free $ DeleteUser DeleteUserPayload with
+  continue = pure
+  locations = getCallStack callStack
+  userId
+
+-- | HIDE List the rights of the given user
+listUserRights : HasCallStack => Text -> Script [UserRight]
+listUserRights userId = lift $ Free $ ListUserRights ListUserRightsPayload with
+  continue = pure
+  locations = getCallStack callStack
+  userId
+
+-- | HIDE Submit the commands with the actAs and readAs claims granted to the user.
+submitUser : HasCallStack => User -> Commands a -> Script a
+submitUser u cmds = do
+  rights <- listUserRights u.id
+  let actAs = [ p | CanActAs p <- rights ]
+  let readAs = [ p | CanReadAs p <- rights ]
+  submitMulti actAs readAs cmds
+
+data CreateUserPayload a = CreateUserPayload
+  with
+    user: User
+    rights: [UserRight]
+    continue : User -> a
+    locations : [(Text, SrcLoc)]
+  deriving Functor
+
+data GetUserPayload a = GetUserPayload
+  with
+    userId : Text
+    continue : Optional User -> a
+    locations : [(Text, SrcLoc)]
+  deriving Functor
+
+data DeleteUserPayload a = DeleteUserPayload
+  with
+    userId : Text
+    continue : () -> a
+    locations : [(Text, SrcLoc)]
+  deriving Functor
+
+data ListUsersPayload a = ListUsersPayload
+  with
+    continue : [User] -> a
+    locations : [(Text, SrcLoc)]
+  deriving Functor
+
+data GrantUserRightsPayload a = GrantUserRightsPayload
+  with
+    userId : Text
+    rights : [UserRight]
+    continue : [UserRight] -> a
+    locations : [(Text, SrcLoc)]
+  deriving Functor
+
+data RevokeUserRightsPayload a = RevokeUserRightsPayload
+  with
+    userId : Text
+    rights : [UserRight]
+    continue : [UserRight] -> a
+    locations : [(Text, SrcLoc)]
+  deriving Functor
+
+data ListUserRightsPayload a = ListUserRightsPayload
+  with
+    userId : Text
+    continue : [UserRight] -> a
+    locations : [(Text, SrcLoc)]
+  deriving Functor


### PR DESCRIPTION
Spun out from #11899 for ease of review, part of #11997

This PR exposes the user management service from
https://github.com/digital-asset/daml/blob/main/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
in the Daml Script Daml API.

It obviously doesn’t actually work without also handling that in the
Daml Script runner. For ease of review I’ll handle that in a separate PR.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
