### PR TITLE
ci: bump Windows vmImage to 2022

### DIFF
--- a/ci/patch_bazel_windows/compile.yml
+++ b/ci/patch_bazel_windows/compile.yml
@@ -44,7 +44,7 @@ jobs:
     should_run: $[ dependencies.patch_bazel_pre_check.outputs['out.should_run'] ]
     bazel_base_version: 4.2.1
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   steps:
   - checkout: self
     condition: eq(variables.should_run, 'true')


### PR DESCRIPTION
Azure is telling us to stop using 2019, so here we go.

CHANGELOG_BEGIN
CHANGELOG_END