### PR TITLE
[ledger-api] - Move deduplication duration validation into the KV WriteService

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -568,6 +568,31 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        # max deduplication duration is no longer enforced in the ledger API
+        "start": first_granular_test_tool,
+        "end": "2.0.0-snapshot.20211210.8653.0.35beb44c ",
+        "platform_ranges": [
+            {
+                "start": "2.0.0-snapshot.20211210.8653.0.35beb44c",
+                "exclusions": [
+                    "LedgerConfigurationServiceIT:CSLSuccessIfMaxDeduplicationTimeExceeded",
+                ],
+            },
+        ],
+    },
+    {
+        # max deduplication duration is no longer enforced in the ledger API
+        "end": last_nongranular_test_tool,
+        "platform_ranges": [
+            {
+                "start": "2.0.0-snapshot.20211210.8653.0.35beb44c",
+                "exclusions": [
+                    "LedgerConfigurationServiceIT",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/ledger/daml-on-sql/BUILD.bazel
+++ b/ledger/daml-on-sql/BUILD.bazel
@@ -124,7 +124,7 @@ conformance_test(
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
         # not enforced
-        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration",
     ],
 )
 

--- a/ledger/daml-on-sql/BUILD.bazel
+++ b/ledger/daml-on-sql/BUILD.bazel
@@ -115,6 +115,7 @@ conformance_test(
         "--verbose",
         "--additional=MultiPartySubmissionIT",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=ContractIdIT:Accept",

--- a/ledger/daml-on-sql/BUILD.bazel
+++ b/ledger/daml-on-sql/BUILD.bazel
@@ -123,6 +123,8 @@ conformance_test(
         # daml-on-sql uses the the sandbox server which has support only for participant side deduplication,
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
+        # not enforced
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
     ],
 )
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -23,11 +23,7 @@ import com.daml.ledger.offset.Offset
 import com.daml.lf.command._
 import com.daml.lf.data._
 import com.daml.lf.value.{Value => Lf}
-import com.daml.platform.server.api.validation.{
-  DeduplicationPeriodValidator,
-  ErrorFactories,
-  FieldValidations,
-}
+import com.daml.platform.server.api.validation.{ErrorFactories, FieldValidations}
 import io.grpc.{Status, StatusRuntimeException}
 import scalaz.syntax.tag._
 
@@ -42,7 +38,6 @@ final class CommandsValidator(
   private val errorFactories = ErrorFactories(errorCodesVersionSwitcher)
   private val fieldValidations = FieldValidations(errorFactories)
   private val valueValidator = new ValueValidator(errorFactories, fieldValidations)
-  private val deduplicationPeriodValidator = new DeduplicationPeriodValidator(errorFactories)
 
   import errorFactories._
   import fieldValidations._
@@ -241,14 +236,10 @@ final class CommandsValidator(
           Right(DeduplicationPeriod.DeduplicationDuration(maxDeduplicationDuration))
         case commands.Commands.DeduplicationPeriod.DeduplicationTime(duration) =>
           val deduplicationDuration = DurationConversion.fromProto(duration)
-          deduplicationPeriodValidator
-            .validateDuration(deduplicationDuration, maxDeduplicationDuration)
-            .map(DeduplicationPeriod.DeduplicationDuration)
+          Right(DeduplicationPeriod.DeduplicationDuration(deduplicationDuration))
         case commands.Commands.DeduplicationPeriod.DeduplicationDuration(duration) =>
           val deduplicationDuration = DurationConversion.fromProto(duration)
-          deduplicationPeriodValidator
-            .validateDuration(deduplicationDuration, maxDeduplicationDuration)
-            .map(DeduplicationPeriod.DeduplicationDuration)
+          Right(DeduplicationPeriod.DeduplicationDuration(deduplicationDuration))
         case commands.Commands.DeduplicationPeriod.DeduplicationOffset(offset) =>
           Ref.HexString
             .fromString(offset)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidator.scala
@@ -29,19 +29,26 @@ class DeduplicationPeriodValidator(
 
   def validateDuration(duration: Duration, maxDeduplicationDuration: Duration)(implicit
       contextualizedErrorLogger: ContextualizedErrorLogger
+  ): Either[StatusRuntimeException, Duration] =
+    validateNonNegativeDuration(duration).flatMap { duration =>
+      if (duration.compareTo(maxDeduplicationDuration) > 0)
+        Left(
+          errorFactories.invalidDeduplicationDuration(
+            fieldName,
+            s"The given deduplication duration of $duration exceeds the maximum deduplication time of $maxDeduplicationDuration",
+            definiteAnswer = Some(false),
+            Some(maxDeduplicationDuration),
+          )
+        )
+      else Right(duration)
+    }
+
+  def validateNonNegativeDuration(duration: Duration)(implicit
+      contextualizedErrorLogger: ContextualizedErrorLogger
   ): Either[StatusRuntimeException, Duration] = if (duration.isNegative)
     Left(
       errorFactories
         .invalidField(fieldName, "Duration must be positive", definiteAnswer = Some(false))
-    )
-  else if (duration.compareTo(maxDeduplicationDuration) > 0)
-    Left(
-      errorFactories.invalidDeduplicationDuration(
-        fieldName,
-        s"The given deduplication duration of $duration exceeds the maximum deduplication time of $maxDeduplicationDuration",
-        definiteAnswer = Some(false),
-        Some(maxDeduplicationDuration),
-      )
     )
   else Right(duration)
 }

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidatorSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidatorSpec.scala
@@ -1,0 +1,49 @@
+package com.daml.platform.server.api.validation
+
+import java.time
+import java.time.Duration
+
+import com.daml.error.definitions.LedgerApiErrors.RequestValidation.InvalidDeduplicationPeriodField.ValidMaxDeduplicationFieldKey
+import com.daml.error.{ContextualizedErrorLogger, NoLogging}
+import com.daml.ledger.api.DeduplicationPeriod.DeduplicationDuration
+import com.daml.ledger.api.validation.ValidatorTestUtils
+import io.grpc.Status.Code.{FAILED_PRECONDITION, INVALID_ARGUMENT}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+
+class DeduplicationPeriodValidatorSpec
+    extends AnyWordSpec
+    with Matchers
+    with ValidatorTestUtils
+    with TableDrivenPropertyChecks {
+
+  private implicit val contextualizedErrorLogger: ContextualizedErrorLogger = NoLogging
+  private val maxDeduplicationDuration = time.Duration.ofSeconds(5)
+  private val deduplicationValidatorFixture = new ValidatorFixture(selfServiceErrorCodesEnabled =>
+    new DeduplicationPeriodValidator(ErrorFactories(selfServiceErrorCodesEnabled))
+  )
+
+  "not allow deduplication duration exceeding maximum deduplication duration" in {
+    val durationSecondsExceedingMax = maxDeduplicationDuration.plusSeconds(1).getSeconds
+    deduplicationValidatorFixture.testRequestFailure(
+      _.validate(
+        DeduplicationDuration(
+          Duration.ofSeconds(durationSecondsExceedingMax)
+        ),
+        maxDeduplicationDuration,
+      ),
+      expectedCodeV1 = INVALID_ARGUMENT,
+      expectedDescriptionV1 =
+        s"Invalid field deduplication_period: The given deduplication duration of ${java.time.Duration
+          .ofSeconds(durationSecondsExceedingMax)} exceeds the maximum deduplication time of ${maxDeduplicationDuration}",
+      expectedCodeV2 = FAILED_PRECONDITION,
+      expectedDescriptionV2 =
+        s"INVALID_DEDUPLICATION_PERIOD(9,0): The submitted command had an invalid deduplication period: The given deduplication duration of ${java.time.Duration
+          .ofSeconds(durationSecondsExceedingMax)} exceeds the maximum deduplication time of ${maxDeduplicationDuration}",
+      metadataV2 = Map(
+        ValidMaxDeduplicationFieldKey -> maxDeduplicationDuration.toString
+      ),
+    )
+  }
+}

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidatorSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidatorSpec.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.platform.server.api.validation
 
 import java.time

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationPeriodValidationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationPeriodValidationIT.scala
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.suites
+
+import java.util.regex.Pattern
+
+import com.daml.error.definitions.LedgerApiErrors
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
+import com.daml.ledger.api.testtool.infrastructure.Assertions._
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
+import com.daml.ledger.test.model.Test.Dummy
+import io.grpc.Status
+
+class CommandDeduplicationPeriodValidationIT extends LedgerTestSuite {
+
+  test(
+    "ValidDeduplicationDuration",
+    "Submission returns OK if deduplication time is within the accepted interval",
+    allocate(SingleParty),
+  )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    // Submission using the maximum allowed deduplication time
+    val request = ledger.submitRequest(party, Dummy(party).create.command)
+    for {
+      config <- ledger.configuration()
+      maxDedupTime = config.maxDeduplicationTime.get
+      _ <- ledger.submit(request.update(_.commands.deduplicationTime := maxDedupTime))
+    } yield {
+      // No assertions to make, since the command went through as expected
+    }
+  })
+
+  test(
+    "DeduplicationDurationExceedsMaxDeduplicationDuration",
+    "Submission returns expected error codes if deduplication time is too big",
+    allocate(SingleParty),
+  )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    val request = ledger.submitRequest(party, Dummy(party).create.command)
+    for {
+      config <- ledger.configuration()
+      maxDedupTime = config.maxDeduplicationTime.get
+      failure <- ledger
+        .submit(
+          request.update(
+            _.commands.deduplicationTime := maxDedupTime.update(
+              _.seconds := maxDedupTime.seconds + 1
+            )
+          )
+        )
+        .mustFail("submitting a command with a deduplication time that is too big")
+    } yield {
+      val expectedCode =
+        if (ledger.features.selfServiceErrorCodes) Status.Code.FAILED_PRECONDITION
+        else Status.Code.INVALID_ARGUMENT
+      val expectedError =
+        if (ledger.features.selfServiceErrorCodes)
+          LedgerApiErrors.RequestValidation.InvalidDeduplicationPeriodField
+        else LedgerApiErrors.RequestValidation.InvalidField
+      assertGrpcErrorRegex(
+        ledger,
+        failure,
+        expectedCode,
+        expectedError,
+        Some(
+          Pattern.compile(
+            "The given deduplication .+ exceeds the maximum deduplication .+"
+          )
+        ),
+      )
+    }
+  })
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/LedgerConfigurationServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/LedgerConfigurationServiceIT.scala
@@ -3,13 +3,10 @@
 
 package com.daml.ledger.api.testtool.suites
 
-import java.util.regex.Pattern
-
 import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
-import com.daml.ledger.test.model.Test.Dummy
 import io.grpc.Status
 
 class LedgerConfigurationServiceIT extends LedgerTestSuite {
@@ -45,59 +42,4 @@ class LedgerConfigurationServiceIT extends LedgerTestSuite {
     }
   )
 
-  test(
-    "CSLSuccessIfMaxDedplicationTimeRight",
-    "Submission returns OK if deduplication time is within the accepted interval",
-    allocate(SingleParty),
-  )(implicit ec => { case Participants(Participant(ledger, party)) =>
-    // Submission using the maximum allowed deduplication time
-    val request = ledger.submitRequest(party, Dummy(party).create.command)
-    for {
-      config <- ledger.configuration()
-      maxDedupTime = config.maxDeduplicationTime.get
-      _ <- ledger.submit(request.update(_.commands.deduplicationTime := maxDedupTime))
-    } yield {
-      // No assertions to make, since the command went through as expected
-    }
-  })
-
-  test(
-    "CSLSuccessIfMaxDeduplicationTimeExceeded",
-    "Submission returns expected error codes if deduplication time is too big",
-    allocate(SingleParty),
-  )(implicit ec => { case Participants(Participant(ledger, party)) =>
-    val request = ledger.submitRequest(party, Dummy(party).create.command)
-    for {
-      config <- ledger.configuration()
-      maxDedupTime = config.maxDeduplicationTime.get
-      failure <- ledger
-        .submit(
-          request.update(
-            _.commands.deduplicationTime := maxDedupTime.update(
-              _.seconds := maxDedupTime.seconds + 1
-            )
-          )
-        )
-        .mustFail("submitting a command with a deduplication time that is too big")
-    } yield {
-      val expectedCode =
-        if (ledger.features.selfServiceErrorCodes) Status.Code.FAILED_PRECONDITION
-        else Status.Code.INVALID_ARGUMENT
-      val expectedError =
-        if (ledger.features.selfServiceErrorCodes)
-          LedgerApiErrors.RequestValidation.InvalidDeduplicationPeriodField
-        else LedgerApiErrors.RequestValidation.InvalidField
-      assertGrpcErrorRegex(
-        ledger,
-        failure,
-        expectedCode,
-        expectedError,
-        Some(
-          Pattern.compile(
-            "The given deduplication .+ exceeds the maximum deduplication .+"
-          )
-        ),
-      )
-    }
-  })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Tests.scala
@@ -72,6 +72,7 @@ object Tests {
       new CompletionDeduplicationInfoIT(CommandService),
       new CompletionDeduplicationInfoIT(CommandSubmissionService),
       new CommandDeduplicationParallelIT,
+      new CommandDeduplicationPeriodValidationIT,
       new ContractIdIT,
       new KVCommandDeduplicationIT(timeoutScaleFactor, ledgerClockGranularity, staticTime),
       new MultiPartySubmissionIT,

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -153,6 +153,7 @@ conformance_test(
         # Notoriously times-out
         #"--additional=ParticipantPruningIT",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",
@@ -180,6 +181,7 @@ conformance_test(
         # Notoriously times-out
         #"--additional=ParticipantPruningIT",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",
@@ -210,6 +212,7 @@ conformance_test(
         "--additional=KVCommandDeduplicationIT",
         # The following two tests don't actually care about multi-participant but they do need append-only.
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--exclude=CommandDeduplicationIT",  # It's a KV ledger so it needs the KV variant
@@ -235,6 +238,7 @@ conformance_test(
         # Notoriously times-out
         #"--additional=ParticipantPruningIT",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -318,6 +318,7 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",
@@ -344,6 +345,7 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",
@@ -369,6 +371,7 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",
@@ -395,6 +398,7 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",
@@ -422,6 +426,7 @@ conformance_test(
         "--verbose",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",
         "--additional=ParticipantPruningIT",

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -9,12 +9,7 @@ import java.util.UUID
 import com.daml.api.util.TimeProvider
 import com.daml.error.ErrorCode.LoggingApiException
 import com.daml.error.definitions.{ErrorCauseExport, RejectionGenerators}
-import com.daml.error.{
-  ContextualizedErrorLogger,
-  DamlContextualizedErrorLogger,
-  ErrorCause,
-  ErrorCodesVersionSwitcher,
-}
+import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger, ErrorCause, ErrorCodesVersionSwitcher}
 import com.daml.ledger.api.domain.{LedgerId, SubmissionId, Commands => ApiCommands}
 import com.daml.ledger.api.messages.command.submission.SubmitRequest
 import com.daml.ledger.api.{DeduplicationPeriod, SubmissionIdGenerator}
@@ -37,6 +32,7 @@ import com.daml.platform.server.api.services.domain.CommandSubmissionService
 import com.daml.platform.server.api.services.grpc.GrpcCommandSubmissionService
 import com.daml.platform.server.api.validation.ErrorFactories
 import com.daml.platform.services.time.TimeProviderType
+import com.daml.scalautil.future.FutureConversion.CompletionStageConversionOps
 import com.daml.telemetry.TelemetryContext
 import com.daml.timer.Delayed
 import io.grpc.{Status, StatusRuntimeException}
@@ -328,7 +324,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
         result.transaction,
         result.interpretationTimeNanos,
       )
-      .toScala
+      .toScalaUnwrapped
   }
 
   /** This method encodes logic related to legacy error codes (V1).

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -9,7 +9,12 @@ import java.util.UUID
 import com.daml.api.util.TimeProvider
 import com.daml.error.ErrorCode.LoggingApiException
 import com.daml.error.definitions.{ErrorCauseExport, RejectionGenerators}
-import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger, ErrorCause, ErrorCodesVersionSwitcher}
+import com.daml.error.{
+  ContextualizedErrorLogger,
+  DamlContextualizedErrorLogger,
+  ErrorCause,
+  ErrorCodesVersionSwitcher,
+}
 import com.daml.ledger.api.domain.{LedgerId, SubmissionId, Commands => ApiCommands}
 import com.daml.ledger.api.messages.command.submission.SubmitRequest
 import com.daml.ledger.api.{DeduplicationPeriod, SubmissionIdGenerator}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupport.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupport.scala
@@ -39,7 +39,7 @@ class DeduplicationPeriodSupport(
   ): Future[DeduplicationPeriod] = {
     val validatedDeduplicationPeriod = deduplicationPeriod match {
       case period: DeduplicationPeriod.DeduplicationDuration =>
-        Future.successful(Right(period))
+        Future { validation.validate(period, maxDeduplicationDuration) }
       case DeduplicationPeriod.DeduplicationOffset(offset) =>
         converter
           .convertOffsetToDuration(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupportSpec.scala
@@ -47,7 +47,7 @@ class DeduplicationPeriodSupportSpec
         }
     }
 
-    "valid and return failure" in {
+    "validate and return failure" in {
       val fixture = getFixture
       import fixture._
       when(

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -367,6 +367,8 @@ server_conformance_test(
         # sandbox classic has support only for participant side deduplication,
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
+        # not enforced
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
     ],
 )
 
@@ -399,6 +401,8 @@ server_conformance_test(
         # sandbox classic has support only for participant side deduplication,
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
+        # not enforced
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
     ],
 )
 
@@ -423,6 +427,8 @@ server_conformance_test(
         # sandbox classic has support only for participant side deduplication,
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
+        # not enforced
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
     ],
 )
 
@@ -447,6 +453,8 @@ server_conformance_test(
         # sandbox classic has support only for participant side deduplication,
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
+        # not enforced
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
     ],
 )
 

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -355,6 +355,7 @@ server_conformance_test(
         "--timeout-scale-factor=2",  # sandbox classic is slow in general
         "--open-world",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=ContractIdIT:Accept",
@@ -386,6 +387,7 @@ server_conformance_test(
         "--timeout-scale-factor=2",  # sandbox classic is slow in general
         "--open-world",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=ContractIdIT:Accept",
@@ -413,6 +415,7 @@ server_conformance_test(
         "--timeout-scale-factor=2",  # sandbox classic is slow in general
         "--open-world",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--exclude=ClosedWorldIT",
@@ -436,6 +439,7 @@ server_conformance_test(
         "--timeout-scale-factor=2",  # sandbox classic is slow in general
         "--open-world",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--exclude=ClosedWorldIT",

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -368,7 +368,7 @@ server_conformance_test(
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
         # not enforced
-        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration",
     ],
 )
 
@@ -402,7 +402,7 @@ server_conformance_test(
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
         # not enforced
-        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration",
     ],
 )
 
@@ -428,7 +428,7 @@ server_conformance_test(
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
         # not enforced
-        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration",
     ],
 )
 
@@ -454,7 +454,7 @@ server_conformance_test(
         # which in turn only has support for durations as deduplication periods
         "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
         # not enforced
-        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration"
+        "--exclude=CommandDeduplicationPeriodValidationIT:DeduplicationDurationExceedsMaxDeduplicationDuration",
     ],
 )
 

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -274,6 +274,7 @@ conformance_test(
     test_tool_args = [
         "--open-world",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",
@@ -311,6 +312,7 @@ conformance_test(
         "--static-time",
         "--open-world",
         "--additional=CommandDeduplicationParallelIT",
+        "--additional=CommandDeduplicationPeriodValidationIT",
         "--additional=CompletionDeduplicationInfoITCommandService",
         "--additional=CompletionDeduplicationInfoITCommandSubmissionService",
         "--additional=KVCommandDeduplicationIT",


### PR DESCRIPTION
- Do not validate the max deduplication duration in the ledeger API but pass it to the Write Service and leave it up to the write service to validate it

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
