### PR TITLE
Drop feature flag for v0 cid support

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -76,13 +76,7 @@ enum CommandDeduplicationType {
 
 // See `daml-lf/spec/contract-id.rst` for more information on contract ID formats.
 message ExperimentalContractIds {
-  ContractIdV0Support v0 = 1;
-  ContractIdV1Support v1 = 2;
-
-  enum ContractIdV0Support {
-    NOT_SUPPORTED = 0;
-    SUPPORTED = 1;
-  }
+  ContractIdV1Support v1 = 1;
 
   enum ContractIdV1Support {
     // Contract IDs must be suffixed.

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractIdIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractIdIT.scala
@@ -30,19 +30,12 @@ import scala.util.{Failure, Success, Try}
 // - Distributed ledger implementations (e.g. Canton) must reject non-suffixed CID
 final class ContractIdIT extends LedgerTestSuite {
   List(
-    TestConfiguration(
-      description = "v0",
-      example = v0Cid,
-      accepted = true,
-      isSupported = features => features.contractIds.v0.isSupported,
-      disabledReason = "V0 contract IDs are not supported",
-    ),
+    // Support for v0 contract ids existed only in sandbox-classic in
+    // SDK 1.18 and older and has been dropped completely.
     TestConfiguration(
       description = "v0",
       example = v0Cid,
       accepted = false,
-      isSupported = features => features.contractIds.v0.isNotSupported,
-      disabledReason = "V0 contract IDs are supported",
     ),
     TestConfiguration(
       description = "non-suffixed v1",

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -220,7 +220,7 @@ final class Runner[T <: ReadWriteService, Extra](
                       maxDeduplicationDurationEnforced = true,
                     ),
                     contractIdFeatures = ExperimentalContractIds.of(
-                      v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED,
+                      v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED
                     ),
                   ),
                 ).acquire()

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -220,7 +220,6 @@ final class Runner[T <: ReadWriteService, Extra](
                       maxDeduplicationDurationEnforced = true,
                     ),
                     contractIdFeatures = ExperimentalContractIds.of(
-                      v0 = ExperimentalContractIds.ContractIdV0Support.NOT_SUPPORTED,
                       v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED,
                     ),
                   ),

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
@@ -248,7 +248,7 @@ object SandboxOnXRunner {
           maxDeduplicationDurationEnforced = false,
         ),
         contractIdFeatures = ExperimentalContractIds.of(
-          v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED,
+          v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED
         ),
       ),
     )

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
@@ -248,7 +248,6 @@ object SandboxOnXRunner {
           maxDeduplicationDurationEnforced = false,
         ),
         contractIdFeatures = ExperimentalContractIds.of(
-          v0 = ExperimentalContractIds.ContractIdV0Support.NOT_SUPPORTED,
           v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED,
         ),
       ),

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -287,7 +287,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
               maxDeduplicationDurationEnforced = true,
             ),
             contractIdFeatures = ExperimentalContractIds.of(
-              v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED,
+              v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED
             ),
           ),
         )

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -287,7 +287,6 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
               maxDeduplicationDurationEnforced = true,
             ),
             contractIdFeatures = ExperimentalContractIds.of(
-              v0 = ExperimentalContractIds.ContractIdV0Support.NOT_SUPPORTED,
               v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED,
             ),
           ),


### PR DESCRIPTION
I’ve kept it on the same test infrastructure that we used before that
can test both ways since it seems nicer to keep this consistent with v1.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
