### PR TITLE
Publish split-release artifacts more granularly

### DIFF
--- a/ci/assembly-split-release-artifacts.sh
+++ b/ci/assembly-split-release-artifacts.sh
@@ -13,3 +13,5 @@ for file in $SOURCE_DIR/github/*; do
     # Copy as a placeholder for potential tweaks we might want to do here.
     cp $file $OUTPUT_DIR/github
 done
+
+cp -r $SOURCE_DIR/split-release $OUTPUT_DIR/split-release


### PR DESCRIPTION
This publishes damlc & the Daml libraries as standalone artifacts so
Canton can avoid downloading the whole SDK tarball (hopefully).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
