### PR TITLE
Attempt to make ConcurrencyLimiterSpec less flaky

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/utils/ConcurrencyLimiterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/utils/ConcurrencyLimiterSpec.scala
@@ -50,7 +50,7 @@ final class ConcurrencyLimiterSpec extends AsyncFlatSpec {
   it should "limit the parallelism to the number of work items" in {
     ConcurrencyLimiterSpec.runTest(
       createLimiter = ec => new QueueBasedConcurrencyLimiter(8, ec),
-      waitTimeMillis = 100,
+      waitTimeMillis = 1000,
       threads = 16,
       items = 4,
       parallelism = 8,


### PR DESCRIPTION
The test runs 4 work tasks in a thread pool. This PR increases the duration of each work task from 100ms to 1s, increasing the chance that they really run in parallel even under heavy load.