### PR TITLE
Revert "devenv: Just require Nix v2.4 or newer."

### DIFF
--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -58,6 +58,10 @@ check_nix_version() {
   fi
 }
 
+nix_tool() {
+  echo "$(nix-build ./nix/default.nix -A "tools.$1" -Q --no-out-link)/$2"
+}
+
 # TODO(gleber): Compatibility mode until JBH is ugraded.
 DADE_DEVENV_DIR="${DADE_DEVENV_DIR:-${DADE_BASE:-}}"
 if [ -z "$DADE_DEVENV_DIR" ]; then
@@ -107,7 +111,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 echo "source $(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 
 # Expose our tools in /dev-env/bin and our version of nixpkgs
-if [[ "$("${DADE_DEVENV_DIR}/bin/semver" compare "$(get_nix_version)" '2.4.0')" -ge 0 ]]; then
+semver="$(nix_tool semver bin/semver)"
+if [[ "$("$semver" compare "$(get_nix_version)" '2.4.0')" -ge 0 ]]; then
   echo "export NIX_USER_CONF_FILES=\"${DADE_DEVENV_DIR}/etc/nix.conf:\${NIX_USER_CONF_FILES:-}:\${XDG_CONFIG_HOME:-\${HOME}/.config}/nix/nix.conf\""
 else
   # On an old version of Nix, overwrite the system config, as we can't support multiple config files.

--- a/dev-env/lib/dade-dump-profile
+++ b/dev-env/lib/dade-dump-profile
@@ -27,17 +27,27 @@ errcho() {
   >&2 echo "[dev-env] $*"
 }
 
+get_nix_version() {
+  local current
+  current="$(nix-env --version)"
+  if [[ "$current" =~ ([0-9])[.]([0-9]+)([.]([0-9]+))?$ ]]; then
+    echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[4]:-0}"
+  else
+    errcho "WARNING: Unexpected output of 'nix-env --version' ($current), dev-env might not work properly."
+    return 1
+  fi
+}
+
 check_nix_version() {
   # Keep in sync with dade-nix-install.
   NIX_MAJOR="$1"
   NIX_MINOR="$2"
   NIX_PATCH="$3"
-  local current
-  current=$(nix-env --version)
-  if [[ $current =~ ([0-9])[.]([0-9]+)([.]([0-9]+))? ]]; then
+  if current="$(get_nix_version)"; then
+    [[ "$current" =~ ([0-9])[.]([0-9]+)[.]([0-9]+)$ ]]
     local current_major="${BASH_REMATCH[1]}"
     local current_minor="${BASH_REMATCH[2]}"
-    local current_patch="${BASH_REMATCH[4]:-0}"
+    local current_patch="${BASH_REMATCH[3]}"
     if [[ $current_major -lt $NIX_MAJOR ]] ||
       [[ $current_major -eq $NIX_MAJOR && $current_minor -lt $NIX_MINOR ]] ||
       [[ $current_major -eq $NIX_MAJOR && $current_minor -eq $NIX_MINOR && $current_patch -lt $NIX_PATCH ]];
@@ -45,8 +55,6 @@ check_nix_version() {
           errcho "WARNING: Version ${current_major}.${current_minor}.${current_patch} detected, but ${NIX_MAJOR}.${NIX_MINOR}.${NIX_PATCH} or higher required."
           errcho "Please run 'nix upgrade-nix' or 'curl -sSfL https://nixos.org/nix/install | sh' to update Nix."
     fi
-  else
-    errcho "WARNING: Unexpected output of 'nix-env --version' ($current), dev-env might not work properly."
   fi
 }
 
@@ -71,7 +79,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
   # shellcheck source=./ensure-nix
   source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 
-  : "${DADE_DESIRED_NIX_VERSION:=2 4 0}"
+  : "${DADE_DESIRED_NIX_VERSION:=2 1 3}"
   check_nix_version $DADE_DESIRED_NIX_VERSION
 
   # If the user has no channels configured, then NIX_PATH might point
@@ -99,7 +107,12 @@ source "$(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 echo "source $(dirname "${BASH_SOURCE[0]}")/ensure-nix"
 
 # Expose our tools in /dev-env/bin and our version of nixpkgs
-echo "export NIX_USER_CONF_FILES=\"${DADE_DEVENV_DIR}/etc/nix.conf:\${NIX_USER_CONF_FILES:-}:\${XDG_CONFIG_HOME:-\${HOME}/.config}/nix/nix.conf\""
+if [[ "$("${DADE_DEVENV_DIR}/bin/semver" compare "$(get_nix_version)" '2.4.0')" -ge 0 ]]; then
+  echo "export NIX_USER_CONF_FILES=\"${DADE_DEVENV_DIR}/etc/nix.conf:\${NIX_USER_CONF_FILES:-}:\${XDG_CONFIG_HOME:-\${HOME}/.config}/nix/nix.conf\""
+else
+  # On an old version of Nix, overwrite the system config, as we can't support multiple config files.
+  echo "export NIX_CONF_DIR=\"${DADE_DEVENV_DIR}/etc\""
+fi
 echo "export NIX_PATH=nixpkgs=\"${DADE_NIXPKGS}\""
 echo "export PATH=\"${DADE_DEVENV_DIR}/bin:\$PATH\""
 echo "export PYTHONPATH=\".\${PYTHONPATH:+:\$PYTHONPATH}\""

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -135,7 +135,6 @@ da_scala_test_suite(
         "//ledger/ledger-api-health",
         "//ledger/metrics",
         "//ledger/metrics:metrics-test-lib",
-        "//ledger/participant-state/kvutils",
         "//ledger/test-common",
         "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",


### PR DESCRIPTION
This reverts commit ed442fa8ae8228369cffed85dad40db8157dfe71.

Turns out we still use Nix 2.3 in places.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
