### PR TITLE
[BACKPORT] Use bazel-provided gRPC on Unix-like OSs (#12273) (#12194)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -828,29 +828,6 @@ load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_depen
 buildifier_dependencies()
 
 nixpkgs_package(
-    name = "grpc_nix",
-    attribute_path = "grpc",
-    build_file_content = """
-load("@os_info//:os_info.bzl", "is_linux")
-cc_library(
-  name = "grpc_lib",
-  srcs = [":lib/libgrpc.so", ":lib/libgrpc.so.19", ":lib/libgrpc.so.19.0.0", ":lib/libgpr.so", ":lib/libgpr.so.19", ":lib/libgpr.so.19.0.0"] if is_linux else [":lib/libgrpc.dylib", ":lib/libgpr.dylib"],
-  visibility = ["//visibility:public"],
-  hdrs = [":include"],
-  includes = ["include"],
-)
-filegroup(
-  name = "grpc_file",
-  srcs = glob(["lib/*"]),
-  visibility = ["//visibility:public"],
-)
-    """,
-    nix_file = "//nix:bazel.nix",
-    nix_file_deps = common_nix_file_deps,
-    repositories = dev_env_nix_repos,
-)
-
-nixpkgs_package(
     name = "postgresql_nix",
     attribute_path = "postgresql_9_6",
     fail_not_supported = False,

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -11,7 +11,6 @@ let shared = rec {
     docker
     gawk
     gnutar
-    grpc
     grpcurl
     gzip
     imagemagick


### PR DESCRIPTION
We switch back to bazel-provided gRPC as a temporary fix for #12194

This partially reverts commit 0de7b2eae5667d652635628177b1b06edeb61faf (#11031)

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
