### PR TITLE
Improve ledger export replay

### DIFF
--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -202,7 +202,6 @@ da_scala_binary(
         ":engine-replay",
         "//daml-lf/data",
         "//daml-lf/engine",
-        "//daml-lf/interpreter",
         "//daml-lf/language",
     ],
 )

--- a/ledger/participant-state/kvutils/tools/README.md
+++ b/ledger/participant-state/kvutils/tools/README.md
@@ -49,26 +49,28 @@ jmh command line functionality:
 
     bazel run //ledger/participant-state/kvutils/tools:benchmark-replay -- \
       -p ledgerFile=<ledger export files>                                  \
-      -p darFile=<dar files>                                               \
       -p choiceName=<exercise choice names>                                \
-      [-p adapt=true]
+      [-p indexChoice=<index of the choice>                                \
+      [-p darFile=<dar files>]                                              
+
 
 where:
 
 * `<ledger export files>`: is the full path of the ledger export
   files to be used separated by commas (`,`)
 
-* `<dar files>` : is the full path of the dar files to be used
-  separated by commas (`,`)
-
-* `<exercise choice names`>: is the full qualified choice name of the
-  exercises to be benchmarked separated by commas (`,`).  A full
+* `<exercise choice names>`: is the full qualified choice name of the
+  root exercise to be benchmarked separated by commas (`,`).  A full
   qualified choice name should be of the form
   `ModuleName:TemplateName:ChoiceName`.  Note the package ID is
-  omitted.
+  omitted. By default, the tool benchmarks the first choice with 
+  such a name it finds in the ledger export.
 
-* the optional parameter `adapt=true` can be set to enable dar-export
-  "adaptation". The adaptation process attempts to map the identifiers
+* the optional parameter `<dar files>` specify the full path of 
+  the dar files to be used  separated by commas (`,`). If defined 
+  the program contained in the dar file is used instead of one
+  present in the ledger export, and the export is "adapted" to this 
+  program. The adaptation process attempts to map the identifiers
   from the export file with the ones of dar file when those latter
   differ only in their package ID.  This can be used when the original
   Daml source used to generate the ledger export is only slightly

--- a/ledger/participant-state/kvutils/tools/README.md
+++ b/ledger/participant-state/kvutils/tools/README.md
@@ -50,7 +50,7 @@ jmh command line functionality:
     bazel run //ledger/participant-state/kvutils/tools:benchmark-replay -- \
       -p ledgerFile=<ledger export files>                                  \
       -p choiceName=<exercise choice names>                                \
-      [-p indexChoice=<index of the choice>                                \
+      [-p exerciseIndex=<index of the exercise node>]                      \
       [-p darFile=<dar files>]                                              
 
 
@@ -60,11 +60,16 @@ where:
   files to be used separated by commas (`,`)
 
 * `<exercise choice names>`: is the full qualified choice name of the
-  root exercise to be benchmarked separated by commas (`,`).  A full
+  root exercise node to be benchmarked separated by commas (`,`). A full
   qualified choice name should be of the form
   `ModuleName:TemplateName:ChoiceName`.  Note the package ID is
   omitted. By default, the tool benchmarks the first choice with 
   such a name it finds in the ledger export.
+
+* the optional parameter `<position of the exercise node>` is the 
+  index of the exercise among the root exercise nodes that matches
+  choice name specified by the `choiceName` parameter in the order 
+  they appear in the export.
 
 * the optional parameter `<dar files>` specify the full path of 
   the dar files to be used  separated by commas (`,`). If defined 

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/replay/ReplayBenchmark.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/replay/ReplayBenchmark.scala
@@ -60,10 +60,7 @@ class ReplayBenchmark {
 
     engine = Replay.compile(benchmark.pkgs)
 
-    // before running the bench, we validate the transaction first to be sure everything is fine.
-    val result = benchmark.validate(engine)
-    remy.log(result)
-    assert(result.isRight)
+    assert(benchmark.validate(engine).isRight)
   }
 
 }

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/replay/ReplayBenchmark.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/replay/ReplayBenchmark.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit
 
 import com.daml.lf.data._
 import com.daml.lf.engine.Engine
-import com.daml.lf.language.Ast
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Benchmark)
@@ -19,10 +18,10 @@ class ReplayBenchmark {
   // format: "ModuleName:TemplateName:ChoiceName"
   var choiceName: String = _
 
-  @Param(Array("-1"))
+  @Param(Array("0"))
   var choiceIndex: Int = _
 
-  @Param(Array())
+  @Param(Array(""))
   // path of the darFile
   var darFile: String = _
 
@@ -30,15 +29,7 @@ class ReplayBenchmark {
   // path of the ledger export
   var ledgerFile: String = _
 
-  @Param(Array("false"))
-  // if 'true' try to adapt the benchmark to the dar
-  var adapt: Boolean = _
-
-  private var readDarFile: Option[String] = None
-  private var loadedPackages: Map[Ref.PackageId, Ast.Package] = _
   private var engine: Engine = _
-  private var benchmarksFile: Option[String] = None
-  private var benchmarks: Benchmarks = _
   private var benchmark: BenchmarkState = _
 
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -49,29 +40,29 @@ class ReplayBenchmark {
 
   @Setup(Level.Trial)
   def init(): Unit = {
-    if (!readDarFile.contains(darFile)) {
-      loadedPackages = Replay.loadDar(Paths.get(darFile))
-      engine = Replay.compile(loadedPackages)
-      readDarFile = Some(darFile)
+    val Array(modNameStr, tmplNameStr, name) = choiceName.split(":")
+    val choice = (
+      Ref.QualifiedName(
+        Ref.DottedName.assertFromString(modNameStr),
+        Ref.DottedName.assertFromString(tmplNameStr),
+      ),
+      Ref.Name.assertFromString(name),
+    )
+    benchmark = Replay.loadBenchmark(
+      Paths.get(ledgerFile),
+      choice,
+      choiceIndex,
+    )
+    if (darFile.nonEmpty) {
+      val loadedPackages = Replay.loadDar(Paths.get(darFile))
+      benchmark = Replay.adapt(loadedPackages, benchmark)
     }
-    if (!benchmarksFile.contains(ledgerFile)) {
-      benchmarks = Replay.loadBenchmarks(Paths.get(ledgerFile))
-      val idx = if (choiceIndex >= 0) Some(choiceIndex) else None
-      val originalBenchmark = benchmarks.get(choiceName, idx)
-      benchmark = if (adapt) {
-        Replay.adapt(
-          loadedPackages,
-          engine.compiledPackages().interface.packageLanguageVersion,
-          originalBenchmark,
-        )
-      } else {
-        originalBenchmark
-      }
-      benchmarksFile = Some(ledgerFile)
-    }
+
+    engine = Replay.compile(benchmark.pkgs)
 
     // before running the bench, we validate the transaction first to be sure everything is fine.
     val result = benchmark.validate(engine)
+    remy.log(result)
     assert(result.isRight)
   }
 

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/replay/ReplayBenchmark.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/replay/ReplayBenchmark.scala
@@ -7,7 +7,6 @@ import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 import com.daml.lf.data._
-import com.daml.lf.engine.Engine
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Benchmark)
@@ -19,7 +18,7 @@ class ReplayBenchmark {
   var choiceName: String = _
 
   @Param(Array("0"))
-  var choiceIndex: Int = _
+  var exerciseIndex: Int = _
 
   @Param(Array(""))
   // path of the darFile
@@ -29,14 +28,11 @@ class ReplayBenchmark {
   // path of the ledger export
   var ledgerFile: String = _
 
-  private var engine: Engine = _
   private var benchmark: BenchmarkState = _
 
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def bench(): Unit = {
-    val result = benchmark.replay(engine)
-    assert(result.isRight)
-  }
+  def bench(): Unit =
+    assert(benchmark.replay().isRight)
 
   @Setup(Level.Trial)
   def init(): Unit = {
@@ -51,16 +47,15 @@ class ReplayBenchmark {
     benchmark = Replay.loadBenchmark(
       Paths.get(ledgerFile),
       choice,
-      choiceIndex,
+      exerciseIndex,
+      None,
     )
     if (darFile.nonEmpty) {
       val loadedPackages = Replay.loadDar(Paths.get(darFile))
       benchmark = Replay.adapt(loadedPackages, benchmark)
     }
 
-    engine = Replay.compile(benchmark.pkgs)
-
-    assert(benchmark.validate(engine).isRight)
+    assert(benchmark.validate().isRight)
   }
 
 }

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Adapter.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.participant.state.kvutils.tools.engine.replay
 
 import com.daml.lf.data._
-import com.daml.lf.language.{Ast, LanguageVersion}
+import com.daml.lf.language.Ast
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
 import com.daml.lf.transaction.{GlobalKey, Node, NodeId, SubmittedTransaction, VersionedTransaction}
 import com.daml.lf.value.Value
@@ -12,14 +12,13 @@ import com.daml.lf.value.Value
 import scala.collection.mutable
 
 private[replay] final class Adapter(
-    packages: Map[Ref.PackageId, Ast.Package],
-    pkgLangVersion: Ref.PackageId => LanguageVersion,
+    packages: Map[Ref.PackageId, Ast.Package]
 ) {
 
   private val interface = com.daml.lf.language.PackageInterface(packages)
 
   def adapt(tx: VersionedTransaction): SubmittedTransaction =
-    tx.foldWithPathState(TxBuilder(pkgLangVersion), Option.empty[NodeId])(
+    tx.foldWithPathState(TxBuilder(interface.packageLanguageVersion), Option.empty[NodeId])(
       (builder, parent, _, node) =>
         (builder, Some(parent.fold(builder.add(adapt(node)))(builder.add(adapt(node), _))))
     ).buildSubmitted()

--- a/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-replay/src/replay/scala/ledger/participant/state/kvutils/tools/engine/replay/Replay.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state.kvutils.tools.engine.replay
 
 import java.lang.System.err.println
 import java.nio.file.Path
-
 import com.daml.ledger.participant.state.kvutils.Conversions._
 import com.daml.ledger.participant.state.kvutils.export.{
   ProtobufBasedLedgerDataImporter,
@@ -13,18 +12,20 @@ import com.daml.ledger.participant.state.kvutils.export.{
 }
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.kvutils.{Conversions, Envelope, Raw}
-import com.daml.lf.archive.UniversalArchiveDecoder
+import com.daml.lf.archive.{ArchiveDecoder, UniversalArchiveDecoder}
 import com.daml.lf.crypto
 import com.daml.lf.data._
 import com.daml.lf.engine.{Engine, EngineConfig, Error}
 import com.daml.lf.language.{Ast, LanguageVersion, Util => AstUtil}
+import com.daml.lf.transaction.Transaction.ChildrenRecursion
 import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers, Node, SubmittedTransaction}
 import com.daml.lf.value.Value.ContractId
 import com.daml.lf.value.Value
+import com.google.protobuf.ByteString
 
-import scala.collection.compat._
-import scala.collection.compat.immutable.LazyList
 import scala.jdk.CollectionConverters._
+
+sealed abstract class SubmissionEntry extends Product with Serializable
 
 final case class TxEntry(
     tx: SubmittedTransaction,
@@ -33,17 +34,16 @@ final case class TxEntry(
     ledgerTime: Time.Timestamp,
     submissionTime: Time.Timestamp,
     submissionSeed: crypto.Hash,
-)
+) extends SubmissionEntry
+
+final case class PkgEntry(archive: ByteString) extends SubmissionEntry
 
 final case class BenchmarkState(
-    name: String,
     transaction: TxEntry,
     contracts: Map[ContractId, Value.VersionedContractInstance],
     contractKeys: Map[GlobalKey, ContractId],
+    pkgs: Map[Ref.PackageId, Ast.Package],
 ) {
-
-  private def getContract(cid: ContractId) =
-    contracts.get(cid)
 
   private def getContractKey(globalKeyWithMaintainers: GlobalKeyWithMaintainers) =
     contractKeys.get(globalKeyWithMaintainers.globalKey)
@@ -58,7 +58,7 @@ final case class BenchmarkState(
         transaction.submissionTime,
         transaction.submissionSeed,
       )
-      .consume(getContract, Replay.unexpectedError, getContractKey)
+      .consume(contracts.get, pkgs.get, getContractKey)
       .map(_ => ())
 
   def validate(engine: Engine): Either[Error, Unit] =
@@ -71,24 +71,8 @@ final case class BenchmarkState(
         transaction.submissionTime,
         transaction.submissionSeed,
       )
-      .consume(getContract, Replay.unexpectedError, getContractKey)
-}
+      .consume(contracts.get, pkgs.get, getContractKey)
 
-class Benchmarks(private val benchmarks: Map[String, Vector[BenchmarkState]]) {
-  def get(choiceName: String, choiceIndex: Option[Int] = None) = {
-    val xs = benchmarks(choiceName)
-    choiceIndex match {
-      case Some(idx) => xs(idx)
-      case None =>
-        if (xs.length > 1) {
-          throw new IllegalArgumentException(
-            s"Found ${xs.length} transactions for $choiceName, use --choice-index to choose one"
-          )
-        } else {
-          xs.head
-        }
-    }
-  }
 }
 
 private[replay] object Replay {
@@ -117,7 +101,7 @@ private[replay] object Replay {
   private[this] def decodeSubmission(
       participantId: Ref.ParticipantId,
       submission: DamlSubmission,
-  ): LazyList[TxEntry] =
+  ): LazyList[SubmissionEntry] = {
     submission.getPayloadCase match {
       case DamlSubmission.PayloadCase.TRANSACTION_ENTRY =>
         val entry = submission.getTransactionEntry
@@ -134,14 +118,18 @@ private[replay] object Replay {
             submissionSeed = parseHash(entry.getSubmissionSeed),
           )
         )
+      case DamlSubmission.PayloadCase.PACKAGE_UPLOAD_ENTRY =>
+        val entry = submission.getPackageUploadEntry
+        entry.getArchivesList.asScala.iterator.map(PkgEntry).to(LazyList)
       case _ =>
         LazyList.empty
     }
+  }
 
   private[this] def decodeEnvelope(
       participantId: Ref.ParticipantId,
       envelope: Raw.Envelope,
-  ): LazyList[TxEntry] =
+  ): LazyList[SubmissionEntry] =
     assertRight(Envelope.open(envelope)) match {
       case Envelope.SubmissionMessage(submission) =>
         decodeSubmission(participantId, submission)
@@ -159,62 +147,77 @@ private[replay] object Replay {
   private[this] def decodeSubmissionInfo(submissionInfo: SubmissionInfo) =
     decodeEnvelope(submissionInfo.participantId, submissionInfo.submissionEnvelope)
 
-  def loadBenchmarks(dumpFile: Path): Benchmarks = {
+  def loadBenchmark(
+      dumpFile: Path,
+      choice: (Ref.QualifiedName, Ref.Name),
+      index: Int,
+  ): BenchmarkState = {
     println(s"%%% load ledger export file  $dumpFile...")
     val importer = ProtobufBasedLedgerDataImporter(dumpFile)
+
+    var idx: Int = index
+    var contracts = Map.empty[ContractId, Value.VersionedContractInstance]
+    var contractKeys = Map.empty[GlobalKey, ContractId]
+    var pkgs = Map.empty[Ref.PackageId, Ast.Package]
+
+    var result = Option.empty[BenchmarkState]
+
     try {
-      val transactions = importer.read().map(_._1).flatMap(decodeSubmissionInfo)
-      if (transactions.isEmpty) sys.error("no transaction find")
+      val entries = importer.read().map(_._1).flatMap(decodeSubmissionInfo).iterator
 
-      val createsNodes: Seq[Node.Create] =
-        transactions.flatMap(entry =>
-          entry.tx.nodes.values.collect { case create: Node.Create =>
-            create
-          }
-        )
-
-      val allContracts: Map[ContractId, Value.VersionedContractInstance] =
-        createsNodes.map(node => node.coid -> node.versionedCoinst).toMap
-
-      val allContractsWithKey = createsNodes.flatMap { node =>
-        node.key.toList.map(key => node.coid -> GlobalKey.assertBuild(node.templateId, key.key))
-      }.toMap
-
-      val benchmarks = transactions.flatMap { entry =>
-        entry.tx.roots.map(entry.tx.nodes) match {
-          case ImmArray(exe: Node.Exercise) =>
-            val inputContracts = entry.tx.inputContracts
-            List(
-              BenchmarkState(
-                name = exe.templateId.qualifiedName.toString + ":" + exe.choiceId,
-                transaction = entry,
-                contracts = allContracts.view.filterKeys(inputContracts).toMap,
-                contractKeys = inputContracts.iterator
-                  .flatMap(cid => allContractsWithKey.get(cid).toList.map(_ -> cid))
-                  .toMap,
-              )
+      while (result.isEmpty && entries.hasNext) {
+        entries.next() match {
+          case entry: TxEntry =>
+            val root = entry.tx.roots.iterator.toSet
+            entry.tx.foreachInExecutionOrder(
+              { (nid, exe) =>
+                if (root(nid) && (exe.templateId.qualifiedName, exe.choiceId) == choice) {
+                  if (idx == 0)
+                    result = Some(BenchmarkState(entry, contracts, contractKeys, pkgs))
+                  idx -= 1
+                }
+                if (exe.consuming) {
+                  contracts = contracts - exe.targetCoid
+                  exe.key.foreach(key =>
+                    contractKeys = contractKeys - GlobalKey.assertBuild(exe.templateId, key.key)
+                  )
+                }
+                ChildrenRecursion.DoRecurse
+              },
+              (_, _) => ChildrenRecursion.DoNotRecurse,
+              {
+                case (_, create: Node.Create) =>
+                  contracts = contracts.updated(create.coid, create.versionedCoinst)
+                  create.key.foreach(key =>
+                    contractKeys = contractKeys
+                      .updated(GlobalKey.assertBuild(create.templateId, key.key), create.coid)
+                  )
+                case (_, _) =>
+              },
+              (_, _) => (),
+              (_, _) => (),
             )
-          case _ =>
-            List.empty
+          case PkgEntry(archive) =>
+            pkgs += ArchiveDecoder.assertFromByteString(archive)
         }
       }
-
-      new Benchmarks(benchmarks.groupBy(_.name).view.mapValues(_.toVector).toMap)
     } finally {
       importer.close()
     }
+
+    result match {
+      case Some(value) => value
+      case None => sys.error(s"choice ${choice._1}:${choice._2} not found")
+    }
   }
 
-  def adapt(
-      pkgs: Map[Ref.PackageId, Ast.Package],
-      pkgLangVersion: Ref.PackageId => LanguageVersion,
-      state: BenchmarkState,
-  ): BenchmarkState = {
-    val adapter = new Adapter(pkgs, pkgLangVersion)
-    state.copy(
+  def adapt(pkgs: Map[Ref.PackageId, Ast.Package], state: BenchmarkState): BenchmarkState = {
+    val adapter = new Adapter(pkgs)
+    BenchmarkState(
       transaction = state.transaction.copy(tx = adapter.adapt(state.transaction.tx)),
       contracts = state.contracts.transform((_, v) => adapter.adapt(v)),
       contractKeys = state.contractKeys.iterator.map { case (k, v) => adapter.adapt(k) -> v }.toMap,
+      pkgs,
     )
   }
 

--- a/ledger/participant-state/kvutils/tools/src/test/sh/profile.sh
+++ b/ledger/participant-state/kvutils/tools/src/test/sh/profile.sh
@@ -23,5 +23,5 @@ JQ=$(rlocation "$TEST_WORKSPACE/$4")
 PROFILE_DIR=$(mktemp -d)
 trap "rm -rf $PROFILE_DIR" EXIT
 
-$PROFILE --choice "Iou:Iou:Iou_Transfer" --choice-index 0 --dar $DAR --export $EXPORT --profile-dir $PROFILE_DIR --adapt
+$PROFILE --choice "Iou:Iou:Iou_Transfer" --choice-index 0 --dar $DAR --export $EXPORT --profile-dir $PROFILE_DIR
 $JQ -e '.shared.frames | map(.name) | contains(["exercise @Iou:Iou Iou_Transfer"])' < $PROFILE_DIR/*.json


### PR DESCRIPTION
This PR

- allows the tool to extract the program directly from the
  export.

- make the tool more robust for large exports.

  Instead of enumerated all the the transaction present in the ledger
  export and then selecting the one to be benchmark, this new version
  look only for the one choice to be benchmark.

  This make the tool more capable to handle large ledger export as
  - it has to maintain less data in memory
  - it can stop as soon the data is encounter

  This should not impact performance of benchmarking as JMH create a
  new JVM for each benchmark step, so we cannot anyway cache anything
  between run.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
