### PR TITLE
Introducing DbSupport, pulling up DbDispatcher building in the factor…

### DIFF
--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/interceptor/AuthorizationInterceptor.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/interceptor/AuthorizationInterceptor.scala
@@ -21,7 +21,7 @@ import scala.util.{Failure, Success, Try}
   */
 final class AuthorizationInterceptor(
     authService: AuthService,
-    userManagementService: UserManagementStore,
+    userManagementStore: UserManagementStore,
     implicit val ec: ExecutionContext,
     errorCodesVersionSwitcher: ErrorCodesVersionSwitcher,
 )(implicit loggingContext: LoggingContext)
@@ -82,7 +82,7 @@ final class AuthorizationInterceptor(
               errorFactories.invalidArgument(None)(s"token $err")(errorLogger)
             )
           case Right(userId) =>
-            userManagementService
+            userManagementStore
               .listUserRights(userId)
               .flatMap {
                 case Left(msg) =>
@@ -132,11 +132,11 @@ object AuthorizationInterceptor {
 
   def apply(
       authService: AuthService,
-      userManagementService: UserManagementStore,
+      userManagementStore: UserManagementStore,
       ec: ExecutionContext,
       errorCodesStatusSwitcher: ErrorCodesVersionSwitcher,
   ): AuthorizationInterceptor =
     LoggingContext.newLoggingContext { implicit loggingContext: LoggingContext =>
-      new AuthorizationInterceptor(authService, userManagementService, ec, errorCodesStatusSwitcher)
+      new AuthorizationInterceptor(authService, userManagementStore, ec, errorCodesStatusSwitcher)
     }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -77,7 +77,7 @@ private[daml] object ApiServices {
       participantId: Ref.ParticipantId,
       optWriteService: Option[state.WriteService],
       indexService: IndexService,
-      userManagementService: UserManagementStore,
+      userManagementStore: UserManagementStore,
       authorizer: Authorizer,
       engine: Engine,
       timeProvider: TimeProvider,
@@ -204,7 +204,7 @@ private[daml] object ApiServices {
       val apiHealthService = new GrpcHealthService(healthChecks, errorsVersionsSwitcher)
 
       val apiUserManagementService =
-        new ApiUserManagementService(userManagementService, errorsVersionsSwitcher)
+        new ApiUserManagementService(userManagementStore, errorsVersionsSwitcher)
 
       apiTimeServiceOpt.toList :::
         writeServiceBackedApiServices :::

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneIndexService.scala
@@ -15,15 +15,15 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Engine, ValueEnricher}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
-import com.daml.platform.configuration.ServerRole
 import com.daml.platform.index.JdbcIndex
 import com.daml.platform.packages.InMemoryPackageStore
-import com.daml.platform.store.LfValueTranslationCache
+import com.daml.platform.store.{DbSupport, LfValueTranslationCache}
 
 import scala.concurrent.ExecutionContextExecutor
 
 object StandaloneIndexService {
   def apply(
+      dbSupport: DbSupport,
       ledgerId: LedgerId,
       config: ApiServerConfig,
       metrics: Metrics,
@@ -74,12 +74,9 @@ object StandaloneIndexService {
       })
       indexService <- JdbcIndex
         .owner(
-          serverRole = ServerRole.ApiServer,
+          dbSupport = dbSupport,
           ledgerId = domain.LedgerId(ledgerId),
           participantId = participantId,
-          jdbcUrl = config.jdbcUrl,
-          databaseConnectionPoolSize = config.databaseConnectionPoolSize,
-          databaseConnectionTimeout = config.databaseConnectionTimeout,
           eventsPageSize = config.eventsPageSize,
           eventsProcessingParallelism = config.eventsProcessingParallelism,
           acsIdPageSize = config.acsIdPageSize,

--- a/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
@@ -12,21 +12,16 @@ import com.daml.lf.data.Ref
 import com.daml.lf.engine.ValueEnricher
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
-import com.daml.platform.configuration.ServerRole
 import com.daml.platform.server.api.validation.ErrorFactories
-import com.daml.platform.store.LfValueTranslationCache
+import com.daml.platform.store.{DbSupport, LfValueTranslationCache}
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
 
 private[platform] object JdbcIndex {
   def owner(
-      serverRole: ServerRole,
+      dbSupport: DbSupport,
       ledgerId: LedgerId,
       participantId: Ref.ParticipantId,
-      jdbcUrl: String,
-      databaseConnectionPoolSize: Int,
-      databaseConnectionTimeout: FiniteDuration,
       eventsPageSize: Int,
       eventsProcessingParallelism: Int,
       acsIdPageSize: Int,
@@ -45,10 +40,7 @@ private[platform] object JdbcIndex {
       enableSelfServiceErrorCodes: Boolean,
   )(implicit mat: Materializer, loggingContext: LoggingContext): ResourceOwner[IndexService] =
     new ReadOnlySqlLedger.Owner(
-      serverRole = serverRole,
-      jdbcUrl = jdbcUrl,
-      databaseConnectionPoolSize = databaseConnectionPoolSize,
-      databaseConnectionTimeout = databaseConnectionTimeout,
+      dbSupport = dbSupport,
       initialLedgerId = ledgerId,
       eventsPageSize = eventsPageSize,
       eventsProcessingParallelism = eventsProcessingParallelism,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/DbSupport.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/DbSupport.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store
+
+import com.daml.ledger.resources.{ResourceContext, ResourceOwner}
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.configuration.ServerRole
+import com.daml.platform.store.appendonlydao.DbDispatcher
+import com.daml.platform.store.backend.StorageBackendFactory
+import com.daml.resources.{PureResource, Resource}
+
+import scala.concurrent.duration.FiniteDuration
+
+case class DbSupport(
+    dbDispatcher: DbDispatcher,
+    storageBackendFactory: StorageBackendFactory,
+)
+
+object DbSupport {
+  def owner(
+      jdbcUrl: String,
+      serverRole: ServerRole,
+      connectionPoolSize: Int,
+      connectionTimeout: FiniteDuration,
+      metrics: Metrics,
+  )(implicit loggingContext: LoggingContext): ResourceOwner[DbSupport] = {
+    val dbType = DbType.jdbcType(jdbcUrl)
+    val storageBackendFactory = StorageBackendFactory.of(dbType)
+    DbDispatcher
+      .owner(
+        dataSource = storageBackendFactory.createDataSourceStorageBackend.createDataSource(jdbcUrl),
+        serverRole = serverRole,
+        connectionPoolSize = connectionPoolSize,
+        connectionTimeout = connectionTimeout,
+        metrics = metrics,
+      )
+      .map(dbDispatcher =>
+        DbSupport(
+          dbDispatcher = dbDispatcher,
+          storageBackendFactory = storageBackendFactory,
+        )
+      )
+  }
+
+  def migratedOwner(
+      jdbcUrl: String,
+      serverRole: ServerRole,
+      connectionPoolSize: Int,
+      connectionTimeout: FiniteDuration,
+      metrics: Metrics,
+  )(implicit loggingContext: LoggingContext): ResourceOwner[DbSupport] = {
+    val migrationOwner = new ResourceOwner[Unit] {
+      override def acquire()(implicit context: ResourceContext): Resource[ResourceContext, Unit] =
+        PureResource(new FlywayMigrations(jdbcUrl).migrate())
+    }
+
+    for {
+      _ <- migrationOwner
+      dbSupport <- owner(
+        jdbcUrl = jdbcUrl,
+        serverRole = serverRole,
+        connectionPoolSize = connectionPoolSize,
+        connectionTimeout = connectionTimeout,
+        metrics = metrics,
+      )
+    } yield dbSupport
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/JdbcLedgerDao.scala
@@ -37,7 +37,6 @@ import com.daml.platform.store.backend.{
   ParameterStorageBackend,
   ReadStorageBackend,
   ResetStorageBackend,
-  StorageBackendFactory,
 }
 import com.daml.platform.store.cache.LedgerEndCache
 import com.daml.platform.store.entries.{
@@ -777,7 +776,7 @@ private[platform] object JdbcLedgerDao {
   }
 
   def read(
-      dbDispatcher: DbDispatcher,
+      dbSupport: DbSupport,
       eventsPageSize: Int,
       eventsProcessingParallelism: Int,
       acsIdPageSize: Int,
@@ -790,14 +789,13 @@ private[platform] object JdbcLedgerDao {
       enricher: Option[ValueEnricher],
       participantId: Ref.ParticipantId,
       errorFactories: ErrorFactories,
-      storageBackendFactory: StorageBackendFactory,
       ledgerEndCache: LedgerEndCache,
       stringInterning: StringInterning,
       materializer: Materializer,
   ): LedgerReadDao =
     new MeteredLedgerReadDao(
       new JdbcLedgerDao(
-        dbDispatcher,
+        dbSupport.dbDispatcher,
         servicesExecutionContext,
         eventsPageSize,
         eventsProcessingParallelism,
@@ -812,10 +810,10 @@ private[platform] object JdbcLedgerDao {
         enricher,
         SequentialWriteDao.noop,
         participantId,
-        storageBackendFactory.readStorageBackend(ledgerEndCache, stringInterning),
-        storageBackendFactory.createParameterStorageBackend,
-        storageBackendFactory.createDeduplicationStorageBackend,
-        storageBackendFactory.createResetStorageBackend,
+        dbSupport.storageBackendFactory.readStorageBackend(ledgerEndCache, stringInterning),
+        dbSupport.storageBackendFactory.createParameterStorageBackend,
+        dbSupport.storageBackendFactory.createDeduplicationStorageBackend,
+        dbSupport.storageBackendFactory.createResetStorageBackend,
         errorFactories,
         materializer = materializer,
       ),
@@ -823,7 +821,7 @@ private[platform] object JdbcLedgerDao {
     )
 
   def write(
-      dbDispatcher: DbDispatcher,
+      dbSupport: DbSupport,
       sequentialWriteDao: SequentialWriteDao,
       eventsPageSize: Int,
       eventsProcessingParallelism: Int,
@@ -837,14 +835,13 @@ private[platform] object JdbcLedgerDao {
       enricher: Option[ValueEnricher],
       participantId: Ref.ParticipantId,
       errorFactories: ErrorFactories,
-      storageBackendFactory: StorageBackendFactory,
       ledgerEndCache: LedgerEndCache,
       stringInterning: StringInterning,
       materializer: Materializer,
   ): LedgerDao =
     new MeteredLedgerDao(
       new JdbcLedgerDao(
-        dbDispatcher,
+        dbSupport.dbDispatcher,
         servicesExecutionContext,
         eventsPageSize,
         eventsProcessingParallelism,
@@ -859,10 +856,10 @@ private[platform] object JdbcLedgerDao {
         enricher,
         sequentialWriteDao,
         participantId,
-        storageBackendFactory.readStorageBackend(ledgerEndCache, stringInterning),
-        storageBackendFactory.createParameterStorageBackend,
-        storageBackendFactory.createDeduplicationStorageBackend,
-        storageBackendFactory.createResetStorageBackend,
+        dbSupport.storageBackendFactory.readStorageBackend(ledgerEndCache, stringInterning),
+        dbSupport.storageBackendFactory.createParameterStorageBackend,
+        dbSupport.storageBackendFactory.createDeduplicationStorageBackend,
+        dbSupport.storageBackendFactory.createResetStorageBackend,
         errorFactories,
         materializer = materializer,
       ),
@@ -870,7 +867,7 @@ private[platform] object JdbcLedgerDao {
     )
 
   def validatingWrite(
-      dbDispatcher: DbDispatcher,
+      dbSupport: DbSupport,
       sequentialWriteDao: SequentialWriteDao,
       eventsPageSize: Int,
       eventsProcessingParallelism: Int,
@@ -885,14 +882,13 @@ private[platform] object JdbcLedgerDao {
       enricher: Option[ValueEnricher],
       participantId: Ref.ParticipantId,
       errorFactories: ErrorFactories,
-      storageBackendFactory: StorageBackendFactory,
       ledgerEndCache: LedgerEndCache,
       stringInterning: StringInterning,
       materializer: Materializer,
   ): LedgerDao =
     new MeteredLedgerDao(
       new JdbcLedgerDao(
-        dbDispatcher,
+        dbSupport.dbDispatcher,
         servicesExecutionContext,
         eventsPageSize,
         eventsProcessingParallelism,
@@ -907,10 +903,10 @@ private[platform] object JdbcLedgerDao {
         enricher,
         sequentialWriteDao,
         participantId,
-        storageBackendFactory.readStorageBackend(ledgerEndCache, stringInterning),
-        storageBackendFactory.createParameterStorageBackend,
-        storageBackendFactory.createDeduplicationStorageBackend,
-        storageBackendFactory.createResetStorageBackend,
+        dbSupport.storageBackendFactory.readStorageBackend(ledgerEndCache, stringInterning),
+        dbSupport.storageBackendFactory.createParameterStorageBackend,
+        dbSupport.storageBackendFactory.createDeduplicationStorageBackend,
+        dbSupport.storageBackendFactory.createResetStorageBackend,
         errorFactories,
         materializer,
       ),

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -20,7 +20,6 @@ import com.daml.lf.transaction.TransactionCommitter
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.common.LedgerIdMode
-import com.daml.platform.configuration.ServerRole
 import com.daml.platform.index.LedgerBackedIndexService
 import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.sandbox.LedgerIdGenerator
@@ -30,7 +29,7 @@ import com.daml.platform.sandbox.stores.ledger.inmemory.InMemoryLedger
 import com.daml.platform.sandbox.stores.ledger.sql.{SqlLedger, SqlStartMode}
 import com.daml.platform.sandbox.stores.ledger.{Ledger, MeteredLedger}
 import com.daml.platform.server.api.validation.ErrorFactories
-import com.daml.platform.store.LfValueTranslationCache
+import com.daml.platform.store.{DbSupport, LfValueTranslationCache}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -50,9 +49,7 @@ private[sandbox] object SandboxIndexAndWriteService {
       name: LedgerName,
       providedLedgerId: LedgerIdMode,
       participantId: Ref.ParticipantId,
-      jdbcUrl: String,
-      databaseConnectionPoolSize: Int,
-      databaseConnectionTimeout: FiniteDuration,
+      dbSupport: DbSupport,
       timeProvider: TimeProvider,
       ledgerEntries: ImmArray[LedgerEntryOrBump],
       startMode: SqlStartMode,
@@ -78,10 +75,7 @@ private[sandbox] object SandboxIndexAndWriteService {
   ): ResourceOwner[IndexAndWriteService] =
     new SqlLedger.Owner(
       name = name,
-      serverRole = ServerRole.Sandbox,
-      jdbcUrl = jdbcUrl,
-      databaseConnectionPoolSize = databaseConnectionPoolSize,
-      databaseConnectionTimeout = databaseConnectionTimeout,
+      dbSupport = dbSupport,
       providedLedgerId = providedLedgerId,
       participantId = domain.ParticipantId(participantId),
       timeProvider = timeProvider,

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/MetricsAround.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/MetricsAround.scala
@@ -9,11 +9,11 @@ import org.scalatest.BeforeAndAfterAll
 trait MetricsAround extends BeforeAndAfterAll {
   self: org.scalatest.Suite =>
 
-  @volatile protected var metrics: MetricRegistry = _
+  @volatile protected var metricRegistry: MetricRegistry = _
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    metrics = new MetricRegistry
+    metricRegistry = new MetricRegistry
   }
 
   override protected def afterAll(): Unit = {

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -62,7 +62,7 @@ class TransactionTimeModelComplianceIT
       case BackendType.InMemory =>
         LedgerResource.inMemory(ledgerId, timeProvider, errorCodesVersionSwitcher)
       case BackendType.Postgres =>
-        LedgerResource.postgres(getClass, ledgerId, timeProvider, metrics, errorFactories)
+        LedgerResource.postgres(getClass, ledgerId, timeProvider, metricRegistry, errorFactories)
     }
   }
 

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -35,7 +35,7 @@ import com.daml.platform.sandbox.config.LedgerName
 import com.daml.platform.sandbox.stores.ledger.Ledger
 import com.daml.platform.sandbox.stores.ledger.sql.SqlLedgerSpec._
 import com.daml.platform.server.api.validation.ErrorFactories
-import com.daml.platform.store.{IndexMetadata, LfValueTranslationCache}
+import com.daml.platform.store.{DbSupport, DbType, IndexMetadata, LfValueTranslationCache}
 import com.daml.platform.testing.LogCollector
 import com.daml.testing.postgresql.PostgresAroundEach
 import com.daml.timer.RetryStrategy
@@ -46,9 +46,9 @@ import org.scalatest.concurrent.{AsyncTimeLimitedTests, Eventually, ScaledTimeSp
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Minute, Seconds, Span}
 import org.scalatest.wordspec.AsyncWordSpec
-
 import java.io.File
 import java.time.{Duration, Instant}
+
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
@@ -421,38 +421,48 @@ final class SqlLedgerSpec
       packages: List[DamlLf.Archive],
       timeProvider: TimeProvider = TimeProvider.UTC,
   ): Future[Ledger] = {
-    metrics.getNames.forEach(name => { val _ = metrics.remove(name) })
-    val ledger =
-      new SqlLedger.Owner(
-        name = LedgerName(getClass.getSimpleName),
-        serverRole = ServerRole.Testing(getClass),
-        jdbcUrl = postgresDatabase.url,
-        databaseConnectionPoolSize = 16,
-        databaseConnectionTimeout = 250.millis,
-        providedLedgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
-        participantId = participantId.getOrElse(DefaultParticipantId),
-        timeProvider = timeProvider,
-        packages = InMemoryPackageStore.empty
-          .withPackages(Timestamp.Epoch, None, packages)
-          .fold(sys.error, identity),
-        initialLedgerEntries = ImmArray.Empty,
-        queueDepth = queueDepth,
-        transactionCommitter = LegacyTransactionCommitter,
-        startMode = SqlStartMode.MigrateAndStart,
-        eventsPageSize = 100,
-        eventsProcessingParallelism = 8,
-        acsIdPageSize = 2000,
-        acsIdFetchingParallelism = 2,
-        acsContractFetchingParallelism = 2,
-        acsGlobalParallelism = 10,
-        servicesExecutionContext = executionContext,
-        metrics = new Metrics(metrics),
-        lfValueTranslationCache = LfValueTranslationCache.Cache.none,
-        engine = new Engine(),
-        validatePartyAllocation = false,
-        enableCompression = false,
-        errorFactories = ErrorFactories(new ErrorCodesVersionSwitcher(true)),
-      ).acquire()(ResourceContext(system.dispatcher))
+    metricRegistry.getNames.forEach(name => { val _ = metricRegistry.remove(name) })
+    val ledger = {
+      val metrics = new Metrics(metricRegistry)
+      for {
+        dbSupport <- DbSupport.migratedOwner(
+          jdbcUrl = postgresDatabase.url,
+          serverRole = ServerRole.Testing(getClass),
+          connectionPoolSize = DbType
+            .jdbcType(postgresDatabase.url)
+            .maxSupportedWriteConnections(16),
+          connectionTimeout = 250.millis,
+          metrics = metrics,
+        )
+        ledger <- new SqlLedger.Owner(
+          name = LedgerName(getClass.getSimpleName),
+          dbSupport = dbSupport,
+          providedLedgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
+          participantId = participantId.getOrElse(DefaultParticipantId),
+          timeProvider = timeProvider,
+          packages = InMemoryPackageStore.empty
+            .withPackages(Timestamp.Epoch, None, packages)
+            .fold(sys.error, identity),
+          initialLedgerEntries = ImmArray.Empty,
+          queueDepth = queueDepth,
+          transactionCommitter = LegacyTransactionCommitter,
+          startMode = SqlStartMode.MigrateAndStart,
+          eventsPageSize = 100,
+          eventsProcessingParallelism = 8,
+          acsIdPageSize = 2000,
+          acsIdFetchingParallelism = 2,
+          acsContractFetchingParallelism = 2,
+          acsGlobalParallelism = 10,
+          servicesExecutionContext = executionContext,
+          metrics = metrics,
+          lfValueTranslationCache = LfValueTranslationCache.Cache.none,
+          engine = new Engine(),
+          validatePartyAllocation = false,
+          enableCompression = false,
+          errorFactories = ErrorFactories(new ErrorCodesVersionSwitcher(true)),
+        )
+      } yield ledger
+    }.acquire()(ResourceContext(system.dispatcher))
     createdLedgers += ledger
     ledger.asFuture
   }


### PR DESCRIPTION
…y hierarchies

This PR prepares the landscape for seamless integration of Index DB with non IndexService related
front components like UserManagementStore.
DbSupport is a simply a DbDispatcher and a StorageBackendFactory. Creation of it comes also in Flyway migrated flavor for capturing common need.
This is a pure refactoring PR: no behavior/feature changes

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
