### PR TITLE
Support split releases in the docs cronjob

### DIFF
--- a/ci/cron/src/Docs.hs
+++ b/ci/cron/src/Docs.hs
@@ -1,6 +1,27 @@
 -- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+
+-- | The docs cronjob runs through the following steps
+--
+-- 1. Download the list of available releases from GH releases.
+-- 2. Download the list of available releases from S3 based on the contents of
+--    `/versions.json` and `/snapshots.json`.
+-- 3. For each version that is in GH but not in S3 run through those steps:
+--    3.1. Check if the release has already been uploaded under `/$version/`. If so do nothing.
+--         We hit this for the split release process for 2.0 and newer.
+--    3.2. If not, build it in the Daml repository and upload.
+--         We hit this for the non-split release process.
+-- 4. At this point, all releases have been uploaded. What remains to be done is
+--    updating the top-level release to the latest stable release that has
+--    been marked stable on GH.
+-- 5. Finally we update the versions.json and snapshots.json on S3 to match GH.
+--
+-- This assumes that:
+--
+-- 1. The assembly repo uploads a release to `/version/` but leaves
+--    moving it to the top-level to this cron job.
+-- 2. The assembly repo uploads to S3 before creating a GH release.
 module Docs (docs, sdkDocOpts, damlOnSqlDocOpts) where
 
 import Control.Exception.Safe
@@ -76,10 +97,18 @@ build_and_push :: DocOptions -> FilePath -> [Version] -> IO ()
 build_and_push opts@DocOptions{build} temp versions = do
     restore_sha $ do
         Data.Foldable.for_ versions (\version -> do
-            putStrLn $ "Building " <> show version <> "..."
-            build temp version
-            putStrLn $ "Pushing " <> show version <> " to S3 (as subfolder)..."
-            push version
+            putStrLn $ "Check if version  " <> show version <> " exists ..."
+            -- We use a check for the versions.json file to check if the docs exists or not.
+            -- This is technically slightly racy if the upload happens concurrently and we end up with a partial upload
+            -- but the window seems small enough to make this acceptable.
+            r <- tryIO $ IO.withTempFile $ \file -> proc_ ["aws", "s3", "cp", s3Path opts (show version </> "versions.json"), file]
+            case r of
+                Left _ -> do
+                    putStrLn $ "Building " <> show version <> "..."
+                    build temp version
+                    putStrLn $ "Pushing " <> show version <> " to S3 (as subfolder)..."
+                    push version
+                Right _ -> putStrLn $ "Version " <> show version <> " already exists (split-release)"
             putStrLn "Done.")
     where
         restore_sha io =
@@ -96,6 +125,8 @@ fetch_if_missing :: DocOptions -> FilePath -> Version -> IO ()
 fetch_if_missing opts temp v = do
     missing <- not <$> Directory.doesDirectoryExist (temp </> show v)
     if missing then do
+        -- We hit this for all split releases as well as non-split releases that
+        -- have been built before being marked stable.
         putStrLn $ "Downloading " <> show v <> "..."
         proc_ ["aws", "s3", "cp", s3Path opts (show v), temp </> show v, "--recursive"]
         putStrLn "Done."


### PR DESCRIPTION
Most of this is just documentation. The actual idea here is fairly
simple:

- The assembly repo pushes to S3 on each release (not yet implemented).
- The cronjob skips releases that are already there.
- Updating the top-level just piggybacks on what we already have.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
