### PR TITLE
interfaces: fix mkMethod erasure

### DIFF
--- a/compiler/damlc/tests/daml-test-files/Interface.daml
+++ b/compiler/damlc/tests/daml-test-files/Interface.daml
@@ -73,6 +73,7 @@ template Asset
             pure (toInterfaceContractId @Token cid)
 
       let noopImpl = \nothing -> do
+            [1] === [1] -- make sure `mkMethod` calls are properly erased in the presence of polymorphism.
             pure ()
 
 main = scenario do


### PR DESCRIPTION
We erase the call to `mkMethod` in `convertExpr` instead of pattern
matching against the binding. This fixes a bug when the method body
contained statements using typeclass dictionaries such as
`do [2] === [2]`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
