### PR TITLE
Remove user-management error cases from scenario-service proto.

### DIFF
--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -354,11 +354,6 @@ prettyScenarioErrorError (Just err) =  do
     ScenarioErrorErrorScenarioPartyAlreadyExists name ->
       pure $ "Tried to allocate a party that already exists: " <-> ltext name
 
-    ScenarioErrorErrorScenarioUserNotFound userId ->
-      pure $ "User not found: " <-> ltext userId
-    ScenarioErrorErrorScenarioUserAlreadyExists userId ->
-      pure $ "User already exists: " <-> ltext userId
-
     ScenarioErrorErrorScenarioContractNotVisible ScenarioError_ContractNotVisible{..} ->
       pure $ vcat
         [ "Attempt to fetch or exercise a contract not visible to the reading parties."

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -279,8 +279,6 @@ message ScenarioError {
     Empty ComparableValueError = 29;
     ContractIdInContractKey contract_id_in_contract_key = 30;
     Empty ValueExceedsMaxNesting = 31;
-    string scenario_user_not_found = 33;
-    string scenario_user_already_exists = 34;
   }
 }
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -251,12 +251,7 @@ final class Conversions(
         builder.setScenarioPartyAlreadyExists(party)
 
       case Error.UserManagement(err) =>
-        err match {
-          case Error.UserManagementError.UserNotFound(userId) =>
-            builder.setScenarioUserNotFound(userId)
-          case Error.UserManagementError.UserExists(userId) =>
-            builder.setScenarioUserAlreadyExists(userId)
-        }
+        builder.setCrash(s"UserManagement error unhandled in scenario service: $err")
     }
     builder.build
   }

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -249,9 +249,6 @@ final class Conversions(
 
       case Error.PartyAlreadyExists(party) =>
         builder.setScenarioPartyAlreadyExists(party)
-
-      case Error.UserManagement(err) =>
-        builder.setCrash(s"UserManagement error unhandled in scenario service: $err")
     }
     builder.build
   }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
@@ -4,7 +4,7 @@
 package com.daml.lf
 package scenario
 
-import com.daml.lf.data.Ref.{Identifier, Party, UserId}
+import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.data.Time
 import com.daml.lf.ledger.EventId
 import com.daml.lf.speedy.SError.SError
@@ -74,11 +74,4 @@ object Error {
 
   /** Tried to allocate a party that already exists. */
   final case class PartyAlreadyExists(name: String) extends Error
-
-  sealed abstract class UserManagementError extends Product with Serializable
-
-  object UserManagementError {
-    final case class UserNotFound(userId: UserId) extends UserManagementError
-    final case class UserExists(userId: UserId) extends UserManagementError
-  }
 }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Error.scala
@@ -75,8 +75,6 @@ object Error {
   /** Tried to allocate a party that already exists. */
   final case class PartyAlreadyExists(name: String) extends Error
 
-  final case class UserManagement(error: UserManagementError) extends Error
-
   sealed abstract class UserManagementError extends Product with Serializable
 
   object UserManagementError {

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
@@ -66,15 +66,6 @@ private[lf] object Pretty {
 
       case Error.PartyAlreadyExists(party) =>
         text(s"Error: Tried to allocate a party that already exists: $party")
-
-      case Error.UserManagement(err) => prettyError(err)
     }
-
-  def prettyError(err: Error.UserManagementError) = err match {
-    case Error.UserManagementError.UserNotFound(userId) =>
-      text(s"Error: User with id $userId does not exist")
-    case Error.UserManagementError.UserExists(userId) =>
-      text(s"Error: Tried to create a user id $userId but such a user already exists")
-  }
 
 }

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -69,7 +69,6 @@ da_scala_test(
     deps = [
         ":script-runner-lib",
         "//daml-lf/data",
-        "//daml-lf/scenario-interpreter",
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
     ],

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -351,10 +351,7 @@ class IdeLedgerClient(
       esf: ExecutionSequencerFactory,
       mat: Materializer,
   ): Future[Option[List[UserRight]]] =
-    userManagementStore.grantRights(id, rights.toSet) match {
-      case None => Future.successful(None)
-      case Some(a) => Future.successful(a).map(_.toList).map(Some(_))
-    }
+    Future.successful(userManagementStore.grantRights(id, rights.toSet).map(_.toList))
 
   override def revokeUserRights(
       id: UserId,
@@ -364,18 +361,12 @@ class IdeLedgerClient(
       esf: ExecutionSequencerFactory,
       mat: Materializer,
   ): Future[Option[List[UserRight]]] =
-    userManagementStore.revokeRights(id, rights.toSet) match {
-      case None => Future.successful(None)
-      case Some(a) => Future.successful(a).map(_.toList).map(Some(_))
-    }
+    Future.successful(userManagementStore.revokeRights(id, rights.toSet).map(_.toList))
 
   override def listUserRights(id: UserId)(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,
   ): Future[Option[List[UserRight]]] =
-    userManagementStore.listUserRights(id) match {
-      case None => Future.successful(None)
-      case Some(a) => Future.successful(a).map(_.toList).map(Some(_))
-    }
+    Future.successful(userManagementStore.listUserRights(id).map(_.toList))
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -59,7 +59,7 @@ class IdeLedgerClient(
   private val userManagementStore = new ide.UserManagementStore()
 
   private def handleUserManagement[T](r: ide.UserManagementStore.Result[T]): Future[T] =
-    r.fold(err => Future.failed(scenario.Error.UserManagement(err)), Future.successful(_))
+    r.fold(err => sys.error(s"handleUserManagement, unexpected: $err"), Future.successful(_))
 
   override def query(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(implicit
       ec: ExecutionContext,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ide/UserManagementStore.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/ide/UserManagementStore.scala
@@ -4,7 +4,6 @@
 package com.daml.lf.engine.script.ledgerinteraction.ide
 
 import com.daml.lf.data.Ref.UserId
-import com.daml.lf.scenario.Error.UserManagementError
 import com.daml.ledger.api.domain.{User, UserRight}
 
 import scala.collection.mutable
@@ -15,55 +14,54 @@ import scala.collection.mutable
 // #11896. While it would be nice to not have to duplicate this for now this seems like the
 // simpler option than trying to reuse participant code in the script service.
 private[ledgerinteraction] class UserManagementStore {
-  import UserManagementError._
   import UserManagementStore._
 
-  def createUser(user: User, rights: Set[UserRight]): Result[Unit] =
+  def createUser(user: User, rights: Set[UserRight]): Option[Unit] =
     putIfAbsent(UserInfo(user, rights)) match {
-      case Some(_) => Left(UserExists(user.id))
-      case None => Right(())
+      case Some(_) => None
+      case None => Some(())
     }
 
-  def getUser(id: UserId): Result[User] =
+  def getUser(id: UserId): Option[User] =
     lookup(id) match {
-      case Some(userInfo) => Right(userInfo.user)
-      case None => Left(UserNotFound(id))
+      case Some(userInfo) => Some(userInfo.user)
+      case None => None
     }
 
-  def deleteUser(id: UserId): Result[Unit] =
+  def deleteUser(id: UserId): Option[Unit] =
     dropExisting(id) match {
-      case Some(_) => Right(())
-      case None => Left(UserNotFound(id))
+      case Some(_) => Some(())
+      case None => None
     }
 
-  def grantRights(id: UserId, granted: Set[UserRight]): Result[Set[UserRight]] =
+  def grantRights(id: UserId, granted: Set[UserRight]): Option[Set[UserRight]] =
     lookup(id) match {
       case Some(userInfo) =>
         val newlyGranted = granted.diff(userInfo.rights)
         replaceInfo(userInfo, userInfo.copy(rights = userInfo.rights ++ newlyGranted))
-        Right(newlyGranted)
+        Some(newlyGranted)
       case None =>
-        Left(UserNotFound(id))
+        None
     }
 
-  def revokeRights(id: UserId, revoked: Set[UserRight]): Result[Set[UserRight]] =
+  def revokeRights(id: UserId, revoked: Set[UserRight]): Option[Set[UserRight]] =
     lookup(id) match {
       case Some(userInfo) =>
         val effectivelyRevoked = revoked.intersect(userInfo.rights)
         replaceInfo(userInfo, userInfo.copy(rights = userInfo.rights -- effectivelyRevoked))
-        Right(effectivelyRevoked)
+        Some(effectivelyRevoked)
       case None =>
-        Left(UserNotFound(id))
+        None
     }
 
-  def listUserRights(id: UserId): Result[Set[UserRight]] =
+  def listUserRights(id: UserId): Option[Set[UserRight]] =
     lookup(id) match {
-      case Some(userInfo) => Right(userInfo.rights)
-      case None => Left(UserNotFound(id))
+      case Some(userInfo) => Some(userInfo.rights)
+      case None => None
     }
 
-  def listUsers(): Result[List[User]] =
-    Right(state.values.map(_.user).toList)
+  def listUsers(): List[User] =
+    state.values.map(_.user).toList
 
   private val state: mutable.Map[UserId, UserInfo] = mutable.Map()
   private def lookup(id: UserId) = state.get(id)
@@ -89,5 +87,4 @@ object UserManagementStore {
   case class UserInfo(user: User, rights: Set[UserRight]) {
     def toStateEntry: (UserId, UserInfo) = user.id -> this
   }
-  type Result[T] = Either[UserManagementError, T]
 }

--- a/daml-script/runner/src/test/com/daml/lf/engine/script/ledgerinteraction/ide/UserManagementStoreSpec.scala
+++ b/daml-script/runner/src/test/com/daml/lf/engine/script/ledgerinteraction/ide/UserManagementStoreSpec.scala
@@ -25,60 +25,60 @@ final class InMemoryUserManagementStoreSpec extends AnyFreeSpec with Matchers {
   "in-memory user management" - {
     "allow creating a fresh user" in {
       val mgmt = new UserManagementStore()
-      mgmt.createUser(User("user1", None), Set.empty) shouldBe Right(())
-      mgmt.createUser(User("user2", None), Set.empty) shouldBe Right(())
+      mgmt.createUser(User("user1", None), Set.empty) shouldBe Some(())
+      mgmt.createUser(User("user2", None), Set.empty) shouldBe Some(())
     }
 
     "disallow re-creating an existing user" in {
       val mgmt = new UserManagementStore()
       val user = User("user1", None)
-      mgmt.createUser(user, Set.empty) shouldBe Right(())
-      mgmt.createUser(user, Set.empty) shouldBe Left(())
+      mgmt.createUser(user, Set.empty) shouldBe Some(())
+      mgmt.createUser(user, Set.empty) shouldBe None
     }
 
     "find a freshly created user" in {
       val mgmt = new UserManagementStore()
       val user = User("user1", None)
-      mgmt.createUser(user, Set.empty) shouldBe Right(())
-      mgmt.getUser("user1") shouldBe Right(user)
+      mgmt.createUser(user, Set.empty) shouldBe Some(())
+      mgmt.getUser("user1") shouldBe Some(user)
     }
 
     "not find a non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.getUser("user1") shouldBe Left(())
+      mgmt.getUser("user1") shouldBe None
     }
     "not find a deleted user" in {
       val mgmt = new UserManagementStore()
       val user = User("user1", None)
-      mgmt.createUser(user, Set.empty) shouldBe Right(())
-      mgmt.getUser("user1") shouldBe Right(user)
-      mgmt.deleteUser("user1") shouldBe Right(())
-      mgmt.getUser("user1") shouldBe Left(())
+      mgmt.createUser(user, Set.empty) shouldBe Some(())
+      mgmt.getUser("user1") shouldBe Some(user)
+      mgmt.deleteUser("user1") shouldBe Some(())
+      mgmt.getUser("user1") shouldBe None
     }
     "allow recreating a deleted user" in {
       val mgmt = new UserManagementStore()
       val user = User("user1", None)
-      mgmt.createUser(user, Set.empty) shouldBe Right(())
-      mgmt.deleteUser(user.id) shouldBe Right(())
-      mgmt.createUser(user, Set.empty) shouldBe Right(())
+      mgmt.createUser(user, Set.empty) shouldBe Some(())
+      mgmt.deleteUser(user.id) shouldBe Some(())
+      mgmt.createUser(user, Set.empty) shouldBe Some(())
     }
     "fail to delete a non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.deleteUser("user1") shouldBe Left(())
+      mgmt.deleteUser("user1") shouldBe None
     }
     "list created users" in {
       val mgmt = new UserManagementStore()
-      mgmt.createUser(User("user1", None), Set.empty) shouldBe Right(())
-      mgmt.createUser(User("user2", None), Set.empty) shouldBe Right(())
-      mgmt.listUsers() shouldBe Right(Seq(User("user1", None), User("user2", None)))
+      mgmt.createUser(User("user1", None), Set.empty) shouldBe Some(())
+      mgmt.createUser(User("user2", None), Set.empty) shouldBe Some(())
+      mgmt.listUsers() shouldBe Seq(User("user1", None), User("user2", None))
     }
     "not list deleted users" in {
       val mgmt = new UserManagementStore()
-      mgmt.createUser(User("user1", None), Set.empty) shouldBe Right(())
-      mgmt.createUser(User("user2", None), Set.empty) shouldBe Right(())
-      mgmt.listUsers() shouldBe Right(Seq(User("user1", None), User("user2", None)))
-      mgmt.deleteUser("user1") shouldBe Right(())
-      mgmt.listUsers() shouldBe Right(Seq(User("user2", None)))
+      mgmt.createUser(User("user1", None), Set.empty) shouldBe Some(())
+      mgmt.createUser(User("user2", None), Set.empty) shouldBe Some(())
+      mgmt.listUsers() shouldBe Seq(User("user1", None), User("user2", None))
+      mgmt.deleteUser("user1") shouldBe Some(())
+      mgmt.listUsers() shouldBe Seq(User("user2", None))
     }
   }
 
@@ -90,56 +90,56 @@ final class InMemoryUserManagementStoreSpec extends AnyFreeSpec with Matchers {
     import UserRight._
     "listUserRights should find the rights of a freshly created user" in {
       val mgmt = new UserManagementStore()
-      mgmt.createUser(User("user1", None), Set.empty) shouldBe Right(())
-      mgmt.listUserRights("user1") shouldBe Right(Set.empty)
+      mgmt.createUser(User("user1", None), Set.empty) shouldBe Some(())
+      mgmt.listUserRights("user1") shouldBe Some(Set.empty)
       mgmt.createUser(
         User("user2", None),
         Set(ParticipantAdmin, CanActAs("party1"), CanReadAs("party2")),
-      ) shouldBe Right(())
-      mgmt.listUserRights("user2") shouldBe Right(
+      ) shouldBe Some(())
+      mgmt.listUserRights("user2") shouldBe Some(
         Set(ParticipantAdmin, CanActAs("party1"), CanReadAs("party2"))
       )
     }
     "listUserRights should fail on non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.listUserRights("user1") shouldBe Left(())
+      mgmt.listUserRights("user1") shouldBe None
     }
     "grantUserRights should add new rights" in {
       val mgmt = new UserManagementStore()
-      mgmt.createUser(User("user1", None), Set.empty) shouldBe Right(())
-      mgmt.grantRights("user1", Set(ParticipantAdmin)) shouldBe Right(Set(ParticipantAdmin))
-      mgmt.grantRights("user1", Set(ParticipantAdmin)) shouldBe Right(Set.empty)
-      mgmt.grantRights("user1", Set(CanActAs("party1"), CanReadAs("party2"))) shouldBe Right(
+      mgmt.createUser(User("user1", None), Set.empty) shouldBe Some(())
+      mgmt.grantRights("user1", Set(ParticipantAdmin)) shouldBe Some(Set(ParticipantAdmin))
+      mgmt.grantRights("user1", Set(ParticipantAdmin)) shouldBe Some(Set.empty)
+      mgmt.grantRights("user1", Set(CanActAs("party1"), CanReadAs("party2"))) shouldBe Some(
         Set(CanActAs("party1"), CanReadAs("party2"))
       )
-      mgmt.listUserRights("user1") shouldBe Right(
+      mgmt.listUserRights("user1") shouldBe Some(
         Set(ParticipantAdmin, CanActAs("party1"), CanReadAs("party2"))
       )
     }
     "grantRights should fail on non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.grantRights("user1", Set.empty) shouldBe Left(())
+      mgmt.grantRights("user1", Set.empty) shouldBe None
     }
     "revokeRights should revoke rights" in {
       val mgmt = new UserManagementStore()
       mgmt.createUser(
         User("user1", None),
         Set(ParticipantAdmin, CanActAs("party1"), CanReadAs("party2")),
-      ) shouldBe Right(())
-      mgmt.listUserRights("user1") shouldBe Right(
+      ) shouldBe Some(())
+      mgmt.listUserRights("user1") shouldBe Some(
         Set(ParticipantAdmin, CanActAs("party1"), CanReadAs("party2"))
       )
-      mgmt.revokeRights("user1", Set(ParticipantAdmin)) shouldBe Right(Set(ParticipantAdmin))
-      mgmt.revokeRights("user1", Set(ParticipantAdmin)) shouldBe Right(Set.empty)
-      mgmt.listUserRights("user1") shouldBe Right(Set(CanActAs("party1"), CanReadAs("party2")))
-      mgmt.revokeRights("user1", Set(CanActAs("party1"), CanReadAs("party2"))) shouldBe Right(
+      mgmt.revokeRights("user1", Set(ParticipantAdmin)) shouldBe Some(Set(ParticipantAdmin))
+      mgmt.revokeRights("user1", Set(ParticipantAdmin)) shouldBe Some(Set.empty)
+      mgmt.listUserRights("user1") shouldBe Some(Set(CanActAs("party1"), CanReadAs("party2")))
+      mgmt.revokeRights("user1", Set(CanActAs("party1"), CanReadAs("party2"))) shouldBe Some(
         Set(CanActAs("party1"), CanReadAs("party2"))
       )
-      mgmt.listUserRights("user1") shouldBe Right(Set.empty)
+      mgmt.listUserRights("user1") shouldBe Some(Set.empty)
     }
     "revokeRights should fail on non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.revokeRights("user1", Set.empty) shouldBe Left(())
+      mgmt.revokeRights("user1", Set.empty) shouldBe None
     }
   }
 }

--- a/daml-script/runner/src/test/com/daml/lf/engine/script/ledgerinteraction/ide/UserManagementStoreSpec.scala
+++ b/daml-script/runner/src/test/com/daml/lf/engine/script/ledgerinteraction/ide/UserManagementStoreSpec.scala
@@ -5,7 +5,6 @@ package com.daml.lf.engine.script.ledgerinteraction.ide
 
 import com.daml.ledger.api.domain.{User, UserRight}
 import com.daml.lf.data.Ref.{Party, UserId}
-import com.daml.lf.scenario.Error.UserManagementError._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.freespec.AnyFreeSpec
 import scala.language.implicitConversions
@@ -34,7 +33,7 @@ final class InMemoryUserManagementStoreSpec extends AnyFreeSpec with Matchers {
       val mgmt = new UserManagementStore()
       val user = User("user1", None)
       mgmt.createUser(user, Set.empty) shouldBe Right(())
-      mgmt.createUser(user, Set.empty) shouldBe Left(UserExists("user1"))
+      mgmt.createUser(user, Set.empty) shouldBe Left(())
     }
 
     "find a freshly created user" in {
@@ -46,7 +45,7 @@ final class InMemoryUserManagementStoreSpec extends AnyFreeSpec with Matchers {
 
     "not find a non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.getUser("user1") shouldBe Left(UserNotFound("user1"))
+      mgmt.getUser("user1") shouldBe Left(())
     }
     "not find a deleted user" in {
       val mgmt = new UserManagementStore()
@@ -54,7 +53,7 @@ final class InMemoryUserManagementStoreSpec extends AnyFreeSpec with Matchers {
       mgmt.createUser(user, Set.empty) shouldBe Right(())
       mgmt.getUser("user1") shouldBe Right(user)
       mgmt.deleteUser("user1") shouldBe Right(())
-      mgmt.getUser("user1") shouldBe Left(UserNotFound("user1"))
+      mgmt.getUser("user1") shouldBe Left(())
     }
     "allow recreating a deleted user" in {
       val mgmt = new UserManagementStore()
@@ -65,7 +64,7 @@ final class InMemoryUserManagementStoreSpec extends AnyFreeSpec with Matchers {
     }
     "fail to delete a non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.deleteUser("user1") shouldBe Left(UserNotFound("user1"))
+      mgmt.deleteUser("user1") shouldBe Left(())
     }
     "list created users" in {
       val mgmt = new UserManagementStore()
@@ -103,7 +102,7 @@ final class InMemoryUserManagementStoreSpec extends AnyFreeSpec with Matchers {
     }
     "listUserRights should fail on non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.listUserRights("user1") shouldBe Left(UserNotFound("user1"))
+      mgmt.listUserRights("user1") shouldBe Left(())
     }
     "grantUserRights should add new rights" in {
       val mgmt = new UserManagementStore()
@@ -119,7 +118,7 @@ final class InMemoryUserManagementStoreSpec extends AnyFreeSpec with Matchers {
     }
     "grantRights should fail on non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.grantRights("user1", Set.empty) shouldBe Left(UserNotFound("user1"))
+      mgmt.grantRights("user1", Set.empty) shouldBe Left(())
     }
     "revokeRights should revoke rights" in {
       val mgmt = new UserManagementStore()
@@ -140,7 +139,7 @@ final class InMemoryUserManagementStoreSpec extends AnyFreeSpec with Matchers {
     }
     "revokeRights should fail on non-existent user" in {
       val mgmt = new UserManagementStore()
-      mgmt.revokeRights("user1", Set.empty) shouldBe Left(UserNotFound("user1"))
+      mgmt.revokeRights("user1", Set.empty) shouldBe Left(())
     }
   }
 }


### PR DESCRIPTION
Since the expected user-management errors are now reified within `ScriptLedgerClient`, remaining errors are unexpected.
#11997 