### PR TITLE
Publish Sandbox-on-X app lib jar

### DIFF
--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -97,11 +97,12 @@ da_scala_test_suite(
 )
 
 da_scala_library(
-    name = "sandbox-on-x-app",
+    name = "sandbox-on-x-app-lib",
     srcs = glob(["src/app/scala/**/*.scala"]),
     resources = glob(["src/app/resources/**/*"]),
     scala_deps = [
     ],
+    tags = ["maven_coordinates=com.daml:sandbox-on-x-app:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [
         ":sandbox-on-x",
@@ -116,7 +117,7 @@ da_scala_binary(
     main_class = "com.daml.ledger.sandbox.Main",
     tags = [
         "fat_jar",
-        "maven_coordinates=com.daml:sandbox-on-x-app:__VERSION__",
+        "maven_coordinates=com.daml:sandbox-on-x-app-jar:__VERSION__",
         "no_scala_version_suffix",
     ],
     visibility = ["//visibility:public"],
@@ -126,7 +127,7 @@ da_scala_binary(
         "@maven//:com_h2database_h2",
     ],
     deps = [
-        ":sandbox-on-x-app",
+        ":sandbox-on-x-app-lib",
     ],
 )
 

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -163,6 +163,8 @@
   type: jar-scala
 - target: //ledger/sandbox-on-x:sandbox-on-x
   type: jar-scala
+- target: //ledger/sandbox-on-x:sandbox-on-x-app-lib
+  type: jar-scala
 - target: //ledger/sandbox-on-x:app
   type: jar-deploy
 - target: //ledger/test-common:dar-files-1.14-lib


### PR DESCRIPTION
This PR re-publishes the removed lib jar for Sandbox-on-X in https://github.com/digital-asset/daml/pull/12386. 
I advised @moritzkiefer-da incorrectly that we can remove it, but some nightly performance runs depend on it. 

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
