### PR TITLE
Drop scenario compat helpers

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Compatible.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Compatible.daml
@@ -82,20 +82,6 @@ type MonadFail = ActionFail
 {-# DEPRECATED Num "Daml compatibility helper, use 'Number' instead of 'Num'" #-}
 type Num = Number
 
-{-# DEPRECATED commits "Daml compatibility helper, use 'submit' instead of 'commits'" #-}
-infixr 0 `commits`
-commits : Party -> Update a -> Scenario a
-commits = submit
-
-{-# DEPRECATED fails "Daml compatibility helper, use 'submitMustFail' instead of 'fails'" #-}
-infixr 0 `fails`
-fails : Party -> Update a -> Scenario ()
-fails = submitMustFail
-
-{-# DEPRECATED test "Daml compatibility helper, use 'scenario' instead" #-}
-test : Scenario a -> Scenario a
-test = identity
-
 {-# DEPRECATED Maybe "Daml compatibility helper, use 'Optional' instead of 'Maybe'" #-}
 type Maybe = Optional
 


### PR DESCRIPTION
They are in Prelude so they steal identifiers and we’re killing
scenarios so keeping these around makes little sense.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
