### PR TITLE
Fix get-daml.sh installation script

### DIFF
--- a/daml-assistant/get-daml.sh
+++ b/daml-assistant/get-daml.sh
@@ -48,11 +48,11 @@ trap cleanup EXIT
 #
 if [ -x "$(command -v df)" -a -x "$(command -v awk)" ]; then
   if [ "$(df $TMPDIR | tail -1 | awk '{print $4}')" -lt "$INSTALL_MINSIZE" ]; then
-      echo "Not enough disk space available to extract Daml SDK in $TMPDIR."
-      echo ""
-      echo "You can specify an alternative extraction directory by"
-      echo "setting the TEMPDIR environment variable."
-      exit 1
+    echo "Not enough disk space available to extract Daml SDK in $TMPDIR."
+    echo ""
+    echo "You can specify an alternative extraction directory by"
+    echo "setting the TEMPDIR environment variable."
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
Summary of changes:

* don't fail if TEMPDIR isn't set
* don't `cd` at all, so the script works even if TEMPDIR is a relative path
* don't use `df` and `awk` unless we know those commands exist -- it feels weird
  to use those without checking, when we check if `curl` and `tar` exist
* remove the daml cache directory on a new install

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
