### PR TITLE
[JSON-API] Fix that tokens without the daml namespace were wrongly interpret as …

### DIFF
--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -299,27 +299,52 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
   final val clientTlsConfig = TlsConfiguration(enabled = true, clientCrt, clientPem, caCrt)
   private val noTlsConfig = TlsConfiguration(enabled = false, None, None, None)
 
-  def jwtForParties(actAs: List[String], readAs: List[String], ledgerId: String) = {
+  def jwtForParties(
+      actAs: List[String],
+      readAs: List[String],
+      ledgerId: String,
+      withoutNamespace: Boolean = false,
+  ) = {
     import AuthServiceJWTCodec.JsonImplicits._
-    val decodedJwt = DecodedJwt(
-      """{"alg": "HS256", "typ": "JWT"}""",
-      AuthServiceJWTPayload(
-        ledgerId = Some(ledgerId),
-        applicationId = Some("test"),
-        actAs = actAs,
-        participantId = None,
-        exp = None,
-        admin = false,
-        readAs = readAs,
-      ).toJson.prettyPrint,
-    )
+    val payload =
+      if (withoutNamespace)
+        s"""{
+               |  "ledgerId": "$ledgerId",
+               |  "applicationId": "test",
+               |  "exp": 0,
+               |  "admin": false,
+               |  "actAs": ${actAs.toJson.prettyPrint},
+               |  "readAs": ${readAs.toJson.prettyPrint}
+               |}
+              """.stripMargin
+      else
+        AuthServiceJWTPayload(
+          ledgerId = Some(ledgerId),
+          applicationId = Some("test"),
+          actAs = actAs,
+          participantId = None,
+          exp = None,
+          admin = false,
+          readAs = readAs,
+        ).toJson.prettyPrint
     JwtSigner.HMAC256
-      .sign(decodedJwt, "secret")
+      .sign(
+        DecodedJwt(
+          """{"alg": "HS256", "typ": "JWT"}""",
+          payload,
+        ),
+        "secret",
+      )
       .fold(e => throw new IllegalArgumentException(s"cannot sign a JWT: ${e.shows}"), identity)
   }
 
-  def headersWithPartyAuth(actAs: List[String], readAs: List[String], ledgerId: String) =
-    authorizationHeader(jwtForParties(actAs, readAs, ledgerId))
+  def headersWithPartyAuth(
+      actAs: List[String],
+      readAs: List[String],
+      ledgerId: String,
+      withoutNamespace: Boolean = false,
+  ) =
+    authorizationHeader(jwtForParties(actAs, readAs, ledgerId, withoutNamespace))
 
   def authorizationHeader(token: Jwt): List[Authorization] =
     List(Authorization(OAuth2BearerToken(token.value)))

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -210,6 +210,12 @@ trait AbstractHttpServiceIntegrationTestFuns
   protected def headersWithPartyAuth(actAs: List[String], readAs: List[String] = List()) =
     HttpServiceTestFixture.headersWithPartyAuth(actAs, readAs, testId)
 
+  protected def headersWithPartyAuthLegacyFormat(
+      actAs: List[String],
+      readAs: List[String] = List(),
+  ) =
+    HttpServiceTestFixture.headersWithPartyAuth(actAs, readAs, testId, withoutNamespace = true)
+
   protected def postJsonStringRequest(
       uri: Uri,
       jsonString: String,
@@ -744,6 +750,37 @@ abstract class AbstractHttpServiceIntegrationTest
         cs should have size 2
       )
     } yield succeed
+  }
+
+  "get all parties using the legacy token format" in withHttpServiceAndClient {
+    (uri, _, _, client, _) =>
+      import scalaz.std.vector._
+      val partyIds = Vector("P1", "P2", "P3", "P4").map(getUniqueParty(_).unwrap)
+      val partyManagement = client.partyManagementClient
+      val _ =
+        headersWithPartyAuthLegacyFormat(List())
+      partyIds
+        .traverse { p =>
+          partyManagement.allocateParty(Some(p), Some(s"$p & Co. LLC"))
+        }
+        .flatMap { allocatedParties =>
+          getRequest(
+            uri = uri.withPath(Uri.Path("/v1/parties")),
+            headersWithPartyAuthLegacyFormat(List()),
+          ).flatMap { case (status, output) =>
+            status shouldBe StatusCodes.OK
+            inside(
+              decode1[domain.OkResponse, List[domain.PartyDetails]](output)
+            ) { case \/-(response) =>
+              response.status shouldBe StatusCodes.OK
+              response.warnings shouldBe empty
+              val actualIds: Set[domain.Party] = response.result.view.map(_.identifier).toSet
+              actualIds should contain allElementsOf domain.Party.subst(partyIds.toSet)
+              response.result.toSet should contain allElementsOf
+                allocatedParties.toSet.map(domain.PartyDetails.fromLedgerApi)
+            }
+          }
+        }: Future[Assertion]
   }
 
   "query POST with empty query" in withHttpService { (uri, encoder, _, _) =>


### PR DESCRIPTION
…user tokens for some endpoints

Officially fixes https://github.com/digital-asset/daml/issues/12215

-----

Changelog entry and commit msg differ here because the bug described in
the changelog was already fixed by adding the user management support
because it caused for the affected endpoints that it will be interpret as
user token while only fetching the ledger id (without actually checking
that it is a user token).

changelog_begin

- [HTTP-JSON] Fixed a bug that caused jwt's without the daml namespace to be rejected for some endpoints (https://github.com/digital-asset/daml/issues/12215)

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
