### PR TITLE
Fixing strange punctuation in the log files

### DIFF
--- a/ledger/daml-on-sql/src/main/resources/logback.xml
+++ b/ledger/daml-on-sql/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/daml-on-sql/src/main/resources/logback.xml
+++ b/ledger/daml-on-sql/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/error/src/test/resources/logback-test.xml
+++ b/ledger/error/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $',
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $',
                 ''} %n
             </pattern>
         </encoder>

--- a/ledger/indexer-benchmark/src/main/resources/logback.xml
+++ b/ledger/indexer-benchmark/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/indexer-benchmark/src/main/resources/logback.xml
+++ b/ledger/indexer-benchmark/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/ledger-api-common/src/test/resources/logback-test.xml
+++ b/ledger/ledger-api-common/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $',
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $',
                 ''} %n
             </pattern>
         </encoder>

--- a/ledger/ledger-on-memory/src/test/resources/logback-test.xml
+++ b/ledger/ledger-on-memory/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/ledger-on-memory/src/test/resources/logback-test.xml
+++ b/ledger/ledger-on-memory/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/ledger-on-sql/src/test/resources/logback-test.xml
+++ b/ledger/ledger-on-sql/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/ledger-on-sql/src/test/resources/logback-test.xml
+++ b/ledger/ledger-on-sql/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
@@ -57,7 +57,7 @@ private[daml] final class LedgerApiServer(
       val host = address.getOrElse("localhost")
       val actualPort = server.getPort
       val transportMedium = if (sslContext.isDefined) "TLS" else "plain text"
-      logger.info(s"Listening on $host:$actualPort over $transportMedium.")
+      logger.info(s"Listening on $host:$actualPort over $transportMedium")
       new ApiServer {
         override val port: Port =
           Port(server.getPort)

--- a/ledger/participant-integration-api/src/test/resources/logback-test.xml
+++ b/ledger/participant-integration-api/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $',
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $',
                 ''} %n
             </pattern>
         </encoder>

--- a/ledger/participant-state/kvutils/app/src/main/resources/com/daml/ledger/participant/state/kvutils/app/logback.base.xml
+++ b/ledger/participant-state/kvutils/app/src/main/resources/com/daml/ledger/participant/state/kvutils/app/logback.base.xml
@@ -7,7 +7,7 @@
 <included>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/participant-state/kvutils/app/src/main/resources/com/daml/ledger/participant/state/kvutils/app/logback.base.xml
+++ b/ledger/participant-state/kvutils/app/src/main/resources/com/daml/ledger/participant/state/kvutils/app/logback.base.xml
@@ -7,7 +7,7 @@
 <included>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/participant-state/kvutils/src/test/resources/logback-test.xml
+++ b/ledger/participant-state/kvutils/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/participant-state/kvutils/src/test/resources/logback-test.xml
+++ b/ledger/participant-state/kvutils/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/resources/logback.xml
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/resources/logback.xml
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/recovering-indexer-integration-tests/src/test/resources/logback-test.xml
+++ b/ledger/recovering-indexer-integration-tests/src/test/resources/logback-test.xml
@@ -3,7 +3,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/recovering-indexer-integration-tests/src/test/resources/logback-test.xml
+++ b/ledger/recovering-indexer-integration-tests/src/test/resources/logback-test.xml
@@ -3,7 +3,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/sandbox-common/src/test/resources/com/daml/platform/sandbox/logback-test.base.xml
+++ b/ledger/sandbox-common/src/test/resources/com/daml/platform/sandbox/logback-test.base.xml
@@ -5,7 +5,7 @@
 <included>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/sandbox-common/src/test/resources/com/daml/platform/sandbox/logback-test.base.xml
+++ b/ledger/sandbox-common/src/test/resources/com/daml/platform/sandbox/logback-test.base.xml
@@ -5,7 +5,7 @@
 <included>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/libs-scala/contextualized-logging/src/test/suite/resources/logback.xml
+++ b/libs-scala/contextualized-logging/src/test/suite/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration debug="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/libs-scala/contextualized-logging/src/test/suite/resources/logback.xml
+++ b/libs-scala/contextualized-logging/src/test/suite/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration debug="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 

--- a/libs-scala/nameof/src/test/suite/resources/logback.xml
+++ b/libs-scala/nameof/src/test/suite/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration debug="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''}%n</pattern>
         </encoder>
     </appender>
 

--- a/libs-scala/nameof/src/test/suite/resources/logback.xml
+++ b/libs-scala/nameof/src/test/suite/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration debug="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %replace(, context: %marker){', context: $', ''} %n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%replace(, context: %marker){', context: $', ''} %n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
The logfile of the `daml-on-sql` contains a line like this:
```
Listening on localhost:6865 over plain text. , context: {participantId: daml-on-sql}
```

- Removing the redundant dot from this specific message
- Removing the redundant space before comma from the logback config
- Making a sweeping change across the board

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
