### PR TITLE
Startup initialization header for runners [DPP-860]

### DIFF
--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionContext
 private[memory] class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state: InMemoryState)
     extends LedgerFactory[Unit] {
 
-  override def ledgerType: String = "in-memory ledger"
+  override def ledgerName: String = "in-memory ledger"
 
   override def readWriteServiceFactoryOwner(
       config: Config[Unit],

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
@@ -27,6 +27,8 @@ import scala.concurrent.ExecutionContext
 private[memory] class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state: InMemoryState)
     extends LedgerFactory[Unit] {
 
+  override def ledgerType: String = "in-memory ledger"
+
   override def readWriteServiceFactoryOwner(
       config: Config[Unit],
       participantConfig: ParticipantConfig,

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -23,6 +23,7 @@ import scopt.OptionParser
 import scala.concurrent.ExecutionContext
 
 object SqlLedgerFactory extends LedgerFactory[ExtraConfig] {
+  override def ledgerType: String = "SQL ledger"
 
   override def readWriteServiceFactoryOwner(
       config: Config[ExtraConfig],

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -23,7 +23,7 @@ import scopt.OptionParser
 import scala.concurrent.ExecutionContext
 
 object SqlLedgerFactory extends LedgerFactory[ExtraConfig] {
-  override def ledgerType: String = "SQL ledger"
+  override def ledgerName: String = "SQL ledger"
 
   override def readWriteServiceFactoryOwner(
       config: Config[ExtraConfig],

--- a/ledger/participant-state/kvutils/app/BUILD.bazel
+++ b/ledger/participant-state/kvutils/app/BUILD.bazel
@@ -45,6 +45,7 @@ da_scala_library(
         "//ledger/participant-state-index",
         "//ledger/participant-state-metrics",
         "//ledger/participant-state/kvutils",
+        "//libs-scala/build-info",
         "//libs-scala/contextualized-logging",
         "//libs-scala/logging-entries",
         "//libs-scala/ports",
@@ -53,6 +54,7 @@ da_scala_library(
         "//libs-scala/resources-grpc",
         "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_netty_netty_handler",
+        "@maven//:org_slf4j_slf4j_api",
     ],
 )
 

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -26,7 +26,7 @@ import com.daml.platform.server.api.validation.{DeduplicationPeriodValidator, Er
 import scala.concurrent.ExecutionContext
 
 trait LedgerFactory[ExtraConfig] {
-  def ledgerType: String
+  def ledgerName: String
   def readWriteServiceFactoryOwner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -26,6 +26,7 @@ import com.daml.platform.server.api.validation.{DeduplicationPeriodValidator, Er
 import scala.concurrent.ExecutionContext
 
 trait LedgerFactory[ExtraConfig] {
+  def ledgerType: String
   def readWriteServiceFactoryOwner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantRunMode.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantRunMode.scala
@@ -8,12 +8,18 @@ sealed abstract class ParticipantRunMode
 object ParticipantRunMode {
 
   /** Run the full participant, including both the indexer and ledger API server */
-  case object Combined extends ParticipantRunMode
+  case object Combined extends ParticipantRunMode {
+    override def toString: String = "combined"
+  }
 
   /** Run only the indexer */
-  case object Indexer extends ParticipantRunMode
+  case object Indexer extends ParticipantRunMode {
+    override def toString: String = "indexer"
+  }
 
   /** Run only the ledger API server */
-  case object LedgerApiServer extends ParticipantRunMode
+  case object LedgerApiServer extends ParticipantRunMode {
+    override def toString: String = "ledger-api"
+  }
 
 }

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -98,11 +98,12 @@ final class Runner[T <: ReadWriteService, Extra](
       )
       .mkString("\n")
     logger.withoutContext.info(
-      s"Initialized {} version {} with ledger-id = {}, ledger = {}, allowed language versions = {}, contract ids seeding = {} with participants: \n{},",
+      s"Initialized {} version {} with ledger-id = {}, ledger = {}, allowed language versions = {}, auth service = {}, contract ids seeding = {} with participants: \n{},",
       name,
       BuildInfo.Version,
       config.ledgerId,
       factory.ledgerType,
+      configProvider.authService(config),
       s"[min = ${config.allowedLanguageVersions.min}, max = ${config.allowedLanguageVersions.max}]",
       config.seeding,
       participantsInitializationText,

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/RunnerSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/RunnerSpec.scala
@@ -212,6 +212,8 @@ object RunnerSpec {
       Timestamp.Epoch,
     )
 
+    override def ledgerType: String = "test ledger"
+
     // This is quite sophisticated because it needs to provision a configuration, and so needs a
     // basic implementation of the write->read flow, at least for configuration updates.
     //

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/RunnerSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/RunnerSpec.scala
@@ -212,7 +212,7 @@ object RunnerSpec {
       Timestamp.Epoch,
     )
 
-    override def ledgerType: String = "test ledger"
+    override def ledgerName: String = "test ledger"
 
     // This is quite sophisticated because it needs to provision a configuration, and so needs a
     // basic implementation of the write->read flow, at least for configuration updates.

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -52,6 +52,7 @@ da_scala_library(
         "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",
         "//libs-scala/logging-entries",
+        "//libs-scala/ports",
         "//libs-scala/resources",
         "//libs-scala/resources-akka",
         "//libs-scala/resources-grpc",
@@ -59,6 +60,7 @@ da_scala_library(
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_dropwizard_metrics_metrics_core",
+        "@maven//:org_slf4j_slf4j_api",
     ],
 )
 

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -48,6 +48,7 @@ da_scala_library(
         "//ledger/participant-state-metrics",
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils/app",
+        "//libs-scala/build-info",
         "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",
         "//libs-scala/logging-entries",


### PR DESCRIPTION
This PR adds a start-up header for Sandbox-on-X runner and kvutils Runner.

Example initialization log for `kvutils.Runner` running in split-participant:
```
12:55:27.927 [program-resource-pool-3] INFO  c.d.l.p.state.kvutils.app.Runner - Initialized In-Memory Ledger version 0.0.0 with ledger-id = e3745852-0484-4245-9eae-b6e9b20454c7, ledger = in-memory ledger, allowed language versions = [min = LanguageVersion(V1,LanguageMinorVersion(6)), max = LanguageVersion(V1,LanguageMinorVersion(14))], authentication = all unauthenticated allowed, contract ids seeding = testing-weak with participants: [{participant-id = split-example, run-mode = ledger-api, port = 6865}, {participant-id = split-example, run-mode = indexer, port = 6865}]
```

Example initialization log for `SandboxOnXRunner`:
```
13:58:01.370 [program-resource-pool-3] INFO  c.d.ledger.sandbox.SandboxOnXRunner - Initialized sandbox-on-x with pass-through ledger bridge (no conflict checking), version 0.0.0, run-mode = combined participant, participant-id = test, ledger-id = f44d53be-17a3-4e90-8130-c44d8d8e4ddd, port = 6865, time mode = wall-clock time, allowed language versions = [min = LanguageVersion(V1,LanguageMinorVersion(6)), max = LanguageVersion(V1,LanguageMinorVersion(14))], authentication = all unauthenticated allowed, contract ids seeding = testing-weak
```

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
