### PR TITLE
LF: Add EToRequiredInterface and EFromRequiredInterface to Scala Ast.

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1147,22 +1147,18 @@ private[archive] class DecodeV1(minor: LV.Minor) {
           assertSince(LV.Features.interfaces, "Expr.to_required_interface")
           val toRequiredInterface = lfExpr.getToRequiredInterface
           EToRequiredInterface(
-            requiredIfaceId =
-              decodeTypeConName(decodeTypeConName(toRequiredInterface.getRequiredInterface)),
-            requiringIfaceId =
-              decodeTypeConName(decodeTypeConName(toRequiredInterface.getRequiringInterface)),
-            body = decodeExpr(toRequiredInterface.getExpr),
+            requiredIfaceId = decodeTypeConName(toRequiredInterface.getRequiredInterface),
+            requiringIfaceId = decodeTypeConName(toRequiredInterface.getRequiringInterface),
+            body = decodeExpr(toRequiredInterface.getExpr, definition),
           )
 
         case PLF.Expr.SumCase.FROM_REQUIRED_INTERFACE =>
           assertSince(LV.Features.interfaces, "Expr.from_required_interface")
           val fromRequiredInterface = lfExpr.getFromRequiredInterface
           EFromRequiredInterface(
-            requiredIfaceId =
-              decodeTypeConName(decodeTypeConName(fromRequiredInterface.getRequiredInterface)),
-            requiringIfaceId =
-              decodeTypeConName(decodeTypeConName(fromRequiredInterface.getRequiringInterface)),
-            body = decodeExpr(fromRequiredInterface.getExpr),
+            requiredIfaceId = decodeTypeConName(fromRequiredInterface.getRequiredInterface),
+            requiringIfaceId = decodeTypeConName(fromRequiredInterface.getRequiringInterface),
+            body = decodeExpr(fromRequiredInterface.getExpr, definition),
           )
 
         case PLF.Expr.SumCase.SUM_NOT_SET =>

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1145,13 +1145,25 @@ private[archive] class DecodeV1(minor: LV.Minor) {
 
         case PLF.Expr.SumCase.TO_REQUIRED_INTERFACE =>
           assertSince(LV.Features.interfaces, "Expr.to_required_interface")
-          // TODO https://github.com/digital-asset/daml/issues/11978
-          throw Error.Parsing("Expr.to_required_interface")
+          val toRequiredInterface = lfExpr.getToRequiredInterface
+          EToRequiredInterface(
+            requiredIfaceId =
+              decodeTypeConName(decodeTypeConName(toRequiredInterface.getRequiredInterface)),
+            requiringIfaceId =
+              decodeTypeConName(decodeTypeConName(toRequiredInterface.getRequiringInterface)),
+            body = decodeExpr(toRequiredInterface.getExpr),
+          )
 
         case PLF.Expr.SumCase.FROM_REQUIRED_INTERFACE =>
           assertSince(LV.Features.interfaces, "Expr.from_required_interface")
-          // TODO https://github.com/digital-asset/daml/issues/11978
-          throw Error.Parsing("Expr.from_required_interface")
+          val fromRequiredInterface = lfExpr.getFromRequiredInterface
+          EFromRequiredInterface(
+            requiredIfaceId =
+              decodeTypeConName(decodeTypeConName(fromRequiredInterface.getRequiredInterface)),
+            requiringIfaceId =
+              decodeTypeConName(decodeTypeConName(fromRequiredInterface.getRequiringInterface)),
+            body = decodeExpr(fromRequiredInterface.getExpr),
+          )
 
         case PLF.Expr.SumCase.SUM_NOT_SET =>
           throw Error.Parsing("Expr.SUM_NOT_SET")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -577,6 +577,12 @@ private[lf] final class Compiler(
         SBFromInterface(tpl)(compile(env, e))
       case ECallInterface(iface, methodName, e) =>
         SBCallInterface(iface, methodName)(compile(env, e))
+      case EToRequiredInterface(requiredIfaceId @ _, requiringIfaceId @ _, body @ _) =>
+        // TODO https://github.com/digital-asset/daml/issues/11978
+        throw CompilationError("EToRequiredInterface is not implemented")
+      case EFromRequiredInterface(requiredIfaceId @ _, requiringIfaceId @ _, body @ _) =>
+        // TODO https://github.com/digital-asset/daml/issues/11978
+        throw CompilationError("EFromRequiredInterface is not implemented")
       case EExperimental(name, _) =>
         SBExperimental(name)
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -163,6 +163,20 @@ object Ast {
   final case class EFromInterface(interfaceId: TypeConName, templateId: TypeConName, value: Expr)
       extends Expr
 
+  /** Upcast from an interface payload to an interface it requires. */
+  final case class EToRequiredInterface(
+      requiredIfaceId: TypeConName,
+      requiringIfaceId: TypeConName,
+      body: Expr,
+  ) extends Expr
+
+  /** Downcast from an interface payload to an interface that requires it, if possible. */
+  final case class EFromRequiredInterface(
+      requiredIfaceId: TypeConName,
+      requiringIfaceId: TypeConName,
+      body: Expr,
+  ) extends Expr
+
   /** Invoke an interface method */
   final case class ECallInterface(interfaceId: TypeConName, methodName: MethodName, value: Expr)
       extends Expr

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -131,6 +131,10 @@ private[daml] class AstRewriter(
           EFromInterface(apply(iface), apply(tpl), apply(value))
         case ECallInterface(iface, method, value) =>
           ECallInterface(apply(iface), method, apply(value))
+        case EToRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
+          EToRequiredInterface(apply(requiredIfaceId), apply(requiringIfaceId), apply(body))
+        case EFromRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
+          EFromRequiredInterface(apply(requiredIfaceId), apply(requiringIfaceId), apply(body))
       }
 
   def apply(x: TypeConApp): TypeConApp = x match {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -1166,6 +1166,18 @@ private[validation] object Typing {
         checkImplements(tpl, iface)
         checkExpr(value, TTyCon(iface))
         TOptional(TTyCon(tpl))
+      case EToRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
+        val requiringIface = handleLookup(ctx, interface.lookupInterface(requiringIfaceId))
+        if (!requiringIface.requires.contains(requiredIfaceId))
+          throw EWrongInterfaceRequirement(ctx, requiringIfaceId, requiredIfaceId)
+        checkExpr(body, TTyCon(requiringIfaceId))
+        TTyCon(requiredIfaceId)
+      case EFromRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
+        val requiringIface = handleLookup(ctx, interface.lookupInterface(requiringIfaceId))
+        if (!requiringIface.requires.contains(requiredIfaceId))
+          throw EWrongInterfaceRequirement(ctx, requiringIfaceId, requiredIfaceId)
+        checkExpr(body, TTyCon(requiredIfaceId))
+        TOptional(TTyCon(requiringIfaceId))
       case ECallInterface(iface, methodName, value) =>
         val method = handleLookup(ctx, interface.lookupInterfaceMethod(iface, methodName))
         checkExpr(value, TTyCon(iface))

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -507,3 +507,11 @@ final case class EMissingRequiredInterface(
   override protected def prettyInternal: String =
     s"Template $template is missing an implementation of interface $missingRequiredIface required by interface $requiringIface"
 }
+final case class EWrongInterfaceRequirement(
+    context: Context,
+    requiringIface: TypeConName,
+    wrongRequiredIface: TypeConName,
+) extends ValidationError {
+  protected def prettyInternal: String =
+    s"Interface $requiringIface does not require $wrongRequiredIface"
+}

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/ExprIterable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/ExprIterable.scala
@@ -70,6 +70,10 @@ private[validation] object ExprIterable {
         Iterator(value)
       case ECallInterface(iface @ _, method @ _, value) =>
         Iterator(value)
+      case EToRequiredInterface(requiredIface @ _, requiringIface @ _, body) =>
+        iterator(body)
+      case EFromRequiredInterface(requiredIface @ _, requiringIface @ _, body) =>
+        iterator(body)
     }
   }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
@@ -84,6 +84,10 @@ private[validation] object TypeIterable {
         Iterator(TTyCon(iface), TTyCon(tpl)) ++ iterator(value)
       case ECallInterface(iface, _, value) =>
         Iterator(TTyCon(iface)) ++ iterator(value)
+      case EToRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
+        Iterator(TTyCon(requiredIfaceId), TTyCon(requiringIfaceId)) ++ iterator(body)
+      case EFromRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
+        Iterator(TTyCon(requiredIfaceId), TTyCon(requiringIfaceId)) ++ iterator(body)
       case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EApp(_, _) | ECase(_, _) |
           ELocation(_, _) | EStructCon(_) | EStructProj(_, _) | EStructUpd(_, _, _) | ETyAbs(_, _) |
           EExperimental(_, _) =>


### PR DESCRIPTION
Part of #11978. Adds typechecking for those primitives.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
