### PR TITLE
interfaces: Add EToRequiredInterface and EFromRequiredInterface in Haskell AST

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -234,6 +234,18 @@ alphaExpr' env = \case
             && alphaMethod m1 m2
             && alphaExpr' env e1 e2
         _ -> False
+    EToRequiredInterface t1a t1b e1 -> \case
+        EToRequiredInterface t2a t2b e2
+            -> alphaTypeCon t1a t2a
+            && alphaTypeCon t1b t2b
+            && alphaExpr' env e1 e2
+        _ -> False
+    EFromRequiredInterface t1a t1b e1 -> \case
+        EFromRequiredInterface t2a t2b e2
+            -> alphaTypeCon t1a t2a
+            && alphaTypeCon t1b t2b
+            && alphaExpr' env e1 e2
+        _ -> False
     EUpdate u1 -> \case
         EUpdate u2 -> alphaUpdate env u1 u2
         _ -> False

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -566,6 +566,18 @@ data Expr
     , callInterfaceMethod :: !MethodName
     , callInterfaceExpr :: !Expr
     }
+  -- | Upcast interface
+  | EToRequiredInterface
+    { triRequiredInterface :: !(Qualified TypeConName)
+    , triRequiringInterface :: !(Qualified TypeConName)
+    , triExpr :: !Expr
+    }
+  -- | Downcast interface
+  | EFromRequiredInterface
+    { friRequiredInterface :: !(Qualified TypeConName)
+    , friRequiringInterface :: !(Qualified TypeConName)
+    , friExpr :: !Expr
+    }
   -- | Update expression.
   | EUpdate !Update
   -- | Scenario expression.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
@@ -107,6 +107,8 @@ freeVarsStep = \case
     EToInterfaceF _ _ e -> e
     EFromInterfaceF _ _ e -> e
     ECallInterfaceF _ _ e -> e
+    EToRequiredInterfaceF _ _ e -> e
+    EFromRequiredInterfaceF _ _ e -> e
     EExperimentalF _ t -> freeVarsInType t
 
   where

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -548,6 +548,10 @@ instance Pretty Expr where
         [interfaceArg ty1, tplArg ty2, TmArg expr]
     ECallInterface ty mth expr -> pPrintAppKeyword lvl prec "call_interface"
         [interfaceArg ty, methodArg mth, TmArg expr]
+    EToRequiredInterface ty1 ty2 expr -> pPrintAppKeyword lvl prec "to_required_interface"
+        [interfaceArg ty1, interfaceArg ty2, TmArg expr]
+    EFromRequiredInterface ty1 ty2 expr -> pPrintAppKeyword lvl prec "from_required_interface"
+        [interfaceArg ty1, interfaceArg ty2, TmArg expr]
     EExperimental name _ ->  pPrint $ "$" <> name
 
 instance Pretty DefTypeSyn where

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -53,6 +53,8 @@ data ExprF expr
   | EToInterfaceF !(Qualified TypeConName) !(Qualified TypeConName) !expr
   | EFromInterfaceF !(Qualified TypeConName) !(Qualified TypeConName) !expr
   | ECallInterfaceF !(Qualified TypeConName) !MethodName !expr
+  | EToRequiredInterfaceF !(Qualified TypeConName) !(Qualified TypeConName) !expr
+  | EFromRequiredInterfaceF !(Qualified TypeConName) !(Qualified TypeConName) !expr
   | EExperimentalF !T.Text !Type
   deriving (Foldable, Functor, Traversable)
 
@@ -207,6 +209,8 @@ instance Recursive Expr where
     EToInterface a b c -> EToInterfaceF a b c
     EFromInterface a b c -> EFromInterfaceF a b c
     ECallInterface a b c -> ECallInterfaceF a b c
+    EToRequiredInterface a b c -> EToRequiredInterfaceF a b c
+    EFromRequiredInterface a b c -> EFromRequiredInterfaceF a b c
     EExperimental a b -> EExperimentalF a b
 
 instance Corecursive Expr where
@@ -244,4 +248,6 @@ instance Corecursive Expr where
     EToInterfaceF a b c -> EToInterface a b c
     EFromInterfaceF a b c -> EFromInterface a b c
     ECallInterfaceF a b c -> ECallInterface a b c
+    EToRequiredInterfaceF a b c -> EToRequiredInterface a b c
+    EFromRequiredInterfaceF a b c -> EFromRequiredInterface a b c
     EExperimentalF a b -> EExperimental a b

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
@@ -198,6 +198,10 @@ applySubstInExpr subst@Subst{..} = \case
         (applySubstInExpr subst e)
     ECallInterface t m e -> ECallInterface t m
         (applySubstInExpr subst e)
+    EToRequiredInterface t1 t2 e -> EToRequiredInterface t1 t2
+        (applySubstInExpr subst e)
+    EFromRequiredInterface t1 t2 e -> EFromRequiredInterface t1 t2
+        (applySubstInExpr subst e)
     EUpdate u -> EUpdate
         (applySubstInUpdate subst u)
     EScenario s -> EScenario

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -667,12 +667,14 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
     <$> mayDecode "expr_CallInterfaceInterfaceType" expr_CallInterfaceInterfaceType decodeTypeConName
     <*> decodeMethodName expr_CallInterfaceMethodInternedName
     <*> mayDecode "expr_CallInterfaceInterfaceExpr" expr_CallInterfaceInterfaceExpr decodeExpr
-  LF1.ExprSumToRequiredInterface _ ->
-    -- TODO https://github.com/digital-asset/daml/issues/11978
-    error "EToRequiredInterface in decoder"
-  LF1.ExprSumFromRequiredInterface _ ->
-    -- TODO https://github.com/digital-asset/daml/issues/11978
-    error "EFromRequiredInterface in decoder"
+  LF1.ExprSumToRequiredInterface LF1.Expr_ToRequiredInterface {..} -> EToRequiredInterface
+    <$> mayDecode "expr_ToRequiredInterfaceRequiredInterface" expr_ToRequiredInterfaceRequiredInterface decodeTypeConName
+    <*> mayDecode "expr_ToRequiredInterfaceRequiringInterface" expr_ToRequiredInterfaceRequiringInterface decodeTypeConName
+    <*> mayDecode "expr_ToRequiredInterfaceExpr" expr_ToRequiredInterfaceExpr decodeExpr
+  LF1.ExprSumFromRequiredInterface LF1.Expr_FromRequiredInterface {..} -> EFromRequiredInterface
+    <$> mayDecode "expr_FromRequiredInterfaceRequiredInterface" expr_FromRequiredInterfaceRequiredInterface decodeTypeConName
+    <*> mayDecode "expr_FromRequiredInterfaceRequiringInterface" expr_FromRequiredInterfaceRequiringInterface decodeTypeConName
+    <*> mayDecode "expr_FromRequiredInterfaceExpr" expr_FromRequiredInterfaceExpr decodeExpr
   LF1.ExprSumExperimental (LF1.Expr_Experimental name mbType) -> do
     ty <- mayDecode "expr_Experimental" mbType decodeType
     pure $ EExperimental (decodeString name) ty

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -719,6 +719,16 @@ encodeExpr' = \case
         expr_CallInterfaceMethodInternedName <- encodeMethodName mth
         expr_CallInterfaceInterfaceExpr <- encodeExpr val
         pureExpr $ P.ExprSumCallInterface P.Expr_CallInterface{..}
+    EToRequiredInterface ty1 ty2 val -> do
+        expr_ToRequiredInterfaceRequiredInterface <- encodeQualTypeConName ty1
+        expr_ToRequiredInterfaceRequiringInterface <- encodeQualTypeConName ty2
+        expr_ToRequiredInterfaceExpr <- encodeExpr val
+        pureExpr $ P.ExprSumToRequiredInterface P.Expr_ToRequiredInterface{..}
+    EFromRequiredInterface ty1 ty2 val -> do
+        expr_FromRequiredInterfaceRequiredInterface <- encodeQualTypeConName ty1
+        expr_FromRequiredInterfaceRequiringInterface <- encodeQualTypeConName ty2
+        expr_FromRequiredInterfaceExpr <- encodeExpr val
+        pureExpr $ P.ExprSumFromRequiredInterface P.Expr_FromRequiredInterface{..}
     EExperimental name ty -> do
         let expr_ExperimentalName = encodeString name
         expr_ExperimentalType <- encodeType ty

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -218,6 +218,8 @@ safetyStep = \case
   EToInterfaceF _ _ s -> s <> Safe 0
   EFromInterfaceF _ _ s -> s <> Safe 0
   ECallInterfaceF _ _ _ -> Unsafe
+  EToRequiredInterfaceF _ _ s -> s <> Safe 0
+  EFromRequiredInterfaceF _ _ s -> s <> Safe 0
   EExperimentalF _ _ -> Unsafe
 
 isTypeClassDictionary :: DefValue -> Bool

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -761,6 +761,18 @@ typeOf' = \case
     method <- inWorld (lookupInterfaceMethod (iface, method))
     checkExpr val (TCon iface)
     pure (ifmType method)
+  EToRequiredInterface requiredIface requiringIface expr -> do
+    allRequiredIfaces <- intRequires <$> inWorld (lookupInterface requiringIface)
+    unless (S.member requiredIface allRequiredIfaces) $ do
+      throwWithContext (EWrongInterfaceRequirement requiringIface requiredIface)
+    checkExpr expr (TCon requiringIface)
+    pure (TCon requiredIface)
+  EFromRequiredInterface requiredIface requiringIface expr -> do
+    allRequiredIfaces <- intRequires <$> inWorld (lookupInterface requiringIface)
+    unless (S.member requiredIface allRequiredIfaces) $ do
+      throwWithContext (EWrongInterfaceRequirement requiringIface requiredIface)
+    checkExpr expr (TCon requiredIface)
+    pure (TOptional (TCon requiringIface))
   EUpdate upd -> typeOfUpdate upd
   EScenario scen -> typeOfScenario scen
   ELocation _ expr -> typeOf' expr

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -143,6 +143,7 @@ data Error
   | EMissingInterfaceMethod !TypeConName !(Qualified TypeConName) !MethodName
   | EUnknownInterfaceMethod !TypeConName !(Qualified TypeConName) !MethodName
   | ETemplateDoesNotImplementInterface !(Qualified TypeConName) !(Qualified TypeConName)
+  | EWrongInterfaceRequirement !(Qualified TypeConName) !(Qualified TypeConName)
 
 contextLocation :: Context -> Maybe SourceLoc
 contextLocation = \case
@@ -414,6 +415,8 @@ instance Pretty Error where
       "Template " <> pretty tpl <> " implements " <> pretty method <> " but interface " <> pretty iface <> " has no such method."
     ETemplateDoesNotImplementInterface tpl iface ->
       "Template " <> pretty tpl <> " does not implement interface " <> pretty iface
+    EWrongInterfaceRequirement requiringIface requiredIface ->
+      "Interface " <> pretty requiringIface <> " does not require interface " <> pretty requiredIface
 
 prettyConsuming :: Bool -> Doc ann
 prettyConsuming consuming = if consuming then "consuming" else "non-consuming"


### PR DESCRIPTION
Adds EToRequiredInterface and EFromRequiredInterface in
the Haskell AST, and the typechecker.

Part of #11978

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
