### PR TITLE
give a break to CI

### DIFF
--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -11,7 +11,7 @@ locals {
     {
       name      = "ci-u2",
       disk_size = 400,
-      size      = 30,
+      size      = 4,
     },
   ]
 }

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -17,7 +17,7 @@ locals {
     },
     {
       name       = "ci-w2"
-      size       = 6,
+      size       = 1,
       assignment = "default",
       disk_size  = 400
     },


### PR DESCRIPTION
I can't think of a good reason to keep 30+ machines running over the
Winter break. I'll bump this back up on Jan 3.

CHANGELOG_BEGIN
CHANGELOG_END