### PR TITLE
Change default sandbox to canton

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -93,7 +93,7 @@ commandParser = subparser $ fold
     , command "run-jar" (info runJarCmd forwardOptions)
     , command "codegen" (info (codegenCmd <**> helper) forwardOptions)
     , command "packages" (info (packagesCmd <**> helper) packagesCmdInfo)
-    , command "sandbox-canton" (info (cantonSandboxCmd <**> helper) cantonSandboxCmdInfo)
+    , command "sandbox" (info (cantonSandboxCmd <**> helper) cantonSandboxCmdInfo)
     ]
   where
 
@@ -166,13 +166,13 @@ commandParser = subparser $ fold
 
     sandboxChoiceOpt =
             flag' SandboxKV (long "sandbox-kv" <> help "Deprecated. Run with Sandbox KV.")
-        <|> flag' SandboxCanton (long "sandbox-canton" <> help "Run with Canton Sandbox. The 2.0 default.")
+        <|> (flag' SandboxCanton (long "sandbox-canton" <> help "Run with Canton Sandbox. The 2.0 default.") <|> pure SandboxCanton)
                 <*> sandboxCantonPortSpecOpt
 
     sandboxCantonPortSpecOpt = do
-        adminApiSpec <- sandboxPortOpt "canton-admin-api-port" "Port number for the canton admin API (--sandbox-canton only)"
-        domainPublicApiSpec <- sandboxPortOpt "canton-domain-public-port" "Port number for the canton domain public API (--sandbox-canton only)"
-        domainAdminApiSpec <- sandboxPortOpt "canton-domain-admin-port" "Port number for the canton domain admin API (--sandbox-canton only)"
+        adminApiSpec <- sandboxPortOpt "sandbox-admin-api-port" "Port number for the canton admin API (--sandbox-canton only)"
+        domainPublicApiSpec <- sandboxPortOpt "sandbox-domain-public-port" "Port number for the canton domain public API (--sandbox-canton only)"
+        domainAdminApiSpec <- sandboxPortOpt "sandbox-domain-admin-port" "Port number for the canton domain admin API (--sandbox-canton only)"
         pure SandboxCantonPortSpec {..}
 
     navigatorPortOption = NavigatorPort <$> option auto
@@ -415,7 +415,7 @@ commandParser = subparser $ fold
              <*> option auto (long "domain-public-port" <> value 6867)
              <*> option auto (long "domain-admin-port" <> value 6868)
              <*> optional (option str (long "port-file" <> metavar "PATH"))
-          )
+             <*> (StaticTime <$> switch (long "static-time"))
       <*> many (argument str (metavar "ARG"))
 
     cantonSandboxCmdInfo =

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -166,7 +166,7 @@ commandParser = subparser $ fold
 
     sandboxChoiceOpt =
             flag' SandboxKV (long "sandbox-kv" <> help "Deprecated. Run with Sandbox KV.")
-        <|> (flag' SandboxCanton (long "sandbox-canton" <> help "Run with Canton Sandbox. The 2.0 default.") <|> pure SandboxCanton)
+        <|> flag SandboxCanton SandboxCanton (long "sandbox-canton" <> help "Run with Canton Sandbox. The 2.0 default.")
                 <*> sandboxCantonPortSpecOpt
 
     sandboxCantonPortSpecOpt = do
@@ -415,7 +415,7 @@ commandParser = subparser $ fold
              <*> option auto (long "domain-public-port" <> value 6867)
              <*> option auto (long "domain-admin-port" <> value 6868)
              <*> optional (option str (long "port-file" <> metavar "PATH"))
-             <*> (StaticTime <$> switch (long "static-time"))
+             <*> (StaticTime <$> switch (long "static-time")))
       <*> many (argument str (metavar "ARG"))
 
     cantonSandboxCmdInfo =

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -71,19 +71,20 @@ navigatorURL (NavigatorPort p) = "http://localhost:" <> show p
 
 -- | Use SandboxPortSpec to determine a sandbox port number.
 -- This is racy thanks to getFreePort, but there's no good alternative at the moment.
-getPortForSandbox :: Int -> Maybe SandboxPortSpec -> IO Int
-getPortForSandbox defaultPort = \case
-    Nothing -> pure defaultPort
-    Just (SpecifiedPort port) -> pure (unSandboxPort port)
-    Just FreePort -> fromIntegral <$> getFreePort
+getPortForSandbox :: SandboxPortSpec -> Maybe SandboxPortSpec -> IO Int
+getPortForSandbox defaultPortSpec portSpecM =
+    case fromMaybe defaultPortSpec portSpecM of
+        SpecifiedPort port -> pure (unSandboxPort port)
+        FreePort -> fromIntegral <$> getFreePort
 
 determineCantonOptions :: Maybe SandboxPortSpec -> SandboxCantonPortSpec -> FilePath -> IO CantonOptions
 determineCantonOptions ledgerApiSpec SandboxCantonPortSpec{..} portFile = do
-    ledgerApi <- getPortForSandbox 6865 ledgerApiSpec
-    adminApi <- getPortForSandbox 6866 adminApiSpec
-    domainPublicApi <- getPortForSandbox 6867 domainPublicApiSpec
-    domainAdminApi <- getPortForSandbox 6868 domainAdminApiSpec
+    ledgerApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6865)) ledgerApiSpec
+    adminApi <- getPortForSandbox FreePort adminApiSpec
+    domainPublicApi <- getPortForSandbox FreePort domainPublicApiSpec
+    domainAdminApi <- getPortForSandbox FreePort domainAdminApiSpec
     let portFileM = Just portFile -- TODO allow canton port file to be passed in from command line?
+    let staticTime = StaticTime False
     pure CantonOptions {..}
 
 withSandbox :: StartOptions -> FilePath -> [String] -> [String] -> (Process () () () -> SandboxPort -> IO a) -> IO a

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -33,7 +33,7 @@ import Test.Tasty.HUnit
 
 import DA.Bazel.Runfiles
 import DA.Daml.Assistant.IntegrationTestUtils
-import DA.Daml.Helper.Util (waitForConnectionOnPort, waitForHttpServer, tokenFor, decodeCantonSandboxPort)
+import DA.Daml.Helper.Util (waitForHttpServer, tokenFor, decodeCantonSandboxPort)
 import DA.Test.Daml2jsUtils
 import DA.Test.Process (callCommandSilent, callCommandSilentIn, callCommandSilentWithEnvIn, subprocessEnv)
 import DA.Test.Util

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -95,31 +95,25 @@ damlStart tmpDir = do
     createDirectoryIfMissing True (projDir </> "daml")
     let scriptOutputFile = "script-output.json"
     writeFileUTF8 (projDir </> "daml.yaml") $
-        unlines $ concat
-            [   [ "sdk-version: " <> sdkVersion
-                , "name: assistant-integration-tests"
-                , "version: \"1.0\""
-                , "source: daml"
-                , "dependencies:"
-                , "  - daml-prim"
-                , "  - daml-stdlib"
-                , "  - daml-script"
-                , "init-script: Main:init"
-                , "script-options:"
-                , "  - --output-file"
-                , "  - " <> scriptOutputFile
-                , "codegen:"
-                , "  js:"
-                , "    output-directory: ui/daml.js"
-                , "    npm-scope: daml.js"
-                , "  java:"
-                , "    output-directory: ui/java"
-                ]
-            , if withCantonSandbox then [] else
-                [ "sandbox-options:"
-                , "  - --ledgerid=sandbox"
-                , "  - --wall-clock-time"
-                ]
+        unlines
+            [ "sdk-version: " <> sdkVersion
+            , "name: assistant-integration-tests"
+            , "version: \"1.0\""
+            , "source: daml"
+            , "dependencies:"
+            , "  - daml-prim"
+            , "  - daml-stdlib"
+            , "  - daml-script"
+            , "init-script: Main:init"
+            , "script-options:"
+            , "  - --output-file"
+            , "  - " <> scriptOutputFile
+            , "codegen:"
+            , "  js:"
+            , "    output-directory: ui/daml.js"
+            , "    npm-scope: daml.js"
+            , "  java:"
+            , "    output-directory: ui/java"
             ]
     writeFileUTF8 (projDir </> "daml/Main.daml") $
         unlines

--- a/docs/source/app-dev/bindings-java/quickstart/template-root/daml/Main.daml
+++ b/docs/source/app-dev/bindings-java/quickstart/template-root/daml/Main.daml
@@ -8,7 +8,7 @@ import Daml.Script
 import Iou
 import IouTrade()
 
-initialize : Script ()
+initialize : Script [Party]
 initialize = do
   -- allocate parties
   alice <- allocatePartyWithHint "Alice" (PartyIdHint "Alice")
@@ -43,4 +43,4 @@ initialize = do
   submit alice do exerciseCmd iouTransferAliceCid IouTransfer_Accept
   submit bob do exerciseCmd iouTransferBobCid IouTransfer_Accept
 
-  pure ()
+  pure [alice, eurBank]

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -130,7 +130,7 @@ patches we backport to the 1.0 release branch).
 
     1. `cd create-daml-app`
 
-       1. `daml start --sandbox-kv`
+       1. `daml start`
 
     1. In a new terminal, from the `ui` folder:
 
@@ -235,7 +235,7 @@ patches we backport to the 1.0 release branch).
 
     1. Verify the new version is specified in `daml.yaml` as the `sdk-version`.
 
-    1. Run `daml start --sandbox-kv`. Your browser should be opened automatically at
+    1. Run `daml start`. Your browser should be opened automatically at
        `http://localhost:7500`. Login as `Alice` and verify that there is
        1 contract and 3 templates. Close the tab and kill `daml start` using
        `Ctrl-C`.

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -44,10 +44,10 @@ commands:
   path: damlc/damlc
   desc: "Run the Daml compiler"
   completion: true
-- name: sandbox-canton
+- name: sandbox
   path: daml-helper/daml-helper
-  desc: "Launch Sandbox Canton."
-  args: ["sandbox-canton"]
+  desc: "Launch Canton Sandbox"
+  args: ["sandbox"]
 - name: sandbox-kv
   path: daml-helper/daml-helper
   desc: "Deprecated. Launch Sandbox KV (the default Sandbox implementation for SDK < 2.0.0)"

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -95,7 +95,6 @@ beforeAll(async () => {
   // Getting Started Guide.
   const startArgs = [
     'start',
-    '--sandbox-kv',
     `--json-api-option=--port-file=${JSON_API_PORT_FILE_NAME}`,
   ];
 

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -95,6 +95,7 @@ beforeAll(async () => {
   // Getting Started Guide.
   const startArgs = [
     'start',
+    '--sandbox-kv',
     `--json-api-option=--port-file=${JSON_API_PORT_FILE_NAME}`,
   ];
 


### PR DESCRIPTION
Some progress on #11831

* make `daml start` use canton sandbox by default
  * changed the non-ledger api ports to use free ports by default
    (still haven't tried using port 0 instead of `getFreePort`).
* rename `daml sandbox-canton` to `daml sandbox`
* implement a `--static-time` option for `daml sandbox` that sets the
  canton clock type parameter to `sim-clock`
* make the hot reload test work with `daml start --sandbox-canton`
* move the `quickstart-java` integration test to the new sandbox
  * the test uses `--static-time` but doesn't really depend on it

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
