### PR TITLE
[ledger-api-test-tool] - Future assertions improvements [KVL-1218]

### DIFF
--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -94,6 +94,7 @@ da_scala_binary(
                 "//ledger/error",
                 "//ledger/ledger-api-common",
                 "//libs-scala/build-info",
+                "//libs-scala/contextualized-logging",
                 "//libs-scala/grpc-utils",
                 "//libs-scala/resources",
                 "//libs-scala/resources-akka",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -3,6 +3,10 @@
 
 package com.daml.ledger.api.testtool
 
+import java.io.File
+import java.nio.file.{Files, Paths, StandardCopyOption}
+import java.util.concurrent.Executors
+
 import com.daml.ledger.api.testtool.infrastructure.Reporter.ColorizedPrintStreamReporter
 import com.daml.ledger.api.testtool.infrastructure.Result.Excluded
 import com.daml.ledger.api.testtool.infrastructure._
@@ -13,9 +17,6 @@ import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
 import org.slf4j.LoggerFactory
 
 import scala.collection.compat._
-import java.io.File
-import java.nio.file.{Files, Paths, StandardCopyOption}
-import java.util.concurrent.Executors
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -179,7 +180,7 @@ object LedgerApiTestTool {
           testsToRun,
         )
 
-    runner.flatMap(_.runTests).onComplete {
+    runner.flatMap(_.runTests(ExecutionContext.global)).onComplete {
       case Success(summaries) =>
         val excludedTestSummaries =
           excludedTests.map { ledgerTestCase =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -144,9 +144,7 @@ object Assertions {
         errorInfo.getMetadataMap
       }
       .getOrElse {
-        fail(
-          s"The error did not contain a definite answer. Details were: ${details.mkString("[", ", ", "]")}"
-        )
+        java.util.Map.of()
       }
   }
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
+import java.util
 import java.util.regex.Pattern
 
 import com.daml.error.ErrorCode
@@ -144,7 +145,7 @@ object Assertions {
         errorInfo.getMetadataMap
       }
       .getOrElse {
-        java.util.Map.of()
+        new util.HashMap()
       }
   }
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/FutureAssertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/FutureAssertions.scala
@@ -55,9 +55,9 @@ object FutureAssertions {
     Delayed.Future.by(delay)(test)
 
   /** Run the test every [[retryDelay]] up to [[maxRetryDuration]].
-    * The assertion will succeed if any of the test case runs are successful.
+    * The test case will run up to [[ceil(maxRetryDuration / retryDelay)]] times.
+    * The assertion will succeed as soon as any of the test case runs are successful.
     * The assertion will fail if no test case runs are successful and the [[maxRetryDuration]] is exceeded.
-    * The test case will run up to [[ceil(maxRetryDuration / retryDelay)]] times
     */
   def succeedsEventually[V](
       retryDelay: FiniteDuration = 100.millis,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -231,12 +231,12 @@ final class LedgerTestCasesRunner(
               ledgerSession,
               concurrentTestCases,
               concurrentTestRuns,
-            )(materializer, materializer.executionContext)
+            )(materializer, executionContext)
             sequentialTestResults <- runTestCases(
               ledgerSession,
               sequentialTestCases,
               concurrency = 1,
-            )(materializer, materializer.executionContext)
+            )(materializer, executionContext)
           } yield concurrentTestResults ++ sequentialTestResults ++ excludedTestResults
 
         testResults.recover {
@@ -259,7 +259,7 @@ final class LedgerTestCasesRunner(
     val results =
       for {
         materializer <- materializerResources.asFuture
-        results <- run(participants)(materializer, materializer.executionContext)
+        results <- run(participants)(materializer, executionContext)
       } yield results
 
     results.onComplete(_ => materializerResources.release())


### PR DESCRIPTION
- Add assertion which is similar to scalatest forAll, which runs multiple test cases in parallel for a sequence of input data, reporting on successes/failures
- Improve logging for succeedUntil and succeedEventually 
- use the global execution context as the execution context passed to the test cases, to decouple from the execution context used by the akka materializer

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
