### PR TITLE
Rename daml sandbox to daml sandbox-kv

### DIFF
--- a/compatibility/bazel_tools/create-daml-app/index.test.ts
+++ b/compatibility/bazel_tools/create-daml-app/index.test.ts
@@ -124,8 +124,9 @@ const npmExeName = process.platform == "win32" ? "npm" : "npm-cli.js";
 beforeAll(async () => {
   await removeFile(`../${SANDBOX_PORT_FILE_NAME}`);
   await removeFile(`../${JSON_API_PORT_FILE_NAME}`);
+
   const sandboxOptions = [
-    "sandbox-kv",
+    (process.env.SANDBOX_VERSION[0] == "1") ? "sandbox" : "sandbox-kv",
     `--ledgerid=${SANDBOX_LEDGER_ID}`,
     `--port=0`,
     `--port-file=${SANDBOX_PORT_FILE_NAME}`,

--- a/compatibility/bazel_tools/create-daml-app/index.test.ts
+++ b/compatibility/bazel_tools/create-daml-app/index.test.ts
@@ -125,7 +125,7 @@ beforeAll(async () => {
   await removeFile(`../${SANDBOX_PORT_FILE_NAME}`);
   await removeFile(`../${JSON_API_PORT_FILE_NAME}`);
   const sandboxOptions = [
-    "sandbox",
+    "sandbox-kv",
     `--ledgerid=${SANDBOX_LEDGER_ID}`,
     `--port=0`,
     `--port-file=${SANDBOX_PORT_FILE_NAME}`,

--- a/compatibility/bazel_tools/daml_script/daml_script.bzl
+++ b/compatibility/bazel_tools/daml_script/daml_script.bzl
@@ -83,7 +83,7 @@ def daml_script_test(compiler_version, runner_version):
         runner = "//bazel_tools/client_server:runner",
         runner_args = ["6865"],
         server = daml_runner,
-        server_args = ["sandbox"],
+        server_args = ["sandbox-kv"],
         server_files = [
             "$(rootpath {})".format(compiled_dar),
         ],

--- a/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
+++ b/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
@@ -191,7 +191,7 @@ chmod +x $(OUTS)
         runner = "//bazel_tools/client_server:runner",
         runner_args = ["6865"],
         server = daml_runner,
-        server_args = ["sandbox"],
+        server_args = ["sandbox-kv"],
         server_files = [
             "$(rootpath {})".format(compiled_dar),
         ],

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -932,7 +932,8 @@ def sdk_platform_test(sdk_version, platform_version):
     # if the CI machine does not have enough entropy.
     sandbox_args = [
         "sandbox-kv" if versions.is_at_least("2.0.0", platform_version) else "sandbox",
-        "--contract-id-seeding=testing-weak"]
+        "--contract-id-seeding=testing-weak",
+    ]
 
     sandbox_classic_args = ["sandbox-classic", "--contract-id-seeding=testing-weak"]
 

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -930,7 +930,9 @@ def sdk_platform_test(sdk_version, platform_version):
 
     # We need to use weak seeding to avoid our tests timing out
     # if the CI machine does not have enough entropy.
-    sandbox_args = ["sandbox-kv", "--contract-id-seeding=testing-weak"]
+    sandbox_args = [
+        "sandbox-kv" if platform_version == "0.0.0" or versions.is_at_least("2.0.0", platform_version) else "sandbox",
+        "--contract-id-seeding=testing-weak"]
 
     sandbox_classic_args = ["sandbox-classic", "--contract-id-seeding=testing-weak"]
 

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -930,7 +930,7 @@ def sdk_platform_test(sdk_version, platform_version):
 
     # We need to use weak seeding to avoid our tests timing out
     # if the CI machine does not have enough entropy.
-    sandbox_args = ["sandbox", "--contract-id-seeding=testing-weak"]
+    sandbox_args = ["sandbox-kv", "--contract-id-seeding=testing-weak"]
 
     sandbox_classic_args = ["sandbox-classic", "--contract-id-seeding=testing-weak"]
 

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -931,7 +931,7 @@ def sdk_platform_test(sdk_version, platform_version):
     # We need to use weak seeding to avoid our tests timing out
     # if the CI machine does not have enough entropy.
     sandbox_args = [
-        "sandbox-kv" if platform_version == "0.0.0" or versions.is_at_least("2.0.0", platform_version) else "sandbox",
+        "sandbox-kv" if versions.is_at_least("2.0.0", platform_version) else "sandbox",
         "--contract-id-seeding=testing-weak"]
 
     sandbox_classic_args = ["sandbox-classic", "--contract-id-seeding=testing-weak"]

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -93,7 +93,7 @@ commandParser = subparser $ fold
     , command "run-jar" (info runJarCmd forwardOptions)
     , command "codegen" (info (codegenCmd <**> helper) forwardOptions)
     , command "packages" (info (packagesCmd <**> helper) packagesCmdInfo)
-    , command "canton-sandbox" (info (cantonSandboxCmd <**> helper) cantonSandboxCmdInfo)
+    , command "sandbox-canton" (info (cantonSandboxCmd <**> helper) cantonSandboxCmdInfo)
     ]
   where
 
@@ -169,9 +169,6 @@ commandParser = subparser $ fold
         <|> flag' SandboxKV (long "sandbox-kv" <> help "Deprecated. Run with Sandbox KV.")
         <|> flag' SandboxCanton (long "sandbox-canton" <> help "Run with Canton Sandbox. The 2.0 default.")
                 <*> sandboxCantonPortSpecOpt
-        <|> pure SandboxKV -- pre-2.0 default
-            -- TODO https://github.com/digital-asset/daml/issues/11831
-            --   Change default to --sandbox-canton
 
     sandboxCantonPortSpecOpt = do
         adminApiSpec <- sandboxPortOpt "canton-admin-api-port" "Port number for the canton admin API (--sandbox-canton only)"

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -90,7 +90,7 @@ withSandbox :: StartOptions -> FilePath -> [String] -> [String] -> (Process () (
 withSandbox StartOptions{..} darPath scenarioArgs sandboxArgs kont =
     case sandboxChoice of
       SandboxClassic -> oldSandbox "sandbox-classic"
-      SandboxKV -> oldSandbox "sandbox"
+      SandboxKV -> oldSandbox "sandbox-kv"
       SandboxCanton cantonPortSpec -> cantonSandbox cantonPortSpec
 
   where

--- a/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
+++ b/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
@@ -11,7 +11,7 @@ import com.daml.auth.middleware.oauth2.{Main => Oauth2Middleware}
 import com.daml.http.{Main => JsonApi}
 import com.daml.navigator.{NavigatorBackend => Navigator}
 import com.daml.platform.sandbox.{SandboxMain => SandboxClassic}
-import com.daml.platform.sandboxnext.{Main => Sandbox}
+import com.daml.platform.sandboxnext.{Main => SandboxKV}
 import com.daml.script.export.{Main => Export}
 
 object SdkMain {
@@ -28,7 +28,7 @@ object SdkMain {
       case "trigger-service" => TriggerService.main(rest)
       case "oauth2-middleware" => Oauth2Middleware.main(rest)
       case "navigator" => Navigator.main(rest)
-      case "sandbox" => Sandbox.main(rest)
+      case "sandbox-kv" => SandboxKV.main(rest)
       case "sandbox-classic" => SandboxClassic.main(rest)
       case _ => sys.exit(1)
     }

--- a/daml-assistant/daml-sdk/validate.sh
+++ b/daml-assistant/daml-sdk/validate.sh
@@ -19,7 +19,7 @@ JAVA=$(rlocation "$TEST_WORKSPACE/$1")
 SDK_CE=$(rlocation "$TEST_WORKSPACE/$2")
 SDK_EE=$(rlocation "$TEST_WORKSPACE/$3")
 
-for cmd in sandbox sandbox-classic; do
+for cmd in sandbox-kv sandbox-classic; do
     ret=0
     $JAVA -jar $SDK_CE $cmd --help | grep -q profile-dir || ret=$?
     if [[ $ret -eq 0 ]]; then
@@ -28,7 +28,7 @@ for cmd in sandbox sandbox-classic; do
     fi
 done
 
-for cmd in sandbox sandbox-classic; do
+for cmd in sandbox-kv sandbox-classic; do
     $JAVA -jar $SDK_EE $cmd --help | grep -q profile-dir
 done
 

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -197,7 +197,7 @@ quickSandbox projDir = do
                 (shell $
                     unwords
                         [ "daml"
-                        , "sandbox"
+                        , "sandbox-kv"
                         , "--"
                         , "--port"
                         , show sandboxPort
@@ -817,7 +817,7 @@ codegenTests codegenDir = testGroup "daml codegen" (
                 assertBool "bindings were written" (not $ null contents)
 
 cantonTests :: TestTree
-cantonTests = testGroup "daml canton-sandbox"
+cantonTests = testGroup "daml sandbox-canton"
   [ testCaseSteps "Can start Canton sandbox and run script" $ \step -> withTempDir $ \dir -> do
       step "Creating project"
       callCommandSilentIn dir $ unwords ["daml new", "skeleton", "--template=skeleton"]
@@ -830,7 +830,7 @@ cantonTests = testGroup "daml canton-sandbox"
       domainAdminApiPort <- getFreePort
       step "Staring Canton sandbox"
       let portFile = dir </> "canton-portfile.json"
-      withDamlServiceIn (dir </> "skeleton") "canton-sandbox"
+      withDamlServiceIn (dir </> "skeleton") "sandbox-canton"
         [ "--port", show ledgerApiPort
         , "--admin-api-port", show adminApiPort
         , "--domain-public-port", show domainPublicApiPort

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -244,7 +244,7 @@ patches we backport to the 1.0 release branch).
 
     1. In 3 separate terminals (since each command blocks), run:
 
-       1. `daml sandbox --wall-clock-time --port 6865 .daml/dist/quickstart-0.0.1.dar`
+       1. `daml sandbox-kv --wall-clock-time --port 6865 .daml/dist/quickstart-0.0.1.dar`
        1. `daml script --dar .daml/dist/quickstart-0.0.1.dar --script-name Main:initialize --ledger-host localhost --ledger-port 6865 --wall-clock-time && daml navigator server localhost 6865 --port 7500`
        1. `daml codegen java && mvn compile exec:java@run-quickstart`
 

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -130,7 +130,7 @@ patches we backport to the 1.0 release branch).
 
     1. `cd create-daml-app`
 
-       1. `daml start`
+       1. `daml start --sandbox-kv`
 
     1. In a new terminal, from the `ui` folder:
 
@@ -235,7 +235,7 @@ patches we backport to the 1.0 release branch).
 
     1. Verify the new version is specified in `daml.yaml` as the `sdk-version`.
 
-    1. Run `daml start`. Your browser should be opened automatically at
+    1. Run `daml start --sandbox-kv`. Your browser should be opened automatically at
        `http://localhost:7500`. Login as `Alice` and verify that there is
        1 contract and 3 templates. Close the tab and kill `daml start` using
        `Ctrl-C`.

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -44,10 +44,14 @@ commands:
   path: damlc/damlc
   desc: "Run the Daml compiler"
   completion: true
-- name: sandbox
+- name: sandbox-canton
   path: daml-helper/daml-helper
-  desc: "Launch Sandbox"
-  args: ["run-jar", "--logback-config=sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox"]
+  desc: "Launch Sandbox Canton."
+  args: ["sandbox-canton"]
+- name: sandbox-kv
+  path: daml-helper/daml-helper
+  desc: "Deprecated. Launch Sandbox KV (the default Sandbox implementation for SDK < 2.0.0)"
+  args: ["run-jar", "--logback-config=sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox-kv"]
 - name: sandbox-classic
   path: daml-helper/daml-helper
   desc: "Deprecated. Launch Sandbox Classic (the default Sandbox implementation for SDK <= 0.13.55)"
@@ -107,6 +111,3 @@ commands:
   path: damlc/damlc
   args: ["repl"]
   desc: "Launch the Daml REPL"
-- name: canton-sandbox
-  path: daml-helper/daml-helper
-  args: ["canton-sandbox"]

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -95,6 +95,7 @@ beforeAll(async () => {
   // Getting Started Guide.
   const startArgs = [
     'start',
+    '--sandbox-kv',
     `--json-api-option=--port-file=${JSON_API_PORT_FILE_NAME}`,
   ];
 


### PR DESCRIPTION
* Rename `daml sandbox` to `daml sandbox-kv`.
* Rename `daml canton-sandbox` to `daml sandbox-canton` (will be changed to `daml sandbox` soon)
* Drop the default sandbox on `daml start`, so you have to specify `--sandbox-canton` or `--sandbox-kv` or `--sandbox-classic`.

Part of #11831.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
