### PR TITLE
kvutils: Remove the DAR upload parameters from the runner.

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MinVersionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MinVersionTest.scala
@@ -96,29 +96,27 @@ final class MinVersionTest
                 commandId = UUID.randomUUID.toString,
                 party = party,
                 commands = Seq(
-                  Command.of(
-                    Command.Command.Create(
-                      CreateCommand(
-                        templateId = Some(
-                          Identifier(
-                            packageId = dar.main._1,
-                            moduleName = "Iou",
-                            entityName = "Iou",
-                          )
-                        ),
-                        createArguments = Some(
-                          Record(
-                            None,
-                            Seq(
-                              RecordField("issuer", Some(Value().withParty(party))),
-                              RecordField("owner", Some(Value().withParty(party))),
-                              RecordField("currency", Some(Value().withText("EUR"))),
-                              RecordField("amount", Some(Value().withNumeric("10.0"))),
-                              RecordField("observers", Some(Value().withList(List()))),
-                            ),
-                          )
-                        ),
-                      )
+                  Command().withCreate(
+                    CreateCommand(
+                      templateId = Some(
+                        Identifier(
+                          packageId = dar.main._1,
+                          moduleName = "Iou",
+                          entityName = "Iou",
+                        )
+                      ),
+                      createArguments = Some(
+                        Record(
+                          None,
+                          Seq(
+                            RecordField("issuer", Some(Value().withParty(party))),
+                            RecordField("owner", Some(Value().withParty(party))),
+                            RecordField("currency", Some(Value().withText("EUR"))),
+                            RecordField("amount", Some(Value().withNumeric("10.0"))),
+                            RecordField("observers", Some(Value().withList(List()))),
+                          ),
+                        )
+                      ),
                     )
                   )
                 ),

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MinVersionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MinVersionTest.scala
@@ -5,11 +5,9 @@ package com.daml.lf.engine.MinVersionTest
 
 import java.io.{File, FileInputStream}
 import java.nio.file.{Files, Path}
+import java.util.UUID
 import java.util.stream.Collectors
 
-import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
-import com.daml.ledger.api.v1.commands.{CreateCommand, Command, Commands}
-import com.daml.ledger.api.v1.value._
 import com.daml.bazeltools.BazelRunfiles._
 import com.daml.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
@@ -17,6 +15,9 @@ import com.daml.ledger.api.testing.utils.{
   SuiteResource,
   SuiteResourceManagementAroundAll,
 }
+import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
+import com.daml.ledger.api.v1.commands.{Command, Commands, CreateCommand}
+import com.daml.ledger.api.v1.value._
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
@@ -32,13 +33,12 @@ import com.daml.ledger.participant.state.kvutils.app.{
 import com.daml.ledger.participant.state.kvutils.{app => kvutils}
 import com.daml.ledger.resources.ResourceContext
 import com.daml.ledger.test.ModelTestDar
+import com.daml.lf.VersionRange
 import com.daml.lf.archive.DarDecoder
 import com.daml.lf.data.Ref
 import com.daml.lf.language.LanguageVersion.v1_14
-import com.daml.lf.VersionRange
 import com.daml.ports.Port
 import com.google.protobuf.ByteString
-import java.util.UUID
 import org.scalatest.Suite
 import org.scalatest.freespec.AsyncFreeSpec
 import scalaz.syntax.tag._
@@ -96,27 +96,29 @@ final class MinVersionTest
                 commandId = UUID.randomUUID.toString,
                 party = party,
                 commands = Seq(
-                  Command().withCreate(
-                    CreateCommand(
-                      templateId = Some(
-                        Identifier(
-                          packageId = dar.main._1,
-                          moduleName = "Iou",
-                          entityName = "Iou",
-                        )
-                      ),
-                      createArguments = Some(
-                        Record(
-                          None,
-                          Seq(
-                            RecordField("issuer", Some(Value().withParty(party))),
-                            RecordField("owner", Some(Value().withParty(party))),
-                            RecordField("currency", Some(Value().withText("EUR"))),
-                            RecordField("amount", Some(Value().withNumeric("10.0"))),
-                            RecordField("observers", Some(Value().withList(List()))),
-                          ),
-                        )
-                      ),
+                  Command.of(
+                    Command.Command.Create(
+                      CreateCommand(
+                        templateId = Some(
+                          Identifier(
+                            packageId = dar.main._1,
+                            moduleName = "Iou",
+                            entityName = "Iou",
+                          )
+                        ),
+                        createArguments = Some(
+                          Record(
+                            None,
+                            Seq(
+                              RecordField("issuer", Some(Value().withParty(party))),
+                              RecordField("owner", Some(Value().withParty(party))),
+                              RecordField("currency", Some(Value().withText("EUR"))),
+                              RecordField("amount", Some(Value().withNumeric("10.0"))),
+                              RecordField("observers", Some(Value().withList(List()))),
+                            ),
+                          )
+                        ),
+                      )
                     )
                   )
                 ),
@@ -141,7 +143,8 @@ final class MinVersionTest
       allowExistingSchema = false
     ),
   )
-  override protected lazy val suiteResource = {
+
+  override protected lazy val suiteResource: OwnedResource[ResourceContext, Port] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
     new OwnedResource[ResourceContext, Port](
       for {
@@ -150,12 +153,11 @@ final class MinVersionTest
             .createDefault(())
             .copy(
               participants = Seq(participant),
-              archiveFiles = Seq(),
               // Bump min version to 1.14 and check that older stable packages are still accepted.
               allowedLanguageVersions = VersionRange(min = v1_14, max = v1_14),
             )
         )
-      } yield (readPortfile(portfile))
+      } yield readPortfile(portfile)
     )
   }
 }

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -153,6 +153,8 @@ da_scala_library(
         "//ledger/sandbox-common:sandbox-common-scala-tests-lib",
         "//libs-scala/ports",
         "//libs-scala/resources",
+        "//libs-scala/resources-akka",
+        "//libs-scala/resources-grpc",
         "@maven//:com_auth0_java_jwt",
         "@maven//:org_scalatest_scalatest_compatible",
     ],

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
@@ -3,12 +3,17 @@
 
 package com.daml.lf.engine.script.test
 
+import java.net.InetAddress
 import java.nio.file.{Files, Path, Paths}
 import java.util.stream.Collectors
 
 import com.daml.bazeltools.BazelRunfiles._
 import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, OwnedResource, SuiteResource}
 import com.daml.ledger.api.tls.TlsConfiguration
+import com.daml.ledger.api.v1.admin.package_management_service.{
+  PackageManagementServiceGrpc,
+  UploadDarFileRequest,
+}
 import com.daml.ledger.on.memory.Owner
 import com.daml.ledger.participant.state.kvutils.app.{
   ParticipantConfig,
@@ -16,15 +21,18 @@ import com.daml.ledger.participant.state.kvutils.app.{
   ParticipantRunMode,
 }
 import com.daml.ledger.participant.state.kvutils.{app => kvutils}
-import com.daml.ledger.resources.ResourceContext
+import com.daml.ledger.resources.{ResourceContext, ResourceOwner}
 import com.daml.lf.data.Ref
 import com.daml.lf.engine.script._
-import com.daml.lf.engine.script.ledgerinteraction.ScriptTimeMode
+import com.daml.lf.engine.script.ledgerinteraction.{GrpcLedgerClient, ScriptTimeMode}
 import com.daml.ports.Port
+import com.google.protobuf.ByteString
+import io.grpc.ManagedChannelBuilder
 import org.scalatest.Suite
 
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.existentials
 
 trait MultiParticipantFixture
     extends AbstractScriptTest
@@ -32,6 +40,7 @@ trait MultiParticipantFixture
     with AkkaBeforeAndAfterAll {
   self: Suite =>
   private def darFile = Paths.get(rlocation("daml-script/test/script-test.dar"))
+
   private val tmpDir = Files.createTempDirectory("testMultiParticipantFixture")
   private val participant1Portfile = tmpDir.resolve("participant1-portfile")
   private val participant2Portfile = tmpDir.resolve("participant2-portfile")
@@ -73,7 +82,7 @@ trait MultiParticipantFixture
       allowExistingSchema = false
     ),
   )
-  override protected lazy val suiteResource = {
+  override protected lazy val suiteResource: OwnedResource[ResourceContext, (Port, Port)] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
     new OwnedResource[ResourceContext, (Port, Port)](
       for {
@@ -81,17 +90,33 @@ trait MultiParticipantFixture
           kvutils.Config
             .createDefault(())
             .copy(
-              participants = Seq(participant1, participant2),
-              archiveFiles = Seq(darFile),
+              participants = Seq(participant1, participant2)
             )
         )
-      } yield (readPortfile(participant1Portfile), readPortfile(participant2Portfile)),
+        participant1Port = readPortfile(participant1Portfile)
+        participant2Port = readPortfile(participant2Portfile)
+        channel = {
+          val builder = ManagedChannelBuilder
+            .forAddress(InetAddress.getLoopbackAddress.getHostName, participant1Port.value)
+          builder.usePlaintext()
+          builder.build()
+        }
+        packageManagement = PackageManagementServiceGrpc.stub(channel)
+        _ <- ResourceOwner.forFuture(() =>
+          packageManagement.uploadDarFile(
+            UploadDarFileRequest.of(
+              darFile = ByteString.copyFrom(Files.readAllBytes(darFile)),
+              submissionId = s"${getClass.getSimpleName}-upload",
+            )
+          )
+        )
+      } yield (participant1Port, participant2Port),
       acquisitionTimeout = 1.minute,
       releaseTimeout = 1.minute,
     )
   }
 
-  def participantClients() = {
+  def participantClients(): Future[Participants[GrpcLedgerClient]] = {
     implicit val ec: ExecutionContext = system.dispatcher
     val params = Participants(
       None,
@@ -103,7 +128,12 @@ trait MultiParticipantFixture
     )
     Runner.connect(
       params,
-      tlsConfig = TlsConfiguration(false, None, None, None),
+      tlsConfig = TlsConfiguration(
+        enabled = false,
+        keyCertChainFile = None,
+        keyFile = None,
+        trustCertCollectionFile = None,
+      ),
       maxInboundMessageSize = RunnerConfig.DefaultMaxInboundMessageSize,
     )
   }

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
@@ -54,14 +54,6 @@ private[memory] class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state
       state = state,
       engine = engine,
       committerExecutionContext = materializer.executionContext,
-    ).map(writer => {
-      new KeyValueReadWriteFactory(
-        config,
-        metrics,
-        reader,
-        writer,
-      )
-    })
+    ).map(writer => new KeyValueReadWriteFactory(config, metrics, reader, writer))
   }
-
 }

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -51,12 +51,7 @@ object SqlLedgerFactory extends LedgerFactory[ExtraConfig] {
         metrics = metrics.daml.kvutils.submission.validator.stateValueCache,
       ),
     ).map(ledgerReaderWriter =>
-      new KeyValueReadWriteFactory(
-        config,
-        metrics,
-        ledgerReaderWriter,
-        ledgerReaderWriter,
-      )
+      new KeyValueReadWriteFactory(config, metrics, ledgerReaderWriter, ledgerReaderWriter)
     )
   }
 }

--- a/ledger/participant-state/kvutils/app/BUILD.bazel
+++ b/ledger/participant-state/kvutils/app/BUILD.bazel
@@ -17,7 +17,6 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
-        "@maven//:org_scala_lang_modules_scala_java8_compat",
     ],
     tags = ["maven_coordinates=com.daml:participant-state-kvutils-app:__VERSION__"],
     visibility = [
@@ -29,8 +28,6 @@ da_scala_library(
         "@maven//:com_h2database_h2",
     ],
     deps = [
-        "//daml-lf/archive:daml_lf_1.dev_archive_proto_java",
-        "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/data",
         "//daml-lf/engine",
         "//daml-lf/language",
@@ -55,7 +52,6 @@ da_scala_library(
         "//libs-scala/resources",
         "//libs-scala/resources-akka",
         "//libs-scala/resources-grpc",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_netty_netty_handler",
     ],

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -4,10 +4,10 @@
 package com.daml.ledger.participant.state.kvutils.app
 
 import java.io.File
-import java.nio.file.Path
 import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+
 import com.daml.caching
 import com.daml.ledger.api.tls.TlsVersion.TlsVersion
 import com.daml.ledger.api.tls.{SecretsUrl, TlsConfiguration}
@@ -32,7 +32,6 @@ import scala.concurrent.duration.FiniteDuration
 final case class Config[Extra](
     mode: Mode,
     ledgerId: String,
-    archiveFiles: Seq[Path],
     commandConfig: CommandConfiguration,
     submissionConfig: SubmissionConfiguration,
     tlsConfig: Option[TlsConfiguration],
@@ -72,7 +71,6 @@ object Config {
     Config(
       mode = Mode.Run,
       ledgerId = UUID.randomUUID().toString,
-      archiveFiles = Vector.empty,
       commandConfig = CommandConfiguration.default,
       submissionConfig = SubmissionConfiguration.default,
       tlsConfig = None,
@@ -156,14 +154,6 @@ object Config {
                 })
               )
           }
-
-        arg[File]("<archive>...")
-          .optional()
-          .unbounded()
-          .text(
-            "DAR files to load. Scenarios are ignored. The server starts with an empty ledger by default."
-          )
-          .action((file, config) => config.copy(archiveFiles = config.archiveFiles :+ file.toPath))
 
         help("help").text("Print this help page.")
 

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ConfigProvider.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ConfigProvider.scala
@@ -54,7 +54,7 @@ trait ConfigProvider[ExtraConfig] {
   ): ApiServerConfig =
     ApiServerConfig(
       participantId = participantConfig.participantId,
-      archiveFiles = config.archiveFiles.map(_.toFile).toList,
+      archiveFiles = Nil,
       port = participantConfig.port,
       address = participantConfig.address,
       jdbcUrl = participantConfig.serverJdbcUrl,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -16,7 +16,7 @@ import com.daml.ledger.participant.state.kvutils.deduplication.{
   CompletionBasedDeduplicationPeriodConverter,
   DeduplicationPeriodSupport,
 }
-import com.daml.ledger.participant.state.v2.{ReadService, WritePackagesService, WriteService}
+import com.daml.ledger.participant.state.v2.{ReadService, WriteService}
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
@@ -39,10 +39,7 @@ trait LedgerFactory[ExtraConfig] {
 }
 
 trait ReadWriteServiceFactory {
-
   def readService(): ReadService
-
-  def writePackagesService(): WritePackagesService
 
   def writeService(): WriteService
 }
@@ -53,7 +50,6 @@ class KeyValueReadWriteFactory(
     ledgerReader: LedgerReader,
     ledgerWriter: LedgerWriter,
 ) extends ReadWriteServiceFactory {
-
   override def readService(): ReadService = {
     KeyValueParticipantStateReader(
       ledgerReader,
@@ -62,15 +58,12 @@ class KeyValueReadWriteFactory(
     )
   }
 
-  override def writePackagesService(): WritePackagesService = writeService()
-
   override def writeService(): WriteService = {
     new KeyValueParticipantStateWriter(
       ledgerWriter,
       metrics,
     )
   }
-
 }
 
 class KeyValueDeduplicationSupportFactory(
@@ -80,8 +73,6 @@ class KeyValueDeduplicationSupportFactory(
 )(implicit materializer: Materializer, ec: ExecutionContext)
     extends ReadWriteServiceFactory {
   override def readService(): ReadService = delegate.readService()
-
-  override def writePackagesService(): WritePackagesService = delegate.writePackagesService()
 
   override def writeService(): WriteService = {
     val writeServiceDelegate = delegate.writeService()

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -114,7 +114,6 @@ final class Runner[T <: ReadWriteService, Extra](
                     metrics,
                   )(materializer, servicesExecutionContext, loggingContext)
                   .acquire()
-                writePackageService = ledgerFactory.writePackagesService()
                 healthChecksWithIndexer <- participantConfig.mode match {
                   case ParticipantRunMode.Combined | ParticipantRunMode.Indexer =>
                     val readService = new TimedReadService(ledgerFactory.readService(), metrics)

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -18,7 +18,6 @@ da_scala_library(
         "@maven//:com_github_scopt_scopt",
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
-        "@maven//:org_scala_lang_modules_scala_java8_compat",
     ],
     tags = ["maven_coordinates=com.daml:sandbox-on-x:__VERSION__"],
     visibility = [
@@ -26,7 +25,6 @@ da_scala_library(
     ],
     deps = [
         "//daml-lf/archive:daml_lf_1.dev_archive_proto_java",
-        "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/data",
         "//daml-lf/engine",
         "//daml-lf/language",

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.sandbox
 
-import java.util.UUID
 import java.util.concurrent.{Executors, TimeUnit}
 
 import akka.NotUsed
@@ -33,8 +32,6 @@ import com.daml.ledger.participant.state.v2.metrics.{TimedReadService, TimedWrit
 import com.daml.ledger.participant.state.v2.{ReadService, Update, WriteService}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.ledger.sandbox.bridge.{BridgeMetrics, LedgerBridge}
-import com.daml.lf.archive.DarParser
-import com.daml.lf.data.Ref
 import com.daml.lf.engine.{Engine, EngineConfig}
 import com.daml.logging.LoggingContext.{newLoggingContext, newLoggingContextWith}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -50,10 +47,8 @@ import com.daml.platform.configuration.{PartyConfiguration, ServerRole}
 import com.daml.platform.indexer.StandaloneIndexerServer
 import com.daml.platform.server.api.validation.ErrorFactories
 import com.daml.platform.store.{DbSupport, LfValueTranslationCache}
-import com.daml.telemetry.{DefaultTelemetry, SpanKind, SpanName}
 
-import scala.compat.java8.FutureConverters.CompletionStageOps
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 import scala.util.chaining._
 
 object SandboxOnXRunner {
@@ -362,20 +357,6 @@ object SandboxOnXRunner {
           submissionBufferSize = config.extra.submissionBufferSize,
           ledgerBridge = ledgerBridge,
           bridgeMetrics = bridgeMetrics,
-        )
-      )
-      _ <- ResourceOwner.forFuture(() =>
-        Future.sequence(
-          config.archiveFiles.map(path =>
-            DefaultTelemetry.runFutureInSpan(SpanName.RunnerUploadDar, SpanKind.Internal) {
-              implicit telemetryContext =>
-                val submissionId = Ref.SubmissionId.assertFromString(UUID.randomUUID().toString)
-                for {
-                  dar <- Future.fromTry(DarParser.readArchiveFromFile(path.toFile).toTry)
-                  _ <- writeService.uploadPackages(submissionId, dar.all, None).toScala
-                } yield ()
-            }
-          )
         )
       )
     } yield writeService


### PR DESCRIPTION
No production ledger needs to upload DARs on participant startup; this
feature is primarily for users of Sandbox. The feature never worked in
the case of multiple participants and was only ever used in testing.

This also removes the associated functionality from Sandbox-on-X as they
share a configuration object. Hopefully this won't be an issue.

Some tests were using this feature, so I have updated them to upload the
DARs through the PackageManagementService instead.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
