### PR TITLE
LF: Wrongly typed local contract is not a internal error

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1033,15 +1033,9 @@ private[lf] object SBuiltin {
       onLedger.cachedContracts.get(coid) match {
         case Some(cached) =>
           if (cached.templateId != templateId) {
-            if (onLedger.ptx.localContracts.contains(coid)) {
-              // This should be prevented by the type checker so it’s an internal error.
-              crash(s"contract ${coid.coid} ($templateId) not found from partial transaction")
-            } else {
-              // This is a user-error.
-              machine.ctrl = SEDamlException(
-                IE.WronglyTypedContract(coid, templateId, cached.templateId)
-              )
-            }
+            machine.ctrl = SEDamlException(
+              IE.WronglyTypedContract(coid, templateId, cached.templateId)
+            )
           } else {
             machine.returnValue = cached.value
           }


### PR DESCRIPTION
Since the introduction of COERCE_CONTRACT_ID, local contract IDs can
be wrongly typed.

CHANGELOG_BEGIN
CHANEGLOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
