### PR TITLE
user management: allow ':' in user ids

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
@@ -353,7 +353,7 @@ private[data] final class IdStringImpl extends IdString {
     new ConcatenableMatchingStringModule("Application ID", "._:-#/!|@^$`+'~ ", 255)
 
   /** Identifiers for participant node users are non-empty strings with a length <= 128 that consist of
-    * lowercase ASCII alphanumeric characters and the symbols "@^$.!`-#+'~_|".
+    * lowercase ASCII alphanumeric characters and the symbols "@^$.!`-#+'~_|:".
     * This character set is chosen such that it maximizes the ease of integration with IAM systems, while removing
     * the ambiguity of allowing both "john" and "John" as separate user names.
     * Concretely, the character set contains the Auth0 allowed characters (https://auth0.com/docs/authenticate/database-connections/require-username#allowed-characters)
@@ -361,6 +361,6 @@ private[data] final class IdStringImpl extends IdString {
     */
   override type UserId = String
   override val UserId: StringModule[UserId] =
-    new MatchingStringModule("User ID", """[a-z0-9@^$.!`\-#+'~_|]{1,128}""")
+    new MatchingStringModule("User ID", """[a-z0-9@^$.!`\-#+'~_|:]{1,128}""")
 
 }

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
@@ -294,7 +294,7 @@ class RefTest extends AnyFreeSpec with Matchers with EitherValues {
   }
 
   "UserId" - {
-    val validCharacters = "abcdefghijklmnopqrstuvwxyz0123456789._-#!|@^$`+'~"
+    val validCharacters = "abcdefghijklmnopqrstuvwxyz0123456789._-#!|@^$`+'~:"
     val validUserIds =
       validCharacters.flatMap(c => Vector(c.toString, s"$c$c")) ++
         Vector(
@@ -318,7 +318,7 @@ class RefTest extends AnyFreeSpec with Matchers with EitherValues {
     }
 
     "reject invalid user ids" in {
-      val invalidCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ \\%&*()=[]{};:<>,?\""
+      val invalidCharacters = "àáABCDEFGHIJKLMNOPQRSTUVWXYZ \\%&*()=[]{};<>,?\""
       val invalidUserIds =
         invalidCharacters.map(c => c.toString) ++
           Vector(

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/user_management_service.proto
@@ -52,7 +52,7 @@ service UserManagementService {
 // Read the :doc:`Authorization documentation </app-dev/authorization>` to learn more.
 message User {
     // The user identifier, which must be a non-empty string of at most 128
-    // characters that are either lowercase alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|".
+    // characters that are either lowercase alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:".
     string id = 1;
 
     // The primary party as which this user reads and acts by default on the ledger


### PR DESCRIPTION
Fixes #12520

CHANGELOG_BEGIN
CHANGELOG_END

FYI: @bame-da @da-tanabe @cocreature @stefanobaghino-da @adriaanm-da 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description
- [x] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
