### PR TITLE
split: do not push exe

### DIFF
--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -4,6 +4,7 @@
 parameters:
   release_tag: ''
   is_release: ''
+  is_split_release: 'false'
   skip_tests: ''
 
 steps:
@@ -51,7 +52,10 @@ steps:
   - bash: |
       set -euo pipefail
       mkdir -p '$(Build.StagingDirectory)'/release
-      ./ci/copy-windows-release-artifacts.sh ${{parameters.release_tag}} '$(Build.StagingDirectory)'/release
+      ./ci/copy-windows-release-artifacts.sh \
+        ${{parameters.release_tag}} \
+        '$(Build.StagingDirectory)'/release \
+        "${{ parameters.is_split_release }}"
     name: publish
     env:
       AZURE_KEY_VAULT_URL: $(AZURE_KEY_VAULT_URL)

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -169,6 +169,8 @@ jobs:
       value: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
     - name: is_release
       value: $[ dependencies.check_for_release.outputs['out.is_release'] ]
+    - name: is_split_release
+      value: $[ dependencies.check_for_release.outputs['out.split_release_process'] ]
     - name: skip_tests
       value: $[ and(eq(variables.is_release, 'true'),
                        eq(variables['Build.SourceBranchName'], 'main')) ]
@@ -196,6 +198,7 @@ jobs:
         # and then splice that in via a template parameter.
         skip_tests: $(skip_tests)
         is_release: variables.is_release
+        is_split_release: variables.is_split_release
     - template: upload-bazel-metrics.yml
     - task: PublishBuildArtifacts@1
       condition: succeededOrFailed()

--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -5,34 +5,38 @@ set -eou pipefail
 
 RELEASE_TAG=$1
 OUTPUT_DIR=$2
+SPLIT_RELEASE=${3:-false}
 
 mkdir -p $OUTPUT_DIR/github
 mkdir -p $OUTPUT_DIR/artifactory
 mkdir -p $OUTPUT_DIR/split-release
-INSTALLER="$OUTPUT_DIR/github/daml-sdk-$RELEASE_TAG-windows.exe"
-EE_INSTALLER="$OUTPUT_DIR/artifactory/daml-sdk-$RELEASE_TAG-windows-ee.exe"
-mv "bazel-bin/release/windows-installer/daml-sdk-installer-ce.exe" "$INSTALLER"
-mv "bazel-bin/release/windows-installer/daml-sdk-installer-ee.exe" "$EE_INSTALLER"
-chmod +wx "$INSTALLER"
-chmod +wx "$EE_INSTALLER"
 
-if ! [ -f /C/Users/u/.dotnet/tools/azuresigntool.exe ]; then
-    "/C/Program Files/dotnet/dotnet.exe" tool install --global AzureSignTool --version 3.0.0
+if [ "$SPLIT_RELEASE" = "false" ]; then
+    INSTALLER="$OUTPUT_DIR/github/daml-sdk-$RELEASE_TAG-windows.exe"
+    EE_INSTALLER="$OUTPUT_DIR/artifactory/daml-sdk-$RELEASE_TAG-windows-ee.exe"
+    mv "bazel-bin/release/windows-installer/daml-sdk-installer-ce.exe" "$INSTALLER"
+    mv "bazel-bin/release/windows-installer/daml-sdk-installer-ee.exe" "$EE_INSTALLER"
+    chmod +wx "$INSTALLER"
+    chmod +wx "$EE_INSTALLER"
+
+    if ! [ -f /C/Users/u/.dotnet/tools/azuresigntool.exe ]; then
+        "/C/Program Files/dotnet/dotnet.exe" tool install --global AzureSignTool --version 3.0.0
+    fi
+
+    /C/Users/u/.dotnet/tools/azuresigntool.exe sign \
+      --azure-key-vault-url "$AZURE_KEY_VAULT_URL" \
+      --azure-key-vault-client-id "$AZURE_CLIENT_ID" \
+      --azure-key-vault-tenant-id "$AZURE_TENANT_ID" \
+      --azure-key-vault-client-secret "$AZURE_CLIENT_SECRET" \
+      --azure-key-vault-certificate "$AZURE_KEY_VAULT_CERTIFICATE" \
+      --description "Daml SDK installer" \
+      --description-url "https://daml.com" \
+      --timestamp-rfc3161 "http://timestamp.digicert.com" \
+      --file-digest sha384 \
+      --verbose \
+      "$INSTALLER" \
+      "$EE_INSTALLER"
 fi
-
-/C/Users/u/.dotnet/tools/azuresigntool.exe sign \
-  --azure-key-vault-url "$AZURE_KEY_VAULT_URL" \
-  --azure-key-vault-client-id "$AZURE_CLIENT_ID" \
-  --azure-key-vault-tenant-id "$AZURE_TENANT_ID" \
-  --azure-key-vault-client-secret "$AZURE_CLIENT_SECRET" \
-  --azure-key-vault-certificate "$AZURE_KEY_VAULT_CERTIFICATE" \
-  --description "Daml SDK installer" \
-  --description-url "https://daml.com" \
-  --timestamp-rfc3161 "http://timestamp.digicert.com" \
-  --file-digest sha384 \
-  --verbose \
-  "$INSTALLER" \
-  "$EE_INSTALLER"
 
 TARBALL=daml-sdk-$RELEASE_TAG-windows.tar.gz
 EE_TARBALL=daml-sdk-$RELEASE_TAG-windows-ee.tar.gz


### PR DESCRIPTION
In the split release process, the executable installer has to be created
later in the pipeline, once we have the Canton parts available.