### PR TITLE
User management application id defaulting

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
@@ -56,7 +56,8 @@ message CompletionStreamRequest {
 
   // Only completions of commands submitted with the same application_id will be visible in the stream.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Required unless authentication is used with a user token or a custom token specifying an application-id.
+  // In that case, the token's user-id, respectively application-id, will be used for the request's application_id.
   string application_id = 2;
 
   // Non-empty list of parties whose data should be included.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -27,10 +27,10 @@ message Commands {
   // Optional
   string workflow_id = 2;
 
-  // Uniquely identifies the application (or its part) that issued the command. This is used in tracing
-  // across different components and to let applications subscribe to their own submissions only.
+  // Uniquely identifies the application or participant user that issued the command.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Required unless authentication is used with a user token or a custom token specifying an application-id.
+  // In that case, the token's user-id, respectively application-id, will be used for the request's application_id.
   string application_id = 3;
 
   // Uniquely identifies the command.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/completion.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/completion.proto
@@ -31,7 +31,7 @@ message Completion {
   // Optional
   string transaction_id = 3;
 
-  // The application ID or user-id that was used for the submission, as described in ``commands.proto``.
+  // The application-id or user-id that was used for the submission, as described in ``commands.proto``.
   // Must be a valid LedgerString (as described in ``value.proto``).
   // Optional for historic completions where this data is not available.
   string application_id = 4;

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/completion.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/completion.proto
@@ -31,7 +31,7 @@ message Completion {
   // Optional
   string transaction_id = 3;
 
-  // The application ID that was used for the submission, as described in ``commands.proto``.
+  // The application ID or user-id that was used for the submission, as described in ``commands.proto``.
   // Must be a valid LedgerString (as described in ``value.proto``).
   // Optional for historic completions where this data is not available.
   string application_id = 4;

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthorizationError.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthorizationError.scala
@@ -23,19 +23,19 @@ object AuthorizationError {
 
   final case class InvalidLedger(authorized: String, actual: String) extends AuthorizationError {
     override val reason =
-      s"Claims are only valid for ledgerId $authorized, actual ledgerId is $actual."
+      s"Claims are only valid for ledgerId '$authorized', actual ledgerId is '$actual'."
   }
 
   final case class InvalidParticipant(authorized: String, actual: String)
       extends AuthorizationError {
     override val reason =
-      s"Claims are only valid for participantId $authorized, actual participantId is $actual."
+      s"Claims are only valid for participantId '$authorized', actual participantId is '$actual'."
   }
 
   final case class InvalidApplication(authorized: String, actual: String)
       extends AuthorizationError {
     override val reason =
-      s"Claims are only valid for applicationId $authorized, actual applicationId is $actual."
+      s"Claims are only valid for applicationId '$authorized', actual applicationId is '$actual'."
   }
 
   case object MissingPublicClaim extends AuthorizationError {
@@ -47,10 +47,10 @@ object AuthorizationError {
   }
 
   final case class MissingReadClaim(party: String) extends AuthorizationError {
-    override val reason = s"Claims do not authorize to read data for party $party"
+    override val reason = s"Claims do not authorize to read data for party '$party'"
   }
 
   final case class MissingActClaim(party: String) extends AuthorizationError {
-    override val reason = s"Claims do not authorize to act as party $party"
+    override val reason = s"Claims do not authorize to act as party '$party'"
   }
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
@@ -122,24 +122,6 @@ final class Authorizer(
       }
     }
 
-  /** Checks whether the current Claims authorize to act as the given party, if any.
-    * Note: A missing party or applicationId does NOT result in an authorization error.
-    */
-  def requireActClaimsForParty[Req, Res](
-      party: Option[String],
-      applicationId: Option[String],
-      call: Req => Future[Res],
-  ): Req => Future[Res] =
-    authorize(call) { claims =>
-      for {
-        _ <- valid(claims)
-        _ <- party.map(claims.canActAs).getOrElse(Right(()))
-        _ <- applicationId.map(claims.validForApplication).getOrElse(Right(()))
-      } yield {
-        ()
-      }
-    }
-
   def requireActAndReadClaimsForParties[Req, Res](
       actAs: Set[String],
       readAs: Set[String],

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandCompletionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandCompletionServiceAuthorization.scala
@@ -10,6 +10,7 @@ import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.ProxyCloseable
 import io.grpc.ServerServiceDefinition
 import io.grpc.stub.StreamObserver
+import scalapb.lenses.Lens
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -28,9 +29,9 @@ private[daml] final class CommandCompletionServiceAuthorization(
       request: CompletionStreamRequest,
       responseObserver: StreamObserver[CompletionStreamResponse],
   ): Unit =
-    authorizer.requireReadClaimsForAllPartiesOnStream(
+    authorizer.requireReadClaimsForAllPartiesOnStreamWithApplicationId(
       parties = request.parties,
-      applicationId = Some(request.applicationId),
+      applicationIdL = Lens.unit[CompletionStreamRequest].applicationId,
       call = service.completionStream,
     )(request, responseObserver)
 

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
@@ -11,6 +11,7 @@ import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.ProxyCloseable
 import com.google.protobuf.empty.Empty
 import io.grpc.ServerServiceDefinition
+import scalapb.lenses.Lens
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -30,7 +31,7 @@ private[daml] final class CommandServiceAuthorization(
     authorizer.requireActAndReadClaimsForParties(
       actAs = effectiveSubmitters.actAs,
       readAs = effectiveSubmitters.readAs,
-      applicationId = request.commands.map(_.applicationId),
+      applicationIdL = Lens.unit[SubmitAndWaitRequest].commands.applicationId,
       call = service.submitAndWait,
     )(request)
   }
@@ -42,7 +43,7 @@ private[daml] final class CommandServiceAuthorization(
     authorizer.requireActAndReadClaimsForParties(
       actAs = effectiveSubmitters.actAs,
       readAs = effectiveSubmitters.readAs,
-      applicationId = request.commands.map(_.applicationId),
+      applicationIdL = Lens.unit[SubmitAndWaitRequest].commands.applicationId,
       call = service.submitAndWaitForTransaction,
     )(request)
   }
@@ -54,7 +55,7 @@ private[daml] final class CommandServiceAuthorization(
     authorizer.requireActAndReadClaimsForParties(
       actAs = effectiveSubmitters.actAs,
       readAs = effectiveSubmitters.readAs,
-      applicationId = request.commands.map(_.applicationId),
+      applicationIdL = Lens.unit[SubmitAndWaitRequest].commands.applicationId,
       call = service.submitAndWaitForTransactionId,
     )(request)
   }
@@ -66,7 +67,7 @@ private[daml] final class CommandServiceAuthorization(
     authorizer.requireActAndReadClaimsForParties(
       actAs = effectiveSubmitters.actAs,
       readAs = effectiveSubmitters.readAs,
-      applicationId = request.commands.map(_.applicationId),
+      applicationIdL = Lens.unit[SubmitAndWaitRequest].commands.applicationId,
       call = service.submitAndWaitForTransactionTree,
     )(request)
   }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandSubmissionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandSubmissionServiceAuthorization.scala
@@ -11,6 +11,7 @@ import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.ProxyCloseable
 import com.google.protobuf.empty.Empty
 import io.grpc.ServerServiceDefinition
+import scalapb.lenses.Lens
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -27,7 +28,7 @@ private[daml] final class CommandSubmissionServiceAuthorization(
     authorizer.requireActAndReadClaimsForParties(
       actAs = effectiveSubmitters.actAs,
       readAs = effectiveSubmitters.readAs,
-      applicationId = request.commands.map(_.applicationId),
+      applicationIdL = Lens.unit[SubmitRequest].commands.applicationId,
       call = service.submit,
     )(request)
   }

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
@@ -3,7 +3,11 @@
 
 package com.daml.platform.sandbox.auth
 
+import scala.concurrent.Future
+
 trait ReadWriteServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
+
+  def serviceCallWithoutApplicationId(token: Option[String]): Future[Any]
 
   it should "deny calls with an expired read/write token" in {
     expectUnauthenticated(serviceCallWithToken(canActAsMainActorExpired))
@@ -39,5 +43,11 @@ trait ReadWriteServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
   }
   it should "deny calls with a random application ID" in {
     expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomApplicationId))
+  }
+  it should "allow calls with an empty application ID for a token with an application id" in {
+    expectSuccess(serviceCallWithoutApplicationId(canActAsMainActorActualApplicationId))
+  }
+  it should "deny calls with an empty application ID for a token without an application id" in {
+    expectInvalidArgument(serviceCallWithoutApplicationId(canActAsMainActor))
   }
 }

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SubmitAndWaitDummyCommand.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SubmitAndWaitDummyCommand.scala
@@ -16,26 +16,44 @@ trait SubmitAndWaitDummyCommand extends TestCommands { self: ServiceCallWithMain
   protected def submitAndWait(): Future[Empty] =
     submitAndWait(Option(customTokenToHeader(readWriteToken(mainActor))))
 
-  protected def dummySubmitAndWaitRequest: SubmitAndWaitRequest =
+  protected def dummySubmitAndWaitRequest(applicationId: String): SubmitAndWaitRequest =
     SubmitAndWaitRequest(
       dummyCommands(wrappedLedgerId, s"$serviceCallName-${UUID.randomUUID}", mainActor)
-        .update(_.commands.applicationId := serviceCallName, _.commands.party := mainActor)
+        .update(_.commands.applicationId := applicationId, _.commands.party := mainActor)
         .commands
     )
 
   private def service(token: Option[String]) =
     stub(CommandServiceGrpc.stub(channel), token)
 
-  protected def submitAndWait(token: Option[String]): Future[Empty] =
-    service(token).submitAndWait(dummySubmitAndWaitRequest)
+  protected def submitAndWait(
+      token: Option[String],
+      applicationId: String = serviceCallName,
+  ): Future[Empty] =
+    service(token).submitAndWait(dummySubmitAndWaitRequest(applicationId))
 
-  protected def submitAndWaitForTransaction(token: Option[String]): Future[Empty] =
-    service(token).submitAndWaitForTransaction(dummySubmitAndWaitRequest).map(_ => Empty())
+  protected def submitAndWaitForTransaction(
+      token: Option[String],
+      applicationId: String = serviceCallName,
+  ): Future[Empty] =
+    service(token)
+      .submitAndWaitForTransaction(dummySubmitAndWaitRequest(applicationId))
+      .map(_ => Empty())
 
-  protected def submitAndWaitForTransactionId(token: Option[String]): Future[Empty] =
-    service(token).submitAndWaitForTransactionId(dummySubmitAndWaitRequest).map(_ => Empty())
+  protected def submitAndWaitForTransactionId(
+      token: Option[String],
+      applicationId: String = serviceCallName,
+  ): Future[Empty] =
+    service(token)
+      .submitAndWaitForTransactionId(dummySubmitAndWaitRequest(applicationId))
+      .map(_ => Empty())
 
-  protected def submitAndWaitForTransactionTree(token: Option[String]): Future[Empty] =
-    service(token).submitAndWaitForTransactionTree(dummySubmitAndWaitRequest).map(_ => Empty())
+  protected def submitAndWaitForTransactionTree(
+      token: Option[String],
+      applicationId: String = serviceCallName,
+  ): Future[Empty] =
+    service(token)
+      .submitAndWaitForTransactionTree(dummySubmitAndWaitRequest(applicationId))
+      .map(_ => Empty())
 
 }

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SubmitDummyCommand.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SubmitDummyCommand.scala
@@ -16,14 +16,18 @@ import scala.concurrent.Future
 
 trait SubmitDummyCommand extends TestCommands { self: ServiceCallWithMainActorAuthTests =>
 
-  protected def dummySubmitRequest: SubmitRequest =
+  protected def dummySubmitRequest(applicationId: String): SubmitRequest =
     SubmitRequest(
       dummyCommands(wrappedLedgerId, s"$serviceCallName-${UUID.randomUUID}", mainActor)
-        .update(_.commands.applicationId := serviceCallName, _.commands.party := mainActor)
+        .update(_.commands.applicationId := applicationId, _.commands.party := mainActor)
         .commands
     )
 
-  protected def submit(token: Option[String]): Future[Empty] =
-    stub(CommandSubmissionServiceGrpc.stub(channel), token).submit(dummySubmitRequest)
+  protected def submit(
+      token: Option[String],
+      applicationId: String = serviceCallName,
+  ): Future[Empty] =
+    stub(CommandSubmissionServiceGrpc.stub(channel), token)
+      .submit(dummySubmitRequest(applicationId))
 
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/CompletionStreamAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/CompletionStreamAuthIT.scala
@@ -8,26 +8,41 @@ import com.daml.ledger.api.v1.command_completion_service.{
   CompletionStreamRequest,
   CompletionStreamResponse,
 }
+import com.daml.platform.testing.StreamConsumer
 import io.grpc.stub.StreamObserver
+
+import scala.concurrent.Future
 
 final class CompletionStreamAuthIT
     extends ExpiringStreamServiceCallAuthTests[CompletionStreamResponse] {
 
   override def serviceCallName: String = "CommandCompletionService#CompletionStream"
 
-  private lazy val request =
+  override protected def stream
+      : Option[String] => StreamObserver[CompletionStreamResponse] => Unit = streamFor(
+    serviceCallName
+  )
+
+  private def mkRequest(applicationId: String) =
     new CompletionStreamRequest(
       unwrappedLedgerId,
-      serviceCallName,
+      applicationId,
       List(mainActor),
       Some(ledgerBegin),
     )
 
-  override protected def stream
-      : Option[String] => StreamObserver[CompletionStreamResponse] => Unit =
+  private def streamFor(
+      applicationId: String
+  ): Option[String] => StreamObserver[CompletionStreamResponse] => Unit =
     token =>
       observer =>
-        stub(CommandCompletionServiceGrpc.stub(channel), token).completionStream(request, observer)
+        stub(CommandCompletionServiceGrpc.stub(channel), token)
+          .completionStream(mkRequest(applicationId), observer)
+
+  private def serviceCallWithoutApplicationId(token: Option[String]): Future[Any] =
+    submitAndWait().flatMap(_ =>
+      new StreamConsumer[CompletionStreamResponse](streamFor("")(token)).first()
+    )
 
   // The completion stream is the one read-only endpoint where the application
   // identifier is part of the request. Hence, we didn't put this test in a shared
@@ -42,4 +57,11 @@ final class CompletionStreamAuthIT
     expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomApplicationId))
   }
 
+  it should "allow calls with an empty application ID for a token with an application id" in {
+    expectSuccess(serviceCallWithoutApplicationId(canReadAsMainActorActualApplicationId))
+  }
+
+  it should "deny calls with an empty application ID for a token without an application id" in {
+    expectInvalidArgument(serviceCallWithoutApplicationId(canReadAsMainActor))
+  }
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAndWaitAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAndWaitAuthIT.scala
@@ -16,4 +16,6 @@ final class SubmitAndWaitAuthIT
   override def serviceCallWithToken(token: Option[String]): Future[Any] =
     submitAndWait(token)
 
+  override def serviceCallWithoutApplicationId(token: Option[String]): Future[Any] =
+    submitAndWait(token, "")
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAndWaitForTransactionAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAndWaitForTransactionAuthIT.scala
@@ -16,4 +16,7 @@ final class SubmitAndWaitForTransactionAuthIT
   override def serviceCallWithToken(token: Option[String]): Future[Any] =
     submitAndWaitForTransaction(token)
 
+  override def serviceCallWithoutApplicationId(token: Option[String]): Future[Any] =
+    submitAndWaitForTransaction(token, "")
+
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAndWaitForTransactionIdAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAndWaitForTransactionIdAuthIT.scala
@@ -16,4 +16,7 @@ final class SubmitAndWaitForTransactionIdAuthIT
   override def serviceCallWithToken(token: Option[String]): Future[Any] =
     submitAndWaitForTransactionId(token)
 
+  override def serviceCallWithoutApplicationId(token: Option[String]): Future[Any] =
+    submitAndWaitForTransactionId(token, "")
+
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAndWaitForTransactionTreeAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAndWaitForTransactionTreeAuthIT.scala
@@ -16,4 +16,7 @@ final class SubmitAndWaitForTransactionTreeAuthIT
   override def serviceCallWithToken(token: Option[String]): Future[Any] =
     submitAndWaitForTransactionTree(token)
 
+  override def serviceCallWithoutApplicationId(token: Option[String]): Future[Any] =
+    submitAndWaitForTransactionTree(token, "")
+
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/SubmitAuthIT.scala
@@ -13,4 +13,6 @@ final class SubmitAuthIT extends ReadWriteServiceCallAuthTests with SubmitDummyC
 
   override def serviceCallWithToken(token: Option[String]): Future[Any] = submit(token)
 
+  override def serviceCallWithoutApplicationId(token: Option[String]): Future[Any] =
+    submit(token, "")
 }


### PR DESCRIPTION
Fixes #12083 .

Follows the defaulting approach for calling `GetUser` and `ListUserRights` as the authenticated user.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description
- [x] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
