### PR TITLE
ledger-api - Rename error method to invalidDeduplicationPeriod [KVL-1222]

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidator.scala
@@ -48,11 +48,10 @@ class DeduplicationPeriodValidator(
   ): Either[StatusRuntimeException, Duration] = if (duration.isNegative)
     Left(
       errorFactories
-        .invalidDeduplicationPeriod(
+        .invalidField(
           fieldName,
           "Duration must be positive",
           definiteAnswer = Some(false),
-          None,
         )
     )
   else Right(duration)

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/DeduplicationPeriodValidator.scala
@@ -33,7 +33,7 @@ class DeduplicationPeriodValidator(
     validateNonNegativeDuration(duration).flatMap { duration =>
       if (duration.compareTo(maxDeduplicationDuration) > 0)
         Left(
-          errorFactories.invalidDeduplicationDuration(
+          errorFactories.invalidDeduplicationPeriod(
             fieldName,
             s"The given deduplication duration of $duration exceeds the maximum deduplication time of $maxDeduplicationDuration",
             definiteAnswer = Some(false),
@@ -48,7 +48,12 @@ class DeduplicationPeriodValidator(
   ): Either[StatusRuntimeException, Duration] = if (duration.isNegative)
     Left(
       errorFactories
-        .invalidField(fieldName, "Duration must be positive", definiteAnswer = Some(false))
+        .invalidDeduplicationPeriod(
+          fieldName,
+          "Duration must be positive",
+          definiteAnswer = Some(false),
+          None,
+        )
     )
   else Right(duration)
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
@@ -316,7 +316,7 @@ class ErrorFactories private (errorCodesVersionSwitcher: ErrorCodesVersionSwitch
         .asGrpcError,
     )
 
-  def invalidDeduplicationDuration(
+  def invalidDeduplicationPeriod(
       fieldName: String,
       message: String,
       definiteAnswer: Option[Boolean],

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
@@ -574,7 +574,7 @@ class ErrorFactoriesSpec
       val msg =
         s"INVALID_DEDUPLICATION_PERIOD(9,$truncatedCorrelationId): The submitted command had an invalid deduplication period: $errorDetailMessage"
       assertVersionedError(
-        _.invalidDeduplicationDuration(
+        _.invalidDeduplicationPeriod(
           fieldName = field,
           message = errorDetailMessage,
           definiteAnswer = None,

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -99,7 +99,6 @@ da_scala_binary(
                 "//libs-scala/resources",
                 "//libs-scala/resources-akka",
                 "//libs-scala/resources-grpc",
-                "//libs-scala/scala-utils",
                 "//libs-scala/timer-utils",
                 "@maven//:com_google_api_grpc_proto_google_common_protos",
                 "@maven//:com_typesafe_config",

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -99,6 +99,7 @@ da_scala_binary(
                 "//libs-scala/resources",
                 "//libs-scala/resources-akka",
                 "//libs-scala/resources-grpc",
+                "//libs-scala/scala-utils",
                 "//libs-scala/timer-utils",
                 "@maven//:com_google_api_grpc_proto_google_common_protos",
                 "@maven//:com_typesafe_config",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
-import java.util
 import java.util.regex.Pattern
 
 import com.daml.error.ErrorCode
@@ -123,29 +122,35 @@ object Assertions {
     }
 
   private def assertDefiniteAnswer(exception: Exception): Unit = {
-    val metadata: java.util.Map[String, String] = extractErrorInfoMetadata(exception)
-    val value = metadata.get("definite_answer")
-    if (value == null) {
-      fail(s"The error did not contain a definite answer. Metadata was: [$metadata]")
-    }
-    if (!Set("true", "false").contains(value.toLowerCase)) {
-      fail(s"The error contained an invalid definite answer: [$value]")
+    val definitiveAnswer = extractErrorInfoMetadataValue(exception, "definite_answer")
+    if (!Set("true", "false").contains(definitiveAnswer.toLowerCase)) {
+      fail(s"The error contained an invalid definite answer: [$definitiveAnswer]")
     }
   }
 
-  def extractErrorInfoMetadata(exception: Exception): java.util.Map[String, String] =
+  def extractErrorInfoMetadataValue(exception: Throwable, key: String): String = {
+    val metadata = extractErrorInfoMetadata(exception)
+    metadata.get(key) match {
+      case Some(value) =>
+        value
+      case None =>
+        fail(s"The error metadata did not contain the key $key. Metadata was: [$metadata]")
+    }
+  }
+
+  def extractErrorInfoMetadata(exception: Throwable): Map[String, String] =
     extractErrorInfoMetadata(StatusProto.fromThrowable(exception))
 
-  def extractErrorInfoMetadata(status: com.google.rpc.Status): java.util.Map[String, String] = {
+  def extractErrorInfoMetadata(status: com.google.rpc.Status): Map[String, String] = {
     val details = status.getDetailsList.asScala
     details
       .find(_.is(classOf[ErrorInfo]))
       .map { any =>
         val errorInfo = any.unpack(classOf[ErrorInfo])
-        errorInfo.getMetadataMap
+        errorInfo.getMetadataMap.asScala.toMap
       }
       .getOrElse {
-        new util.HashMap()
+        Map.empty
       }
   }
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/FutureAssertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/FutureAssertions.scala
@@ -7,7 +7,6 @@ import java.time.Instant
 
 import com.daml.ledger.api.testtool.infrastructure.FutureAssertions.ExpectedFailureException
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
-import com.daml.scalautil.Statement.discard
 import com.daml.timer.Delayed
 
 import scala.concurrent.duration._
@@ -133,18 +132,16 @@ object FutureAssertions {
       }
     )
     .map { results =>
-      discard {
-        val (failures, successes) = results.partitionMap(identity)
-        if (failures.nonEmpty) {
-          failures
-            .foreach(res => logger.error(s"Failed parallel test case for input ${res._1}", res._2))
-          throw ParallelTestFailureException(
-            s"Failed parallel test case. Failures: ${failures.length}. Success: ${successes.length}\nFailed inputs: ${failures
-              .map(_._1)
-              .mkString("[", ",", "]")}",
-            failures.last._2,
-          )
-        } else successes
+      val (failures, successes) = results.partitionMap(identity)
+      if (failures.nonEmpty) {
+        failures
+          .foreach(res => logger.error(s"Failed parallel test case for input ${res._1}", res._2))
+        throw ParallelTestFailureException(
+          s"Failed parallel test case. Failures: ${failures.length}. Success: ${successes.length}\nFailed inputs: ${failures
+            .map(_._1)
+            .mkString("[", ",", "]")}",
+          failures.last._2,
+        )
       }
     }
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
-import java.{time, util}
+import java.time
 
 import com.daml.error.ErrorCode
 import com.daml.error.definitions.LedgerApiErrors
@@ -723,10 +723,10 @@ final class CommandDeduplicationIT(
   }
 
   private def assertExistingSubmissionIdOnMetadata(
-      metadata: util.Map[String, String],
+      metadata: Map[String, String],
       acceptedSubmissionId: SubmissionId,
   ): Unit =
-    Option(metadata.get("existing_submission_id")).foreach { metadataExistingSubmissionId =>
+    metadata.get("existing_submission_id").foreach { metadataExistingSubmissionId =>
       assertEquals(
         "submission ID mismatch",
         metadataExistingSubmissionId,
@@ -735,10 +735,10 @@ final class CommandDeduplicationIT(
     }
 
   private def assertExistingCompletionOffsetOnMetadata(
-      metadata: util.Map[String, String],
+      metadata: Map[String, String],
       acceptedCompletionOffset: LedgerOffset,
   ): Unit =
-    Option(metadata.get("completion_offset")).foreach { offset =>
+    metadata.get("completion_offset").foreach { offset =>
       assertEquals(
         "completion offset mismatch",
         absoluteLedgerOffset(offset),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupport.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupport.scala
@@ -40,6 +40,7 @@ class DeduplicationPeriodSupport(
       case period: DeduplicationPeriod.DeduplicationDuration =>
         Future { validation.validate(period, maxDeduplicationDuration) }
       case DeduplicationPeriod.DeduplicationOffset(offset) =>
+        logger.debug(s"Converting deduplication period offset $offset to duration")
         converter
           .convertOffsetToDuration(
             offset.toHexString,
@@ -58,7 +59,7 @@ class DeduplicationPeriodSupport(
                     s"Failed to convert deduplication offset $offset to duration: $reason"
                   )
                   Left(
-                    errorFactories.invalidDeduplicationDuration(
+                    errorFactories.invalidDeduplicationPeriod(
                       "deduplication_period",
                       s"Cannot convert deduplication offset to duration because there is no completion at given offset $offset.",
                       Some(false),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/deduplication/DeduplicationPeriodSupportSpec.scala
@@ -140,7 +140,7 @@ class DeduplicationPeriodSupportSpec
         Future.successful(Left(DeduplicationConversionFailure.CompletionOffsetNotMatching))
       )
       when(
-        errorFactories.invalidDeduplicationDuration(
+        errorFactories.invalidDeduplicationPeriod(
           any[String],
           any[String],
           any[Option[Boolean]],
@@ -157,7 +157,7 @@ class DeduplicationPeriodSupportSpec
             Set.empty,
             maxRecordTimeFromSubmissionTime,
           )
-          verify(errorFactories).invalidDeduplicationDuration(
+          verify(errorFactories).invalidDeduplicationPeriod(
             any[String],
             any[String],
             any[Option[Boolean]],


### PR DESCRIPTION
- rename `invalidDeduplicationDuration` to `invalidDeduplicationPeriod` to be in sync with the error used (INVALID_DEDUPLICATION_PERIOD)

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
