### PR TITLE
devenv: Use `NIX_USER_CONF_FILES` to set caches.

### DIFF
--- a/dev-env/etc/nix.conf
+++ b/dev-env/etc/nix.conf
@@ -1,10 +1,11 @@
 build-max-jobs = 2
-binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
+
+extra-substituters = https://nix-cache.da-ext.net
 # Note: the "hydra.da-int.net" string is now part of the name of the key for
 # legacy reasons; it bears no relation to the DNS hostname of the current
 # cache.
-# If you change this, you also need to update the config in infra/vsts_agent_linux_startup.sh.
-binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
+# If you change this, you also need to update the config in infra/vsts_agent_ubuntu_20_04_startup.sh.
+extra-trusted-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g=
 
 # Keep build-time dependencies of non-garbage outputs around
 gc-keep-outputs = true

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -104,10 +104,15 @@ source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 )
 
 # Make sure nix gets ensured in main shell
-echo source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
+echo "source $(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 
 # Expose our tools in /dev-env/bin and our version of nixpkgs
-echo "export NIX_CONF_DIR=\"${DADE_DEVENV_DIR}/etc\""
+if [[ "$("${DADE_DEVENV_DIR}/bin/semver" compare "$(get_nix_version)" '2.4.0')" -ge 0 ]]; then
+  echo "export NIX_USER_CONF_FILES=\"${DADE_DEVENV_DIR}/etc/nix.conf:\${NIX_USER_CONF_FILES}:\${XDG_CONFIG_HOME:-\${HOME}/.config}/nix/nix.conf\""
+else
+  # On an old version of Nix, overwrite the system config, as we can't support multiple config files.
+  echo "export NIX_CONF_DIR=\"${DADE_DEVENV_DIR}/etc\""
+fi
 echo "export NIX_PATH=nixpkgs=\"${DADE_NIXPKGS}\""
 echo "export PATH=\"${DADE_DEVENV_DIR}/bin:\$PATH\""
 echo "export PYTHONPATH=\".\${PYTHONPATH:+:\$PYTHONPATH}\""

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -20,34 +20,42 @@ unset NIX_PATH
 set -Eeuo pipefail
 
 if [[ -n "${DADE_DEBUG+x}" ]]; then
-    set -x
+  set -x
 fi
 
 errcho() {
-    >&2 echo "[dev-env] $*"
+  >&2 echo "[dev-env] $*"
+}
+
+get_nix_version() {
+  local current
+  current="$(nix-env --version)"
+  if [[ "$current" =~ ([0-9])[.]([0-9]+)([.]([0-9]+))?$ ]]; then
+    echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[4]:-0}"
+  else
+    errcho "WARNING: Unexpected output of 'nix-env --version' ($current), dev-env might not work properly."
+    return 1
+  fi
 }
 
 check_nix_version() {
-    # Keep in sync with dade-nix-install.
-    NIX_MAJOR="$1"
-    NIX_MINOR="$2"
-    NIX_PATCH="$3"
-    local current
-    current=$(nix-env --version)
-    if [[ $current =~ ([0-9])[.]([0-9]+)([.]([0-9]+))? ]]; then
-        local current_major="${BASH_REMATCH[1]}"
-        local current_minor="${BASH_REMATCH[2]}"
-        local current_patch="${BASH_REMATCH[4]:-0}"
-        if [[ $current_major -lt $NIX_MAJOR ]] ||
-           [[ $current_major -eq $NIX_MAJOR && $current_minor -lt $NIX_MINOR ]] ||
-           [[ $current_major -eq $NIX_MAJOR && $current_minor -eq $NIX_MINOR && $current_patch -lt $NIX_PATCH ]];
+  # Keep in sync with dade-nix-install.
+  NIX_MAJOR="$1"
+  NIX_MINOR="$2"
+  NIX_PATCH="$3"
+  if current="$(get_nix_version)"; then
+    [[ "$current" =~ ([0-9])[.]([0-9]+)[.]([0-9]+)$ ]]
+    local current_major="${BASH_REMATCH[1]}"
+    local current_minor="${BASH_REMATCH[2]}"
+    local current_patch="${BASH_REMATCH[3]}"
+    if [[ $current_major -lt $NIX_MAJOR ]] ||
+      [[ $current_major -eq $NIX_MAJOR && $current_minor -lt $NIX_MINOR ]] ||
+      [[ $current_major -eq $NIX_MAJOR && $current_minor -eq $NIX_MINOR && $current_patch -lt $NIX_PATCH ]];
         then
-            errcho "WARNING: Version ${current_major}.${current_minor}.${current_patch} detected, but ${NIX_MAJOR}.${NIX_MINOR}.${NIX_PATCH} or higher required."
-            errcho "Please run 'nix upgrade-nix' or 'curl -sSfL https://nixos.org/nix/install | sh' to update Nix."
-        fi
-    else
-      errcho "WARNING: Unexpected output of 'nix-env --version' ($current), dev-env might not work properly. Contact #disc-enterprise-pipe immediately!"
+          errcho "WARNING: Version ${current_major}.${current_minor}.${current_patch} detected, but ${NIX_MAJOR}.${NIX_MINOR}.${NIX_PATCH} or higher required."
+          errcho "Please run 'nix upgrade-nix' or 'curl -sSfL https://nixos.org/nix/install | sh' to update Nix."
     fi
+  fi
 }
 
 # TODO(gleber): Compatibility mode until JBH is ugraded.

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -27,27 +27,17 @@ errcho() {
   >&2 echo "[dev-env] $*"
 }
 
-get_nix_version() {
-  local current
-  current="$(nix-env --version)"
-  if [[ "$current" =~ ([0-9])[.]([0-9]+)([.]([0-9]+))?$ ]]; then
-    echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[4]:-0}"
-  else
-    errcho "WARNING: Unexpected output of 'nix-env --version' ($current), dev-env might not work properly."
-    return 1
-  fi
-}
-
 check_nix_version() {
   # Keep in sync with dade-nix-install.
   NIX_MAJOR="$1"
   NIX_MINOR="$2"
   NIX_PATCH="$3"
-  if current="$(get_nix_version)"; then
-    [[ "$current" =~ ([0-9])[.]([0-9]+)[.]([0-9]+)$ ]]
+  local current
+  current=$(nix-env --version)
+  if [[ $current =~ ([0-9])[.]([0-9]+)([.]([0-9]+))? ]]; then
     local current_major="${BASH_REMATCH[1]}"
     local current_minor="${BASH_REMATCH[2]}"
-    local current_patch="${BASH_REMATCH[3]}"
+    local current_patch="${BASH_REMATCH[4]:-0}"
     if [[ $current_major -lt $NIX_MAJOR ]] ||
       [[ $current_major -eq $NIX_MAJOR && $current_minor -lt $NIX_MINOR ]] ||
       [[ $current_major -eq $NIX_MAJOR && $current_minor -eq $NIX_MINOR && $current_patch -lt $NIX_PATCH ]];
@@ -55,6 +45,8 @@ check_nix_version() {
           errcho "WARNING: Version ${current_major}.${current_minor}.${current_patch} detected, but ${NIX_MAJOR}.${NIX_MINOR}.${NIX_PATCH} or higher required."
           errcho "Please run 'nix upgrade-nix' or 'curl -sSfL https://nixos.org/nix/install | sh' to update Nix."
     fi
+  else
+    errcho "WARNING: Unexpected output of 'nix-env --version' ($current), dev-env might not work properly."
   fi
 }
 
@@ -79,7 +71,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
   # shellcheck source=./ensure-nix
   source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 
-  : "${DADE_DESIRED_NIX_VERSION:=2 1 3}"
+  : "${DADE_DESIRED_NIX_VERSION:=2 4 0}"
   check_nix_version $DADE_DESIRED_NIX_VERSION
 
   # If the user has no channels configured, then NIX_PATH might point
@@ -107,12 +99,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 echo "source $(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 
 # Expose our tools in /dev-env/bin and our version of nixpkgs
-if [[ "$("${DADE_DEVENV_DIR}/bin/semver" compare "$(get_nix_version)" '2.4.0')" -ge 0 ]]; then
-  echo "export NIX_USER_CONF_FILES=\"${DADE_DEVENV_DIR}/etc/nix.conf:\${NIX_USER_CONF_FILES}:\${XDG_CONFIG_HOME:-\${HOME}/.config}/nix/nix.conf\""
-else
-  # On an old version of Nix, overwrite the system config, as we can't support multiple config files.
-  echo "export NIX_CONF_DIR=\"${DADE_DEVENV_DIR}/etc\""
-fi
+echo "export NIX_USER_CONF_FILES=\"${DADE_DEVENV_DIR}/etc/nix.conf:\${NIX_USER_CONF_FILES}:\${XDG_CONFIG_HOME:-\${HOME}/.config}/nix/nix.conf\""
 echo "export NIX_PATH=nixpkgs=\"${DADE_NIXPKGS}\""
 echo "export PATH=\"${DADE_DEVENV_DIR}/bin:\$PATH\""
 echo "export PYTHONPATH=\".\${PYTHONPATH:+:\$PYTHONPATH}\""

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -99,7 +99,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 echo "source $(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 
 # Expose our tools in /dev-env/bin and our version of nixpkgs
-echo "export NIX_USER_CONF_FILES=\"${DADE_DEVENV_DIR}/etc/nix.conf:\${NIX_USER_CONF_FILES}:\${XDG_CONFIG_HOME:-\${HOME}/.config}/nix/nix.conf\""
+echo "export NIX_USER_CONF_FILES=\"${DADE_DEVENV_DIR}/etc/nix.conf:\${NIX_USER_CONF_FILES:-}:\${XDG_CONFIG_HOME:-\${HOME}/.config}/nix/nix.conf\""
 echo "export NIX_PATH=nixpkgs=\"${DADE_NIXPKGS}\""
 echo "export PATH=\"${DADE_DEVENV_DIR}/bin:\$PATH\""
 echo "export PYTHONPATH=\".\${PYTHONPATH:+:\$PYTHONPATH}\""

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -199,8 +199,8 @@ rm /etc/sudoers.d/nix_installation
 # legacy reasons; it bears no relation to the DNS hostname of the current
 # cache.
 cat <<NIX_CONF > /etc/nix/nix.conf
-binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
-binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
+extra-substituters = https://nix-cache.da-ext.net
+extra-trusted-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g=
 build-users-group = nixbld
 cores = 1
 max-jobs = 0


### PR DESCRIPTION
This means that configs stack, rather than being clobbered.

I also updated the configuration file itself so it appends cache information, rather than overwriting, using the "extra-" prefix.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
