### PR TITLE
interfaces: Prevent circular and non-closed requirements.

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -840,11 +840,11 @@ checkIface m iface = do
     throwWithContext (ECircularInterfaceRequires (intName iface) Nothing)
   forM_ (intRequires iface) $ \requiredIfaceId -> do
     requiredIface <- inWorld (lookupInterface requiredIfaceId)
-    let missing = intRequires requiredIface `S.difference` intRequires iface
     when (tcon `S.member` intRequires requiredIface) $
       throwWithContext (ECircularInterfaceRequires (intName iface) (Just requiredIfaceId))
-    whenJust (listToMaybe (S.toList missing)) $ \missingIfaceId ->
-      throwWithContext (ENotClosedInterfaceRequires (intName iface) requiredIfaceId missingIfaceId)
+    let missing = intRequires requiredIface `S.difference` intRequires iface
+    unless (S.null missing) $ throwWithContext $
+      ENotClosedInterfaceRequires (intName iface) requiredIfaceId (S.toList missing)
 
   -- check methods
   checkUnique (EDuplicateInterfaceMethodName (intName iface)) $ NM.names (intMethods iface)

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -841,7 +841,7 @@ checkIface m iface = do
   forM_ (intRequires iface) $ \requiredIfaceId -> do
     requiredIface <- inWorld (lookupInterface requiredIfaceId)
     let missing = intRequires requiredIface `S.difference` intRequires iface
-    when (tcon `S.member` missing) $
+    when (tcon `S.member` intRequires requiredIface) $
       throwWithContext (ECircularInterfaceRequires (intName iface) (Just requiredIfaceId))
     whenJust (listToMaybe (S.toList missing)) $ \missingIfaceId ->
       throwWithContext (ENotClosedInterfaceRequires (intName iface) requiredIfaceId missingIfaceId)

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -134,6 +134,8 @@ data Error
   | EDuplicateInterfaceChoiceName !TypeConName !ChoiceName
   | EDuplicateInterfaceMethodName !TypeConName !MethodName
   | EUnknownInterface !TypeConName
+  | ECircularInterfaceRequires !TypeConName !(Maybe (Qualified TypeConName))
+  | ENotClosedInterfaceRequires !TypeConName !(Qualified TypeConName) !(Qualified TypeConName)
   | EMissingRequiredInterface { emriTemplate :: !TypeConName, emriRequiringInterface :: !(Qualified TypeConName), emriRequiredInterface :: !(Qualified TypeConName) }
   | EBadInheritedChoices { ebicInterface :: !(Qualified TypeConName), ebicExpected :: ![ChoiceName], ebicGot :: ![ChoiceName] }
   | EMissingInterfaceChoice !ChoiceName
@@ -380,6 +382,17 @@ instance Pretty Error where
     EDuplicateInterfaceMethodName iface method ->
       "Duplicate method name '" <> pretty method <> "' in interface definition for " <> pretty iface
     EUnknownInterface tcon -> "Unknown interface: " <> pretty tcon
+    ECircularInterfaceRequires iface Nothing ->
+      "Circular interface requirement is not allowed: interface " <> pretty iface <> " requires itself."
+    ECircularInterfaceRequires iface (Just otherIface) ->
+      "Circular interface requirement is not allowed: interface "
+        <> pretty iface <> " requires "
+        <> pretty otherIface <> " requires "
+        <> pretty iface
+    ENotClosedInterfaceRequires iface ifaceRequired ifaceMissing ->
+      "Interface " <> pretty iface
+        <> " is missing requirement " <> pretty ifaceMissing
+        <> " required by " <> pretty ifaceRequired
     EMissingRequiredInterface {..} ->
       "Template " <> pretty emriTemplate <>
       " is missing an implementation of interface " <> pretty emriRequiredInterface <>

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -135,7 +135,7 @@ data Error
   | EDuplicateInterfaceMethodName !TypeConName !MethodName
   | EUnknownInterface !TypeConName
   | ECircularInterfaceRequires !TypeConName !(Maybe (Qualified TypeConName))
-  | ENotClosedInterfaceRequires !TypeConName !(Qualified TypeConName) !(Qualified TypeConName)
+  | ENotClosedInterfaceRequires !TypeConName !(Qualified TypeConName) ![Qualified TypeConName]
   | EMissingRequiredInterface { emriTemplate :: !TypeConName, emriRequiringInterface :: !(Qualified TypeConName), emriRequiredInterface :: !(Qualified TypeConName) }
   | EBadInheritedChoices { ebicInterface :: !(Qualified TypeConName), ebicExpected :: ![ChoiceName], ebicGot :: ![ChoiceName] }
   | EMissingInterfaceChoice !ChoiceName

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircular.daml
@@ -1,0 +1,15 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_INTERFACE
+-- @ERROR Circular interface requirement is not allowed: interface A requires itself.
+
+-- | Check that an interface cannot require itself.
+module InterfaceRequiresCircular where
+
+interface A where
+
+-- TODO https://github.com/digital-asset/daml/issues/11978
+--   Implement "requires" syntax.
+_requires_A_A : DA.Internal.Desugar.RequiresT A A
+_requires_A_A = DA.Internal.Desugar.RequiresT

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresCircularIndirect.daml
@@ -1,0 +1,20 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_INTERFACE
+-- @ERROR Circular interface requirement is not allowed: interface A requires InterfaceRequiresCircularIndirect:B requires A
+
+-- | Check that an interface cannot require itself indirectly.
+module InterfaceRequiresCircularIndirect where
+
+interface A where
+
+interface B where
+
+-- TODO https://github.com/digital-asset/daml/issues/11978
+--   Implement "requires" syntax.
+_requires_A_B : DA.Internal.Desugar.RequiresT A B
+_requires_A_B = DA.Internal.Desugar.RequiresT
+
+_requires_B_A : DA.Internal.Desugar.RequiresT B A
+_requires_B_A = DA.Internal.Desugar.RequiresT

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.daml
@@ -1,0 +1,22 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_INTERFACE
+-- @ERROR Interface C is missing requirement InterfaceRequiresNotClosed:A required by InterfaceRequiresNotClosed:B
+
+-- | Check that interface requirements are transitively closed.
+module InterfaceRequiresNotClosed where
+
+interface A where
+
+interface B where
+
+interface C where
+
+-- TODO https://github.com/digital-asset/daml/issues/11978
+--   Implement "requires" syntax.
+_requires_B_A : DA.Internal.Desugar.RequiresT B A
+_requires_B_A = DA.Internal.Desugar.RequiresT
+
+_requires_C_B : DA.Internal.Desugar.RequiresT C B
+_requires_C_B = DA.Internal.Desugar.RequiresT

--- a/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceRequiresNotClosed.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SINCE-LF-FEATURE DAML_INTERFACE
--- @ERROR Interface C is missing requirement InterfaceRequiresNotClosed:A required by InterfaceRequiresNotClosed:B
+-- @ERROR Interface C is missing requirement [InterfaceRequiresNotClosed:A] required by InterfaceRequiresNotClosed:B
 
 -- | Check that interface requirements are transitively closed.
 module InterfaceRequiresNotClosed where


### PR DESCRIPTION
Updates the haskell side to be more strict about requirements:
- requirements must be transitively closed, so if A requires B, and B requires C,
  then A requires C.
- no circular requirements allowed

The logic for circular requirements is a bit duplicated to get a better
error message.

(Also refactored the typechecker a little bit to use `whenJust` instead of pattern matching where appropriate.)

Part of https://github.com/digital-asset/daml/issues/11978

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
