### PR TITLE
Avoid stale DAML_SDK_VERSION_LATEST in assistant

### DIFF
--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -202,7 +202,6 @@ runCommand env@Env{..} = \case
         let asstVersion = unwrapDamlAssistantSdkVersion <$> envDamlAssistantSdkVersion
             envVersions = catMaybes
                 [ envSdkVersion
-                , envLatestStableSdkVersion
                 , guard vAssistant >> asstVersion
                 , projectVersionM
                 , defaultVersionM
@@ -241,6 +240,7 @@ runCommand env@Env{..} = \case
 
             versions = nubSort . concat $
                 [ envVersions
+                , maybeToList latestVersionM
                 , fromRight [] installedVersionsE
                 , if vAll then fromRight [] availableVersionsE else []
                 , fromRight [] snapshotVersionsE

--- a/daml-assistant/src/DA/Daml/Assistant/Cache.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Cache.hs
@@ -5,6 +5,7 @@
 module DA.Daml.Assistant.Cache
     ( cacheAvailableSdkVersions
     , saveAvailableSdkVersions
+    , CacheAge (..)
     ) where
 
 import DA.Daml.Assistant.Types
@@ -53,15 +54,15 @@ cacheAvailableSdkVersions
     :: DamlPath
     -> CachePath
     -> IO [SdkVersion]
-    -> IO [SdkVersion]
+    -> IO ([SdkVersion], CacheAge)
 cacheAvailableSdkVersions damlPath cachePath getVersions = do
     damlConfigE <- tryConfig $ readDamlConfig damlPath
     let updateCheckM = join $ eitherToMaybe (queryDamlConfig ["update-check"] =<< damlConfigE)
         defaultUpdateCheck = UpdateCheckEvery (CacheTimeout 86400)
     case fromMaybe defaultUpdateCheck updateCheckM of
         UpdateCheckNever -> do
-            valueAgeM <- loadFromCacheWith cachePath versionsKey (CacheTimeout 0) deserializeVersions
-            pure (maybe [] fst valueAgeM)
+            valueAgeM <- loadFromCacheWith cachePath versionsKey (CacheTimeout 86400) deserializeVersions
+            pure $ fromMaybe ([], Stale) valueAgeM
 
         UpdateCheckEvery timeout ->
             cacheWith cachePath versionsKey timeout
@@ -86,22 +87,22 @@ cacheWith
     -> Serialize t
     -> Deserialize t
     -> IO t
-    -> IO t
+    -> IO (t, CacheAge)
 cacheWith cachePath key timeout serialize deserialize getFresh = do
     valueAgeM <- loadFromCacheWith cachePath key timeout deserialize
     case valueAgeM of
-        Just (value, Fresh) -> pure value
+        Just (value, Fresh) -> pure (value, Fresh)
         Just (value, Stale) -> do
             valueE <- tryAny getFresh
             case valueE of
-                Left _ -> pure value
+                Left _ -> pure (value, Stale)
                 Right value' -> do
                     saveToCacheWith cachePath key serialize value'
-                    pure value'
+                    pure (value', Fresh)
         Nothing -> do
             value <- getFresh
             saveToCacheWith cachePath key serialize value
-            pure value
+            pure (value, Fresh)
 
 -- | A representation of the age of a cache value. We only care if the value is stale or fresh.
 data CacheAge
@@ -141,4 +142,3 @@ loadFromCacheWith cachePath key timeout deserialize = do
         (valueStr, age) <- valueAgeM
         value <- deserialize valueStr
         Just (value, age)
-

--- a/daml-assistant/src/DA/Daml/Assistant/Cache.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Cache.hs
@@ -61,7 +61,7 @@ cacheAvailableSdkVersions damlPath cachePath getVersions = do
         defaultUpdateCheck = UpdateCheckEvery (CacheTimeout 86400)
     case fromMaybe defaultUpdateCheck updateCheckM of
         UpdateCheckNever -> do
-            valueAgeM <- loadFromCacheWith cachePath versionsKey (CacheTimeout 86400) deserializeVersions
+            valueAgeM <- loadFromCacheWith cachePath versionsKey (CacheTimeout 0) deserializeVersions
             pure $ fromMaybe ([], Stale) valueAgeM
 
         UpdateCheckEvery timeout ->

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -172,7 +172,7 @@ refreshAvailableSdkVersions cachePath = do
 
 -- | Same as getAvailableSdkVersions, but result is cached based on the duration
 -- of the update-check value in daml-config.yaml (defaults to 1 day).
-getAvailableSdkVersionsCached :: DamlPath -> CachePath -> IO [SdkVersion]
+getAvailableSdkVersionsCached :: DamlPath -> CachePath -> IO ([SdkVersion], CacheAge)
 getAvailableSdkVersionsCached damlPath cachePath =
     cacheAvailableSdkVersions damlPath cachePath getAvailableSdkVersions
 
@@ -181,8 +181,10 @@ getLatestSdkVersionCached :: DamlPath -> CachePath -> IO (Maybe SdkVersion)
 getLatestSdkVersionCached damlPath cachePath = do
     versionsE <- tryAssistant $ getAvailableSdkVersionsCached damlPath cachePath
     pure $ do
-        versions <- eitherToMaybe versionsE
-        maximumMay versions
+        (versions, age) <- eitherToMaybe versionsE
+        case age of
+            Stale -> Nothing
+            Fresh -> maximumMay versions
 
 -- | Get the latest snapshot SDK version.
 getLatestSdkSnapshotVersion :: IO (Maybe SdkVersion)


### PR DESCRIPTION
This PR changes how DAML_SDK_VERSION_LATEST is computed, so that its
value is never stale (it will be blank instead).

This PR also changes what gets printed in `daml version` to not rely on this
environment variable. It shows the latest available version from `docs.daml.com` instead.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
