### PR TITLE
split: do not tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,11 +173,6 @@ jobs:
     - template: ci/bash-lib.yml
       parameters:
         var_name: bash-lib
-    - bash: |
-        set -euo pipefail
-        if git tag v$(release_tag) $(release_sha); then
-          git push origin v$(release_tag)
-        fi
     - task: DownloadPipelineArtifact@0
       inputs:
         artifactName: linux-release


### PR DESCRIPTION
We use tags to track releases; in particular, we want tags to correspond
to GitHub releases. In the split release process, the `assembly` repo is
responsible for creating GitHub releases, so it would make sense that it
is also the one responsible for creating tags.

I wouldd also like to take this opportunity to manually remove all the
tags that have been created by the split release process so far and that
don't correspond to any release (which is all of them as we haven't done
a full split release yet), since they have already caused some
confusion.

CHANGELOG_BEGIN
CHANGELOG_END