### PR TITLE
Fix error codes for V1 cid rejections

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -87,6 +87,7 @@ conformance_test(
             "CommandDeduplicationIT:DeduplicateUsingOffsets",  # disabled while Canton does not support the feature descriptors
             "CommandDeduplicationParallelIT",  # can be re-enabled once canton exposes the feature descriptors
             "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # TODO https://github.com/DACH-NY/canton/issues/6301
+            "ContractIdIT:RejectV0", # TODO Reenable after Canton changes error codes
             "ContractIdIT:AcceptNonSuffixedV1Cid",
             "ContractIdIT:AcceptSuffixedV1CidExerciseTarget",
             "DeeplyNestedValueIT",  # FIXME: Too deeply nested values flake with a time out (half of the time)

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -87,7 +87,7 @@ conformance_test(
             "CommandDeduplicationIT:DeduplicateUsingOffsets",  # disabled while Canton does not support the feature descriptors
             "CommandDeduplicationParallelIT",  # can be re-enabled once canton exposes the feature descriptors
             "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # TODO https://github.com/DACH-NY/canton/issues/6301
-            "ContractIdIT:RejectV0", # TODO Reenable after Canton changes error codes
+            "ContractIdIT:RejectV0",  # TODO Reenable after Canton changes error codes
             "ContractIdIT:AcceptNonSuffixedV1Cid",
             "ContractIdIT:AcceptSuffixedV1CidExerciseTarget",
             "DeeplyNestedValueIT",  # FIXME: Too deeply nested values flake with a time out (half of the time)

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -87,7 +87,8 @@ conformance_test(
             "CommandDeduplicationIT:DeduplicateUsingOffsets",  # disabled while Canton does not support the feature descriptors
             "CommandDeduplicationParallelIT",  # can be re-enabled once canton exposes the feature descriptors
             "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # TODO https://github.com/DACH-NY/canton/issues/6301
-            "ContractIdIT",  # temporarily disabled due to changed error codes
+            "ContractIdIT:AcceptNonSuffixedV1Cid",
+            "ContractIdIT:AcceptSuffixedV1CidExerciseTarget",
             "DeeplyNestedValueIT",  # FIXME: Too deeply nested values flake with a time out (half of the time)
             "RaceConditionIT:RWArchiveVsFailedLookupByKey",  # finding a lookup failure after contract creation
             # dynamic config management not supported by Canton

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractIdIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractIdIT.scala
@@ -43,6 +43,7 @@ final class ContractIdIT extends LedgerTestSuite {
       accepted = true,
       isSupported = features => features.contractIds.v1.isNonSuffixed,
       disabledReason = "non-suffixed V1 contract IDs are not supported",
+      failsInPreprocessing = true,
     ),
     TestConfiguration(
       description = "non-suffixed v1",
@@ -50,6 +51,7 @@ final class ContractIdIT extends LedgerTestSuite {
       accepted = false,
       isSupported = features => !features.contractIds.v1.isNonSuffixed,
       disabledReason = "non-suffixed V1 contract IDs are supported",
+      failsInPreprocessing = true,
     ),
     TestConfiguration(
       description = "suffixed v1",
@@ -57,12 +59,12 @@ final class ContractIdIT extends LedgerTestSuite {
       accepted = true,
     ),
   ).foreach {
-    case TestConfiguration(cidDescription, example, accepted, isSupported, disabledReason) =>
+    case TestConfiguration(cidDescription, example, accepted, isSupported, disabledReason, failsInPreprocessing) =>
       val result = if (accepted) "Accept" else "Reject"
 
       def test(
           description: String,
-          errorCode: ErrorCode = LedgerApiErrors.RequestValidation.InvalidArgument,
+          parseErrorCode: ErrorCode = LedgerApiErrors.RequestValidation.InvalidArgument,
       )(
           update: ExecutionContext => (
               ParticipantTestContext,
@@ -79,12 +81,16 @@ final class ContractIdIT extends LedgerTestSuite {
           update(ec)(alpha, party).map {
             case Success(_) if accepted => ()
             case Failure(err: Throwable) if !accepted =>
+              val (prefix, errorCode)  = if (failsInPreprocessing)
+                ("Illegal Contract ID", LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed)
+              else
+                ("cannot parse ContractId", parseErrorCode)
               assertGrpcError(
                 alpha,
                 err,
                 Status.Code.INVALID_ARGUMENT,
                 errorCode,
-                Some(s"""cannot parse ContractId "$example""""),
+                Some(s"""$prefix "$example""""),
                 checkDefiniteAnswerMetadata = true,
               )
               ()
@@ -100,7 +106,7 @@ final class ContractIdIT extends LedgerTestSuite {
           .transformWith(Future.successful)
       }
 
-      test("exercise target", errorCode = LedgerApiErrors.RequestValidation.InvalidField) {
+      test("exercise target", parseErrorCode = LedgerApiErrors.RequestValidation.InvalidField) {
         implicit ec => (alpha, party) =>
           for {
             contractCid <- alpha.create(party, Contract(party))
@@ -208,6 +214,9 @@ object ContractIdIT {
       example: String,
       accepted: Boolean,
       isSupported: Features => Boolean = _ => true,
-      disabledReason: String = "",
+    disabledReason: String = "",
+    // Invalid v1 cids (e.g. no suffix when one is required) fail during command preprocessing
+    // while invalid v0 cids fail earlier.
+    failsInPreprocessing: Boolean = false,
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractIdIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractIdIT.scala
@@ -59,7 +59,14 @@ final class ContractIdIT extends LedgerTestSuite {
       accepted = true,
     ),
   ).foreach {
-    case TestConfiguration(cidDescription, example, accepted, isSupported, disabledReason, failsInPreprocessing) =>
+    case TestConfiguration(
+          cidDescription,
+          example,
+          accepted,
+          isSupported,
+          disabledReason,
+          failsInPreprocessing,
+        ) =>
       val result = if (accepted) "Accept" else "Reject"
 
       def test(
@@ -81,10 +88,14 @@ final class ContractIdIT extends LedgerTestSuite {
           update(ec)(alpha, party).map {
             case Success(_) if accepted => ()
             case Failure(err: Throwable) if !accepted =>
-              val (prefix, errorCode)  = if (failsInPreprocessing)
-                ("Illegal Contract ID", LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed)
-              else
-                ("cannot parse ContractId", parseErrorCode)
+              val (prefix, errorCode) =
+                if (failsInPreprocessing)
+                  (
+                    "Illegal Contract ID",
+                    LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
+                  )
+                else
+                  ("cannot parse ContractId", parseErrorCode)
               assertGrpcError(
                 alpha,
                 err,
@@ -214,9 +225,9 @@ object ContractIdIT {
       example: String,
       accepted: Boolean,
       isSupported: Features => Boolean = _ => true,
-    disabledReason: String = "",
-    // Invalid v1 cids (e.g. no suffix when one is required) fail during command preprocessing
-    // while invalid v0 cids fail earlier.
-    failsInPreprocessing: Boolean = false,
+      disabledReason: String = "",
+      // Invalid v1 cids (e.g. no suffix when one is required) fail during command preprocessing
+      // while invalid v0 cids fail earlier.
+      failsInPreprocessing: Boolean = false,
   )
 }


### PR DESCRIPTION
Those still fail in preprocessing and not in parsing so they need to
keep the old error codes.

This only breaks in Canton and due to the delay in updating Canton here it doesn’t break our CI atm.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
