### PR TITLE
compatibility: Disable MultiParticipantIT for old versions. [KVL-1261]

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -687,6 +687,18 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        # The test requires the "definite_answer" gRPC error metadata entry, which is not present in old releases.
+        "start": "2.0.0-snapshot.20220118.8919.1",
+        "platform_ranges": [
+            {
+                "end": "1.16.0",
+                "exclusions": [
+                    "MultiPartySubmissionIT",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):


### PR DESCRIPTION
They don't support the `definite_answer` gRPC error metadata entry.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
