### PR TITLE
Fix #12129: allow users' access to their own info

### DIFF
--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/ServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/ServiceCallAuthTests.scala
@@ -9,6 +9,11 @@ import java.util.UUID
 import com.daml.grpc.{GrpcException, GrpcStatus}
 import com.daml.ledger.api.auth.client.LedgerCallCredentials
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.ledger.api.v1.admin.user_management_service.{
+  CreateUserRequest,
+  User,
+  UserManagementServiceGrpc,
+}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
 import com.daml.platform.sandbox.SandboxRequiringAuthorization
@@ -141,4 +146,11 @@ trait ServiceCallAuthTests
   protected val canReadAsAdminRandomParticipantId: Option[String] =
     Option(customTokenToHeader(forParticipantId(UUID.randomUUID.toString, adminToken)))
 
+  protected def createUserAsAdmin(userId: String): Future[(User, Option[String])] = {
+    val userToken = Option(toHeader(standardToken(userId)))
+    val req = CreateUserRequest(Some(User(userId)))
+    stub(UserManagementServiceGrpc.stub(channel), canReadAsAdminStandardJWT)
+      .createUser(req)
+      .map((_, userToken))
+  }
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/GetUserWithGivenUserIdAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/GetUserWithGivenUserIdAuthIT.scala
@@ -13,15 +13,23 @@ import scala.concurrent.Future
 class GetUserWithGivenUserIdAuthIT extends AdminServiceCallAuthTests {
   override def serviceCallName: String = "UserManagementService#GetUser(given-user-id)"
 
-  // only admin users are allowed to specify a user-id for which to retrieve a user
+  // only admin users are allowed to specify a user-id other than their own for which to retrieve a user
   override def serviceCallWithToken(token: Option[String]): Future[Any] = {
+    val testId = UUID.randomUUID().toString
+
+    def getUser(userId: String): Future[User] =
+      stub(UserManagementServiceGrpc.stub(channel), token).getUser(GetUserRequest(userId))
+
     for {
-      // test for an existing user
-      _ <- stub(UserManagementServiceGrpc.stub(channel), token)
-        .getUser(GetUserRequest("participant_admin"))
+      // create a normal users
+      (alice, _) <- createUserAsAdmin(testId + "-alice")
+
+      // test that only admins can retrieve his own user and the newly created alice user
+      _ <- getUser("participant_admin")
+      _ <- getUser(alice.id)
+
       // test for a non-existent user
-      _ <- stub(UserManagementServiceGrpc.stub(channel), token)
-        .getUser(GetUserRequest("non-existent-user-" + UUID.randomUUID().toString))
+      _ <- getUser("non-existent-user-" + testId)
         .transform({
           case scala.util.Success(u) =>
             scala.util.Failure(new RuntimeException(s"User $u unexpectedly exists."))


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description
- [x] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
