### PR TITLE
Enable accidentially disabled ContractIdIT suite against canton

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -87,7 +87,8 @@ conformance_test(
             "CommandDeduplicationIT:DeduplicateUsingOffsets",  # disabled while Canton does not support the feature descriptors
             "CommandDeduplicationParallelIT",  # can be re-enabled once canton exposes the feature descriptors
             "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # TODO https://github.com/DACH-NY/canton/issues/6301
-            "ContractIdIT",  # temporarily disabled due to changed error codes
+            "ContractIdIT:AcceptNonSuffixedV1Cid",
+            "ContractIdIT:AcceptSuffixedV1CidExerciseTarget",
             "DeeplyNestedValueIT",  # FIXME: Too deeply nested values flake with a time out (half of the time)
             "RaceConditionIT:RWArchiveVsFailedLookupByKey",  # finding a lookup failure after contract creation
             # dynamic config management not supported by Canton


### PR DESCRIPTION
@cocreature , enabling the `ContractIdIT` suite in the daml repo (on a slightly older daml-snapshot) - also produces the error on my machine:

```
^[[36m- [ContractIdIT:RejectNonSuffixedV1CidCreatePayload] Rejects non-suffixed v1 Contract Id in create payload ... ^[[0m^[[31mAssertion failed^[[0m
^[[31m  Actual error id (COMMAND_PREPROCESSING_FAILED) does not match expected error id (INVALID_ARGUMENT}^[[0m
^[[31m  java.lang.AssertionError: Actual error id (COMMAND_PREPROCESSING_FAILED) does not match expected error id (INVALID_ARGUMENT}^[[0m
^[[31m          at com.daml.ledger.api.testtool.infrastructure.Assertions$.fail(Assertions.scala:25)^[[0m
^[[31m          at com.daml.ledger.api.testtool.infrastructure.Assertions$.assertSelfServiceErrorCode(Assertions.scala:201)^[[0m
^[[31m          at com.daml.ledger.api.testtool.infrastructure.Assertions$.assertGrpcErrorRegex(Assertions.scala:128)^[[0m
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
