### PR TITLE
Use canton sandbox in script and trigger compat tests

### DIFF
--- a/bazel_tools/client_server/client_server_test.bzl
+++ b/bazel_tools/client_server/client_server_test.bzl
@@ -19,6 +19,7 @@ def client_server_test(
         server = None,
         server_args = [],
         server_files = [],
+        server_files_prefix = "",
         data = [],
         **kwargs):
     """Create a client-server test.
@@ -65,7 +66,7 @@ client=$$(canonicalize_rlocation $$(get_exe $(rootpaths {client})))
 server=$$(canonicalize_rlocation $$(get_exe $(rootpaths {server})))
 server_args="{server_args}"
 for file in {server_files}; do
-    server_args+=" $$(canonicalize_rlocation $$file)"
+    server_args+=" {server_files_prefix}$$(canonicalize_rlocation $$file)"
 done
 
 client_args="$$@"
@@ -86,6 +87,7 @@ $$runner $$client "$$client_args" $$server "$$server_args" "$$runner_args"
             server = server,
             server_args = _escape_args(server_args),
             server_files = _escape_args(server_files),
+            server_files_prefix = server_files_prefix,
         ),
         **kwargs
     )

--- a/compatibility/bazel_tools/daml_script/daml_script.bzl
+++ b/compatibility/bazel_tools/daml_script/daml_script.bzl
@@ -83,9 +83,10 @@ def daml_script_test(compiler_version, runner_version):
         runner = "//bazel_tools/client_server:runner",
         runner_args = ["6865"],
         server = daml_runner,
-        server_args = ["sandbox-kv" if versions.is_at_least("2.0.0", runner_version) else "sandbox"],
+        server_args = ["sandbox"],
         server_files = [
             "$(rootpath {})".format(compiled_dar),
         ],
+        server_files_prefix = "--dar=" if versions.is_at_least("2.0.0", runner_version) else "",
         tags = ["exclusive"],
     )

--- a/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
+++ b/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
@@ -191,9 +191,10 @@ chmod +x $(OUTS)
         runner = "//bazel_tools/client_server:runner",
         runner_args = ["6865"],
         server = daml_runner,
-        server_args = ["sandbox-kv" if versions.is_at_least("2.0.0", runner_version) else "sandbox"],
+        server_args = ["sandbox"],
         server_files = [
             "$(rootpath {})".format(compiled_dar),
         ],
+        server_files_prefix = "--dar=" if versions.is_at_least("2.0.0", runner_version) else "",
         tags = ["exclusive"],
     )

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -7,6 +7,7 @@ module DA.Daml.Helper.Ledger (
     LedgerFlags(..),
     RemoteDalf(..),
     defaultLedgerFlags,
+    sandboxLedgerFlags,
     getDefaultArgs,
     LedgerApi(..),
     L.ClientSSLConfig(..),
@@ -101,6 +102,12 @@ defaultLedgerFlags api = LedgerFlags
   , fPortM = Nothing
   , fTokFileM = Nothing
   , fMaxReceiveLengthM = Nothing
+  }
+
+sandboxLedgerFlags :: Int -> LedgerFlags
+sandboxLedgerFlags port = (defaultLedgerFlags Grpc)
+  { fHostM = Just "localhost"
+  , fPortM = Just port
   }
 
 data LedgerArgs = LedgerArgs

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -477,7 +477,7 @@ runCommand = \case
                 sandboxPort <- readPortFileWith decodeCantonSandboxPort (unsafeProcessHandle ph) maxRetries cantonPortFile
                 putStrLn ("Listening at port " <> show sandboxPort)
                 forM_ darPaths $ \darPath -> do
-                    runLedgerUploadDar ((defaultLedgerFlags Grpc) {fPortM = Just sandboxPort}) (Just darPath)
+                    runLedgerUploadDar (sandboxLedgerFlags sandboxPort) (Just darPath)
                 whenJust portFileM $ \portFile -> do
                     putStrLn ("Writing ledger API port to " <> portFile)
                     writeFileUTF8 portFile (show sandboxPort)

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -100,7 +100,7 @@ withSandbox StartOptions{..} darPath scenarioArgs sandboxArgs kont =
       withCantonSandbox cantonOptions sandboxArgs $ \ph -> do
         putStrLn "Waiting for canton sandbox to start."
         sandboxPort <- readPortFileWith decodeCantonSandboxPort (unsafeProcessHandle ph) maxRetries portFile
-        runLedgerUploadDar ((defaultLedgerFlags Grpc) {fPortM = Just sandboxPort}) (Just darPath)
+        runLedgerUploadDar (sandboxLedgerFlags sandboxPort) (Just darPath)
         kont ph (SandboxPort sandboxPort)
 
     oldSandbox sandbox = withTempDir $ \tempDir -> do
@@ -268,9 +268,9 @@ runStart startOptions@StartOptions{..} =
             whenJust mbOutputPath $ \_outputPath -> do
               runCodegen lang []
         doReset (SandboxPort sandboxPort) =
-          runLedgerReset $ (defaultLedgerFlags Grpc) {fPortM = Just sandboxPort}
+          runLedgerReset (sandboxLedgerFlags sandboxPort)
         doUploadDar darPath (SandboxPort sandboxPort) =
-          runLedgerUploadDar ((defaultLedgerFlags Grpc) {fPortM = Just sandboxPort}) (Just darPath)
+          runLedgerUploadDar (sandboxLedgerFlags sandboxPort) (Just darPath)
         listenForKeyPress projectConfig darPath sandboxPort runInitScript = do
           hSetBuffering stdin NoBuffering
           void $


### PR DESCRIPTION
Part of #11831. This kills another two uses of sandbox-kv.

Also fixes a daml-helper issue where we weren't passing "localhost" to the
ledger flags, so it was complaining about starting outside of a project.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
