### PR TITLE
Add Ledger API feature descriptor for user management.

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
@@ -44,9 +44,18 @@ message GetLedgerApiVersionResponse {
 }
 
 message FeaturesDescriptor {
+  // If set, then the Ledger API server supports user management.
+  // It is recommended that clients query this field to gracefully adjust their behavior for
+  // ledgers that do not support user management.
+  UserManagementFeature user_management = 2;
+
   // Features under development or features that are used
   // for ledger implementation testing purposes only.
   //
   // Daml applications SHOULD not depend on these in production.
   ExperimentalFeatures experimental = 1;
 }
+
+// Used to signal the presence of the user management service.
+// Defined as a message to enable future addition of individual per-service features.
+message UserManagementFeature {}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -187,7 +187,7 @@ object LedgerApiTestTool {
               suite = ledgerTestCase.suite.name,
               name = ledgerTestCase.name,
               description = ledgerTestCase.description,
-              result = Right(Excluded),
+              result = Right(Excluded("excluded test")),
             )
           }
         new ColorizedPrintStreamReporter(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -8,7 +8,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestCasesRunner._
 import com.daml.ledger.api.testtool.infrastructure.PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants
-import com.daml.ledger.api.testtool.infrastructure.Result.Retired
+import com.daml.ledger.api.testtool.infrastructure.Result
 import com.daml.ledger.api.testtool.infrastructure.participant.{
   ParticipantSession,
   ParticipantTestContext,
@@ -105,8 +105,10 @@ final class LedgerTestCasesRunner(
     startedTest
       .map[Either[Result.Failure, Result.Success]](duration => Right(Result.Succeeded(duration)))
       .recover[Either[Result.Failure, Result.Success]] {
-        case Retired =>
-          Right(Retired)
+        case Result.Retired =>
+          Right(Result.Retired)
+        case Result.Excluded(reason) =>
+          Right(Result.Excluded(reason))
         case _: TimeoutException =>
           Left(Result.TimedOut)
         case failure: AssertionError =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -73,8 +73,8 @@ object Reporter {
               s.println(green(s"Success (${duration.toMillis} ms)"))
             case Right(Result.Retired) =>
               s.println(yellow(s"Skipped (retired test)"))
-            case Right(Result.Excluded) =>
-              s.println(yellow(s"Skipped (excluded test)"))
+            case Right(Result.Excluded(reason)) =>
+              s.println(yellow(s"Skipped ($reason)"))
             case Left(Result.TimedOut) => s.println(red(s"Timeout"))
             case Left(Result.Failed(cause)) =>
               val message =

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Result.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Result.scala
@@ -12,7 +12,7 @@ private[daml] object Result {
 
   final case class Succeeded(duration: Duration) extends Success
   case object Retired extends RuntimeException with NoStackTrace with Success
-  case object Excluded extends RuntimeException with NoStackTrace with Success
+  final case class Excluded(reason: String) extends RuntimeException with NoStackTrace with Success
 
   sealed trait Failure
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
@@ -105,11 +105,10 @@ object ParticipantSession {
             .getLedgerApiVersion(new GetLedgerApiVersionRequest(ledgerId))
             .map(Features.fromApiVersionResponse)
             .recover { case failure =>
-              // TODO feature descriptors: Remove once all Ledger API implementations respond successfully on VersionService endpoint
               logger.warn(
-                s"Failure in retrieving the feature descriptors from the version service: $failure"
+                s"Could not retrieve feature descriptors from the version service: $failure"
               )
-              Features(Seq.empty)
+              Features.noFeatures
             }
       } yield new ParticipantSession(
         partyAllocation = partyAllocation,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -13,6 +13,7 @@ import com.daml.ledger.api.testtool.infrastructure.{
   Identification,
   LedgerServices,
   PartyAllocationConfiguration,
+  Result,
 }
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.api.v1.active_contracts_service.{
@@ -141,6 +142,10 @@ private[testtool] final class ParticipantTestContext private[participant] (
   val nextKeyId: () => String = nextId("key")
 
   override def toString: String = s"participant $endpointId"
+
+  /** Skips test if user management feature is not supported */
+  def mustSupportUserManagement(): Unit =
+    if (!features.userManagement) throw Result.Excluded("requires user management feature")
 
   /** Gets the absolute offset of the ledger end at a point in time. Use [[end]] if you need
     * a reference to the moving end of the ledger.

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/UserManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/UserManagementServiceIT.scala
@@ -92,6 +92,8 @@ final class UserManagementServiceIT extends LedgerTestSuite {
     "Test argument validation for UserManagement#GetUser",
     allocate(NoParties),
   )(implicit ec => { case Participants(Participant(ledger)) =>
+    ledger.mustSupportUserManagement()
+
     def getAndCheck(problem: String, userId: String, errorCode: ErrorCode): Future[Unit] =
       for {
         error <- ledger.userManagement

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/UserManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/UserManagementServiceIT.scala
@@ -42,6 +42,8 @@ final class UserManagementServiceIT extends LedgerTestSuite {
     "Test argument validation for UserManagement#CreateUser",
     allocate(NoParties),
   )(implicit ec => { case Participants(Participant(ledger)) =>
+    ledger.mustSupportUserManagement()
+
     val userId = UUID.randomUUID.toString
 
     def createAndCheck(
@@ -108,6 +110,8 @@ final class UserManagementServiceIT extends LedgerTestSuite {
     "Exercise every rpc once with success and once with a failure",
     allocate(NoParties),
   )(implicit ec => { case Participants(Participant(ledger)) =>
+    ledger.mustSupportUserManagement()
+
     for {
       // TODO: actually exercise all RPCs
       createResult <- ledger.userManagement.createUser(CreateUserRequest(Some(User("a", "b")), Nil))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Tests.scala
@@ -56,6 +56,7 @@ object Tests {
       new TransactionServiceStreamsIT,
       new TransactionServiceValidationIT,
       new TransactionServiceVisibilityIT,
+      new UserManagementServiceIT,
       new ValueLimitsIT,
       new WitnessesIT,
       new WronglyTypedContractIdIT,
@@ -78,7 +79,6 @@ object Tests {
       new MonotonicRecordTimeIT,
       new TLSOnePointThreeIT,
       new TLSAtLeastOnePointTwoIT,
-      new UserManagementServiceIT, // TODO (i12076): make this a default test once it reads a feature descriptor
       // TODO sandbox-classic removal: Remove
       new DeprecatedSandboxClassicMemoryContractKeysIT,
       new DeprecatedSandboxClassicMemoryExceptionsIT,


### PR DESCRIPTION
Fixes #12076 

Includes:
- enabling the UserManagementServiceIT tests by default; and skipping them for ledgers that do not support user management. The correct working of this is tested by the cross-version compatibility checks between the ledger-api-test-tool
- some refactoring wrt the parsing and representation of features the the ledger-api-test tool.

FYI: @nmarton-da @realvictorprm @stefanobaghino-da @cocreature @adriaanm-da 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description
- [x] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
