### PR TITLE
Revert "Use nix-provided gRPC on Unix-like OSs (#11031)"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -811,29 +811,6 @@ load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_depen
 buildifier_dependencies()
 
 nixpkgs_package(
-    name = "grpc_nix",
-    attribute_path = "grpc",
-    build_file_content = """
-load("@os_info//:os_info.bzl", "is_linux")
-cc_library(
-  name = "grpc_lib",
-  srcs = [":lib/libgrpc.so", ":lib/libgrpc.so.20", ":lib/libgrpc.so.20.0.0", ":lib/libgpr.so", ":lib/libgpr.so.20", ":lib/libgpr.so.20.0.0"] if is_linux else [":lib/libgrpc.dylib", ":lib/libgpr.dylib"],
-  visibility = ["//visibility:public"],
-  hdrs = [":include"],
-  includes = ["include"],
-)
-filegroup(
-  name = "grpc_file",
-  srcs = glob(["lib/*"]),
-  visibility = ["//visibility:public"],
-)
-    """,
-    nix_file = "//nix:bazel.nix",
-    nix_file_deps = common_nix_file_deps,
-    repositories = dev_env_nix_repos,
-)
-
-nixpkgs_package(
     name = "postgresql_nix",
     attribute_path = "postgresql_10",
     fail_not_supported = False,

--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -197,38 +197,8 @@ c2hs_suite(
     compiler_flags = ["-XCPP", "-Wno-unused-imports", "-Wno-unused-record-wildcards"],
     visibility = ["//visibility:public"],
     deps = [
-        "{cbit_dep}",
+        ":fat_cbits",
     ],
-)
-
-cc_library(
-  name = "needed-cbits-clib",
-  srcs = [":libneeded-cbits.so"],
-  deps = ["{grpc_dep}"],
-  hdrs = glob(["include/*.h"]),
-  includes = ["include/"],
-)
-
-# Bazel produces cbits without NEEDED entries which makes
-# ghci unhappy. We cannot use fat_cbits on the nix-built grpc
-# since it lacks static libs but we can patchelf the cbits to add
-# the NEEDED entry.
-# Apparently this is not needed on macos for whatever reason and patchelf
-# doesn’t work there anyway so we only use it on Linux.
-genrule(
-  name = "needed-cbits",
-  srcs = [":cbits", "@grpc_nix//:grpc_file"],
-  outs = ["libneeded-cbits.so"],
-  tools = ["@patchelf_nix//:bin/patchelf"],
-  cmd = '''
-  set -eou pipefail
-  # We get 3 libs. We want the shared lib which comes last.
-  CBITS=$$(echo $(locations :cbits) | cut -f 3 -d ' ')
-  OLD_RPATH=$$($(location @patchelf_nix//:bin/patchelf) --print-rpath $$CBITS)
-  GRPC_RPATH=$$(dirname $$(readlink -f $$(echo $(locations @grpc_nix//:grpc_file) | cut -f 1 -d ' ')))
-  $(location @patchelf_nix//:bin/patchelf) $$CBITS --add-needed libgrpc.so.20 --output $(location libneeded-cbits.so)
-  $(location @patchelf_nix//:bin/patchelf) $(location libneeded-cbits.so) --set-rpath "$$OLD_RPATH:$$GRPC_RPATH"
-  '''
 )
 
 fat_cc_library(
@@ -241,10 +211,10 @@ cc_library(
   hdrs = glob(["include/*.h"]),
   includes = ["include/"],
   deps = [
-    "{grpc_dep}",
+    "@com_github_grpc_grpc//:grpc",
   ]
 )
-""".format(cbit_dep = cbit_dep, grpc_dep = grpc_dep),
+""",
         patch_args = ["-p1"],
         patches = [
             "@com_github_digital_asset_daml//bazel_tools:grpc-haskell-core-cpp-options.patch",

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -12,7 +12,6 @@ let shared = rec {
     docker
     gawk
     gnutar
-    grpc
     grpcurl
     gzip
     imagemagick


### PR DESCRIPTION
This reverts commit 0de7b2eae5667d652635628177b1b06edeb61faf. 

This seems to fix the gRPC timeouts on macOS Monterey

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
