### PR TITLE
iface docs: add method docs

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
@@ -73,7 +73,7 @@ getInterfaceDocs DocCtx{..} typeMap =
       , if_name = ad_name ifADT
       , if_descr = ad_descr ifADT
       , if_choices = map (mkChoiceDoc typeMap) choices
-      , if_methods = [] -- TODO (drsk) https://github.com/digital-asset/daml/issues/11347
+      , if_methods = [] -- filled by distributeInstanceDocs
       }
       where
         ifADT = asADT typeMap name

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -93,6 +93,7 @@ instance RenderDoc InterfaceDoc where
         , RenderBlock $ mconcat
             [ renderDoc if_descr
             , RenderList (map renderDoc if_choices)
+            , RenderList (map renderDoc if_methods)
             ]
         ]
 
@@ -100,6 +101,11 @@ instance RenderDoc ImplDoc where
     renderDoc ImplDoc {..} =
         RenderParagraph $
             renderUnwords [ RenderStrong "implements", renderType impl_iface ]
+
+instance RenderDoc MethodDoc where
+    renderDoc MethodDoc {..} = mconcat
+      [ RenderParagraph $ RenderStrong ("Method " <> unTypename mtd_name <> " : ") <> renderType mtd_type
+      ]
 
 instance RenderDoc ChoiceDoc where
     renderDoc ChoiceDoc{..} = mconcat

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Instances.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Instances.hs
@@ -10,6 +10,7 @@ import DA.Daml.Doc.Transform.Options
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified Data.Text as T
 
 type InstanceMap = Map.Map Anchor (Set.Set InstanceDoc)
 
@@ -54,7 +55,7 @@ distributeInstanceDocs opts docs =
         , md_descr = md_descr
         , md_functions = md_functions
         , md_templates = md_templates
-        , md_interfaces = md_interfaces
+        , md_interfaces = map (addIfaceMethods imap) md_interfaces
         , md_classes = map (addClassInstances imap) md_classes
         , md_adts = map (addTypeInstances imap) md_adts
         , md_instances =
@@ -76,3 +77,17 @@ distributeInstanceDocs opts docs =
             anchor <- ad_anchor ad
             Map.lookup anchor imap
         }
+    addIfaceMethods :: InstanceMap -> InterfaceDoc -> InterfaceDoc
+    addIfaceMethods imap idoc = idoc
+      { if_methods =
+          [ MethodDoc{..}
+          | InstanceDoc {id_type, id_module} <-
+                maybe [] Set.toList $ do
+                  anchor <- if_anchor idoc
+                  Map.lookup anchor imap
+          , Just "HasMethod" == getTypeAppName id_type
+          , "DA.Internal.Desugar" == id_module
+          , Just [_if_name, TypeLit name, mtd_type] <- [getTypeAppArgs id_type]
+          , let mtd_name = Typename $ T.dropEnd 1 $ T.drop 1 name -- drop enclosing double-quotes.
+          ]
+      }

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -123,7 +123,7 @@ data InterfaceDoc = InterfaceDoc
   { if_anchor :: Maybe Anchor
   , if_name :: Typename
   , if_choices :: [ChoiceDoc]
-  , if_methods :: [ClassMethodDoc]
+  , if_methods :: [MethodDoc]
   , if_descr :: Maybe DocText
   }
   deriving (Eq, Show, Generic)
@@ -229,6 +229,11 @@ data ChoiceDoc = ChoiceDoc
   }
   deriving (Eq, Show, Generic)
 
+data MethodDoc = MethodDoc
+  { mtd_name :: Typename
+  , mtd_type :: Type
+  }
+  deriving (Eq, Show, Generic)
 
 -- | Documentation data for a field in a record
 data FieldDoc = FieldDoc
@@ -333,6 +338,12 @@ instance ToJSON InterfaceDoc where
     toJSON = genericToJSON aesonOptions
 
 instance FromJSON InterfaceDoc where
+    parseJSON = genericParseJSON aesonOptions
+
+instance ToJSON MethodDoc where
+    toJSON = genericToJSON aesonOptions
+
+instance FromJSON MethodDoc where
     parseJSON = genericParseJSON aesonOptions
 
 instance ToJSON InstanceDoc where

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
@@ -43,6 +43,18 @@
 >   | Field                                                                                   | Type                                                                                    | Description |
 >   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
 >   | newOwner                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
+> 
+> * **Method getAmount : **[Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
+> 
+> * **Method getOwner : **[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311)
+> 
+> * **Method noopImpl : **() -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-36457) ()
+> 
+> * **Method setAmount : **[Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728) -\> [Token](#type-interface-token-72202)
+> 
+> * **Method splitImpl : **[Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-36457) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-47171) [Token](#type-interface-token-72202), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-47171) [Token](#type-interface-token-72202))
+> 
+> * **Method transferImpl : **[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-36457) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-47171) [Token](#type-interface-token-72202))
 
 ## Functions
 

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
@@ -90,6 +90,18 @@ Interfaces
        * - newOwner
          - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
          - 
+  
+  + **Method getAmount \: **`Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
+  
+  + **Method getOwner \: **`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
+  
+  + **Method noopImpl \: **() \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-36457>`_ ()
+  
+  + **Method setAmount \: **`Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_ \-\> `Token <type-interface-token-72202_>`_
+  
+  + **Method splitImpl \: **`Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-36457>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-47171>`_ `Token <type-interface-token-72202_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-47171>`_ `Token <type-interface-token-72202_>`_)
+  
+  + **Method transferImpl \: **`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-36457>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-47171>`_ `Token <type-interface-token-72202_>`_)
 
 Functions
 ^^^^^^^^^


### PR DESCRIPTION
This generates documentation for methods present in interface
definitions.

Not sure if we could also have doc strings added to the methods.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
