### PR TITLE
revert to use synopsys detect 7.1.0

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -349,7 +349,7 @@ jobs:
 
   - job: blackduck_scan
     timeoutInMinutes: 1200
-    condition: eq(variables['Build.SourceBranchName'], 'not-main')
+    condition: eq(variables['Build.SourceBranchName'], 'main')
     pool:
       name: ubuntu_20_04
       demands: assignment -equals default
@@ -438,13 +438,13 @@ jobs:
         displayName: open PR
         name: out
         condition: and(succeeded(),
-                       eq(variables['Build.SourceBranchName'], 'not-main'))
+                       eq(variables['Build.SourceBranchName'], 'main'))
 
   - job: run_notices_pr_build
     timeoutInMinutes: 60
     dependsOn: ["blackduck_scan"]
     condition: and(succeeded(),
-                   eq(variables['Build.SourceBranchName'], 'not-main'))
+                   eq(variables['Build.SourceBranchName'], 'main'))
     pool:
       vmImage: ubuntu-20.04
     variables:

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -376,7 +376,7 @@ jobs:
           #code location name uniquely identified to avoid stomping
           BAZEL_DEPENDENCY_TYPE="haskell_cabal_library"
 
-          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/revert-detect-7.9.0/synopsys-detect) \
           ci-build digital-asset_daml $(Build.SourceBranchName) \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
@@ -396,7 +396,7 @@ jobs:
           #by qualifying as a maven_install (aka jvm) bazel blackduck scan
           BAZEL_DEPENDENCY_TYPE="maven_install"
 
-          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/revert-detect-7.9.0/synopsys-detect) \
           ci-build digital-asset_daml $(Build.SourceBranchName) \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -349,7 +349,7 @@ jobs:
 
   - job: blackduck_scan
     timeoutInMinutes: 1200
-    condition: eq(variables['Build.SourceBranchName'], 'revert-to-blackduck-detect-7.1.0')
+    condition: eq(variables['Build.SourceBranchName'], 'not-main')
     pool:
       name: ubuntu_20_04
       demands: assignment -equals default
@@ -438,13 +438,13 @@ jobs:
         displayName: open PR
         name: out
         condition: and(succeeded(),
-                       eq(variables['Build.SourceBranchName'], 'revert-to-blackduck-detect-7.1.0'))
+                       eq(variables['Build.SourceBranchName'], 'not-main'))
 
   - job: run_notices_pr_build
     timeoutInMinutes: 60
     dependsOn: ["blackduck_scan"]
     condition: and(succeeded(),
-                   eq(variables['Build.SourceBranchName'], 'revert-to-blackduck-detect-7.1.0'))
+                   eq(variables['Build.SourceBranchName'], 'not-main'))
     pool:
       vmImage: ubuntu-20.04
     variables:

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -349,7 +349,7 @@ jobs:
 
   - job: blackduck_scan
     timeoutInMinutes: 1200
-    condition: eq(variables['Build.SourceBranchName'], 'main')
+    condition: eq(variables['Build.SourceBranchName'], 'revert-to-blackduck-detect-7.1.0')
     pool:
       name: ubuntu_20_04
       demands: assignment -equals default
@@ -438,13 +438,13 @@ jobs:
         displayName: open PR
         name: out
         condition: and(succeeded(),
-                       eq(variables['Build.SourceBranchName'], 'main'))
+                       eq(variables['Build.SourceBranchName'], 'revert-to-blackduck-detect-7.1.0'))
 
   - job: run_notices_pr_build
     timeoutInMinutes: 60
     dependsOn: ["blackduck_scan"]
     condition: and(succeeded(),
-                   eq(variables['Build.SourceBranchName'], 'main'))
+                   eq(variables['Build.SourceBranchName'], 'revert-to-blackduck-detect-7.1.0'))
     pool:
       vmImage: ubuntu-20.04
     variables:


### PR DESCRIPTION
Revert to use prior synopsys detect 7.1.0 version that was used last week before blackduck scans started timing out