### PR TITLE
DPP-553 Consistently use anorm string interpolation

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ConfigurationStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ConfigurationStorageBackendTemplate.scala
@@ -64,7 +64,7 @@ private[backend] class ConfigurationStorageBackendTemplate(ledgerEndCache: Ledge
         configuration_entries
       where
         configuration_entries.typ = '#$acceptType' and
-        ${ledgerEndOffset} >= ledger_offset
+        $ledgerEndOffset >= ledger_offset
       order by ledger_offset desc
       fetch next 1 row only
   """
@@ -92,11 +92,11 @@ private[backend] class ConfigurationStorageBackendTemplate(ledgerEndCache: Ledge
       from
         configuration_entries
       where
-        (${startExclusive} is null or ledger_offset>${startExclusive}) and
-        ledger_offset <= ${endInclusive}
+        ($startExclusive is null or ledger_offset>$startExclusive) and
+        ledger_offset <= $endInclusive
       order by ledger_offset asc
-      offset ${queryOffset} rows
-      fetch next ${pageSize} rows only
+      offset $queryOffset rows
+      fetch next $pageSize rows only
   """
       .asVectorOf(configurationEntryParser)(connection)
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ConfigurationStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ConfigurationStorageBackendTemplate.scala
@@ -51,7 +51,8 @@ private[backend] class ConfigurationStorageBackendTemplate(ledgerEndCache: Ledge
       }
 
   def ledgerConfiguration(connection: Connection): Option[(Offset, Configuration)] = {
-    val ledgerEndOffset = ledgerEndCache()._1.toHexString.toString
+    import com.daml.platform.store.Conversions.OffsetToStatement
+    val ledgerEndOffset = ledgerEndCache()._1
     SQL"""
       select
         configuration_entries.ledger_offset,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/DeduplicationStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/DeduplicationStorageBackendTemplate.scala
@@ -21,7 +21,7 @@ private[backend] trait DeduplicationStorageBackendTemplate extends Deduplication
     SQL"""
       select deduplicate_until
       from participant_command_submissions
-      where deduplication_key = ${deduplicationKey}
+      where deduplication_key = $deduplicationKey
     """
       .as(CommandDataParser.single)(connection)
       .deduplicateUntil
@@ -40,7 +40,7 @@ private[backend] trait DeduplicationStorageBackendTemplate extends Deduplication
   override def stopDeduplicatingCommand(deduplicationKey: String)(connection: Connection): Unit = {
     SQL"""
       delete from participant_command_submissions
-      where deduplication_key = ${deduplicationKey}
+      where deduplication_key = $deduplicationKey
     """
       .execute()(connection)
     ()

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/DeduplicationStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/DeduplicationStorageBackendTemplate.scala
@@ -4,19 +4,13 @@
 package com.daml.platform.store.backend.common
 
 import java.sql.Connection
-import anorm.{RowParser, SQL}
+import anorm.RowParser
 import com.daml.lf.data.Time.Timestamp
 import com.daml.platform.store.Conversions.timestampFromMicros
+import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
 import com.daml.platform.store.backend.DeduplicationStorageBackend
 
 private[backend] trait DeduplicationStorageBackendTemplate extends DeduplicationStorageBackend {
-
-  private val SQL_SELECT_COMMAND = SQL("""
-                                         |select deduplicate_until
-                                         |from participant_command_submissions
-                                         |where deduplication_key = {deduplicationKey}
-    """.stripMargin)
-
   private case class ParsedCommandData(deduplicateUntil: Timestamp)
 
   private val CommandDataParser: RowParser[ParsedCommandData] =
@@ -24,33 +18,30 @@ private[backend] trait DeduplicationStorageBackendTemplate extends Deduplication
       .map(ParsedCommandData)
 
   override def deduplicatedUntil(deduplicationKey: String)(connection: Connection): Timestamp =
-    SQL_SELECT_COMMAND
-      .on("deduplicationKey" -> deduplicationKey)
+    SQL"""
+      select deduplicate_until
+      from participant_command_submissions
+      where deduplication_key = ${deduplicationKey}
+    """
       .as(CommandDataParser.single)(connection)
       .deduplicateUntil
-
-  private val SQL_DELETE_EXPIRED_COMMANDS = SQL("""
-                                                  |delete from participant_command_submissions
-                                                  |where deduplicate_until < {currentTime}
-    """.stripMargin)
 
   override def removeExpiredDeduplicationData(
       currentTime: Timestamp
   )(connection: Connection): Unit = {
-    SQL_DELETE_EXPIRED_COMMANDS
-      .on("currentTime" -> currentTime.micros)
+    SQL"""
+      delete from participant_command_submissions
+      where deduplicate_until < ${currentTime.micros}
+    """
       .execute()(connection)
     ()
   }
 
-  private val SQL_DELETE_COMMAND = SQL("""
-                                         |delete from participant_command_submissions
-                                         |where deduplication_key = {deduplicationKey}
-    """.stripMargin)
-
   override def stopDeduplicatingCommand(deduplicationKey: String)(connection: Connection): Unit = {
-    SQL_DELETE_COMMAND
-      .on("deduplicationKey" -> deduplicationKey)
+    SQL"""
+      delete from participant_command_submissions
+      where deduplication_key = ${deduplicationKey}
+    """
       .execute()(connection)
     ()
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -484,11 +484,13 @@ abstract class EventStorageBackendTemplate(
       filterParams: FilterParams,
   )(connection: Connection): Vector[EventsTable.Entry[Raw.FlatEvent]] = {
     import com.daml.platform.store.Conversions.ledgerStringToStatement
+    import com.daml.platform.store.Conversions.OffsetToStatement
+    val ledgerEndOffset = ledgerEndCache()._1
     events(
       columnPrefix = "",
       joinClause = cSQL"""JOIN parameters ON
             (participant_pruned_up_to_inclusive is null or event_offset > participant_pruned_up_to_inclusive)
-            AND event_offset <= ${ledgerEndCache()._1.toHexString.toString}""",
+            AND event_offset <= $ledgerEndOffset""",
       additionalAndClause = cSQL"""
             transaction_id = $transactionId AND
             event_kind != 0 AND -- we do not want to fetch divulgence events""",
@@ -529,11 +531,13 @@ abstract class EventStorageBackendTemplate(
       filterParams: FilterParams,
   )(connection: Connection): Vector[EventsTable.Entry[Raw.TreeEvent]] = {
     import com.daml.platform.store.Conversions.ledgerStringToStatement
+    import com.daml.platform.store.Conversions.OffsetToStatement
+    val ledgerEndOffset = ledgerEndCache()._1
     events(
       columnPrefix = "",
       joinClause = cSQL"""JOIN parameters ON
             (participant_pruned_up_to_inclusive is null or event_offset > participant_pruned_up_to_inclusive)
-            AND event_offset <= ${ledgerEndCache()._1.toHexString.toString}""",
+            AND event_offset <= $ledgerEndOffset""",
       additionalAndClause = cSQL"""
             transaction_id = $transactionId AND
             event_kind != 0 AND -- we do not want to fetch divulgence events""",

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/IngestionStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/IngestionStorageBackendTemplate.scala
@@ -16,7 +16,8 @@ private[backend] class IngestionStorageBackendTemplate(schema: Schema[DbDto])
       ledgerEnd: Option[ParameterStorageBackend.LedgerEnd]
   )(connection: Connection): Unit = {
     ledgerEnd.foreach { existingLedgerEnd =>
-      val ledgerOffset = existingLedgerEnd.lastOffset.toHexString.toString
+      import com.daml.platform.store.Conversions.OffsetToStatement
+      val ledgerOffset = existingLedgerEnd.lastOffset
       val lastStringInterningId = existingLedgerEnd.lastStringInterningId
       val lastEventSequentialId = existingLedgerEnd.lastEventSeqId
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/IngestionStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/IngestionStorageBackendTemplate.scala
@@ -20,28 +20,19 @@ private[backend] class IngestionStorageBackendTemplate(schema: Schema[DbDto])
       val lastStringInterningId = existingLedgerEnd.lastStringInterningId
       val lastEventSequentialId = existingLedgerEnd.lastEventSeqId
 
-      SQL"DELETE FROM configuration_entries WHERE ledger_offset > ${ledgerOffset}"
-        .execute()(connection)
-      SQL"DELETE FROM package_entries WHERE ledger_offset > ${ledgerOffset}"
-        .execute()(connection)
-      SQL"DELETE FROM packages WHERE ledger_offset > ${ledgerOffset}"
-        .execute()(connection)
-      SQL"DELETE FROM participant_command_completions WHERE completion_offset > ${ledgerOffset}"
-        .execute()(connection)
-      SQL"DELETE FROM participant_events_divulgence WHERE event_offset > ${ledgerOffset}"
-        .execute()(connection)
-      SQL"DELETE FROM participant_events_create WHERE event_offset > ${ledgerOffset}"
-        .execute()(connection)
-      SQL"DELETE FROM participant_events_consuming_exercise WHERE event_offset > ${ledgerOffset}"
-        .execute()(connection)
-      SQL"DELETE FROM participant_events_non_consuming_exercise WHERE event_offset > ${ledgerOffset}"
-        .execute()(connection)
-      SQL"DELETE FROM party_entries WHERE ledger_offset > ${ledgerOffset}"
-        .execute()(connection)
-      SQL"DELETE FROM string_interning WHERE internal_id > ${lastStringInterningId}"
-        .execute()(connection)
-      SQL"DELETE FROM participant_events_create_filter WHERE event_sequential_id > ${lastEventSequentialId}"
-        .execute()(connection)
+      List(
+        SQL"DELETE FROM configuration_entries WHERE ledger_offset > $ledgerOffset",
+        SQL"DELETE FROM package_entries WHERE ledger_offset > $ledgerOffset",
+        SQL"DELETE FROM packages WHERE ledger_offset > $ledgerOffset",
+        SQL"DELETE FROM participant_command_completions WHERE completion_offset > $ledgerOffset",
+        SQL"DELETE FROM participant_events_divulgence WHERE event_offset > $ledgerOffset",
+        SQL"DELETE FROM participant_events_create WHERE event_offset > $ledgerOffset",
+        SQL"DELETE FROM participant_events_consuming_exercise WHERE event_offset > $ledgerOffset",
+        SQL"DELETE FROM participant_events_non_consuming_exercise WHERE event_offset > $ledgerOffset",
+        SQL"DELETE FROM party_entries WHERE ledger_offset > $ledgerOffset",
+        SQL"DELETE FROM string_interning WHERE internal_id > $lastStringInterningId",
+        SQL"DELETE FROM participant_events_create_filter WHERE event_sequential_id > $lastEventSequentialId",
+      ).map(_.execute()(connection))
 
       ()
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PackageStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PackageStorageBackendTemplate.scala
@@ -42,7 +42,7 @@ private[backend] class PackageStorageBackendTemplate(ledgerEndCache: LedgerEndCa
     SQL"""
       select packages.package_id, packages.source_description, packages.known_since, packages.package_size
       from packages
-      where packages.ledger_offset <= ${ledgerEndOffset}
+      where packages.ledger_offset <= $ledgerEndOffset
     """
       .as(PackageDataParser.*)(connection)
       .map(d =>
@@ -61,8 +61,8 @@ private[backend] class PackageStorageBackendTemplate(ledgerEndCache: LedgerEndCa
     SQL"""
       select packages.package
       from packages
-      where package_id = ${packageId}
-      and packages.ledger_offset <= ${ledgerEndOffset}
+      where package_id = $packageId
+      and packages.ledger_offset <= $ledgerEndOffset
     """
       .as[Option[Array[Byte]]](SqlParser.byteArray("package").singleOpt)(connection)
   }
@@ -94,11 +94,11 @@ private[backend] class PackageStorageBackendTemplate(ledgerEndCache: LedgerEndCa
     import com.daml.platform.store.Conversions.OffsetToStatement
     SQL"""
       select * from package_entries
-      where (${startExclusive} is null or ledger_offset>${startExclusive})
-      and ledger_offset<=${endInclusive}
+      where ($startExclusive is null or ledger_offset>$startExclusive)
+      and ledger_offset<=$endInclusive
       order by ledger_offset asc
-      offset ${queryOffset} rows
-      fetch next ${pageSize} rows only
+      offset $queryOffset rows
+      fetch next $pageSize rows only
     """
       .asVectorOf(packageEntryParser)(connection)
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PackageStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PackageStorageBackendTemplate.scala
@@ -38,7 +38,8 @@ private[backend] class PackageStorageBackendTemplate(ledgerEndCache: LedgerEndCa
     )
 
   def lfPackages(connection: Connection): Map[PackageId, PackageDetails] = {
-    val ledgerEndOffset = ledgerEndCache()._1.toHexString.toString
+    import com.daml.platform.store.Conversions.OffsetToStatement
+    val ledgerEndOffset = ledgerEndCache()._1
     SQL"""
       select packages.package_id, packages.source_description, packages.known_since, packages.package_size
       from packages
@@ -57,7 +58,8 @@ private[backend] class PackageStorageBackendTemplate(ledgerEndCache: LedgerEndCa
 
   def lfArchive(packageId: PackageId)(connection: Connection): Option[Array[Byte]] = {
     import com.daml.platform.store.Conversions.packageIdToStatement
-    val ledgerEndOffset = ledgerEndCache()._1.toHexString.toString
+    import com.daml.platform.store.Conversions.OffsetToStatement
+    val ledgerEndOffset = ledgerEndCache()._1
     SQL"""
       select packages.package
       from packages

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PackageStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PackageStorageBackendTemplate.scala
@@ -6,7 +6,7 @@ package com.daml.platform.store.backend.common
 import java.sql.Connection
 
 import anorm.SqlParser.{flatten, str}
-import anorm.{Macro, RowParser, SQL, SqlParser}
+import anorm.{Macro, RowParser, SqlParser}
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.PackageDetails
 import com.daml.platform.store.Conversions.{ledgerString, offset, timestampFromMicros}
@@ -14,20 +14,13 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.data.Time.Timestamp
 import com.daml.platform.store.SimpleSqlAsVectorOf.SimpleSqlAsVectorOf
 import com.daml.platform.store.appendonlydao.JdbcLedgerDao.{acceptType, rejectType}
+import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
 import com.daml.platform.store.backend.PackageStorageBackend
 import com.daml.platform.store.cache.LedgerEndCache
 import com.daml.platform.store.entries.PackageLedgerEntry
 
 private[backend] class PackageStorageBackendTemplate(ledgerEndCache: LedgerEndCache)
     extends PackageStorageBackend {
-
-  private val SQL_SELECT_PACKAGES =
-    SQL(
-      """select packages.package_id, packages.source_description, packages.known_since, packages.package_size
-        |from packages
-        |where packages.ledger_offset <= {ledgerEndOffset}
-        |""".stripMargin
-    )
 
   private case class ParsedPackageData(
       packageId: String,
@@ -44,9 +37,13 @@ private[backend] class PackageStorageBackendTemplate(ledgerEndCache: LedgerEndCa
       "known_since",
     )
 
-  def lfPackages(connection: Connection): Map[PackageId, PackageDetails] =
-    SQL_SELECT_PACKAGES
-      .on("ledgerEndOffset" -> ledgerEndCache()._1.toHexString.toString)
+  def lfPackages(connection: Connection): Map[PackageId, PackageDetails] = {
+    val ledgerEndOffset = ledgerEndCache()._1.toHexString.toString
+    SQL"""
+      select packages.package_id, packages.source_description, packages.known_since, packages.package_size
+      from packages
+      where packages.ledger_offset <= ${ledgerEndOffset}
+    """
       .as(PackageDataParser.*)(connection)
       .map(d =>
         PackageId.assertFromString(d.packageId) -> PackageDetails(
@@ -56,32 +53,19 @@ private[backend] class PackageStorageBackendTemplate(ledgerEndCache: LedgerEndCa
         )
       )
       .toMap
-
-  private val SQL_SELECT_PACKAGE =
-    SQL("""select packages.package
-          |from packages
-          |where package_id = {package_id}
-          |and packages.ledger_offset <= {ledgerEndOffset}
-          |""".stripMargin)
+  }
 
   def lfArchive(packageId: PackageId)(connection: Connection): Option[Array[Byte]] = {
     import com.daml.platform.store.Conversions.packageIdToStatement
-    SQL_SELECT_PACKAGE
-      .on(
-        "package_id" -> packageId,
-        "ledgerEndOffset" -> ledgerEndCache()._1.toHexString.toString,
-      )
+    val ledgerEndOffset = ledgerEndCache()._1.toHexString.toString
+    SQL"""
+      select packages.package
+      from packages
+      where package_id = ${packageId}
+      and packages.ledger_offset <= ${ledgerEndOffset}
+    """
       .as[Option[Array[Byte]]](SqlParser.byteArray("package").singleOpt)(connection)
   }
-
-  private val SQL_GET_PACKAGE_ENTRIES = SQL(
-    """select * from package_entries
-      |where ({startExclusive} is null or ledger_offset>{startExclusive})
-      |and ledger_offset<={endInclusive}
-      |order by ledger_offset asc
-      |offset {queryOffset} rows
-      |fetch next {pageSize} rows only""".stripMargin
-  )
 
   private val packageEntryParser: RowParser[(Offset, PackageLedgerEntry)] =
     (offset("ledger_offset") ~
@@ -108,13 +92,14 @@ private[backend] class PackageStorageBackendTemplate(ledgerEndCache: LedgerEndCa
       queryOffset: Long,
   )(connection: Connection): Vector[(Offset, PackageLedgerEntry)] = {
     import com.daml.platform.store.Conversions.OffsetToStatement
-    SQL_GET_PACKAGE_ENTRIES
-      .on(
-        "startExclusive" -> startExclusive,
-        "endInclusive" -> endInclusive,
-        "pageSize" -> pageSize,
-        "queryOffset" -> queryOffset,
-      )
+    SQL"""
+      select * from package_entries
+      where (${startExclusive} is null or ledger_offset>${startExclusive})
+      and ledger_offset<=${endInclusive}
+      order by ledger_offset asc
+      offset ${queryOffset} rows
+      fetch next ${pageSize} rows only
+    """
       .asVectorOf(packageEntryParser)(connection)
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ParameterStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/ParameterStorageBackendTemplate.scala
@@ -143,8 +143,8 @@ private[backend] object ParameterStorageBackendTemplate extends ParameterStorage
   def updatePrunedUptoInclusive(prunedUpToInclusive: Offset)(connection: Connection): Unit = {
     import com.daml.platform.store.Conversions.OffsetToStatement
     SQL"""
-      update parameters set participant_pruned_up_to_inclusive=${prunedUpToInclusive}
-      where participant_pruned_up_to_inclusive < ${prunedUpToInclusive} or participant_pruned_up_to_inclusive is null
+      update parameters set participant_pruned_up_to_inclusive=$prunedUpToInclusive
+      where participant_pruned_up_to_inclusive < $prunedUpToInclusive or participant_pruned_up_to_inclusive is null
       """
       .execute()(connection)
     ()
@@ -155,8 +155,8 @@ private[backend] object ParameterStorageBackendTemplate extends ParameterStorage
   )(connection: Connection): Unit = {
     import com.daml.platform.store.Conversions.OffsetToStatement
     SQL"""
-      update parameters set participant_all_divulged_contracts_pruned_up_to_inclusive=${prunedUpToInclusive}
-      where participant_all_divulged_contracts_pruned_up_to_inclusive < ${prunedUpToInclusive} or participant_all_divulged_contracts_pruned_up_to_inclusive is null
+      update parameters set participant_all_divulged_contracts_pruned_up_to_inclusive=$prunedUpToInclusive
+      where participant_all_divulged_contracts_pruned_up_to_inclusive < $prunedUpToInclusive or participant_all_divulged_contracts_pruned_up_to_inclusive is null
       """
       .execute()(connection)
     ()

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PartyStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/PartyStorageBackendTemplate.scala
@@ -77,10 +77,10 @@ class PartyStorageBackendTemplate(queryStrategy: QueryStrategy, ledgerEndCache: 
   )(connection: Connection): Vector[(Offset, PartyLedgerEntry)] = {
     import com.daml.platform.store.Conversions.OffsetToStatement
     SQL"""select * from party_entries
-      where (${startExclusive} is null or ledger_offset>${startExclusive}) and ledger_offset<=${endInclusive}
+      where ($startExclusive is null or ledger_offset>$startExclusive) and ledger_offset<=$endInclusive
       order by ledger_offset asc
-      offset ${queryOffset} rows
-      fetch next ${pageSize} rows only
+      offset $queryOffset rows
+      fetch next $pageSize rows only
       """
       .asVectorOf(partyEntryParser)(connection)
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2DeduplicationStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2DeduplicationStorageBackend.scala
@@ -36,10 +36,10 @@ object H2DeduplicationStorageBackend extends DeduplicationStorageBackendTemplate
     retry(
       SQL"""
         merge into participant_command_submissions pcs
-        using dual on deduplication_key = ${key}
+        using dual on deduplication_key = $key
         when not matched then
           insert (deduplication_key, deduplicate_until)
-          values (${key}, ${deduplicateUntil.micros})
+          values ($key, ${deduplicateUntil.micros})
         when matched and pcs.deduplicate_until < ${submittedAt.micros} then
           update set deduplicate_until=${deduplicateUntil.micros}
       """

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2ResetStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2ResetStorageBackend.scala
@@ -5,29 +5,31 @@ package com.daml.platform.store.backend.h2
 
 import java.sql.Connection
 
-import anorm.SQL
+import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
 import com.daml.platform.store.backend.ResetStorageBackend
 
 object H2ResetStorageBackend extends ResetStorageBackend {
 
   override def resetAll(connection: Connection): Unit = {
-    SQL("""set referential_integrity false;
-          |truncate table configuration_entries;
-          |truncate table packages;
-          |truncate table package_entries;
-          |truncate table parameters;
-          |truncate table participant_command_completions;
-          |truncate table participant_command_submissions;
-          |truncate table participant_events_divulgence;
-          |truncate table participant_events_create;
-          |truncate table participant_events_consuming_exercise;
-          |truncate table participant_events_non_consuming_exercise;
-          |truncate table party_entries;
-          |truncate table string_interning;
-          |truncate table participant_events_create_filter;
-          |truncate table participant_users;
-          |truncate table participant_user_rights;
-          |set referential_integrity true;""".stripMargin)
+    SQL"""
+      set referential_integrity false;
+      truncate table configuration_entries;
+      truncate table packages;
+      truncate table package_entries;
+      truncate table parameters;
+      truncate table participant_command_completions;
+      truncate table participant_command_submissions;
+      truncate table participant_events_divulgence;
+      truncate table participant_events_create;
+      truncate table participant_events_consuming_exercise;
+      truncate table participant_events_non_consuming_exercise;
+      truncate table party_entries;
+      truncate table string_interning;
+      truncate table participant_events_create_filter;
+      truncate table participant_users;
+      truncate table participant_user_rights;
+      set referential_integrity true;
+    """
       .execute()(connection)
     ()
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleDeduplicationStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleDeduplicationStorageBackend.scala
@@ -37,13 +37,13 @@ object OracleDeduplicationStorageBackend extends DeduplicationStorageBackendTemp
       SQL"""
         merge into participant_command_submissions pcs
         using dual
-        on (pcs.deduplication_key = ${key})
+        on (pcs.deduplication_key = $key)
         when matched then
           update set pcs.deduplicate_until=${deduplicateUntil.micros}
           where pcs.deduplicate_until < ${submittedAt.micros}
         when not matched then
           insert (pcs.deduplication_key, pcs.deduplicate_until)
-          values (${key}, ${deduplicateUntil.micros})
+          values ($key, ${deduplicateUntil.micros})
       """
         .executeUpdate()(connection)
     )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleDeduplicationStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleDeduplicationStorageBackend.scala
@@ -5,26 +5,15 @@ package com.daml.platform.store.backend.oracle
 
 import java.sql.Connection
 
-import anorm.SQL
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
 import com.daml.platform.store.backend.common.DeduplicationStorageBackendTemplate
 
 import scala.util.control.NonFatal
 
 object OracleDeduplicationStorageBackend extends DeduplicationStorageBackendTemplate {
   private val logger = ContextualizedLogger.get(this.getClass)
-
-  val SQL_INSERT_COMMAND: String =
-    """merge into participant_command_submissions pcs
-      |using dual
-      |on (pcs.deduplication_key ={deduplicationKey})
-      |when matched then
-      |  update set pcs.deduplicate_until={deduplicateUntil}
-      |  where pcs.deduplicate_until < {submittedAt}
-      |when not matched then
-      | insert (pcs.deduplication_key, pcs.deduplicate_until)
-      |  values ({deduplicationKey}, {deduplicateUntil})""".stripMargin
 
   override def upsertDeduplicationEntry(
       key: String,
@@ -45,12 +34,17 @@ object OracleDeduplicationStorageBackend extends DeduplicationStorageBackendTemp
           op
       }
     retry(
-      SQL(SQL_INSERT_COMMAND)
-        .on(
-          "deduplicationKey" -> key,
-          "submittedAt" -> submittedAt.micros,
-          "deduplicateUntil" -> deduplicateUntil.micros,
-        )
+      SQL"""
+        merge into participant_command_submissions pcs
+        using dual
+        on (pcs.deduplication_key = ${key})
+        when matched then
+          update set pcs.deduplicate_until=${deduplicateUntil.micros}
+          where pcs.deduplicate_until < ${submittedAt.micros}
+        when not matched then
+          insert (pcs.deduplication_key, pcs.deduplicate_until)
+          values (${key}, ${deduplicateUntil.micros})
+      """
         .executeUpdate()(connection)
     )
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleResetStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleResetStorageBackend.scala
@@ -24,7 +24,7 @@ object OracleResetStorageBackend extends ResetStorageBackend {
       "party_entries",
       "string_interning",
       "participant_events_create_filter",
-      "truncate table participant_users cascade",
-      "truncate table participant_user_rights cascade",
+      "participant_users",
+      "participant_user_rights",
     ).map(table => SQL"truncate table #$table cascade").foreach(_.execute()(connection))
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleResetStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleResetStorageBackend.scala
@@ -5,26 +5,26 @@ package com.daml.platform.store.backend.oracle
 
 import java.sql.Connection
 
-import anorm.SQL
+import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
 import com.daml.platform.store.backend.ResetStorageBackend
 
 object OracleResetStorageBackend extends ResetStorageBackend {
   override def resetAll(connection: Connection): Unit =
     List(
-      "truncate table configuration_entries cascade",
-      "truncate table packages cascade",
-      "truncate table package_entries cascade",
-      "truncate table parameters cascade",
-      "truncate table participant_command_completions cascade",
-      "truncate table participant_command_submissions cascade",
-      "truncate table participant_events_divulgence cascade",
-      "truncate table participant_events_create cascade",
-      "truncate table participant_events_consuming_exercise cascade",
-      "truncate table participant_events_non_consuming_exercise cascade",
-      "truncate table party_entries cascade",
-      "truncate table string_interning cascade",
-      "truncate table participant_events_create_filter cascade",
+      "configuration_entries",
+      "packages",
+      "package_entries",
+      "parameters",
+      "participant_command_completions",
+      "participant_command_submissions",
+      "participant_events_divulgence",
+      "participant_events_create",
+      "participant_events_consuming_exercise",
+      "participant_events_non_consuming_exercise",
+      "party_entries",
+      "string_interning",
+      "participant_events_create_filter",
       "truncate table participant_users cascade",
       "truncate table participant_user_rights cascade",
-    ).map(SQL(_)).foreach(_.execute()(connection))
+    ).map(table => SQL"truncate table #$table cascade").foreach(_.execute()(connection))
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresDeduplicationStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresDeduplicationStorageBackend.scala
@@ -19,7 +19,7 @@ object PostgresDeduplicationStorageBackend extends DeduplicationStorageBackendTe
   )(connection: Connection)(implicit loggingContext: LoggingContext): Int =
     SQL"""
       insert into participant_command_submissions as pcs (deduplication_key, deduplicate_until)
-      values (${key}, ${deduplicateUntil.micros})
+      values ($key, ${deduplicateUntil.micros})
       on conflict (deduplication_key)
         do update
         set deduplicate_until=${deduplicateUntil.micros}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresDeduplicationStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresDeduplicationStorageBackend.scala
@@ -5,31 +5,25 @@ package com.daml.platform.store.backend.postgresql
 
 import java.sql.Connection
 
-import anorm.SQL
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
+import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
 import com.daml.platform.store.backend.common.DeduplicationStorageBackendTemplate
 
 object PostgresDeduplicationStorageBackend extends DeduplicationStorageBackendTemplate {
-
-  private val SQL_INSERT_COMMAND: String =
-    """insert into participant_command_submissions as pcs (deduplication_key, deduplicate_until)
-      |values ({deduplicationKey}, {deduplicateUntil})
-      |on conflict (deduplication_key)
-      |  do update
-      |  set deduplicate_until={deduplicateUntil}
-      |  where pcs.deduplicate_until < {submittedAt}""".stripMargin
 
   override def upsertDeduplicationEntry(
       key: String,
       submittedAt: Timestamp,
       deduplicateUntil: Timestamp,
   )(connection: Connection)(implicit loggingContext: LoggingContext): Int =
-    SQL(SQL_INSERT_COMMAND)
-      .on(
-        "deduplicationKey" -> key,
-        "submittedAt" -> submittedAt.micros,
-        "deduplicateUntil" -> deduplicateUntil.micros,
-      )
+    SQL"""
+      insert into participant_command_submissions as pcs (deduplication_key, deduplicate_until)
+      values (${key}, ${deduplicateUntil.micros})
+      on conflict (deduplication_key)
+        do update
+        set deduplicate_until=${deduplicateUntil.micros}
+        where pcs.deduplicate_until < ${submittedAt.micros}
+    """
       .executeUpdate()(connection)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresResetStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresResetStorageBackend.scala
@@ -5,27 +5,28 @@ package com.daml.platform.store.backend.postgresql
 
 import java.sql.Connection
 
-import anorm.SQL
+import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpolation
 import com.daml.platform.store.backend.ResetStorageBackend
 
 object PostgresResetStorageBackend extends ResetStorageBackend {
   override def resetAll(connection: Connection): Unit = {
-    SQL("""truncate table configuration_entries cascade;
-          |truncate table packages cascade;
-          |truncate table package_entries cascade;
-          |truncate table parameters cascade;
-          |truncate table participant_command_completions cascade;
-          |truncate table participant_command_submissions cascade;
-          |truncate table participant_events_divulgence cascade;
-          |truncate table participant_events_create cascade;
-          |truncate table participant_events_consuming_exercise cascade;
-          |truncate table participant_events_non_consuming_exercise cascade;
-          |truncate table party_entries cascade;
-          |truncate table string_interning cascade;
-          |truncate table participant_events_create_filter cascade;
-          |truncate table participant_users cascade;
-          |truncate table participant_user_rights cascade;
-          |""".stripMargin)
+    SQL"""
+      truncate table configuration_entries cascade;
+      truncate table packages cascade;
+      truncate table package_entries cascade;
+      truncate table parameters cascade;
+      truncate table participant_command_completions cascade;
+      truncate table participant_command_submissions cascade;
+      truncate table participant_events_divulgence cascade;
+      truncate table participant_events_create cascade;
+      truncate table participant_events_consuming_exercise cascade;
+      truncate table participant_events_non_consuming_exercise cascade;
+      truncate table party_entries cascade;
+      truncate table string_interning cascade;
+      truncate table participant_events_create_filter cascade;
+      truncate table participant_users cascade;
+      truncate table participant_user_rights cascade;
+    """
       .execute()(connection)
     ()
   }


### PR DESCRIPTION
This PR:
- Makes sure we use anorm string interpolation everywhere in the storage backend (i.e., replace `SQL("...").on("foo" -> ???)` with `SQL"...$foo..."`)
- Renames SQL constants according to Scala style

This is pure refactoring, none of the queries should change. Using anorm string interpolation could potentially affect the performance.