### PR TITLE
Drop support for no seeding in sandbox-classic

### DIFF
--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
@@ -49,7 +49,7 @@ trait SandboxFixture extends SandboxNextFixture {
     damlPackages = damlPackages,
     timeProviderType = Some(TimeProviderType.Static),
     engineMode = SandboxConfig.EngineMode.Dev,
-    seeding = Some(Seeding.Weak),
+    seeding = Seeding.Weak,
   )
 
   protected val ClientConfiguration: LedgerClientConfiguration = LedgerClientConfiguration(

--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -229,7 +229,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
       tlsConfig = if (useTls) Some(serverTlsConfig) else None,
       ledgerIdMode = LedgerIdMode.Static(ledgerId),
       authService = authService,
-      seeding = Some(Seeding.Weak),
+      seeding = Seeding.Weak,
     )
 
   private def clientConfig(

--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/util/SandboxTestLedger.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/util/SandboxTestLedger.scala
@@ -43,7 +43,7 @@ trait SandboxTestLedger extends SandboxNextFixture {
     authService = authService,
     scenario = scenario,
     engineMode = SandboxConfig.EngineMode.Dev,
-    seeding = Some(Seeding.Weak),
+    seeding = Seeding.Weak,
   )
 
   def clientCfg(token: Option[String], testName: String): LedgerClientConfiguration =

--- a/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
+++ b/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
@@ -17,7 +17,7 @@ private[sql] final class Cli(
   override protected val parser: OptionParser[SandboxConfig] = {
     val parser =
       new CommonCli(Name)
-        .withContractIdSeeding(defaultConfig, Some(Seeding.Strong), Some(Seeding.Weak))
+        .withContractIdSeeding(defaultConfig, Seeding.Strong, Seeding.Weak)
         .parser
 
     parser

--- a/ledger/daml-on-sql/src/test/lib/scala/on/sql/MainWithEphemeralPostgresql.scala
+++ b/ledger/daml-on-sql/src/test/lib/scala/on/sql/MainWithEphemeralPostgresql.scala
@@ -15,7 +15,7 @@ object MainWithEphemeralPostgresql extends PostgresAround {
     sys.addShutdownHook(disconnectFromPostgresqlServer())
     val defaultConfig: SandboxConfig =
       DefaultConfig.copy(
-        seeding = Some(Seeding.Weak),
+        seeding = Seeding.Weak,
         jdbcUrl = Some(database.url),
       )
     val config = new Cli(defaultConfig).parse(args).getOrElse(sys.exit(1))

--- a/ledger/daml-on-sql/src/test/suite/scala/on/sql/CliSpec.scala
+++ b/ledger/daml-on-sql/src/test/suite/scala/on/sql/CliSpec.scala
@@ -85,7 +85,7 @@ class CliSpec
     "parse the contract-id-seeding mode when given" in {
       checkOption(
         Array("--contract-id-seeding", "testing-weak"),
-        _.copy(seeding = Some(Seeding.Weak)),
+        _.copy(seeding = Seeding.Weak),
       )
     }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/SeedService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/SeedService.scala
@@ -20,8 +20,6 @@ object SeedService {
 
   object Seeding {
 
-    val NoSeedingModeName = "no"
-
     case object Strong extends Seeding("strong")
 
     case object Weak extends Seeding("testing-weak")

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -412,22 +412,6 @@ server_conformance_test(
     ],
 )
 
-# Feature test: --contract-id-seeding=no (legacy contract ids)
-server_conformance_test(
-    name = "conformance-test-legacy-cid",
-    lf_versions = ["legacy"],
-    server_args = [
-        "--contract-id-seeding=no",
-    ],
-    servers = APPEND_ONLY_SCHEMA_SERVERS,
-    test_tool_args = [
-        "--concurrent-test-runs=1",  # sandbox classic doesn't scale well with concurrent tests (almost no effect on overall run time)
-        "--timeout-scale-factor=2",  # sandbox classic is slow in general
-        "--open-world",
-        "--exclude=ClosedWorldIT",
-    ],
-)
-
 # =============================================================================
 # Conformance tests: deprecated ledger backends (in-memory ledger)
 # =============================================================================

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/Cli.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/Cli.scala
@@ -16,10 +16,9 @@ private[sandbox] object Cli extends SandboxCli {
     val parser = new CommonCli(Name).withEarlyAccess.withDevEngine
       .withContractIdSeeding(
         defaultConfig,
-        None,
-        Some(Seeding.Strong),
-        Some(Seeding.Weak),
-        Some(Seeding.Static),
+        Seeding.Strong,
+        Seeding.Weak,
+        Seeding.Static,
       )
       .parser
     parser

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -30,17 +30,12 @@ import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Engine, EngineConfig}
 import com.daml.lf.language.LanguageVersion
-import com.daml.lf.transaction.{
-  LegacyTransactionCommitter,
-  StandardTransactionCommitter,
-  TransactionCommitter,
-}
+import com.daml.lf.transaction.StandardTransactionCommitter
 import com.daml.logging.LoggingContext.newLoggingContextWith
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, MetricsReporting}
-import com.daml.platform.apiserver.SeedService.Seeding
 import com.daml.platform.apiserver._
-import com.daml.platform.configuration.{InvalidConfigException, PartyConfiguration, ServerRole}
+import com.daml.platform.configuration.{PartyConfiguration, ServerRole}
 import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.sandbox.SandboxServer._
 import com.daml.platform.sandbox.banner.Banner
@@ -145,18 +140,12 @@ final class SandboxServer(
     val engineConfig = {
       val allowedLanguageVersions =
         config.engineMode match {
-          case EngineMode.Stable if config.seeding.nonEmpty =>
-            LanguageVersion.StableVersions
           case EngineMode.Stable =>
-            LanguageVersion.LegacyVersions
-          case EngineMode.EarlyAccess if config.seeding.nonEmpty =>
+            LanguageVersion.StableVersions
+          case EngineMode.EarlyAccess =>
             LanguageVersion.EarlyAccessVersions
-          case EngineMode.Dev if config.seeding.nonEmpty =>
+          case EngineMode.Dev =>
             LanguageVersion.DevVersions
-          case mode =>
-            throw new InvalidConfigException(
-              s""""${Seeding.NoSeedingModeName}" contract IDs seeding mode is not compatible with $mode mode"""
-            )
         }
       EngineConfig(
         allowedLanguageVersions = allowedLanguageVersions,
@@ -173,7 +162,7 @@ final class SandboxServer(
     this(DefaultName, config, materializer, new Metrics(new MetricRegistry))
 
   private val authService: AuthService = config.authService.getOrElse(AuthServiceWildcard)
-  private val seedingService = SeedService(config.seeding.getOrElse(Seeding.Weak))
+  private val seedingService = SeedService(config.seeding)
 
   // We store a Future rather than a Resource to avoid keeping old resources around after a reset.
   // It's package-private so we can test that we drop the reference properly in ResetServiceIT.
@@ -251,9 +240,7 @@ final class SandboxServer(
           (ts, Some(ts))
       }
 
-    val transactionCommitter =
-      config.seeding
-        .fold[TransactionCommitter](LegacyTransactionCommitter)(_ => StandardTransactionCommitter)
+    val transactionCommitter = StandardTransactionCommitter
 
     val lfValueTranslationCache =
       LfValueTranslationCache.Cache.newInstrumentedInstance(
@@ -424,7 +411,7 @@ final class SandboxServer(
         timeProviderType.description,
         ledgerType,
         authService.getClass.getSimpleName,
-        config.seeding.fold(Seeding.NoSeedingModeName)(_.name),
+        config.seeding.name,
         if (config.stackTraces) "" else ", stack traces = no",
         config.profileDir match {
           case None => ""
@@ -441,13 +428,6 @@ final class SandboxServer(
         logger.withoutContext.warn(
           """|Using early access mode is dangerous as the backward compatibility of future SDKs is not guaranteed.
              |Should be used for testing purpose only.""".stripMargin
-        )
-      }
-      if (config.seeding.isEmpty) {
-        logger.withoutContext.warn(
-          s"""|'${Seeding.NoSeedingModeName}' contract IDs seeding mode is not compatible with the LF 1.11 languages or later.
-              |A ledger stared with ${Seeding.NoSeedingModeName} contract IDs seeding will refuse to load LF 1.11 language or later.
-              |To make sure you can load LF 1.11, use the option '--contract-id-seeding=strong' to set up the contract IDs seeding mode.""".stripMargin
         )
       }
       apiServer

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/package.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/package.scala
@@ -12,8 +12,7 @@ package object sandbox {
   private[sandbox] val Name = LedgerName("Sandbox")
 
   val DefaultConfig: SandboxConfig = SandboxConfig.defaultConfig.copy(
-    seeding = None,
-    delayBeforeSubmittingLedgerConfiguration = Duration.ZERO,
+    delayBeforeSubmittingLedgerConfiguration = Duration.ZERO
   )
 
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/TransactionCommitter.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/TransactionCommitter.scala
@@ -4,7 +4,6 @@
 package com.daml.lf.transaction
 
 import com.daml.lf.data.Ref
-import com.daml.lf.value.Value
 
 // Convert a SubmittedTransaction to CommittedTransaction
 abstract class TransactionCommitter {
@@ -21,28 +20,4 @@ object StandardTransactionCommitter extends TransactionCommitter {
       transaction: SubmittedTransaction,
   ): CommittedTransaction =
     Transaction.commitTransaction(transaction)
-}
-
-// Committer emulating Contract ID legacy scheme
-object LegacyTransactionCommitter extends TransactionCommitter {
-
-  def commitTransaction(
-      transactionId: Ref.LedgerString,
-      transaction: SubmittedTransaction,
-  ): CommittedTransaction = {
-
-    val prefix = "#" + transactionId + ":"
-
-    val contractMapping =
-      transaction
-        .localContracts[Value.ContractId]
-        .transform { case (_, (nid, _)) =>
-          Value.ContractId.V0(Ref.ContractIdString.assertFromString(prefix + nid.index.toString))
-        }
-        .withDefault(identity)
-
-    CommittedTransaction(transaction.mapCid(contractMapping))
-
-  }
-
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/CliSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/CliSpec.scala
@@ -42,13 +42,7 @@ class CliSpec extends CommonCliSpecBase(Cli) {
     }
 
     "parse the contract-id-seeding mode when given" in {
-      checkOption(Array("--contract-id-seeding", "strong"), _.copy(seeding = Some(Seeding.Strong)))
-    }
-
-    "use no seeding by default" in {
-      // do not change the default seeding of sandbox classic without
-      // formal agreement of Bernhard Elsner.
-      cli.defaultConfig.seeding shouldBe None
+      checkOption(Array("--contract-id-seeding", "strong"), _.copy(seeding = Seeding.Strong))
     }
   }
 

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/EngineModeIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/EngineModeIT.scala
@@ -114,7 +114,7 @@ class EngineModeIT
         DefaultConfig.copy(
           port = Port.Dynamic,
           engineMode = mode,
-          seeding = Some(Seeding.Weak),
+          seeding = Seeding.Weak,
         )
       )
 

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -25,7 +25,7 @@ import com.daml.lf.archive.DarParser
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.engine.Engine
-import com.daml.lf.transaction.LegacyTransactionCommitter
+import com.daml.lf.transaction.StandardTransactionCommitter
 import com.daml.lf.transaction.test.TransactionBuilder.EmptySubmitted
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
@@ -449,7 +449,7 @@ final class SqlLedgerSpec
             .fold(sys.error, identity),
           initialLedgerEntries = ImmArray.Empty,
           queueDepth = queueDepth,
-          transactionCommitter = LegacyTransactionCommitter,
+          transactionCommitter = StandardTransactionCommitter,
           eventsPageSize = 100,
           eventsProcessingParallelism = 8,
           acsIdPageSize = 2000,

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -433,13 +433,12 @@ class CommonCliBase(name: LedgerName) {
 
   def withContractIdSeeding(
       defaultConfig: SandboxConfig,
-      seedingModes: Option[Seeding]*
+      seedingModes: Seeding*
   ): CommonCliBase = {
     val seedingModesMap =
-      seedingModes.map(mode => (mode.map(_.name).getOrElse(Seeding.NoSeedingModeName), mode)).toMap
+      seedingModes.map(mode => (mode.name, mode)).toMap
     val allSeedingModeNames = seedingModesMap.keys.mkString(", ")
-    val defaultSeedingModeName =
-      defaultConfig.seeding.map(_.name).getOrElse(Seeding.NoSeedingModeName)
+    val defaultSeedingModeName = defaultConfig.seeding.name
     parser
       .opt[String]("contract-id-seeding")
       .optional()

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -53,7 +53,7 @@ final case class SandboxConfig(
     eagerPackageLoading: Boolean,
     logLevel: Option[Level],
     authService: Option[AuthService],
-    seeding: Option[Seeding],
+    seeding: Seeding,
     metricsReporter: Option[MetricsReporter],
     metricsReportingInterval: FiniteDuration,
     maxParallelSubmissions: Int, // only used by Sandbox Classic
@@ -156,7 +156,7 @@ object SandboxConfig {
       eagerPackageLoading = false,
       logLevel = None, // the default is in logback.xml
       authService = None,
-      seeding = Some(Seeding.Strong),
+      seeding = Seeding.Strong,
       metricsReporter = None,
       metricsReportingInterval = 10.seconds,
       maxParallelSubmissions = 512,

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/AbstractSandboxFixture.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/AbstractSandboxFixture.scala
@@ -67,7 +67,7 @@ trait AbstractSandboxFixture extends AkkaBeforeAndAfterAll {
       timeProviderType = Some(TimeProviderType.Static),
       scenario = scenario,
       ledgerIdMode = LedgerIdMode.Static(LedgerId("sandbox-server")),
-      seeding = Some(Seeding.Weak),
+      seeding = Seeding.Weak,
       engineMode = SandboxConfig.EngineMode.Dev,
       authService = authService,
     )

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Cli.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Cli.scala
@@ -16,9 +16,9 @@ private[sandboxnext] object Cli extends SandboxCli {
     val parser = new CommonCli(Name).withEarlyAccess.withDevEngine
       .withContractIdSeeding(
         defaultConfig,
-        Some(Seeding.Strong),
-        Some(Seeding.Weak),
-        Some(Seeding.Static),
+        Seeding.Strong,
+        Seeding.Weak,
+        Seeding.Static,
       )
       .parser
 

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -154,7 +154,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
           jdbcUrl = ledgerJdbcUrl,
           resetOnStartup = false,
           offsetVersion = 0,
-          logEntryIdAllocator = new SeedServiceLogEntryIdAllocator(SeedService(config.seeding.get)),
+          logEntryIdAllocator = new SeedServiceLogEntryIdAllocator(SeedService(config.seeding)),
           stateValueCache = caching.WeightedCache.from(
             caching.WeightedCache.Configuration(
               maximumWeight = MaximumStateValueCacheSize
@@ -217,7 +217,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
           eventsPageSize = config.eventsPageSize,
           portFile = config.portFile,
           // TODO append-only: augment the following defaults for enabling the features for sandbox next
-          seeding = config.seeding.get,
+          seeding = config.seeding,
           managementServiceTimeout = config.managementServiceTimeout,
           maxContractStateCacheSize = 0L,
           maxContractKeyStateCacheSize = 0L,
@@ -296,7 +296,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
           timeProviderType.description,
           ledgerType,
           authService.getClass.getSimpleName,
-          config.seeding.get.name,
+          config.seeding.name,
           if (config.stackTraces) "" else ", stack traces = no",
           config.profileDir match {
             case None => ""

--- a/ledger/sandbox/src/test/suite/scala/platform/sandboxnext/CliSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/platform/sandboxnext/CliSpec.scala
@@ -30,7 +30,7 @@ class CliSpec extends CommonCliSpecBase(Cli) {
     "parse the contract-id-seeding mode when given" in {
       checkOption(
         Array("--contract-id-seeding", "testing-weak"),
-        _.copy(seeding = Some(Seeding.Weak)),
+        _.copy(seeding = Seeding.Weak),
       )
     }
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -266,7 +266,7 @@ trait SandboxFixture extends BeforeAndAfterAll with AbstractAuthFixture with Akk
     timeProviderType = Some(TimeProviderType.Static),
     delayBeforeSubmittingLedgerConfiguration = JDuration.ZERO,
     authService = authService,
-    seeding = Some(Seeding.Weak),
+    seeding = Seeding.Weak,
   )
 
   protected lazy val sandboxPort: Port = resource.value._1


### PR DESCRIPTION
Sandbox classic is going away in SDK 2.0 and so is support for v0
contract ids which is the only thing no seeding was used for.

This has been cleared by product.

I’ll drop v0 contract ids completely in #12464 as a follow-up. Just
wanted to factor this out for ease of review.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
