### PR TITLE
Add forM_ compat definition

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Foldable.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Foldable.daml
@@ -99,6 +99,10 @@ mapA_ f = foldr ((*>) . f) (pure ())
 forA_ : (Foldable t, Applicative f) => t a -> (a -> f b) -> f ()
 forA_ = flip mapA_
 
+{-# DEPRECATED forM_ "Daml compatibility helper, use 'forA_' instead of 'forM_'" #-}
+forM_ : (Foldable t, Applicative f) => t a -> (a -> f b) -> f ()
+forM_ = forA_
+
 -- | Evaluate each action in the structure from left to right,
 -- and ignore the results. For a version that doesn't ignore the
 -- results see 'DA.Traversable.sequence'.

--- a/compiler/damlc/tests/daml-test-files/ActionCompat.daml
+++ b/compiler/damlc/tests/daml-test-files/ActionCompat.daml
@@ -1,0 +1,7 @@
+-- @WARN use 'forA_' instead of 'forM_'
+module ActionCompat where
+
+import DA.Foldable
+
+test : Update ()
+test = forM_ [0..3] $ \i -> debug i


### PR DESCRIPTION
I keep confusing myself because of this and I expect I’m not the only
one. We have this for forM already so this only seems natural.

The definition is in DA.Foldable rather than DA.Internal.Compatible
since it doesn’t make sense to have it imported when you don’t import forA_.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
