### PR TITLE
Upgrade to oracle 19.14 image for ci

### DIFF
--- a/ci/oracle_image
+++ b/ci/oracle_image
@@ -1,1 +1,1 @@
-digitalasset/oracle:enterprise-19.12.0-preloaded-20210817-24-6f020d6
+digitalasset/oracle:enterprise-19.14.0-preloaded-20220120-27-36701e3


### PR DESCRIPTION
Oracle has just released their Jan bi-monthly patch -- this upgrades CI to test with that (19.14)