### PR TITLE
Migrate migration tests to Sandbox on X

### DIFF
--- a/compatibility/sandbox-migration/test.sh
+++ b/compatibility/sandbox-migration/test.sh
@@ -12,7 +12,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
-set -euox pipefail
+set -euo pipefail
 
 RUNNER="$(rlocation $TEST_WORKSPACE/sandbox-migration/sandbox-migration-runner)"
 MODEL_DAR="$(rlocation $TEST_WORKSPACE/sandbox-migration/migration-model.dar)"

--- a/compatibility/sandbox-migration/util.bzl
+++ b/compatibility/sandbox-migration/util.bzl
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@os_info//:os_info.bzl", "is_linux")
+load("//bazel_tools:versions.bzl", "versions")
+
+def runfiles(ver):
+  return ["@daml-sdk-{}//:daml".format(ver)] + (["@daml-sdk-{}//:sandbox-on-x".format(ver) ] if versions.is_at_least("2.0.0", ver) else [])
 
 def migration_test(name, versions, tags, quick_tags, **kwargs):
     native.sh_test(
@@ -12,7 +16,7 @@ def migration_test(name, versions, tags, quick_tags, **kwargs):
             "//sandbox-migration:sandbox-migration-runner",
             "//sandbox-migration:migration-model.dar",
             "//sandbox-migration:migration-step",
-        ] + ["@daml-sdk-{}//:daml".format(ver) for ver in versions],
+        ] + [dep for ver in versions for dep in runfiles(ver)],
         args = versions,
         tags = tags + quick_tags,
         **kwargs

--- a/compatibility/sandbox-migration/util.bzl
+++ b/compatibility/sandbox-migration/util.bzl
@@ -32,7 +32,7 @@ def migration_test(name, versions, tags, quick_tags, **kwargs):
             "//sandbox-migration:sandbox-migration-runner",
             "//sandbox-migration:migration-model.dar",
             "//sandbox-migration:migration-step",
-        ] + ["@daml-sdk-{}//:daml".format(ver) for ver in versions],
+        ] + [dep for ver in versions for dep in runfiles(ver)],
         args = ["--append-only"] + versions,
         **kwargs
     )

--- a/compatibility/sandbox-migration/util.bzl
+++ b/compatibility/sandbox-migration/util.bzl
@@ -5,7 +5,7 @@ load("@os_info//:os_info.bzl", "is_linux")
 load("//bazel_tools:versions.bzl", "versions")
 
 def runfiles(ver):
-  return ["@daml-sdk-{}//:daml".format(ver)] + (["@daml-sdk-{}//:sandbox-on-x".format(ver) ] if versions.is_at_least("2.0.0", ver) else [])
+    return ["@daml-sdk-{}//:daml".format(ver)] + (["@daml-sdk-{}//:sandbox-on-x".format(ver)] if versions.is_at_least("2.0.0", ver) else [])
 
 def migration_test(name, versions, tags, quick_tags, **kwargs):
     native.sh_test(


### PR DESCRIPTION
This PR switches the data continuity tests for Sandbox from Sandbox
classic to Sandbox on X for newer versions. (Data continuity between
the two is expected and desired).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
