### PR TITLE
version-service - Move command deduplication feature descriptors into the experimental features [kvl-1218]

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -27,56 +27,37 @@ message ExperimentalSelfServiceErrorCodes {}
 // Ledger is in the static time mode and exposes a time service.
 message ExperimentalStaticTime {}
 
-// Command deduplication feature descriptors used for testing
-//
-// KV ledger configuration:
-//  deduplication_period_support {
-//    offset_support = OFFSET_CONVERT_TO_DURATION
-//    duration_support = DURATION_NATIVE_SUPPORT
-//  }
-//  deduplication_type = ASYNC
-//
-// Canton configuration:
-//  deduplication_period_support {
-//    offset_support = OFFSET_NATIVE_SUPPORT
-//    duration_support = DURATION_CONVERT_TO_OFFSET
-//  }
-//  deduplication_type = ASYNC
+// Feature descriptors for command deduplication intended to be used for adapting Ledger API tests.
 message CommandDeduplicationFeatures {
-  // Feature descriptor for support for different deduplication periods
-  DeduplicationPeriodSupport deduplication_period_support = 1;
-  // Feature descriptor for support for participant deduplication
-  // Used to adapt the conformance tests based on the deduplication type supported by the ledger
-  DeduplicationType deduplication_type = 2;
+  CommandDeduplicationPeriodSupport deduplication_period_support = 1;
+  CommandDeduplicationType deduplication_type = 2;
 }
 
-message DeduplicationPeriodSupport {
+// Feature descriptor specifying how deduplication periods can be specified and how they are handled by the participant
+// node.
+message CommandDeduplicationPeriodSupport {
+  // How the participant node supports deduplication periods specified using offsets.
   enum OffsetSupport {
-    // The ledger natively supports deduplication periods specified as offsets.
-    OFFSET_NATIVE_SUPPORT = 0;
-    // The ledger doesn't natively support deduplication periods specified as offsets but it converts them into durations.
-    OFFSET_CONVERT_TO_DURATION = 1;
-    // The ledger does not support specifiying deduplication periods as offsets.
-    OFFSET_NOT_SUPPORTED = 2;
+    OFFSET_NOT_SUPPORTED = 0;
+    OFFSET_NATIVE_SUPPORT = 1;
+    OFFSET_CONVERT_TO_DURATION = 2;
   }
+  // How the participant node supports deduplication periods specified as durations.
   enum DurationSupport {
-    // The ledger natively support deduplication periods specified as durations.
     DURATION_NATIVE_SUPPORT = 0;
-    // The ledger doesn't natively support deduplication periods specified as durations but it converts them into offsets.
     DURATION_CONVERT_TO_OFFSET = 1;
   }
-  // Feature descriptor for how the ledger handles offsets as deduplication periods
   OffsetSupport offset_support = 1;
-  // Feature descriptor for how the ledger handles durations as deduplication periods
   DurationSupport duration_support = 2;
 }
 
-// Ledger support for participant deduplication
-enum DeduplicationType {
-  // The participant does not support deduplication.
-  ASYNC = 0;
-  // The participant only supports deduplicating submissions that are being concurrently processed.
+// How the participant node reports duplicate command submissions.
+enum CommandDeduplicationType {
+  // Duplicate commands are exclusively reported asynchronous via completions.
+  ASYNC_ONLY = 0;
+  // Commands that are duplicates of concurrently submitted commands are reported synchronously via a gRPC error on the
+  // command submission, while all other duplicate commands are reported asynchronously via completions.
   ASYNC_AND_CONCURRENT_SYNC = 1;
-  // The participant supports deduplication for all the submissions it receives.
+  // Duplicate commands are always reported synchronously via a synchronous gRPC error on the command submission.
   ONLY_SYNC = 2;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -28,11 +28,26 @@ message ExperimentalSelfServiceErrorCodes {}
 message ExperimentalStaticTime {}
 
 // Command deduplication feature descriptors used for testing
+//
+// KV ledger configuration:
+//  deduplication_period_support {
+//    offset_support = OFFSET_CONVERT_TO_DURATION
+//    duration_support = DURATION_NATIVE_SUPPORT
+//  }
+//  deduplication_type = ASYNC
+//
+// Canton configuration:
+//  deduplication_period_support {
+//    offset_support = OFFSET_NATIVE_SUPPORT
+//    duration_support = DURATION_CONVERT_TO_OFFSET
+//  }
+//  deduplication_type = ASYNC
 message CommandDeduplicationFeatures {
   // Feature descriptor for support for different deduplication periods
   DeduplicationPeriodSupport deduplication_period_support = 1;
   // Feature descriptor for support for participant deduplication
-  ParticipantDeduplicationSupport participant_deduplication_support = 2;
+  // Used to adapt the conformance tests based on the deduplication type supported by the ledger
+  DeduplicationType deduplication_type = 2;
 }
 
 message DeduplicationPeriodSupport {
@@ -57,11 +72,11 @@ message DeduplicationPeriodSupport {
 }
 
 // Ledger support for participant deduplication
-enum ParticipantDeduplicationSupport {
+enum DeduplicationType {
   // The participant does not support deduplication.
-  PARTICIPANT_DEDUPLICATION_NOT_SUPPORTED = 0;
+  ASYNC = 0;
   // The participant only supports deduplicating submissions that are being concurrently processed.
-  PARTICIPANT_DEDUPLICATION_PARALLEL_ONLY = 1;
+  ASYNC_AND_CONCURRENT_SYNC = 1;
   // The participant supports deduplication for all the submissions it receives.
-  PARTICIPANT_DEDUPLICATION_SUPPORTED = 2;
+  ONLY_SYNC = 2;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -27,8 +27,11 @@ message ExperimentalSelfServiceErrorCodes {}
 // Ledger is in the static time mode and exposes a time service.
 message ExperimentalStaticTime {}
 
+// Command deduplication feature descriptors used for testing
 message CommandDeduplicationFeatures {
+  // Feature descriptor for support for different deduplication periods
   DeduplicationPeriodSupport deduplication_period_support = 1;
+  // Feature descriptor for support for participant deduplication
   ParticipantDeduplicationSupport participant_deduplication_support = 2;
 }
 
@@ -47,7 +50,9 @@ message DeduplicationPeriodSupport {
     // The ledger doesn't natively support deduplication periods specified as durations but it converts them into offsets.
     DURATION_CONVERT_TO_OFFSET = 1;
   }
+  // Feature descriptor for how the ledger handles offsets as deduplication periods
   OffsetSupport offset_support = 1;
+  // Feature descriptor for how the ledger handles durations as deduplication periods
   DurationSupport duration_support = 2;
 }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -34,15 +34,17 @@ message CommandDeduplicationFeatures {
 
 message DeduplicationPeriodSupport {
   enum OffsetSupport {
-    // Ledgers use offsets for command deduplication
+    // The ledger natively supports deduplication periods specified as offsets.
     OFFSET_NATIVE_SUPPORT = 0;
-    // Ledger convert offsets into a duration for command deduplication
+    // The ledger doesn't natively support deduplication periods specified as offsets but it converts them into durations.
     OFFSET_CONVERT_TO_DURATION = 1;
-    // Ledger does not support offsets for command deduplication
+    // The ledger does not support specifiying deduplication periods as offsets.
     OFFSET_NOT_SUPPORTED = 2;
   }
   enum DurationSupport {
+    // The ledger natively support deduplication periods specified as durations.
     DURATION_NATIVE_SUPPORT = 0;
+    // The ledger doesn't natively support deduplication periods specified as durations but it converts them into offsets.
     DURATION_CONVERT_TO_OFFSET = 1;
   }
   OffsetSupport offset_support = 1;
@@ -51,7 +53,10 @@ message DeduplicationPeriodSupport {
 
 // Ledger support for participant deduplication
 enum ParticipantDeduplicationSupport {
+  // The participant does not support deduplication.
   PARTICIPANT_DEDUPLICATION_NOT_SUPPORTED = 0;
+  // The participant only supports deduplicating submissions that are being concurrently processed.
   PARTICIPANT_DEDUPLICATION_PARALLEL_ONLY = 1;
+  // The participant supports deduplication for all the submissions it receives.
   PARTICIPANT_DEDUPLICATION_SUPPORTED = 2;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -18,6 +18,7 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 message ExperimentalFeatures {
   ExperimentalSelfServiceErrorCodes self_service_error_codes = 1;
   ExperimentalStaticTime static_time = 2;
+  CommandDeduplicationFeatures command_deduplication = 3;
 }
 
 // GRPC self-service error codes are returned by the Ledger API.
@@ -25,3 +26,32 @@ message ExperimentalSelfServiceErrorCodes {}
 
 // Ledger is in the static time mode and exposes a time service.
 message ExperimentalStaticTime {}
+
+message CommandDeduplicationFeatures {
+  DeduplicationPeriodSupport deduplication_period_support = 1;
+  ParticipantDeduplicationSupport participant_deduplication_support = 2;
+}
+
+message DeduplicationPeriodSupport {
+  enum OffsetSupport {
+    // Ledgers use offsets for command deduplication
+    OFFSET_NATIVE_SUPPORT = 0;
+    // Ledger convert offsets into a duration for command deduplication
+    OFFSET_CONVERT_TO_DURATION = 1;
+    // Ledger does not support offsets for command deduplication
+    OFFSET_NOT_SUPPORTED = 2;
+  }
+  enum DurationSupport {
+    DURATION_NATIVE_SUPPORT = 0;
+    DURATION_CONVERT_TO_OFFSET = 1;
+  }
+  OffsetSupport offset_support = 1;
+  DurationSupport duration_support = 2;
+}
+
+// Ledger support for participant deduplication
+enum ParticipantDeduplicationSupport {
+  PARTICIPANT_DEDUPLICATION_NOT_SUPPORTED = 0;
+  PARTICIPANT_DEDUPLICATION_PARALLEL_ONLY = 1;
+  PARTICIPANT_DEDUPLICATION_SUPPORTED = 2;
+}

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -59,5 +59,5 @@ enum CommandDeduplicationType {
   // command submission, while all other duplicate commands are reported asynchronously via completions.
   ASYNC_AND_CONCURRENT_SYNC = 1;
   // Duplicate commands are always reported synchronously via a synchronous gRPC error on the command submission.
-  ONLY_SYNC = 2;
+  SYNC_ONLY = 2;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -53,7 +53,7 @@ message CommandDeduplicationPeriodSupport {
 
 // How the participant node reports duplicate command submissions.
 enum CommandDeduplicationType {
-  // Duplicate commands are exclusively reported asynchronous via completions.
+  // Duplicate commands are exclusively reported asynchronously via completions.
   ASYNC_ONLY = 0;
   // Commands that are duplicates of concurrently submitted commands are reported synchronously via a gRPC error on the
   // command submission, while all other duplicate commands are reported asynchronously via completions.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
@@ -55,34 +55,8 @@ message FeaturesDescriptor {
   // Daml applications SHOULD not depend on these in production.
   ExperimentalFeatures experimental = 1;
 
-  // Features related to command deduplication
-  CommandDeduplicationFeatures command_deduplication = 3;
 }
 
 // Used to signal the presence of the user management service.
 // Defined as a message to enable future addition of individual per-service features.
 message UserManagementFeature {}
-
-message CommandDeduplicationFeatures {
-  DeduplicationPeriodSupport deduplication_period_support = 1;
-  ParticipantDeduplicationSupport participant_deduplication_support = 2;
-}
-
-message DeduplicationPeriodSupport {
-  enum OffsetSupport {
-    OFFSET_NATIVE_SUPPORT = 0;
-    OFFSET_CONVERT_TO_DURATION = 1;
-    OFFSET_NOT_SUPPORTED = 2;
-  }
-  enum DurationSupport {
-    DURATION_NATIVE_SUPPORT = 0;
-    DURATION_CONVERT_TO_OFFSET = 1;
-  }
-  OffsetSupport offset_support = 1;
-  DurationSupport duration_support = 2;
-}
-enum ParticipantDeduplicationSupport {
-  PARTICIPANT_DEDUPLICATION_NOT_SUPPORTED = 0;
-  PARTICIPANT_DEDUPLICATION_PARALLEL_ONLY = 1;
-  PARTICIPANT_DEDUPLICATION_SUPPORTED = 2;
-}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantFeature.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantFeature.scala
@@ -3,10 +3,8 @@
 
 package com.daml.ledger.api.testtool.infrastructure.participant
 
-import com.daml.ledger.api.v1.version_service.{
-  CommandDeduplicationFeatures,
-  GetLedgerApiVersionResponse,
-}
+import com.daml.ledger.api.v1.experimental_features.CommandDeduplicationFeatures
+import com.daml.ledger.api.v1.version_service.GetLedgerApiVersionResponse
 
 final case class Features(
     selfServiceErrorCodes: Boolean = false,
@@ -26,8 +24,8 @@ object Features {
     Features(
       selfServiceErrorCodes = experimental.flatMap(_.selfServiceErrorCodes).isDefined,
       userManagement = features.flatMap(_.userManagement).isDefined,
-      commandDeduplicationFeatures = response.getFeatures.getCommandDeduplication,
       staticTime = experimental.flatMap(_.staticTime).isDefined,
+      commandDeduplicationFeatures = response.getFeatures.getExperimental.getCommandDeduplication,
     )
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
@@ -32,8 +32,8 @@ import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.api.v1.completion.Completion.{
   DeduplicationPeriod => CompletionDeduplicationPeriod
 }
+import com.daml.ledger.api.v1.experimental_features.CommandDeduplicationPeriodSupport.OffsetSupport
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
-import com.daml.ledger.api.v1.version_service.DeduplicationPeriodSupport.OffsetSupport
 import com.daml.ledger.client.binding.Primitive.Party
 import com.daml.ledger.test.model.DA.Types.Tuple2
 import com.daml.ledger.test.model.Test.{Dummy, DummyWithAnnotation, TextKey, TextKeyOperations}
@@ -328,7 +328,7 @@ final class CommandDeduplicationIT(
         submitAndAssertAccepted(thirdCall)
       }
       _ = if ( // participant deduplication is based on submittedAt, and thus the delta between record times can actually be smaller than the deduplication duration
-        !ledger.features.commandDeduplicationFeatures.participantDeduplicationSupport.isParticipantDeduplicationSupported
+        !ledger.features.commandDeduplicationFeatures.deduplicationType.isSyncOnly
       )
         assert(
           time.Duration
@@ -586,9 +586,7 @@ final class CommandDeduplicationIT(
   )(implicit
       ec: ExecutionContext
   ): Future[Option[Completion]] =
-    if (
-      ledger.features.commandDeduplicationFeatures.participantDeduplicationSupport.isParticipantDeduplicationSupported
-    )
+    if (ledger.features.commandDeduplicationFeatures.deduplicationType.isSyncOnly)
       submitRequestAndAssertSyncDeduplication(ledger, request, acceptedSubmissionId, acceptedOffset)
         .map(_ => None)
     else

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationParallelIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationParallelIT.scala
@@ -106,9 +106,8 @@ class CommandDeduplicationParallelIT extends LedgerTestSuite {
       // Canton can return ABORTED for parallel in-flight duplicate submissions
       val abortedResponses = responses.getOrElse(Code.ABORTED, 0)
       val duplicateResponses =
-        if (
-          ledger.features.commandDeduplicationFeatures.participantDeduplicationSupport.isParticipantDeduplicationParallelOnly
-        ) alreadyExistsResponses + abortedResponses
+        if (ledger.features.commandDeduplicationFeatures.deduplicationType.isAsyncAndConcurrentSync)
+          alreadyExistsResponses + abortedResponses
         else alreadyExistsResponses
       assert(
         okResponses == 1 && duplicateResponses == numberOfParallelRequests - 1,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.api.auth.Authorizer
 import com.daml.ledger.api.auth.services._
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.health.HealthChecks
-import com.daml.ledger.api.v1.version_service.CommandDeduplicationFeatures
+import com.daml.ledger.api.v1.experimental_features.CommandDeduplicationFeatures
 import com.daml.ledger.client.services.commands.CommandSubmissionFlow
 import com.daml.ledger.participant.state.index.v2._
 import com.daml.ledger.participant.state.{v2 => state}

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -13,7 +13,7 @@ import com.daml.error.ErrorCodesVersionSwitcher
 import com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor
 import com.daml.ledger.api.auth.{AuthService, Authorizer}
 import com.daml.ledger.api.health.HealthChecks
-import com.daml.ledger.api.v1.version_service.CommandDeduplicationFeatures
+import com.daml.ledger.api.v1.experimental_features.CommandDeduplicationFeatures
 import com.daml.ledger.configuration.LedgerId
 import com.daml.ledger.participant.state.index.v2.{IndexService, UserManagementStore}
 import com.daml.ledger.participant.state.{v2 => state}

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
@@ -9,13 +9,13 @@ import com.daml.error.{
   ErrorCodesVersionSwitcher,
 }
 import com.daml.ledger.api.v1.experimental_features.{
+  CommandDeduplicationFeatures,
   ExperimentalFeatures,
   ExperimentalSelfServiceErrorCodes,
   ExperimentalStaticTime,
 }
 import com.daml.ledger.api.v1.version_service.VersionServiceGrpc.VersionService
 import com.daml.ledger.api.v1.version_service.{
-  CommandDeduplicationFeatures,
   FeaturesDescriptor,
   GetLedgerApiVersionRequest,
   GetLedgerApiVersionResponse,
@@ -59,9 +59,9 @@ private[apiserver] final class ApiVersionService private (
           selfServiceErrorCodes =
             Option.when(enableSelfServiceErrorCodes)(ExperimentalSelfServiceErrorCodes()),
           staticTime = Option.when(enableStaticTime)(ExperimentalStaticTime()),
+          commandDeduplication = Some(commandDeduplicationFeatures),
         )
       ),
-      commandDeduplication = Some(commandDeduplicationFeatures),
     )
 
   override def getLedgerApiVersion(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -14,8 +14,8 @@ import com.daml.error.ErrorCodesVersionSwitcher
 import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
-  DeduplicationPeriodSupport,
-  ParticipantDeduplicationSupport,
+  CommandDeduplicationPeriodSupport,
+  CommandDeduplicationType,
 }
 import com.daml.ledger.participant.state.index.impl.inmemory.InMemoryUserManagementStore
 import com.daml.ledger.participant.state.v2.WritePackagesService
@@ -201,14 +201,14 @@ final class Runner[T <: ReadWriteService, Extra](
                         servicesExecutionContext = servicesExecutionContext,
                         commandDeduplicationFeatures = CommandDeduplicationFeatures.of(
                           Some(
-                            DeduplicationPeriodSupport.of(
+                            CommandDeduplicationPeriodSupport.of(
                               offsetSupport =
-                                DeduplicationPeriodSupport.OffsetSupport.OFFSET_CONVERT_TO_DURATION,
+                                CommandDeduplicationPeriodSupport.OffsetSupport.OFFSET_CONVERT_TO_DURATION,
                               durationSupport =
-                                DeduplicationPeriodSupport.DurationSupport.DURATION_NATIVE_SUPPORT,
+                                CommandDeduplicationPeriodSupport.DurationSupport.DURATION_NATIVE_SUPPORT,
                             )
                           ),
-                          ParticipantDeduplicationSupport.PARTICIPANT_DEDUPLICATION_NOT_SUPPORTED,
+                          CommandDeduplicationType.ASYNC_ONLY,
                         ),
                       ).acquire()
                     } yield {}

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -12,7 +12,7 @@ import akka.stream.Materializer
 import com.codahale.metrics.InstrumentedExecutorService
 import com.daml.error.ErrorCodesVersionSwitcher
 import com.daml.ledger.api.health.HealthChecks
-import com.daml.ledger.api.v1.version_service.{
+import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
   DeduplicationPeriodSupport,
   ParticipantDeduplicationSupport,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -18,7 +18,7 @@ import com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor
 import com.daml.ledger.api.auth.{AuthService, AuthServiceWildcard, Authorizer}
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.health.HealthChecks
-import com.daml.ledger.api.v1.version_service.{
+import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
   DeduplicationPeriodSupport,
   ParticipantDeduplicationSupport,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -20,8 +20,8 @@ import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
-  DeduplicationPeriodSupport,
-  ParticipantDeduplicationSupport,
+  CommandDeduplicationPeriodSupport,
+  CommandDeduplicationType,
 }
 import com.daml.ledger.participant.state.index.impl.inmemory.InMemoryUserManagementStore
 import com.daml.ledger.participant.state.v2.metrics.TimedWriteService
@@ -428,12 +428,13 @@ final class SandboxServer(
         userManagementStore = userManagementStore,
         commandDeduplicationFeatures = CommandDeduplicationFeatures.of(
           Some(
-            DeduplicationPeriodSupport.of(
-              offsetSupport = DeduplicationPeriodSupport.OffsetSupport.OFFSET_NOT_SUPPORTED,
-              durationSupport = DeduplicationPeriodSupport.DurationSupport.DURATION_NATIVE_SUPPORT,
+            CommandDeduplicationPeriodSupport.of(
+              offsetSupport = CommandDeduplicationPeriodSupport.OffsetSupport.OFFSET_NOT_SUPPORTED,
+              durationSupport =
+                CommandDeduplicationPeriodSupport.DurationSupport.DURATION_NATIVE_SUPPORT,
             )
           ),
-          ParticipantDeduplicationSupport.PARTICIPANT_DEDUPLICATION_SUPPORTED,
+          CommandDeduplicationType.ASYNC_ONLY,
         ),
       )(materializer, executionSequencerFactory, loggingContext)
         .map(_.withServices(List(resetService)))

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -434,7 +434,7 @@ final class SandboxServer(
                 CommandDeduplicationPeriodSupport.DurationSupport.DURATION_NATIVE_SUPPORT,
             )
           ),
-          CommandDeduplicationType.ASYNC_ONLY,
+          CommandDeduplicationType.SYNC_ONLY,
         ),
       )(materializer, executionSequencerFactory, loggingContext)
         .map(_.withServices(List(resetService)))

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.sandbox
 
 import java.util.UUID
 import java.util.concurrent.{Executors, TimeUnit}
+
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.Materializer
@@ -13,7 +14,7 @@ import com.codahale.metrics.InstrumentedExecutorService
 import com.daml.api.util.TimeProvider
 import com.daml.error.ErrorCodesVersionSwitcher
 import com.daml.ledger.api.health.HealthChecks
-import com.daml.ledger.api.v1.version_service.{
+import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
   DeduplicationPeriodSupport,
   ParticipantDeduplicationSupport,

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
@@ -16,8 +16,8 @@ import com.daml.error.ErrorCodesVersionSwitcher
 import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
-  DeduplicationPeriodSupport,
-  ParticipantDeduplicationSupport,
+  CommandDeduplicationPeriodSupport,
+  CommandDeduplicationType,
 }
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.impl.inmemory.InMemoryUserManagementStore
@@ -267,12 +267,12 @@ object SandboxOnXRunner {
       userManagementStore = new InMemoryUserManagementStore, // TODO persistence wiring comes here
       commandDeduplicationFeatures = CommandDeduplicationFeatures.of(
         Some(
-          DeduplicationPeriodSupport.of(
-            DeduplicationPeriodSupport.OffsetSupport.OFFSET_NOT_SUPPORTED,
-            DeduplicationPeriodSupport.DurationSupport.DURATION_NATIVE_SUPPORT,
+          CommandDeduplicationPeriodSupport.of(
+            CommandDeduplicationPeriodSupport.OffsetSupport.OFFSET_NOT_SUPPORTED,
+            CommandDeduplicationPeriodSupport.DurationSupport.DURATION_NATIVE_SUPPORT,
           )
         ),
-        ParticipantDeduplicationSupport.PARTICIPANT_DEDUPLICATION_SUPPORTED,
+        CommandDeduplicationType.SYNC_ONLY,
       ),
     )
 

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -19,8 +19,8 @@ import com.daml.ledger.api.domain
 import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
-  DeduplicationPeriodSupport,
-  ParticipantDeduplicationSupport,
+  CommandDeduplicationPeriodSupport,
+  CommandDeduplicationType,
 }
 import com.daml.ledger.configuration.LedgerId
 import com.daml.ledger.on.sql.Database.InvalidDatabaseException
@@ -319,14 +319,14 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                 servicesExecutionContext = servicesExecutionContext,
                 commandDeduplicationFeatures = CommandDeduplicationFeatures.of(
                   Some(
-                    DeduplicationPeriodSupport.of(
+                    CommandDeduplicationPeriodSupport.of(
                       offsetSupport =
-                        DeduplicationPeriodSupport.OffsetSupport.OFFSET_CONVERT_TO_DURATION,
+                        CommandDeduplicationPeriodSupport.OffsetSupport.OFFSET_CONVERT_TO_DURATION,
                       durationSupport =
-                        DeduplicationPeriodSupport.DurationSupport.DURATION_NATIVE_SUPPORT,
+                        CommandDeduplicationPeriodSupport.DurationSupport.DURATION_NATIVE_SUPPORT,
                     )
                   ),
-                  ParticipantDeduplicationSupport.PARTICIPANT_DEDUPLICATION_NOT_SUPPORTED,
+                  CommandDeduplicationType.ASYNC_ONLY,
                 ),
               )
               _ = apiServerServicesClosed.completeWith(apiServer.servicesClosed())

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -17,7 +17,7 @@ import com.daml.error.ErrorCodesVersionSwitcher
 import com.daml.ledger.api.auth.{AuthServiceWildcard, Authorizer}
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.health.HealthChecks
-import com.daml.ledger.api.v1.version_service.{
+import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
   DeduplicationPeriodSupport,
   ParticipantDeduplicationSupport,


### PR DESCRIPTION
- As the command deduplication descriptors are used for testing purposes only, they should be set in the message of the experimental feature

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
