### PR TITLE
LF: `SErrorCrash` should not be thrown by Speedy callbacks

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -521,7 +521,7 @@ private[lf] object Speedy {
                       this.compiledPackages = packages
                       // To avoid infinite loop in case the packages are not updated properly by the caller
                       assert(compiledPackages.packageIds.contains(ref.packageId))
-                      lookupVal(eval)
+                      ctrl = eval
                     },
                   )
                 )

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -10,6 +10,7 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.language.LanguageVersion
 import com.daml.lf.language.Util._
 import com.daml.lf.speedy.SError._
+import com.daml.lf.speedy.SExpr.LfDefRef
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.testing.parser.Implicits._
 import org.scalatest.Inside
@@ -252,14 +253,14 @@ class InterpreterTest extends AnyWordSpec with Inside with Matchers with TableDr
         case SResultNeedPackage(pkgId, _, cb) =>
           ref.packageId shouldBe pkgId
           cb(pkgs3)
-          inside(machine.run()) { case SResultError(_: SErrorCrash) =>
+          inside(machine.run()) { case SResultError(SErrorCrash(loc, msg)) =>
+            loc shouldBe "com.daml.lf.speedy.Speedy.Machine.lookupVal"
+            msg should include(s"definition ${LfDefRef(ref)} not found")
           }
         case _ =>
           fail(s"expected result to be missing definition, got $result")
       }
-
     }
-
   }
 
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -12,14 +12,15 @@ import com.daml.lf.language.Util._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.testing.parser.Implicits._
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.matchers.should.Matchers
 import org.slf4j.LoggerFactory
 
 import scala.language.implicitConversions
 
-class InterpreterTest extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+class InterpreterTest extends AnyWordSpec with Inside with Matchers with TableDrivenPropertyChecks {
 
   private implicit def id(s: String): Ref.Name = Name.assertFromString(s)
 
@@ -250,14 +251,11 @@ class InterpreterTest extends AnyWordSpec with Matchers with TableDrivenProperty
       result match {
         case SResultNeedPackage(pkgId, _, cb) =>
           ref.packageId shouldBe pkgId
-          try {
-            cb(pkgs3)
-            sys.error(s"expected crash when definition not provided")
-          } catch {
-            case _: SErrorCrash => ()
+          cb(pkgs3)
+          inside(machine.run()) { case SResultError(_: SErrorCrash) =>
           }
         case _ =>
-          sys.error(s"expected result to be missing definition, got $result")
+          fail(s"expected result to be missing definition, got $result")
       }
 
     }


### PR DESCRIPTION
as it is normally caught in the interpreter loop.  In particular the
caller of the engine should not have to catch such an error.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
