### PR TITLE
Add eager timeouts to the polling functions used in daml start and assistant integration tests.

### DIFF
--- a/bazel_tools/client_server/runner_with_port_file/Main.hs
+++ b/bazel_tools/client_server/runner_with_port_file/Main.hs
@@ -28,7 +28,7 @@ main = do
     let portFile = tempDir </> "portfile"
     let interpolatedServerArgs = map (replace "%PORT_FILE%" portFile) splitServerArgs
     let serverProc = proc serverExe interpolatedServerArgs
-    withCreateProcess serverProc $ \_stdin _stdout _stderr _ph -> do
-      port <- readPortFile maxRetries portFile
+    withCreateProcess serverProc $ \_stdin _stdout _stderr ph -> do
+      port <- readPortFile ph maxRetries portFile
       let interpolatedClientArgs = map (replace "%PORT%" (show port)) splitClientArgs
       callProcess clientExe interpolatedClientArgs

--- a/compiler/repl-service/client/src/DA/Daml/LF/ReplClient.hs
+++ b/compiler/repl-service/client/src/DA/Daml/LF/ReplClient.hs
@@ -113,7 +113,7 @@ withReplClient opts@Options{..} f = withTempFile $ \portFile -> do
         , concat [ ["--max-inbound-message-size", show (getMaxInboundMessageSize size)] | Just size <- [optMaxInboundMessageSize] ]
         ]
     withCreateProcess replServer { std_out = optStdout } $ \_ stdout _ ph -> do
-      port <- readPortFile maxRetries portFile
+      port <- readPortFile ph maxRetries portFile
       let grpcConfig = ClientConfig (Host "127.0.0.1") (Port port) [] Nothing Nothing
       threadDelay 1000000
       withGRPCClient grpcConfig $ \client -> do

--- a/libs-haskell/da-hs-base/BUILD.bazel
+++ b/libs-haskell/da-hs-base/BUILD.bazel
@@ -35,6 +35,7 @@ da_haskell_library(
         "optparse-applicative",
         "pretty-show",
         "pretty",
+        "process",
         "random",
         "safe",
         "safe-exceptions",

--- a/libs-haskell/da-hs-base/src/DA/PortFile.hs
+++ b/libs-haskell/da-hs-base/src/DA/PortFile.hs
@@ -13,20 +13,38 @@ import Safe (readMay)
 import System.Exit
 import System.IO
 import System.IO.Error
+import System.Process
 
-readPortFileWith :: (String -> Maybe t) -> Int -> String -> IO t
-readPortFileWith _ 0 file = do
+readOnce :: (String -> Maybe t) -> FilePath -> IO (Maybe t)
+readOnce parseFn file = catchJust
+    (guard . shouldCatch)
+    (parseFn <$> readFile file)
+    (const $ pure Nothing)
+
+readPortFileWith :: (String -> Maybe t) -> ProcessHandle -> Int -> FilePath -> IO t
+readPortFileWith _ _ 0 file = do
   T.hPutStrLn stderr ("Port file was not written to '" <> pack file <> "' in time.")
   exitFailure
-readPortFileWith parseFn n file = do
-  fileContent <- catchJust (guard . shouldCatch) (readFile file) (const $ pure "")
-  case parseFn fileContent of
-    Nothing -> do
-      threadDelay (1000 * retryDelayMillis)
-      readPortFileWith parseFn (n-1) file
+readPortFileWith parseFn ph n file = do
+  result <- readOnce parseFn file
+  case result of
     Just p -> pure p
+    Nothing -> do
+      status <- getProcessExitCode ph
+      case status of
+        Nothing -> do -- Process still active. Try again.
+          threadDelay (1000 * retryDelayMillis)
+          readPortFileWith parseFn ph (n-1) file
+        Just exitCode -> do -- Process exited already. Try reading one last time, then give up.
+          threadDelay (1000 * retryDelayMillis)
+          result <- readOnce parseFn file
+          case result of
+            Just p -> pure p
+            Nothing -> do
+              T.hPutStrLn stderr ("Port file was not written to '" <> pack file <> "' before process exit with " <> pack (show exitCode))
+              exitFailure
 
-readPortFile :: Int -> String -> IO Int
+readPortFile :: ProcessHandle -> Int -> FilePath -> IO Int
 readPortFile = readPortFileWith readMay
 
 -- On Windows we sometimes get permission errors. It looks like

--- a/libs-haskell/test-utils/DA/Test/HttpJson.hs
+++ b/libs-haskell/test-utils/DA/Test/HttpJson.hs
@@ -58,10 +58,10 @@ createHttpJson httpJsonOutput getLedgerPort HttpJsonConfig {actor, mbSharedSecre
   writeFileUTF8 tokenFile $ T.unpack token
   httpJsonProc <- getHttpJsonProc getLedgerPort portFile
   mask $ \unmask -> do
-    ph <- createProcess httpJsonProc {std_out = UseHandle httpJsonOutput}
+    ph@(_,_,_,ph') <- createProcess httpJsonProc {std_out = UseHandle httpJsonOutput}
     let cleanup = cleanupProcess ph >> rmTmpDir
     let waitForStart = do
-          port <- readPortFile maxRetries portFile
+          port <- readPortFile ph' maxRetries portFile
           pure
             (HttpJsonResource
                { httpJsonProcess = ph

--- a/libs-haskell/test-utils/DA/Test/Sandbox.hs
+++ b/libs-haskell/test-utils/DA/Test/Sandbox.hs
@@ -88,9 +88,9 @@ createSandbox :: FilePath -> Handle -> SandboxConfig -> IO SandboxResource
 createSandbox portFile sandboxOutput conf = do
     sandboxProc <- getSandboxProc conf portFile
     mask $ \unmask -> do
-        ph <- createProcess sandboxProc { std_out = UseHandle sandboxOutput }
+        ph@(_,_,_,ph') <- createProcess sandboxProc { std_out = UseHandle sandboxOutput }
         let waitForStart = do
-                port <- readPortFile maxRetries portFile
+                port <- readPortFile ph' maxRetries portFile
                 pure (SandboxResource ph port)
         unmask (waitForStart `onException` cleanupProcess ph)
 


### PR DESCRIPTION
This PR adds timeouts to some polling functions used in daml start and
the assistant integration tests, and also early exits based on a process
exit status. E.g. waitForHttpServer will make sure some process is
still running, instead of waiting to timeout.

The effect of this is that now whenever there is some error in a
subprocess, daml start and the integration tests will finish early
instead of running forever (or timing out in bazel).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
