### PR TITLE
Fixed a bug that caused JWTs without the `daml` namespace to be rejected by some endpoints

### DIFF
--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -199,6 +199,12 @@ trait AbstractHttpServiceIntegrationTestFuns
   protected def headersWithPartyAuth(actAs: List[String], readAs: List[String] = List()) =
     HttpServiceTestFixture.headersWithPartyAuth(actAs, readAs, testId)
 
+  protected def headersWithPartyAuthLegacyFormat(
+      actAs: List[String],
+      readAs: List[String] = List(),
+  ) =
+    HttpServiceTestFixture.headersWithPartyAuth(actAs, readAs, testId, withoutNamespace = true)
+
   protected def postJsonStringRequest(
       uri: Uri,
       jsonString: String,
@@ -732,6 +738,37 @@ abstract class AbstractHttpServiceIntegrationTest
         cs should have size 2
       )
     } yield succeed
+  }
+
+  "get all parties using the legacy token format" in withHttpServiceAndClient {
+    (uri, _, _, client, _) =>
+      import scalaz.std.vector._
+      val partyIds = Vector("P1", "P2", "P3", "P4").map(getUniqueParty(_).unwrap)
+      val partyManagement = client.partyManagementClient
+      val _ =
+        headersWithPartyAuthLegacyFormat(List())
+      partyIds
+        .traverse { p =>
+          partyManagement.allocateParty(Some(p), Some(s"$p & Co. LLC"))
+        }
+        .flatMap { allocatedParties =>
+          getRequest(
+            uri = uri.withPath(Uri.Path("/v1/parties")),
+            headersWithPartyAuthLegacyFormat(List()),
+          ).flatMap { case (status, output) =>
+            status shouldBe StatusCodes.OK
+            inside(
+              decode1[domain.OkResponse, List[domain.PartyDetails]](output)
+            ) { case \/-(response) =>
+              response.status shouldBe StatusCodes.OK
+              response.warnings shouldBe empty
+              val actualIds: Set[domain.Party] = response.result.view.map(_.identifier).toSet
+              actualIds should contain allElementsOf domain.Party.subst(partyIds.toSet)
+              response.result.toSet should contain allElementsOf
+                allocatedParties.toSet.map(domain.PartyDetails.fromLedgerApi)
+            }
+          }
+        }: Future[Assertion]
   }
 
   "query POST with empty query" in withHttpService { (uri, encoder, _, _) =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
@@ -104,10 +104,10 @@ object EndpointsCompanion {
         val ast = jwt.payload.parseJson
         for {
           obj <- asJsObject(ast).toRightDisjunction(Unauthorized("invalid access token"))
-          namespace <- obj
+          namespace = obj
             .get(AuthServiceJWTCodec.oidcNamespace)
             .flatMap(asJsObject)
-            .toRightDisjunction(Unauthorized("namespace missing in access token"))
+            .getOrElse(obj)
           ledgerId <- namespace
             .get("ledgerId")
             .flatMap(asString)


### PR DESCRIPTION
This fix was originally added to the `main` branch by @realvictorprm in #12261.
The ticket that originally tracked this issue was #12215

changelog_begin
- [HTTP-JSON] Fixed a bug that caused JWTs without the `daml` namespace to be rejected by some endpoints (https://github.com/digital-asset/daml/issues/12215)
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
