### PR TITLE
navigator supports user management

### DIFF
--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/Session.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/Session.scala
@@ -14,6 +14,7 @@ import scala.reflect.ClassTag
 final case class User(
     id: String,
     party: PartyState,
+    // TODO: where is `role` used? frontend has some references, but doesn't seem to impact anything?
     role: Option[String] = None,
     canAdvanceTime: Boolean = true,
 )

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/Session.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/Session.scala
@@ -3,7 +3,6 @@
 
 package com.daml.navigator
 
-import com.daml.navigator.config.UserConfig
 import com.daml.navigator.model.PartyState
 import scalaz.Tag
 
@@ -43,10 +42,10 @@ object Session {
   def open(
       sessionId: String,
       userId: String,
-      userConfig: UserConfig,
+      userRole: Option[String],
       state: PartyState,
   ): Session = {
-    val user = Session(User(userId, state, userConfig.role))
+    val user = Session(User(userId, state, userRole))
     sessions += sessionId -> user
     user
   }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
@@ -253,6 +253,7 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
         arguments.ledgerInboundMessageSizeMax,
       )
     )
+    // TODO: usermgmt switching: for now we just poll both user and party mgmt
     // If no parties are specified, we periodically poll from the party management service.
     // If parties are specified, we only use those. This allows users to use custom display names
     // if they are non-unique or use only a subset of parties for performance reasons.
@@ -261,7 +262,8 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
     val partyRefresh: Option[Cancellable] =
       if (config.users.isEmpty || arguments.ignoreProjectParties) {
         Some(
-          system.scheduler.scheduleWithFixedDelay(Duration.Zero, 1.seconds, store, UpdateParties)
+          system.scheduler
+            .scheduleWithFixedDelay(Duration.Zero, 1.seconds, store, UpdatePartiesAndUsers)
         )
       } else {
         config.users.foreach { case (displayName, config) =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
@@ -251,6 +251,7 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
         arguments.time,
         applicationInfo,
         arguments.ledgerInboundMessageSizeMax,
+        arguments.enableUserManagement,
       )
     )
     // TODO: usermgmt switching: for now we just poll both user and party mgmt
@@ -263,7 +264,7 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
       if (config.users.isEmpty || arguments.ignoreProjectParties) {
         Some(
           system.scheduler
-            .scheduleWithFixedDelay(Duration.Zero, 1.seconds, store, UpdatePartiesAndUsers)
+            .scheduleWithFixedDelay(Duration.Zero, 1.seconds, store, UpdateUsersOrParties)
         )
       } else {
         config.users.foreach { case (displayName, config) =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
@@ -32,6 +32,7 @@ case class Arguments(
     useDatabase: Boolean = false,
     ledgerInboundMessageSizeMax: Int = 50 * 1024 * 1024, // 50 MiB
     ignoreProjectParties: Boolean = false,
+    enableUserManagement: Boolean = true,
 )
 
 trait ArgumentsHelper { self: OptionParser[Arguments] =>
@@ -172,6 +173,13 @@ object Arguments {
           "Ignore the parties specified in the project configuration file and query the ledger for parties instead."
         )
         .action((_, arguments) => arguments.copy(ignoreProjectParties = true))
+
+      opt[Boolean]("feature-user-management")
+        .optional()
+        .text(
+          "By default, the login screen is now populated by quering the user mgmt service. Disable to query party mgmt instead (the pre-2.0 default)."
+        )
+        .action((enabled, arguments) => arguments.copy(enableUserManagement = enabled))
 
       cmd("server")
         .text("serve data from platform")

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
@@ -17,6 +17,7 @@ case class State(ledger: Ledger, packageRegistry: PackageRegistry)
 /** A DA party and its ledger view(s). */
 class PartyState(
     val name: ApiTypes.Party,
+    // A named role specified in our config. Not sure if this is really used?
     val userRole: Option[String] = None,
     val useDatabase: Boolean = false,
 ) {

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
@@ -4,18 +4,25 @@
 package com.daml.navigator.model
 
 import java.util.concurrent.atomic.AtomicReference
-
 import com.daml.lf.{iface => DamlLfIface}
 import com.daml.ledger.api.refinements.ApiTypes
-import com.daml.navigator.config.UserConfig
+
+import scala.collection.immutable.LazyList
 import scalaz.Tag
+
+import java.net.URLEncoder
 
 case class State(ledger: Ledger, packageRegistry: PackageRegistry)
 
 /** A DA party and its ledger view(s). */
-class PartyState(val config: UserConfig) {
-  val name = config.party
-  val useDatabase = config.useDatabase
+class PartyState(
+    val name: ApiTypes.Party,
+    val userRole: Option[String] = None,
+    val useDatabase: Boolean = false,
+) {
+  def actorName: String =
+    "party-" + URLEncoder.encode(ApiTypes.Party.unwrap(name), "UTF-8")
+
   private val stateRef: AtomicReference[State] = new AtomicReference(
     State(Ledger(name, None, useDatabase), new PackageRegistry)
   )

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
@@ -17,7 +17,7 @@ case class State(ledger: Ledger, packageRegistry: PackageRegistry)
 /** A DA party and its ledger view(s). */
 class PartyState(
     val name: ApiTypes.Party,
-    // A named role specified in our config. Not sure if this is really used?
+    // A named role specified in our config. The role is an arbitrary string chosen by the user. It gets passed to the frontend, which can display a custom theme or custom views depending on the role.
     val userRole: Option[String] = None,
     val useDatabase: Boolean = false,
 ) {

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
@@ -29,11 +29,9 @@ object Store {
   /** Reinitialize the platform connection and reset all local state `Unit` */
   case object ResetConnection
 
-  case object UpdateUsers
+  case object UpdatePartiesAndUsers
   case class UpdatedUsers(details: Seq[User])
-  case class SubscribeUser(displayName: String, config: UserConfig)
 
-  case object UpdateParties
   case class UpdatedParties(details: List[PartyDetails])
 
   /** Request to subscribe a party to the store (without response to sender). */

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
@@ -7,7 +7,6 @@ import java.time.Instant
 import com.daml.ledger.api.domain.{PartyDetails, User}
 import com.daml.navigator.model._
 import com.daml.ledger.api.refinements.ApiTypes
-import com.daml.navigator.config.UserConfig
 import com.daml.navigator.time.TimeProviderWithType
 
 trait ActorStatus
@@ -35,7 +34,7 @@ object Store {
   case class UpdatedParties(details: List[PartyDetails])
 
   /** Request to subscribe a party to the store (without response to sender). */
-  case class Subscribe(displayName: String, config: UserConfig)
+  case class Subscribe(displayName: String, partyState: PartyState)
 
   /** Request to create a contract instance for a template and respond with a `scala.util.Try[CommandId]`. */
   case class CreateContract(party: PartyState, templateId: TemplateStringId, argument: ApiRecord)

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
@@ -28,7 +28,7 @@ object Store {
   /** Reinitialize the platform connection and reset all local state `Unit` */
   case object ResetConnection
 
-  case object UpdatePartiesAndUsers
+  case object UpdateUsersOrParties
   case class UpdatedUsers(details: Seq[User])
 
   case class UpdatedParties(details: List[PartyDetails])

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
@@ -85,7 +85,7 @@ object Store {
       applicationId: String,
       ledgerId: String,
       ledgerTime: TimeProviderWithType,
-      // the keys of this map are passed to the frontend as possible user ids to log in as
+      // `partyActors`'s keys are passed to the frontend as possible user ids to log in as
       partyActors: Map[String, PartyActorResponse],
   ) extends ApplicationStateInfo
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
@@ -4,8 +4,7 @@
 package com.daml.navigator.store
 
 import java.time.Instant
-
-import com.daml.ledger.api.domain.PartyDetails
+import com.daml.ledger.api.domain.{PartyDetails, User}
 import com.daml.navigator.model._
 import com.daml.ledger.api.refinements.ApiTypes
 import com.daml.navigator.config.UserConfig
@@ -30,8 +29,11 @@ object Store {
   /** Reinitialize the platform connection and reset all local state `Unit` */
   case object ResetConnection
 
-  case object UpdateParties
+  case object UpdateUsers
+  case class UpdatedUsers(details: Seq[User])
+  case class SubscribeUser(displayName: String, config: UserConfig)
 
+  case object UpdateParties
   case class UpdatedParties(details: List[PartyDetails])
 
   /** Request to subscribe a party to the store (without response to sender). */
@@ -86,6 +88,7 @@ object Store {
       applicationId: String,
       ledgerId: String,
       ledgerTime: TimeProviderWithType,
+      // the keys of this map are passed to the frontend as possible user ids to log in as
       partyActors: Map[String, PartyActorResponse],
   ) extends ApplicationStateInfo
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
@@ -6,13 +6,13 @@ package com.daml.navigator.store.platform
 import java.time.{Duration, Instant}
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
-
 import akka.actor.{Actor, ActorLogging, ActorRef, Props, Scheduler, Stash}
 import akka.pattern.{ask, pipe}
 import akka.stream.Materializer
 import akka.util.Timeout
 import com.daml.grpc.GrpcException
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
+import com.daml.ledger.api.domain.Feature
 import com.daml.ledger.api.refinements.{ApiTypes, IdGenerator}
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.api.v1.testing.time_service.TimeServiceGrpc
@@ -49,6 +49,7 @@ object PlatformStore {
       timeProviderType: TimeProviderType,
       applicationInfo: ApplicationInfo,
       ledgerMaxInbound: Int,
+      enableUserManagement: Boolean,
   ): Props =
     Props(
       classOf[PlatformStore],
@@ -59,6 +60,7 @@ object PlatformStore {
       timeProviderType,
       applicationInfo,
       ledgerMaxInbound,
+      enableUserManagement,
     )
 
   type PlatformTime = Instant
@@ -72,8 +74,7 @@ object PlatformStore {
 
   case class StateConnected(
       ledgerClient: LedgerClient,
-      // TODO: more structure? parties.keys is a mixed bag, but only used for display purposes, so probably ok as-is
-      // A key could be: a Party's displayName, a party's name, a User's id, or a name specified in our config
+      // A key in `parties` could be: a Party's displayName, a party's name, a User's id, or a name specified in our config
       parties: Map[String, PartyState],
       staticTime: Option[StaticTime],
       time: TimeProviderWithType,
@@ -92,6 +93,7 @@ class PlatformStore(
     timeProviderType: TimeProviderType,
     applicationInfo: ApplicationInfo,
     ledgerMaxInbound: Int,
+    enableUserManagement: Boolean,
 ) extends Actor
     with ActorLogging
     with Stash {
@@ -159,17 +161,33 @@ class PlatformStore(
       stash()
   }
 
+  @SuppressWarnings(
+    Array(
+      "org.wartremover.warts.JavaSerializable",
+      "org.wartremover.warts.Product",
+      "org.wartremover.warts.Serializable",
+    )
+  ) // for the andThen below
   def connected(state: StateConnected): Receive = {
-    case UpdatePartiesAndUsers =>
-      state.ledgerClient.partyManagementClient
-        .listKnownParties()
-        .map(UpdatedParties(_))
-        .pipeTo(self)
+    case UpdateUsersOrParties =>
+      state.ledgerClient.versionClient
+        .getApiFeatures(state.ledgerClient.ledgerId)
+        .filter(features => // if we have user management (and it's not disabled)....
+          enableUserManagement && features.contains(Feature.UserManagement)
+        )
+        .andThen {
+          case Success(_) => // .. then only list users on the login screen
+            state.ledgerClient.userManagementClient
+              .listUsers() // don't pass token here -- it's already set on startup (LedgerClientConfiguration)
+              .map(UpdatedUsers(_))
+              .pipeTo(self)
+          case Failure(_) => // ... else fallback to parties
+            state.ledgerClient.partyManagementClient
+              .listKnownParties()
+              .map(UpdatedParties(_))
+              .pipeTo(self)
+        }
 
-      state.ledgerClient.userManagementClient
-        .listUsers() // don't pass token here -- it's already set on startup (LedgerClientConfiguration)
-        .map(UpdatedUsers(_))
-        .pipeTo(self)
       ()
 
     case UpdatedUsers(users) =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
@@ -179,13 +179,20 @@ class PlatformStore(
               hasUserManagement
             }
 
+      // TODO https://github.com/digital-asset/daml/issues/12663 participant user management: Emulating no-pagination
+      def listAllUsers(client: LedgerClient) =
+        client.userManagementClient
+          .listUsers(token = None /* set at startup */, pageToken = "", pageSize = 10000)
+          .map { case (users, _) =>
+            users.toList
+          }
+
       hasUserManagement
         .flatMap {
           case true =>
-            state.ledgerClient.userManagementClient
-              .listUsers() // don't pass token here -- it's already set on startup (LedgerClientConfiguration)
+            listAllUsers(state.ledgerClient)
               .map(details => UpdatedUsers(details): Any)
-          //                                   ^^^^^
+          //                                       ^^^^^
           // make wartremover happy about the lub of UpdatedUsers and UpdatedParties
           case false =>
             state.ledgerClient.partyManagementClient

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/IntegrationTest.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/IntegrationTest.scala
@@ -6,8 +6,11 @@ package com.daml.navigator
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes, Uri}
+import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.settings.ServerSettings
 import akka.util.ByteString
+import com.daml.buildinfo.BuildInfo
+import com.daml.ledger.api.domain
 import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundAll}
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
@@ -15,6 +18,8 @@ import com.daml.ledger.client.configuration.{
   LedgerClientConfiguration,
   LedgerIdRequirement,
 }
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.UserId
 import com.daml.navigator.config.{Arguments, Config}
 import com.daml.platform.sandbox.fixture.SandboxFixture
 import org.scalatest._
@@ -22,7 +27,8 @@ import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
 import com.daml.timer.RetryStrategy
 
-import scala.concurrent.Future
+import java.util.UUID
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class IntegrationTest
@@ -32,14 +38,32 @@ class IntegrationTest
     with SuiteResourceManagementAroundAll
     with Matchers {
   self: Suite =>
-  private def withNavigator[A](testFn: (Uri, LedgerClient) => Future[A]): Future[A] = {
-    val args = Arguments(port = 0, participantPort = serverPort.value)
-    val sys = ActorSystem("navigator")
-    val (graphQL, info, _, getAppState, partyRefresh) = NavigatorBackend.setup(args, Config())(sys)
+
+  private def withNavigator[A](
+      userMgmt: Boolean
+  )(testFn: Uri => LedgerClient => Future[A]): Future[A] = {
+    import scala.jdk.FutureConverters
+    val args = Arguments(
+      port = 0,
+      participantPort = serverPort.value,
+      enableUserManagement = userMgmt,
+    )
+    val sys = ActorSystem(s"navigator-${UUID.randomUUID().toString}")
+    val backend = new UIBackend {
+      override def customEndpoints: Set[CustomEndpoint[_]] = Set()
+      override def customRoutes: List[Route] = Nil
+      override def applicationInfo: ApplicationInfo = ApplicationInfo(
+        id = s"Test-Navigator-${UUID.randomUUID().toString}",
+        name = "Test-Navigator",
+        version = BuildInfo.Version,
+      )
+    }
+
+    val (graphQL, info, _, getAppState, partyRefresh) = backend.setup(args, Config())(sys)
     val bindingF = Http()
       .newServerAt("localhost", 0)
       .withSettings(ServerSettings(system).withTransparentHeadRequests(true))
-      .bind(NavigatorBackend.getRoute(system, args, graphQL, info, getAppState))
+      .bind(backend.getRoute(system, args, graphQL, info, getAppState))
     val clientF = LedgerClient(
       channel,
       LedgerClientConfiguration(
@@ -48,7 +72,12 @@ class IntegrationTest
         commandClient = CommandClientConfiguration.default,
       ),
     )
-    val fa = for {
+    sys.registerOnTermination {
+      partyRefresh.foreach(_.cancel())
+      Await.ready(bindingF.flatMap(_.terminate(30.seconds)), 30.seconds)
+    }
+    import FutureConverters._
+    for {
       binding <- bindingF
       client <- clientF
       uri = Uri.from(
@@ -56,45 +85,93 @@ class IntegrationTest
         host = binding.localAddress.getHostName,
         port = binding.localAddress.getPort,
       )
-      a <- testFn(uri, client)
+      a <- testFn(uri)(client)
+      _ <- sys.terminate()
+      _ <- Await.ready(sys.getWhenTerminated.asScala, 30.seconds)
     } yield a
-    fa.transformWith { ta =>
-      partyRefresh.foreach(_.cancel())
-      Future
-        .sequence(
-          Seq[Future[Unit]](
-            clientF.map(_.close()),
-            bindingF.flatMap(_.unbind()).map(_ => ()),
-            sys.terminate().map(_ => ()),
-          )
-        )
-        .transform(_ => ta)
-    }
+//    fa.transformWith { ta =>
+
+    // Don't close the LedgerClient because all it does is close the channel,
+    // which then causes a subsequent test to fail when creating a LedgerClient using a closed channel
+    // ("io.grpc.StatusRuntimeException: UNAVAILABLE: Channel shutdown invoked")
+//      bindingF
+//        .flatMap(_.unbind())
+//        .flatMap(_ => sys.terminate())
+//        .transform(_ => ta)
+//    }
   }
 
-  def getResponseDataBytes(resp: HttpResponse): Future[String] = {
-    val fb = resp.entity.dataBytes.runFold(ByteString.empty)((b, a) => b ++ a).map(_.utf8String)
-    fb
-  }
+  def getResponseDataBytes(resp: HttpResponse): Future[String] =
+    resp.entity.dataBytes.runFold(ByteString.empty)((b, a) => b ++ a).map(_.utf8String)
 
-  "Navigator" - {
-    "picks up newly allocated parties" in withNavigator { case (uri, client) =>
+  private def okSessionBody(expectedBody: String)(implicit uri: Uri): Future[Assertion] = {
+    RetryStrategy.constant(20, 1.second) { case (_, _) =>
       for {
-        resp <- Http().singleRequest(HttpRequest(uri = uri.withPath(Uri.Path("/api/session/"))))
+        resp <- Http().singleRequest(
+          HttpRequest(uri = uri.withPath(Uri.Path("/api/session/")))
+        )
         respBody <- getResponseDataBytes(resp)
-        _ = respBody shouldBe """{"method":{"type":"select","users":[]},"type":"sign-in"}"""
         _ = resp.status shouldBe StatusCodes.OK
-        _ <- client.partyManagementClient
-          .allocateParty(hint = None, displayName = Some("display-name"))
-        _ <- RetryStrategy.constant(20, 1.second) { case (run @ _, duration @ _) =>
-          for {
-            resp <- Http().singleRequest(HttpRequest(uri = uri.withPath(Uri.Path("/api/session/"))))
-            respBody <- getResponseDataBytes(resp)
-          } yield {
-            respBody shouldBe """{"method":{"type":"select","users":["display-name"]},"type":"sign-in"}"""
-          }
-        }
-      } yield succeed
+      } yield {
+        respBody shouldBe expectedBody
+      }
     }
   }
+
+  private def allocateParty(partyName: String)(implicit client: LedgerClient) = {
+    client.partyManagementClient
+      .allocateParty(hint = None, displayName = Some(partyName))
+  }
+
+  private def createUser(userName: String, primaryParty: Ref.Party)(implicit
+      client: LedgerClient
+  ): Future[domain.User] = {
+    client.userManagementClient
+      .createUser(
+        domain.User(UserId.assertFromString(userName), Some(primaryParty))
+      )
+  }
+
+  "Navigator (parties)" - {
+    "picks up newly allocated parties" in withNavigator(userMgmt = false) {
+      implicit uri => implicit client =>
+        for {
+          _ <- okSessionBody("""{"method":{"type":"select","users":[]},"type":"sign-in"}""")
+          _ <- allocateParty("display-name")
+          _ <- okSessionBody(
+            """{"method":{"type":"select","users":["display-name"]},"type":"sign-in"}"""
+          )
+        } yield succeed
+    }
+  }
+
+  "Navigator (basic user)" - {
+    "picks up newly created users (1 user)" in withNavigator(userMgmt = true) {
+      implicit uri => implicit client =>
+        for {
+          _ <- okSessionBody("""{"method":{"type":"select","users":[]},"type":"sign-in"}""")
+          partyDetails <- allocateParty("primary-party")
+          _ <- createUser("user-name", partyDetails.party)
+          _ <- okSessionBody(
+            """{"method":{"type":"select","users":["user-name"]},"type":"sign-in"}"""
+          )
+        } yield succeed
+    }
+  }
+
+  "Navigator (users)" - {
+    "picks up newly created users (2 users, 1 primary party)" in withNavigator(userMgmt = true) {
+      implicit uri => implicit client =>
+        for {
+          _ <- okSessionBody("""{"method":{"type":"select","users":[]},"type":"sign-in"}""")
+          partyDetails <- allocateParty("primary-party")
+          _ <- createUser("user-name-1", partyDetails.party)
+          _ <- createUser("user-name-2", partyDetails.party)
+          _ <- okSessionBody(
+            """{"method":{"type":"select","users":["user-name-1"]},"type":"sign-in"}"""
+          )
+        } yield succeed
+    }
+  }
+
 }

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/SessionJsonProtocolTest.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/SessionJsonProtocolTest.scala
@@ -8,7 +8,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import SessionJsonProtocol.userWriter
 import com.daml.ledger.api.refinements.ApiTypes
-import com.daml.navigator.config.UserConfig
 import spray.json.{JsBoolean, JsObject, JsString}
 
 class SessionJsonProtocolTest extends AnyFlatSpec with Matchers {
@@ -20,7 +19,7 @@ class SessionJsonProtocolTest extends AnyFlatSpec with Matchers {
 
   it should s"encode $userClassName without role" in {
     val user =
-      User(id = "id", party = new PartyState(UserConfig(party, None, false)), canAdvanceTime = true)
+      User(id = "id", party = new PartyState(party, None, false), canAdvanceTime = true)
     val userJson = JsObject(
       "id" -> JsString("id"),
       "party" -> JsString("party"),
@@ -32,7 +31,7 @@ class SessionJsonProtocolTest extends AnyFlatSpec with Matchers {
   it should s"encode $userClassName with role" in {
     val user = User(
       id = "id",
-      party = new PartyState(UserConfig(party, Some("role"), false)),
+      party = new PartyState(party, Some("role"), false),
       role = Some("role"),
       canAdvanceTime = false,
     )

--- a/navigator/frontend/src/ui-core/src/session/UI.tsx
+++ b/navigator/frontend/src/ui-core/src/session/UI.tsx
@@ -116,7 +116,7 @@ export default class Component<A extends Action>
     } else if (failure === 'unknown-error') {
       errorEl = (
         <ErrorMessage>
-          <div>An error occured when connecting to the ledger</div>
+          <div>An error occurred when connecting to the ledger</div>
           <div>Refer to the Navigator server logs to know the cause</div>
         </ErrorMessage>
       )


### PR DESCRIPTION
Add basic support for user management to navigator: log in as a user, act/read as its primary party.

When user management is supported & enabled, you can only log in as a user (and that user must have a primary party, which is what you'll actually be acting/reading as).

This behavior is enabled by default, but there's a feature flag you can use to disable it (`--feature-user-management`).

See https://github.com/digital-asset/daml/issues/12020

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
