### PR TITLE
daml-lf, kvutils: Move Daml-LF transaction and value handling logic to `kv-support` [KVL-1168]

### DIFF
--- a/daml-lf/kv-support/BUILD.bazel
+++ b/daml-lf/kv-support/BUILD.bazel
@@ -24,6 +24,7 @@ da_scala_library(
         "//daml-lf/data",
         "//daml-lf/transaction",
         "//daml-lf/transaction:transaction_proto_java",
+        "//daml-lf/transaction:value_proto_java",
         "@maven//:com_google_protobuf_protobuf_java",
     ],
 )

--- a/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/ConversionError.scala
+++ b/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/ConversionError.scala
@@ -13,4 +13,6 @@ object ConversionError {
       extends ConversionError(errorMessage)
   final case class DecodeError(cause: ValueCoder.DecodeError)
       extends ConversionError(cause.errorMessage)
+  final case class InternalError(override val errorMessage: String)
+      extends ConversionError(errorMessage)
 }

--- a/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionConversions.scala
+++ b/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionConversions.scala
@@ -5,12 +5,13 @@ package com.daml.lf.kv.transactions
 
 import com.daml.lf.kv.ConversionError
 import com.daml.lf.transaction.{
+  GlobalKey,
   NodeId,
   TransactionCoder,
   TransactionOuterClass,
   VersionedTransaction,
 }
-import com.daml.lf.value.ValueCoder
+import com.daml.lf.value.{Value, ValueCoder}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -92,9 +93,88 @@ object TransactionConversions {
       .sequence_
       .map(_ => RawTransaction(transactionBuilder.build.toByteString))
   }
+
+  def decodeContractIdsAndKeys(
+      rawTransaction: RawTransaction
+  ): Either[ConversionError, Set[ContractIdOrKey]] =
+    Try(TransactionOuterClass.Transaction.parseFrom(rawTransaction.byteString)) match {
+      case Failure(throwable) =>
+        Left(ConversionError.ParseError(throwable.getMessage))
+      case Success(transaction) =>
+        TransactionCoder
+          .decodeVersion(transaction.getVersion)
+          .flatMap { txVersion =>
+            transaction.getNodesList.asScala
+              .foldLeft[Either[ValueCoder.DecodeError, Set[ContractIdOrKey]]](Right(Set.empty)) {
+                case (Right(contractIdsOrKeys), node) =>
+                  TransactionCoder.decodeNodeVersion(txVersion, node).flatMap { nodeVersion =>
+                    node.getNodeTypeCase match {
+                      case TransactionOuterClass.Node.NodeTypeCase.ROLLBACK =>
+                        // Nodes under rollback will potentially produce outputs such as divulgence.
+                        // Actual outputs must be a subset of, or the same as, computed outputs and
+                        // we currently relax this check by widening the latter set, treating a node the
+                        // same regardless of whether it was under a rollback node or not.
+                        // Computed outputs that are not actual outputs can be safely trimmed: examples
+                        // are transient contracts and, now, potentially also outputs from nodes under
+                        // rollback.
+                        Right(contractIdsOrKeys)
+
+                      case TransactionOuterClass.Node.NodeTypeCase.CREATE =>
+                        val protoCreate = node.getCreate
+                        for {
+                          newContractIdsOrKeys <- TransactionCoder
+                            .nodeKey(nodeVersion, protoCreate)
+                            .map {
+                              case Some(key) => contractIdsOrKeys + ContractIdOrKey.Key(key)
+                              case None => contractIdsOrKeys
+                            }
+                          contractId <- ValueCoder.CidDecoder
+                            .decode(protoCreate.getContractIdStruct)
+                        } yield newContractIdsOrKeys + ContractIdOrKey.Id(contractId)
+
+                      case TransactionOuterClass.Node.NodeTypeCase.EXERCISE =>
+                        val protoExercise = node.getExercise
+                        for {
+                          newContractIdsOrKeys <- TransactionCoder
+                            .nodeKey(nodeVersion, protoExercise)
+                            .map {
+                              case Some(key) => contractIdsOrKeys + ContractIdOrKey.Key(key)
+                              case None => contractIdsOrKeys
+                            }
+                          contractId <- ValueCoder.CidDecoder
+                            .decode(protoExercise.getContractIdStruct)
+                        } yield newContractIdsOrKeys + ContractIdOrKey.Id(contractId)
+
+                      case TransactionOuterClass.Node.NodeTypeCase.FETCH =>
+                        // A fetch may cause a divulgence, which is why the target contract is a potential output.
+                        ValueCoder.CidDecoder.decode(node.getFetch.getContractIdStruct).map {
+                          contractId => contractIdsOrKeys + ContractIdOrKey.Id(contractId)
+                        }
+
+                      case TransactionOuterClass.Node.NodeTypeCase.LOOKUP_BY_KEY =>
+                        // Contract state only modified on divulgence, in which case we'll have a fetch node,
+                        // so no outputs from lookup node.
+                        Right(contractIdsOrKeys)
+
+                      case TransactionOuterClass.Node.NodeTypeCase.NODETYPE_NOT_SET =>
+                        Left(ValueCoder.DecodeError("NODETYPE_NOT_SET not supported"))
+                    }
+                  }
+                case (Left(error), _) => Left(error)
+              }
+          }
+          .left
+          .map(ConversionError.DecodeError)
+    }
 }
 
 final case class TransactionNodeIdWithNode(
     nodeId: RawTransaction.NodeId,
     node: RawTransaction.Node,
 )
+
+sealed trait ContractIdOrKey extends Product with Serializable
+object ContractIdOrKey {
+  final case class Id(id: Value.ContractId) extends ContractIdOrKey
+  final case class Key(key: GlobalKey) extends ContractIdOrKey
+}

--- a/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionConversionsSpec.scala
+++ b/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionConversionsSpec.scala
@@ -11,14 +11,16 @@ import com.daml.lf.kv.transactions.TransactionConversions.{
   extractTransactionVersion,
   reconstructTransaction,
 }
+import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.transaction.{
+  GlobalKey,
   Node,
   NodeId,
   TransactionOuterClass,
   TransactionVersion,
   VersionedTransaction,
 }
-import com.daml.lf.value.{Value, ValueOuterClass}
+import com.daml.lf.value.{Value, ValueCoder, ValueOuterClass}
 import com.google.protobuf
 import com.google.protobuf.ByteString
 import org.scalatest.matchers.should.Matchers
@@ -27,6 +29,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class TransactionConversionsSpec extends AnyWordSpec with Matchers {
 
   import TransactionConversionsSpec._
+  import TransactionBuilder.Implicits._
 
   "TransactionUtilsSpec" should {
     "encodeTransaction" in {
@@ -89,6 +92,220 @@ class TransactionConversionsSpec extends AnyWordSpec with Matchers {
       )
     }
   }
+
+  "decodeContractIdsAndKeys" should {
+    "return a single output for a create without a key" in {
+      val builder = TransactionBuilder()
+      val createNode = create(builder, "#1")
+      builder.add(createNode)
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        TransactionConversions
+          .encodeTransaction(builder.build())
+          .fold(error => fail(error.errorMessage), identity)
+      )
+      result shouldBe Right(Set(ContractIdOrKey.Id(createNode.coid)))
+    }
+
+    "return two outputs for a create with a key" in {
+      val builder = TransactionBuilder()
+      val createNode = create(builder, "#2", hasKey = true)
+      builder.add(createNode)
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        TransactionConversions
+          .encodeTransaction(builder.build())
+          .fold(error => fail(error.errorMessage), identity)
+      )
+      result shouldBe Right(
+        Set(
+          ContractIdOrKey.Id(createNode.coid),
+          ContractIdOrKey.Key(aGlobalKey),
+        )
+      )
+    }
+
+    "return a single output for a transient contract" in {
+      val builder = TransactionBuilder()
+      val createNode = create(builder, "#3", hasKey = true)
+      builder.add(createNode)
+      builder.add(exercise(builder, "#3"))
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        TransactionConversions
+          .encodeTransaction(builder.build())
+          .fold(error => fail(error.errorMessage), identity)
+      )
+      result shouldBe Right(
+        Set(
+          ContractIdOrKey.Id(createNode.coid),
+          ContractIdOrKey.Key(aGlobalKey),
+        )
+      )
+    }
+
+    "return a single output for an exercise without a key" in {
+      val builder = TransactionBuilder()
+      val exerciseNode = exercise(builder, "#4")
+      builder.add(exerciseNode)
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        TransactionConversions
+          .encodeTransaction(builder.build())
+          .fold(error => fail(error.errorMessage), identity)
+      )
+      result shouldBe Right(Set(ContractIdOrKey.Id(exerciseNode.targetCoid)))
+    }
+
+    "return two outputs for an exercise with a key" in {
+      val builder = TransactionBuilder()
+      val exerciseNode = exercise(builder, "#5", hasKey = true)
+      builder.add(exerciseNode)
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        TransactionConversions
+          .encodeTransaction(builder.build())
+          .fold(error => fail(error.errorMessage), identity)
+      )
+      result shouldBe Right(
+        Set(
+          ContractIdOrKey.Id(exerciseNode.targetCoid),
+          ContractIdOrKey.Key(aGlobalKey),
+        )
+      )
+    }
+
+    "return one output per fetch and fetch-by-key" in {
+      val builder = TransactionBuilder()
+      val fetchNode1 = fetch(builder, "#6", byKey = true)
+      val fetchNode2 = fetch(builder, "#7", byKey = false)
+      builder.add(fetchNode1)
+      builder.add(fetchNode2)
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        TransactionConversions
+          .encodeTransaction(builder.build())
+          .fold(error => fail(error.errorMessage), identity)
+      )
+      result shouldBe Right(
+        Set(
+          ContractIdOrKey.Id(fetchNode1.coid),
+          ContractIdOrKey.Id(fetchNode2.coid),
+        )
+      )
+    }
+
+    "return no output for a failing lookup-by-key" in {
+      val builder = TransactionBuilder()
+      builder.add(lookup(builder, "#8", found = false))
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        TransactionConversions
+          .encodeTransaction(builder.build())
+          .fold(error => fail(error.errorMessage), identity)
+      )
+      result shouldBe Right(Set.empty)
+    }
+
+    "return no output for a successful lookup-by-key" in {
+      val builder = TransactionBuilder()
+      builder.add(lookup(builder, "#9", found = true))
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        TransactionConversions
+          .encodeTransaction(builder.build())
+          .fold(error => fail(error.errorMessage), identity)
+      )
+      result shouldBe Right(Set.empty)
+    }
+
+    "return outputs for nodes under a rollback node" in {
+      val builder = TransactionBuilder()
+      val rollback = builder.add(builder.rollback())
+      val createNode = create(builder, "#10", hasKey = true)
+      builder.add(createNode, rollback)
+      val exerciseNode = exercise(builder, "#11", hasKey = true)
+      builder.add(exerciseNode, rollback)
+      val fetchNode = fetch(builder, "#12", byKey = true)
+      builder.add(fetchNode, rollback)
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        TransactionConversions
+          .encodeTransaction(builder.build())
+          .fold(error => fail(error.errorMessage), identity)
+      )
+      result shouldBe Right(
+        Set(
+          ContractIdOrKey.Id(createNode.coid),
+          ContractIdOrKey.Key(aGlobalKey),
+          ContractIdOrKey.Id(exerciseNode.targetCoid),
+          ContractIdOrKey.Id(fetchNode.coid),
+        )
+      )
+    }
+
+    "fail on a non-parsable transaction" in {
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        RawTransaction(ByteString.copyFromUtf8("wrong"))
+      )
+      result shouldBe Left(
+        ConversionError.ParseError("Protocol message tag had invalid wire type.")
+      )
+    }
+
+    "fail on a broken transaction version" in {
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        RawTransaction(
+          TransactionOuterClass.Transaction.newBuilder().setVersion("???").build().toByteString
+        )
+      )
+      result shouldBe Left(
+        ConversionError.DecodeError(ValueCoder.DecodeError("Unsupported transaction version '???'"))
+      )
+    }
+
+    "fail on a broken transaction node version" in {
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        RawTransaction(
+          TransactionOuterClass.Transaction
+            .newBuilder()
+            .setVersion(TransactionVersion.VDev.protoValue)
+            .addRoots(aRawRootNodeId.value)
+            .addNodes(
+              TransactionOuterClass.Node
+                .newBuilder()
+                .setNodeId(aRawRootNodeId.value)
+                .setVersion("???")
+            )
+            .build()
+            .toByteString
+        )
+      )
+      result shouldBe Left(
+        ConversionError.DecodeError(ValueCoder.DecodeError("Unsupported transaction version '???'"))
+      )
+    }
+
+    "fail on a broken contract ID" in {
+      val result = TransactionConversions.decodeContractIdsAndKeys(
+        RawTransaction(
+          TransactionOuterClass.Transaction
+            .newBuilder()
+            .setVersion(TransactionVersion.VDev.protoValue)
+            .addRoots(aRawRootNodeId.value)
+            .addNodes(
+              TransactionOuterClass.Node
+                .newBuilder()
+                .setNodeId(aRawRootNodeId.value)
+                .setVersion(TransactionVersion.VDev.protoValue)
+                .setExercise(
+                  TransactionOuterClass.NodeExercise
+                    .newBuilder()
+                    .setContractIdStruct(
+                      ValueOuterClass.ContractId.newBuilder().setContractId("???")
+                    )
+                )
+            )
+            .build()
+            .toByteString
+        )
+      )
+      result shouldBe Left(
+        ConversionError.DecodeError(ValueCoder.DecodeError("cannot parse contractId \"???\""))
+      )
+    }
+  }
 }
 
 object TransactionConversionsSpec {
@@ -102,15 +319,20 @@ object TransactionConversionsSpec {
   private val aDummyName = "dummyName"
   private val aModuleName = "DummyModule"
   private val aPackageId = "-dummyPkg-"
-  private val aRootObserver = Ref.Party.assertFromString("rootObserver")
-  private val aTargetContractId = Value.ContractId.V1(crypto.Hash.hashPrivateKey("dummyCoid"))
-  private val aTemplateId = ValueOuterClass.Identifier
+  private val aProtoTemplateId = ValueOuterClass.Identifier
     .newBuilder()
     .setPackageId(aPackageId)
     .addModuleName(aModuleName)
     .addName(aDummyName)
+  private val aRootObserver = Ref.Party.assertFromString("rootObserver")
+  private val aTargetContractId = Value.ContractId.V1(crypto.Hash.hashPrivateKey("dummyCoid"))
+  private val aTemplateId = Ref.Identifier(
+    Ref.PackageId.assertFromString(aPackageId),
+    Ref.QualifiedName.assertFromString(s"$aModuleName:$aDummyName"),
+  )
   private val aUnitArg =
     ValueOuterClass.Value.newBuilder().setUnit(protobuf.Empty.newBuilder()).build().toByteString
+  private val aUnitValue = Value.ValueUnit
 
   private val aChildNode = TransactionOuterClass.Node
     .newBuilder()
@@ -126,11 +348,12 @@ object TransactionConversionsSpec {
         .setContractIdStruct(
           ValueOuterClass.ContractId.newBuilder().setContractId(aTargetContractId.coid)
         )
-        .setTemplateId(aTemplateId)
+        .setTemplateId(aProtoTemplateId)
     )
-  private val aChildExerciseNode = createExerciseNode(Set(aChildObserver), ImmArray.empty)
+  private val aChildExerciseNode = exercise(Set(aChildObserver), ImmArray.empty)
+  private val aGlobalKey = GlobalKey(aTemplateId, aUnitValue)
   private val aRawChildNode = RawTransaction.Node(aChildNode.build().toByteString)
-  private val aRootExerciseNode = createExerciseNode(Set(aRootObserver), ImmArray(aChildNodeId))
+  private val aRootExerciseNode = exercise(Set(aRootObserver), ImmArray(aChildNodeId))
   private val aRootNode = TransactionOuterClass.Node
     .newBuilder()
     .setNodeId(aRawRootNodeId.value)
@@ -146,7 +369,7 @@ object TransactionConversionsSpec {
         .setContractIdStruct(
           ValueOuterClass.ContractId.newBuilder().setContractId(aTargetContractId.coid)
         )
-        .setTemplateId(aTemplateId)
+        .setTemplateId(aProtoTemplateId)
     )
   private val aRawRootNode = RawTransaction.Node(aRootNode.build().toByteString)
   private val aRawTransaction = RawTransaction(
@@ -165,17 +388,39 @@ object TransactionConversionsSpec {
     ImmArray(aRootNodeId),
   )
 
-  private def createExerciseNode(choiceObservers: Set[Ref.Party], children: ImmArray[NodeId]) =
+  private def create(builder: TransactionBuilder, id: Value.ContractId, hasKey: Boolean = false) =
+    builder.create(
+      id = id,
+      templateId = aTemplateId,
+      argument = Value.ValueRecord(None, ImmArray.Empty),
+      signatories = Set.empty,
+      observers = Set.empty,
+      key = if (hasKey) Some(aUnitValue) else None,
+    )
+
+  private def exercise(
+      builder: TransactionBuilder,
+      id: Value.ContractId,
+      hasKey: Boolean = false,
+      consuming: Boolean = true,
+  ) =
+    builder.exercise(
+      contract = create(builder, id, hasKey),
+      choice = aChoiceId,
+      argument = Value.ValueRecord(None, ImmArray.Empty),
+      actingParties = Set.empty,
+      consuming = consuming,
+      result = Some(aUnitValue),
+    )
+
+  private def exercise(choiceObservers: Set[Ref.Party], children: ImmArray[NodeId]) =
     Node.Exercise(
       targetCoid = aTargetContractId,
-      templateId = Ref.Identifier(
-        Ref.PackageId.assertFromString(aPackageId),
-        Ref.QualifiedName.assertFromString(s"$aModuleName:$aDummyName"),
-      ),
+      templateId = aTemplateId,
       choiceId = aChoiceId,
       consuming = true,
       actingParties = Set.empty,
-      chosenValue = Value.ValueUnit,
+      chosenValue = aUnitValue,
       stakeholders = Set.empty,
       signatories = Set.empty,
       choiceObservers = choiceObservers,
@@ -186,4 +431,10 @@ object TransactionConversionsSpec {
       byInterface = None,
       version = TransactionVersion.VDev,
     )
+
+  private def fetch(builder: TransactionBuilder, id: Value.ContractId, byKey: Boolean) =
+    builder.fetch(contract = create(builder, id, hasKey = true), byKey = byKey)
+
+  private def lookup(builder: TransactionBuilder, id: Value.ContractId, found: Boolean) =
+    builder.lookupByKey(contract = create(builder, id, hasKey = true), found = found)
 }

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -49,7 +49,6 @@ da_scala_library(
         "//daml-lf/kv-support",
         "//daml-lf/language",
         "//daml-lf/transaction",
-        "//daml-lf/transaction:transaction_proto_java",
         "//ledger-api/grpc-definitions:ledger_api_proto_scala",
         "//ledger/caching",
         "//ledger/error",

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -50,7 +50,6 @@ da_scala_library(
         "//daml-lf/language",
         "//daml-lf/transaction",
         "//daml-lf/transaction:transaction_proto_java",
-        "//daml-lf/transaction:value_proto_java",
         "//ledger-api/grpc-definitions:ledger_api_proto_scala",
         "//ledger/caching",
         "//ledger/error",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -55,7 +55,7 @@ import com.daml.lf.kv.contracts.{ContractConversions, RawContractInstance}
 import com.daml.lf.kv.transactions.{RawTransaction, TransactionConversions}
 import com.daml.lf.transaction._
 import com.daml.lf.value.Value.ContractId
-import com.daml.lf.value.{Value, ValueCoder}
+import com.daml.lf.value.Value
 import com.daml.lf.{crypto, data}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.protobuf.Empty
@@ -291,12 +291,10 @@ object Conversions {
     Duration.ofSeconds(dur.getSeconds, dur.getNanos.toLong)
   }
 
-  def assertEncodeTransaction(versionedTransaction: VersionedTransaction): RawTransaction = {
-    val transaction = TransactionCoder
-      .encodeTransaction(TransactionCoder.NidEncoder, ValueCoder.CidEncoder, versionedTransaction)
+  def assertEncodeTransaction(versionedTransaction: VersionedTransaction): RawTransaction =
+    TransactionConversions
+      .encodeTransaction(versionedTransaction)
       .fold(err => throw Err.EncodeError("Transaction", err.errorMessage), identity)
-    RawTransaction(transaction.toByteString)
-  }
 
   def assertDecodeTransaction(rawTransaction: RawTransaction): VersionedTransaction =
     assertDecode("Transaction", TransactionConversions.decodeTransaction(rawTransaction))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -55,7 +55,7 @@ import com.daml.lf.kv.contracts.{ContractConversions, RawContractInstance}
 import com.daml.lf.kv.transactions.{RawTransaction, TransactionConversions}
 import com.daml.lf.transaction._
 import com.daml.lf.value.Value.ContractId
-import com.daml.lf.value.{Value, ValueCoder, ValueOuterClass}
+import com.daml.lf.value.{Value, ValueCoder}
 import com.daml.lf.{crypto, data}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.protobuf.Empty
@@ -307,19 +307,6 @@ object Conversions {
     assertDecode(
       "ContractInstance",
       ContractConversions.decodeContractInstance(rawContractInstance),
-    )
-
-  def contractIdStructOrStringToStateKey[A](
-      coidStruct: ValueOuterClass.ContractId
-  ): DamlStateKey =
-    contractIdToStateKey(
-      assertDecode(
-        "ContractId",
-        ValueCoder.CidDecoder
-          .decode(coidStruct)
-          .left
-          .map(ConversionError.DecodeError),
-      )
     )
 
   private def assertDecode[X](context: => String, x: Either[ConversionError, X]): X =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -27,15 +27,16 @@ import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.engine.{Blinding, Engine}
+import com.daml.lf.kv.ConversionError
 import com.daml.lf.kv.contracts.{ContractConversions, RawContractInstance}
-import com.daml.lf.transaction.{BlindingInfo, TransactionOuterClass}
+import com.daml.lf.kv.transactions.{RawTransaction, TransactionConversions}
+import com.daml.lf.transaction.BlindingInfo
 import com.daml.lf.value.Value.ContractId
 import com.daml.logging.entries.LoggingEntries
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.google.protobuf.{Timestamp => ProtoTimestamp}
 
-import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
 
 private[kvutils] class TransactionCommitter(
@@ -156,72 +157,27 @@ private[kvutils] class TransactionCommitter(
     }
   }
 
-  /** Removes `Fetch` and `LookupByKey` nodes from the transactionEntry.
+  /** Removes `Fetch`, `LookupByKey` and `Rollback` nodes from the transactionEntry.
     */
   private[transaction] def trimUnnecessaryNodes: Step = new Step {
     def apply(
         commitContext: CommitContext,
         transactionEntry: DamlTransactionEntrySummary,
     )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
-      val transaction =
-        TransactionOuterClass.Transaction.parseFrom(transactionEntry.submission.getRawTransaction)
-      val nodes = transaction.getNodesList.asScala
-      val nodeMap: Map[String, TransactionOuterClass.Node] =
-        nodes.view.map(n => n.getNodeId -> n).toMap
-
-      @tailrec
-      def goNodesToKeep(todo: List[String], result: Set[String]): Set[String] = todo match {
-        case Nil => result
-        case head :: tail =>
-          import TransactionOuterClass.Node.NodeTypeCase
-          val node =
-            nodeMap.getOrElse(head, throw Err.InternalError(s"Invalid transaction node id $head"))
-          node.getNodeTypeCase match {
-            case NodeTypeCase.CREATE =>
-              goNodesToKeep(tail, result + head)
-            case NodeTypeCase.EXERCISE =>
-              goNodesToKeep(node.getExercise.getChildrenList.asScala.toList ++ tail, result + head)
-            case NodeTypeCase.ROLLBACK | NodeTypeCase.FETCH | NodeTypeCase.LOOKUP_BY_KEY |
-                NodeTypeCase.NODETYPE_NOT_SET =>
-              goNodesToKeep(tail, result)
-          }
-      }
-
-      val nodesToKeep = goNodesToKeep(transaction.getRootsList.asScala.toList, Set.empty)
-
-      val filteredRoots = transaction.getRootsList.asScala.filter(nodesToKeep)
-
-      def stripUnnecessaryNodes(node: TransactionOuterClass.Node): TransactionOuterClass.Node =
-        if (node.hasExercise) {
-          val exerciseNode = node.getExercise
-          val keptChildren =
-            exerciseNode.getChildrenList.asScala.filter(nodesToKeep)
-          val newExerciseNode = exerciseNode.toBuilder
-            .clearChildren()
-            .addAllChildren(keptChildren.asJavaCollection)
-            .build()
-
-          node.toBuilder
-            .setExercise(newExerciseNode)
-            .build()
-        } else {
-          node
-        }
-
-      val filteredNodes = nodes
-        .collect {
-          case node if nodesToKeep(node.getNodeId) => stripUnnecessaryNodes(node)
-        }
-
-      val newTransaction = transaction
-        .newBuilderForType()
-        .addAllRoots(filteredRoots.asJavaCollection)
-        .addAllNodes(filteredNodes.asJavaCollection)
-        .setVersion(transaction.getVersion)
-        .build()
+      val rawTransaction = RawTransaction(transactionEntry.submission.getRawTransaction)
+      val newRawTransaction = TransactionConversions
+        .filterCreateAndExerciseNodes(rawTransaction)
+        .fold(
+          {
+            case ConversionError.InternalError(errorMessage) =>
+              throw Err.InternalError(errorMessage)
+            case error => throw Err.DecodeError("Transaction", error.errorMessage)
+          },
+          identity,
+        )
 
       val newTransactionEntry = transactionEntry.submission.toBuilder
-        .setRawTransaction(newTransaction.toByteString)
+        .setRawTransaction(newRawTransaction.byteString)
         .build()
 
       StepContinue(DamlTransactionEntrySummary(newTransactionEntry))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -166,7 +166,7 @@ private[kvutils] class TransactionCommitter(
     )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
       val rawTransaction = RawTransaction(transactionEntry.submission.getRawTransaction)
       val newRawTransaction = TransactionConversions
-        .filterCreateAndExerciseNodes(rawTransaction)
+        .keepCreateAndExerciseNodes(rawTransaction)
         .fold(
           {
             case ConversionError.InternalError(errorMessage) =>

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommittingSpec.scala
@@ -8,6 +8,7 @@ import java.time.Duration
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.{DeduplicationPeriod => ApiDeduplicationPeriod}
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
+import com.daml.ledger.participant.state.kvutils.store.events.DamlTransactionEntry
 import com.daml.ledger.participant.state.kvutils.store.{DamlCommandDedupKey, DamlStateKey}
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.v2.{SubmitterInfo, TransactionMeta}
@@ -17,6 +18,7 @@ import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.value.Value
 import com.daml.metrics.Metrics
+import com.google.protobuf.ByteString
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -62,6 +64,8 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
   private def toSubmission(builder: TransactionBuilder): DamlSubmission =
     this.toSubmission(builder.buildSubmitted())
 
+  private val contractId = "#1"
+
   private val dedupKey = DamlStateKey.newBuilder
     .setCommandDedup(
       DamlCommandDedupKey.newBuilder
@@ -75,56 +79,22 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
   private val keyValue = Value.ValueUnit
   private val templateId = Ref.Identifier.assertFromString("pkg:M:T")
 
-  private def create(builder: TransactionBuilder, id: Value.ContractId, hasKey: Boolean = false) =
+  private def create(builder: TransactionBuilder) =
     builder.create(
-      id = id,
+      id = contractId,
       templateId = templateId,
       argument = Value.ValueRecord(None, ImmArray.Empty),
       signatories = Set.empty,
       observers = Set.empty,
-      key = if (hasKey) Some(keyValue) else None,
+      key = Some(keyValue),
     )
-
-  private def exercise(
-      builder: TransactionBuilder,
-      id: Value.ContractId,
-      hasKey: Boolean = false,
-      consuming: Boolean = true,
-  ) =
-    builder.exercise(
-      contract = create(builder, id, hasKey),
-      choice = "Choice",
-      argument = Value.ValueRecord(None, ImmArray.Empty),
-      actingParties = Set.empty,
-      consuming = consuming,
-      result = Some(Value.ValueUnit),
-    )
-
-  private def fetch(builder: TransactionBuilder, id: Value.ContractId, byKey: Boolean) =
-    builder.fetch(contract = create(builder, id, hasKey = true), byKey = byKey)
-
-  private def lookup(builder: TransactionBuilder, id: Value.ContractId, found: Boolean) =
-    builder.lookupByKey(contract = create(builder, id, hasKey = true), found = found)
 
   import Conversions.{contractIdToStateKey, contractKeyToStateKey}
 
   "submissionOutputs" should {
-
-    "return a single output for a create without a key" in {
+    "return outputs for a create with a key" in {
       val builder = TransactionBuilder()
-      val createNode = create(builder, "#1")
-      builder.add(createNode)
-      val key = contractIdToStateKey(createNode.coid)
-      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
-      result shouldBe Set(
-        dedupKey,
-        key,
-      )
-    }
-
-    "return two outputs for a create with a key" in {
-      val builder = TransactionBuilder()
-      val createNode = create(builder, "#1", true)
+      val createNode = create(builder)
       builder.add(createNode)
       val contractIdKey = contractIdToStateKey(createNode.coid)
       val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
@@ -136,90 +106,14 @@ class KeyValueCommittingSpec extends AnyWordSpec with Matchers {
       )
     }
 
-    "return a single output for a transient contract" in {
-      val builder = TransactionBuilder()
-      val createNode = create(builder, "#1", true)
-      builder.add(createNode)
-      builder.add(exercise(builder, "#1"))
-      val contractIdKey = contractIdToStateKey(createNode.coid)
-      val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
-      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
-      result shouldBe Set(
-        dedupKey,
-        contractIdKey,
-        contractKeyKey,
-      )
-    }
-
-    "return a single output for an exercise without a key" in {
-      val builder = TransactionBuilder()
-      val exerciseNode = exercise(builder, "#1")
-      builder.add(exerciseNode)
-      val contractIdKey = contractIdToStateKey(exerciseNode.targetCoid)
-      KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(
-        dedupKey,
-        contractIdKey,
-      )
-    }
-
-    "return two outputs for an exercise with a key" in {
-      val builder = TransactionBuilder()
-      val exerciseNode = exercise(builder, "#1", hasKey = true)
-      builder.add(exerciseNode)
-      val contractIdKey = contractIdToStateKey(exerciseNode.targetCoid)
-      val contractKeyKey = contractKeyToStateKey(templateId, keyValue)
-      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
-      result shouldBe Set(
-        dedupKey,
-        contractIdKey,
-        contractKeyKey,
-      )
-    }
-
-    "return one output per fetch and fetch-by-key" in {
-      val builder = TransactionBuilder()
-      val fetchNode1 = fetch(builder, "#1", byKey = true)
-      val fetchNode2 = fetch(builder, "#2", byKey = false)
-      builder.add(fetchNode1)
-      builder.add(fetchNode2)
-      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
-      result shouldBe Set(
-        dedupKey,
-        contractIdToStateKey(fetchNode1.coid),
-        contractIdToStateKey(fetchNode2.coid),
-      )
-    }
-
-    "return no output for a failing lookup-by-key" in {
-      val builder = TransactionBuilder()
-      builder.add(lookup(builder, "#1", found = false))
-      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
-      result shouldBe Set(dedupKey)
-    }
-
-    "return no output for a successful lookup-by-key" in {
-      val builder = TransactionBuilder()
-      builder.add(lookup(builder, "#1", found = true))
-      KeyValueCommitting.submissionOutputs(toSubmission(builder)) shouldBe Set(dedupKey)
-    }
-
-    "return outputs for nodes under a rollback node" in {
-      val builder = TransactionBuilder()
-      val rollback = builder.add(builder.rollback())
-      val createNode = create(builder, "#1", hasKey = true)
-      builder.add(createNode, rollback)
-      val exerciseNode = exercise(builder, "#2", hasKey = true)
-      builder.add(exerciseNode, rollback)
-      val fetchNode = fetch(builder, "#3", byKey = true)
-      builder.add(fetchNode, rollback)
-      val result = KeyValueCommitting.submissionOutputs(toSubmission(builder))
-      result shouldBe Set(
-        dedupKey,
-        contractIdToStateKey(createNode.coid),
-        contractKeyToStateKey(templateId, keyValue),
-        contractIdToStateKey(exerciseNode.targetCoid),
-        contractIdToStateKey(fetchNode.coid),
-      )
+    "fail on a broken transaction" in {
+      val brokenTransaction = DamlSubmission
+        .newBuilder()
+        .setTransactionEntry(
+          DamlTransactionEntry.newBuilder().setRawTransaction(ByteString.copyFromUtf8("wrong"))
+        )
+        .build()
+      an[Err.DecodeError] should be thrownBy KeyValueCommitting.submissionOutputs(brokenTransaction)
     }
   }
 }


### PR DESCRIPTION
* Moves two functions from `KeyValueCommitting` and `TransactionCommitter` to `kv-support` which allows to stop depending on `//daml-lf/transaction:transaction_proto_java` and `//daml-lf/transaction:value_proto_java` in `kvutils`.
* Adds error handling.
* Adds new tests.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
