### PR TITLE
Fix terraform

### DIFF
--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -31,9 +31,10 @@ locals {
 }
 
 resource "google_project_iam_member" "periodic-killer" {
-  count  = length(local.accounts_that_can_kill_machines)
-  role   = google_project_iam_custom_role.periodic-killer.id
-  member = local.accounts_that_can_kill_machines[count.index]
+  count   = length(local.accounts_that_can_kill_machines)
+  project = local.project
+  role    = google_project_iam_custom_role.periodic-killer.id
+  member  = local.accounts_that_can_kill_machines[count.index]
 }
 
 resource "google_compute_instance" "periodic-killer" {

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -6,7 +6,7 @@ locals {
     {
       name      = "ci-u1",
       disk_size = 200,
-      size      = 30,
+      size      = 0,
       nix_cache = <<EOF
 binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
 binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -15,7 +15,7 @@ EOF
     {
       name      = "ci-u2",
       disk_size = 400,
-      size      = 0,
+      size      = 30,
       nix_cache = <<EOF
 extra-substituters = https://nix-cache.da-ext.net
 extra-trusted-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g=

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -7,19 +7,11 @@ locals {
       name      = "ci-u1",
       disk_size = 200,
       size      = 0,
-      nix_cache = <<EOF
-binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
-binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
-EOF
     },
     {
       name      = "ci-u2",
       disk_size = 400,
       size      = 30,
-      nix_cache = <<EOF
-extra-substituters = https://nix-cache.da-ext.net
-extra-trusted-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g=
-EOF
     },
   ]
 }
@@ -32,7 +24,6 @@ data "template_file" "vsts-agent-ubuntu_20_04-startup" {
     vsts_token   = secret_resource.vsts-token.value
     vsts_account = "digitalasset"
     vsts_pool    = "ubuntu_20_04"
-    nix_cache    = local.ubuntu[count.index].nix_cache
   }
 }
 

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -17,8 +17,8 @@ EOF
       disk_size = 400,
       size      = 0,
       nix_cache = <<EOF
-binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
-binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
+extra-substituters = https://nix-cache.da-ext.net
+extra-trusted-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g=
 EOF
     },
   ]

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -7,11 +7,19 @@ locals {
       name      = "ci-u1",
       disk_size = 200,
       size      = 30,
+      nix_cache = <<EOF
+binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
+binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
+EOF
     },
     {
       name      = "ci-u2",
       disk_size = 400,
       size      = 0,
+      nix_cache = <<EOF
+binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
+binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
+EOF
     },
   ]
 }
@@ -24,6 +32,7 @@ data "template_file" "vsts-agent-ubuntu_20_04-startup" {
     vsts_token   = secret_resource.vsts-token.value
     vsts_account = "digitalasset"
     vsts_pool    = "ubuntu_20_04"
+    nix_cache    = local.ubuntu[count.index].nix_cache
   }
 }
 

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -199,8 +199,7 @@ rm /etc/sudoers.d/nix_installation
 # legacy reasons; it bears no relation to the DNS hostname of the current
 # cache.
 cat <<NIX_CONF > /etc/nix/nix.conf
-binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
-binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
+${nix_cache ~}
 build-users-group = nixbld
 cores = 1
 max-jobs = 0

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -199,7 +199,8 @@ rm /etc/sudoers.d/nix_installation
 # legacy reasons; it bears no relation to the DNS hostname of the current
 # cache.
 cat <<NIX_CONF > /etc/nix/nix.conf
-${nix_cache ~}
+extra-substituters = https://nix-cache.da-ext.net
+extra-trusted-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g=
 build-users-group = nixbld
 cores = 1
 max-jobs = 0

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -199,8 +199,8 @@ rm /etc/sudoers.d/nix_installation
 # legacy reasons; it bears no relation to the DNS hostname of the current
 # cache.
 cat <<NIX_CONF > /etc/nix/nix.conf
-extra-substituters = https://nix-cache.da-ext.net
-extra-trusted-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g=
+binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
+binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
 build-users-group = nixbld
 cores = 1
 max-jobs = 0


### PR DESCRIPTION
Our Terraform configuration has been slightly broken by two recent changes:

- The nixpkgs upgrade in #12280 means a new version of our GCP plugin for Terraform, which as a breaking change added a required argument to `google_project_iam_member`. The new version also results in a number of smaller changes in the way Terraform handles default arguments, which doesn't result in any changes to our configuration files or to the behaviour of our deployed infrastructure, but does require re-syncing the Terraform state (by running `terraform apply`, which would essentially be a no-op if it were not for the next bullet point).
- The nix configuration changes in #12265 have changed the Linux CI nodes configuration but have not been deployed yet.

This PR is an audit log of the steps taken to rectfy those and bring us back to a state where our deployed configuration and our recorded Terraform state both agree with our current `main` branch tip.

CHANGELOG_BEGIN
CHANGELOG_END