### PR TITLE
Split channel configuration from LedgerClientConfiguration

### DIFF
--- a/daml-lf/engine/BUILD.bazel
+++ b/daml-lf/engine/BUILD.bazel
@@ -146,6 +146,5 @@ da_scala_test(
         "//libs-scala/ports",
         "//libs-scala/resources",
         "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:io_netty_netty_handler",
     ],
 )

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MinVersionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/MinVersionTest.scala
@@ -69,7 +69,6 @@ final class MinVersionTest
     applicationId = "minversiontest",
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = None,
   )
   // This is an integration test to make sure that the version restrictions for stable packages
   // apply across the whole stack.
@@ -77,7 +76,7 @@ final class MinVersionTest
   "MinVersionTest" - {
     "can upload an LF 1.14 package and use it in a transaction" in {
       for {
-        client <- LedgerClient.singleHost(
+        client <- LedgerClient.insecureSingleHost(
           "localhost",
           suiteResource.value.value,
           ledgerClientConfig,

--- a/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
+++ b/daml-script/export/integration-tests/reproduces-transactions/test/scala/com/daml/script/export/ReproducesTransactions.scala
@@ -60,7 +60,6 @@ trait ReproducesTransactions
     applicationId = appId,
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = None,
     token = None,
   )
   val isWindows: Boolean = sys.props("os.name").toLowerCase.contains("windows")

--- a/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Main.scala
@@ -9,6 +9,7 @@ import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFact
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
+  LedgerClientChannelConfiguration,
   LedgerClientConfiguration,
   LedgerIdRequirement,
 }
@@ -53,6 +54,7 @@ object Main {
             config.ledgerHost,
             config.ledgerPort,
             clientConfig(config),
+            clientChannelConfig(config),
           )
           parties <- LedgerUtils.getAllParties(client, config.accessToken, config.partyConfig)
           acs <- LedgerUtils.getACS(client, parties, config.start)
@@ -82,8 +84,12 @@ object Main {
     applicationId = "script-export",
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = config.tlsConfig.client(),
     token = config.accessToken.flatMap(_.token),
-    maxInboundMessageSize = config.maxInboundMessageSize,
   )
+
+  private def clientChannelConfig(config: Config): LedgerClientChannelConfiguration =
+    LedgerClientChannelConfiguration(
+      sslContext = config.tlsConfig.client(),
+      maxInboundMessageSize = config.maxInboundMessageSize,
+    )
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -15,6 +15,7 @@ import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
+  LedgerClientChannelConfiguration,
   LedgerClientConfiguration,
   LedgerIdRequirement,
 }
@@ -230,12 +231,14 @@ object Runner {
       applicationId = ApplicationId.unwrap(applicationId),
       ledgerIdRequirement = LedgerIdRequirement.none,
       commandClient = CommandClientConfiguration.default,
-      sslContext = tlsConfig.client(),
       token = params.access_token,
+    )
+    val clientChannelConfig = LedgerClientChannelConfiguration(
+      sslContext = tlsConfig.client(),
       maxInboundMessageSize = maxInboundMessageSize,
     )
     LedgerClient
-      .singleHost(params.host, params.port, clientConfig)
+      .singleHost(params.host, params.port, clientConfig, clientChannelConfig)
       .map(new GrpcLedgerClient(_, applicationId))
   }
   // We might want to have one config per participant at some point but for now this should be sufficient.

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -557,7 +557,6 @@ final class JsonApiIt
             applicationId = "appid",
             ledgerIdRequirement = LedgerIdRequirement.none,
             commandClient = CommandClientConfiguration.default,
-            sslContext = None,
             token = Some(getUserToken(UserId.assertFromString("participant_admin"))),
           ),
         )

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
@@ -52,11 +52,10 @@ trait SandboxFixture extends SandboxNextFixture {
     seeding = Some(Seeding.Weak),
   )
 
-  protected val ClientConfiguration = LedgerClientConfiguration(
+  protected val ClientConfiguration: LedgerClientConfiguration = LedgerClientConfiguration(
     applicationId = TestUtil.LedgerID,
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = None,
     token = None,
   )
 

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/config/LedgerClientConfig.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/config/LedgerClientConfig.scala
@@ -7,12 +7,9 @@ import java.io.File
 import java.time.Duration
 
 import com.daml.ledger.client.binding.LedgerClientConfigurationError.MalformedTypesafeConfig
-import com.daml.ledger.client.configuration.{
-  CommandClientConfiguration,
-  LedgerClientConfiguration,
-  LedgerIdRequirement,
-}
-import com.typesafe.config.{Config, ConfigFactory}
+import com.daml.ledger.client.binding.config.LedgerClientConfig.ClientSslConfig
+import com.daml.ledger.client.configuration.CommandClientConfiguration
+import com.typesafe.config.{ConfigFactory, Config}
 import io.grpc.netty.GrpcSslContexts
 import io.netty.handler.ssl.SslContext
 import pureconfig._
@@ -20,20 +17,12 @@ import pureconfig.generic.auto._
 
 import scala.util.Try
 
-case class LedgerClientConfig(
+final case class LedgerClientConfig(
     ledgerId: Option[String],
     commandClient: CommandClientConfiguration,
     maxRetryTime: Duration,
-) {
-  def toBindingConfig(applicationId: String) =
-    LedgerClientConfiguration(
-      applicationId,
-      ledgerIdRequirement,
-      commandClient,
-    )
-
-  private val ledgerIdRequirement = LedgerIdRequirement(ledgerId)
-}
+    ssl: Option[ClientSslConfig],
+)
 
 object LedgerClientConfig {
 

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/config/LedgerClientConfig.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/config/LedgerClientConfig.scala
@@ -7,7 +7,6 @@ import java.io.File
 import java.time.Duration
 
 import com.daml.ledger.client.binding.LedgerClientConfigurationError.MalformedTypesafeConfig
-import com.daml.ledger.client.binding.config.LedgerClientConfig.ClientSslConfig
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
   LedgerClientConfiguration,
@@ -25,14 +24,12 @@ case class LedgerClientConfig(
     ledgerId: Option[String],
     commandClient: CommandClientConfiguration,
     maxRetryTime: Duration,
-    ssl: Option[ClientSslConfig],
 ) {
   def toBindingConfig(applicationId: String) =
     LedgerClientConfiguration(
       applicationId,
       ledgerIdRequirement,
       commandClient,
-      ssl.map(_.sslContext),
     )
 
   private val ledgerIdRequirement = LedgerIdRequirement(ledgerId)

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala
@@ -90,7 +90,6 @@ class ScalaCodeGenIT
     applicationId = applicationId,
     ledgerIdRequirement = LedgerIdRequirement.matching(ledgerId),
     commandClient = CommandClientConfiguration.default,
-    sslContext = None,
   )
 
   private var ledger: LedgerClient = _

--- a/language-support/scala/examples/iou-no-codegen/application/src/main/scala/com/digitalasset/quickstart/iou/IouMain.scala
+++ b/language-support/scala/examples/iou-no-codegen/application/src/main/scala/com/digitalasset/quickstart/iou/IouMain.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
   LedgerClientConfiguration,
   LedgerIdRequirement,
+  LedgerClientChannelConfiguration,
 }
 import com.daml.quickstart.iou.ClientUtil.workflowIdFromParty
 import com.daml.quickstart.iou.DecodeUtil.decodeCreatedEvent
@@ -59,11 +60,12 @@ object IouMain extends App with StrictLogging {
     applicationId = ApplicationId.unwrap(applicationId),
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = None,
   )
 
+  private val clientChannelConfig = LedgerClientChannelConfiguration.InsecureDefaults
+
   private val clientF: Future[LedgerClient] =
-    LedgerClient.singleHost(ledgerHost, ledgerPort, clientConfig)(ec, aesf)
+    LedgerClient.singleHost(ledgerHost, ledgerPort, clientConfig, clientChannelConfig)(ec, aesf)
 
   private val clientUtilF: Future[ClientUtil] =
     clientF.map(client => new ClientUtil(client, applicationId))

--- a/language-support/scala/examples/quickstart-scala/application/src/main/scala/com/digitalasset/quickstart/iou/IouMain.scala
+++ b/language-support/scala/examples/quickstart-scala/application/src/main/scala/com/digitalasset/quickstart/iou/IouMain.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
   LedgerClientConfiguration,
   LedgerIdRequirement,
+  LedgerClientChannelConfiguration,
 }
 import com.daml.quickstart.iou.ClientUtil.workflowIdFromParty
 import com.daml.quickstart.iou.DecodeUtil.{decodeAllCreated, decodeArchived, decodeCreated}
@@ -65,13 +66,14 @@ object IouMain extends App with StrictLogging {
     applicationId = ApplicationId.unwrap(applicationId),
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = None,
     token = None,
   )
   // </doc-ref:ledger-client-configuration>
 
+  private val clientChannelConfig = LedgerClientChannelConfiguration.InsecureDefaults
+
   private val clientF: Future[LedgerClient] =
-    LedgerClient.singleHost(ledgerHost, ledgerPort, clientConfig)(ec, aesf)
+    LedgerClient.singleHost(ledgerHost, ledgerPort, clientConfig, clientChannelConfig)(ec, aesf)
 
   private val clientUtilF: Future[ClientUtil] =
     clientF.map(client => new ClientUtil(client, applicationId))

--- a/ledger-service/http-json-ledger-client/ce/src/main/scala/com/daml/http/LedgerClient.scala
+++ b/ledger-service/http-json-ledger-client/ce/src/main/scala/com/daml/http/LedgerClient.scala
@@ -16,6 +16,6 @@ object LedgerClient extends LedgerClientBase {
       clientChannelConfig: LedgerClientChannelConfiguration,
       nonRepudiationConfig: nonrepudiation.Configuration.Cli,
   )(implicit executionContext: ExecutionContext): Future[NettyChannelBuilder] =
-    Future(NettyChannelBuilder.forAddress(ledgerHost, ledgerPort))
+    Future(clientChannelConfig.builderFor(ledgerHost, ledgerPort))
 
 }

--- a/ledger-service/http-json-ledger-client/ce/src/main/scala/com/daml/http/LedgerClient.scala
+++ b/ledger-service/http-json-ledger-client/ce/src/main/scala/com/daml/http/LedgerClient.scala
@@ -3,6 +3,7 @@
 
 package com.daml.http
 
+import com.daml.ledger.client.configuration.LedgerClientChannelConfiguration
 import io.grpc.netty.NettyChannelBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -12,6 +13,7 @@ object LedgerClient extends LedgerClientBase {
   def channelBuilder(
       ledgerHost: String,
       ledgerPort: Int,
+      clientChannelConfig: LedgerClientChannelConfiguration,
       nonRepudiationConfig: nonrepudiation.Configuration.Cli,
   )(implicit executionContext: ExecutionContext): Future[NettyChannelBuilder] =
     Future(NettyChannelBuilder.forAddress(ledgerHost, ledgerPort))

--- a/ledger-service/http-json-ledger-client/ee/src/main/scala/com/daml/http/LedgerClient.scala
+++ b/ledger-service/http-json-ledger-client/ee/src/main/scala/com/daml/http/LedgerClient.scala
@@ -8,6 +8,7 @@ import java.security.{KeyFactory, PrivateKey}
 import java.security.cert.{CertificateFactory, X509Certificate}
 import java.security.spec.PKCS8EncodedKeySpec
 
+import com.daml.ledger.client.configuration.LedgerClientChannelConfiguration
 import com.daml.nonrepudiation.client.SigningInterceptor
 import io.grpc.netty.NettyChannelBuilder
 
@@ -44,9 +45,10 @@ object LedgerClient extends LedgerClientBase {
   def channelBuilder(
       ledgerHost: String,
       ledgerPort: Int,
+      clientChannelConfig: LedgerClientChannelConfiguration,
       nonRepudiationConfig: nonrepudiation.Configuration.Cli,
   )(implicit executionContext: ExecutionContext): Future[NettyChannelBuilder] = {
-    val base = NettyChannelBuilder.forAddress(ledgerHost, ledgerPort)
+    val base = clientChannelConfig.builderFor(ledgerHost, ledgerPort)
     Future
       .fromTry(nonRepudiationConfig.validated)
       .map(_.fold(base) { config =>

--- a/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/LedgerClientAuthIT.scala
+++ b/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/LedgerClientAuthIT.scala
@@ -35,7 +35,6 @@ final class LedgerClientAuthIT
     applicationId = classOf[LedgerClientAuthIT].getSimpleName,
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = None,
     token = None,
   )
 

--- a/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/LedgerClientIT.scala
+++ b/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/LedgerClientIT.scala
@@ -35,7 +35,6 @@ final class LedgerClientIT
     applicationId = classOf[LedgerClientIT].getSimpleName,
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = None,
     token = None,
   )
 

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientChannelConfiguration.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientChannelConfiguration.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.client.configuration
+
+import io.grpc.internal.GrpcUtil
+import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
+import io.netty.handler.ssl.SslContext
+
+/** @param sslContext             If defined, the context will be passed on to the underlying gRPC code to ensure the communication channel is secured by TLS
+  * @param maxInboundMetadataSize The maximum size of the response headers.
+  * @param maxInboundMessageSize  The maximum (uncompressed) size of the response body.
+  */
+final case class LedgerClientChannelConfiguration(
+    sslContext: Option[SslContext],
+    maxInboundMetadataSize: Int = GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
+    maxInboundMessageSize: Int = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE,
+) {
+
+  def builderFor(host: String, port: Int): NettyChannelBuilder = {
+    val builder = NettyChannelBuilder.forAddress(host, port)
+    sslContext
+      .fold(builder.usePlaintext())(builder.sslContext(_).negotiationType(NegotiationType.TLS))
+      .maxInboundMetadataSize(maxInboundMetadataSize)
+      .maxInboundMessageSize(maxInboundMessageSize)
+  }
+
+}
+
+object LedgerClientChannelConfiguration {
+
+  val InsecureDefaults: LedgerClientChannelConfiguration =
+    LedgerClientChannelConfiguration(sslContext = None)
+
+}

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
@@ -3,23 +3,14 @@
 
 package com.daml.ledger.client.configuration
 
-import io.grpc.internal.GrpcUtil
-import io.netty.handler.ssl.SslContext
-
 /** @param applicationId          The string that will be used as an application identifier when issuing commands and retrieving transactions
   * @param ledgerIdRequirement    A [[LedgerIdRequirement]] specifying how the ledger identifier must be checked against the one returned by the LedgerIdentityService
   * @param commandClient          The [[CommandClientConfiguration]] that defines how the command client should be setup with regards to timeouts, commands in flight and command TTL
-  * @param sslContext             If defined, the context will be passed on to the underlying gRPC code to ensure the communication channel is secured by TLS
   * @param token                  If defined, the access token that will be passed by default, unless overridden in individual calls (mostly useful for short-lived applications)
-  * @param maxInboundMetadataSize The maximum size of the response headers.
-  * @param maxInboundMessageSize  The maximum (uncompressed) size of the response body.
   */
 final case class LedgerClientConfiguration(
     applicationId: String,
     ledgerIdRequirement: LedgerIdRequirement,
     commandClient: CommandClientConfiguration,
-    sslContext: Option[SslContext],
     token: Option[String] = None,
-    maxInboundMetadataSize: Int = GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
-    maxInboundMessageSize: Int = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE,
 )

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/apiserver/tls/TlsFixture.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/apiserver/tls/TlsFixture.scala
@@ -10,11 +10,7 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.grpc.sampleservice.implementations.HelloServiceReferenceImplementation
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.client.GrpcChannel
-import com.daml.ledger.client.configuration.{
-  CommandClientConfiguration,
-  LedgerClientConfiguration,
-  LedgerIdRequirement,
-}
+import com.daml.ledger.client.configuration.LedgerClientChannelConfiguration
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
@@ -99,18 +95,14 @@ case class TlsFixture(
       trustCertCollectionFile = Some(caCrt),
     )
 
-  private val ledgerClientConfiguration = LedgerClientConfiguration(
-    applicationId = s"TlsCertificates-app",
-    ledgerIdRequirement = LedgerIdRequirement.none,
-    commandClient = CommandClientConfiguration.default,
-    sslContext = clientTlsConfiguration.client(),
-    token = None,
+  private val ledgerClientChannelConfiguration = LedgerClientChannelConfiguration(
+    sslContext = clientTlsConfiguration.client()
   )
 
   private def resources(): ResourceOwner[ManagedChannel] =
     for {
       apiServer <- apiServerOwner()
-      channel <- new GrpcChannel.Owner(apiServer.port, ledgerClientConfiguration)
+      channel <- new GrpcChannel.Owner(apiServer.port, ledgerClientChannelConfiguration)
     } yield channel
 
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
@@ -10,11 +10,7 @@ import com.daml.error.DamlContextualizedErrorLogger
 import com.daml.error.definitions.LedgerApiErrors
 import com.daml.grpc.sampleservice.implementations.HelloServiceReferenceImplementation
 import com.daml.ledger.client.GrpcChannel
-import com.daml.ledger.client.configuration.{
-  CommandClientConfiguration,
-  LedgerClientConfiguration,
-  LedgerIdRequirement,
-}
+import com.daml.ledger.client.configuration.LedgerClientChannelConfiguration
 import com.daml.ledger.resources.{ResourceOwner, TestResourceContext}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
@@ -99,13 +95,6 @@ object GrpcServerSpec {
 
   private val maxInboundMessageSize = 4 * 1024 * 1024 /* copied from the Sandbox configuration */
 
-  private val clientConfiguration = LedgerClientConfiguration(
-    applicationId = classOf[GrpcServerSpec].getSimpleName,
-    ledgerIdRequirement = LedgerIdRequirement.none,
-    commandClient = CommandClientConfiguration.default,
-    sslContext = None,
-  )
-
   class TestedHelloService extends HelloServiceReferenceImplementation {
     override def fails(request: HelloRequest): Future[HelloResponse] = {
       val errorLogger =
@@ -129,7 +118,10 @@ object GrpcServerSpec {
         servicesExecutor = executor,
         services = Seq(new TestedHelloService),
       )
-      channel <- new GrpcChannel.Owner(Port(server.getPort), clientConfiguration)
+      channel <- new GrpcChannel.Owner(
+        Port(server.getPort),
+        LedgerClientChannelConfiguration.InsecureDefaults,
+      )
     } yield channel
 
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/EngineModeIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/EngineModeIT.scala
@@ -52,7 +52,6 @@ class EngineModeIT
       applicationId = ApplicationId.unwrap(applicationId),
       ledgerIdRequirement = ledger.client.configuration.LedgerIdRequirement.none,
       commandClient = ledger.client.configuration.CommandClientConfiguration.default,
-      sslContext = None,
       token = None,
     )
 

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/BaseTlsServerIT.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/BaseTlsServerIT.scala
@@ -11,6 +11,7 @@ import com.daml.ledger.api.v1.transaction_service.GetLedgerEndResponse
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
+  LedgerClientChannelConfiguration,
   LedgerClientConfiguration,
   LedgerIdRequirement,
 }
@@ -92,20 +93,19 @@ abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
       )
     )
 
-  private lazy val clientConfig_noTls: LedgerClientConfiguration =
+  private val clientConfig: LedgerClientConfiguration =
     LedgerClientConfiguration(
       "appId",
       LedgerIdRequirement.none,
       CommandClientConfiguration.default,
-      None,
     )
 
   protected def assertFailedClient(enabledProtocols: Seq[TlsVersion]): Future[Assertion] = {
     // given
-    val clientConfig = if (enabledProtocols.nonEmpty) {
-      getClientConfigWithTls(enabledProtocols)
+    val clientChannelConfig = if (enabledProtocols.nonEmpty) {
+      getClientChannelConfigWithTls(enabledProtocols)
     } else {
-      clientConfig_noTls
+      LedgerClientChannelConfiguration.InsecureDefaults
     }
     val clueMsg = s"Client enabled following protocols: ${enabledProtocols}. "
     val prependClueMsg: Throwable => Throwable = {
@@ -116,7 +116,7 @@ abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
 
     // when
     recoverToSucceededIf[StatusRuntimeException] {
-      createLedgerClient(clientConfig).flatMap(_.transactionClient.getLedgerEnd())
+      createLedgerClient(clientChannelConfig).flatMap(_.transactionClient.getLedgerEnd())
     }.transform(
       identity,
       prependClueMsg,
@@ -126,9 +126,9 @@ abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
   protected def assertSuccessfulClient(enabledProtocols: Seq[TlsVersion]): Future[Assertion] = {
     // given
     val clientConfig = if (enabledProtocols.nonEmpty) {
-      getClientConfigWithTls(enabledProtocols)
+      getClientChannelConfigWithTls(enabledProtocols)
     } else {
-      clientConfig_noTls
+      LedgerClientChannelConfiguration.InsecureDefaults
     }
     val clueMsg = s"Client enabled protocols: ${enabledProtocols}. "
     val addClueThrowable: Throwable => Throwable = { t =>
@@ -149,9 +149,9 @@ abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
       .transform(identity, addClueThrowable)
   }
 
-  private def getClientConfigWithTls(
+  private def getClientChannelConfigWithTls(
       enabledProtocols: Seq[TlsVersion]
-  ): LedgerClientConfiguration = {
+  ): LedgerClientChannelConfiguration = {
     val tlsConfiguration = TlsConfiguration(
       enabled = true,
       Some(clientCertChainFilePath),
@@ -159,11 +159,17 @@ abstract class BaseTlsServerIT(minimumServerProtocolVersion: Option[TlsVersion])
       Some(trustCertCollectionFilePath),
     )
     val sslContext = tlsConfiguration.client(enabledProtocols = enabledProtocols)
-    clientConfig_noTls.copy(sslContext = sslContext)
+    LedgerClientChannelConfiguration(sslContext)
   }
 
-  private def createLedgerClient(config: LedgerClientConfiguration): Future[LedgerClient] = {
-    LedgerClient.singleHost(hostIp = serverHost, port = serverPort.value, configuration = config)
-  }
+  private def createLedgerClient(
+      channelConfig: LedgerClientChannelConfiguration
+  ): Future[LedgerClient] =
+    LedgerClient.singleHost(
+      hostIp = serverHost,
+      port = serverPort.value,
+      configuration = clientConfig,
+      channelConfig = channelConfig,
+    )
 
 }

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/IntegrationTest.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/IntegrationTest.scala
@@ -46,7 +46,6 @@ class IntegrationTest
         applicationId = "foobar",
         LedgerIdRequirement.none,
         commandClient = CommandClientConfiguration.default,
-        sslContext = None,
       ),
     )
     val fa = for {

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -13,6 +13,7 @@ import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
+  LedgerClientChannelConfiguration,
   LedgerClientConfiguration,
   LedgerIdRequirement,
 }
@@ -25,7 +26,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 object RunnerMain {
 
-  def listTriggers(darPath: File, dar: Dar[(PackageId, Package)]) = {
+  private def listTriggers(darPath: File, dar: Dar[(PackageId, Package)]): Unit = {
     println(s"Listing triggers in $darPath:")
     for ((modName, mod) <- dar.main._2.modules) {
       for ((defName, defVal) <- mod.definitions) {
@@ -77,8 +78,11 @@ object RunnerMain {
           ledgerIdRequirement = LedgerIdRequirement.none,
           commandClient =
             CommandClientConfiguration.default.copy(defaultDeduplicationTime = config.commandTtl),
-          sslContext = config.tlsConfig.client(),
           token = tokenHolder.flatMap(_.token),
+        )
+
+        val channelConfig = LedgerClientChannelConfiguration(
+          sslContext = config.tlsConfig.client(),
           maxInboundMessageSize = config.maxInboundMessageSize,
         )
 
@@ -87,6 +91,7 @@ object RunnerMain {
             config.ledgerHost,
             config.ledgerPort,
             clientConfig,
+            channelConfig,
           )(ec, sequencer)
 
           parties <- config.ledgerClaims.resolveClaims(client)

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
+  LedgerClientChannelConfiguration,
   LedgerClientConfiguration,
   LedgerIdRequirement,
 }
@@ -22,8 +23,8 @@ import com.daml.lf.engine.trigger.TriggerRunner.{QueryingACS, Running, TriggerSt
 import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import io.grpc.Status.Code
 import scalaz.syntax.tag._
-
 import java.util.UUID
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -73,8 +74,11 @@ object TriggerRunnerImpl {
         commandClient = CommandClientConfiguration.default.copy(
           defaultDeduplicationTime = config.ledgerConfig.commandTtl
         ),
-        sslContext = None,
         token = AccessToken.unsubst(config.accessToken),
+      )
+
+      val channelConfig = LedgerClientChannelConfiguration(
+        sslContext = None,
         maxInboundMessageSize = config.ledgerConfig.maxInboundMessageSize,
       )
 
@@ -181,6 +185,7 @@ object TriggerRunnerImpl {
           config.ledgerConfig.host,
           config.ledgerConfig.port,
           clientConfig,
+          channelConfig,
         )
         runner = new Runner(
           config.compiledPackages,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -283,7 +283,6 @@ trait SandboxFixture extends BeforeAndAfterAll with AbstractAuthFixture with Akk
         applicationId = ApplicationId.unwrap(applicationId),
         ledgerIdRequirement = LedgerIdRequirement.none,
         commandClient = CommandClientConfiguration.default,
-        sslContext = None,
         token = authToken(
           CustomDamlJWTPayload(
             ledgerId = None,

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -19,6 +19,7 @@ import com.daml.ledger.api.v1.{value => LedgerApi}
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
+  LedgerClientChannelConfiguration,
   LedgerClientConfiguration,
   LedgerIdRequirement,
 }
@@ -61,9 +62,11 @@ trait AbstractTriggerTest
       applicationId = ApplicationId.unwrap(applicationId),
       ledgerIdRequirement = LedgerIdRequirement.none,
       commandClient = CommandClientConfiguration.default,
-      sslContext = None,
       token = None,
     )
+
+  protected def ledgerClientChannelConfiguration =
+    LedgerClientChannelConfiguration.InsecureDefaults
 
   protected def ledgerClient(
       maxInboundMessageSize: Int = RunnerConfig.DefaultMaxInboundMessageSize
@@ -73,7 +76,8 @@ trait AbstractTriggerTest
         .singleHost(
           "localhost",
           serverPort.value,
-          ledgerClientConfiguration.copy(maxInboundMessageSize = maxInboundMessageSize),
+          ledgerClientConfiguration,
+          ledgerClientChannelConfiguration.copy(maxInboundMessageSize = maxInboundMessageSize),
         )
     } yield client
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/ConfigSpec.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/ConfigSpec.scala
@@ -36,7 +36,6 @@ class ConfigSpec
     applicationId = "myappid",
     ledgerIdRequirement = LedgerIdRequirement.none,
     commandClient = CommandClientConfiguration.default,
-    sslContext = None,
     token = None,
   )
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
@@ -31,13 +31,14 @@ class Tls
     }
   }
 
-  override protected def config =
-    super.config
-      .copy(tlsConfig = Some(TlsConfiguration(enabled = true, serverCrt, serverPem, caCrt)))
+  private val tlsConfig = TlsConfiguration(enabled = true, serverCrt, serverPem, caCrt)
 
-  override protected def ledgerClientConfiguration =
-    super.ledgerClientConfiguration
-      .copy(sslContext = TlsConfiguration(enabled = true, clientCrt, clientPem, caCrt).client())
+  override protected def config =
+    super.config.copy(tlsConfig = Some(tlsConfig))
+
+  override protected def ledgerClientChannelConfiguration =
+    super.ledgerClientChannelConfiguration
+      .copy(sslContext = tlsConfig.client())
 
   "TLS" can {
     // We just need something simple to test the connection.


### PR DESCRIPTION
Fixes #12391

The channel configuration now has to be provided separately from the
configuration specific to the ledger client. In this way we avoid
situations where the builder is provided with some configuration
that gets overridden.

changelog_begin
[Scala bindings] The channel configuration has been split from the
LedgerClientConfiguration class. Provide the gRPC channel specific
configuration separately or use a builder. The channel configuration
no longer overrides the builder.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
