### PR TITLE
Escape daml-lf tracelog messages

### DIFF
--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -40,6 +40,7 @@ da_scala_library(
         "//libs-scala/nameof",
         "//libs-scala/scala-utils",
         "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:org_apache_commons_commons_text",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/TraceLog.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/TraceLog.scala
@@ -4,6 +4,7 @@
 package com.daml.lf.speedy
 
 import com.daml.lf.data.Ref.Location
+import org.apache.commons.text.StringEscapeUtils
 import org.slf4j.Logger
 
 private[lf] trait TraceLog {
@@ -19,7 +20,11 @@ private[lf] final case class RingBufferTraceLog(logger: Logger, capacity: Int) e
 
   def add(message: String, optLocation: Option[Location]): Unit = {
     if (logger.isDebugEnabled) {
-      logger.debug(s"${Pretty.prettyLoc(optLocation).renderWideStream.mkString}: $message")
+      logger.debug(
+        "{}: {}",
+        StringEscapeUtils.escapeJava(Pretty.prettyLoc(optLocation).renderWideStream.mkString),
+        StringEscapeUtils.escapeJava(message),
+      )
     }
     buffer(pos) = (message, optLocation)
     pos = (pos + 1) % capacity

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -203,9 +203,9 @@ traceOrder : Script ()
 traceOrder = do
   let y: Script () = abort "foobar"
   forA_ [0,1] $ \i -> do
-    debug "abc"
+    debugRaw "abc"
     x <- getTime
-    debug "def"
+    debugRaw "def"
 
 jsonBasic : Party -> Script Int
 jsonBasic p = do

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -276,7 +276,7 @@ abstract class AbstractFuncIT
     }
     "traceOrder" should {
       "emit trace statements in correct order" in {
-        val msgRegex = raw"""\[DA.Internal.Prelude:\d+]: "(.*)"""".r
+        val msgRegex = raw"""\[DA.Internal.Prelude:\d+]: (.*)""".r
         def stripLoc(msg: String) = msg match {
           case msgRegex(msg_) => msg_
         }
@@ -290,7 +290,7 @@ abstract class AbstractFuncIT
           )
         } yield {
           assert(v == SUnit)
-          val logMsgs = LogCollector.events.map(_.getMessage)
+          val logMsgs = LogCollector.events.map(_.getFormattedMessage)
           assert(logMsgs.map(stripLoc(_)) == Seq("abc", "def", "abc", "def"))
         }
       }


### PR DESCRIPTION
Currently veracode complains because this allows for clrf
injection (injecting newlines to make user input look like separate
log statements).

With this change
```
debug "abc"
debug "eaiu\neaiu"
debug "def"
debugRaw "abc
```

is logged as

```
[DA.Internal.Prelude:555]: \"abc\"
[DA.Internal.Prelude:555]: \"eaiu\neaiu\"
[DA.Internal.Prelude:555]: \"def\"
[DA.Internal.Prelude:555]: abc
```

You can debate whether we should escape the quotes are necessary but
90% of the reason why people add them is because they call `debug` on
strings when they should be using `debugRaw` so this seems fine to me.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
