### PR TITLE
ci: use service account for Windows nodes

### DIFF
--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -21,7 +21,7 @@ locals {
       size             = 0,
       assignment       = "default",
       disk_size        = 400,
-      service_accounts = [],
+      service_accounts = [{}],
     },
   ]
 }

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -11,7 +11,7 @@ locals {
   w = [
     {
       name             = "ci-w1",
-      size             = 0,
+      size             = 6,
       assignment       = "default",
       disk_size        = 400,
       service_accounts = [{}],

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -10,16 +10,18 @@ locals {
 locals {
   w = [
     {
-      name       = "ci-w1",
-      size       = 0,
-      assignment = "default",
-      disk_size  = 400,
+      name             = "ci-w1",
+      size             = 0,
+      assignment       = "default",
+      disk_size        = 400,
+      service_accounts = [],
     },
     {
-      name       = "ci-w2"
-      size       = 6,
-      assignment = "default",
-      disk_size  = 400,
+      name             = "ci-w2"
+      size             = 6,
+      assignment       = "default",
+      disk_size        = 400,
+      service_accounts = [],
     },
   ]
 }
@@ -177,6 +179,14 @@ SYSPREP_SPECIALIZE
 
     // Ephemeral IP to get access to the Internet
     access_config {}
+  }
+
+  dynamic "service_account" {
+    for_each = local.w[count.index].service_accounts
+    content {
+      scopes = ["cloud-platform"]
+      email  = "log-writer@da-dev-gcp-daml-language.iam.gserviceaccount.com"
+    }
   }
 
   scheduling {

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -10,18 +10,16 @@ locals {
 locals {
   w = [
     {
-      name             = "ci-w1",
-      size             = 6,
-      assignment       = "default",
-      disk_size        = 400,
-      service_accounts = [{}],
+      name       = "ci-w1",
+      size       = 6,
+      assignment = "default",
+      disk_size  = 400,
     },
     {
-      name             = "ci-w2"
-      size             = 0,
-      assignment       = "default",
-      disk_size        = 400,
-      service_accounts = [{}],
+      name       = "ci-w2"
+      size       = 0,
+      assignment = "default",
+      disk_size  = 400,
     },
   ]
 }
@@ -181,12 +179,9 @@ SYSPREP_SPECIALIZE
     access_config {}
   }
 
-  dynamic "service_account" {
-    for_each = local.w[count.index].service_accounts
-    content {
-      scopes = ["cloud-platform"]
-      email  = "log-writer@da-dev-gcp-daml-language.iam.gserviceaccount.com"
-    }
+  service_account {
+    scopes = ["cloud-platform"]
+    email  = "log-writer@da-dev-gcp-daml-language.iam.gserviceaccount.com"
   }
 
   scheduling {

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -18,7 +18,7 @@ locals {
     },
     {
       name             = "ci-w2"
-      size             = 6,
+      size             = 0,
       assignment       = "default",
       disk_size        = 400,
       service_accounts = [],

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -14,7 +14,7 @@ locals {
       size             = 0,
       assignment       = "default",
       disk_size        = 400,
-      service_accounts = [],
+      service_accounts = [{}],
     },
     {
       name             = "ci-w2"


### PR DESCRIPTION
When no service account is explicitly selected, GCP provides a default
one, which happens to have way more access rights than we're comfortable
with. I'm not quite sure how the total lack of a service account slipped
through here, but I've noticed today so I'm changing it.

CHANGELOG_BEGIN
CHANGELOG_END
