### PR TITLE
dev-env: Don't use the "extra-" prefix in nix.conf.

### DIFF
--- a/dev-env/etc/nix.conf
+++ b/dev-env/etc/nix.conf
@@ -1,11 +1,11 @@
 build-max-jobs = 2
 
-extra-substituters = https://nix-cache.da-ext.net
+substituters = https://nix-cache.da-ext.net https://cache.nixos.org
 # Note: the "hydra.da-int.net" string is now part of the name of the key for
 # legacy reasons; it bears no relation to the DNS hostname of the current
 # cache.
 # If you change this, you also need to update the config in infra/vsts_agent_ubuntu_20_04_startup.sh.
-extra-trusted-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g=
+trusted-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
 
 # Keep build-time dependencies of non-garbage outputs around
 gc-keep-outputs = true


### PR DESCRIPTION
It turns out this prefix is only supported as of Nix 2.4.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
