### PR TITLE
Fix damlc warnings & compile flags

### DIFF
--- a/ledger/test-common/src/main/daml/semantic/TimeTests.daml
+++ b/ledger/test-common/src/main/daml/semantic/TimeTests.daml
@@ -3,8 +3,6 @@
 
 module TimeTests where
 
-import DA.Time
-
 template TimeChecker
   with
     party: Party

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -147,7 +147,7 @@ _daml_build = rule(
         ),
         "ghc_options": attr.string_list(
             doc = "Options passed to GHC.",
-            default = ["--ghc-option=-Werror", "--ghc-option=-Wwarn", "--log-level=WARNING"],
+            default = ["--ghc-option=-Werror", "--log-level=WARNING"],
         ),
         "damlc": _damlc,
     },
@@ -256,7 +256,7 @@ _inspect_dar = rule(
 
 _default_project_version = "1.0.0"
 
-default_damlc_opts = ["--ghc-option=-Werror", "--ghc-option=-Wwarn", "--log-level=WARNING"]
+default_damlc_opts = ["--ghc-option=-Werror", "--log-level=WARNING"]
 
 def damlc_for_target(target):
     if not target or target in COMPILER_LF_VERSIONS:


### PR DESCRIPTION
`--ghc-option=-Werror` turns warnings into errors, `--ghc-option=-Wwarn`
undoes exactly that so this clearly was not doing anything sensible.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
