### PR TITLE
kvutils: Move `TransactionUtils` from `pkvutils` [KVL-1166]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -76,4 +76,8 @@ object Raw {
 
   /** We store node IDs as strings (see [[com.daml.ledger.participant.state.kvutils.store.events.DamlTransactionBlindingInfo.DisclosureEntry]]). */
   final case class NodeId(value: String) extends AnyVal
+
+  final case class TransactionNode(override val bytes: ByteString) extends Raw.Bytes
+
+  object TransactionNode extends Raw.Companion[TransactionNode]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/TransactionUtils.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/TransactionUtils.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import com.daml.lf.data.{FrontStack, FrontStackCons, ImmArray, Ref}
+import com.daml.lf.transaction.TransactionOuterClass.Node
+import com.daml.lf.transaction.{TransactionCoder, TransactionOuterClass, TransactionVersion}
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+object TransactionUtils {
+
+  def extractTransactionVersion(rawTransaction: Raw.Transaction): String =
+    TransactionOuterClass.Transaction.parseFrom(rawTransaction.bytes).getVersion
+
+  def extractNodeId(rawTransactionNode: Raw.TransactionNode): Raw.NodeId =
+    Raw.NodeId(TransactionOuterClass.Node.parseFrom(rawTransactionNode.bytes).getNodeId)
+
+  // Helper to traverse the transaction, top-down, while keeping track of the
+  // witnessing parties of each node.
+  def traverseTransactionWithWitnesses(rawTx: Raw.Transaction)(
+      f: (Raw.NodeId, Raw.TransactionNode, Set[Ref.Party]) => Unit
+  ): Unit = {
+    val tx = TransactionOuterClass.Transaction.parseFrom(rawTx.bytes)
+    val nodes = tx.getNodesList.iterator.asScala.map(n => n.getNodeId -> n).toMap
+    val txVersion = TransactionVersion.assertFromString(tx.getVersion)
+
+    @tailrec
+    @throws[Err.InvalidSubmission]
+    def go(toVisit: FrontStack[(Raw.NodeId, Set[Ref.Party])]): Unit = {
+      toVisit match {
+        case FrontStack() => ()
+        case FrontStackCons((nodeId, parentWitnesses), toVisit) =>
+          val node = nodes(nodeId.value)
+          val witnesses = parentWitnesses union informeesOfNode(txVersion, node)
+          f(nodeId, Raw.TransactionNode(node.toByteString), witnesses)
+          // Recurse into children (if any).
+          node.getNodeTypeCase match {
+            case Node.NodeTypeCase.EXERCISE =>
+              val next = node.getExercise.getChildrenList.asScala.view
+                .map(Raw.NodeId(_) -> witnesses)
+                .to(ImmArray)
+              go(next ++: toVisit)
+
+            case _ =>
+              go(toVisit)
+          }
+      }
+    }
+
+    def informeesOfNode(
+        txVersion: TransactionVersion,
+        node: TransactionOuterClass.Node,
+    ): Set[Ref.Party] =
+      TransactionCoder
+        .protoActionNodeInfo(txVersion, node)
+        .fold(err => throw Err.InvalidSubmission(err.errorMessage), _.informeesOfNode)
+
+    go(tx.getRootsList.asScala.view.map(Raw.NodeId(_) -> Set.empty[Ref.Party]).to(FrontStack))
+  }
+
+  def reconstructTransaction(
+      transactionVersion: String,
+      nodesWithIds: Seq[TransactionNodeIdWithNode],
+  ): Raw.Transaction = {
+    // Reconstruct roots by considering the transaction nodes in order and
+    // marking all child nodes as non-roots and skipping over them.
+    val nonRoots = mutable.HashSet.empty[Raw.NodeId]
+    val txBuilder = TransactionOuterClass.Transaction.newBuilder.setVersion(transactionVersion)
+    for (TransactionNodeIdWithNode(nodeId, rawNode) <- nodesWithIds) {
+      val node = TransactionOuterClass.Node.parseFrom(rawNode.bytes)
+      txBuilder.addNodes(node)
+      if (!nonRoots.contains(nodeId)) {
+        txBuilder.addRoots(nodeId.value)
+      }
+      if (node.hasExercise) {
+        val children = node.getExercise.getChildrenList.asScala.map(Raw.NodeId).toSet
+        nonRoots ++= children
+      }
+    }
+    Raw.Transaction(txBuilder.build.toByteString)
+  }
+
+  final case class TransactionNodeIdWithNode(
+      nodeId: Raw.NodeId,
+      node: Raw.TransactionNode,
+  )
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TransactionTraversalSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TransactionTraversalSpec.scala
@@ -1,0 +1,164 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import com.daml.lf.transaction.TransactionOuterClass.{Node, Transaction}
+import com.daml.lf.transaction.TransactionVersion
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
+
+class TransactionTraversalSpec extends AnyFunSuite with Matchers {
+
+  test("traverseTransactionWithWitnesses - consuming nested exercises") {
+    val builder = TransactionBuilder()
+
+    // Creation of a contract with Alice as signatory, and Bob is controller of one of the choices.
+    val createNid = builder.addNode(
+      createNode(List("Alice"), List("Alice", "Bob"))
+    )
+
+    // Exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
+    val exeNid = builder.addNode(
+      exerciseNode(
+        signatories = List("Alice"),
+        stakeholders = List("Alice", "Charlie"),
+        consuming = true,
+        createNid,
+      )
+    )
+
+    // Non-consuming exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
+    val nonConsumingExeNid = builder.addNode(
+      exerciseNode(
+        signatories = List("Alice"),
+        stakeholders = List("Alice", "Charlie"),
+        consuming = false,
+      )
+    )
+
+    // A fetch of some contract created by Bob.
+    val fetchNid = builder.addNode(
+      fetchNode(
+        signatories = List("Bob"),
+        stakeholders = List("Bob"),
+      )
+    )
+
+    // Root node exercising a contract only known to Alice.
+    val rootNid = builder.addRoot(
+      exerciseNode(
+        signatories = List("Alice"),
+        stakeholders = List("Alice"),
+        consuming = true,
+        fetchNid,
+        nonConsumingExeNid,
+        exeNid,
+      )
+    )
+    val rawTx = Raw.Transaction(builder.build.toByteString)
+
+    TransactionUtils.traverseTransactionWithWitnesses(rawTx) {
+      case (Raw.NodeId(`createNid`), _, witnesses) =>
+        witnesses should contain.only("Alice", "Bob", "Charlie")
+        ()
+      case (Raw.NodeId(`exeNid`), _, witnesses) =>
+        witnesses should contain.only("Alice", "Charlie")
+        ()
+      case (Raw.NodeId(`nonConsumingExeNid`), _, witnesses) =>
+        // Non-consuming exercises are only witnessed by signatories.
+        witnesses should contain only "Alice"
+        ()
+      case (Raw.NodeId(`rootNid`), _, witnesses) =>
+        witnesses should contain only "Alice"
+        ()
+      case (Raw.NodeId(`fetchNid`), _, witnesses) =>
+        // This is of course ill-authorized, but we check that parent witnesses are included.
+        witnesses should contain.only("Alice", "Bob")
+        ()
+      case what =>
+        fail(s"Traversed to unknown node: $what")
+    }
+  }
+
+  // --------------------------------------------------------
+  // Helpers for constructing transactions.
+
+  case class TransactionBuilder() {
+    private var roots = List.empty[String]
+    private var nodes = Map.empty[String, Node]
+    private var nextNodeId = -1
+
+    def addNode(node: Node.Builder): String = {
+      nextNodeId += 1
+      val nodeId = nextNodeId.toString
+      nodes += nodeId -> node.setNodeId(nodeId).build
+      nodeId
+    }
+
+    def addRoot(node: Node.Builder): String = {
+      // Check that children actually exist.
+      assert(
+        !node.hasExercise ||
+          node.getExercise.getChildrenList.asScala.map(nodes.contains).forall(identity)
+      )
+      val nodeId = addNode(node)
+      roots ::= nodeId
+      nodeId
+    }
+
+    def build: Transaction =
+      Transaction.newBuilder
+        .setVersion(TransactionVersion.minVersion.protoValue)
+        .addAllNodes(nodes.values.asJava)
+        .addAllRoots(roots.reverse.asJava)
+        .build
+  }
+
+  private def withNodeBuilder[A](build: Node.Builder => A): Node.Builder = {
+    val b = Node.newBuilder
+    build(b)
+    b
+  }
+
+  /** Construct a create node. Signatories are the parties whose signature is required to create the
+    * contract. Stakeholders of a contract are the signatories and observers.
+    */
+  private def createNode(signatories: Iterable[String], stakeholders: Iterable[String]) =
+    withNodeBuilder {
+      _.getCreateBuilder
+        .addAllSignatories(signatories.asJava)
+        .addAllStakeholders(stakeholders.asJava)
+    }
+
+  /** Construct a fetch node. Signatories are the signatories of the contract we're fetching.
+    * Stakeholders of a contract are the signatories and observers.
+    */
+  private def fetchNode(signatories: Iterable[String], stakeholders: Iterable[String]) =
+    withNodeBuilder {
+      _.getFetchBuilder
+        .addAllSignatories(signatories.asJava)
+        .addAllStakeholders(stakeholders.asJava)
+    }
+
+  /** Construct an exercise node. Signatories are the signatories of the contract we're exercising
+    * on.
+    */
+  private def exerciseNode(
+      signatories: Iterable[String],
+      stakeholders: Iterable[String],
+      consuming: Boolean,
+      children: String*
+  ) =
+    withNodeBuilder {
+      _.getExerciseBuilder
+        .setConsuming(consuming)
+        .addAllSignatories(signatories.asJava)
+        .addAllStakeholders(stakeholders.asJava)
+        /* NOTE(JM): Actors are no longer included in exercises by the compiler, hence we don't set them */
+        .addAllChildren(children.asJava)
+    }
+
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TransactionUtilsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TransactionUtilsSpec.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import com.daml.ledger.participant.state.kvutils.TransactionUtils.TransactionNodeIdWithNode
+import com.daml.lf.transaction.{TransactionOuterClass, TransactionVersion}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** [[TransactionUtils.traverseTransactionWithWitnesses]] is covered by [[TransactionTraversalSpec]]. */
+class TransactionUtilsSpec extends AnyWordSpec with Matchers {
+
+  import TransactionUtilsSpec._
+
+  "TransactionUtilsSpec" should {
+    "extractTransactionVersion" in {
+      val actualVersion = TransactionUtils.extractTransactionVersion(aRawTransaction)
+      actualVersion shouldBe TransactionVersion.VDev.protoValue
+    }
+
+    "extractNodeId" in {
+      val actualNodeId = TransactionUtils.extractNodeId(aRawRootNode)
+      actualNodeId shouldBe Raw.NodeId("rootId")
+    }
+
+    "reconstructTransaction" in {
+      val reconstructedTransaction = TransactionUtils.reconstructTransaction(
+        TransactionVersion.VDev.protoValue,
+        Seq(
+          TransactionNodeIdWithNode(aRawRootNodeId, aRawRootNode),
+          TransactionNodeIdWithNode(aRawChildNodeId, aRawChildNode),
+        ),
+      )
+      reconstructedTransaction shouldBe aRawTransaction
+    }
+  }
+}
+
+object TransactionUtilsSpec {
+  private val aRootNodeId = "rootId"
+  private val aChildNodeId = "childId"
+  private val aRawRootNodeId = Raw.NodeId(aRootNodeId)
+  private val aRawChildNodeId = Raw.NodeId(aChildNodeId)
+
+  private val aChildNode = TransactionOuterClass.Node
+    .newBuilder()
+    .setNodeId(aChildNodeId)
+    .setExercise(
+      TransactionOuterClass.NodeExercise
+        .newBuilder()
+        .addObservers("childObserver")
+    )
+  private val aRawChildNode = Raw.TransactionNode(aChildNode.build().toByteString)
+  private val aRootNode = TransactionOuterClass.Node
+    .newBuilder()
+    .setNodeId(aRootNodeId)
+    .setExercise(
+      TransactionOuterClass.NodeExercise
+        .newBuilder()
+        .addChildren(aChildNodeId)
+        .addObservers("rootObserver")
+    )
+  private val aRawRootNode = Raw.TransactionNode(aRootNode.build().toByteString)
+  private val aRawTransaction = Raw.Transaction(
+    TransactionOuterClass.Transaction
+      .newBuilder()
+      .addRoots(aRootNodeId)
+      .addNodes(aRootNode)
+      .addNodes(aChildNode)
+      .setVersion(TransactionVersion.VDev.protoValue)
+      .build()
+      .toByteString
+  )
+}


### PR DESCRIPTION
This is needed to remove Daml-LF message references from the `pkvutils` production code. The migrated class is a subject to the `kv-transaction-support` library formation in a later step.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
