### PR TITLE
Add --port-file and --dar flags in daml sandbox

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -4,7 +4,7 @@
 module DA.Daml.Helper.Main (main) where
 
 import Control.Exception.Safe
-import Control.Monad
+import Control.Monad.Extra
 import DA.Bazel.Runfiles
 import Data.Foldable
 import Data.List.Extra
@@ -12,8 +12,9 @@ import Numeric.Natural
 import Options.Applicative.Extended
 import System.Environment
 import System.Exit
-import System.IO
+import System.IO.Extra
 import System.Process (showCommandForUser)
+import System.Process.Typed (unsafeProcessHandle)
 import Text.Read (readMaybe)
 
 import DA.Signals
@@ -24,6 +25,7 @@ import DA.Daml.Helper.Start
 import DA.Daml.Helper.Studio
 import DA.Daml.Helper.Util
 import DA.Daml.Helper.Codegen
+import DA.PortFile
 
 main :: IO ()
 main = do
@@ -70,9 +72,11 @@ data Command
     | Codegen { lang :: Lang, remainingArguments :: [String] }
     | PackagesList {flags :: LedgerFlags}
     | CantonSandbox
-      { ports :: CantonOptions
-      , remainingArguments :: [String]
-      }
+        { cantonOptions :: CantonOptions
+        , portFileM :: Maybe FilePath
+        , darPathM :: Maybe FilePath
+        , remainingArguments :: [String]
+        }
 
 data AppTemplate
   = AppTemplateDefault
@@ -408,15 +412,22 @@ commandParser = subparser $ fold
         , help "Timeout of gRPC operations in seconds. Defaults to 60s. Must be > 0."
         ]
 
-    cantonSandboxCmd = CantonSandbox
-      <$> (CantonOptions
-             <$> option auto (long "port" <> value 6865)
-             <*> option auto (long "admin-api-port" <> value 6866)
-             <*> option auto (long "domain-public-port" <> value 6867)
-             <*> option auto (long "domain-admin-port" <> value 6868)
-             <*> optional (option str (long "port-file" <> metavar "PATH"))
-             <*> (StaticTime <$> switch (long "static-time")))
-      <*> many (argument str (metavar "ARG"))
+    cantonSandboxCmd = do
+        cantonOptions <- do
+            cantonLedgerApi <- option auto (long "port" <> value 6865)
+            cantonAdminApi <- option auto (long "admin-api-port" <> value 6866)
+            cantonDomainPublicApi <- option auto (long "domain-public-port" <> value 6867)
+            cantonDomainAdminApi <- option auto (long "domain-admin-port" <> value 6868)
+            cantonPortFileM <- optional $ option str (long "canton-port-file" <> metavar "PATH"
+                <> help "File to write canton participant ports when ready")
+            cantonStaticTime <- StaticTime <$> switch (long "static-time")
+            pure CantonOptions{..}
+        portFileM <- optional $ option str (long "port-file" <> metavar "PATH"
+            <> help "File to write ledger API port when ready")
+        darPathM <- optional $ option str (long "dar" <> metavar "PATH"
+            <> help "DAR file to upload to sandbox")
+        remainingArguments <- many (argument str (metavar "ARG"))
+        pure CantonSandbox {..}
 
     cantonSandboxCmdInfo =
         forwardOptions
@@ -459,4 +470,16 @@ runCommand = \case
     LedgerExport {..} -> runLedgerExport flags remainingArguments
     LedgerNavigator {..} -> runLedgerNavigator flags remainingArguments
     Codegen {..} -> runCodegen lang remainingArguments
-    CantonSandbox {..} -> runCantonSandbox ports remainingArguments
+    CantonSandbox {..} ->
+        withCantonPortFile cantonOptions $ \cantonOptions cantonPortFile ->
+            withCantonSandbox cantonOptions remainingArguments $ \ph -> do
+                putStrLn "Starting Canton sandbox."
+                sandboxPort <- readPortFileWith decodeCantonSandboxPort (unsafeProcessHandle ph) maxRetries cantonPortFile
+                putStrLn ("Listening at port " <> show sandboxPort)
+                whenJust darPathM $ \darPath -> do
+                    putStrLn ("Uploading DAR file " <> darPath)
+                    runLedgerUploadDar ((defaultLedgerFlags Grpc) {fPortM = Just sandboxPort}) (Just darPath)
+                whenJust portFileM $ \portFile -> do
+                    putStrLn ("Writing ledger API port file " <> portFile)
+                    writeFileUTF8 portFile (show sandboxPort)
+                putStrLn "Canton sandbox is ready."

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -477,9 +477,8 @@ runCommand = \case
                 sandboxPort <- readPortFileWith decodeCantonSandboxPort (unsafeProcessHandle ph) maxRetries cantonPortFile
                 putStrLn ("Listening at port " <> show sandboxPort)
                 whenJust darPathM $ \darPath -> do
-                    putStrLn ("Uploading DAR file " <> darPath)
                     runLedgerUploadDar ((defaultLedgerFlags Grpc) {fPortM = Just sandboxPort}) (Just darPath)
                 whenJust portFileM $ \portFile -> do
-                    putStrLn ("Writing ledger API port file " <> portFile)
+                    putStrLn ("Writing ledger API port to " <> portFile)
                     writeFileUTF8 portFile (show sandboxPort)
                 putStrLn "Canton sandbox is ready."

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -79,12 +79,12 @@ getPortForSandbox defaultPortSpec portSpecM =
 
 determineCantonOptions :: Maybe SandboxPortSpec -> SandboxCantonPortSpec -> FilePath -> IO CantonOptions
 determineCantonOptions ledgerApiSpec SandboxCantonPortSpec{..} portFile = do
-    ledgerApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6865)) ledgerApiSpec
-    adminApi <- getPortForSandbox FreePort adminApiSpec
-    domainPublicApi <- getPortForSandbox FreePort domainPublicApiSpec
-    domainAdminApi <- getPortForSandbox FreePort domainAdminApiSpec
-    let portFileM = Just portFile -- TODO allow canton port file to be passed in from command line?
-    let staticTime = StaticTime False
+    cantonLedgerApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6865)) ledgerApiSpec
+    cantonAdminApi <- getPortForSandbox FreePort adminApiSpec
+    cantonDomainPublicApi <- getPortForSandbox FreePort domainPublicApiSpec
+    cantonDomainAdminApi <- getPortForSandbox FreePort domainAdminApiSpec
+    let cantonPortFileM = Just portFile -- TODO allow canton port file to be passed in from command line?
+    let cantonStaticTime = StaticTime False
     pure CantonOptions {..}
 
 withSandbox :: StartOptions -> FilePath -> [String] -> [String] -> (Process () () () -> SandboxPort -> IO a) -> IO a

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -194,17 +194,14 @@ quickSandbox projDir = do
                         , "--domain-public-port", show domainPublicApiPort
                         , "--domain-admin-port", show domainAdminApiPort
                         , "--port-file", portFile
-                        , "--static-time"
+                        , "--dar", darFile
+                        -- , "--static-time"
+                            -- TODO https://github.com/digital-asset/daml/issues/11831
+                            --   Re-enable once sim-clock is working.
                         ])
                     {std_out = UseHandle devNull, create_group = True, cwd = Just projDir}
         (_, _, _, sandboxPh) <- createProcess sandboxProc
-        _ <- readPortFileWith decodeCantonSandboxPort sandboxPh maxRetries (projDir </> portFile)
-        callCommandSilentIn projDir $ unwords
-             [ "daml ledger upload-dar"
-             , "--host=localhost"
-             , "--port=" <> show sandboxPort
-             , darFile
-             ]
+        _ <- readPortFile sandboxPh maxRetries (projDir </> portFile)
         pure $
             QuickSandboxResource
                 { quickProjDir = projDir
@@ -801,7 +798,7 @@ cantonTests = testGroup "daml sandbox"
         , "--admin-api-port", show adminApiPort
         , "--domain-public-port", show domainPublicApiPort
         , "--domain-admin-port", show domainAdminApiPort
-        , "--port-file", portFile
+        , "--canton-port-file", portFile
         ] $ \ ph -> do
         -- wait for port file to be written
         _ <- readPortFileWith decodeCantonSandboxPort ph maxRetries portFile


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/11831

This PR is just to make it easier to migrate to the new sandbox.
I changed the behavior of --port-file to output a simple port (the
old behavior can be obtained with --canton-port-file instead, which
outputs all the port files of each participant), and I added a --dar
option to upload a dar after setting up the sandbox.

In addition, I made the `daml sandbox` command output something on
startup & success. The previous version was completely silent, so
you couldn't tell just from running it whether it was succesful.

However, I did discover that `--static-time` was accidentally
a no-op. Upon enabling it, I find that sim-clock doesn't work,
it causes canton to hang. This seems like a canton issue, but
needs further investigation.

For testing, I'm using --port-file and --dar in the quickstart
integration test, and --canton-port-file in the other canton
sandbox test.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
