### PR TITLE
Fix trigger compat test for canton sandbox

### DIFF
--- a/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
+++ b/compatibility/bazel_tools/daml_trigger/daml_trigger.bzl
@@ -144,10 +144,21 @@ canonicalize_rlocation() {{
 runner=$$(canonicalize_rlocation $(rootpath {runner}))
 # Cleanup the trigger runner process but maintain the script runner exit code.
 trap 'status=$$?; kill -TERM $$PID; wait $$PID; exit $$status' INT TERM
+
+SCRIPTOUTPUT=$$(mktemp -d)
+$$runner script \\
+  --ledger-host localhost \\
+  --ledger-port 6865 \\
+  --wall-clock-time \\
+  --dar $$(canonicalize_rlocation $(rootpath {dar})) \\
+  --script-name TestScript:allocateAlice \\
+  --output-file $$SCRIPTOUTPUT/alice.json
+ALICE=$$(cat $$SCRIPTOUTPUT/alice.json | sed 's/"//g')
+rm -rf $$SCRIPTOUTPUT
 $$runner trigger \\
   --ledger-host localhost \\
   --ledger-port 6865 \\
-  --ledger-party Alice \\
+  --ledger-party $$ALICE \\
   --wall-clock-time \\
   --dar $$(canonicalize_rlocation $(rootpath {dar})) \\
   --trigger-name CopyTrigger:copyTrigger &

--- a/compatibility/bazel_tools/daml_trigger/example/src/TestScript.daml
+++ b/compatibility/bazel_tools/daml_trigger/example/src/TestScript.daml
@@ -8,10 +8,24 @@ import DA.Assert
 import DA.Time
 import Daml.Script
 
+allocateAlice : Script Party
+allocateAlice = do
+  debug "Creating Alice ..."
+  alice <- allocatePartyWithHint "Alice" (PartyIdHint "Alice")
+  debug alice
+  debug "... done"
+  pure alice
+
 test : Script ()
 test = do
-  debug "Creating parties ..."
-  alice <- allocatePartyWithHint "Alice" (PartyIdHint "Alice")
+  debug "Searching for Alice ..."
+  let isAlice x = displayName x == Some "Alice"
+  Some aliceDetails <- find isAlice <$> listKnownParties
+  let alice = party aliceDetails
+  debug alice
+  debug "... done"
+
+  debug "Creating Bob ..."
   bob <- allocatePartyWithHint "Bob" (PartyIdHint "Bob")
   debug alice
   debug bob


### PR DESCRIPTION
This fixes the timeout on trigger compat tests for the new sandbox (when LF >= 1.14).

The issue was that the trigger was "readAs"-ing with a party that
doesn't exist, since party ids aren't predictable with the new sandbox.

The solution is to allocate the Alice party ahead of time, and then
pass the allocated party in when calling `daml trigger`.

[This PR does not fix the issue of using < LF 1.14 with canton-sandbox.]

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
