### PR TITLE
Add missing serializability checks for interfaces

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -161,6 +161,15 @@ checkTemplate mod0 tpl = do
   for_ (tplKey tpl) $ \key -> withContext (ContextTemplate mod0 tpl TPKey) $ do
     checkType SRKey (tplKeyType key)
 
+-- | Check whether a template satisfies all serializability constraints.
+checkInterface :: MonadGamma m => Module -> DefInterface -> m ()
+checkInterface _mod0 iface = do
+  -- TODO https://github.com/digital-asset/daml/issues/12051
+  -- Add per interface choice context.
+  for_ (intFixedChoices iface) $ \ch -> do
+      checkType SRChoiceArg (snd (chcArgBinder ch))
+      checkType SRChoiceRes (chcReturnType ch)
+
 -- | Check whether exception is serializable.
 checkException :: MonadGamma m => Module -> DefException -> m ()
 checkException mod0 exn = do
@@ -179,3 +188,6 @@ checkModule mod0 = do
   for_ (moduleExceptions mod0) $ \exn ->
     withContext (ContextDefException mod0 exn) $
       checkException mod0 exn
+  for_ (moduleInterfaces mod0) $ \iface ->
+    withContext (ContextDefInterface mod0 iface) $
+      checkInterface mod0 iface

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.daml
@@ -1,0 +1,20 @@
+-- @ERROR expected serializable type
+module InterfaceSerializabilityArgument where
+
+data NonSerializable = NonSerializable (() -> ())
+
+-- Dummy Eq and Show instances so we blow up in the serializability checker rather than
+-- the GHC typechecker.
+
+instance Eq NonSerializable where
+  (==) = error "undefined"
+instance Show NonSerializable where
+  show = error "undefined"
+
+interface I where
+   p : Party
+
+   choice NonSerializableArgument : ()
+     with f : NonSerializable
+     controller p this
+     do pure ()

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityArgument.daml
@@ -1,3 +1,4 @@
+-- @SINCE-LF-FEATURE DAML_INTERFACE
 -- @ERROR expected serializable type
 module InterfaceSerializabilityArgument where
 

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.daml
@@ -1,0 +1,19 @@
+-- @ERROR expected serializable type
+module InterfaceSerializabilityResult where
+
+data NonSerializable = NonSerializable (() -> ())
+
+-- Dummy Eq and Show instances so we blow up in the serializability checker rather than
+-- the GHC typechecker.
+
+instance Eq NonSerializable where
+  (==) = error "undefined"
+instance Show NonSerializable where
+  show = error "undefined"
+
+interface I where
+   p : Party
+
+   choice NonSerializableResult : NonSerializable
+     controller p this
+     do pure (NonSerializable identity)

--- a/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceSerializabilityResult.daml
@@ -1,3 +1,4 @@
+-- @SINCE-LF-FEATURE DAML_INTERFACE
 -- @ERROR expected serializable type
 module InterfaceSerializabilityResult where
 


### PR DESCRIPTION
The checks for argument & result type were missing before. I openey
https://github.com/digital-asset/daml/issues/12482 to do the same fix
on the Scala side.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
