### PR TITLE
Drop non-type synonym code from LF conversion

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -111,13 +111,6 @@ featureGenMap = Feature
     , featureCppFlag = Just "DAML_GENMAP"
     }
 
-featureTypeSynonyms :: Feature
-featureTypeSynonyms = Feature
-    { featureName = "LF type synonyms"
-    , featureMinVersion = version1_8
-    , featureCppFlag = Nothing
-    }
-
 featurePackageMetadata :: Feature
 featurePackageMetadata = Feature
     { featureName = "Package metadata"
@@ -196,7 +189,6 @@ allFeatures =
     [ featureNumeric
     , featureAnyType
     , featureTypeRep
-    , featureTypeSynonyms
     , featureStringInterning
     , featureGenericComparison
     , featureGenMap

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -762,8 +762,6 @@ convertClassDef env tycon
     pure $ [typeDef]
         ++ [funDepDef | classHasFds cls]
         ++ [minimalDef | not minimalIsDefault]
-        -- NOTE (SF): No reason to generate fundep & minimal metadata with old-style typeclasses,
-        -- since data-dependencies support for old-style typeclasses is extremely limited.
 
 convertDepOrphanModules :: Env -> [GHC.Module] -> ConvertM [Definition]
 convertDepOrphanModules env orphanModules = do

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -695,7 +695,6 @@ tests tools@Tools{damlc,validate,oldProjDar} = testGroup "Data Dependencies" $
           validate $ projb </> "projb.dar"
 
     | (depLfVer, targetLfVer) <- lfVersionTestPairs
-    , LF.supports depLfVer LF.featureTypeSynonyms -- only test for new-style typeclasses
     ] <>
     [ testCase "Cross-SDK typeclasses" $ withTempDir $ \tmpDir -> do
           writeFileUTF8 (tmpDir </> "daml.yaml") $ unlines


### PR DESCRIPTION
We stopped emitting LF < 1.8, this is unused and untested at this
point.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
