### PR TITLE
LF: Cache field index inside structural record projection builtin

### DIFF
--- a/daml-lf/interpreter/src/bench/com/daml/lf/interpreter/StructProjBench.scala
+++ b/daml-lf/interpreter/src/bench/com/daml/lf/interpreter/StructProjBench.scala
@@ -25,9 +25,6 @@ class StructProjBench {
   var n: Int = _
   private def N = 1 << n
 
-  @Param(Array("true", "false"))
-  var validation: Boolean = _
-
   // Parsing of this program may require a stack larger that the default one.
   // 100 MB seems to be fine for m = 12.
   private[this] def pkg = {
@@ -52,10 +49,7 @@ class StructProjBench {
   def init(): Unit = {
     assert(m >= n)
     println(s"M = $M, N = $N")
-    val config =
-      Compiler.Config.Dev.copy(packageValidation =
-        if (validation) Compiler.FullPackageValidation else Compiler.NoPackageValidation
-      )
+    val config = Compiler.Config.Dev.copy(packageValidation = Compiler.NoPackageValidation)
     compiledPackages = PureCompiledPackages.assertBuild(Map(defaultPackageId -> pkg), config)
     sexpr = compiledPackages.compiler.unsafeCompile(e"Mod:bench Mod:struct")
     val value = bench()

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -497,11 +497,8 @@ private[lf] final class Compiler(
           s.SEBuiltin(SBStructCon(fieldsInputOrder)),
           mapToArray(fields) { case (_, e) => compile(env, e) },
         )
-      case structProj: EStructProj =>
-        structProj.fieldIndex match {
-          case None => SBStructProjByName(structProj.field)(compile(env, structProj.struct))
-          case Some(index) => SBStructProj(index)(compile(env, structProj.struct))
-        }
+      case EStructProj(field, struct) =>
+        SBStructProj(field)(compile(env, struct))
       case structUpd: EStructUpd =>
         structUpd.fieldIndex match {
           case None =>

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -85,10 +85,7 @@ object Ast {
   final case class EStructCon(fields: ImmArray[(FieldName, Expr)]) extends Expr
 
   /** Struct projection. */
-  final case class EStructProj(field: FieldName, struct: Expr) extends Expr {
-    // The actual index is filled in by the type checker.
-    private[lf] var fieldIndex: Option[Int] = None
-  }
+  final case class EStructProj(field: FieldName, struct: Expr) extends Expr
 
   /** Non-destructive struct update. */
   final case class EStructUpd(field: FieldName, struct: Expr, update: Expr) extends Expr {

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -648,16 +648,11 @@ private[validation] object Typing {
         .fromSeq(fields.iterator.map { case (f, x) => f -> typeOf(x) }.toSeq)
         .fold(name => throw EDuplicateField(ctx, name), TStruct)
 
-    private def typeOfStructProj(proj: EStructProj): Type = {
-      val TStruct(structType) = toStruct(typeOf(proj.struct))
-      val index = structType.indexOf(proj.field)
-      if (index < 0)
-        throw EUnknownField(ctx, proj.field)
-      else {
-        proj.fieldIndex = Some(index)
-        structType.toImmArray(index)._2
+    private def typeOfStructProj(proj: EStructProj): Type =
+      toStruct(typeOf(proj.struct)).fields.get(proj.field) match {
+        case Some(value) => value
+        case None => throw EUnknownField(ctx, proj.field)
       }
-    }
 
     private def typeOfStructUpd(upd: EStructUpd): Type = {
       val typ @ TStruct(structType) = toStruct(typeOf(upd.struct))


### PR DESCRIPTION
Currently we have two implementations for the projection of structural
record.

1- The first implementation takes as parameter the index of the
projected field and is therefore constant. This implementations is
used when the type checking is enable, as the index cannot be directly
inferred from the AST and must hence be filled in by the DAML-LF type
checker.

2- The second implementation takes as parameter the name of the
projected field and is therefore logarithmic as the field must be
lookup by binary search at each call. This version is used when the
type checking is disable as the index cannot be inferred without type
inference.

In this PR, we modify the second implementation so it caches the index
at the first call, hence avoiding the recomputation during further
calls.  In this way we reach an amortized constant complexity.  The
first implementation is decommissioned in benefit of the second one.

The advantages of this approach are:

- We have a unique implementation of the projection, so the behavior
  of a program is the same whenever the type checking is on or off.

- The AST for structural projection is immutable.

Benchmarks show no performance difference when the type checking is on.

The idea was suggested by @sofiafaro-da.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
