### PR TITLE
Fix a docs display issue with Safari and Firefox

### DIFF
--- a/docs/theme/sass/_theme_layout.sass
+++ b/docs/theme/sass/_theme_layout.sass
@@ -2042,6 +2042,7 @@ div.pdf-download
 
 #inpageContent
   display: block
+  overflow: hidden
   position: fixed
   bottom: 50px
   right: 20px


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

Fixes and issue where a small circle or dot was displayed on the far left of the docs page because CSS.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
