### PR TITLE
[TS-Bindings] Add support for get user which recently has been added to the json api

### DIFF
--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -86,6 +86,7 @@ sh_test(
         "$(location //language-support/ts/daml-ledger:npm_package)",
         sdk_version,
         "$(location //ledger/test-common:model-tests-default.dar)",
+        "$(location @grpcurl_nix//:bin)",
     ],
     data = [
         "//:java",
@@ -97,6 +98,7 @@ sh_test(
         "//ledger/test-common:model-tests-default.dar",
         "//language-support/ts/daml-types:npm_package",
         "//language-support/ts/daml-ledger:npm_package",
+        "@grpcurl_nix//:bin",
     ] + glob(
         ["ts/**"],
         exclude = [

--- a/language-support/ts/codegen/tests/build-and-lint.sh
+++ b/language-support/ts/codegen/tests/build-and-lint.sh
@@ -47,6 +47,7 @@ DAML_TYPES=$(rlocation "$TEST_WORKSPACE/$8")
 DAML_LEDGER=$(rlocation "$TEST_WORKSPACE/$9")
 SDK_VERSION=${10}
 UPLOAD_DAR=$(rlocation "$TEST_WORKSPACE/${11}")
+GRPCURL=$(rlocation "$TEST_WORKSPACE/${12}" | xargs dirname)
 
 TMP_DAML_TYPES=$TMP_DIR/daml-types
 TMP_DAML_LEDGER=$TMP_DIR/daml-ledger
@@ -62,6 +63,7 @@ cd $TMP_DIR
 
 # Call daml2js.
 PATH=`dirname $YARN`:$PATH $DAML2TS -o daml2js $DAR
+PATH=$PATH:$GRPCURL
 
 # Build, lint, test.
 cd build-and-lint-test

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -93,13 +93,11 @@ beforeAll(async () => {
     "-plaintext",
     "-d",
     JSON.stringify(USER_DETAILS),
-    "localhost:6865",
+    "localhost:" + sandboxPort.toString(),
     "com.daml.ledger.api.v1.admin.UserManagementService/CreateUser",
   ];
-  
-  spawnSync('grpcurl', grpcurlUserArgs, {"encoding": "utf8"});
+  spawnSync('grpcurl', grpcurlUserArgs, {"encoding": "utf8"})
   console.log('Created user')
-
 
   jsonApiProcess = spawnJvm(
     getEnv('JSON_API'),

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -88,6 +88,7 @@ beforeAll(async () => {
   sandboxPort = parseInt(sandboxPortData);
   console.log('Sandbox listening on port ' + sandboxPort.toString());
 
+  // TODO: Replace this with a call to the json api as soon as the CreateUser endpoint has been merged.
   const grpcurlUserArgs = [
     "-plaintext",
     "-d",

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -34,7 +34,7 @@ const BOB_PARTY = 'Bob';
 const BOB_TOKEN = computeToken(BOB_PARTY);
 const CHARLIE_PARTY = 'Charlie'
 const CHARLIE_TOKEN = computeToken(CHARLIE_PARTY)
-const USERNAME = "NiceUser"
+const USERNAME = "nice.user"
 const USER_DETAILS = {
   "user": {
     "id": USERNAME,

--- a/language-support/ts/daml-ledger/README.md
+++ b/language-support/ts/daml-ledger/README.md
@@ -131,6 +131,11 @@ Return an array of PartyInfo for all parties on the ledger.
 
 Allocate a new party.
 
+`getUser`
+------------------
+
+Returns the current User implicitly described by the currently used JWT.
+
 `listPackages`
 --------------
 

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -1416,7 +1416,7 @@ class Ledger {
   /**
    * Fetch a list of all package IDs from the ledger.
    *
-   * @returns List of package IDs. 
+   * @returns List of package IDs.
    *
    */
   async listPackages(): Promise<PackageId[]> {

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -1389,6 +1389,12 @@ class Ledger {
     return decode(jtv.array(partyInfoDecoder), json);
   }
 
+  /**
+   * Get the current user details obtained by the currently used JWT.
+   *
+   * @returns User details
+   *
+   */
   async getUser(): Promise<User> {
     const json = await this.submit('v1/user', undefined, 'get');
     return decode(userDecoder, json);
@@ -1410,7 +1416,7 @@ class Ledger {
   /**
    * Fetch a list of all package IDs from the ledger.
    *
-   * @returns List of package IDs.
+   * @returns List of package IDs. 
    *
    */
   async listPackages(): Promise<PackageId[]> {

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -40,6 +40,17 @@ const partyInfoDecoder: jtv.Decoder<PartyInfo> =
     isLocal: jtv.boolean(),
   });
 
+export type User = {
+  userId: string;
+  primaryParty?: Party;
+}
+
+const userDecoder: jtv.Decoder<User> =
+  jtv.object({
+    userId: jtv.string(),
+    primaryParty: jtv.optional(jtv.string()),
+  });
+
 export type PackageId = string;
 
 const decode = <R>(decoder: jtv.Decoder<R>, data: unknown): R => {
@@ -1376,6 +1387,11 @@ class Ledger {
   async listKnownParties(): Promise<PartyInfo[]> {
     const json = await this.submit('v1/parties', undefined, 'get');
     return decode(jtv.array(partyInfoDecoder), json);
+  }
+
+  async getUser(): Promise<User> {
+    const json = await this.submit('v1/user', undefined, 'get');
+    return decode(userDecoder, json);
   }
 
   /**


### PR DESCRIPTION
API changes are based on the work [here](https://github.com/digital-asset/daml/pull/12089). Props to @cocreature!

changelog_begin

- [TS-Bindings] You can now call getUser to gain information about
    the user that is associated with the currently used JWT.

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
