### PR TITLE
KV: `VALIDATION_ERROR` is not an internal error as it can also be caused by pruned contracts [KVL-1207]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.participant.state.kvutils.committer.Committer._
 import com.daml.ledger.participant.state.kvutils.committer._
 import com.daml.ledger.participant.state.kvutils.committer.transaction.validation.{
   LedgerTimeValidator,
-  ModelConformanceValidator,
+  CommitterModelConformanceValidator,
   TransactionConsistencyValidator,
 }
 import com.daml.ledger.participant.state.kvutils.store.events.DamlTransactionRejectionEntry
@@ -64,7 +64,8 @@ private[kvutils] class TransactionCommitter(
 
   private val rejections = new Rejections(metrics)
   private val ledgerTimeValidator = new LedgerTimeValidator(defaultConfig)
-  private val modelConformanceValidator = new ModelConformanceValidator(engine, metrics)
+  private val committerModelConformanceValidator =
+    new CommitterModelConformanceValidator(engine, metrics)
 
   override protected val steps: Steps[DamlTransactionEntrySummary] = Iterable(
     "authorize_submitter" -> authorizeSubmitters,
@@ -72,7 +73,8 @@ private[kvutils] class TransactionCommitter(
     "set_time_bounds" -> TimeBoundBindingStep.setTimeBoundsInContextStep(defaultConfig),
     "deduplicate" -> CommandDeduplication.deduplicateCommandStep(rejections),
     "validate_ledger_time" -> ledgerTimeValidator.createValidationStep(rejections),
-    "validate_model_conformance" -> modelConformanceValidator.createValidationStep(rejections),
+    "validate_committer_model_conformance" -> committerModelConformanceValidator
+      .createValidationStep(rejections),
     "validate_consistency" -> TransactionConsistencyValidator.createValidationStep(rejections),
     "set_deduplication_entry" -> CommandDeduplication.setDeduplicationEntryStep(defaultConfig),
     "blind" -> blind,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidator.scala
@@ -112,7 +112,7 @@ private[transaction] class CommitterModelConformanceValidator(engine: Engine, me
       } yield ()
       stepResult.fold(identity, _ => StepContinue(transactionEntry))
     } catch {
-      case missingInputErr @ Err.MissingInputState(key) =>
+      case missingInputErr @ Err.MissingInputState(key) => // Missing package or contract not specified as input
         logger.error(
           "Model conformance validation using on-ledger data failed due to a missing input state (most likely due to an invalid participant state).",
           missingInputErr,
@@ -122,7 +122,7 @@ private[transaction] class CommitterModelConformanceValidator(engine: Engine, me
           Rejection.MissingInputState(key),
           commitContext.recordTime,
         )
-      case err: Err =>
+      case err: Err => // Archive decoding error or other bug
         logger.error(
           "Model conformance validation using on-ledger data failed (most likely due to an invalid participant state).",
           err,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidator.scala
@@ -35,21 +35,25 @@ import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 
-/** Validates the submission's conformance to the Daml model.
+/** Validates the submission's conformance to the Daml model in the KV committer context.
   *
   * @param engine An [[Engine]] instance to reinterpret and validate the transaction.
   * @param metrics A [[Metrics]] instance to record metrics.
   */
-private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Metrics)
+private[transaction] class CommitterModelConformanceValidator(engine: Engine, metrics: Metrics)
     extends TransactionValidator {
-  import ModelConformanceValidator._
+  import CommitterModelConformanceValidator._
 
   private final val logger = ContextualizedLogger.get(getClass)
 
   /** Validates model conformance based on the transaction itself (where it's possible).
-    * Because fetch nodes don't contain contracts, we still need to get them from the current state ([[CommitContext]]).
-    * It first reinterprets the transaction to detect a potentially malicious participant or bugs.
-    * Then, checks the causal monotonicity.
+    * Because fetch nodes don't contain contract instances for performance reasons, we need to get
+    * them from the current committer state ([[CommitContext]]) instead, which means that we cannot
+    * really distinguish malicious participants inventing contracts from validation failures due to
+    * such contracts having been pruned.
+    *
+    * This validation step first reinterprets the transaction to detect a potentially malicious
+    * participant, bugs or pruned contracts. Then, it ensures causal monotonicity.
     *
     * @param rejections A helper object for creating rejection [[Step]]s.
     * @return A committer [[Step]] that performs validation.
@@ -110,7 +114,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
     } catch {
       case missingInputErr @ Err.MissingInputState(key) =>
         logger.error(
-          "Model conformance validation failed due to a missing input state (most likely due to invalid state on the participant).",
+          "Model conformance validation using on-ledger data failed due to a missing input state (most likely due to an invalid participant state).",
           missingInputErr,
         )
         rejections.reject(
@@ -120,7 +124,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
         )
       case err: Err =>
         logger.error(
-          "Model conformance validation failed most likely due to invalid state on the participant.",
+          "Model conformance validation using on-ledger data failed (most likely due to an invalid participant state).",
           err,
         )
         rejections.reject(
@@ -233,7 +237,7 @@ private[transaction] class ModelConformanceValidator(engine: Engine, metrics: Me
   }
 }
 
-private[transaction] object ModelConformanceValidator {
+private[transaction] object CommitterModelConformanceValidator {
 
   private def rejectionForKeyInputError(
       transactionEntry: DamlTransactionEntrySummary,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidator.scala
@@ -112,7 +112,9 @@ private[transaction] class CommitterModelConformanceValidator(engine: Engine, me
       } yield ()
       stepResult.fold(identity, _ => StepContinue(transactionEntry))
     } catch {
-      case missingInputErr @ Err.MissingInputState(key) => // Missing package or contract not specified as input
+      case missingInputErr @ Err.MissingInputState(
+            key
+          ) => // Missing package or contract not specified as input
         logger.error(
           "Model conformance validation using on-ledger data failed due to a missing input state (most likely due to an invalid participant state).",
           missingInputErr,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidator.scala
@@ -112,9 +112,8 @@ private[transaction] class CommitterModelConformanceValidator(engine: Engine, me
       } yield ()
       stepResult.fold(identity, _ => StepContinue(transactionEntry))
     } catch {
-      case missingInputErr @ Err.MissingInputState(
-            key
-          ) => // Missing package or contract not specified as input
+      // Missing package or contract not specified as input
+      case missingInputErr @ Err.MissingInputState(key) =>
         logger.error(
           "Model conformance validation using on-ledger data failed due to a missing input state (most likely due to an invalid participant state).",
           missingInputErr,
@@ -124,7 +123,9 @@ private[transaction] class CommitterModelConformanceValidator(engine: Engine, me
           Rejection.MissingInputState(key),
           commitContext.recordTime,
         )
-      case err: Err => // Archive decoding error or other bug
+
+      // Archive decoding error or other bug
+      case err: Err =>
         logger.error(
           "Model conformance validation using on-ledger data failed (most likely due to an invalid participant state).",
           err,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVErrors.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVErrors.scala
@@ -21,6 +21,26 @@ import com.daml.ledger.participant.state.kvutils.committer.transaction.Rejection
 )
 object KVErrors extends ErrorGroup()(ErrorGroups.rootErrorClass) {
 
+  @Explanation("Errors that highlight transaction consistency issues in the committer context.")
+  object Consistency extends ErrorGroup() {
+
+    @Explanation("Validation of a transaction submission failed using on-ledger data.")
+    @Resolution("Either some input contracts have been pruned or the participant is misbehaving.")
+    object ValidationFailure
+        extends ErrorCode(
+          id = "VALIDATION_FAILURE",
+          ErrorCategory.InvalidGivenCurrentSystemStateOther,
+        ) {
+      case class Reject(
+          details: String
+      )(implicit loggingContext: ContextualizedErrorLogger)
+          extends KVLoggingTransactionErrorImpl(
+            cause = s"Validation failure: $details"
+          )
+    }
+
+  }
+
   @Explanation("Errors that relate to the Daml concepts of time.")
   object Time extends ErrorGroup() {
 
@@ -90,6 +110,7 @@ object KVErrors extends ErrorGroup()(ErrorGroups.rootErrorClass) {
 
   @Explanation("Errors that relate to system resources.")
   object Resources extends ErrorGroup() {
+
     @Explanation("A system resource has been exhausted.")
     @Resolution(
       "Retry the transaction submission or provide the details to the participant operator."
@@ -106,6 +127,7 @@ object KVErrors extends ErrorGroup()(ErrorGroups.rootErrorClass) {
             cause = s"Resources exhausted: $details"
           )
     }
+
   }
 
   @Explanation("Errors that arise from an internal system misbehavior.")
@@ -122,21 +144,6 @@ object KVErrors extends ErrorGroup()(ErrorGroups.rootErrorClass) {
       )(implicit loggingContext: ContextualizedErrorLogger)
           extends KVLoggingTransactionErrorImpl(
             cause = "No reason set for rejection"
-          )
-    }
-
-    @Explanation("An invalid transaction submission was not detected by the participant.")
-    @Resolution("Contact support.")
-    object ValidationFailure
-        extends ErrorCode(
-          id = "VALIDATION_FAILURE",
-          ErrorCategory.SystemInternalAssumptionViolated, // It should have been caught by the participant
-        ) {
-      case class Reject(
-          details: String
-      )(implicit loggingContext: ContextualizedErrorLogger)
-          extends KVLoggingTransactionErrorImpl(
-            cause = s"Validation failure: $details"
           )
     }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/updates/TransactionRejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/updates/TransactionRejections.scala
@@ -546,7 +546,7 @@ private[kvutils] object TransactionRejections {
     def validationFailureStatus(
         details: String
     )(implicit loggingContext: ContextualizedErrorLogger): Status =
-      KVErrors.Internal.ValidationFailure
+      KVErrors.Consistency.ValidationFailure
         .Reject(details)
         .asStatus
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -131,7 +131,7 @@ class ConversionsSpec extends AnyWordSpec with Matchers with OptionValues {
             ("Rejection", "Expected Code", "Expected Additional Details"),
             (
               Rejection.ValidationFailure(Error.Package(Error.Package.Internal("ERROR", "ERROR"))),
-              Code.INVALID_ARGUMENT,
+              Code.FAILED_PRECONDITION,
               Map.empty,
             ),
             (
@@ -242,7 +242,7 @@ class ConversionsSpec extends AnyWordSpec with Matchers with OptionValues {
             ),
             (
               Rejection.ValidationFailure(Error.Package(Error.Package.Internal("ERROR", "ERROR"))),
-              Code.INTERNAL,
+              Code.FAILED_PRECONDITION,
               Map.empty,
               Map.empty,
             ),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -131,7 +131,7 @@ class ConversionsSpec extends AnyWordSpec with Matchers with OptionValues {
             ("Rejection", "Expected Code", "Expected Additional Details"),
             (
               Rejection.ValidationFailure(Error.Package(Error.Package.Internal("ERROR", "ERROR"))),
-              Code.FAILED_PRECONDITION,
+              Code.INVALID_ARGUMENT,
               Map.empty,
             ),
             (

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidatorSpec.scala
@@ -50,19 +50,19 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
 
-class ModelConformanceValidatorSpec
+class CommitterModelConformanceValidatorSpec
     extends AnyWordSpec
     with Matchers
     with MockitoSugar
     with ArgumentMatchersSugar
     with TableDrivenPropertyChecks {
-  import ModelConformanceValidatorSpec._
+  import CommitterModelConformanceValidatorSpec._
 
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
   private val metrics = new Metrics(new MetricRegistry)
 
-  private val defaultValidator = new ModelConformanceValidator(mock[Engine], metrics)
+  private val defaultValidator = new CommitterModelConformanceValidator(mock[Engine], metrics)
   private val rejections = new Rejections(metrics)
 
   private val inputCreate = create(
@@ -125,7 +125,7 @@ class ModelConformanceValidatorSpec
         )
       ).thenReturn(mockValidationResult)
 
-      val validator = new ModelConformanceValidator(mockEngine, metrics)
+      val validator = new CommitterModelConformanceValidator(mockEngine, metrics)
 
       validator.createValidationStep(rejections)(
         createCommitContext(
@@ -158,7 +158,7 @@ class ModelConformanceValidatorSpec
         )
       )
 
-      val validator = new ModelConformanceValidator(mockEngine, metrics)
+      val validator = new CommitterModelConformanceValidator(mockEngine, metrics)
 
       val step = validator
         .createValidationStep(rejections)(
@@ -206,7 +206,7 @@ class ModelConformanceValidatorSpec
       }
     }
 
-    def createThrowingValidator(consumeError: Err): ModelConformanceValidator = {
+    def createThrowingValidator(consumeError: Err): CommitterModelConformanceValidator = {
       val mockEngine = mock[Engine]
       val mockValidationResult = mock[Result[Unit]]
 
@@ -231,7 +231,7 @@ class ModelConformanceValidatorSpec
         )
       ).thenReturn(mockValidationResult)
 
-      new ModelConformanceValidator(mockEngine, metrics)
+      new CommitterModelConformanceValidator(mockEngine, metrics)
     }
   }
 
@@ -398,7 +398,7 @@ class ModelConformanceValidatorSpec
   }
 }
 
-object ModelConformanceValidatorSpec {
+object CommitterModelConformanceValidatorSpec {
 
   private val inputContractId = "#inputContractId"
   private val inputContractIdStateKey = makeContractIdStateKey(inputContractId)


### PR DESCRIPTION
CHANGELOG_BEGIN
[Integration Kit] `VALIDATION_ERROR` is not an internal error anymore as it can also be caused by pruned contracts
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
