### PR TITLE
Fix target name of non-sphinx tarball

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -349,7 +349,7 @@ genrule(
         "//language-support/ts/daml-types:docs",
         "@daml-cheat-sheet//:site",
     ],
-    outs = ["other-html-docs.tar.gz"],
+    outs = ["non-sphinx-html-docs.tar.gz"],
     cmd = """
     set -eou pipefail
     DIR=$$(mktemp -d)


### PR DESCRIPTION
We reference that in copy-unix-release-artifacts.sh so the name
actually matters.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
