### PR TITLE
Be explicit in the usage of feature descriptors

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -23,7 +23,6 @@ message ExperimentalFeatures {
 
 // GRPC self-service error codes are returned by the Ledger API.
 message ExperimentalSelfServiceErrorCodes {
-  bool supported = 1;
 }
 
 // Ledger is in the static time mode and exposes a time service.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -22,10 +22,14 @@ message ExperimentalFeatures {
 }
 
 // GRPC self-service error codes are returned by the Ledger API.
-message ExperimentalSelfServiceErrorCodes {}
+message ExperimentalSelfServiceErrorCodes {
+  bool supported = 1;
+}
 
 // Ledger is in the static time mode and exposes a time service.
-message ExperimentalStaticTime {}
+message ExperimentalStaticTime {
+  bool supported = 1;
+}
 
 // Feature descriptors for command deduplication intended to be used for adapting Ledger API tests.
 message CommandDeduplicationFeatures {

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
@@ -59,4 +59,6 @@ message FeaturesDescriptor {
 
 // Used to signal the presence of the user management service.
 // Defined as a message to enable future addition of individual per-service features.
-message UserManagementFeature {}
+message UserManagementFeature {
+  bool supported = 1;
+}

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/version_service.proto
@@ -57,8 +57,7 @@ message FeaturesDescriptor {
 
 }
 
-// Used to signal the presence of the user management service.
-// Defined as a message to enable future addition of individual per-service features.
+// Whether the Ledger API server provides the user management service.
 message UserManagementFeature {
   bool supported = 1;
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantFeature.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantFeature.scala
@@ -18,15 +18,14 @@ object Features {
     Features(commandDeduplicationFeatures = CommandDeduplicationFeatures.defaultInstance)
 
   def fromApiVersionResponse(response: GetLedgerApiVersionResponse): Features = {
-    val features = response.features
-    val experimental = features.flatMap(_.experimental)
+    val features = response.getFeatures
+    val experimental = features.getExperimental
 
     Features(
-      selfServiceErrorCodes =
-        experimental.flatMap(_.selfServiceErrorCodes.map(_.supported)).contains(true),
-      userManagement = features.flatMap(_.userManagement.map(_.supported)).contains(true),
-      staticTime = experimental.flatMap(_.staticTime.map(_.supported)).contains(true),
-      commandDeduplicationFeatures = response.getFeatures.getExperimental.getCommandDeduplication,
+      selfServiceErrorCodes = experimental.selfServiceErrorCodes.isDefined,
+      userManagement = features.getUserManagement.supported,
+      staticTime = experimental.getStaticTime.supported,
+      commandDeduplicationFeatures = experimental.getCommandDeduplication,
     )
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantFeature.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantFeature.scala
@@ -22,9 +22,10 @@ object Features {
     val experimental = features.flatMap(_.experimental)
 
     Features(
-      selfServiceErrorCodes = experimental.flatMap(_.selfServiceErrorCodes).isDefined,
-      userManagement = features.flatMap(_.userManagement).isDefined,
-      staticTime = experimental.flatMap(_.staticTime).isDefined,
+      selfServiceErrorCodes =
+        experimental.flatMap(_.selfServiceErrorCodes.map(_.supported)).contains(true),
+      userManagement = features.flatMap(_.userManagement.map(_.supported)).contains(true),
+      staticTime = experimental.flatMap(_.staticTime.map(_.supported)).contains(true),
       commandDeduplicationFeatures = response.getFeatures.getExperimental.getCommandDeduplication,
     )
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
@@ -57,7 +57,7 @@ private[apiserver] final class ApiVersionService private (
       experimental = Some(
         ExperimentalFeatures(
           selfServiceErrorCodes =
-            Some(ExperimentalSelfServiceErrorCodes(supported = enableSelfServiceErrorCodes)),
+            Option.when(enableSelfServiceErrorCodes)(ExperimentalSelfServiceErrorCodes()),
           staticTime = Some(ExperimentalStaticTime(supported = enableStaticTime)),
           commandDeduplication = Some(commandDeduplicationFeatures),
         )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
@@ -53,12 +53,12 @@ private[apiserver] final class ApiVersionService private (
 
   private val featuresDescriptor =
     FeaturesDescriptor.of(
-      userManagement = Some(UserManagementFeature()),
+      userManagement = Some(UserManagementFeature(supported = true)),
       experimental = Some(
         ExperimentalFeatures(
           selfServiceErrorCodes =
-            Option.when(enableSelfServiceErrorCodes)(ExperimentalSelfServiceErrorCodes()),
-          staticTime = Option.when(enableStaticTime)(ExperimentalStaticTime()),
+            Some(ExperimentalSelfServiceErrorCodes(supported = enableSelfServiceErrorCodes)),
+          staticTime = Some(ExperimentalStaticTime(supported = enableStaticTime)),
           commandDeduplication = Some(commandDeduplicationFeatures),
         )
       ),


### PR DESCRIPTION
Use an explicit  `supported` boolean flag in place of depending on the presence/absence of a given field.
This makes the proto definitions easier to extend in the future.
Using the default message and not setting the message has the same behavior, which is more in turn with protobuf expectations.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
