### PR TITLE
Use --sandbox-kv in create-daml-app release tests.

### DIFF
--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -130,7 +130,7 @@ patches we backport to the 1.0 release branch).
 
     1. `cd create-daml-app`
 
-       1. `daml start`
+       1. `daml start --sandbox-kv`
 
     1. In a new terminal, from the `ui` folder:
 


### PR DESCRIPTION
Was a bit too eager in the last PR, and changed the release test to use
`daml start` instead of `daml start --sandbox-kv`. This PR reverts this
until we make create-daml-app work with the new sandbox.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
