### PR TITLE
interfaces: Remove envEmptyInterfaces in LFConversion

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -178,7 +178,6 @@ data Env = Env
     ,envChoiceData :: MS.Map TypeConName [ChoiceData]
     ,envImplements :: MS.Map TypeConName [GHC.TyCon]
     ,envInterfaceMethodInstances :: MS.Map (GHC.Module, TypeConName, TypeConName) [(T.Text, GHC.Expr GHC.CoreBndr)]
-    ,envEmptyInterfaces :: S.Set (GHC.Module, TypeConName)
     ,envInterfaceChoiceData :: MS.Map TypeConName [ChoiceData]
     ,envInterfaces :: MS.Map TypeConName GHC.TyCon
     ,envIsGenerated :: Bool
@@ -560,26 +559,6 @@ convertModule lfVersion pkgMap stablePackages isGenerated file x depOrphanModule
             `App` body
               <- [untick val]
           ]
-        emptyInterfaces :: S.Set (GHC.Module, TypeConName)
-        emptyInterfaces = S.fromList
-          [ (mod, mkTypeCon [getOccText ifc])
-          |
-          -- We're looking for `data DamlInterface => I = ...`
-            (_, ifc) <- MS.toList interfaceCons
-          -- such that there are no `instance HasMethod I _ _`
-          , null
-            [ ()
-            | (name, _) <- binds
-            , DFunId _ <- [idDetails name]
-            , TypeCon hasMethodCls
-              [ TypeCon ((== ifc) -> True) []
-              , _
-              , _
-              ] <- [varType name]
-            , NameIn DA_Internal_Desugar "HasMethod" <- [hasMethodCls]
-            ]
-          , Just mod <- [nameModule_maybe (getName ifc)]
-          ]
         choiceData = MS.fromListWith (++)
             [ (mkTypeCon [getOccText tplTy], [ChoiceData ty v])
             | (name, v) <- binds
@@ -615,7 +594,6 @@ convertModule lfVersion pkgMap stablePackages isGenerated file x depOrphanModule
           , envExceptionBinds = exceptionBinds
           , envImplements = tplImplements
           , envInterfaceMethodInstances = tplInterfaceMethodInstances
-          , envEmptyInterfaces = emptyInterfaces
           , envChoiceData = choiceData
           , envIsGenerated = isGenerated
           , envTypeVars = MS.empty
@@ -1003,11 +981,9 @@ convertImplements env tpl = NM.fromList <$>
         _ -> unhandled "interface type" iface
       let mod = nameModule (getName iface)
 
-      methods <- if S.member (mod, qualObject con) (envEmptyInterfaces env)
-        then pure NM.empty
-        else case MS.lookup (mod, qualObject con, tpl) (envInterfaceMethodInstances env) of
-          Just ms -> convertMethods ms
-          Nothing -> unhandled ("missing interface instance for " <> show (con, tpl)) ()
+      methods <- convertMethods $ MS.findWithDefault []
+        (mod, qualObject con, tpl)
+        (envInterfaceMethodInstances env)
 
       let inheritedChoiceNames = S.empty -- This is filled during LF post-processing (in the LF completer).
       pure (TemplateImplements con methods inheritedChoiceNames)

--- a/compiler/damlc/tests/daml-test-files/InterfaceEmpty.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEmpty.daml
@@ -1,0 +1,17 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_INTERFACE
+
+-- | Test that empty interfaces are fine.
+module InterfaceEmpty (I) where
+
+interface I where
+
+template T
+  with
+    p : Party
+  where
+    signatory p
+
+    implements I where

--- a/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceEmptyIndirect.daml
@@ -1,0 +1,17 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_INTERFACE
+
+-- | Test that empty interfaces work fine across modules.
+module InterfaceEmptyIndirect where
+
+import InterfaceEmpty (I)
+
+template T
+  with
+    p : Party
+  where
+    signatory p
+
+    implements I where


### PR DESCRIPTION
The problem with envEmptyInterfaces is that it can only detect
interfaces in the current module. When you try to implement an
interface across a module boundary, LFConversion has very little
information about the interface. This caused an error in the new
test case, `InterfaceEmptyIndirect`.

This PR removes envEmptyInterfaces and simplifies the code
that used it, so it works uniformly for all interfaces
regardless of how many methods it has. The alternative would be
to pass more information into LFConversion, but this seems simpler.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
