### PR TITLE
DPP-579 Convert storage backend tests to AnyFlatSuite

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendSuite.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.store.backend
 
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 trait StorageBackendSuite
     extends StorageBackendTestsInitialization
@@ -18,5 +18,5 @@ trait StorageBackendSuite
     with StorageBackendTestsDeduplication
     with StorageBackendTestsTimestamps
     with StorageBackendTestsStringInterning {
-  this: AsyncFlatSpec =>
+  this: AnyFlatSpec =>
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsEvents.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsEvents.scala
@@ -5,14 +5,14 @@ package com.daml.platform.store.backend
 
 import com.daml.lf.data.Ref
 import org.scalatest.Inside
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 private[backend] trait StorageBackendTestsEvents
     extends Matchers
     with Inside
     with StorageBackendSpec {
-  this: AsyncFlatSpec =>
+  this: AnyFlatSpec =>
 
   behavior of "StorageBackend (events)"
 
@@ -32,44 +32,40 @@ private[backend] trait StorageBackendTestsEvents
       dtoCreateFilter(2L, someTemplateId, partyObserver2),
     )
 
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      _ <- executeSql(ingest(dtos, _))
-      _ <- executeSql(
-        updateLedgerEnd(offset(2), 2L)
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+    executeSql(ingest(dtos, _))
+    executeSql(updateLedgerEnd(offset(2), 2L))
+    val resultSignatory = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partySignatory,
+        templateIdFilter = None,
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultSignatory <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partySignatory,
-          templateIdFilter = None,
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
+    )
+    val resultObserver1 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partyObserver1,
+        templateIdFilter = None,
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultObserver1 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partyObserver1,
-          templateIdFilter = None,
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
+    )
+    val resultObserver2 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partyObserver2,
+        templateIdFilter = None,
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultObserver2 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partyObserver2,
-          templateIdFilter = None,
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
-      )
-    } yield {
-      resultSignatory should contain theSameElementsAs Vector(1L, 2L)
-      resultObserver1 should contain theSameElementsAs Vector(1L)
-      resultObserver2 should contain theSameElementsAs Vector(2L)
-    }
+    )
+
+    resultSignatory should contain theSameElementsAs Vector(1L, 2L)
+    resultObserver1 should contain theSameElementsAs Vector(1L)
+    resultObserver2 should contain theSameElementsAs Vector(2L)
   }
 
   it should "find contracts by party and template" in {
@@ -86,44 +82,40 @@ private[backend] trait StorageBackendTestsEvents
       dtoCreateFilter(2L, someTemplateId, partyObserver2),
     )
 
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      _ <- executeSql(ingest(dtos, _))
-      _ <- executeSql(
-        updateLedgerEnd(offset(2), 2L)
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+    executeSql(ingest(dtos, _))
+    executeSql(updateLedgerEnd(offset(2), 2L))
+    val resultSignatory = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partySignatory,
+        templateIdFilter = Some(someTemplateId),
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultSignatory <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partySignatory,
-          templateIdFilter = Some(someTemplateId),
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
+    )
+    val resultObserver1 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partyObserver1,
+        templateIdFilter = Some(someTemplateId),
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultObserver1 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partyObserver1,
-          templateIdFilter = Some(someTemplateId),
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
+    )
+    val resultObserver2 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partyObserver2,
+        templateIdFilter = Some(someTemplateId),
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultObserver2 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partyObserver2,
-          templateIdFilter = Some(someTemplateId),
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
-      )
-    } yield {
-      resultSignatory should contain theSameElementsAs Vector(1L, 2L)
-      resultObserver1 should contain theSameElementsAs Vector(1L)
-      resultObserver2 should contain theSameElementsAs Vector(2L)
-    }
+    )
+
+    resultSignatory should contain theSameElementsAs Vector(1L, 2L)
+    resultObserver1 should contain theSameElementsAs Vector(1L)
+    resultObserver2 should contain theSameElementsAs Vector(2L)
   }
 
   it should "not find contracts when the template doesn't match" in {
@@ -141,44 +133,40 @@ private[backend] trait StorageBackendTestsEvents
       dtoCreateFilter(2L, someTemplateId, partyObserver2),
     )
 
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      _ <- executeSql(ingest(dtos, _))
-      _ <- executeSql(
-        updateLedgerEnd(offset(2), 2L)
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+    executeSql(ingest(dtos, _))
+    executeSql(updateLedgerEnd(offset(2), 2L))
+    val resultSignatory = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partySignatory,
+        templateIdFilter = Some(otherTemplate),
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultSignatory <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partySignatory,
-          templateIdFilter = Some(otherTemplate),
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
+    )
+    val resultObserver1 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partyObserver1,
+        templateIdFilter = Some(otherTemplate),
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultObserver1 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partyObserver1,
-          templateIdFilter = Some(otherTemplate),
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
+    )
+    val resultObserver2 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partyObserver2,
+        templateIdFilter = Some(otherTemplate),
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultObserver2 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partyObserver2,
-          templateIdFilter = Some(otherTemplate),
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
-      )
-    } yield {
-      resultSignatory shouldBe empty
-      resultObserver1 shouldBe empty
-      resultObserver2 shouldBe empty
-    }
+    )
+
+    resultSignatory shouldBe empty
+    resultObserver1 shouldBe empty
+    resultObserver2 shouldBe empty
   }
 
   it should "not find contracts when unknown names are used" in {
@@ -193,44 +181,40 @@ private[backend] trait StorageBackendTestsEvents
       dtoCreateFilter(1L, someTemplateId, partyObserver),
     )
 
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      _ <- executeSql(ingest(dtos, _))
-      _ <- executeSql(
-        updateLedgerEnd(offset(1), 1L)
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+    executeSql(ingest(dtos, _))
+    executeSql(updateLedgerEnd(offset(1), 1L))
+    val resultUnknownParty = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partyUnknown,
+        templateIdFilter = None,
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultUnknownParty <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partyUnknown,
-          templateIdFilter = None,
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
+    )
+    val resultUnknownTemplate = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partySignatory,
+        templateIdFilter = Some(unknownTemplate),
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultUnknownTemplate <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partySignatory,
-          templateIdFilter = Some(unknownTemplate),
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
+    )
+    val resultUnknownPartyAndTemplate = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partyUnknown,
+        templateIdFilter = Some(unknownTemplate),
+        startExclusive = 0L,
+        endInclusive = 10L,
+        limit = 10,
       )
-      resultUnknownPartyAndTemplate <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partyUnknown,
-          templateIdFilter = Some(unknownTemplate),
-          startExclusive = 0L,
-          endInclusive = 10L,
-          limit = 10,
-        )
-      )
-    } yield {
-      resultUnknownParty shouldBe empty
-      resultUnknownTemplate shouldBe empty
-      resultUnknownPartyAndTemplate shouldBe empty
-    }
+    )
+
+    resultUnknownParty shouldBe empty
+    resultUnknownTemplate shouldBe empty
+    resultUnknownPartyAndTemplate shouldBe empty
   }
 
   it should "respect bounds and limits" in {
@@ -247,53 +231,49 @@ private[backend] trait StorageBackendTestsEvents
       dtoCreateFilter(2L, someTemplateId, partyObserver2),
     )
 
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      _ <- executeSql(ingest(dtos, _))
-      _ <- executeSql(
-        updateLedgerEnd(offset(2), 2L)
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+    executeSql(ingest(dtos, _))
+    executeSql(updateLedgerEnd(offset(2), 2L))
+    val result01L2 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partySignatory,
+        templateIdFilter = None,
+        startExclusive = 0L,
+        endInclusive = 1L,
+        limit = 2,
       )
-      result01L2 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partySignatory,
-          templateIdFilter = None,
-          startExclusive = 0L,
-          endInclusive = 1L,
-          limit = 2,
-        )
+    )
+    val result12L2 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partySignatory,
+        templateIdFilter = None,
+        startExclusive = 1L,
+        endInclusive = 2L,
+        limit = 2,
       )
-      result12L2 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partySignatory,
-          templateIdFilter = None,
-          startExclusive = 1L,
-          endInclusive = 2L,
-          limit = 2,
-        )
+    )
+    val result02L1 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partySignatory,
+        templateIdFilter = None,
+        startExclusive = 0L,
+        endInclusive = 2L,
+        limit = 1,
       )
-      result02L1 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partySignatory,
-          templateIdFilter = None,
-          startExclusive = 0L,
-          endInclusive = 2L,
-          limit = 1,
-        )
+    )
+    val result02L2 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = partySignatory,
+        templateIdFilter = None,
+        startExclusive = 0L,
+        endInclusive = 2L,
+        limit = 2,
       )
-      result02L2 <- executeSql(
-        backend.event.activeContractEventIds(
-          partyFilter = partySignatory,
-          templateIdFilter = None,
-          startExclusive = 0L,
-          endInclusive = 2L,
-          limit = 2,
-        )
-      )
-    } yield {
-      result01L2 should contain theSameElementsAs Vector(1L)
-      result12L2 should contain theSameElementsAs Vector(2L)
-      result02L1 should contain theSameElementsAs Vector(1L)
-      result02L2 should contain theSameElementsAs Vector(1L, 2L)
-    }
+    )
+
+    result01L2 should contain theSameElementsAs Vector(1L)
+    result12L2 should contain theSameElementsAs Vector(2L)
+    result02L1 should contain theSameElementsAs Vector(1L)
+    result02L2 should contain theSameElementsAs Vector(1L, 2L)
   }
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsMigrationPruning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsMigrationPruning.scala
@@ -7,15 +7,13 @@ import java.sql.Connection
 
 import com.daml.lf.data.Ref
 import com.daml.platform.store.appendonlydao.events.ContractId
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
-import scala.concurrent.Future
 
 private[backend] trait StorageBackendTestsMigrationPruning
     extends Matchers
     with StorageBackendSpec {
-  this: AsyncFlatSpec =>
+  this: AnyFlatSpec =>
 
   import StorageBackendTestValues._
 
@@ -27,56 +25,57 @@ private[backend] trait StorageBackendTestsMigrationPruning
     val divulgence = dtoDivulgence(None, 2L, "#1", submitter, divulgee)
     val archive = dtoExercise(offset(2), 3L, consuming = true, "#1", submitter)
 
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      _ <- executeSql(ingest(Vector(create, divulgence, archive), _))
-      _ <- executeSql(
-        updateLedgerEnd(offset(2), 3L)
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+    executeSql(ingest(Vector(create, divulgence, archive), _))
+    executeSql(updateLedgerEnd(offset(2), 3L))
+
+    // Simulate that the archive happened after the migration to append-only schema
+    executeSql(updateMigrationHistoryTable(ledgerSequentialIdBefore = 2))
+    val beforePruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString("#1"),
       )
-      // Simulate that the archive happened after the migration to append-only schema
-      _ <- executeSql(updateMigrationHistoryTable(ledgerSequentialIdBefore = 2))
-      beforePruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString("#1"),
-        )
+    )
+
+    // Check that the divulgee can fetch the divulged event
+    beforePruning should not be empty
+
+    // Trying to prune all divulged contracts before the migration should fail
+    executeSql(
+      backend.event.isPruningOffsetValidAgainstMigration(
+        offset(1),
+        pruneAllDivulgedContracts = true,
+        _,
       )
-      // Check that the divulgee can fetch the divulged event
-      _ <- Future.successful(beforePruning should not be empty)
-      // Trying to prune all divulged contracts before the migration should fail
-      _ <-
-        executeSql(
-          backend.event.isPruningOffsetValidAgainstMigration(
-            offset(1),
-            pruneAllDivulgedContracts = true,
-            _,
-          )
-        ).map(_ shouldBe false)
-      // Validation passes the pruning offset for all divulged contracts is after the migration
-      _ <- executeSql(
-        backend.event.isPruningOffsetValidAgainstMigration(
-          offset(2),
-          pruneAllDivulgedContracts = true,
-          _,
-        )
-      ).map(_ shouldBe true)
-      _ <- executeSql(
-        backend.event.pruneEvents(offset(2), pruneAllDivulgedContracts = true)(
-          _,
-          loggingContext,
-        )
+    ) shouldBe false
+
+    // Validation passes the pruning offset for all divulged contracts is after the migration
+    executeSql(
+      backend.event.isPruningOffsetValidAgainstMigration(
+        offset(2),
+        pruneAllDivulgedContracts = true,
+        _,
       )
-      // Ensure the divulged contract is not visible anymore
-      afterPruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString("#1"),
-        )
+    ) shouldBe true
+
+    executeSql(
+      backend.event.pruneEvents(offset(2), pruneAllDivulgedContracts = true)(
+        _,
+        loggingContext,
       )
-    } yield {
-      // Pruning succeeded
-      afterPruning shouldBe empty
-    }
+    )
+
+    // Ensure the divulged contract is not visible anymore
+    val afterPruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString("#1"),
+      )
+    )
+
+    // Pruning succeeded
+    afterPruning shouldBe empty
   }
 
   private def updateMigrationHistoryTable(ledgerSequentialIdBefore: Long) = { conn: Connection =>

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsPruning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsPruning.scala
@@ -6,11 +6,11 @@ package com.daml.platform.store.backend
 import com.daml.lf.data.Ref
 import com.daml.platform.store.appendonlydao.events.ContractId
 import com.daml.platform.store.backend.EventStorageBackend.{FilterParams, RangeParams}
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 private[backend] trait StorageBackendTestsPruning extends Matchers with StorageBackendSpec {
-  this: AsyncFlatSpec =>
+  this: AnyFlatSpec =>
 
   behavior of "StorageBackend (pruning)"
 
@@ -20,64 +20,62 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
     val offset_1 = offset(3)
     val offset_2 = offset(2)
     val offset_3 = offset(4)
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      initialPruningOffset <- executeSql(backend.parameter.prunedUpToInclusive)
 
-      _ <- executeSql(backend.parameter.updatePrunedUptoInclusive(offset_1))
-      updatedPruningOffset_1 <- executeSql(backend.parameter.prunedUpToInclusive)
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+    val initialPruningOffset = executeSql(backend.parameter.prunedUpToInclusive)
 
-      _ <- executeSql(backend.parameter.updatePrunedUptoInclusive(offset_2))
-      updatedPruningOffset_2 <- executeSql(backend.parameter.prunedUpToInclusive)
+    executeSql(backend.parameter.updatePrunedUptoInclusive(offset_1))
+    val updatedPruningOffset_1 = executeSql(backend.parameter.prunedUpToInclusive)
 
-      _ <- executeSql(backend.parameter.updatePrunedUptoInclusive(offset_3))
-      updatedPruningOffset_3 <- executeSql(backend.parameter.prunedUpToInclusive)
-    } yield {
-      initialPruningOffset shouldBe empty
-      updatedPruningOffset_1 shouldBe Some(offset_1)
-      // The pruning offset is not updated if lower than the existing offset
-      updatedPruningOffset_2 shouldBe Some(offset_1)
-      updatedPruningOffset_3 shouldBe Some(offset_3)
-    }
+    executeSql(backend.parameter.updatePrunedUptoInclusive(offset_2))
+    val updatedPruningOffset_2 = executeSql(backend.parameter.prunedUpToInclusive)
+
+    executeSql(backend.parameter.updatePrunedUptoInclusive(offset_3))
+    val updatedPruningOffset_3 = executeSql(backend.parameter.prunedUpToInclusive)
+
+    initialPruningOffset shouldBe empty
+    updatedPruningOffset_1 shouldBe Some(offset_1)
+    // The pruning offset is not updated if lower than the existing offset
+    updatedPruningOffset_2 shouldBe Some(offset_1)
+    updatedPruningOffset_3 shouldBe Some(offset_3)
   }
 
   it should "correctly update the pruning offset of all divulged contracts" in {
     val offset_1 = offset(3)
     val offset_2 = offset(2)
     val offset_3 = offset(4)
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      initialPruningOffset <- executeSql(
-        backend.parameter.participantAllDivulgedContractsPrunedUpToInclusive
-      )
 
-      _ <- executeSql(
-        backend.parameter.updatePrunedAllDivulgedContractsUpToInclusive(offset_1)
-      )
-      updatedPruningOffset_1 <- executeSql(
-        backend.parameter.participantAllDivulgedContractsPrunedUpToInclusive
-      )
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+    val initialPruningOffset = executeSql(
+      backend.parameter.participantAllDivulgedContractsPrunedUpToInclusive
+    )
 
-      _ <- executeSql(
-        backend.parameter.updatePrunedAllDivulgedContractsUpToInclusive(offset_2)
-      )
-      updatedPruningOffset_2 <- executeSql(
-        backend.parameter.participantAllDivulgedContractsPrunedUpToInclusive
-      )
+    executeSql(
+      backend.parameter.updatePrunedAllDivulgedContractsUpToInclusive(offset_1)
+    )
+    val updatedPruningOffset_1 = executeSql(
+      backend.parameter.participantAllDivulgedContractsPrunedUpToInclusive
+    )
 
-      _ <- executeSql(
-        backend.parameter.updatePrunedAllDivulgedContractsUpToInclusive(offset_3)
-      )
-      updatedPruningOffset_3 <- executeSql(
-        backend.parameter.participantAllDivulgedContractsPrunedUpToInclusive
-      )
-    } yield {
-      initialPruningOffset shouldBe empty
-      updatedPruningOffset_1 shouldBe Some(offset_1)
-      // The pruning offset is not updated if lower than the existing offset
-      updatedPruningOffset_2 shouldBe Some(offset_1)
-      updatedPruningOffset_3 shouldBe Some(offset_3)
-    }
+    executeSql(
+      backend.parameter.updatePrunedAllDivulgedContractsUpToInclusive(offset_2)
+    )
+    val updatedPruningOffset_2 = executeSql(
+      backend.parameter.participantAllDivulgedContractsPrunedUpToInclusive
+    )
+
+    executeSql(
+      backend.parameter.updatePrunedAllDivulgedContractsUpToInclusive(offset_3)
+    )
+    val updatedPruningOffset_3 = executeSql(
+      backend.parameter.participantAllDivulgedContractsPrunedUpToInclusive
+    )
+
+    initialPruningOffset shouldBe empty
+    updatedPruningOffset_1 shouldBe Some(offset_1)
+    // The pruning offset is not updated if lower than the existing offset
+    updatedPruningOffset_2 shouldBe Some(offset_1)
+    updatedPruningOffset_3 shouldBe Some(offset_3)
   }
 
   it should "prune an archived contract" in {
@@ -100,66 +98,67 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
     )
     val range = RangeParams(0L, 2L, None, None)
     val filter = FilterParams(Set(someParty), Set.empty)
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      // Ingest a create and archive event
-      _ <- executeSql(ingest(Vector(create, createFilter1, createFilter2, archive), _))
-      _ <- executeSql(
-        updateLedgerEnd(offset(2), 2L)
-      )
-      // Make sure the events are visible
-      before1 <- executeSql(backend.event.transactionEvents(range, filter))
-      before3 <- executeSql(backend.event.flatTransaction(createTransactionId, filter))
-      before4 <- executeSql(backend.event.transactionTreeEvents(range, filter))
-      before5 <- executeSql(backend.event.transactionTree(createTransactionId, filter))
-      before6 <- executeSql(backend.event.rawEvents(0, 2L))
-      before7 <- executeSql(
-        backend.event
-          .activeContractEventIds(Ref.Party.assertFromString("signatory"), None, 0L, 2L, 1000)
-      )
-      before8 <- executeSql(
-        backend.event
-          .activeContractEventBatch(List(1L), Set(Ref.Party.assertFromString("signatory")), 2L)
-      )
-      // Prune
-      _ <- executeSql(
-        backend.event.pruneEvents(offset(2), pruneAllDivulgedContracts = true)(
-          _,
-          loggingContext,
-        )
-      )
-      _ <- executeSql(backend.parameter.updatePrunedUptoInclusive(offset(2)))
-      // Make sure the events are not visible anymore
-      after1 <- executeSql(backend.event.transactionEvents(range, filter))
-      after3 <- executeSql(backend.event.flatTransaction(createTransactionId, filter))
-      after4 <- executeSql(backend.event.transactionTreeEvents(range, filter))
-      after5 <- executeSql(backend.event.transactionTree(createTransactionId, filter))
-      after6 <- executeSql(backend.event.rawEvents(0, 2L))
-      after7 <- executeSql(
-        backend.event
-          .activeContractEventIds(Ref.Party.assertFromString("signatory"), None, 0L, 2L, 1000)
-      )
-      after8 <- executeSql(
-        backend.event
-          .activeContractEventBatch(List(1L), Set(Ref.Party.assertFromString("signatory")), 2L)
-      )
-    } yield {
-      before1 should not be empty
-      before3 should not be empty
-      before4 should not be empty
-      before5 should not be empty
-      before6 should not be empty
-      before7 should have size 1
-      before8 shouldBe empty
 
-      after1 shouldBe empty
-      after3 shouldBe empty
-      after4 shouldBe empty
-      after5 shouldBe empty
-      after6 shouldBe empty
-      after7 shouldBe empty
-      after8 shouldBe empty
-    }
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+
+    // Ingest a create and archive event
+    executeSql(ingest(Vector(create, createFilter1, createFilter2, archive), _))
+    executeSql(updateLedgerEnd(offset(2), 2L))
+
+    // Make sure the events are visible
+    val before1 = executeSql(backend.event.transactionEvents(range, filter))
+    val before3 = executeSql(backend.event.flatTransaction(createTransactionId, filter))
+    val before4 = executeSql(backend.event.transactionTreeEvents(range, filter))
+    val before5 = executeSql(backend.event.transactionTree(createTransactionId, filter))
+    val before6 = executeSql(backend.event.rawEvents(0, 2L))
+    val before7 = executeSql(
+      backend.event
+        .activeContractEventIds(Ref.Party.assertFromString("signatory"), None, 0L, 2L, 1000)
+    )
+    val before8 = executeSql(
+      backend.event
+        .activeContractEventBatch(List(1L), Set(Ref.Party.assertFromString("signatory")), 2L)
+    )
+
+    // Prune
+    executeSql(
+      backend.event.pruneEvents(offset(2), pruneAllDivulgedContracts = true)(
+        _,
+        loggingContext,
+      )
+    )
+    executeSql(backend.parameter.updatePrunedUptoInclusive(offset(2)))
+
+    // Make sure the events are not visible anymore
+    val after1 = executeSql(backend.event.transactionEvents(range, filter))
+    val after3 = executeSql(backend.event.flatTransaction(createTransactionId, filter))
+    val after4 = executeSql(backend.event.transactionTreeEvents(range, filter))
+    val after5 = executeSql(backend.event.transactionTree(createTransactionId, filter))
+    val after6 = executeSql(backend.event.rawEvents(0, 2L))
+    val after7 = executeSql(
+      backend.event
+        .activeContractEventIds(Ref.Party.assertFromString("signatory"), None, 0L, 2L, 1000)
+    )
+    val after8 = executeSql(
+      backend.event
+        .activeContractEventBatch(List(1L), Set(Ref.Party.assertFromString("signatory")), 2L)
+    )
+
+    before1 should not be empty
+    before3 should not be empty
+    before4 should not be empty
+    before5 should not be empty
+    before6 should not be empty
+    before7 should have size 1
+    before8 shouldBe empty
+
+    after1 shouldBe empty
+    after3 shouldBe empty
+    after4 shouldBe empty
+    after5 shouldBe empty
+    after6 shouldBe empty
+    after7 shouldBe empty
+    after8 shouldBe empty
   }
 
   it should "not prune an active contract" in {
@@ -177,67 +176,68 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
     val createTransactionId = dtoTransactionId(create)
     val range = RangeParams(0L, 1L, None, None)
     val filter = FilterParams(Set(someParty), Set.empty)
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      // Ingest a create and archive event
-      _ <- executeSql(ingest(Vector(partyEntry, create, createFilter1, createFilter2), _))
-      _ <- executeSql(
-        updateLedgerEnd(offset(2), 1L)
-      )
-      // Make sure the events are visible
-      before1 <- executeSql(backend.event.transactionEvents(range, filter))
-      before3 <- executeSql(backend.event.flatTransaction(createTransactionId, filter))
-      before4 <- executeSql(backend.event.transactionTreeEvents(range, filter))
-      before5 <- executeSql(backend.event.transactionTree(createTransactionId, filter))
-      before6 <- executeSql(backend.event.rawEvents(0, 1L))
-      before7 <- executeSql(
-        backend.event
-          .activeContractEventIds(Ref.Party.assertFromString("signatory"), None, 0L, 1L, 1000)
-      )
-      before8 <- executeSql(
-        backend.event
-          .activeContractEventBatch(List(1L), Set(Ref.Party.assertFromString("signatory")), 1L)
-      )
-      // Prune
-      _ <- executeSql(
-        backend.event.pruneEvents(offset(2), pruneAllDivulgedContracts = true)(
-          _,
-          loggingContext,
-        )
-      )
-      _ <- executeSql(backend.parameter.updatePrunedUptoInclusive(offset(2)))
-      // Make sure the events are still visible - active contracts should not be pruned
-      after1 <- executeSql(backend.event.transactionEvents(range, filter))
-      after3 <- executeSql(backend.event.flatTransaction(createTransactionId, filter))
-      after4 <- executeSql(backend.event.transactionTreeEvents(range, filter))
-      after5 <- executeSql(backend.event.transactionTree(createTransactionId, filter))
-      after6 <- executeSql(backend.event.rawEvents(0, 1L))
-      after7 <- executeSql(
-        backend.event
-          .activeContractEventIds(Ref.Party.assertFromString("signatory"), None, 0L, 1L, 1000)
-      )
-      after8 <- executeSql(
-        backend.event
-          .activeContractEventBatch(List(1L), Set(Ref.Party.assertFromString("signatory")), 1L)
-      )
-    } yield {
-      before1 should not be empty
-      before3 should not be empty
-      before4 should not be empty
-      before5 should not be empty
-      before6 should not be empty
-      before7 should have size 1
-      before8 should have size 1
 
-      // TODO is it intended that the transaction lookups don't see the active contracts?
-      after1 should not be empty
-      after3 shouldBe empty // should not be empty
-      after4 should not be empty
-      after5 shouldBe empty // should not be empty
-      after6 should not be empty
-      after7 should have size 1
-      after8 should have size 1
-    }
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+
+    // Ingest a create and archive event
+    executeSql(ingest(Vector(partyEntry, create, createFilter1, createFilter2), _))
+    executeSql(updateLedgerEnd(offset(2), 1L))
+
+    // Make sure the events are visible
+    val before1 = executeSql(backend.event.transactionEvents(range, filter))
+    val before3 = executeSql(backend.event.flatTransaction(createTransactionId, filter))
+    val before4 = executeSql(backend.event.transactionTreeEvents(range, filter))
+    val before5 = executeSql(backend.event.transactionTree(createTransactionId, filter))
+    val before6 = executeSql(backend.event.rawEvents(0, 1L))
+    val before7 = executeSql(
+      backend.event
+        .activeContractEventIds(Ref.Party.assertFromString("signatory"), None, 0L, 1L, 1000)
+    )
+    val before8 = executeSql(
+      backend.event
+        .activeContractEventBatch(List(1L), Set(Ref.Party.assertFromString("signatory")), 1L)
+    )
+
+    // Prune
+    executeSql(
+      backend.event.pruneEvents(offset(2), pruneAllDivulgedContracts = true)(
+        _,
+        loggingContext,
+      )
+    )
+    executeSql(backend.parameter.updatePrunedUptoInclusive(offset(2)))
+
+    // Make sure the events are still visible - active contracts should not be pruned
+    val after1 = executeSql(backend.event.transactionEvents(range, filter))
+    val after3 = executeSql(backend.event.flatTransaction(createTransactionId, filter))
+    val after4 = executeSql(backend.event.transactionTreeEvents(range, filter))
+    val after5 = executeSql(backend.event.transactionTree(createTransactionId, filter))
+    val after6 = executeSql(backend.event.rawEvents(0, 1L))
+    val after7 = executeSql(
+      backend.event
+        .activeContractEventIds(Ref.Party.assertFromString("signatory"), None, 0L, 1L, 1000)
+    )
+    val after8 = executeSql(
+      backend.event
+        .activeContractEventBatch(List(1L), Set(Ref.Party.assertFromString("signatory")), 1L)
+    )
+
+    before1 should not be empty
+    before3 should not be empty
+    before4 should not be empty
+    before5 should not be empty
+    before6 should not be empty
+    before7 should have size 1
+    before8 should have size 1
+
+    // TODO is it intended that the transaction lookups don't see the active contracts?
+    after1 should not be empty
+    after3 shouldBe empty // should not be empty
+    after4 should not be empty
+    after5 shouldBe empty // should not be empty
+    after6 should not be empty
+    after7 should have size 1
+    after8 should have size 1
   }
 
   it should "prune all retroactively and immediately divulged contracts (if pruneAllDivulgedContracts is set)" in {
@@ -267,62 +267,61 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
         divulgee = partyName,
       )
 
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      // Ingest
-      _ <- executeSql(
-        ingest(
-          Vector(
-            contract1_immediateDivulgence,
-            partyEntry,
-            contract1_retroactiveDivulgence,
-            contract2_createWithLocalStakeholder,
-          ),
-          _,
-        )
-      )
-      _ <- executeSql(
-        updateLedgerEnd(offset(4), 4L)
-      )
-      contract1_beforePruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString(contract1_id),
-        )
-      )
-      contract2_beforePruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString(contract2_id),
-        )
-      )
-      _ <- executeSql(
-        backend.event.pruneEvents(offset(3), pruneAllDivulgedContracts = true)(
-          _,
-          loggingContext,
-        )
-      )
-      contract1_afterPruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString(contract1_id),
-        )
-      )
-      contract2_afterPruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString(contract2_id),
-        )
-      )
-    } yield {
-      contract1_beforePruning should not be empty
-      contract2_beforePruning should not be empty
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
 
-      contract1_afterPruning shouldBe empty
-      // Immediate divulgence for contract2 occurred after the associated party became locally hosted
-      // so it is not pruned
-      contract2_afterPruning should not be empty
-    }
+    // Ingest
+    executeSql(
+      ingest(
+        Vector(
+          contract1_immediateDivulgence,
+          partyEntry,
+          contract1_retroactiveDivulgence,
+          contract2_createWithLocalStakeholder,
+        ),
+        _,
+      )
+    )
+    executeSql(
+      updateLedgerEnd(offset(4), 4L)
+    )
+    val contract1_beforePruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString(contract1_id),
+      )
+    )
+    val contract2_beforePruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString(contract2_id),
+      )
+    )
+    executeSql(
+      backend.event.pruneEvents(offset(3), pruneAllDivulgedContracts = true)(
+        _,
+        loggingContext,
+      )
+    )
+    val contract1_afterPruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString(contract1_id),
+      )
+    )
+    val contract2_afterPruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString(contract2_id),
+      )
+    )
+
+    contract1_beforePruning should not be empty
+    contract2_beforePruning should not be empty
+
+    contract1_afterPruning shouldBe empty
+    // Immediate divulgence for contract2 occurred after the associated party became locally hosted
+    // so it is not pruned
+    contract2_afterPruning should not be empty
   }
 
   it should "only prune retroactively divulged contracts if there exists an associated consuming exercise (if pruneAllDivulgedContracts is not set)" in {
@@ -356,66 +355,65 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
       divulgee = divulgee,
     )
 
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      // Ingest
-      _ <- executeSql(
-        ingest(
-          Vector(
-            contract1_create,
-            contract1_divulgence,
-            contract1_consumingExercise,
-            contract2_divulgence,
-          ),
-          _,
-        )
-      )
-      // Set the ledger end past the last ingested event so we can prune up to it inclusively
-      _ <- executeSql(
-        updateLedgerEnd(offset(5), 5L)
-      )
-      contract1_beforePruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString(contract1_id),
-        )
-      )
-      contract2_beforePruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString(contract2_id),
-        )
-      )
-      _ <- executeSql(
-        backend.event.pruneEvents(offset(4), pruneAllDivulgedContracts = false)(
-          _,
-          loggingContext,
-        )
-      )
-      contract1_afterPruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString(contract1_id),
-        )
-      )
-      contract2_afterPruning <- executeSql(
-        backend.contract.activeContractWithoutArgument(
-          Set(divulgee),
-          ContractId.assertFromString(contract2_id),
-        )
-      )
-    } yield {
-      // Contract 1 appears as active tu `divulgee` before pruning
-      contract1_beforePruning should not be empty
-      // Contract 2 appears as active tu `divulgee` before pruning
-      contract2_beforePruning should not be empty
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
 
-      // Contract 1 should not be visible anymore to `divulgee` after pruning
-      contract1_afterPruning shouldBe empty
-      // Contract 2 did not have a locally stored exercise event
-      // hence its divulgence is not pruned - appears active to `divulgee`
-      contract2_afterPruning should not be empty
-    }
+    // Ingest
+    executeSql(
+      ingest(
+        Vector(
+          contract1_create,
+          contract1_divulgence,
+          contract1_consumingExercise,
+          contract2_divulgence,
+        ),
+        _,
+      )
+    )
+    // Set the ledger end past the last ingested event so we can prune up to it inclusively
+    executeSql(
+      updateLedgerEnd(offset(5), 5L)
+    )
+    val contract1_beforePruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString(contract1_id),
+      )
+    )
+    val contract2_beforePruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString(contract2_id),
+      )
+    )
+    executeSql(
+      backend.event.pruneEvents(offset(4), pruneAllDivulgedContracts = false)(
+        _,
+        loggingContext,
+      )
+    )
+    val contract1_afterPruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString(contract1_id),
+      )
+    )
+    val contract2_afterPruning = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        Set(divulgee),
+        ContractId.assertFromString(contract2_id),
+      )
+    )
+
+    // Contract 1 appears as active tu `divulgee` before pruning
+    contract1_beforePruning should not be empty
+    // Contract 2 appears as active tu `divulgee` before pruning
+    contract2_beforePruning should not be empty
+
+    // Contract 1 should not be visible anymore to `divulgee` after pruning
+    contract1_afterPruning shouldBe empty
+    // Contract 2 did not have a locally stored exercise event
+    // hence its divulgence is not pruned - appears active to `divulgee`
+    contract2_afterPruning should not be empty
   }
 
   it should "prune completions" in {
@@ -425,37 +423,38 @@ private[backend] trait StorageBackendTestsPruning extends Matchers with StorageB
       submitter = someParty,
     )
     val applicationId = dtoApplicationId(completion)
-    for {
-      _ <- executeSql(backend.parameter.initializeParameters(someIdentityParams))
-      // Ingest a completion
-      _ <- executeSql(ingest(Vector(completion), _))
-      _ <- executeSql(
-        updateLedgerEnd(offset(1), 1L)
+
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+
+    // Ingest a completion
+    executeSql(ingest(Vector(completion), _))
+    executeSql(updateLedgerEnd(offset(1), 1L))
+
+    // Make sure the completion is visible
+    val before = executeSql(
+      backend.completion.commandCompletions(
+        offset(0),
+        offset(1),
+        applicationId,
+        Set(someParty),
       )
-      // Make sure the completion is visible
-      before <- executeSql(
-        backend.completion.commandCompletions(
-          offset(0),
-          offset(1),
-          applicationId,
-          Set(someParty),
-        )
+    )
+
+    // Prune
+    executeSql(backend.completion.pruneCompletions(offset(1))(_, loggingContext))
+    executeSql(backend.parameter.updatePrunedUptoInclusive(offset(1)))
+
+    // Make sure the completion is not visible anymore
+    val after = executeSql(
+      backend.completion.commandCompletions(
+        offset(0),
+        offset(1),
+        applicationId,
+        Set(someParty),
       )
-      // Prune
-      _ <- executeSql(backend.completion.pruneCompletions(offset(1))(_, loggingContext))
-      _ <- executeSql(backend.parameter.updatePrunedUptoInclusive(offset(1)))
-      // Make sure the completion is not visible anymore
-      after <- executeSql(
-        backend.completion.commandCompletions(
-          offset(0),
-          offset(1),
-          applicationId,
-          Set(someParty),
-        )
-      )
-    } yield {
-      before should not be empty
-      after shouldBe empty
-    }
+    )
+
+    before should not be empty
+    after shouldBe empty
   }
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsStringInterning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsStringInterning.scala
@@ -4,14 +4,14 @@
 package com.daml.platform.store.backend
 
 import org.scalatest.Inside
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 private[backend] trait StorageBackendTestsStringInterning
     extends Matchers
     with Inside
     with StorageBackendSpec {
-  this: AsyncFlatSpec =>
+  this: AnyFlatSpec =>
 
   behavior of "StorageBackend (StringInterning)"
 
@@ -23,33 +23,31 @@ private[backend] trait StorageBackendTestsStringInterning
       DbDto.StringInterningDto(5, "d"),
     )
 
-    for {
-      interningIdsBeforeBegin <- executeSql(
-        backend.stringInterning.loadStringInterningEntries(0, 5)
-      )
-      _ <- executeSql(ingest(dtos, _))
-      interningIdsFull <- executeSql(backend.stringInterning.loadStringInterningEntries(0, 5))
-      interningIdsOverFetch <- executeSql(
-        backend.stringInterning.loadStringInterningEntries(0, 10)
-      )
-      interningIdsEmpty <- executeSql(
-        backend.stringInterning.loadStringInterningEntries(5, 10)
-      )
-      interningIdsSubset <- executeSql(
-        backend.stringInterning.loadStringInterningEntries(3, 10)
-      )
-    } yield {
-      val expectedFullList = List(
-        2 -> "a",
-        3 -> "b",
-        4 -> "c",
-        5 -> "d",
-      )
-      interningIdsBeforeBegin shouldBe Nil
-      interningIdsFull shouldBe expectedFullList
-      interningIdsOverFetch shouldBe expectedFullList
-      interningIdsEmpty shouldBe Nil
-      interningIdsSubset shouldBe expectedFullList.drop(2)
-    }
+    val interningIdsBeforeBegin = executeSql(
+      backend.stringInterning.loadStringInterningEntries(0, 5)
+    )
+    executeSql(ingest(dtos, _))
+    val interningIdsFull = executeSql(backend.stringInterning.loadStringInterningEntries(0, 5))
+    val interningIdsOverFetch = executeSql(
+      backend.stringInterning.loadStringInterningEntries(0, 10)
+    )
+    val interningIdsEmpty = executeSql(
+      backend.stringInterning.loadStringInterningEntries(5, 10)
+    )
+    val interningIdsSubset = executeSql(
+      backend.stringInterning.loadStringInterningEntries(3, 10)
+    )
+
+    val expectedFullList = List(
+      2 -> "a",
+      3 -> "b",
+      4 -> "c",
+      5 -> "d",
+    )
+    interningIdsBeforeBegin shouldBe Nil
+    interningIdsFull shouldBe expectedFullList
+    interningIdsOverFetch shouldBe expectedFullList
+    interningIdsEmpty shouldBe Nil
+    interningIdsSubset shouldBe expectedFullList.drop(2)
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ha/TestDBLockStorageBackendSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ha/TestDBLockStorageBackendSpec.scala
@@ -7,10 +7,10 @@ import java.sql.Connection
 
 import com.daml.platform.store.backend.{DBLockStorageBackend, StorageBackendTestsDBLock}
 import org.scalatest.BeforeAndAfter
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 class TestDBLockStorageBackendSpec
-    extends AsyncFlatSpec
+    extends AnyFlatSpec
     with StorageBackendTestsDBLock
     with BeforeAndAfter {
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/StorageBackendH2Spec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/StorageBackendH2Spec.scala
@@ -3,9 +3,9 @@
 
 package com.daml.platform.store.backend
 
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 final class StorageBackendH2Spec
-    extends AsyncFlatSpec
+    extends AnyFlatSpec
     with StorageBackendProviderH2
     with StorageBackendSuite

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/StorageBackendOracleSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/StorageBackendOracleSpec.scala
@@ -3,9 +3,9 @@
 
 package com.daml.platform.store.backend
 
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 final class StorageBackendOracleSpec
-    extends AsyncFlatSpec
+    extends AnyFlatSpec
     with StorageBackendProviderOracle
     with StorageBackendSuite

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/StorageBackendPostgresSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/backend/StorageBackendPostgresSpec.scala
@@ -5,10 +5,10 @@ package com.daml.platform.store.backend
 
 import com.daml.platform.store.backend.postgresql.PostgresDataSourceStorageBackend
 import org.scalatest.Inside
-import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 final class StorageBackendPostgresSpec
-    extends AsyncFlatSpec
+    extends AnyFlatSpec
     with StorageBackendProviderPostgres
     with StorageBackendSuite
     with StorageBackendTestsMigrationPruning
@@ -17,14 +17,12 @@ final class StorageBackendPostgresSpec
   behavior of "StorageBackend (Postgres)"
 
   it should "find the Postgres version" in {
-    for {
-      version <- executeSql(PostgresDataSourceStorageBackend.getPostgresVersion)
-    } yield {
-      inside(version) { case Some(versionNumbers) =>
-        // Minimum Postgres version used in tests
-        versionNumbers._1 should be >= 9
-        versionNumbers._2 should be >= 0
-      }
+    val version = executeSql(PostgresDataSourceStorageBackend.getPostgresVersion)
+
+    inside(version) { case Some(versionNumbers) =>
+      // Minimum Postgres version used in tests
+      versionNumbers._1 should be >= 9
+      versionNumbers._2 should be >= 0
     }
   }
 


### PR DESCRIPTION
This PR converts `StorageBackendSuite` from AsyncFlatSuite to AnyFlatSuite and removes the use of dbDispatcher - the tests themselves are mostly sequential.
