### PR TITLE
[DPP-829] Make ledger-id field optional in requests

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/active_contracts_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/active_contracts_service.proto
@@ -32,7 +32,7 @@ message GetActiveContractsRequest {
 
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 
   // Templates to include in the served snapshot, per party.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
@@ -51,7 +51,7 @@ service CommandCompletionService {
 message CompletionStreamRequest {
   // Must correspond to the ledger id reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 
   // Only completions of commands submitted with the same application_id will be visible in the stream.
@@ -104,7 +104,7 @@ message Checkpoint {
 message CompletionEndRequest {
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -19,7 +19,7 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 message Commands {
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 
   // Identifier of the on-ledger workflow that this command is a part of.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -19,6 +19,7 @@ message ExperimentalFeatures {
   ExperimentalSelfServiceErrorCodes self_service_error_codes = 1;
   ExperimentalStaticTime static_time = 2;
   CommandDeduplicationFeatures command_deduplication = 3;
+  ExperimentalOptionalLedgerId optional_ledger_id = 4;
 }
 
 // GRPC self-service error codes are returned by the Ledger API.
@@ -37,6 +38,10 @@ message CommandDeduplicationFeatures {
   // The ledger will reject any requests which specify a deduplication period which exceeds the specified max deduplication duration.
   // This is also enforced for ledgers that convert deduplication periods specified as offsets to durations.
   bool max_deduplication_duration_enforced = 3;
+}
+
+// Ledger API does not require ledgerId to be set in the requests.
+message ExperimentalOptionalLedgerId {
 }
 
 // Feature descriptor specifying how deduplication periods can be specified and how they are handled by the participant

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/ledger_configuration_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/ledger_configuration_service.proto
@@ -27,7 +27,7 @@ message GetLedgerConfigurationRequest {
 
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/ledger_identity_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/ledger_identity_service.proto
@@ -27,6 +27,6 @@ message GetLedgerIdentityResponse {
 
   // The ID of the ledger exposed by the server.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/package_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/package_service.proto
@@ -39,7 +39,7 @@ message ListPackagesRequest {
 
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 }
 
@@ -55,7 +55,7 @@ message GetPackageRequest {
 
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 
   // The ID of the requested package.
@@ -84,7 +84,7 @@ message GetPackageStatusRequest {
 
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 
   // The ID of the requested package.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/testing/reset_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/testing/reset_service.proto
@@ -45,6 +45,6 @@ service ResetService {
 message ResetRequest {
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as describe in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/testing/time_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/testing/time_service.proto
@@ -32,7 +32,7 @@ message GetTimeRequest {
 
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as describe in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 }
 
@@ -46,7 +46,7 @@ message SetTimeRequest {
 
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as describe in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 
   // MUST precisely match the current time as it's known to the ledger server.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -87,7 +87,7 @@ message GetTransactionsRequest {
 
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 
   // Beginning of the requested ledger section.
@@ -125,7 +125,7 @@ message GetTransactionTreesResponse {
 message GetTransactionByEventIdRequest {
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 
   // The ID of a particular event.
@@ -143,7 +143,7 @@ message GetTransactionByEventIdRequest {
 message GetTransactionByIdRequest {
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as describe in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 
   // The ID of a particular transaction.
@@ -169,7 +169,7 @@ message GetFlatTransactionResponse {
 message GetLedgerEndRequest {
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as describe in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
@@ -22,7 +22,7 @@ message GetLedgerApiVersionRequest {
 
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
   // Must be a valid LedgerString (as described in ``value.proto``).
-  // Required
+  // Optional
   string ledger_id = 1;
 }
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -7,7 +7,7 @@ import java.time.{Duration, Instant}
 
 import com.daml.api.util.{DurationConversion, TimestampConversion}
 import com.daml.error.{ContextualizedErrorLogger, ErrorCodesVersionSwitcher}
-import com.daml.ledger.api.domain.LedgerId
+import com.daml.ledger.api.domain.{LedgerId, optionalLedgerId}
 import com.daml.ledger.api.v1.commands
 import com.daml.ledger.api.v1.commands.Command.Command.{
   Create => ProtoCreate,
@@ -57,8 +57,7 @@ final class CommandsValidator(
       contextualizedErrorLogger: ContextualizedErrorLogger
   ): Either[StatusRuntimeException, domain.Commands] =
     for {
-      cmdLegerId <- requireLedgerString(commands.ledgerId, "ledger_id")
-      ledgerId <- matchLedgerId(ledgerId)(LedgerId(cmdLegerId))
+      ledgerId <- matchLedgerId(ledgerId)(optionalLedgerId(commands.ledgerId))
       workflowId <-
         if (commands.workflowId.isEmpty) Right(None)
         else requireLedgerString(commands.workflowId).map(x => Some(domain.WorkflowId(x)))

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidator.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.api.validation
 
 import com.daml.error.{ContextualizedErrorLogger, ErrorCodesVersionSwitcher}
-import com.daml.ledger.api.domain.{LedgerId, LedgerOffset}
+import com.daml.ledger.api.domain.{LedgerId, LedgerOffset, optionalLedgerId}
 import com.daml.ledger.api.messages.command.completion
 import com.daml.ledger.api.messages.command.completion.CompletionStreamRequest
 import com.daml.ledger.api.v1.command_completion_service.{
@@ -34,7 +34,7 @@ class CompletionServiceRequestValidator(
       contextualizedErrorLogger: ContextualizedErrorLogger
   ): Either[StatusRuntimeException, CompletionStreamRequest] =
     for {
-      validLedgerId <- matchLedgerId(ledgerId)(LedgerId(request.ledgerId))
+      validLedgerId <- matchLedgerId(ledgerId)(optionalLedgerId(request.ledgerId))
       appId <- requireApplicationId(request.applicationId, "application_id")
       parties <- requireParties(request.parties.toSet)
       convertedOffset <- ledgerOffsetValidator.validateOptional(request.offset, "offset")
@@ -68,7 +68,7 @@ class CompletionServiceRequestValidator(
       contextualizedErrorLogger: ContextualizedErrorLogger
   ): Either[StatusRuntimeException, completion.CompletionEndRequest] =
     for {
-      ledgerId <- matchLedgerId(ledgerId)(LedgerId(req.ledgerId))
-    } yield completion.CompletionEndRequest(ledgerId)
+      _ <- matchLedgerId(ledgerId)(optionalLedgerId(req.ledgerId))
+    } yield completion.CompletionEndRequest()
 
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandCompletionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandCompletionService.scala
@@ -5,7 +5,6 @@ package com.daml.platform.server.api.services.domain
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.api.domain
 import com.daml.ledger.api.domain.LedgerOffset
 import com.daml.ledger.api.messages.command.completion.CompletionStreamRequest
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
@@ -14,7 +13,7 @@ import scala.concurrent.Future
 
 trait CommandCompletionService {
 
-  def getLedgerEnd(ledgerId: domain.LedgerId): Future[LedgerOffset.Absolute]
+  def getLedgerEnd(): Future[LedgerOffset.Absolute]
 
   def completionStreamSource(
       request: CompletionStreamRequest

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandCompletionService.scala
@@ -46,9 +46,9 @@ class GrpcCommandCompletionService(
       .validateCompletionEndRequest(request)
       .fold(
         t => Future.failed[CompletionEndResponse](ValidationLogger.logFailure(request, t)),
-        req =>
+        _ =>
           service
-            .getLedgerEnd(req.ledgerId)
+            .getLedgerEnd()
             .map(abs =>
               CompletionEndResponse(Some(LedgerOffset(LedgerOffset.Value.Absolute(abs.value))))
             ),

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ActiveContractsServiceValidation.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ActiveContractsServiceValidation.scala
@@ -5,6 +5,7 @@ package com.daml.platform.server.api.validation
 
 import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger}
 import com.daml.ledger.api.domain.LedgerId
+import com.daml.ledger.api.domain.optionalLedgerId
 import com.daml.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc.ActiveContractsService
 import com.daml.ledger.api.v1.active_contracts_service.{
   ActiveContractsServiceGrpc,
@@ -37,7 +38,7 @@ class ActiveContractsServiceValidation(
       responseObserver: StreamObserver[GetActiveContractsResponse],
   ): Unit =
     fieldValidations
-      .matchLedgerId(ledgerId)(LedgerId(request.ledgerId))
+      .matchLedgerId(ledgerId)(optionalLedgerId(request.ledgerId))
       .fold(
         t => responseObserver.onError(ValidationLogger.logFailure(request, t)),
         _ => service.getActiveContracts(request, responseObserver),

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/FieldValidations.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/FieldValidations.scala
@@ -20,12 +20,12 @@ class FieldValidations private (errorFactories: ErrorFactories) {
       ledgerId: LedgerId
   )(receivedO: Option[LedgerId])(implicit
       contextualizedErrorLogger: ContextualizedErrorLogger
-  ): Either[StatusRuntimeException, Option[LedgerId]] =
-    receivedO.fold[Either[StatusRuntimeException, Option[LedgerId]]](Right(None)) {
-      received: LedgerId =>
-        if (received == ledgerId) Right(Some(received))
-        else Left(ledgerIdMismatch(ledgerId, received, definiteAnswer = Some(false)))
-    }
+  ): Either[StatusRuntimeException, Option[LedgerId]] = receivedO match {
+    case None => Right(None)
+    case Some(`ledgerId`) => Right(Some(ledgerId))
+    case Some(mismatching) =>
+      Left(ledgerIdMismatch(ledgerId, mismatching, definiteAnswer = Some(false)))
+  }
 
   def requireNonEmptyString(s: String, fieldName: String)(implicit
       contextualizedErrorLogger: ContextualizedErrorLogger

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/FieldValidations.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/FieldValidations.scala
@@ -18,11 +18,14 @@ class FieldValidations private (errorFactories: ErrorFactories) {
 
   def matchLedgerId(
       ledgerId: LedgerId
-  )(received: LedgerId)(implicit
+  )(receivedO: Option[LedgerId])(implicit
       contextualizedErrorLogger: ContextualizedErrorLogger
-  ): Either[StatusRuntimeException, LedgerId] =
-    if (ledgerId == received) Right(received)
-    else Left(ledgerIdMismatch(ledgerId, received, definiteAnswer = Some(false)))
+  ): Either[StatusRuntimeException, Option[LedgerId]] =
+    receivedO.fold[Either[StatusRuntimeException, Option[LedgerId]]](Right(None)) {
+      received: LedgerId =>
+        if (received == ledgerId) Right(Some(received))
+        else Left(ledgerIdMismatch(ledgerId, received, definiteAnswer = Some(false)))
+    }
 
   def requireNonEmptyString(s: String, fieldName: String)(implicit
       contextualizedErrorLogger: ContextualizedErrorLogger

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/LedgerConfigurationServiceValidation.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/LedgerConfigurationServiceValidation.scala
@@ -4,7 +4,7 @@
 package com.daml.platform.server.api.validation
 
 import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger}
-import com.daml.ledger.api.domain.LedgerId
+import com.daml.ledger.api.domain.{LedgerId, optionalLedgerId}
 import com.daml.ledger.api.v1.ledger_configuration_service.LedgerConfigurationServiceGrpc.LedgerConfigurationService
 import com.daml.ledger.api.v1.ledger_configuration_service.{
   GetLedgerConfigurationRequest,
@@ -37,7 +37,7 @@ class LedgerConfigurationServiceValidation(
       responseObserver: StreamObserver[GetLedgerConfigurationResponse],
   ): Unit =
     fieldValidations
-      .matchLedgerId(ledgerId)(LedgerId(request.ledgerId))
+      .matchLedgerId(ledgerId)(optionalLedgerId(request.ledgerId))
       .fold(
         t => responseObserver.onError(ValidationLogger.logFailure(request, t)),
         _ => service.getLedgerConfiguration(request, responseObserver),

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/PackageServiceValidation.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/PackageServiceValidation.scala
@@ -4,7 +4,7 @@
 package com.daml.platform.server.api.validation
 
 import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger}
-import com.daml.ledger.api.domain.LedgerId
+import com.daml.ledger.api.domain.{LedgerId, optionalLedgerId}
 import com.daml.ledger.api.v1.package_service.PackageServiceGrpc.PackageService
 import com.daml.ledger.api.v1.package_service._
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -30,7 +30,7 @@ class PackageServiceValidation(
 
   override def listPackages(request: ListPackagesRequest): Future[ListPackagesResponse] =
     fieldValidations
-      .matchLedgerId(ledgerId)(LedgerId(request.ledgerId))
+      .matchLedgerId(ledgerId)(optionalLedgerId(request.ledgerId))
       .map(const(request))
       .fold(
         t => Future.failed(ValidationLogger.logFailure(request, t)),
@@ -39,7 +39,7 @@ class PackageServiceValidation(
 
   override def getPackage(request: GetPackageRequest): Future[GetPackageResponse] =
     fieldValidations
-      .matchLedgerId(ledgerId)(LedgerId(request.ledgerId))
+      .matchLedgerId(ledgerId)(optionalLedgerId(request.ledgerId))
       .map(const(request))
       .fold(
         t => Future.failed(ValidationLogger.logFailure(request, t)),
@@ -50,7 +50,7 @@ class PackageServiceValidation(
       request: GetPackageStatusRequest
   ): Future[GetPackageStatusResponse] =
     fieldValidations
-      .matchLedgerId(ledgerId)(LedgerId(request.ledgerId))
+      .matchLedgerId(ledgerId)(optionalLedgerId(request.ledgerId))
       .map(const(request))
       .fold(
         t => Future.failed(ValidationLogger.logFailure(request, t)),

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -84,7 +84,7 @@ class SubmitRequestValidatorTest
     )
 
     val emptyCommands = ApiCommands(
-      ledgerId = ledgerId,
+      ledgerId = Some(ledgerId),
       workflowId = Some(workflowId),
       applicationId = applicationId,
       commandId = commandId,
@@ -183,21 +183,14 @@ class SubmitRequestValidatorTest
         )
       }
 
-      "not allow missing ledgerId" in {
+      "allow missing ledgerId" in {
+        testedCommandValidator.validateCommands(
+          api.commands.withLedgerId(""),
+          internal.ledgerTime,
+          internal.submittedAt,
+          Some(internal.maxDeduplicationDuration),
+        ) shouldEqual Right(internal.emptyCommands.copy(ledgerId = None))
 
-        commandValidatorFixture.testRequestFailure(
-          _.validateCommands(
-            api.commands.withLedgerId(""),
-            internal.ledgerTime,
-            internal.submittedAt,
-            Some(internal.maxDeduplicationDuration),
-          ),
-          expectedCodeV1 = INVALID_ARGUMENT,
-          expectedDescriptionV1 = "Missing field: ledger_id",
-          expectedCodeV2 = INVALID_ARGUMENT,
-          expectedDescriptionV2 =
-            "MISSING_FIELD(8,0): The submitted command is missing a mandatory field: ledger_id",
-        )
       }
 
       "tolerate a missing workflowId" in {

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -288,9 +288,8 @@ object domain {
   type LedgerId = String @@ LedgerIdTag
   val LedgerId: Tag.TagOf[LedgerIdTag] = Tag.of[LedgerIdTag]
 
-  def optionalLedgerId(raw: String): Option[LedgerId] = {
+  def optionalLedgerId(raw: String): Option[LedgerId] =
     if (raw.isEmpty) None else Some(LedgerId(raw))
-  }
 
   sealed trait ParticipantIdTag
 

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/command/completion/CompletionEndRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/command/completion/CompletionEndRequest.scala
@@ -3,6 +3,4 @@
 
 package com.daml.ledger.api.messages.command.completion
 
-import com.daml.ledger.api.domain.LedgerId
-
-case class CompletionEndRequest(ledgerId: LedgerId)
+case class CompletionEndRequest()

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/command/completion/CompletionStreamRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/command/completion/CompletionStreamRequest.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.api.domain.{LedgerId, LedgerOffset}
 import com.daml.lf.data.Ref
 
 case class CompletionStreamRequest(
-    ledgerId: LedgerId,
+    ledgerId: Option[LedgerId],
     applicationId: Ref.ApplicationId,
     parties: Set[Ref.Party],
     offset: Option[LedgerOffset],

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetLedgerEndRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetLedgerEndRequest.scala
@@ -3,6 +3,4 @@
 
 package com.daml.ledger.api.messages.transaction
 
-import com.daml.ledger.api.domain.LedgerId
-
-final case class GetLedgerEndRequest(ledgerId: LedgerId)
+final case class GetLedgerEndRequest()

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByEventIdRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByEventIdRequest.scala
@@ -7,7 +7,7 @@ import com.daml.lf.data.Ref.Party
 import com.daml.ledger.api.domain.{EventId, LedgerId}
 
 final case class GetTransactionByEventIdRequest(
-    ledgerId: LedgerId,
+    ledgerId: Option[LedgerId],
     eventId: EventId,
     requestingParties: Set[Party],
 )

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByIdRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionByIdRequest.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.api.domain.{LedgerId, TransactionId}
 import com.daml.lf.data.Ref.Party
 
 final case class GetTransactionByIdRequest(
-    ledgerId: LedgerId,
+    ledgerId: Option[LedgerId],
     transactionId: TransactionId,
     requestingParties: Set[Party],
 )

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionTreesRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionTreesRequest.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.api.domain.{LedgerId, LedgerOffset}
 import com.daml.lf.data.Ref.Party
 
 final case class GetTransactionTreesRequest(
-    ledgerId: LedgerId,
+    ledgerId: Option[LedgerId],
     startExclusive: LedgerOffset,
     endInclusive: Option[LedgerOffset],
     parties: Set[Party],

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionsRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionsRequest.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.api.messages.transaction
 import com.daml.ledger.api.domain.{LedgerId, LedgerOffset, TransactionFilter}
 
 final case class GetTransactionsRequest(
-    ledgerId: LedgerId,
+    ledgerId: Option[LedgerId],
     startExclusive: LedgerOffset,
     endInclusive: Option[LedgerOffset],
     filter: TransactionFilter,

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -81,6 +81,7 @@ conformance_test(
         ",ParticipantPruningIT" +  # see "conformance-test-participant-pruning" below
         ",ClosedWorldIT" +  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
         ",CommandServiceIT:CSsubmitAndWaitCompletionOffset" +  # Canton does not fill the offsets
+        ",CommandServiceIT:CSsubmitAndWaitForTransactionBasicEmptyLedgerId" +  # Canton requires non-empty ledger id
         # Excluding tests that require contract key uniqueness and RWArchiveVsFailedLookupByKey (finding a lookup failure after contract creation)
         ",RaceConditionIT:WWDoubleNonTransientCreate,RaceConditionIT:WWArchiveVsNonTransientCreate,RaceConditionIT:RWTransientCreateVsNonTransientCreate,RaceConditionIT:RWArchiveVsFailedLookupByKey" +
         ",RaceConditionIT:RWArchiveVsLookupByKey,RaceConditionIT:RWArchiveVsNonConsumingChoice,RaceConditionIT:RWArchiveVsFetch,RaceConditionIT:WWDoubleArchive" +

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -81,7 +81,6 @@ conformance_test(
         ",ParticipantPruningIT" +  # see "conformance-test-participant-pruning" below
         ",ClosedWorldIT" +  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
         ",CommandServiceIT:CSsubmitAndWaitCompletionOffset" +  # Canton does not fill the offsets
-        ",CommandServiceIT:CSsubmitAndWaitForTransactionBasicEmptyLedgerId" +  # Canton requires non-empty ledger id
         # Excluding tests that require contract key uniqueness and RWArchiveVsFailedLookupByKey (finding a lookup failure after contract creation)
         ",RaceConditionIT:WWDoubleNonTransientCreate,RaceConditionIT:WWArchiveVsNonTransientCreate,RaceConditionIT:RWTransientCreateVsNonTransientCreate,RaceConditionIT:RWArchiveVsFailedLookupByKey" +
         ",RaceConditionIT:RWArchiveVsLookupByKey,RaceConditionIT:RWArchiveVsNonConsumingChoice,RaceConditionIT:RWArchiveVsFetch,RaceConditionIT:WWDoubleArchive" +

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantFeature.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantFeature.scala
@@ -11,6 +11,7 @@ final case class Features(
     userManagement: Boolean = false,
     commandDeduplicationFeatures: CommandDeduplicationFeatures,
     staticTime: Boolean = false,
+    optionalLedgerId: Boolean = false,
 )
 
 object Features {
@@ -26,6 +27,7 @@ object Features {
       userManagement = features.getUserManagement.supported,
       staticTime = experimental.getStaticTime.supported,
       commandDeduplicationFeatures = experimental.getCommandDeduplication,
+      optionalLedgerId = experimental.optionalLedgerId.isDefined,
     )
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -105,7 +105,7 @@ final class CommandServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "CSsubmitAndWaitForTransactionBasicEmptyLedgerId",
+    "CSsubmitAndWaitForTransactionEmptyLedgerId",
     "SubmitAndWaitForTransaction should accept requests with empty ledgerId",
     allocate(SingleParty),
     enabled = _.optionalLedgerId,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -108,6 +108,8 @@ final class CommandServiceIT extends LedgerTestSuite {
     "CSsubmitAndWaitForTransactionBasicEmptyLedgerId",
     "SubmitAndWaitForTransaction should accept requests with empty ledgerId",
     allocate(SingleParty),
+    enabled = _.optionalLedgerId,
+    disabledReason = "Optional ledger id must be enabled",
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
     val request = ledger
       .submitAndWaitRequest(party, Dummy(party).create.command)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -10,6 +10,7 @@ import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.v1.commands.Command
+import com.daml.ledger.api.v1.command_service.SubmitAndWaitForTransactionResponse
 import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.client.binding.Value.encode
@@ -20,7 +21,6 @@ import com.daml.ledger.test.model.Test.WithObservers._
 import com.daml.ledger.test.model.Test._
 import io.grpc.Status
 import scalaz.syntax.tag._
-
 import java.util.regex.Pattern
 
 final class CommandServiceIT extends LedgerTestSuite {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -10,7 +10,6 @@ import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.v1.commands.Command
-import com.daml.ledger.api.v1.command_service.SubmitAndWaitForTransactionResponse
 import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.client.binding.Value.encode

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -10,7 +10,6 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.daml.error.{DamlContextualizedErrorLogger, ErrorCodesVersionSwitcher}
 import com.daml.grpc.adapter.ExecutionSequencerFactory
-import com.daml.ledger.api.domain
 import com.daml.ledger.api.domain.{LedgerId, LedgerOffset}
 import com.daml.ledger.api.messages.command.completion.CompletionStreamRequest
 import com.daml.ledger.api.v1.command_completion_service._
@@ -51,7 +50,7 @@ private[apiserver] final class ApiCommandCompletionService private (
   override def completionStreamSource(
       request: CompletionStreamRequest
   ): Source[CompletionStreamResponse, NotUsed] =
-    Source.future(getLedgerEnd(request.ledgerId)).flatMapConcat { ledgerEnd =>
+    Source.future(getLedgerEnd()).flatMapConcat { ledgerEnd =>
       validator
         .validateCompletionStreamRequest(request, ledgerEnd)
         .fold(
@@ -80,7 +79,7 @@ private[apiserver] final class ApiCommandCompletionService private (
         )
     }
 
-  override def getLedgerEnd(ledgerId: domain.LedgerId): Future[LedgerOffset.Absolute] =
+  override def getLedgerEnd(): Future[LedgerOffset.Absolute] =
     completionsService.currentLedgerEnd().andThen(logger.logErrorsOnCall[LedgerOffset.Absolute])
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -294,7 +294,7 @@ private[apiserver] object ApiCommandService {
       implicit val contextualizedErrorLogger: DamlContextualizedErrorLogger =
         new DamlContextualizedErrorLogger(logger, loggingContext, None)
       for {
-        ledgerEnd <- completionServices.getLedgerEnd(configuration.ledgerId)
+        ledgerEnd <- completionServices.getLedgerEnd()
       } yield {
         val commandTrackerFlow =
           CommandTrackerFlow[Promise[Either[CompletionFailure, CompletionSuccess]], NotUsed](
@@ -308,7 +308,7 @@ private[apiserver] object ApiCommandService {
                     completionServices
                       .completionStreamSource(
                         CompletionStreamRequest(
-                          configuration.ledgerId,
+                          Some(configuration.ledgerId),
                           key.applicationId,
                           key.parties,
                           Some(offset),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
@@ -11,6 +11,7 @@ import com.daml.error.{
 import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
   ExperimentalFeatures,
+  ExperimentalOptionalLedgerId,
   ExperimentalSelfServiceErrorCodes,
   ExperimentalStaticTime,
 }
@@ -60,6 +61,7 @@ private[apiserver] final class ApiVersionService private (
             Option.when(enableSelfServiceErrorCodes)(ExperimentalSelfServiceErrorCodes()),
           staticTime = Some(ExperimentalStaticTime(supported = enableStaticTime)),
           commandDeduplication = Some(commandDeduplicationFeatures),
+          optionalLedgerId = Some(ExperimentalOptionalLedgerId()),
         )
       ),
     )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -13,6 +13,7 @@ import com.daml.ledger.api.domain.{
 }
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.logging._
+import com.daml.logging.entries.LoggingValue.OfString
 import com.daml.logging.entries.ToLoggingKey._
 import com.daml.logging.entries.{LoggingEntries, LoggingEntry, LoggingValue}
 import scalaz.syntax.tag.ToTagOps
@@ -55,8 +56,8 @@ package object logging {
   private[services] def offset(offset: String): LoggingEntry =
     "offset" -> offset
 
-  private[services] def ledgerId(id: LedgerId): LoggingEntry =
-    "ledgerId" -> id.unwrap
+  private[services] def ledgerId(id: Option[LedgerId]): LoggingEntry =
+    "ledgerId" -> OfString(id.map(_.unwrap).getOrElse("<empty-ledger-id>"))
 
   private[services] def commandId(id: String): LoggingEntry =
     "commandId" -> id

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
@@ -104,7 +104,7 @@ class LedgerTimeAwareCommandExecutorSpec
     }
 
     val commands = Commands(
-      ledgerId = LedgerId("ledgerId"),
+      ledgerId = Some(LedgerId("ledgerId")),
       workflowId = None,
       applicationId = Ref.ApplicationId.assertFromString("applicationId"),
       commandId = CommandId(Ref.CommandId.assertFromString("commandId")),

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
@@ -56,7 +56,7 @@ class StoreBackedCommandExecutorSpec
         )
 
       val commands = Commands(
-        ledgerId = LedgerId("ledgerId"),
+        ledgerId = Some(LedgerId("ledgerId")),
         workflowId = None,
         applicationId = Ref.ApplicationId.assertFromString("applicationId"),
         commandId = CommandId(Ref.CommandId.assertFromString("commandId")),

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
@@ -451,7 +451,7 @@ object ApiSubmissionServiceSpec {
   private def newSubmitRequest() = {
     SubmitRequest(
       Commands(
-        ledgerId = LedgerId("ledger-id"),
+        ledgerId = Some(LedgerId("ledger-id")),
         workflowId = None,
         applicationId = DomainMocks.applicationId,
         commandId = CommandId(


### PR DESCRIPTION
CHANGELOG_BEGIN
The field "ledger_id" in all request to Participant API is now optional (was required).
CHANGELOG_END

