### PR TITLE
Add transaction statistics to CompletionInfo

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -338,6 +338,7 @@ private class JdbcLedgerDao(
                 commandId,
                 None,
                 Some(submissionId),
+                None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
               )
 
               sequentialIndexer.store(
@@ -378,7 +379,8 @@ private class JdbcLedgerDao(
                   state.Update.CommandRejected(
                     recordTime = recordTime,
                     completionInfo = state
-                      .CompletionInfo(actAs, applicationId, commandId, None, submissionId),
+                      .CompletionInfo(actAs, applicationId, commandId, None, submissionId
+                        , None), // TODO https://digitalasset.atlassian.net/browse/DPP-813
                     reasonTemplate = reason.toParticipantStateRejectionReason(errorFactories)(
                       new DamlContextualizedErrorLogger(logger, loggingContext, submissionId)
                     ),

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -338,7 +338,7 @@ private class JdbcLedgerDao(
                 commandId,
                 None,
                 Some(submissionId),
-                None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+                None, // TODO Ledger Metering
               )
 
               sequentialIndexer.store(
@@ -385,7 +385,7 @@ private class JdbcLedgerDao(
                         commandId,
                         None,
                         submissionId,
-                        None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+                        None, // TODO Ledger Metering
                       ),
                     reasonTemplate = reason.toParticipantStateRejectionReason(errorFactories)(
                       new DamlContextualizedErrorLogger(logger, loggingContext, submissionId)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -379,8 +379,14 @@ private class JdbcLedgerDao(
                   state.Update.CommandRejected(
                     recordTime = recordTime,
                     completionInfo = state
-                      .CompletionInfo(actAs, applicationId, commandId, None, submissionId
-                        , None), // TODO https://digitalasset.atlassian.net/browse/DPP-813
+                      .CompletionInfo(
+                        actAs,
+                        applicationId,
+                        commandId,
+                        None,
+                        submissionId,
+                        None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+                      ),
                     reasonTemplate = reason.toParticipantStateRejectionReason(errorFactories)(
                       new DamlContextualizedErrorLogger(logger, loggingContext, submissionId)
                     ),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/indexer/ha/EndlessReadService.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/indexer/ha/EndlessReadService.scala
@@ -176,6 +176,7 @@ object EndlessReadService {
     commandId = commandId(i),
     optDeduplicationPeriod = None,
     submissionId = None,
+    statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
   )
   def transactionMeta(i: Int): TransactionMeta = TransactionMeta(
     ledgerEffectiveTime = recordTime(i),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/indexer/ha/EndlessReadService.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/indexer/ha/EndlessReadService.scala
@@ -176,7 +176,7 @@ object EndlessReadService {
     commandId = commandId(i),
     optDeduplicationPeriod = None,
     submissionId = None,
-    statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+    statistics = None, // TODO Ledger Metering
   )
   def transactionMeta(i: Int): TransactionMeta = TransactionMeta(
     ledgerEffectiveTime = recordTime(i),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
@@ -226,7 +226,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
             commandId = commandId,
             optDeduplicationPeriod = None,
             submissionId = Some(submissionId),
-            None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+            statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
           )
         ),
         recordTime = Timestamp.now(),
@@ -251,7 +251,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
             commandId = commandId,
             optDeduplicationPeriod = None,
             submissionId = Some(submissionId),
-            None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+            statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
           )
         ),
         recordTime = Timestamp.now(),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
@@ -226,6 +226,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
             commandId = commandId,
             optDeduplicationPeriod = None,
             submissionId = Some(submissionId),
+            None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
           )
         ),
         recordTime = Timestamp.now(),
@@ -250,6 +251,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
             commandId = commandId,
             optDeduplicationPeriod = None,
             submissionId = Some(submissionId),
+            None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
           )
         ),
         recordTime = Timestamp.now(),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
@@ -226,7 +226,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
             commandId = commandId,
             optDeduplicationPeriod = None,
             submissionId = Some(submissionId),
-            statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+            statistics = None, // TODO Ledger Metering
           )
         ),
         recordTime = Timestamp.now(),
@@ -251,7 +251,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
             commandId = commandId,
             optDeduplicationPeriod = None,
             submissionId = Some(submissionId),
-            statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+            statistics = None, // TODO Ledger Metering
           )
         ),
         recordTime = Timestamp.now(),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -675,7 +675,8 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
       applicationId <- entry.applicationId
       commandId <- entry.commandId
       submissionId <- entry.submissionId
-    } yield state.CompletionInfo(actAs, applicationId, commandId, None, Some(submissionId))
+    } yield state.CompletionInfo(actAs, applicationId, commandId, None, Some(submissionId),
+      None) // TODO https://digitalasset.atlassian.net/browse/DPP-813
 
   protected final def store(
       offsetAndTx: (Offset, LedgerEntry.Transaction)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -681,7 +681,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
       commandId,
       None,
       Some(submissionId),
-      None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+      None, // TODO Ledger Metering
     )
 
   protected final def store(

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -675,8 +675,14 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
       applicationId <- entry.applicationId
       commandId <- entry.commandId
       submissionId <- entry.submissionId
-    } yield state.CompletionInfo(actAs, applicationId, commandId, None, Some(submissionId),
-      None) // TODO https://digitalasset.atlassian.net/browse/DPP-813
+    } yield state.CompletionInfo(
+      actAs,
+      applicationId,
+      commandId,
+      None,
+      Some(submissionId),
+      None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+    )
 
   protected final def store(
       offsetAndTx: (Offset, LedgerEntry.Transaction)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
@@ -1463,7 +1463,7 @@ object UpdateToDbDtoSpec {
     commandId = someCommandId,
     optDeduplicationPeriod = None,
     submissionId = Some(someSubmissionId),
-    statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+    statistics = None, // TODO Ledger Metering
   )
   private val someTransactionMeta = state.TransactionMeta(
     ledgerEffectiveTime = Time.Timestamp.assertFromLong(2),

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
@@ -1463,7 +1463,7 @@ object UpdateToDbDtoSpec {
     commandId = someCommandId,
     optDeduplicationPeriod = None,
     submissionId = Some(someSubmissionId),
-    None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+    statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
   )
   private val someTransactionMeta = state.TransactionMeta(
     ledgerEffectiveTime = Time.Timestamp.assertFromLong(2),

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/UpdateToDbDtoSpec.scala
@@ -1463,6 +1463,7 @@ object UpdateToDbDtoSpec {
     commandId = someCommandId,
     optDeduplicationPeriod = None,
     submissionId = Some(someSubmissionId),
+    None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
   )
   private val someTransactionMeta = state.TransactionMeta(
     ledgerEffectiveTime = Time.Timestamp.assertFromLong(2),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -217,6 +217,7 @@ object Conversions {
         .map(
           Ref.SubmissionId.assertFromString
         ),
+      None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
     )
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -217,7 +217,7 @@ object Conversions {
         .map(
           Ref.SubmissionId.assertFromString
         ),
-      None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+      statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
     )
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -217,7 +217,7 @@ object Conversions {
         .map(
           Ref.SubmissionId.assertFromString
         ),
-      statistics = None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+      statistics = None, // TODO Ledger Metering
     )
   }
 

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -804,7 +804,7 @@ object ParticipantStateIntegrationSpecBase {
   private def matchTransaction(update: Update, expectedCommandId: String): Assertion =
     inside(update) {
       case TransactionAccepted(
-            Some(CompletionInfo(_, _, actualCommandId, _, _)),
+            Some(CompletionInfo(_, _, actualCommandId, _, _, _)),
             _,
             _,
             _,

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/CompletionInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/CompletionInfo.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.participant.state.v2
 
 import com.daml.ledger.api.DeduplicationPeriod
 import com.daml.lf.data.Ref
+import com.daml.lf.transaction.TransactionNodesStatistics
 import com.daml.logging.entries.{LoggingValue, ToLoggingValue}
 
 /** Information about a completion for a submission.
@@ -42,19 +43,20 @@ case class CompletionInfo(
     commandId: Ref.CommandId,
     optDeduplicationPeriod: Option[DeduplicationPeriod],
     submissionId: Option[Ref.SubmissionId],
+    statistics: Option[TransactionNodesStatistics]
 ) {
   def changeId: ChangeId = ChangeId(applicationId, commandId, actAs.toSet)
 }
 
 object CompletionInfo {
   implicit val `CompletionInfo to LoggingValue`: ToLoggingValue[CompletionInfo] = {
-    case CompletionInfo(actAs, applicationId, commandId, deduplicationPeriod, submissionId) =>
+    case CompletionInfo(actAs, applicationId, commandId, deduplicationPeriod, submissionId, _) =>
       LoggingValue.Nested.fromEntries(
         "actAs " -> actAs,
         "applicationId " -> applicationId,
         "commandId " -> commandId,
         "deduplicationPeriod " -> deduplicationPeriod,
-        "submissionId" -> submissionId,
+        "submissionId" -> submissionId
       )
   }
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/CompletionInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/CompletionInfo.scala
@@ -43,7 +43,7 @@ case class CompletionInfo(
     commandId: Ref.CommandId,
     optDeduplicationPeriod: Option[DeduplicationPeriod],
     submissionId: Option[Ref.SubmissionId],
-    statistics: Option[TransactionNodesStatistics]
+    statistics: Option[TransactionNodesStatistics],
 ) {
   def changeId: ChangeId = ChangeId(applicationId, commandId, actAs.toSet)
 }
@@ -56,7 +56,7 @@ object CompletionInfo {
         "applicationId " -> applicationId,
         "commandId " -> commandId,
         "deduplicationPeriod " -> deduplicationPeriod,
-        "submissionId" -> submissionId
+        "submissionId" -> submissionId,
       )
   }
 }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
@@ -45,6 +45,7 @@ final case class SubmitterInfo(
     commandId,
     Some(deduplicationPeriod),
     submissionId,
+    None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
   )
 }
 

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/SubmitterInfo.scala
@@ -45,7 +45,7 @@ final case class SubmitterInfo(
     commandId,
     Some(deduplicationPeriod),
     submissionId,
-    None, // TODO https://digitalasset.atlassian.net/browse/DPP-813
+    None, // TODO Ledger Metering
   )
 }
 


### PR DESCRIPTION
Adding the statistics to the CompletionInfo (as None) allows ledger teams to start updating their implementation to supply transaction statistics.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

