### PR TITLE
Fix filters in ExceptionRaceConditionIT

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/RaceConditionTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/RaceConditionTests.scala
@@ -5,8 +5,7 @@ package com.daml.ledger.api.testtool.infrastructure
 
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
-import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
-import com.daml.ledger.api.v1.value.RecordField
+import com.daml.ledger.api.v1.transaction.TransactionTree
 import com.daml.ledger.client.binding.Primitive
 import com.daml.lf.data.{Bytes, Ref}
 import com.daml.timer.Delayed
@@ -74,79 +73,5 @@ private[testtool] object RaceConditionTests {
 
   private def offsetBytes(offset: String): Bytes = {
     Bytes.fromHexString(Ref.HexString.assertFromString(offset))
-  }
-
-  object TransactionUtil {
-
-    private implicit class TransactionTreeTestOps(tx: TransactionTree) {
-      def hasEventsNumber(expectedNumberOfEvents: Int): Boolean =
-        tx.eventsById.size == expectedNumberOfEvents
-
-      def containsEvent(condition: TreeEvent => Boolean): Boolean =
-        tx.eventsById.values.toList.exists(condition)
-    }
-
-    private def isCreated(templateName: String)(event: TreeEvent): Boolean =
-      event.kind.isCreated && event.getCreated.templateId.exists(_.entityName == templateName)
-
-    private def isExerciseEvent(choiceName: String)(event: TreeEvent): Boolean =
-      event.kind.isExercised && event.getExercised.choice == choiceName
-
-    def isCreateDummyContract(tx: TransactionTree): Boolean =
-      tx.containsEvent(isCreated(RaceTests.DummyContract.TemplateName))
-
-    def isCreateNonTransient(tx: TransactionTree): Boolean =
-      tx.hasEventsNumber(1) &&
-        tx.containsEvent(isCreated(RaceTests.ContractWithKey.TemplateName))
-
-    def isTransientCreate(tx: TransactionTree): Boolean =
-      tx.containsEvent(isExerciseEvent(RaceTests.CreateWrapper.ChoiceCreateTransient)) &&
-        tx.containsEvent(isCreated(RaceTests.ContractWithKey.TemplateName))
-
-    def isArchival(tx: TransactionTree): Boolean =
-      tx.hasEventsNumber(1) &&
-        tx.containsEvent(isExerciseEvent(RaceTests.ContractWithKey.ChoiceArchive))
-
-    def isNonConsumingExercise(tx: TransactionTree): Boolean =
-      tx.hasEventsNumber(1) &&
-        tx.containsEvent(isExerciseEvent(RaceTests.ContractWithKey.ChoiceExercise))
-
-    def isFetch(tx: TransactionTree): Boolean =
-      tx.hasEventsNumber(1) &&
-        tx.containsEvent(isExerciseEvent(RaceTests.FetchWrapper.ChoiceFetch))
-
-    private def isFoundContractField(found: Boolean)(field: RecordField) = {
-      field.label == "found" && field.value.exists(_.getBool == found)
-    }
-
-    def isContractLookup(success: Boolean)(tx: TransactionTree): Boolean =
-      tx.containsEvent { event =>
-        isCreated(RaceTests.LookupResult.TemplateName)(event) &&
-        event.getCreated.getCreateArguments.fields.exists(isFoundContractField(found = success))
-      }
-  }
-
-  private object RaceTests {
-    object ContractWithKey {
-      val TemplateName = "ContractWithKey"
-      val ChoiceArchive = "ContractWithKey_Archive"
-      val ChoiceExercise = "ContractWithKey_Exercise"
-    }
-
-    object DummyContract {
-      val TemplateName = "DummyContract"
-    }
-
-    object FetchWrapper {
-      val ChoiceFetch = "FetchWrapper_Fetch"
-    }
-
-    object LookupResult {
-      val TemplateName = "LookupResult"
-    }
-
-    object CreateWrapper {
-      val ChoiceCreateTransient = "CreateWrapper_CreateTransient"
-    }
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionRaceConditionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionRaceConditionIT.scala
@@ -193,9 +193,6 @@ object ExceptionRaceConditionIT {
     private def isExerciseEvent(choiceName: String)(event: TreeEvent): Boolean =
       event.kind.isExercised && event.getExercised.choice == choiceName
 
-    // def isCreateDummyContract(tx: TransactionTree): Boolean =
-    //   tx.containsEvent(isCreated(RaceTests.DummyContract.TemplateName))
-
     def isCreateNonTransient(tx: TransactionTree): Boolean =
       tx.hasEventsNumber(1) &&
         tx.containsEvent(isCreated(ExceptionRaceTests.ContractWithKey.TemplateName))
@@ -240,12 +237,7 @@ object ExceptionRaceConditionIT {
     object ContractWithKey {
       val TemplateName = "ContractWithKey"
       val ChoiceArchive = "ContractWithKey_Archive"
-//      val ChoiceExercise = "ContractWithKey_Exercise"
     }
-
-    // object DummyContract {
-    //   val TemplateName = "DummyContract"
-    // }
 
     object FetchWrapper {
       val ChoiceFetch = "FetchWrapper_Fetch"

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionRaceConditionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionRaceConditionIT.scala
@@ -36,10 +36,11 @@ final class ExceptionRaceConditionIT extends LedgerTestSuite {
 
       // We deliberately allow situations where no non-transient contract is created and verify the transactions
       // order when such contract is actually created.
-      transactions.find(isCreate(_, ExceptionRaceTests.ContractWithKey.TemplateName)).foreach { nonTransientCreateTransaction =>
-        transactions
-          .filter(isExercise(_, ExceptionRaceTests.CreateWrapper.ChoiceCreateRollback))
-          .foreach(assertTransactionOrder(_, nonTransientCreateTransaction))
+      transactions.find(isCreate(_, ExceptionRaceTests.ContractWithKey.TemplateName)).foreach {
+        nonTransientCreateTransaction =>
+          transactions
+            .filter(isExercise(_, ExceptionRaceTests.CreateWrapper.ChoiceCreateRollback))
+            .foreach(assertTransactionOrder(_, nonTransientCreateTransaction))
       }
     }
   }
@@ -198,7 +199,7 @@ object ExceptionRaceConditionIT {
 
     def isCreate(tx: TransactionTree, templateName: String): Boolean =
       tx.hasEventsNumber(1) &&
-    tx.containsEvent(isCreated(templateName))
+        tx.containsEvent(isCreated(templateName))
 
     def isExercise(tx: TransactionTree, choiceName: String): Boolean =
       tx.hasEventsNumber(1) &&

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/RaceConditionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/RaceConditionIT.scala
@@ -8,6 +8,8 @@ import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 import com.daml.ledger.api.testtool.infrastructure.RaceConditionTests._
+import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
+import com.daml.ledger.api.v1.value.RecordField
 import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.test.semantic.RaceTests._
 import com.daml.timer.Delayed
@@ -49,7 +51,7 @@ final class RaceConditionIT extends LedgerTestSuite {
       }
       transactions <- transactions(ledger, alice)
     } yield {
-      import TransactionUtil._
+      import RaceConditionIT.TransactionUtil._
       assertSingleton(
         "Successful contract archivals",
         transactions.filter(isArchival),
@@ -85,7 +87,7 @@ final class RaceConditionIT extends LedgerTestSuite {
       ) // Create a dummy contract to ensure that we're not stuck with previous commands
       transactions <- transactions(ledger, alice)
     } yield {
-      import TransactionUtil._
+      import RaceConditionIT.TransactionUtil._
 
       assert(
         isCreateNonTransient(transactions.head),
@@ -130,7 +132,7 @@ final class RaceConditionIT extends LedgerTestSuite {
       )
       transactions <- transactions(ledger, alice)
     } yield {
-      import TransactionUtil._
+      import RaceConditionIT.TransactionUtil._
 
       // We deliberately allow situations where no non-transient contract is created and verify the transactions
       // order when such contract is actually created.
@@ -155,7 +157,7 @@ final class RaceConditionIT extends LedgerTestSuite {
       )
       transactions <- transactions(ledger, alice)
     } yield {
-      import TransactionUtil._
+      import RaceConditionIT.TransactionUtil._
       val archivalTransaction = assertSingleton("archivals", transactions.filter(isArchival))
       transactions
         .filter(isNonConsumingExercise)
@@ -177,7 +179,7 @@ final class RaceConditionIT extends LedgerTestSuite {
       )
       transactions <- transactions(ledger, alice)
     } yield {
-      import TransactionUtil._
+      import RaceConditionIT.TransactionUtil._
       val archivalTransaction = assertSingleton("archivals", transactions.filter(isArchival))
       transactions
         .filter(isFetch)
@@ -199,7 +201,7 @@ final class RaceConditionIT extends LedgerTestSuite {
       )
       transactions <- transactions(ledger, alice)
     } yield {
-      import TransactionUtil._
+      import RaceConditionIT.TransactionUtil._
       val archivalTransaction = assertSingleton("archivals", transactions.filter(isArchival))
       transactions
         .filter(isContractLookup(success = true))
@@ -220,7 +222,7 @@ final class RaceConditionIT extends LedgerTestSuite {
       )
       transactions <- transactions(ledger, alice)
     } yield {
-      import TransactionUtil._
+      import RaceConditionIT.TransactionUtil._
       val createNonTransientTransaction = assertSingleton(
         "create-non-transient transactions",
         transactions.filter(isCreateNonTransient),
@@ -246,4 +248,80 @@ final class RaceConditionIT extends LedgerTestSuite {
     )(implicit ec => { case Participants(Participant(ledger, party)) =>
       testCase(ec)(ledger)(party)
     })
+}
+
+object RaceConditionIT {
+  object TransactionUtil {
+
+    private implicit class TransactionTreeTestOps(tx: TransactionTree) {
+      def hasEventsNumber(expectedNumberOfEvents: Int): Boolean =
+        tx.eventsById.size == expectedNumberOfEvents
+
+      def containsEvent(condition: TreeEvent => Boolean): Boolean =
+        tx.eventsById.values.toList.exists(condition)
+    }
+
+    private def isCreated(templateName: String)(event: TreeEvent): Boolean =
+      event.kind.isCreated && event.getCreated.templateId.exists(_.entityName == templateName)
+
+    private def isExerciseEvent(choiceName: String)(event: TreeEvent): Boolean =
+      event.kind.isExercised && event.getExercised.choice == choiceName
+
+    def isCreateDummyContract(tx: TransactionTree): Boolean =
+      tx.containsEvent(isCreated(RaceTests.DummyContract.TemplateName))
+
+    def isCreateNonTransient(tx: TransactionTree): Boolean =
+      tx.hasEventsNumber(1) &&
+        tx.containsEvent(isCreated(RaceTests.ContractWithKey.TemplateName))
+
+    def isTransientCreate(tx: TransactionTree): Boolean =
+      tx.containsEvent(isExerciseEvent(RaceTests.CreateWrapper.ChoiceCreateTransient)) &&
+        tx.containsEvent(isCreated(RaceTests.ContractWithKey.TemplateName))
+
+    def isArchival(tx: TransactionTree): Boolean =
+      tx.hasEventsNumber(1) &&
+        tx.containsEvent(isExerciseEvent(RaceTests.ContractWithKey.ChoiceArchive))
+
+    def isNonConsumingExercise(tx: TransactionTree): Boolean =
+      tx.hasEventsNumber(1) &&
+        tx.containsEvent(isExerciseEvent(RaceTests.ContractWithKey.ChoiceExercise))
+
+    def isFetch(tx: TransactionTree): Boolean =
+      tx.hasEventsNumber(1) &&
+        tx.containsEvent(isExerciseEvent(RaceTests.FetchWrapper.ChoiceFetch))
+
+    private def isFoundContractField(found: Boolean)(field: RecordField) = {
+      field.label == "found" && field.value.exists(_.getBool == found)
+    }
+
+    def isContractLookup(success: Boolean)(tx: TransactionTree): Boolean =
+      tx.containsEvent { event =>
+        isCreated(RaceTests.LookupResult.TemplateName)(event) &&
+        event.getCreated.getCreateArguments.fields.exists(isFoundContractField(found = success))
+      }
+  }
+
+  private object RaceTests {
+    object ContractWithKey {
+      val TemplateName = "ContractWithKey"
+      val ChoiceArchive = "ContractWithKey_Archive"
+      val ChoiceExercise = "ContractWithKey_Exercise"
+    }
+
+    object DummyContract {
+      val TemplateName = "DummyContract"
+    }
+
+    object FetchWrapper {
+      val ChoiceFetch = "FetchWrapper_Fetch"
+    }
+
+    object LookupResult {
+      val TemplateName = "LookupResult"
+    }
+
+    object CreateWrapper {
+      val ChoiceCreateTransient = "CreateWrapper_CreateTransient"
+    }
+  }
 }


### PR DESCRIPTION
Unfortunately I messed up all the filters (probably got confused by
the very generic sounding names) and it resulted in us just asserting
on nothing.

I am a bit worried about the fragility of those tests. If you mistype
a choice name you run into the same issue. A potentially more robust
option might be to assert that the filters are non-empty or run them
with the assertion reversed and check that they fail but that seems
out of scope for this PR.

I did reverse all assertions manually and checked that the tests do
fail so they properly assert on what they should.

Very sorry for messing this up

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
