### PR TITLE
Mark the `withExpectedLedgerId` method in `DamlLedgerClient.Builder` as deprecated

### DIFF
--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/DamlLedgerClient.java
@@ -57,6 +57,13 @@ public final class DamlLedgerClient implements LedgerClient {
       return this;
     }
 
+    /**
+     * @deprecated since 2.0 the ledger identifier has been deprecated as a fail-safe against
+     *     contacting an unexpected participant. You are recommended to use the participant
+     *     identifier in the access token as a way to validate that you are accessing the ledger
+     *     through the expected participant node (as well as authorize your calls).
+     */
+    @Deprecated
     public Builder withExpectedLedgerId(@NonNull String expectedLedgerId) {
       this.expectedLedgerId = Optional.of(expectedLedgerId);
       return this;

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/DamlLedgerClientTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/DamlLedgerClientTest.scala
@@ -45,7 +45,9 @@ class DamlLedgerClientTest
       val damlLedgerClient = DamlLedgerClient
         .newBuilder("localhost", server.getPort)
         .withExpectedLedgerId(ledgerServices.ledgerId)
-        .build()
+        .build(): @annotation.nowarn(
+        "cat=deprecation&origin=com\\.daml\\.ledger\\.rxjava\\.DamlLedgerClient\\.Builder\\.withExpectedLedgerId"
+      )
       testDamlLedgerClient(damlLedgerClient, impls)
     }
   }
@@ -63,7 +65,9 @@ class DamlLedgerClientTest
         .newBuilder("localhost", server.getPort)
         .withExpectedLedgerId(ledgerServices.ledgerId)
         .withAccessToken(somePartyReadWriteToken)
-        .build()
+        .build(): @annotation.nowarn(
+        "cat=deprecation&origin=com\\.daml\\.ledger\\.rxjava\\.DamlLedgerClient\\.Builder\\.withExpectedLedgerId"
+      )
       damlLedgerClient.connect()
       damlLedgerClient.getLedgerId shouldBe ledgerServices.ledgerId
       testActiveContractSetClient(


### PR DESCRIPTION
changelog_begin
[Java bindings] Deprecate `DamlLedgerClient.Builder.withExpectedLedgerId`
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
