### PR TITLE
Disable printer sharing

### DIFF
--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -14,12 +14,18 @@ locals {
       size       = 0,
       assignment = "default",
       disk_size  = 200,
+      sharing    = <<EOF
+
+# Disable File & Printer sharing
+Set-NetFirewallRule -DisplayGroup "File And Printer Sharing" -Enabled False -Profile Any
+EOF
     },
     {
       name       = "ci-w2"
       size       = 6,
       assignment = "default",
       disk_size  = 400
+      sharing    = ""
     },
   ]
 }
@@ -95,7 +101,7 @@ Set-MpPreference -DisableRealtimeMonitoring $true
 # Disable Print Spooler service (security)
 Stop-Service -Name Spooler -Force
 Set-Service -Name Spooler -StartupType Disabled
-
+${local.w[count.index].sharing}
 # Enable long paths
 Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name LongPathsEnabled -Type DWord -Value 1
 

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -17,7 +17,7 @@ locals {
     },
     {
       name       = "ci-w2"
-      size       = 0,
+      size       = 6,
       assignment = "default",
       disk_size  = 400,
     },

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -11,7 +11,7 @@ locals {
   w = [
     {
       name       = "ci-w1",
-      size       = 0,
+      size       = 6,
       assignment = "default",
       disk_size  = 200,
       sharing    = <<EOF

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -11,7 +11,7 @@ locals {
   w = [
     {
       name       = "ci-w1",
-      size       = 6,
+      size       = 0,
       assignment = "default",
       disk_size  = 200,
     },

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -22,7 +22,7 @@ EOF
     },
     {
       name       = "ci-w2"
-      size       = 6,
+      size       = 0,
       assignment = "default",
       disk_size  = 400
       sharing    = ""

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -14,18 +14,12 @@ locals {
       size       = 6,
       assignment = "default",
       disk_size  = 200,
-      sharing    = <<EOF
-
-# Disable File & Printer sharing
-Set-NetFirewallRule -DisplayGroup "File And Printer Sharing" -Enabled False -Profile Any
-EOF
     },
     {
       name       = "ci-w2"
       size       = 0,
       assignment = "default",
-      disk_size  = 400
-      sharing    = ""
+      disk_size  = 400,
     },
   ]
 }
@@ -101,7 +95,10 @@ Set-MpPreference -DisableRealtimeMonitoring $true
 # Disable Print Spooler service (security)
 Stop-Service -Name Spooler -Force
 Set-Service -Name Spooler -StartupType Disabled
-${local.w[count.index].sharing}
+
+# Disable File & Printer sharing
+Set-NetFirewallRule -DisplayGroup "File And Printer Sharing" -Enabled False -Profile Any
+
 # Enable long paths
 Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name LongPathsEnabled -Type DWord -Value 1
 

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -13,7 +13,7 @@ locals {
       name       = "ci-w1",
       size       = 0,
       assignment = "default",
-      disk_size  = 200,
+      disk_size  = 400,
     },
     {
       name       = "ci-w2"


### PR DESCRIPTION
As the title suggests. We already disable all communication between CI
nodes through network rules, but we currently get a lot of noise from
GCP logging violations to those rules from Windows trying to feel its
way out for file share buddies.

CHANGELOG_BEGIN
CHANGELOG_END

As usual, this branch will contain intermediate commits that may serve
as an audit log of sorts.