### PR TITLE
Split up docs postprocessing & release in split-release

### DIFF
--- a/ci/copy-unix-release-artifacts.sh
+++ b/ci/copy-unix-release-artifacts.sh
@@ -98,4 +98,11 @@ if [[ "$NAME" == "linux" ]]; then
     mkdir -p $OUTPUT_DIR/split-release/daml-libs/daml-trigger
     bazel build //triggers/daml:daml-trigger-dars
     cp bazel-bin/triggers/daml/*.dar $OUTPUT_DIR/split-release/daml-libs/daml-trigger/
+
+    mkdir -p $OUTPUT_DIR/split-release/docs
+
+    bazel build //docs:sphinx-source-tree //docs:pdf-fonts-tar //docs:non-sphinx-html-docs
+    cp bazel-bin/docs/sphinx-source-tree.tar.gz $OUTPUT_DIR/split-release/docs/sphinx-source-tree-$RELEASE_TAG.tar.gz
+    cp bazel-bin/docs/pdf-fonts-tar.tar.gz $OUTPUT_DIR/split-release/docs/pdf-fonts-$RELEASE_TAG.tar.gz
+    cp bazel-bin/docs/non-sphinx-html-docs.tar.gz $OUTPUT_DIR/split-release/docs/non-sphinx-html-docs-$RELEASE_TAG.tar.gz
 fi

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -333,50 +333,75 @@ filegroup(
     srcs = glob(["configs/pdf/fonts/**"]),
 )
 
+pkg_tar(
+  name = "pdf-fonts-tar",
+  extension = "tar.gz",
+  srcs = [":pdf-fonts"],
+)
+
+genrule(
+  name = "non-sphinx-html-docs",
+  outs = ["other-html-docs.tar.gz"],
+  srcs = [
+     ":hoogle_db.tar.gz",
+     "//language-support/java:javadoc",
+     "//language-support/ts/daml-react:docs",
+     "//language-support/ts/daml-ledger:docs",
+     "//language-support/ts/daml-types:docs",
+     "@daml-cheat-sheet//:site",
+  ],
+  cmd = """
+    set -eou pipefail
+    DIR=$$(mktemp -d)
+    trap "rm -rf DIR" EXIT
+    mkdir -p $$DIR/html/app-dev/bindings-java/javadocs
+
+    # Copy Javadoc using unzip to avoid having to know the path to the 'jar' binary. Note flag to overwrite
+    unzip -q -o $(locations //language-support/java:javadoc) -d $$DIR/html/app-dev/bindings-java/javadocs
+    # Remove JAR metadata
+    rm -r $$DIR/html/app-dev/bindings-java/javadocs/META-INF
+
+    # Copy generated documentation for typescript libraries
+    mkdir -p $$DIR/html/app-dev/bindings-ts/daml-react
+    mkdir -p $$DIR/html/app-dev/bindings-ts/daml-ledger
+    mkdir -p $$DIR/html/app-dev/bindings-ts/daml-types
+    tar -xzf $(location //language-support/ts/daml-react:docs) --strip-components 1 -C $$DIR/html/app-dev/bindings-ts/daml-react/
+    tar -xzf $(location //language-support/ts/daml-ledger:docs) --strip-components 1 -C $$DIR/html/app-dev/bindings-ts/daml-ledger/
+    tar -xzf $(location //language-support/ts/daml-types:docs) --strip-components 1 -C $$DIR/html/app-dev/bindings-ts/daml-types/
+    # The generated docs of the typescript libraries are published at two places: The npm
+    # registry and on docs.daml.com. The docs at the npm registry contain a link pointing
+    # to docs.daml.com. We remove it for the version published at docs.daml.com as it would be
+    # pointing to itself.
+    sed -i -e 's,^.*\\(Comprehensive documentation\\|<h2>Documentation</h2>\\|0.0.0-SDKVERSION\\).*$$,,' $$DIR/html/app-dev/bindings-ts/*/index.html
+
+    # Get the daml cheat sheet
+    mkdir -p $$DIR/html/cheat-sheet
+    tar -xzf $(location @daml-cheat-sheet//:site) --strip-components 1 -C $$DIR/html/cheat-sheet
+
+    # Copy in hoogle DB
+    cp -L $(location :hoogle_db.tar.gz) $$DIR/html/hoogle_db.tar.gz
+
+    MKTGZ=$$PWD/$(execpath //bazel_tools/sh:mktgz)
+    OUT_PATH=$$PWD/$@
+    cd $$DIR
+    $$MKTGZ $$OUT_PATH html
+  """,
+    tools = ["//bazel_tools/sh:mktgz"],
+)
+
 genrule(
     name = "docs-no-pdf",
     srcs = [
         ":sphinx-html",
-        ":hoogle_db.tar.gz",
-        "//language-support/java:javadoc",
-        "//language-support/ts/daml-react:docs",
-        "//language-support/ts/daml-ledger:docs",
-        "//language-support/ts/daml-types:docs",
-        "@daml-cheat-sheet//:site",
+        ":non-sphinx-html-docs",
     ],
     outs = ["html-only.tar.gz"],
     cmd = """
         set -eou pipefail
         mkdir -p build/html
         tar xf $(location :sphinx-html) -C build/html --strip-components=1
-
+        tar xf $(location :non-sphinx-html-docs) -C build/html --strip-components=1
         cd build
-
-        # Copy Javadoc using unzip to avoid having to know the path to the 'jar' binary. Note flag to overwrite
-        unzip -q -o ../$(locations //language-support/java:javadoc) -d html/app-dev/bindings-java/javadocs
-        # Remove JAR metadata
-        rm -r html/app-dev/bindings-java/javadocs/META-INF
-
-        # Copy generated documentation for typescript libraries
-        mkdir -p html/app-dev/bindings-ts/daml-react
-        mkdir -p html/app-dev/bindings-ts/daml-ledger
-        mkdir -p html/app-dev/bindings-ts/daml-types
-        tar -xzf ../$(location //language-support/ts/daml-react:docs) --strip-components 1 -C html/app-dev/bindings-ts/daml-react/
-        tar -xzf ../$(location //language-support/ts/daml-ledger:docs) --strip-components 1 -C html/app-dev/bindings-ts/daml-ledger/
-        tar -xzf ../$(location //language-support/ts/daml-types:docs) --strip-components 1 -C html/app-dev/bindings-ts/daml-types/
-        # The generated docs of the typescript libraries are published at two places: The npm
-        # registry and on docs.daml.com. The docs at the npm registry contain a link pointing
-        # to docs.daml.com. We remove it for the version published at docs.daml.com as it would be
-        # pointing to itself.
-        sed -i -e 's,^.*\\(Comprehensive documentation\\|<h2>Documentation</h2>\\|0.0.0-SDKVERSION\\).*$$,,' html/app-dev/bindings-ts/*/index.html
-
-        # Get the daml cheat sheet
-        mkdir -p html/cheat-sheet
-        tar -xzf ../$(location @daml-cheat-sheet//:site) --strip-components 1 -C html/cheat-sheet
-
-        # Copy in hoogle DB
-        cp -L ../$(location :hoogle_db.tar.gz) html/hoogle_db.tar.gz
-
         ../$(execpath //bazel_tools/sh:mktgz) ../$@ html
         """.format(sdk = sdk_version),
     tools = [

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -334,23 +334,23 @@ filegroup(
 )
 
 pkg_tar(
-  name = "pdf-fonts-tar",
-  extension = "tar.gz",
-  srcs = [":pdf-fonts"],
+    name = "pdf-fonts-tar",
+    srcs = [":pdf-fonts"],
+    extension = "tar.gz",
 )
 
 genrule(
-  name = "non-sphinx-html-docs",
-  outs = ["other-html-docs.tar.gz"],
-  srcs = [
-     ":hoogle_db.tar.gz",
-     "//language-support/java:javadoc",
-     "//language-support/ts/daml-react:docs",
-     "//language-support/ts/daml-ledger:docs",
-     "//language-support/ts/daml-types:docs",
-     "@daml-cheat-sheet//:site",
-  ],
-  cmd = """
+    name = "non-sphinx-html-docs",
+    srcs = [
+        ":hoogle_db.tar.gz",
+        "//language-support/java:javadoc",
+        "//language-support/ts/daml-react:docs",
+        "//language-support/ts/daml-ledger:docs",
+        "//language-support/ts/daml-types:docs",
+        "@daml-cheat-sheet//:site",
+    ],
+    outs = ["other-html-docs.tar.gz"],
+    cmd = """
     set -eou pipefail
     DIR=$$(mktemp -d)
     trap "rm -rf DIR" EXIT

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -387,7 +387,7 @@ genrule(
     $$MKTGZ $$OUT_PATH html
   """,
     tools = ["//bazel_tools/sh:mktgz"],
-)
+) if not is_windows else None
 
 genrule(
     name = "docs-no-pdf",


### PR DESCRIPTION
Follow up to #12172

The buld in the separate assembly should now only have to run the
sphinx-build step and then merge it with the non sphinx sources and
run lualatex on the pdf sources with the pdf fonts which is hopefully
simple enough that we can easily replicate it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
