### PR TITLE
Wait for server process in client_server_test

### DIFF
--- a/bazel_tools/client_server/runner_with_port_check/BUILD.bazel
+++ b/bazel_tools/client_server/runner_with_port_check/BUILD.bazel
@@ -9,7 +9,7 @@ da_haskell_binary(
     hackage_deps = [
         "base",
         "extra",
-        "process",
+        "typed-process",
         "async",
         "text",
         "safe",

--- a/bazel_tools/client_server/runner_with_port_check/BUILD.bazel
+++ b/bazel_tools/client_server/runner_with_port_check/BUILD.bazel
@@ -10,6 +10,7 @@ da_haskell_binary(
         "base",
         "extra",
         "typed-process",
+        "process",
         "async",
         "text",
         "safe",

--- a/bazel_tools/client_server/runner_with_port_check/Main.hs
+++ b/bazel_tools/client_server/runner_with_port_check/Main.hs
@@ -18,9 +18,11 @@ main = do
   let splitArgs = filter (/= "") . splitOn " "
   let serverProc = proc serverExe (splitArgs serverArgs)
   let ports :: [Int] = read <$> splitArgs runnerArgs
-  withProcessTerm serverProc $ \_ph -> do
+  withProcessTerm serverProc $ \ph -> do
     forM_ ports $ \port -> waitForConnectionOnPort (threadDelay 500000) port
     runProcess_ (proc clientExe (splitArgs clientArgs))
+    -- See the comment on DA.Daml.Helper.Util.withProcessWait_'
+    when isWindows (terminateProcess $ unsafeProcessHandle ph)
 
 
 waitForConnectionOnPort :: IO () -> Int -> IO ()

--- a/bazel_tools/client_server/runner_with_port_check/Main.hs
+++ b/bazel_tools/client_server/runner_with_port_check/Main.hs
@@ -8,9 +8,11 @@ import Control.Exception.Safe
 import Control.Monad.Loops (untilJust)
 import System.Process.Typed
 import Data.List.Split (splitOn)
-import Control.Monad (forM_)
+import Control.Monad (forM_, when)
 import Network.Socket
 import Control.Concurrent
+import System.Info.Extra
+import System.Process (terminateProcess)
 
 main :: IO ()
 main = do

--- a/bazel_tools/client_server/runner_with_port_check/Main.hs
+++ b/bazel_tools/client_server/runner_with_port_check/Main.hs
@@ -6,7 +6,7 @@ module Main(main) where
 import System.Environment
 import Control.Exception.Safe
 import Control.Monad.Loops (untilJust)
-import System.Process
+import System.Process.Typed
 import Data.List.Split (splitOn)
 import Control.Monad (forM_)
 import Network.Socket
@@ -18,9 +18,9 @@ main = do
   let splitArgs = filter (/= "") . splitOn " "
   let serverProc = proc serverExe (splitArgs serverArgs)
   let ports :: [Int] = read <$> splitArgs runnerArgs
-  withCreateProcess serverProc $ \_stdin _stdout _stderr _ph -> do
+  withProcessTerm serverProc $ \_ph -> do
     forM_ ports $ \port -> waitForConnectionOnPort (threadDelay 500000) port
-    callProcess clientExe (splitArgs clientArgs)
+    runProcess_ (proc clientExe (splitArgs clientArgs))
 
 
 waitForConnectionOnPort :: IO () -> Int -> IO ()

--- a/bazel_tools/client_server/runner_with_port_file/BUILD.bazel
+++ b/bazel_tools/client_server/runner_with_port_file/BUILD.bazel
@@ -11,7 +11,7 @@ da_haskell_binary(
         "directory",
         "extra",
         "filepath",
-        "process",
+        "typed-process",
     ],
     visibility = ["//visibility:public"],
     deps = ["//libs-haskell/da-hs-base"],

--- a/bazel_tools/client_server/runner_with_port_file/BUILD.bazel
+++ b/bazel_tools/client_server/runner_with_port_file/BUILD.bazel
@@ -12,6 +12,7 @@ da_haskell_binary(
         "extra",
         "filepath",
         "typed-process",
+        "process",
     ],
     visibility = ["//visibility:public"],
     deps = ["//libs-haskell/da-hs-base"],

--- a/bazel_tools/client_server/runner_with_port_file/Main.hs
+++ b/bazel_tools/client_server/runner_with_port_file/Main.hs
@@ -3,7 +3,7 @@
 
 module Main (main) where
 
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Data.List.Extra (replace, splitOn, stripInfix)
 import Data.Maybe (isJust)
 import System.Environment (getArgs)
@@ -12,6 +12,8 @@ import System.Process.Typed (proc, runProcess_, withProcessTerm, unsafeProcessHa
 import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
 import System.IO.Extra (withTempDir)
+import System.Info.Extra
+import System.Process (terminateProcess)
 
 import DA.PortFile
 

--- a/bazel_tools/client_server/runner_with_port_file/Main.hs
+++ b/bazel_tools/client_server/runner_with_port_file/Main.hs
@@ -32,3 +32,5 @@ main = do
       port <- readPortFile (unsafeProcessHandle ph) maxRetries portFile
       let interpolatedClientArgs = map (replace "%PORT%" (show port)) splitClientArgs
       runProcess_ (proc clientExe interpolatedClientArgs)
+      -- See the comment on DA.Daml.Helper.Util.withProcessWait_'
+      when isWindows (terminateProcess $ unsafeProcessHandle ph)


### PR DESCRIPTION
withCreateProcess kills the server process but it doesn’t wait for it
to finish. The `typed-process` version does things properly here which
is also why we switched to it in other places.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
