### PR TITLE
Simplify sphinx -Werror

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -248,18 +248,13 @@ export LOCALE_ARCHIVE="$$PWD/$(location @glibc_locales//:locale-archive)"
     # the PDF documentation due to issues with the FreeSerif font in the
     # fontspec package. So, for now we ignore `FutureWarning`.
     SPHINX_BUILD_EXIT_CODE=0
-    SPHINX_BUILD_OUTPUT=$$($(location @sphinx_nix//:bin/sphinx-build) -b {target} -c $$DIR/source/configs/{name} $$DIR/source/source $$DIR/target 2>&1) || SPHINX_BUILD_EXIT_CODE=$$?
+    # We hide the output unless we get a failure to make the builds less noisy.
+    SPHINX_BUILD_OUTPUT=$$($(location @sphinx_nix//:bin/sphinx-build) -W -b {target} -c $$DIR/source/configs/{name} $$DIR/source/source $$DIR/target 2>&1) || SPHINX_BUILD_EXIT_CODE=$$?
 
     if [ "$$SPHINX_BUILD_EXIT_CODE" -ne 0 ]; then
         >&2 echo "## SPHINX-BUILD OUTPUT:"
         >&2 echo "$$SPHINX_BUILD_OUTPUT"
         >&2 echo "## SPHINX-BUILD OUTPUT END"
-        exit 1
-    fi
-    # NOTE: appending ' || true' to force exit code of 0 from grep because grep normally exits with 1 if no lines are selected:
-    WARNINGS=$$(echo "$$SPHINX_BUILD_OUTPUT" | grep -Pi "(?<!future)warning:" || true)
-    if [ "$$WARNINGS" != "" ]; then
-        echo "$$WARNINGS"
         exit 1
     fi
 


### PR DESCRIPTION
Grepping for warnings seems unnecessarily complex given that sphinx
has `-W` for that. I did verify that this indeed fails the builds on
warnings (tried out with a missing include).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
