### PR TITLE
[SoX conflict checking] Configuration upload conflict checking

### DIFF
--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -170,7 +170,7 @@ conformance_test(
 )
 
 conformance_test(
-    name = "conformance-test-conflict-checking",
+    name = "conformance-test-conflict-checking-static-time",
     ports = [6865],
     server = ":app",
     server_args = [

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -160,7 +160,31 @@ conformance_test(
         "--verbose",
         "--additional=ParticipantPruningIT",
         "--additional=MultiPartySubmissionIT",
-        "--exclude=ConfigManagementServiceIT:CMConcurrentSetConflicting",
+        # Exclude offset command deduplication tests as
+        # Sandbox-on-X has support only for participant side deduplication,
+        # which in turn only has support for durations as deduplication periods.
+        "--exclude=CommandDeduplicationIT:ParticipantCommandDeduplicationDeduplicateUsingOffsets",
+        # Disable tests targeting only multi-participant setups
+        "--exclude=ParticipantPruningIT:PRImmediateAndRetroactiveDivulgence",
+    ],
+)
+
+conformance_test(
+    name = "conformance-test-conflict-checking",
+    ports = [6865],
+    server = ":app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant participant-id=example,port=6865",
+        "--mutable-contract-state-cache",
+        "--enable-conflict-checking",
+        "--static-time",
+    ],
+    test_tool_args = [
+        "--verbose",
+        "--static-time",
+        "--additional=ParticipantPruningIT",
+        "--additional=MultiPartySubmissionIT",
         # Exclude offset command deduplication tests as
         # Sandbox-on-X has support only for participant side deduplication,
         # which in turn only has support for durations as deduplication periods.

--- a/ledger/sandbox-on-x/src/test/suite/scala/com/daml/ledger/sandbox/BridgeWriteServiceTest.scala
+++ b/ledger/sandbox-on-x/src/test/suite/scala/com/daml/ledger/sandbox/BridgeWriteServiceTest.scala
@@ -81,5 +81,4 @@ class BridgeWriteServiceTest extends AnyFlatSpec with MockitoSugar with Matchers
       .optCompletionInfo
       .flatMap(_.statistics) shouldBe Some(expected)
   }
-
 }


### PR DESCRIPTION
This PR implements the configuration upload conflict checking:
* Checks record time vs provided max record time
* Checks configuration generation
* `ConfigManagementServiceIT:CMConcurrentSetConflicting` test that asserts it is enabled.

Additionally, the `--static-time` flag is added on the BridgeConfig CLI for toggling between the wall-clock and static time mode.
CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
