### PR TITLE
kvutils - use the command readAs parties alongside the actAs parties 

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -77,6 +77,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
           CommandExecutionResult(
             submitterInfo = state.SubmitterInfo(
               commands.actAs.toList,
+              commands.readAs.toList,
               commands.applicationId.unwrap,
               commands.commandId.unwrap,
               commands.deduplicationPeriod,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
@@ -71,6 +71,7 @@ class LedgerTimeAwareCommandExecutorSpec
     def commandExecutionResult(let: Time.Timestamp) = CommandExecutionResult(
       SubmitterInfo(
         Nil,
+        Nil,
         Ref.ApplicationId.assertFromString("foobar"),
         Ref.CommandId.assertFromString("foobar"),
         DeduplicationDuration(Duration.ofMinutes(1)),
@@ -130,6 +131,7 @@ class LedgerTimeAwareCommandExecutorSpec
         val expectedResult = finalExecutionResult.map(let =>
           CommandExecutionResult(
             SubmitterInfo(
+              Nil,
               Nil,
               Ref.ApplicationId.assertFromString("foobar"),
               Ref.CommandId.assertFromString("foobar"),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupport.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupport.scala
@@ -53,13 +53,14 @@ class WriteServiceWithDeduplicationSupport(
   ): CompletionStage[SubmissionResult] = {
     implicit val contextualizedLogger: DamlContextualizedErrorLogger =
       new DamlContextualizedErrorLogger(logger, loggingContext, submitterInfo.submissionId)
+    val readers = submitterInfo.actAs ++ submitterInfo.readAs
     deduplicationPeriodSupport
       .supportedDeduplicationPeriod(
         submitterInfo.deduplicationPeriod,
         submitterInfo.ledgerConfiguration.maxDeduplicationTime,
         submitterInfo.ledgerConfiguration.timeModel,
         ApplicationId(submitterInfo.applicationId),
-        submitterInfo.actAs.toSet,
+        readers.toSet,
         transactionMeta.submissionTime.toInstant,
       )
       .flatMap { supportedDeduplicationPeriod =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupport.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupport.scala
@@ -29,7 +29,7 @@ class DeduplicationPeriodSupport(
       maxDeduplicationDuration: Duration,
       timeModel: LedgerTimeModel,
       applicationId: ApplicationId,
-      actAs: Set[Ref.Party],
+      readers: Set[Ref.Party],
       submittedAt: Instant,
   )(implicit
       mat: Materializer,
@@ -45,7 +45,7 @@ class DeduplicationPeriodSupport(
           .convertOffsetToDuration(
             offset.toHexString,
             applicationId,
-            actAs,
+            readers,
             timeModel.maxRecordTime(Time.Timestamp.assertFromInstant(submittedAt)).toInstant,
           )
           .map(

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -448,6 +448,7 @@ object KVTest {
   ): SubmitterInfo = {
     SubmitterInfo(
       actAs = List(submitter),
+      readAs = List.empty,
       applicationId = Ref.LedgerString.assertFromString("test"),
       commandId = commandId,
       deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(deduplicationDuration),

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -722,6 +722,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)(i
   private def submitterInfo(party: Ref.Party, commandId: String = "X") =
     SubmitterInfo(
       actAs = List(party),
+      readAs = List.empty,
       applicationId = Ref.LedgerString.assertFromString("tests"),
       commandId = Ref.LedgerString.assertFromString(commandId),
       deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(Duration.ofSeconds(10)),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
@@ -44,6 +44,7 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
     )
     val submitterInfo = SubmitterInfo(
       actAs = List(alice),
+      readAs = List.empty,
       applicationId = applicationId,
       commandId = commandId,
       deduplicationPeriod = ApiDeduplicationPeriod.DeduplicationDuration(Duration.ZERO),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -169,6 +169,7 @@ object KeyValueParticipantStateWriterSpec {
   private def submitterInfo(party: Ref.Party, submissionId: String) =
     SubmitterInfo(
       actAs = List(party),
+      readAs = List.empty,
       applicationId = Ref.LedgerString.assertFromString("tests"),
       commandId = Ref.LedgerString.assertFromString("someCommandId"),
       deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(Duration.ofDays(1)),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupportSpec.scala
@@ -151,7 +151,7 @@ class WriteServiceWithDeduplicationSupportSpec
     ).thenReturn(Future.successful[SubmissionResult](Acknowledged).asJava)
     service
       .submitTransaction(
-        submitterInfo,
+        submitterInfoWithParties,
         transactionMeta,
         submittedTransaction,
         0,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupportSpec.scala
@@ -158,7 +158,8 @@ class WriteServiceWithDeduplicationSupportSpec
       )
       .asScala
       .map { _ =>
-        val expectedReaders = (submitterInfoWithParties.readAs ++ submitterInfoWithParties.actAs).toSet
+        val expectedReaders =
+          (submitterInfoWithParties.readAs ++ submitterInfoWithParties.actAs).toSet
         verify(mockDeduplicationPeriodSupport).supportedDeduplicationPeriod(
           any[DeduplicationPeriod],
           any[Duration],

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupportSpec.scala
@@ -110,7 +110,7 @@ class WriteServiceWithDeduplicationSupportSpec
         0,
       )
       .asScala
-      .map(_ => {
+      .map { _ =>
         verify(mockWriteService).submitTransaction(
           submitterInfo.copy(deduplicationPeriod = convertedDeduplicationPeriod),
           transactionMeta,
@@ -118,7 +118,7 @@ class WriteServiceWithDeduplicationSupportSpec
           0,
         )
         succeed
-      })
+      }
   }
 
   "use actAs and readAs as readers for the completion stream" in {
@@ -157,13 +157,14 @@ class WriteServiceWithDeduplicationSupportSpec
         0,
       )
       .asScala
-      .map(_ => {
+      .map { _ =>
+        val expectedReaders = (submitterInfoWithParties.readAs ++ submitterInfoWithParties.actAs).toSet
         verify(mockDeduplicationPeriodSupport).supportedDeduplicationPeriod(
           any[DeduplicationPeriod],
           any[Duration],
           any[LedgerTimeModel],
           any[ApplicationId],
-          eqTo((submitterInfoWithParties.readAs ++ submitterInfoWithParties.actAs).toSet),
+          eqTo(expectedReaders),
           any[Instant],
         )(
           any[Materializer],
@@ -172,7 +173,7 @@ class WriteServiceWithDeduplicationSupportSpec
           any[ContextualizedErrorLogger],
         )
         succeed
-      })
+      }
   }
 
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/WriteServiceWithDeduplicationSupportSpec.scala
@@ -121,7 +121,7 @@ class WriteServiceWithDeduplicationSupportSpec
       }
   }
 
-  "use actAs and readAs as readers for the completion stream" in {
+  "use all parties in `actAs` and `readAs` as readers for the completion stream" in {
     val submitterInfoWithParties = submitterInfo.copy(
       actAs = List(Ref.Party.assertFromString("party1")),
       readAs = List(Ref.Party.assertFromString("party2")),

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
@@ -14,6 +14,7 @@ import com.daml.logging.entries.{LoggingValue, ToLoggingValue}
   * Ledger API.
   *
   * @param actAs                the non-empty set of parties that submitted the change.
+  * @param readAs               the parties on whose behalf (in addition to all parties listed in [[actAs]]) contracts can be retrieved.
   * @param applicationId        an identifier for the Daml application that
   *                             submitted the command. This is used for monitoring, command
   *                             deduplication, and to allow Daml applications subscribe to their own
@@ -29,6 +30,7 @@ import com.daml.logging.entries.{LoggingValue, ToLoggingValue}
   */
 final case class SubmitterInfo(
     actAs: List[Ref.Party],
+    readAs: List[Ref.Party],
     applicationId: Ref.ApplicationId,
     commandId: Ref.CommandId,
     deduplicationPeriod: DeduplicationPeriod,
@@ -50,9 +52,18 @@ final case class SubmitterInfo(
 
 object SubmitterInfo {
   implicit val `SubmitterInfo to LoggingValue`: ToLoggingValue[SubmitterInfo] = {
-    case SubmitterInfo(actAs, applicationId, commandId, deduplicationPeriod, submissionId, _) =>
+    case SubmitterInfo(
+          actAs,
+          readAs,
+          applicationId,
+          commandId,
+          deduplicationPeriod,
+          submissionId,
+          _,
+        ) =>
       LoggingValue.Nested.fromEntries(
         "actAs " -> actAs,
+        "readAs" -> readAs,
         "applicationId " -> applicationId,
         "commandId " -> commandId,
         "deduplicationPeriod " -> deduplicationPeriod,

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -99,6 +99,7 @@ class TransactionTimeModelComplianceIT
 
     val submitterInfo = state.SubmitterInfo(
       actAs = List(Ref.Party.assertFromString("submitter")),
+      readAs = List.empty,
       applicationId = Ref.ApplicationId.assertFromString("appId"),
       commandId = Ref.CommandId.assertFromString(commandId + UUID.randomUUID().toString),
       deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(JDuration.ZERO),

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -262,6 +262,7 @@ final class SqlLedgerSpec
         result <- sqlLedger.publishTransaction(
           submitterInfo = SubmitterInfo(
             actAs = List(party1),
+            readAs = List.empty,
             applicationId = applicationId,
             commandId = commandId1,
             deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(Duration.ofHours(1)),
@@ -298,6 +299,7 @@ final class SqlLedgerSpec
         result <- sqlLedger.publishTransaction(
           submitterInfo = SubmitterInfo(
             actAs = List(party1),
+            readAs = List.empty,
             applicationId = applicationId,
             commandId = commandId1,
             deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(Duration.ofHours(1)),
@@ -358,6 +360,7 @@ final class SqlLedgerSpec
         result <- sqlLedger.publishTransaction(
           submitterInfo = SubmitterInfo(
             actAs = List(party1),
+            readAs = List.empty,
             applicationId = applicationId,
             commandId = commandId1,
             deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(Duration.ofHours(1)),


### PR DESCRIPTION
- add readAs to the v2 SubmitterInfo
- use a union of actAs + readAs to find the completion at the offset specified by the deduplication offset for KV. This allows us to use any completion which can be seen by the parties involved in the command

changelog_begin

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
