### PR TITLE
Add artifactory & SDK EE artifacts to split-release process

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -194,6 +194,24 @@ jobs:
         targetPath: $(Build.StagingDirectory)/release-artifacts
       condition: and(succeeded(), not(eq(variables['skip-github'], 'TRUE')))
     - bash: |
+        set -euo pipefail
+        KEY_FILE=$(mktemp)
+        GPG_DIR=$(mktemp -d)
+        cleanup() {
+            rm -rf $KEY_FILE $GPG_DIR
+        }
+        trap cleanup EXIT
+        echo "$GPG_KEY" | base64 -d > $KEY_FILE
+        gpg --homedir $GPG_DIR --no-tty --quiet --import $KEY_FILE
+        # For now we only sign artifactory artifacts here and leave signing of artifacts
+        # published to GH to the assembly repo.
+        cd $(Build.StagingDirectory)/release-artifacts/artifactory
+        for f in *; do
+            gpg --homedir $GPG_DIR -ab $f
+        done
+      env:
+        GPG_KEY: $(gpg-code-signing)
+    - bash: |
         set -eou pipefail
         eval "$(./dev-env/bin/dade-assist)"
         mkdir -p $(Build.StagingDirectory)/split-release
@@ -208,6 +226,11 @@ jobs:
       name: upload_to_gcs
       env:
         GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+    - bash: |
+        set -euo pipefail
+        ./ci/publish-artifactory.sh $(Build.StagingDirectory) $(release_tag) split
+      env:
+        AUTH: $(ARTIFACTORY_USERNAME):$(ARTIFACTORY_PASSWORD)
     - template: ci/tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'

--- a/ci/copy-unix-release-artifacts.sh
+++ b/ci/copy-unix-release-artifacts.sh
@@ -17,7 +17,10 @@ TARBALL=daml-sdk-$RELEASE_TAG-$NAME.tar.gz
 EE_TARBALL=daml-sdk-$RELEASE_TAG-$NAME-ee.tar.gz
 bazel build //release:sdk-release-tarball-ce //release:sdk-release-tarball-ee
 cp bazel-bin/release/sdk-release-tarball-ce.tar.gz $OUTPUT_DIR/github/$TARBALL
+# Used for the non-split release process.
 cp bazel-bin/release/sdk-release-tarball-ee.tar.gz $OUTPUT_DIR/artifactory/$EE_TARBALL
+# Used for the split release process.
+cp bazel-bin/release/sdk-release-tarball-ee.tar.gz $OUTPUT_DIR/split-release/$EE_TARBALL
 
 
 bazel build //compiler/damlc:damlc-dist

--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -8,6 +8,7 @@ OUTPUT_DIR=$2
 
 mkdir -p $OUTPUT_DIR/github
 mkdir -p $OUTPUT_DIR/artifactory
+mkdir -p $OUTPUT_DIR/split-release
 INSTALLER="$OUTPUT_DIR/github/daml-sdk-$RELEASE_TAG-windows.exe"
 EE_INSTALLER="$OUTPUT_DIR/artifactory/daml-sdk-$RELEASE_TAG-windows-ee.exe"
 mv "bazel-bin/release/windows-installer/daml-sdk-installer-ce.exe" "$INSTALLER"
@@ -36,4 +37,7 @@ fi
 TARBALL=daml-sdk-$RELEASE_TAG-windows.tar.gz
 EE_TARBALL=daml-sdk-$RELEASE_TAG-windows-ee.tar.gz
 cp bazel-bin/release/sdk-release-tarball-ce.tar.gz "$OUTPUT_DIR/github/$TARBALL"
+# Used for the non-split release process.
 cp bazel-bin/release/sdk-release-tarball-ee.tar.gz "$OUTPUT_DIR/artifactory/$EE_TARBALL"
+# Used for the split release process.
+cp bazel-bin/release/sdk-release-tarball-ee.tar.gz "$OUTPUT_DIR/split-release/$EE_TARBALL"

--- a/ci/publish-artifactory.sh
+++ b/ci/publish-artifactory.sh
@@ -51,11 +51,14 @@ for base in non-repudiation-core non-repudiation-client; do
     done
 done
 
-for platform in linux macos windows; do
-    EE_TARBALL=daml-sdk-$RELEASE_TAG-$platform-ee.tar.gz
-    push sdk-ee $EE_TARBALL
-    push sdk-ee $EE_TARBALL.asc
-done
-EE_INSTALLER=daml-sdk-$RELEASE_TAG-windows-ee.exe
-push sdk-ee $EE_INSTALLER
-push sdk-ee $EE_INSTALLER.asc
+# For the split release process these are not published to artifactory.
+if [[ "$#" -lt 3 || $3 != "split" ]]; then
+   for platform in linux macos windows; do
+       EE_TARBALL=daml-sdk-$RELEASE_TAG-$platform-ee.tar.gz
+       push sdk-ee $EE_TARBALL
+       push sdk-ee $EE_TARBALL.asc
+   done
+   EE_INSTALLER=daml-sdk-$RELEASE_TAG-windows-ee.exe
+   push sdk-ee $EE_INSTALLER
+   push sdk-ee $EE_INSTALLER.asc
+fi


### PR DESCRIPTION
Apologies for doing two things in one PR but they seemed somewhat
entangled.

For artifactory we follow the approach we use for Maven artifacts and
publish there directly.

For the SDK EE tarball, we just throw it in the split-release
directory and then the assembly repo can pick it up.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
