### PR TITLE
Update ci nodes for copyright update

### DIFF
--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -7,7 +7,7 @@ locals {
       name      = "ci-u1",
       disk_size = 200,
       size      = 0,
-      year      = 2021,
+      year      = 2022,
     },
     {
       name      = "ci-u2",

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -13,7 +13,7 @@ locals {
       name      = "ci-u2",
       disk_size = 400,
       size      = 0,
-      year      = 2021,
+      year      = 2022,
     },
   ]
 }

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -7,13 +7,11 @@ locals {
       name      = "ci-u1",
       disk_size = 200,
       size      = 30,
-      year      = 2022,
     },
     {
       name      = "ci-u2",
       disk_size = 400,
       size      = 0,
-      year      = 2022,
     },
   ]
 }
@@ -26,7 +24,6 @@ data "template_file" "vsts-agent-ubuntu_20_04-startup" {
     vsts_token   = secret_resource.vsts-token.value
     vsts_account = "digitalasset"
     vsts_pool    = "ubuntu_20_04"
-    year         = local.ubuntu[count.index].year
   }
 }
 

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -6,7 +6,7 @@ locals {
     {
       name      = "ci-u1",
       disk_size = 200,
-      size      = 0,
+      size      = 30,
       year      = 2022,
     },
     {

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -12,7 +12,7 @@ locals {
     {
       name      = "ci-u2",
       disk_size = 400,
-      size      = 30,
+      size      = 0,
       year      = 2021,
     },
   ]

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -7,23 +7,26 @@ locals {
       name      = "ci-u1",
       disk_size = 200,
       size      = 0,
+      year      = 2021,
     },
     {
       name      = "ci-u2",
       disk_size = 400,
       size      = 30,
+      year      = 2021,
     },
   ]
 }
 
 data "template_file" "vsts-agent-ubuntu_20_04-startup" {
+  count    = length(local.ubuntu)
   template = file("${path.module}/vsts_agent_ubuntu_20_04_startup.sh")
 
   vars = {
     vsts_token   = secret_resource.vsts-token.value
     vsts_account = "digitalasset"
     vsts_pool    = "ubuntu_20_04"
-    year         = 2021
+    year         = local.ubuntu[count.index].year
   }
 }
 
@@ -70,7 +73,7 @@ resource "google_compute_instance_template" "vsts-agent-ubuntu_20_04" {
   }
 
   metadata = {
-    startup-script = data.template_file.vsts-agent-ubuntu_20_04-startup.rendered
+    startup-script = data.template_file.vsts-agent-ubuntu_20_04-startup[count.index].rendered
 
     shutdown-script = "#!/usr/bin/env bash\nset -euo pipefail\ncd /home/vsts/agent\nsu vsts <<SHUTDOWN_AGENT\nexport VSTS_AGENT_INPUT_TOKEN='${secret_resource.vsts-token.value}'\n./config.sh remove --unattended --auth PAT\nSHUTDOWN_AGENT\n    "
   }

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -23,6 +23,7 @@ data "template_file" "vsts-agent-ubuntu_20_04-startup" {
     vsts_token   = secret_resource.vsts-token.value
     vsts_account = "digitalasset"
     vsts_pool    = "ubuntu_20_04"
+    year         = 2021
   }
 }
 

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) ${year} Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Agent startup script

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Agent startup script

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# Copyright (c) ${year} Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Agent startup script


### PR DESCRIPTION
Audit log for CI rotation.

CHANGELOG_BEGIN
CHANGELOG_END

--

All already applied. Bottom line is our (Ubuntu) CI nodes now have proper copyright headers in their internal startup scripts nobody's ever going to look at.