### PR TITLE
Stop flyway from printing sensitive jdbc string at info level

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/resources/com/daml/ledger/participant/state/kvutils/app/logback.base.xml
+++ b/ledger/participant-state/kvutils/app/src/main/resources/com/daml/ledger/participant/state/kvutils/app/logback.base.xml
@@ -18,6 +18,8 @@
     <!-- Disable noisy DB logging at the start of sandbox -->
     <logger name="com.daml.platform.store.FlywayMigrations" level="WARN" />
     <logger name="org.flywaydb" level="INFO" />
+    <!-- Flyway prints jdbc string at info level -->
+    <logger name="org.flywaydb.core.internal.database.base.BaseDatabaseType" level="WARN" />
     <logger name="com.zaxxer.hikari" level="ERROR" />
     <logger name="com.daml.platform" level="WARN" />
 


### PR DESCRIPTION
Example:
```
17:55:55.838 [program-resource-pool-3] INFO  o.f.c.i.d.base.BaseDatabaseType - Database: jdbc:oracle:thin:user/password@localhost:1521/ORCLPDB1 (Oracle 19.0)
```

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
