### PR TITLE
Tell users to use --install-assistant=yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ On Windows:
 bazel build //release:sdk-release-tarball
 tar -vxf .\bazel-bin\release\sdk-release-tarball-ce.tar.gz
 cd sdk-*
-daml\daml.exe install . --activate
+daml\daml.exe install . --install-assistant=yes
 ```
 
 That should tell you what to put in the path, something along the lines of `C:\Users\admin\AppData\Roaming\daml\bin`.

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -503,12 +503,12 @@ uninstallVersion Env{..} sdkVersion = wrapErr "Uninstalling SDK version." $ do
     if exists then do
         when (Just (DamlAssistantSdkVersion sdkVersion) == envDamlAssistantSdkVersion) $ do
             hPutStr stderr . unlines $
-                [ "Cannot uninstall currently activated SDK version."
-                , "Please activate a different SDK version and try again."
-                , "To activate a different version, run:"
+                [ "Cannot uninstall SDK version of daml assistant."
+                , "Please switch to a different version of daml assistant and try again."
+                , "To switch to a different version of daml assistant, use:"
                 , ""
                 , "    daml install VERSION --install-assistant=yes"
-                ] -- TODO (FAFM): suggest a version that will work.
+                ] -- TODO: suggest a version that will work.
             exitFailure
 
         requiredIO "Failed to set write permission for SDK files to remove." $ do

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -503,7 +503,7 @@ uninstallVersion Env{..} sdkVersion = wrapErr "Uninstalling SDK version." $ do
     if exists then do
         when (Just (DamlAssistantSdkVersion sdkVersion) == envDamlAssistantSdkVersion) $ do
             hPutStr stderr . unlines $
-                [ "Cannot uninstall SDK version of daml assistant."
+                [ "Cannot uninstall SDK version of current daml assistant."
                 , "Please switch to a different version of daml assistant and try again."
                 , "To switch to a different version of daml assistant, use:"
                 , ""

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -507,7 +507,7 @@ uninstallVersion Env{..} sdkVersion = wrapErr "Uninstalling SDK version." $ do
                 , "Please activate a different SDK version and try again."
                 , "To activate a different version, run:"
                 , ""
-                , "    daml install VERSION --activate"
+                , "    daml install VERSION --install-assistant=yes"
                 ] -- TODO (FAFM): suggest a version that will work.
             exitFailure
 

--- a/language-support/hs/bindings/examples/nim/demo.md
+++ b/language-support/hs/bindings/examples/nim/demo.md
@@ -11,7 +11,7 @@ Notes on the format of this file:
 
     $ cd daml
     $ bazel build language-support/hs/bindings/examples/nim/...
-    $ daml install latest --activate
+    $ daml install latest --install-assistant=yes
 
 ## 1. Look at [Nim.daml](https://github.com/digital-asset/daml/blob/main/language-support/hs/bindings/examples/nim/daml/Nim.daml)
 


### PR DESCRIPTION
`daml install --activate` is deprecated since forever, we should tell
users to use `daml install --install-assistant=yes` instead.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
