### PR TITLE
Refactor daml start options, add true/false to yes/no/auto flags.

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -60,21 +60,7 @@ data Command
     -- `daml new foobar create-daml-app` we also make `daml create-daml-app foobar` work.
     | Init { targetFolderM :: Maybe FilePath }
     | ListTemplates
-    | Start
-      { sandboxPortM :: Maybe SandboxPortSpec
-      , openBrowser :: OpenBrowser
-      , startNavigator :: Maybe StartNavigator
-      , navigatorPort :: NavigatorPort
-      , jsonApiCfg :: JsonApiConfig
-      , onStartM :: Maybe String
-      , waitForSignal :: WaitForSignal
-      , sandboxOptions :: SandboxOptions
-      , navigatorOptions :: NavigatorOptions
-      , jsonApiOptions :: JsonApiOptions
-      , scriptOptions :: ScriptOptions
-      , shutdownStdinClose :: Bool
-      , sandboxClassic :: SandboxClassic
-      }
+    | Start StartOptions
     | Deploy { flags :: LedgerFlags }
     | LedgerListParties { flags :: LedgerFlags, json :: JsonFlag }
     | LedgerAllocateParties { flags :: LedgerFlags, parties :: [String] }
@@ -166,37 +152,21 @@ commandParser = subparser $ fold
     initCmd = Init
         <$> optional (argument str (metavar "TARGET_PATH" <> help "Project folder to initialize."))
 
-    startCmd = Start
-        <$> optional (option (maybeReader (toSandboxPortSpec <=< readMaybe)) (long "sandbox-port" <> metavar "PORT_NUM" <> help "Port number for the sandbox"))
-        <*> (OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser after navigator" idm)
-        <*> optional navigatorFlag
-        <*> navigatorPortOption
-        <*> jsonApiCfg
-        <*> optional (option str (long "on-start" <> metavar "COMMAND" <> help "Command to run once sandbox and navigator are running."))
-        <*> (WaitForSignal <$> flagYesNoAuto "wait-for-signal" True "Wait for Ctrl+C or interrupt after starting servers." idm)
-        <*> (SandboxOptions <$> many (strOption (long "sandbox-option" <> metavar "SANDBOX_OPTION" <> help "Pass option to sandbox")))
-        <*> (NavigatorOptions <$> many (strOption (long "navigator-option" <> metavar "NAVIGATOR_OPTION" <> help "Pass option to navigator")))
-        <*> (JsonApiOptions <$> many (strOption (long "json-api-option" <> metavar "JSON_API_OPTION" <> help "Pass option to HTTP JSON API")))
-        <*> (ScriptOptions <$> many (strOption (long "script-option" <> metavar "SCRIPT_OPTION" <> help "Pass option to Daml script interpreter")))
-        <*> stdinCloseOpt
-        <*> (SandboxClassic <$> switch (long "sandbox-classic" <> help "Deprecated. Run with Sandbox Classic."))
-
-    navigatorFlag =
-        -- We do not use flagYesNoAuto here since that doesn’t allow us to differentiate
-        -- if the flag was passed explicitly or not.
-        StartNavigator <$>
-        option reader (long "start-navigator" <> help helpText <> completeWith ["true", "false"] <> idm)
-        where
-            reader = eitherReader $ \case
-                -- We allow for both yes and true since we want a boolean in daml.yaml
-                "true" -> Right True
-                "yes" -> Right True
-                "false" -> Right False
-                "no" -> Right False
-                "auto" -> Right True
-                s -> Left ("Expected \"yes\", \"true\", \"no\", \"false\" or \"auto\" but got " <> show s)
-            -- To make things less confusing, we do not mention yes, no and auto here.
-            helpText = "Start navigator as part of daml start. Can be set to true or false. Defaults to true."
+    startCmd = do
+        sandboxPortM <- optional (option (maybeReader (toSandboxPortSpec <=< readMaybe)) (long "sandbox-port" <> metavar "PORT_NUM" <> help "Port number for the sandbox"))
+        shouldOpenBrowser <- flagYesNoAuto "open-browser" True "Open the browser after navigator" idm
+        shouldStartNavigator <- flagYesNoAuto' "start-navigator" "Start navigator as part of daml start. Can be set to true or false. Defaults to true." idm
+        navigatorPort <- navigatorPortOption
+        jsonApiConfig <- jsonApiCfg
+        onStartM <- optional (option str (long "on-start" <> metavar "COMMAND" <> help "Command to run once sandbox and navigator are running."))
+        shouldWaitForSignal <- flagYesNoAuto "wait-for-signal" True "Wait for Ctrl+C or interrupt after starting servers." idm
+        sandboxOptions <- many (strOption (long "sandbox-option" <> metavar "SANDBOX_OPTION" <> help "Pass option to sandbox"))
+        navigatorOptions <- many (strOption (long "navigator-option" <> metavar "NAVIGATOR_OPTION" <> help "Pass option to navigator"))
+        jsonApiOptions <- many (strOption (long "json-api-option" <> metavar "JSON_API_OPTION" <> help "Pass option to HTTP JSON API"))
+        scriptOptions <- many (strOption (long "script-option" <> metavar "SCRIPT_OPTION" <> help "Pass option to Daml script interpreter"))
+        shutdownStdinClose <- stdinCloseOpt
+        sandboxClassic <- SandboxClassic <$> switch (long "sandbox-classic" <> help "Deprecated. Run with Sandbox Classic.")
+        pure $ Start StartOptions {..}
 
     navigatorPortOption = NavigatorPort <$> option auto
         (long "navigator-port"
@@ -473,21 +443,9 @@ runCommand = \case
     CreateDamlApp{..} -> runNew targetFolder (Just "create-daml-app")
     Init {..} -> runInit targetFolderM
     ListTemplates -> runListTemplates
-    Start {..} ->
+    Start options@StartOptions{..} ->
         (if shutdownStdinClose then withCloseOnStdin else id) $
-        runStart
-            sandboxPortM
-            startNavigator
-            navigatorPort
-            jsonApiCfg
-            openBrowser
-            onStartM
-            waitForSignal
-            sandboxOptions
-            navigatorOptions
-            jsonApiOptions
-            scriptOptions
-            sandboxClassic
+        runStart options
     Deploy {..} -> runDeploy flags
     LedgerListParties {..} -> runLedgerListParties flags json
     PackagesList {..} -> runLedgerListPackages0 flags

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -175,7 +175,6 @@ data StartOptions = StartOptions
     , navigatorOptions :: [String]
     , jsonApiOptions :: [String]
     , scriptOptions :: [String]
-    , shutdownStdinClose :: Bool
     , sandboxClassic :: SandboxClassic
     }
 

--- a/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Options/Applicative/Extended.hs
@@ -7,6 +7,7 @@ module Options.Applicative.Extended
     , flagYesNoAuto
     , flagYesNoAuto'
     , determineAuto
+    , determineAutoM
     ) where
 
 import Options.Applicative
@@ -25,16 +26,25 @@ determineAuto b = \case
     Auto -> b
     Yes -> True
 
+-- | Convert YesNoAuto value to Bool by specifying how default value for Auto should be determined, in a monad.
+determineAutoM :: Monad m => m Bool -> YesNoAuto -> m Bool
+determineAutoM m = \case
+    No -> pure False
+    Auto -> m
+    Yes -> pure True
+
 -- | This constructs flags that can be set to yes, no, or auto, with auto being the default.
 -- This maps yes to "Just true", no to "Just False" and auto to "Nothing"
 flagYesNoAuto' :: String -> String -> Mod OptionFields YesNoAuto -> Parser YesNoAuto
 flagYesNoAuto' flagName helpText mods =
-    option reader (long flagName <> value Auto <> help helpText <> completeWith ["yes", "no", "auto"] <> mods)
+    option reader (long flagName <> value Auto <> help helpText <> completeWith ["true", "false", "yes", "no", "auto"] <> mods)
   where reader = eitherReader $ \case
             "yes" -> Right Yes
+            "true" -> Right Yes
             "no" -> Right No
+            "false" -> Right No
             "auto" -> Right Auto
-            s -> Left ("Expected \"yes\", \"no\" or \"auto\" but got " <> show s)
+            s -> Left ("Expected \"yes\", \"true\", \"no\", \"false\", or \"auto\" but got " <> show s)
 
 -- | This constructs flags that can be set to yes, no, or auto to control a boolean value
 -- with auto using the default.


### PR DESCRIPTION
- Refactor the way we pass arguments to daml start. We were relying on
  positional arguments with newtypes, but this was getting cumbersome. I
  changed it to a RecordWildCards-style approach, where we don't need
  quite so many newtypes, and no more positional arguments.

- "--start-navigator" flag had some custom logic to accept "true" and
  "false". I don't see why we can't just accept "true" and "false"
  anywhere we use the "yes/no/auto" flags, so I just added that and
  got rid of the custom logic. (This means we can now use "true" and
  "false" for a lot of assistant options that would only accept "yes",
  "no", or "auto" before.)

- The way "auto" was handled for "--start-navigator" was incorrect, since "auto"
  is supposed to be equivalent the default, i.e. not passing any
  flag. I changed it so auto is equivalent to not passing an argument.
  (I.e. it looks in daml.yaml for the start-navigator option).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
