### PR TITLE
Avoid nix result-* symlinks on CI

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -60,7 +60,7 @@ jobs:
 
           eval "$(dev-env/bin/dade-assist)"
           HEAD=$(git rev-parse HEAD)
-          while ! nix-build -A tools.sed -A tools.jq -A tools.curl -A tools.base64 nix; do :; done
+          while ! nix-build --no-out-link -A tools.sed -A tools.jq -A tools.curl -A tools.base64 nix; do :; done
 
           trap 'rm -rf ~/.docker' EXIT
           echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin

--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -78,7 +78,7 @@ robustly_download_nix_packages :: IO ()
 robustly_download_nix_packages = do
     h (10 :: Integer)
     where
-        cmd = "nix-build nix -A tools -A ci-cached"
+        cmd = "nix-build nix -A tools -A ci-cached --no-out-link"
         h n = do
             (exit, out, err) <- System.readCreateProcessWithExitCode (System.shell cmd) ""
             case (exit, n) of

--- a/ci/dev-env-install.sh
+++ b/ci/dev-env-install.sh
@@ -40,7 +40,7 @@ step "Building dev-env dependencies"
 NIX_FAILED=0
 for i in `seq 10`; do
     NIX_FAILED=0
-    nix-build nix -A tools -A ci-cached 2>&1 | tee nix_log || NIX_FAILED=1
+    nix-build --no-out-link nix -A tools -A ci-cached 2>&1 | tee nix_log || NIX_FAILED=1
     # It should be in the last line but let’s use the last 3 and wildcards
     # to be robust against slight changes.
     if [[ $NIX_FAILED -ne 0 ]] &&

--- a/dev-env/lib/dade-common
+++ b/dev-env/lib/dade-common
@@ -57,7 +57,7 @@ dadeBaseHash() {
 
 # List tools defined in dade
 dadeListTools() {
-    cat $(nix-build $DADE_BASE_ROOT/nix -A dade.tools-list)
+    cat $(nix-build --no-out-link $DADE_BASE_ROOT/nix -A dade.tools-list)
 }
 
 # dadeGetOutput get output of a target


### PR DESCRIPTION
We really don’t want those anywhere and they currently trip up
blackduck which starts scanning our nix store.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
