### PR TITLE
Move more docs post processing to non-sphinx docs

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -343,6 +343,8 @@ genrule(
         "//language-support/ts/daml-ledger:docs",
         "//language-support/ts/daml-types:docs",
         "@daml-cheat-sheet//:site",
+        ":redirects",
+        "error.html",
     ],
     outs = ["non-sphinx-html-docs.tar.gz"],
     cmd = """
@@ -376,11 +378,15 @@ genrule(
     # Copy in hoogle DB
     cp -L $(location :hoogle_db.tar.gz) $$DIR/html/hoogle_db.tar.gz
 
+    echo {{ \\"{version}\\" : \\"{version}\\" }} > $$DIR/html/versions.json
+    cp $(location :error.html) $$DIR/html/
+    tar xf $(location :redirects) --strip-components=1 -C $$DIR/html
+
     MKTGZ=$$PWD/$(execpath //bazel_tools/sh:mktgz)
     OUT_PATH=$$PWD/$@
     cd $$DIR
     $$MKTGZ $$OUT_PATH html
-  """,
+  """.format(version = sdk_version),
     tools = ["//bazel_tools/sh:mktgz"],
 ) if not is_windows else None
 
@@ -433,16 +439,11 @@ genrule(
     srcs = [
         ":docs-no-pdf",
         ":pdf-docs",
-        ":redirects",
-        "error.html",
     ],
     outs = ["html.tar.gz"],
     cmd = """
         VERSION_DATE=$$(cat bazel-out/stable-status.txt | grep STABLE_VERSION_DATE | head -1 | cut -f 2 -d' ')
-        tar -zxf $(location :redirects)
         tar -zxf $(location :docs-no-pdf)
-        cp -rn redirects/* html
-        cp -L docs/error.html html
         cd html
         find . -name '*.html' | sort | sed -e 's,^\\./,https://docs.daml.com/,' > sitemap
         SMHEAD="{head}"
@@ -454,11 +455,10 @@ genrule(
         done < sitemap
         rm sitemap
         echo $$SMFOOT >> sitemap.xml
-        echo {{ \\"{version}\\" : \\"{version}\\" }} > versions.json
         cd ..
         cp -L $(location :pdf-docs) html/_downloads
         # Remove Sphinx build products
-        rm -rf .buildinfo .doctrees objects.inv
+        rm -r html/.buildinfo html/.doctrees html/objects.inv
         $(execpath //bazel_tools/sh:mktgz) $@ html
     """.format(
         head = """<?xml version='1.0' encoding='UTF-8'?><urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd'>""",


### PR DESCRIPTION
This moves the redirects, the error page and the dummy versions file
to the non-sphinx html tarball which is handled in the split release
process.

This leaves only copying the pdf docs and the site map as a post
processing step which I cannot easily do here (since they should both
refer to the final artifact) so I’ll add that
directly in the assembly repo.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
