### PR TITLE
Make skeleton template work with canton sandbox

### DIFF
--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -209,8 +209,8 @@ patches we backport to the 1.0 release branch).
 1. Run through the following test plan on Windows. This is slightly shortened to
    make testing faster and since most issues are not platform specific.
 
-   1. Run `daml new quickstart` to create a new project and switch to it using
-      `cd quickstart`.
+   1. Run `daml new myproject` to create a new project and switch to it using
+      `cd myproject`.
    1. Run `daml start`.
    1. Open your browser at `http://localhost:7500`, verify that you can login as
       Alice and there is one template and one contract.

--- a/templates/skeleton/daml.yaml.template
+++ b/templates/skeleton/daml.yaml.template
@@ -5,13 +5,8 @@ sdk-version: __VERSION__
 name: __PROJECT_NAME__
 source: daml
 init-script: Main:setup
-parties:
-  - Alice
-  - Bob
 version: 0.0.1
 dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time


### PR DESCRIPTION
And change the relevant release test instructions to make it clear this
isn't a quickstart-java project, but a project that uses the default
template (skeleton).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
