### PR TITLE
Make daml start integration tests use canton.

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -168,13 +168,15 @@ withJsonApi (SandboxPort sandboxPort) (JsonApiPort jsonApiPort) extraArgs a = do
             , "--http-port", show jsonApiPort
             , "--allow-insecure-tokens"
             ] ++ extraArgs
-    putStrLn ("Starting JSON API: " <> unwords args)
     withPlatformJar args "json-api-logback.xml" $ \ph -> do
         putStrLn "Waiting for JSON API to start: "
         -- The secret doesn’t matter here
         let token = JWT.encodeSigned (JWT.HMACSecret "secret") mempty mempty
                 { JWT.unregisteredClaims = JWT.ClaimsMap $
-                      Map.fromList [("https://daml.com/ledger-api", Object $ HashMap.fromList [("actAs", toJSON ["Alice" :: T.Text]), ("ledgerId", "sandbox"), ("applicationId", "foobar")])]
+                      Map.fromList [("https://daml.com/ledger-api", Object $ HashMap.fromList
+                        [("actAs", toJSON ["Alice" :: T.Text]), ("ledgerId", "sandbox"), ("applicationId", "foobar")])]
+                        -- TODO https://github.com/digital-asset/daml/issues/12145
+                        --   Drop the ledgerId field once it becomes optional.
                 }
         -- For now, we have a dummy authorization header here to wait for startup since we cannot get a 200
         -- response otherwise. We probably want to add some method to detect successful startup without

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -168,12 +168,13 @@ withJsonApi (SandboxPort sandboxPort) (JsonApiPort jsonApiPort) extraArgs a = do
             , "--http-port", show jsonApiPort
             , "--allow-insecure-tokens"
             ] ++ extraArgs
+    putStrLn ("Starting JSON API: " <> unwords args)
     withPlatformJar args "json-api-logback.xml" $ \ph -> do
         putStrLn "Waiting for JSON API to start: "
         -- The secret doesn’t matter here
         let token = JWT.encodeSigned (JWT.HMACSecret "secret") mempty mempty
                 { JWT.unregisteredClaims = JWT.ClaimsMap $
-                      Map.fromList [("https://daml.com/ledger-api", Object $ HashMap.fromList [("actAs", toJSON ["Alice" :: T.Text]), ("ledgerId", "MyLedger"), ("applicationId", "foobar")])]
+                      Map.fromList [("https://daml.com/ledger-api", Object $ HashMap.fromList [("actAs", toJSON ["Alice" :: T.Text]), ("ledgerId", "sandbox"), ("applicationId", "foobar")])]
                 }
         -- For now, we have a dummy authorization header here to wait for startup since we cannot get a 200
         -- response otherwise. We probably want to add some method to detect successful startup without

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -254,7 +254,7 @@ withCantonSandbox ports remainingArgs k = do
     let cantonJar = sdkPath </> "canton" </> "canton.jar"
     withTempFile $ \config -> do
         BSL.writeFile config (cantonConfig ports)
-        withJar cantonJar [] ("daemon" : "-v" :  "-c" : config :  "--auto-connect-local" : remainingArgs) k
+        withJar cantonJar [] ("daemon" : "-c" : config :  "--auto-connect-local" : remainingArgs) k
 
 data CantonPorts = CantonPorts
   { ledgerApi :: Int

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -35,7 +35,6 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable
 import Data.Maybe
 import qualified Data.Text as T
-import qualified Data.Text.Extended as T
 import qualified Network.HTTP.Simple as HTTP
 import qualified Network.HTTP.Types as HTTP
 import Network.Socket
@@ -254,13 +253,8 @@ withCantonSandbox ports remainingArgs k = do
     sdkPath <- getSdkPath
     let cantonJar = sdkPath </> "canton" </> "canton.jar"
     withTempFile $ \config -> do
-      withTempFile $ \bootstrap -> do
         BSL.writeFile config (cantonConfig ports)
-        T.writeFileUtf8 bootstrap $ T.unlines
-           [ "sandbox.domains.connect_local(local)"
-           , "println(\"Canton sandbox started\")"
-           ]
-        withJar cantonJar [] ("daemon" : "-c" : config :  "--bootstrap" : bootstrap : remainingArgs) k
+        withJar cantonJar [] ("daemon" : "-v" :  "-c" : config :  "--auto-connect-local" : remainingArgs) k
 
 data CantonPorts = CantonPorts
   { ledgerApi :: Int

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -127,6 +127,7 @@ da_haskell_test(
         "aeson",
         "async",
         "base",
+        "bytestring",
         "conduit",
         "conduit-extra",
         "containers",


### PR DESCRIPTION
- Switch to using --auto-connect-local instead of a bootstrap script in daml start and daml canton-sandbox.
- Fixed the ledger id used in the daml start json api header (else it hangs).
- Changed the daml start integration tests to use --sandbox-canton
  - Haven't fixed the hot reload test yet.
- Separated out a daml start test that doesn't use the shared instance.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
