### PR TITLE
Replace silencer plugin with built-in warning configuration

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -39,28 +39,9 @@ def resolve_scala_deps(deps, scala_deps = [], versioned_deps = {}, versioned_sca
                         versioned_scala_deps.get(scala_major_version, [])
            ]
 
-def extra_scalacopts(scala_deps, plugins):
-    return (["-P:silencer:lineContentFilters=import scala.collection.compat._"] if (scala_major_version != "2.12" and
-                                                                                    silencer_plugin in plugins and
-                                                                                    "@maven//:org_scala_lang_modules_scala_collection_compat" in scala_deps) else [])
-
+# Please don't remove, this will be useful in the future to transition to Scala 3
 version_specific = {
-    "2.12": [
-        # these two flags turn on source-incompatible enhancements that are always
-        # on in Scala 2.13.  Despite the naming, though, the most impactful and
-        # 2.13-like change is -Ypartial-unification.  -Xsource:2.13 only turns on
-        # some minor, but in one specific case (scala/bug#10283) essential bug fixes
-        "-Xsource:2.13",
-        "-Ypartial-unification",
-        # adapted args is a deprecated feature:
-        # `def foo(a: (A, B))` can be called with `foo(a, b)`.
-        # properly it should be `foo((a,b))`
-        "-Yno-adapted-args",
-        "-Xlint:unsound-match",
-        "-Xlint:by-name-right-associative",  # will never be by-name if used correctly
-        "-Xfuture",
-        "-language:higherKinds",
-    ],
+    "2.13": [],
 }
 
 common_scalacopts = version_specific.get(scala_major_version, []) + [
@@ -96,8 +77,7 @@ common_scalacopts = version_specific.get(scala_major_version, []) + [
     # Gives a warning for functions declared as returning Unit, but the body returns a value
     "-Ywarn-value-discard",
     "-Ywarn-unused:imports",
-    # Allow `@nowarn` annotations that allegedly do nothing (necessary because of false positives)
-    "-Ywarn-unused:-nowarn",
+    "-Ywarn-unused:nowarn",
     "-Ywarn-unused",
 ]
 
@@ -109,12 +89,9 @@ common_plugins = [
     "@maven//:org_wartremover_wartremover_{}".format(scala_version_suffix),
 ]
 
+# Please don't remove, this will be useful in the future to transition to Scala 3
 version_specific_warts = {
-    "2.12": [
-        # On 2.13, this also triggers in string interpolation
-        # https://github.com/wartremover/wartremover/issues/447
-        "StringPlusAny",
-    ],
+    "2.13": [],
 }
 
 plugin_scalacopts = [
@@ -233,10 +210,9 @@ def _wrap_rule(
     exports = resolve_scala_deps(exports, scala_exports)
     if (len(exports) > 0):
         kwargs["exports"] = exports
-    compat_scalacopts = extra_scalacopts(scala_deps = scala_deps, plugins = plugins)
     rule(
         name = name,
-        scalacopts = common_scalacopts + plugin_scalacopts + compat_scalacopts + scalacopts,
+        scalacopts = common_scalacopts + plugin_scalacopts + scalacopts,
         plugins = common_plugins + plugins,
         deps = deps,
         runtime_deps = runtime_deps,
@@ -542,12 +518,11 @@ def _create_scaladoc_jar(
     # Limit execution to Linux and MacOS
     if is_windows == False:
         deps = resolve_scala_deps(deps, scala_deps, versioned_deps, versioned_scala_deps)
-        compat_scalacopts = extra_scalacopts(scala_deps = scala_deps, plugins = plugins)
         scaladoc_jar(
             name = name + "_scaladoc",
             deps = deps,
             srcs = srcs,
-            scalacopts = common_scalacopts + plugin_scalacopts + compat_scalacopts + scalacopts,
+            scalacopts = common_scalacopts + plugin_scalacopts + scalacopts,
             plugins = common_plugins + plugins,
             generated_srcs = generated_srcs,
             tags = ["scaladoc"],

--- a/compiler/scenario-service/server/BUILD.bazel
+++ b/compiler/scenario-service/server/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel_tools:scala.bzl", "da_scala_binary", "silencer_plugin")
+load("//bazel_tools:scala.bzl", "da_scala_binary")
 
 genrule(
     name = "scenario_service_jar",
@@ -15,12 +15,8 @@ da_scala_binary(
     name = "scenario-service-raw",
     srcs = glob(["src/main/scala/**/*.scala"]),
     main_class = "com.daml.lf.scenario.ScenarioServiceMain",
-    plugins = [
-        silencer_plugin,
-    ],
     resources = glob(["src/main/resources/*"]),
     scala_deps = [
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:com_github_scopt_scopt",

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -22,7 +22,6 @@ import com.daml.lf.engine.script.{Participants, Runner, Script, ScriptF, ScriptI
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.collection.compat._
 import scala.collection.immutable.HashMap
 import scala.util.{Failure, Success}
 

--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -12,7 +12,6 @@ load(
     "da_scala_test_suite",
     "lf_scalacopts",
     "lf_scalacopts_stricter",
-    "silencer_plugin",
 )
 load("//daml-lf/language:daml-lf.bzl", "LF_MAJOR_VERSIONS", "PROTO_LF_VERSIONS", "mangle_for_java", "versions")
 load(
@@ -96,12 +95,8 @@ da_haskell_library(
 da_scala_library(
     name = "daml_lf_archive_reader",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = lf_scalacopts_stricter,
     tags = ["maven_coordinates=com.daml:daml-lf-archive-reader:__VERSION__"],

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -16,7 +16,6 @@ import com.daml.nameof.NameOf
 import com.daml.scalautil.Statement.discard
 
 import scala.Ordering.Implicits.infixOrderingOps
-import scala.collection.compat._
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 

--- a/daml-lf/data/BUILD.bazel
+++ b/daml-lf/data/BUILD.bazel
@@ -8,7 +8,6 @@ load(
     "kind_projector_plugin",
     "lf_scalacopts",
     "lf_scalacopts_stricter",
-    "silencer_plugin",
 )
 
 da_scala_library(
@@ -17,14 +16,11 @@ da_scala_library(
         glob(["src/main/scala/**/*.scala"]),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     scala_deps = [
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = lf_scalacopts_stricter + [
-        "-P:silencer:lineContentFilters=import ImmArraySeq.Implicits._",
-    ],
+    scalacopts = lf_scalacopts_stricter,
     tags = ["maven_coordinates=com.daml:daml-lf-data:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -41,20 +37,13 @@ da_scala_library(
 da_scala_test(
     name = "data-test",
     size = "small",
-    srcs = glob(["src/test/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalatestplus_scalacheck_1_15",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scalaz_scalaz_scalacheck_binding",
     ],
-    scalacopts = lf_scalacopts + [
-        "-P:silencer:lineContentFilters=import ImmArraySeq.Implicits._",
-        "-P:silencer:lineContentFilters=signum",
-    ],
+    scalacopts = lf_scalacopts,
     deps = [
         ":data",
         "//daml-lf/data-scalacheck",

--- a/daml-lf/interface/BUILD.bazel
+++ b/daml-lf/interface/BUILD.bazel
@@ -7,18 +7,13 @@ load(
     "da_scala_test",
     "lf_scalacopts",
     "lf_scalacopts_stricter",
-    "silencer_plugin",
 )
 
 da_scala_library(
     name = "interface",
     srcs = glob(["src/main/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = lf_scalacopts_stricter,
     tags = ["maven_coordinates=com.daml:daml-lf-interface:__VERSION__"],

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/Errors.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/Errors.scala
@@ -7,7 +7,6 @@ package reader
 import com.daml.lf.data.Ref.{DottedName, Name}
 
 import scala.language.implicitConversions
-import scala.collection.compat._
 import scala.collection.immutable.Map
 import scalaz.{-\/, ==>>, @@, Applicative, Cord, Monoid, Order, Semigroup, Tag, Traverse, \/, \/-}
 import scalaz.std.map._

--- a/daml-lf/language/BUILD.bazel
+++ b/daml-lf/language/BUILD.bazel
@@ -7,7 +7,6 @@ load(
     "da_scala_test",
     "lf_scalacopts",
     "lf_scalacopts_stricter",
-    "silencer_plugin",
 )
 
 da_scala_library(
@@ -29,12 +28,7 @@ da_scala_test(
     name = "language-test",
     size = "small",
     srcs = glob(["src/test/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
-    scalacopts = lf_scalacopts + [
-        "-P:silencer:lineContentFilters=signum",
-    ],
+    scalacopts = lf_scalacopts,
     deps = [
         ":language",
         "//daml-lf/data",

--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/LanguageVersionSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/LanguageVersionSpec.scala
@@ -27,7 +27,7 @@ class LanguageVersionSpec extends AnyWordSpec with Matchers with TableDrivenProp
       forEvery(versions)(v2 =>
         LV.Ordering
           .compare(v1, v2)
-          .signum shouldBe (versionRank(v1) compareTo versionRank(v2)).signum
+          .sign shouldBe (versionRank(v1) compareTo versionRank(v2)).sign
       )
     )
   }

--- a/daml-lf/parser/BUILD.bazel
+++ b/daml-lf/parser/BUILD.bazel
@@ -7,22 +7,16 @@ load(
     "da_scala_test",
     "lf_scalacopts",
     "lf_scalacopts_stricter",
-    "silencer_plugin",
 )
 
 da_scala_library(
     name = "parser",
     srcs = glob(["src/main/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:org_scala_lang_modules_scala_parser_combinators",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    scalacopts = lf_scalacopts_stricter + [
-        "-P:silencer:lineContentFilters=standardInterpolator",
-    ],
+    scalacopts = lf_scalacopts_stricter,
     visibility = [
         "//daml-lf:__subpackages__",
         "//ledger:__subpackages__",

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Implicits.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Implicits.scala
@@ -31,11 +31,16 @@ object Implicits {
 
     @SuppressWarnings(Array("org.wartremover.warts.Any"))
     def n(args: Any*): Ref.Name =
-      Ref.Name.assertFromString(sc.standardInterpolator(identity, args.map(prettyPrint)))
+      Ref.Name.assertFromString(
+        StringContext.standardInterpolator(identity, args.map(prettyPrint), sc.parts)
+      )
 
     @SuppressWarnings(Array("org.wartremover.warts.Any"))
     private def interpolate[T](p: Parsers.Parser[T])(args: Seq[Any]): T =
-      Parsers.parseAll(Parsers.phrase(p), sc.standardInterpolator(identity, args.map(prettyPrint)))
+      Parsers.parseAll(
+        Parsers.phrase(p),
+        StringContext.standardInterpolator(identity, args.map(prettyPrint), sc.parts),
+      )
   }
 
   private def toString(x: BigDecimal) =

--- a/daml-lf/transaction-test-lib/BUILD.bazel
+++ b/daml-lf/transaction-test-lib/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_library",
     "kind_projector_plugin",
     "lf_scalacopts_stricter",
-    "silencer_plugin",
 )
 
 da_scala_library(
@@ -14,7 +13,6 @@ da_scala_library(
     srcs = glob(["src/main/**/*.scala"]),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     scala_deps = [
         "@maven//:com_chuusai_shapeless",
@@ -23,11 +21,7 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_scalacheck_binding",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    scalacopts = lf_scalacopts_stricter + [
-        "-P:silencer:lineContentFilters=import elt.injshrink",
-        # Forced upon us by Shrink
-        "-P:silencer:lineContentFilters=Stream.empty",
-    ],
+    scalacopts = lf_scalacopts_stricter,
     tags = ["maven_coordinates=com.daml:daml-lf-transaction-test-lib:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/TypedValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/TypedValueGenerators.scala
@@ -147,7 +147,6 @@ object TypedValueGenerators {
         Tag unsubst implicitly[Arbitrary[Vector[elt.Inj] @@ Div3]]
       }
       override def injshrink(implicit shr: Shrink[Value.ContractId]) = {
-        import elt.injshrink
         implicitly[Shrink[Vector[elt.Inj]]]
       }
     }
@@ -169,7 +168,6 @@ object TypedValueGenerators {
         implicitly[Arbitrary[Option[elt.Inj]]]
       }
       override def injshrink(implicit cid: Shrink[Value.ContractId]) = {
-        import elt.injshrink
         implicitly[Shrink[Option[elt.Inj]]]
       }
     }
@@ -306,7 +304,7 @@ object TypedValueGenerators {
           override def injshrink(implicit shr: Shrink[Value.ContractId]) =
             Shrink { ev =>
               if (!(values.headOption contains ev)) values.headOption.toStream
-              else Stream.empty
+              else Stream.empty: @annotation.nowarn("cat=deprecation")
             }
         },
       )

--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -8,7 +8,6 @@ load(
     "da_scala_test",
     "lf_scalacopts",
     "lf_scalacopts_stricter",
-    "silencer_plugin",
 )
 
 #
@@ -47,12 +46,8 @@ proto_jars(
 da_scala_library(
     name = "transaction",
     srcs = glob(["src/main/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = lf_scalacopts_stricter,
     tags = ["maven_coordinates=com.daml:daml-lf-transaction:__VERSION__"],
@@ -77,16 +72,12 @@ da_scala_test(
         "src/test/**/value/*.scala",
         "src/test/**/transaction/*.scala",
     ]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_chuusai_shapeless",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalatestplus_scalacheck_1_15",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scalaz_scalaz_scalacheck_binding",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = lf_scalacopts,
     deps = [
@@ -107,9 +98,6 @@ da_scala_test(
     srcs = glob([
         "src/test/**/validation/*.scala",
     ]),
-    plugins = [
-        silencer_plugin,
-    ],
     scalacopts = lf_scalacopts,
     deps = [
         ":transaction",

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
@@ -3,7 +3,7 @@
 
 package com.daml.lf
 
-import scala.collection.compat._
+import scala.collection.BuildFrom
 
 package object transaction {
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -14,12 +14,10 @@ import shapeless.record.{Record => HRecord}
 import shapeless.syntax.singleton._
 import shapeless.{Coproduct => HSum}
 
-import scala.annotation.nowarn
 import scala.language.implicitConversions
 
 class HashSpec extends AnyWordSpec with Matchers {
 
-  @nowarn("msg=dead code following this construct")
   private val packageId0 = Ref.PackageId.assertFromString("package")
 
   private val complexRecordT =

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -18,7 +18,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import scala.collection.compat._
 import scala.Ordering.Implicits.infixOrderingOps
 import scala.jdk.CollectionConverters._
 

--- a/daml-lf/validation/BUILD.bazel
+++ b/daml-lf/validation/BUILD.bazel
@@ -8,7 +8,6 @@ load(
     "da_scala_test",
     "lf_scalacopts",
     "lf_scalacopts_stricter",
-    "silencer_plugin",
 )
 
 da_scala_library(
@@ -36,12 +35,7 @@ da_scala_test(
     name = "validation-test",
     size = "small",
     srcs = glob(["src/test/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
-    scalacopts = lf_scalacopts + [
-        "-P:silencer:lineContentFilters=standardInterpolator",
-    ],
+    scalacopts = lf_scalacopts,
     deps = [
         ":validation",
         "//daml-lf/data",

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SpecUtil.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SpecUtil.scala
@@ -38,9 +38,12 @@ private[validation] object SpecUtil {
   )
 
   implicit class SyntaxHelper2(val sc: StringContext) extends AnyVal {
-    def K(args: Any*): Kind = k"${replace(sc.standardInterpolator(identity, args))}"
-    def T(args: Any*): Type = t"${replace(sc.standardInterpolator(identity, args))}"
-    def E(args: Any*): Expr = e"${replace(sc.standardInterpolator(identity, args))}"
+    def K(args: Any*): Kind =
+      k"${replace(StringContext.standardInterpolator(identity, args, sc.parts))}"
+    def T(args: Any*): Type =
+      t"${replace(StringContext.standardInterpolator(identity, args, sc.parts))}"
+    def E(args: Any*): Expr =
+      e"${replace(StringContext.standardInterpolator(identity, args, sc.parts))}"
 
     def replace(s: String): String = {
       val b = new StringBuilder()

--- a/daml-script/export/BUILD.bazel
+++ b/daml-script/export/BUILD.bazel
@@ -14,7 +14,6 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
     "da_scala_test",
-    "silencer_plugin",
 )
 
 exports_files(["src/main/resources/logback.xml"])
@@ -23,15 +22,11 @@ da_scala_binary(
     name = "export",
     srcs = glob(["src/main/scala/**/*.scala"]),
     main_class = "com.daml.script.export.Main",
-    plugins = [
-        silencer_plugin,
-    ],
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [
         "@maven//:com_github_scopt_scopt",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:io_spray_spray_json",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_typelevel_paiges_core",
         "@maven//:io_circe_circe_core",
@@ -76,6 +71,5 @@ da_scala_test(
         "//language-support/scala/bindings",
         "//ledger/ledger-api-common",
         "//libs-scala/auth-utils",
-        "@maven//:org_scalatest_scalatest_compatible",
     ],
 )

--- a/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/TreeUtils.scala
@@ -20,7 +20,6 @@ import scalaz.std.iterable._
 import scalaz.std.set._
 import scalaz.syntax.foldable._
 
-import scala.collection.compat._
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 

--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -5,7 +5,6 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
     "da_scala_test_suite",
-    "silencer_plugin",
 )
 load("//bazel_tools:proto.bzl", "proto_gen")
 load("//bazel_tools:java.bzl", "da_java_library")
@@ -107,9 +106,6 @@ da_scala_test_suite(
         "src/test/**/*Spec.scala",
         "src/test/**/*Test.scala",
     ]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalatest_scalatest_core",
@@ -117,11 +113,6 @@ da_scala_test_suite(
         "@maven//:org_scalatest_scalatest_shouldmatchers",
         "@maven//:org_scalatest_scalatest_wordspec",
         "@maven//:org_scalatestplus_scalacheck_1_15",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
-    ],
-    scalacopts = [
-        "-P:silencer:globalFilters=DeduplicationTime.*deprecated",  # deprecated field that needs to be tested
-        "-P:silencer:globalFilters=DEDUPLICATION_TIME.*deprecated",  # deprecated field that needs to be tested
     ],
     deps = [
         ":bindings-java",

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/SubmitCommandsRequestSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/SubmitCommandsRequestSpec.scala
@@ -13,6 +13,8 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.jdk.CollectionConverters._
 
+// Allows using deprecated Protobuf fields for testing
+@annotation.nowarn("cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\..*")
 final class SubmitCommandsRequestSpec extends AnyFlatSpec with Matchers {
 
   behavior of "SubmitCommandsRequest.toProto/fromProto"

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/ValueSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/ValueSpec.scala
@@ -14,7 +14,6 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
-import scala.collection.compat._
 
 class ValueSpec
     extends AnyFlatSpec

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -8,7 +8,6 @@ load(
     "da_scala_test",
     "scala_source_jar",
     "scaladoc_jar",
-    "silencer_plugin",
 )
 load(
     "//rules_daml:daml.bzl",
@@ -43,9 +42,6 @@ da_scala_binary(
 da_scala_library(
     name = "lib",
     srcs = glob(["src/main/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     resources = [
         "src/main/resources/logback.xml",
     ],
@@ -53,7 +49,6 @@ da_scala_library(
         "@maven//:com_github_scopt_scopt",
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     tags = ["maven_coordinates=com.daml:codegen-java-lib:__VERSION__"],
     visibility = ["//visibility:public"],

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/InterfaceTree.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/InterfaceTree.scala
@@ -10,7 +10,6 @@ import com.typesafe.scalalogging.StrictLogging
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
-import scala.collection.compat._
 import scala.jdk.CollectionConverters._
 
 private[codegen] sealed trait Node

--- a/language-support/scala/bindings-akka/BUILD.bazel
+++ b/language-support/scala/bindings-akka/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_library",
     "da_scala_test_suite",
     "kind_projector_plugin",
-    "silencer_plugin",
 )
 
 da_scala_library(
@@ -14,7 +13,6 @@ da_scala_library(
     srcs = glob(["src/main/**/*.scala"]),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [
@@ -24,7 +22,6 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:com_typesafe_scala_logging_scala_logging",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
     ],
     scala_exports = [

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/DomainTransactionMapper.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/DomainTransactionMapper.scala
@@ -17,7 +17,6 @@ import scalaz.std.either._
 import scalaz.std.list._
 import scalaz.syntax.traverse._
 
-import scala.collection.compat._
 import scala.collection.immutable
 
 object DomainTransactionMapper {

--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_library",
     "da_scala_test",
     "kind_projector_plugin",
-    "silencer_plugin",
 )
 load(
     "//rules_daml:daml.bzl",
@@ -46,22 +45,14 @@ da_scala_library(
     srcs = [":MyMain.srcjar"] + glob(["src/main/**/*.scala"]),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     scala_deps = [
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = [
-        "-P:silencer:checkUnused",
-        # codegen eliminates the vast majority of potential unused warnings. For example,
-        # it checks whether tparams are phantom or not and requires evidence only if they
-        # are not. It misses the case where a tparam is used in ContractId position, which
-        # is essentially phantom for the typeclasses.  The fix requires recurring into
-        # referenced types, and only occurs here in this source tree, so I don't consider
-        # it worth fixing for now. -SC
-        "-P:silencer:lineContentFilters=ContractIdNT (Value|LfEncodable).*?implicit .?ev",
-        "-P:silencer:lineContentFilters=import _root_.scala.language.higherKinds;",
+        "-Wconf:cat=unused-imports&site=com\\.daml\\.sample\\..*:s",
+        "-Wconf:msg=parameter value ev.. in method ContractIdNT (Value)|(LfEncodable) is never used:s",
     ],
     visibility = [
         "//visibility:public",

--- a/language-support/scala/codegen-testing/BUILD.bazel
+++ b/language-support/scala/codegen-testing/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_library",
     "da_scala_test_suite",
     "kind_projector_plugin",
-    "silencer_plugin",
 )
 load("@scala_version//:index.bzl", "scala_major_version")
 
@@ -15,17 +14,11 @@ da_scala_library(
     srcs = glob(["src/main/**/*.scala"]),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     scala_deps = [
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_scalaz_scalaz_scalacheck_binding",
-    ],
-    scalacopts = [
-        # Forced upon us by scalatest
-        "-P:silencer:lineContentFilters=Stream",
     ],
     visibility = [
         "//visibility:public",
@@ -86,9 +79,6 @@ da_scala_test_suite(
         ],
         exclude = testing_utils,
     ) + glob(["src/test/{}/scala/**/*.scala".format(scala_major_version)]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_chuusai_shapeless",
         "@maven//:org_scalacheck_scalacheck",
@@ -97,7 +87,6 @@ da_scala_test_suite(
         "@maven//:org_scalatest_scalatest_shouldmatchers",
         "@maven//:org_scalatest_scalatest_wordspec",
         "@maven//:org_scalatestplus_scalacheck_1_15",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
     ],
     deps = [

--- a/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/DamlDates.scala
+++ b/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/DamlDates.scala
@@ -5,8 +5,6 @@ package com.daml.ledger.client.binding.encoding
 import java.time.{LocalDate, ZoneOffset}
 
 import com.daml.api.util.TimestampConversion
-import com.daml.ledger.client.binding.{Primitive => P}
-import scalaz.std.stream
 
 object DamlDates {
   val Min: LocalDate = TimestampConversion.MIN.atZone(ZoneOffset.UTC).toLocalDate
@@ -32,20 +30,4 @@ object DamlDates {
     */
   val RangeOfLocalDatesWithoutInjectiveFunctionToSqlDate: (LocalDate, LocalDate) =
     (LocalDate.parse("1582-10-05"), LocalDate.parse("1582-10-14"))
-
-  def localDatesWithoutInjectiveFunctionToSqlDate: Stream[LocalDate] =
-    stream
-      .unfold(RangeOfLocalDatesWithoutInjectiveFunctionToSqlDate._1) { a: LocalDate =>
-        if (!a.isAfter(RangeOfLocalDatesWithoutInjectiveFunctionToSqlDate._2))
-          Some((a, a.plusDays(1)))
-        else None
-      }
-
-  def damlDatesWithoutInjectiveFunctionToSqlDate: Stream[P.Date] =
-    localDatesWithoutInjectiveFunctionToSqlDate.map(pDate)
-
-  private def pDate(d: LocalDate): P.Date =
-    P.Date
-      .fromLocalDate(d)
-      .getOrElse(sys.error(s"expected `P.Date` friendly `LocalDate`, but got: $d"))
 }

--- a/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/ShrinkEncoding.scala
+++ b/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/ShrinkEncoding.scala
@@ -44,6 +44,7 @@ abstract class ShrinkEncoding extends LfTypeEncoding {
 
   override def variant[A](variantId: rpcvalue.Identifier, cases: VariantCases[A]): Out[A] = cases
 
+  @annotation.nowarn("cat=deprecation&origin=scala\\.Stream")
   override def enumAll[A](
       enumId: Identifier,
       index: A => Int,
@@ -53,6 +54,7 @@ abstract class ShrinkEncoding extends LfTypeEncoding {
       if (index(a) == 0) Stream.empty else Stream(cases.head._2)
     }
 
+  @annotation.nowarn("cat=deprecation&origin=scala\\.Stream")
   override def variantCase[B, A](caseName: String, o: Out[B])(
       inject: B => A
   )(select: A PartialFunction B): VariantCases[A] = Shrink[A] { a: A =>
@@ -98,6 +100,7 @@ object ShrinkEncoding extends ShrinkEncoding {
 
     override val valueText: Out[P.Text] = myShrinkString
 
+    @annotation.nowarn("cat=deprecation&origin=scala\\.Stream")
     private def myShrinkString: Shrink[String] = Shrink { s0: String =>
       import scalaz.std.stream.unfold
 

--- a/language-support/scala/codegen-testing/src/test/2.13/scala/com/digitalasset/ledger/client/binding/Primitive213Spec.scala
+++ b/language-support/scala/codegen-testing/src/test/2.13/scala/com/digitalasset/ledger/client/binding/Primitive213Spec.scala
@@ -7,7 +7,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.annotation.nowarn
-import scala.collection.compat._
 import scala.collection.immutable.Map
 
 class Primitive213Spec extends AnyWordSpec with Matchers {

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/PrimitiveSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/PrimitiveSpec.scala
@@ -13,7 +13,6 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shapeless.test.illTyped
 
 import scala.annotation.nowarn
-import scala.collection.compat._
 import scala.collection.immutable.Map
 
 class PrimitiveSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {

--- a/language-support/scala/codegen/BUILD.bazel
+++ b/language-support/scala/codegen/BUILD.bazel
@@ -7,7 +7,6 @@ load(
     "da_scala_library",
     "da_scala_test_suite",
     "kind_projector_plugin",
-    "silencer_plugin",
 )
 
 common_scalacopts = [
@@ -28,12 +27,10 @@ da_scala_library(
         ),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     scala_deps = [
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = common_scalacopts,
     tags = ["maven_coordinates=com.daml:codegen-scala:__VERSION__"],
@@ -85,9 +82,6 @@ da_scala_test_suite(
     name = "tests",
     size = "small",
     srcs = glob(["src/test/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalacheck_scalacheck",

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/CodeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/CodeGen.scala
@@ -27,7 +27,6 @@ import scalaz.syntax.std.option._
 import scalaz.syntax.bind._
 import scalaz.syntax.traverse1._
 
-import scala.collection.compat._
 import scala.util.matching.Regex
 
 object CodeGen {

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/Util.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/Util.scala
@@ -11,7 +11,6 @@ import com.daml.lf.data.ImmArray.ImmArraySeq
 
 import java.io.File
 
-import scala.collection.compat._
 import scala.reflect.runtime.universe._
 import scalaz.{Tree => _, _}
 import scalaz.std.list._

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/dependencygraph/DependencyGraph.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/dependencygraph/DependencyGraph.scala
@@ -13,8 +13,6 @@ import scalaz.syntax.bifoldable._
 import scalaz.syntax.foldable._
 import scalaz.Bifoldable
 
-import scala.collection.compat._
-
 sealed abstract class DependencyGraph[Iface, TmplI] {
   def orderedDependencies(
       library: Iface

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/dependencygraph/Graph.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/dependencygraph/Graph.scala
@@ -5,8 +5,6 @@ package com.daml.codegen.dependencygraph
 
 import com.daml.codegen.exception.UnsopportedTypeError
 
-import scala.collection.compat._
-
 object Graph {
 
   /** Orders the nodes such that given a node n, its dependencies are placed in the resultant vector before n

--- a/language-support/scala/codegen/src/test/scala/com/digitalasset/codegen/UtilTest.scala
+++ b/language-support/scala/codegen/src/test/scala/com/digitalasset/codegen/UtilTest.scala
@@ -15,8 +15,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-import scala.collection.compat._
-
 class UtilTest extends UtilTestHelpers with ScalaCheckDrivenPropertyChecks {
 
   val packageInterface =

--- a/language-support/scala/examples/BUILD.bazel
+++ b/language-support/scala/examples/BUILD.bazel
@@ -5,7 +5,6 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
     "da_scala_library",
-    "silencer_plugin",
 )
 load("//rules_daml:daml.bzl", "daml_compile")
 load("//language-support/scala/codegen:codegen.bzl", "dar_to_scala")
@@ -59,11 +58,8 @@ dar_to_scala(
 da_scala_library(
     name = "quickstart-scala-codegen-lib",
     srcs = [":quickstart-scala-codegen.srcjar"],
-    plugins = [
-        silencer_plugin,
-    ],
     scalacopts = [
-        "-P:silencer:lineContentFilters=import _root_.scala.language.higherKinds;",
+        "-Wconf:cat=unused-imports&site=com\\.daml\\.quickstart\\.iou\\.model..*:s",
     ],
     deps = ["//language-support/scala/bindings"],
 )
@@ -73,9 +69,6 @@ da_scala_binary(
     srcs = glob(["quickstart-scala/application/src/main/scala/**/*.scala"]),
     main_class = "com.daml.quickstart.iou.IouMain",
     resources = glob(["quickstart-scala/application/src/main/resources/**/*"]),
-    scala_deps = [
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
-    ],
     deps = [
         ":quickstart-scala-codegen-lib",
         "//language-support/scala/bindings",

--- a/ledger-api/perf-testing/BUILD.bazel
+++ b/ledger-api/perf-testing/BUILD.bazel
@@ -4,21 +4,16 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
-    "silencer_plugin",
 )
 
 da_scala_library(
     name = "perf-testing",
     srcs = glob(["src/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_storm_enroute_scalameter",
         "@maven//:com_storm_enroute_scalameter_core",
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     visibility = [
         "//visibility:public",

--- a/ledger-api/perf-testing/src/main/scala/com/digitalasset/ledger/api/perf/util/reporter/JMeterXmlGenerator.scala
+++ b/ledger-api/perf-testing/src/main/scala/com/digitalasset/ledger/api/perf/util/reporter/JMeterXmlGenerator.scala
@@ -11,8 +11,6 @@ import org.scalameter.utils.Tree
 import org.scalameter.{CurveData, Parameters}
 import org.w3c.dom.{Document, Element}
 
-import scala.collection.compat._
-
 private[reporter] object JMeterXmlGenerator {
 
   private val rootElementName = "testResults"

--- a/ledger-api/testing-utils/BUILD.bazel
+++ b/ledger-api/testing-utils/BUILD.bazel
@@ -5,15 +5,11 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
     "da_scala_test_suite",
-    "silencer_plugin",
 )
 
 da_scala_library(
     name = "testing-utils",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
@@ -21,7 +17,6 @@ da_scala_library(
         "@maven//:org_scalatest_scalatest_core",
         "@maven//:org_scalatest_scalatest_matchers_core",
         "@maven//:org_scalatest_scalatest_shouldmatchers",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     tags = ["maven_coordinates=com.daml:testing-utils:__VERSION__"],
     visibility = [

--- a/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/MultiResourceBase.scala
+++ b/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/MultiResourceBase.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.api.testing.utils
 
 import org.scalatest.AsyncTestSuite
 
-import scala.collection.compat._
 import scala.collection.immutable
 
 trait MultiResourceBase[FixtureId, TestContext]

--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -6,19 +6,14 @@ load(
     "da_scala_library",
     "da_scala_test",
     "lf_scalacopts",
-    "silencer_plugin",
 )
 
 da_scala_library(
     name = "db-backend",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_chuusai_shapeless",
         "@maven//:io_spray_spray_json",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_tpolecat_doobie_core",
         "@maven//:org_tpolecat_doobie_free",
@@ -73,6 +68,5 @@ da_scala_test(
     # data = ["//docs:quickstart-model.dar"],
     deps = [
         ":db-backend",
-        "@maven//:org_scalatest_scalatest_compatible",
     ],
 )

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -11,7 +11,6 @@ import nonempty.NonEmptyReturningOps._
 import doobie._
 import doobie.implicits._
 import scala.annotation.nowarn
-import scala.collection.compat._
 import scala.collection.immutable.{Seq => ISeq, SortedMap}
 import scalaz.{@@, Cord, Functor, OneAnd, Tag, \/, -\/, \/-}
 import scalaz.Digit._0

--- a/ledger-service/fetch-contracts/BUILD.bazel
+++ b/ledger-service/fetch-contracts/BUILD.bazel
@@ -7,7 +7,6 @@ load(
     "da_scala_test",
     "kind_projector_plugin",
     "lf_scalacopts",
-    "silencer_plugin",
 )
 
 hj_scalacopts = lf_scalacopts + [
@@ -19,11 +18,9 @@ da_scala_library(
     srcs = glob(["src/main/scala/**/*.scala"]),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     scala_deps = [
         "@maven//:io_spray_spray_json",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_tpolecat_doobie_core",
         "@maven//:org_tpolecat_doobie_free",
@@ -52,10 +49,8 @@ da_scala_test(
     srcs = glob(["src/test/scala/**/*.scala"]),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     scala_deps = [
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalatest_scalatest_core",
         "@maven//:org_scalatest_scalatest_matchers_core",

--- a/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/util/ContractStreamStep.scala
+++ b/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/util/ContractStreamStep.scala
@@ -10,7 +10,7 @@ import scalaz.{Semigroup, \/}
 import scalaz.std.tuple._
 import scalaz.syntax.functor._
 
-import scala.collection.compat._
+import scala.collection.Factory
 
 private[daml] sealed abstract class ContractStreamStep[+D, +C] extends Product with Serializable {
   import ContractStreamStep._

--- a/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/util/InsertDeleteStep.scala
+++ b/ledger-service/fetch-contracts/src/main/scala/fetchcontracts/util/InsertDeleteStep.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.api.v1.{event => evv1}
 import scalaz.{Monoid, \/, \/-}
 import scalaz.syntax.tag._
 
-import scala.collection.compat._
+import scala.collection.Factory
 import scala.runtime.AbstractFunction1
 
 private[daml] final case class InsertDeleteStep[+D, +C](

--- a/ledger-service/http-json-cli/BUILD.bazel
+++ b/ledger-service/http-json-cli/BUILD.bazel
@@ -4,19 +4,16 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
-    "silencer_plugin",
 )
 
 da_scala_library(
     name = "base",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [silencer_plugin],
     scala_deps = [
         "@maven//:com_chuusai_shapeless",
         "@maven//:com_github_pureconfig_pureconfig_core",
         "@maven//:com_github_pureconfig_pureconfig_generic",
         "@maven//:com_github_scopt_scopt",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:com_typesafe_scala_logging_scala_logging",

--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/dbbackend/DbStartupMode.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/dbbackend/DbStartupMode.scala
@@ -3,8 +3,6 @@
 
 package com.daml.http.dbbackend
 
-import scala.collection.compat._
-
 private[http] sealed trait DbStartupMode
 private[http] object DbStartupMode {
   private[http] case object CreateOnly extends DbStartupMode

--- a/ledger-service/http-json-testing/BUILD.bazel
+++ b/ledger-service/http-json-testing/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_library",
     "kind_projector_plugin",
     "lf_scalacopts",
-    "silencer_plugin",
 )
 
 hj_scalacopts = lf_scalacopts + [
@@ -19,14 +18,12 @@ hj_scalacopts = lf_scalacopts + [
         srcs = glob(["src/main/scala/**/*.scala"]),
         plugins = [
             kind_projector_plugin,
-            silencer_plugin,
         ],
         scala_deps = [
             "@maven//:com_typesafe_akka_akka_actor",
             "@maven//:com_typesafe_akka_akka_http_core",
             "@maven//:com_typesafe_akka_akka_stream",
             "@maven//:io_spray_spray_json",
-            "@maven//:org_scala_lang_modules_scala_collection_compat",
             "@maven//:org_scalacheck_scalacheck",
             "@maven//:org_scalactic_scalactic",
             "@maven//:org_scalatest_scalatest_core",

--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/WebsocketTestFixture.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/WebsocketTestFixture.scala
@@ -39,7 +39,6 @@ import spray.json.{
   enrichString => `sj enrichString`,
 }
 
-import scala.collection.compat._
 import scala.concurrent.Future
 
 private[http] object WebsocketTestFixture extends StrictLogging with Assertions {

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -10,7 +10,6 @@ load(
     "da_scala_test_suite",
     "kind_projector_plugin",
     "lf_scalacopts",
-    "silencer_plugin",
 )
 load("//rules_daml:daml.bzl", "daml_compile")
 load("@os_info//:os_info.bzl", "is_windows")
@@ -26,7 +25,6 @@ hj_scalacopts = lf_scalacopts + [
         srcs = glob(["src/main/scala/**/*.scala"]),
         plugins = [
             kind_projector_plugin,
-            silencer_plugin,
         ],
         scala_deps = [
             "@maven//:com_chuusai_shapeless",
@@ -34,7 +32,6 @@ hj_scalacopts = lf_scalacopts + [
             "@maven//:com_typesafe_akka_akka_http",
             "@maven//:com_typesafe_akka_akka_http_core",
             "@maven//:io_spray_spray_json",
-            "@maven//:org_scala_lang_modules_scala_collection_compat",
             "@maven//:org_scalaz_scalaz_core",
             "@maven//:org_tpolecat_doobie_core",
             "@maven//:org_tpolecat_doobie_free",
@@ -102,7 +99,6 @@ json_scala_deps = [
     "@maven//:com_typesafe_akka_akka_slf4j",
     "@maven//:com_typesafe_scala_logging_scala_logging",
     "@maven//:io_spray_spray_json",
-    "@maven//:org_scala_lang_modules_scala_collection_compat",
     "@maven//:org_scalaz_scalaz_core",
     "@maven//:org_tpolecat_doobie_core",
     "@maven//:org_tpolecat_doobie_free",
@@ -206,13 +202,11 @@ daml_compile(
         ],
         plugins = [
             kind_projector_plugin,
-            silencer_plugin,
         ],
         scala_deps = [
             "@maven//:com_chuusai_shapeless",
             "@maven//:com_typesafe_akka_akka_http_core",
             "@maven//:io_spray_spray_json",
-            "@maven//:org_scala_lang_modules_scala_collection_compat",
             "@maven//:org_scalacheck_scalacheck",
             "@maven//:org_scalatest_scalatest_core",
             "@maven//:org_scalatest_scalatest_matchers_core",
@@ -271,14 +265,12 @@ alias(
     da_scala_library(
         name = "integration-tests-lib-{}".format(edition),
         srcs = glob(["src/itlib/scala/**/*.scala"]),
-        plugins = [silencer_plugin],
         resources = glob(["src/itlib/resources/**/*"]),
         scala_deps = [
             "@maven//:com_chuusai_shapeless",
             "@maven//:com_typesafe_akka_akka_http_core",
             "@maven//:com_typesafe_scala_logging_scala_logging",
             "@maven//:io_spray_spray_json",
-            "@maven//:org_scala_lang_modules_scala_collection_compat",
             "@maven//:org_scalacheck_scalacheck",
             "@maven//:org_scalactic_scalactic",
             "@maven//:org_scalatest_scalatest_core",
@@ -354,7 +346,6 @@ alias(
         ]),
         plugins = [
             kind_projector_plugin,
-            silencer_plugin,
         ],
         scala_deps = [
             "@maven//:com_chuusai_shapeless",
@@ -421,7 +412,6 @@ alias(
         flaky = True,
         plugins = [
             kind_projector_plugin,
-            silencer_plugin,
         ],
         resources = glob(["src/it/resources/**/*"]),
         scala_deps = [
@@ -443,7 +433,6 @@ alias(
             "@maven//:org_typelevel_cats_effect",
             "@maven//:org_typelevel_cats_free",
             "@maven//:org_typelevel_cats_kernel",
-            "@maven//:org_scala_lang_modules_scala_collection_compat",
         ],
         scalacopts = hj_scalacopts,
         deps = [

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryBenchmark.scala
@@ -6,12 +6,9 @@ package com.daml.http.dbbackend
 import com.daml.http.dbbackend.Queries.SurrogateTpId
 import com.daml.http.domain.{Party, TemplateId}
 import com.daml.http.util.Logging.instanceUUIDLogCtx
-import com.daml.scalautil.Statement.discard
 import com.daml.scalautil.nonempty.NonEmpty
 import doobie.implicits._
 import org.openjdk.jmh.annotations._
-
-import scala.collection.compat._
 
 trait QueryBenchmark extends ContractDaoBenchmark {
   self: BenchmarkDbConnection =>
@@ -59,7 +56,6 @@ trait QueryBenchmark extends ContractDaoBenchmark {
     assert(result.size == batchSize)
   }
 
-  discard(IterableOnce) // only needed for scala 2.12
 }
 
 class QueryBenchmarkOracle extends QueryBenchmark with OracleBenchmarkDbConn

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
@@ -10,12 +10,9 @@ import com.daml.http.dbbackend.Queries.SurrogateTpId
 import com.daml.http.domain.{Party, TemplateId}
 import com.daml.http.query.ValuePredicate
 import com.daml.http.util.Logging.instanceUUIDLogCtx
-import com.daml.scalautil.Statement.discard
 import com.daml.scalautil.nonempty.NonEmpty
 import org.openjdk.jmh.annotations._
 import spray.json._
-
-import scala.collection.compat._
 
 trait QueryPayloadBenchmark extends ContractDaoBenchmark {
   self: BenchmarkDbConnection =>
@@ -83,7 +80,6 @@ trait QueryPayloadBenchmark extends ContractDaoBenchmark {
     assert(result.size == batchSize)
   }
 
-  discard(IterableOnce) // only needed for scala 2.12
 }
 
 class QueryPayloadBenchmarkOracle extends QueryPayloadBenchmark with OracleBenchmarkDbConn

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractDatabaseIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractDatabaseIntegrationTest.scala
@@ -17,7 +17,6 @@ import org.scalatest.{Assertion, AsyncTestSuite, BeforeAndAfterAll, Inside}
 import org.scalatest.matchers.should.Matchers
 import scalaz.std.list._
 
-import scala.collection.compat._
 import scala.concurrent.Future
 
 abstract class AbstractDatabaseIntegrationTest extends AsyncFreeSpecLike with BeforeAndAfterAll {

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -31,7 +31,6 @@ import spray.json.{
 }
 
 import scala.annotation.nowarn
-import scala.collection.compat._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -34,7 +34,6 @@ import scalaz.syntax.traverse._
 import scalaz.{-\/, OneAnd, OptionT, Show, \/, \/-}
 import spray.json.JsValue
 
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 import com.daml.ledger.api.{domain => LedgerApiDomain}
 import scalaz.std.scalaFuture._

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/PackageService.scala
@@ -16,7 +16,6 @@ import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import scalaz.Scalaz._
 import scalaz._
 
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 import java.time._
 import com.daml.ledger.api.{domain => LedgerApiDomain}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -48,7 +48,7 @@ import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
 import com.daml.metrics.Metrics
 import spray.json.{JsArray, JsObject, JsValue, JsonReader, JsonWriter, enrichAny => `sj enrichAny`}
 
-import scala.collection.compat._
+import scala.collection.Factory
 import scala.collection.mutable.HashSet
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
@@ -11,8 +11,6 @@ import com.daml.ledger.api.v1.transaction.Transaction
 import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, TransactionFilter}
 import com.daml.ledger.api.refinements.{ApiTypes => lar}
 
-import scala.collection.compat._
-
 object Transactions {
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   def allCreatedEvents(transaction: Transaction): ImmArraySeq[CreatedEvent] =

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/DomainSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/DomainSpec.scala
@@ -9,8 +9,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import scalaz.NonEmptyList
 
-import scala.collection.compat._
-
 final class DomainSpec extends AnyFreeSpec with Matchers {
   private val ledgerId = LedgerId("myledger")
   private val appId = ApplicationId("myAppId")

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/ResponseFormatsTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/ResponseFormatsTest.scala
@@ -17,7 +17,6 @@ import scalaz.syntax.show._
 import scalaz.{Show, \/}
 import spray.json._
 
-import scala.collection.compat._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 

--- a/ledger-service/pureconfig-utils/BUILD.bazel
+++ b/ledger-service/pureconfig-utils/BUILD.bazel
@@ -6,15 +6,11 @@ load(
     "da_scala_library",
     "da_scala_test",
     "lf_scalacopts",
-    "silencer_plugin",
 )
 
 da_scala_library(
     name = "pureconfig-utils",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_chuusai_shapeless",
         "@maven//:com_github_pureconfig_pureconfig_core",
@@ -26,7 +22,6 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
     ],
     scalacopts = lf_scalacopts,
-    #    tags = ["maven_coordinates=com.daml:pureconfig-utils:__VERSION__"],
     visibility = [
         "//visibility:public",
     ],

--- a/ledger/error/generator/test/suite/scala/com/daml/error/generator/ErrorCodeDocumentationGeneratorSpec.scala
+++ b/ledger/error/generator/test/suite/scala/com/daml/error/generator/ErrorCodeDocumentationGeneratorSpec.scala
@@ -12,9 +12,6 @@ import com.daml.error._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.annotation.nowarn
-
-@nowarn("msg=deprecated")
 class ErrorCodeDocumentationGeneratorSpec extends AnyFlatSpec with Matchers {
   private val className = ErrorCodeDocumentationGenerator.getClass.getSimpleName
 

--- a/ledger/indexer-benchmark/BUILD.bazel
+++ b/ledger/indexer-benchmark/BUILD.bazel
@@ -9,7 +9,6 @@ load(
     "da_scala_library",
     "da_scala_test_suite",
     "scaladoc_jar",
-    "silencer_plugin",
 )
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("@scala_version//:index.bzl", "scala_major_version_suffix")

--- a/ledger/ledger-api-client/BUILD.bazel
+++ b/ledger/ledger-api-client/BUILD.bazel
@@ -5,18 +5,13 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
     "da_scala_test_suite",
-    "silencer_plugin",
 )
 load("@scala_version//:index.bzl", "scala_major_version")
 
 da_scala_library(
     name = "ledger-api-client",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
     ],
@@ -51,9 +46,6 @@ da_scala_library(
 da_scala_test_suite(
     name = "ledger-api-client-tests",
     srcs = glob(["src/test/suite/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
@@ -63,9 +55,6 @@ da_scala_test_suite(
         "@maven//:org_scalatest_scalatest_matchers_core",
         "@maven//:org_scalatest_scalatest_shouldmatchers",
         "@maven//:org_scalatest_scalatest_wordspec",
-    ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import Compat._",
     ],
     deps = [
         ":ledger-api-client",

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -27,7 +27,6 @@ import com.google.rpc.status.{Status => StatusProto}
 import io.grpc.Status
 import org.slf4j.LoggerFactory
 
-import scala.annotation.nowarn
 import scala.collection.{immutable, mutable}
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Future, Promise}
@@ -235,7 +234,6 @@ private[commands] class CommandTracker[Context](
         }
       }
 
-      @nowarn("msg=deprecated")
       private def registerSubmission(submission: Ctx[Context, CommandSubmission]): Unit = {
         val commands = submission.value.commands
         val submissionId = commands.submissionId

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -28,7 +28,6 @@ import io.grpc.Status
 import org.slf4j.LoggerFactory
 
 import scala.annotation.nowarn
-import scala.collection.compat._
 import scala.collection.{immutable, mutable}
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Future, Promise}

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -38,12 +38,10 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.annotation.nowarn
 import scala.concurrent.duration.DurationLong
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
 
-@nowarn("msg=deprecated")
 class CommandTrackerFlowTest
     extends AsyncWordSpec
     with Matchers

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_library",
     "da_scala_test_suite",
     "kind_projector_plugin",
-    "silencer_plugin",
 )
 load("@scala_version//:index.bzl", "scala_major_version")
 
@@ -92,9 +91,6 @@ da_scala_test_suite(
     data = [
         "//ledger/test-common/test-certificates",
     ],
-    plugins = [
-        silencer_plugin,
-    ],
     resources = ["src/test/resources/logback-test.xml"],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
@@ -111,11 +107,7 @@ da_scala_test_suite(
         "@maven//:org_scalatest_scalatest_wordspec",
         "@maven//:org_scalatestplus_scalacheck_1_15",
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scala_lang_modules_scala_parallel_collections",
-    ],
-    scalacopts = [
-        "-P:silencer:lineContentFilters=import scala.collection.parallel.CollectionConverters._",
     ],
     deps = [
         ":ledger-api-common",

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherSpec.scala
@@ -19,8 +19,6 @@ import org.scalatest.{Assertion, BeforeAndAfter}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.collection.compat._
-import scala.collection.compat.immutable.LazyList
 import scala.collection.immutable
 import scala.collection.immutable.TreeMap
 import scala.concurrent.Future.successful

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -7,7 +7,6 @@ load(
     "da_scala_library",
     "da_scala_library_suite",
     "da_scala_test_suite",
-    "silencer_plugin",
 )
 load(
     "//rules_daml:daml.bzl",
@@ -73,13 +72,9 @@ da_scala_binary(
         da_scala_library(
             name = "ledger-api-test-tool-%s-lib" % lf_version,
             srcs = glob(["src/main/scala/com/daml/ledger/api/testtool/infrastructure/**/*.scala"]),
-            plugins = [
-                silencer_plugin,
-            ],
             scala_deps = [
                 "@maven//:com_typesafe_akka_akka_actor",
                 "@maven//:com_typesafe_akka_akka_stream",
-                "@maven//:org_scala_lang_modules_scala_collection_compat",
                 "@maven//:org_scala_lang_modules_scala_java8_compat",
                 "@maven//:org_scalameta_munit",
             ],
@@ -111,12 +106,8 @@ da_scala_binary(
         da_scala_library_suite(
             name = "ledger-api-test-tool-%s-test-suites" % lf_version,
             srcs = suites_sources(lf_version),
-            plugins = [
-                silencer_plugin,
-            ],
             scala_deps = [
                 "@maven//:com_chuusai_shapeless",
-                "@maven//:org_scala_lang_modules_scala_collection_compat",
             ],
             scaladoc = False,
             visibility = [
@@ -165,14 +156,10 @@ da_scala_binary(
             name = "ledger-api-test-tool-%s" % lf_version,
             srcs = glob(["src/main/scala/com/daml/ledger/api/testtool/*.scala"]),
             main_class = "com.daml.ledger.api.testtool.LedgerApiTestTool",
-            plugins = [
-                silencer_plugin,
-            ],
             resources = [
                 "src/main/resources/logback.xml",
             ],
             scala_deps = [
-                "@maven//:org_scala_lang_modules_scala_collection_compat",
                 "@maven//:com_github_scopt_scopt",
             ],
             tags = [

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -10,7 +10,6 @@ import scopt.{OptionParser, Read}
 
 import java.io.File
 import java.nio.file.{Path, Paths}
-import scala.collection.compat.immutable.LazyList
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Try
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -16,7 +16,6 @@ import io.grpc.Channel
 import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
 import org.slf4j.LoggerFactory
 
-import scala.collection.compat._
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationParallelIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationParallelIT.scala
@@ -27,7 +27,6 @@ import com.daml.ledger.test.model.Test.DummyWithAnnotation
 import io.grpc.Status
 import io.grpc.Status.Code
 
-import scala.collection.compat._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
@@ -14,7 +14,6 @@ import com.google.protobuf.ByteString
 import io.grpc.Status
 
 import java.util.regex.Pattern
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 
 final class PackageManagementServiceIT extends LedgerTestSuite {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
@@ -15,7 +15,6 @@ import io.grpc.Status
 import scalaz.Tag
 import scalaz.syntax.tag.ToTagOps
 
-import scala.collection.compat._
 import scala.util.Random
 
 final class PartyManagementServiceIT extends LedgerTestSuite {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceCorrectnessIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceCorrectnessIT.scala
@@ -13,7 +13,6 @@ import com.daml.ledger.test.model.Test.Dummy._
 import com.daml.ledger.test.model.Test._
 import com.daml.platform.api.v1.event.EventOps.{EventOps, TreeEventOps}
 
-import scala.collection.compat._
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_binary",
     "da_scala_library",
     "da_scala_test_suite",
-    "silencer_plugin",
 )
 load("//ledger/ledger-api-test-tool:conformance.bzl", "conformance_test")
 load("@oracle//:index.bzl", "oracle_testing")
@@ -35,16 +34,12 @@ all_database_runtime_deps = {dep: None for db in supported_databases for dep in 
 da_scala_library(
     name = "ledger-on-sql",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_playframework_anorm_anorm",
         "@maven//:org_playframework_anorm_anorm_tokenizer",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
     ],
     tags = ["maven_coordinates=com.daml:ledger-on-sql:__VERSION__"],

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/migrations/V3__Backfill_Key_Hash_State_Table.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/migrations/V3__Backfill_Key_Hash_State_Table.scala
@@ -9,7 +9,6 @@ import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 
 import java.security.MessageDigest
 import java.sql.{Connection, ResultSet}
-import scala.collection.compat.immutable.LazyList
 import scala.jdk.CollectionConverters._
 
 private[migrations] abstract class V3__Backfill_Key_Hash_State_Table extends BaseJavaMigration {

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
@@ -12,7 +12,6 @@ import com.daml.ledger.on.sql.queries.Queries._
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
 import com.daml.ledger.participant.state.kvutils.{KVOffsetBuilder, Raw}
 
-import scala.collection.compat._
 import scala.collection.immutable
 import scala.util.Try
 

--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -13,7 +13,6 @@ load(
     "da_scala_test",
     "da_scala_test_suite",
     "scaladoc_jar",
-    "silencer_plugin",
 )
 load("//bazel_tools:pom_file.bzl", "pom_file")
 load("//rules_daml:daml.bzl", "daml_compile")
@@ -93,7 +92,6 @@ scala_compile_deps = [
     "@maven//:com_typesafe_akka_akka_stream",
     "@maven//:org_playframework_anorm_anorm",
     "@maven//:org_playframework_anorm_anorm_tokenizer",
-    "@maven//:org_scala_lang_modules_scala_collection_compat",
     "@maven//:org_scala_lang_modules_scala_java8_compat",
     "@maven//:org_scalaz_scalaz_core",
     "@maven//:io_spray_spray_json",
@@ -106,9 +104,6 @@ runtime_deps = [
 da_scala_library(
     name = "participant-integration-api",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     resources =
         glob(
             ["src/main/resources/**/*"],
@@ -130,9 +125,6 @@ da_scala_library(
 da_scala_library(
     name = "ledger-api-server",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     resources =
         glob(
             ["src/main/resources/**/*"],
@@ -152,13 +144,9 @@ da_scala_library(
 da_scala_library(
     name = "participant-integration-api-tests-lib",
     srcs = glob(["src/test/lib/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalactic_scalactic",
         "@maven//:org_scalatest_scalatest_core",
@@ -241,9 +229,6 @@ da_scala_test_suite(
     jvm_flags = [
         "-Djava.security.debug=\"certpath ocsp\"",  # This facilitates debugging of the OCSP checks mechanism
     ],
-    plugins = [
-        silencer_plugin,
-    ],
     resources = glob(["src/test/resources/**/*"]),
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
@@ -253,7 +238,6 @@ da_scala_test_suite(
         "@maven//:org_mockito_mockito_scala",
         "@maven//:org_playframework_anorm_anorm",
         "@maven//:org_playframework_anorm_anorm_tokenizer",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalactic_scalactic",
         "@maven//:org_scalatest_scalatest_core",
@@ -410,13 +394,7 @@ scaladoc_jar(
         "//ledger/participant-state:sources",
     ],
     doctitle = "Daml participant integration API",
-    plugins = [
-        silencer_plugin,
-    ],
     root_content = "rootdoc.txt",
-    scalacopts = [
-        "-P:silencer:checkUnused",
-    ] + (["-P:silencer:lineContentFilters=import scala.collection.compat._"] if scala_major_version != "2.12" else []),
     visibility = [
         "//visibility:public",
     ],

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -34,7 +34,6 @@ import com.daml.platform.store.{ActiveLedgerState, ActiveLedgerStateManager, Let
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 import org.slf4j.LoggerFactory
 
-import scala.collection.compat._
 import scala.collection.immutable
 
 /** V1 was missing divulgence info

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
@@ -14,8 +14,6 @@ import com.daml.lf.value.Value.ContractId
 import com.daml.platform.store.serialization.{KeyHasher, ValueSerializer}
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 
-import scala.collection.compat.immutable.LazyList
-
 private[migration] class V3__Recompute_Key_Hash extends BaseJavaMigration {
 
   // the number of contracts proceeded in a batch.

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V4_1__Collect_Parties.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V4_1__Collect_Parties.scala
@@ -14,8 +14,6 @@ import com.daml.platform.store.Conversions._
 import com.daml.platform.db.migration.translation.TransactionSerializer
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 
-import scala.collection.compat.immutable.LazyList
-
 private[migration] class V4_1__Collect_Parties extends BaseJavaMigration {
 
   // the number of contracts proceeded in a batch.

--- a/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/Raw.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/appendonlydao/events/Raw.scala
@@ -14,7 +14,7 @@ import com.daml.logging.LoggingContext
 import com.daml.platform.participant.util.LfEngineToApi
 import com.daml.platform.store.serialization.Compression
 
-import scala.collection.compat.immutable.ArraySeq
+import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
 /** An event as it's fetched from the participant index, before

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -21,7 +21,7 @@ import com.daml.platform.store.backend.common.ComposableQuery.{CompositeSql, Sql
 import com.daml.platform.store.cache.LedgerEndCache
 import com.daml.platform.store.interning.StringInterning
 
-import scala.collection.compat.immutable.ArraySeq
+import scala.collection.immutable.ArraySeq
 
 abstract class EventStorageBackendTemplate(
     eventStrategy: EventStrategy,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
@@ -19,7 +19,6 @@ import org.scalatest._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.compat._
 import scala.concurrent.Future
 
 private[dao] trait JdbcLedgerDaoTransactionTreesSpec

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
@@ -22,7 +22,6 @@ import io.grpc.ManagedChannel
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.collection.compat.immutable.LazyList
 import scala.concurrent.Future
 
 final class GrpcServerSpec extends AsyncWordSpec with Matchers with TestResourceContext {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerMapSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.Inside.inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.collection.compat._
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
     "da_scala_test_suite",
-    "silencer_plugin",
 )
 load(
     "//bazel_tools/client_server:client_server_build.bzl",
@@ -24,15 +23,11 @@ load("//ledger/test-common:test-common.bzl", "da_scala_dar_resources_library")
 da_scala_library(
     name = "kvutils",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_scala_lang_modules_scala_java8_compat",
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     tags = ["maven_coordinates=com.daml:participant-state-kvutils:__VERSION__"],
     visibility = [
@@ -86,14 +81,10 @@ da_scala_library(
         "src/test/lib/scala/**/*.scala",
         "src/test/lib/{}/**/*.scala".format(scala_major_version),
     ]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_mockito_mockito_scala",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scala_lang_modules_scala_java8_compat",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalactic_scalactic",
@@ -152,15 +143,11 @@ da_scala_test_suite(
     data = [
         "//ledger/test-common:model-tests-default.dar",
     ],
-    plugins = [
-        silencer_plugin,
-    ],
     resources = glob(["src/test/resources/*"]),
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_mockito_mockito_scala",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalactic_scalactic",
         "@maven//:org_scalatest_scalatest_core",

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ConfigProvider.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ConfigProvider.scala
@@ -16,10 +16,9 @@ import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode}
 import io.grpc.ServerInterceptor
 import scopt.OptionParser
 
-import scala.annotation.{nowarn, unused}
+import scala.annotation.unused
 import scala.concurrent.duration.FiniteDuration
 
-@nowarn("msg=parameter value config .* is never used") // possibly used in overrides
 trait ConfigProvider[ExtraConfig] {
   val defaultExtraConfig: ExtraConfig
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -9,7 +9,7 @@ import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 
-import scala.collection.compat._
+import scala.collection.Factory
 import scala.collection.mutable
 
 /** Commit context provides access to state inputs, commit parameters (e.g. record time) and

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataImporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataImporter.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-import scala.collection.compat.immutable.LazyList
-
 trait LedgerDataImporter {
   def read(): LazyList[(SubmissionInfo, WriteSet)]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
@@ -10,7 +10,6 @@ import com.daml.ledger.participant.state.kvutils.export.LedgerExport.LedgerExpor
 import com.daml.ledger.participant.state.kvutils.{Conversions, Raw}
 import com.daml.lf.data.Ref
 
-import scala.collection.compat.immutable.LazyList
 import scala.jdk.CollectionConverters._
 
 final class ProtobufBasedLedgerDataImporter(input: InputStream)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.participant.state.kvutils.store.{DamlStateKey, DamlStateV
 import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 
 import scala.collection.SortedMap
-import scala.collection.compat._
+import scala.collection.Factory
 
 final class StateSerializationStrategy(keyStrategy: StateKeySerializationStrategy) {
   def serializeState(key: DamlStateKey, value: DamlStateValue): Raw.StateEntry =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -18,7 +18,6 @@ import com.daml.lf.data.Ref
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
 
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -47,7 +47,6 @@ import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatest.{Assertion, BeforeAndAfterEach}
 
-import scala.collection.compat._
 import scala.collection.immutable.SortedSet
 import scala.collection.mutable
 import scala.compat.java8.FutureConverters._

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/preexecution/PreExecutionTestHelper.scala
@@ -8,7 +8,6 @@ import com.daml.ledger.validator.HasDamlStateValue
 import com.daml.ledger.validator.reading.StateReader
 import com.daml.logging.LoggingContext
 
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 
 object PreExecutionTestHelper {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -33,7 +33,6 @@ import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.collection.compat.immutable.LazyList
 import scala.jdk.CollectionConverters._
 
 class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -35,10 +35,8 @@ import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
-@nowarn("msg=deprecated")
 class TransactionCommitterSpec
     extends AnyWordSpec
     with Matchers

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -8,7 +8,6 @@ load(
     "da_scala_library",
     "da_scala_test",
     "lf_scalacopts",
-    "silencer_plugin",
 )
 load("@os_info//:os_info.bzl", "is_windows")
 load("@scala_version//:index.bzl", "scala_major_version")
@@ -21,7 +20,6 @@ da_scala_library(
         "@maven//:com_github_scopt_scopt",
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     tags = ["maven_coordinates=com.daml:participant-state-kvutils-tools:__VERSION__"],
     visibility = [
@@ -154,11 +152,7 @@ da_scala_test(
 da_scala_library(
     name = "engine-replay",
     srcs = glob(["engine-replay/src/replay/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
     ],
     deps = [

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_binary",
     "da_scala_library",
     "da_scala_test_suite",
-    "silencer_plugin",
 )
 load("//ledger/ledger-api-test-tool:conformance.bzl", "server_conformance_test")
 load("@os_info//:os_info.bzl", "is_windows")
@@ -22,9 +21,6 @@ alias(
     da_scala_library(
         name = "sandbox-classic-{}".format(edition),
         srcs = glob(["src/main/scala/**/*.scala"]),
-        plugins = [
-            silencer_plugin,
-        ],
         # Do not include logback.xml into the library: let the user
         # of the sandbox-as-a-library decide how to log.
         resources = ["//ledger/sandbox-common:src/main/resources/banner.txt"],
@@ -34,11 +30,6 @@ alias(
             "@maven//:com_typesafe_akka_akka_stream",
             "@maven//:org_scala_lang_modules_scala_java8_compat",
             "@maven//:org_scalaz_scalaz_core",
-        ],
-        scalacopts = [
-            # retain is deprecated in 2.13 but the replacement filterInPlace
-            # does not exist in 2.12.
-            "-P:silencer:lineContentFilters=retain",
         ],
         tags = ["maven_coordinates=com.daml:sandbox-classic:__VERSION__"],
         visibility = [

--- a/ledger/test-common/BUILD.bazel
+++ b/ledger/test-common/BUILD.bazel
@@ -4,7 +4,6 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
-    "silencer_plugin",
 )
 load(
     "//language-support/scala/codegen:codegen.bzl",
@@ -87,16 +86,16 @@ alias(
 ]
 
 # Correspond to the directories under src/test/lib/daml
-test_names_with_dependencies = {
-    "model": ["@maven//:org_scala_lang_modules_scala_collection_compat"],
-    "semantic": ["@maven//:org_scala_lang_modules_scala_collection_compat"],
-    "performance": [],
-    "package_management": [],
-}
+test_names = [
+    "model",
+    "semantic",
+    "performance",
+    "package_management",
+]
 
 da_scala_dar_resources_library(
     add_maven_tag = True,
-    daml_dir_names = test_names_with_dependencies.keys(),
+    daml_dir_names = test_names,
     daml_root_dir = "src/main/daml",
     enable_scenarios = True,
     exclusions = {
@@ -122,12 +121,8 @@ da_scala_dar_resources_library(
                 srcs = [
                     ":%s-tests-%s.scala-codegen" % (test_name, target),
                 ],
-                plugins = [
-                    silencer_plugin,
-                ],
-                scala_deps = extra_deps,
                 scalacopts = [
-                    "-P:silencer:lineContentFilters=import _root_.scala.language.higherKinds;",
+                    "-Wconf:cat=unused-imports&site=com\\.daml\\.ledger\\.test\\.{}\\..*:s".format(test_name),
                 ],
                 visibility = ["//visibility:public"],
                 deps = [
@@ -135,7 +130,7 @@ da_scala_dar_resources_library(
                 ],
             ),
         ]
-        for (test_name, extra_deps) in test_names_with_dependencies.items()
+        for test_name in test_names
     ]
     for target in lf_version_configuration_versions
 ]

--- a/libs-scala/db-utils/BUILD.bazel
+++ b/libs-scala/db-utils/BUILD.bazel
@@ -6,15 +6,11 @@ load(
     "da_scala_library",
     "da_scala_test",
     "lf_scalacopts",
-    "silencer_plugin",
 )
 
 da_scala_library(
     name = "db-utils",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_github_scopt_scopt",
         "@maven//:org_scalaz_scalaz_core",

--- a/libs-scala/gatling-utils/BUILD.bazel
+++ b/libs-scala/gatling-utils/BUILD.bazel
@@ -7,7 +7,6 @@ load(
     "da_scala_test",
     "kind_projector_plugin",
     "lf_scalacopts",
-    "silencer_plugin",
 )
 load("@scala_version//:index.bzl", "scala_major_version")
 
@@ -20,14 +19,12 @@ da_scala_library(
     srcs = glob(["src/main/scala/**/*.scala"]),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:com_typesafe_scala_logging_scala_logging",
         "@maven//:io_spray_spray_json",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = scalacopts,
     tags = ["maven_coordinates=com.daml:gatling-utils:__VERSION__"],

--- a/libs-scala/gatling-utils/src/main/scala/com/daml/gatling/stats/SimulationLog.scala
+++ b/libs-scala/gatling-utils/src/main/scala/com/daml/gatling/stats/SimulationLog.scala
@@ -7,7 +7,6 @@ import java.nio.file.Path
 
 import scalaz._
 
-import scala.collection.compat._
 import scala.collection.immutable.ListMap
 import spray.json._
 

--- a/libs-scala/nameof/src/test/suite/scala/com/digitalasset/logging/NameOfSpec.scala
+++ b/libs-scala/nameof/src/test/suite/scala/com/digitalasset/logging/NameOfSpec.scala
@@ -7,13 +7,10 @@ import com.daml.nameof.NameOf.qualifiedNameOfCurrentFunc
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.annotation.nowarn
-
 final class NameOfSpec extends AnyFlatSpec with Matchers {
 
   behavior of "NameOf"
 
-  @nowarn()
   case class Ham() {
     def ham(): String = qualifiedNameOfCurrentFunc
   }

--- a/libs-scala/resources/BUILD.bazel
+++ b/libs-scala/resources/BUILD.bazel
@@ -9,7 +9,6 @@ da_scala_library(
     srcs = glob(["src/main/scala/**/*.scala"]) + glob(["src/main/{}/**/*.scala".format(scala_major_version)]),
     scala_deps = [
         "@maven//:org_scala_lang_modules_scala_java8_compat",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     tags = ["maven_coordinates=com.daml:resources:__VERSION__"],
     visibility = [
@@ -34,9 +33,6 @@ da_scala_library(
 da_scala_test_suite(
     name = "resources-tests",
     srcs = glob(["src/test/suite/**/*.scala"]),
-    scala_deps = [
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
-    ],
     deps = [
         ":resources",
         ":resources-test-lib",

--- a/libs-scala/resources/src/main/2.13/com/daml/resources/UnitCanBuildFrom.scala
+++ b/libs-scala/resources/src/main/2.13/com/daml/resources/UnitCanBuildFrom.scala
@@ -3,7 +3,7 @@
 
 package com.daml.resources
 
-import scala.collection.compat._
+import scala.collection.Factory
 import scala.collection.mutable
 
 private[resources] final class UnitCanBuildFrom[T, C[_]] extends Factory[T, Unit] {

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceFactories.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceFactories.scala
@@ -5,7 +5,7 @@ package com.daml.resources
 
 import com.daml.resources.HasExecutionContext.executionContext
 
-import scala.collection.compat._
+import scala.collection.Factory
 import scala.concurrent.Future
 import scala.util.Try
 

--- a/libs-scala/scala-utils/BUILD.bazel
+++ b/libs-scala/scala-utils/BUILD.bazel
@@ -7,7 +7,6 @@ load(
     "da_scala_test",
     "kind_projector_plugin",
     "lf_scalacopts",
-    "silencer_plugin",
 )
 load("@scala_version//:index.bzl", "scala_major_version")
 
@@ -22,7 +21,6 @@ da_scala_library(
     ]),
     plugins = [
         kind_projector_plugin,
-        silencer_plugin,
     ],
     scala_deps = [
         "@maven//:org_scalaz_scalaz_core",

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -55,7 +55,7 @@ import scalaz.{-\/, Functor, \/, \/-}
 
 import java.time.Instant
 import java.util.UUID
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.tailrec
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -77,7 +77,6 @@ final case class Trigger(
     // Whether the trigger supports readAs claims (SDK 1.18 and newer) or not.
     hasReadAs: Boolean,
 ) {
-  @nowarn("msg=parameter value label .* is never used") // Proxy only
   private[trigger] final class withLoggingContext[P] private (
       label: label[Trigger with P],
       kvs: Seq[LoggingEntry],

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_binary",
     "da_scala_library",
     "da_scala_test",
-    "silencer_plugin",
 )
 
 exports_files(["release/oauth2-middleware-logback.xml"])
@@ -52,9 +51,6 @@ da_scala_library(
 da_scala_library(
     name = "oauth2-middleware",
     srcs = glob(["src/main/scala/com/daml/auth/middleware/oauth2/**/*.scala"]),
-    plugins = [
-        silencer_plugin,
-    ],
     resources = glob(["src/main/resources/com/daml/auth/middleware/oauth2/**"]),
     scala_deps = [
         "@maven//:com_github_scopt_scopt",
@@ -75,7 +71,6 @@ da_scala_library(
         "@maven//:com_github_pureconfig_pureconfig_core",
         "@maven//:com_github_pureconfig_pureconfig_generic",
         "@maven//:io_spray_spray_json",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalaz_scalaz_core",
     ],
     scalacopts = scalacopts,

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Request.scala
@@ -13,7 +13,6 @@ import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, Party}
 import scalaz.{@@, Tag}
 import spray.json._
 
-import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent._
 import scala.util.Try

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/RequestTemplates.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/RequestTemplates.scala
@@ -11,7 +11,6 @@ import com.daml.auth.middleware.api.Request
 import com.daml.auth.middleware.api.Tagged.RefreshToken
 import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, Party}
 
-import scala.collection.compat._
 import scala.collection.concurrent.TrieMap
 import scala.io.{BufferedSource, Source}
 import scala.util.Try

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
@@ -27,7 +27,6 @@ import com.daml.ports.{Port, PortFiles}
 import scalaz.{-\/, \/-}
 import spray.json._
 
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -6,7 +6,6 @@ load(
     "da_scala_binary",
     "da_scala_library",
     "da_scala_test_suite",
-    "silencer_plugin",
 )
 load("@build_environment//:configuration.bzl", "sdk_version")
 
@@ -82,12 +81,8 @@ da_scala_library(
         "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala",
         "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala",
     ],
-    plugins = [
-        silencer_plugin,
-    ],
     scala_deps = [
         "@maven//:com_typesafe_akka_akka_stream",
-        "@maven//:org_scala_lang_modules_scala_collection_compat",
         "@maven//:org_scalactic_scalactic",
         "@maven//:org_scalatest_scalatest_core",
         "@maven//:org_scalatest_scalatest_matchers_core",

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -33,7 +33,6 @@ import com.daml.platform.sandbox.services.TestCommands
 import org.scalatest._
 import scalaz.syntax.tag._
 
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 


### PR DESCRIPTION
Since Scala 2.13.2, Scala introduced built-in support to
manage warnings in a more granular fashion, thus making
the silencer plugin we are currently using no longer
strictly useful. Removing compiler plugins also removes
friction from migrating to Scala 3 in the future. As a
cherry on top, the built-in warning configuration also
allows to check whether a `@nowarn` actually does
anything, allowing us to proactively remove unused
warnings should the need arise.

[Here][1] is s a blog post by the Scala team about it.

Warnings have been either solved or preserved if useful,
trying to minimize the scope (keeping it at the single
expression scope if possible). In particular, all
remaining usages of the Scala Collection API compatibility
module have been removed.

Using the silencer plugin also apparently hid a few
remaining usages of compatibility libraries that were used
as part of the transition from Scala 2.12 to Scala 2.13
that are no longer needed. Removing those warnings
highlighted those.

changelog_begin
changelog_end

[1]: https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
