### PR TITLE
Add conversions for CompletionStage to Future which unwraps failures

### DIFF
--- a/libs-scala/scala-utils/src/main/scala/com/daml/scalautil/future/FutureConversion.scala
+++ b/libs-scala/scala-utils/src/main/scala/com/daml/scalautil/future/FutureConversion.scala
@@ -1,0 +1,29 @@
+package com.daml.scalautil.future
+
+import java.util.concurrent.{CompletionException, CompletionStage}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.javaapi.FutureConverters
+
+object FutureConversion {
+
+  /** Converts a java [[CompletionStage]] into a scala [[Future]]
+    * Java [[CompletionStage]] wraps any exception that causes failure into a [[CompletionException]]
+    * Compared to the standard library conversions found in [[scala.jdk.FutureConverters]]
+    * this conversion unwraps any failure and fails the future with the root cause found in the [[CompletionException]]
+    */
+  def toScalaUnwrapped[T](cs: CompletionStage[T]): Future[T] = {
+    FutureConverters
+      .asScala(cs)
+      .recover {
+        case ex: CompletionException if ex.getCause != null =>
+          throw ex.getCause
+      }(ExecutionContext.parasitic)
+  }
+
+  implicit class CompletionStageConversionOps[T](private val cs: CompletionStage[T])
+      extends AnyVal {
+    def toScalaUnwrapped: Future[T] = FutureConversion.toScalaUnwrapped(cs)
+  }
+
+}

--- a/libs-scala/scala-utils/src/main/scala/com/daml/scalautil/future/FutureConversion.scala
+++ b/libs-scala/scala-utils/src/main/scala/com/daml/scalautil/future/FutureConversion.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.scalautil.future
 
 import java.util.concurrent.{CompletionException, CompletionStage}

--- a/libs-scala/scala-utils/src/main/scala/com/daml/scalautil/future/FutureConversion.scala
+++ b/libs-scala/scala-utils/src/main/scala/com/daml/scalautil/future/FutureConversion.scala
@@ -10,10 +10,10 @@ import scala.jdk.javaapi.FutureConverters
 
 object FutureConversion {
 
-  /** Converts a java [[CompletionStage]] into a scala [[Future]]
-    * Java [[CompletionStage]] wraps any exception that causes failure into a [[CompletionException]]
+  /** Converts a java [[CompletionStage]] into a scala [[Future]].
+    * Java [[CompletionStage]] wraps any exception that causes failure into a [[CompletionException]].
     * Compared to the standard library conversions found in [[scala.jdk.FutureConverters]]
-    * this conversion unwraps any failure and fails the future with the root cause found in the [[CompletionException]]
+    * this conversion unwraps any failure and fails the future with the root cause found in the [[CompletionException]].
     */
   def toScalaUnwrapped[T](cs: CompletionStage[T]): Future[T] = {
     FutureConverters

--- a/libs-scala/scala-utils/src/test/scala/com/daml/scalautil/future/FutureConversionSpec.scala
+++ b/libs-scala/scala-utils/src/test/scala/com/daml/scalautil/future/FutureConversionSpec.scala
@@ -1,0 +1,44 @@
+package com.daml.scalautil.future
+
+import java.util.concurrent.{CompletableFuture, CompletionStage}
+
+import com.daml.scalautil.future.FutureConversionSpec.TestException
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.Future
+import scala.jdk.FutureConverters._
+
+class FutureConversionSpec extends AsyncWordSpec with Matchers {
+  import FutureConversion._
+  "converting a java CompletionStage into a scala Future" should {
+    "fail the future with the same exception as the CompletionStage" in {
+      val exception = new TestException
+      // build a completion stage that fails with CompletionException
+      // this is NOT the same as CompletableFuture.failedStage
+      val cs: CompletionStage[Unit] =
+        CompletableFuture.completedStage(()).thenApply(_ => throw exception)
+      recoverToExceptionIf[TestException](cs.toScalaUnwrapped).map { ex => ex shouldBe exception }
+    }
+
+    "convert futures and have the same result" in {
+      val exception = new TestException
+      val failedFuture = Future.failed(exception)
+      // For the CompletionStage to complete with CompletionException
+      // we need to call whenComplete even if that does not affect the result of the CompletionStage
+      recoverToExceptionIf[TestException](failedFuture.asJava.whenComplete {
+        (_: Unit, _: Throwable) =>
+          ()
+      }.toScalaUnwrapped)
+        .map { ex =>
+          ex shouldBe exception
+        }
+    }
+
+  }
+
+}
+
+object FutureConversionSpec {
+  private class TestException extends RuntimeException
+}

--- a/libs-scala/scala-utils/src/test/scala/com/daml/scalautil/future/FutureConversionSpec.scala
+++ b/libs-scala/scala-utils/src/test/scala/com/daml/scalautil/future/FutureConversionSpec.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.scalautil.future
 
 import java.util.concurrent.{CompletableFuture, CompletionStage}

--- a/libs-scala/scala-utils/src/test/scala/com/daml/scalautil/future/FutureConversionSpec.scala
+++ b/libs-scala/scala-utils/src/test/scala/com/daml/scalautil/future/FutureConversionSpec.scala
@@ -26,7 +26,7 @@ class FutureConversionSpec extends AsyncWordSpec with Matchers {
       // build a completion stage that fails with CompletionException
       // this is NOT the same as CompletableFuture.failedStage
       val cs: CompletionStage[Unit] = CompletableFuture.failedStage(exception)
-      recoverToExceptionIf[TestException](cs.toScalaUnwrapped).map { ex => ex shouldBe exception }
+      recoverToExceptionIf[TestException](cs.toScalaUnwrapped).map(_ shouldBe exception)
     }
 
     "fail the future with the same exception as the CompletionStage when wrapped in a CompletionException" in {
@@ -35,7 +35,7 @@ class FutureConversionSpec extends AsyncWordSpec with Matchers {
       // this is NOT the same as CompletableFuture.failedStage
       val cs: CompletionStage[Unit] =
         CompletableFuture.completedStage(()).thenApply(_ => throw exception)
-      recoverToExceptionIf[TestException](cs.toScalaUnwrapped).map { ex => ex shouldBe exception }
+      recoverToExceptionIf[TestException](cs.toScalaUnwrapped).map(_ shouldBe exception)
     }
 
     "convert futures and have the same result when wrapped in a CompletionException" in {
@@ -46,10 +46,7 @@ class FutureConversionSpec extends AsyncWordSpec with Matchers {
       recoverToExceptionIf[TestException](failedFuture.asJava.whenComplete {
         (_: Unit, _: Throwable) =>
           ()
-      }.toScalaUnwrapped)
-        .map { ex =>
-          ex shouldBe exception
-        }
+      }.toScalaUnwrapped).map(_ shouldBe exception)
     }
 
   }


### PR DESCRIPTION
In some cases failures contained in a CompletionStage are wrapped in a CompletionException. This makes conversions between Future and CompletionStage difficult as it changes the expected failure.

Side-note: The wrapping inside the CompletionStage does not always happen. it seems to happen only when adding an 'action' on the CompletionStage. If we convert a Future into a CompletionStage and back into a Future,without any in-between action, no CompletionException will be involved.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
