### PR TITLE
[JSON-API] Remove /user/delete GET endpoint

### DIFF
--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
@@ -384,44 +384,6 @@ class HttpServiceIntegrationTestUserManagementNoAuth
       getResult(output3).convertTo[List[UserDetails]] should not contain createUserRequest.userId
     }
   }
-
-  "deleting the current user should be possible via the user/delete endpoint" in withHttpServiceAndClient(
-    participantAdminJwt
-  ) { (uri, _, _, _, _) =>
-    import spray.json._
-    import spray.json.DefaultJsonProtocol._
-    val alice = getUniqueParty("Alice")
-    val createUserRequest = domain.CreateUserRequest(
-      getUniqueUserName("nice.user"),
-      Some(alice.unwrap),
-      List(alice),
-      List.empty,
-      isAdmin = true,
-    )
-    for {
-      (status1, output1) <- postRequest(
-        uri.withPath(Uri.Path("/v1/user/create")),
-        createUserRequest.toJson,
-        headers = authorizationHeader(participantAdminJwt),
-      )
-      _ <- {
-        status1 shouldBe StatusCodes.OK
-        getResult(output1).convertTo[Boolean] shouldBe true
-      }
-      (status2, _) <- getRequest(
-        uri.withPath(Uri.Path(s"/v1/user/delete")),
-        headers = headersWithUserAuth(createUserRequest.userId),
-      )
-      _ = status2 shouldBe StatusCodes.OK
-      (status3, output3) <- getRequest(
-        uri.withPath(Uri.Path("/v1/users")),
-        headers = authorizationHeader(participantAdminJwt),
-      )
-    } yield {
-      status3 shouldBe StatusCodes.OK
-      getResult(output3).convertTo[List[UserDetails]] should not contain createUserRequest.userId
-    }
-  }
 }
 
 class HttpServiceIntegrationTestUserManagement

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -232,7 +232,6 @@ class Endpoints(
           path("query") & withTimer(queryAllTimer) apply
             toRoute(retrieveAll(req)),
           path("user") apply toRoute(getAuthenticatedUser(req)),
-          path("user" / "delete") apply toRoute(deleteAuthenticatedUser(req)),
           path("user" / "rights") apply toRoute(
             listAuthenticatedUserRights(req)
           ),
@@ -495,15 +494,6 @@ class Endpoints(
         _ <- EitherT.rightT(userManagementClient.deleteUser(userId, Some(jwt.value)))
       } yield domain.OkResponse(true): domain.SyncResponse[Boolean]
     }(req)
-
-  def deleteAuthenticatedUser(req: HttpRequest)(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID]
-  ): ET[domain.SyncResponse[Boolean]] =
-    for {
-      jwt <- eitherT(input(req)).bimap(identity[Error], _._1)
-      userId <- decodeAndParseUserIdFromToken(jwt, decodeJwt).leftMap(identity[Error])
-      _ <- EitherT.rightT(userManagementClient.deleteUser(userId, Some(jwt.value)))
-    } yield domain.OkResponse(true)
 
   def listUsers(req: HttpRequest)(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]


### PR DESCRIPTION
After discussion we decided to remove this endpoint because it is too easy to accidentally use it and besides that having this for GET isn't correct either.

changelog_begin

- [HTTP-JSON] Removed the /user/delete GET endpoint. Please use the /user/delete POST endpoint with the own user ID if you need to delete the user associated with the current token

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
