### PR TITLE
[JSON-API] User management endpoint adjustments

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -484,12 +484,12 @@ class Endpoints(
 
   def deleteUser(req: HttpRequest)(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
-  ): ET[domain.SyncResponse[Boolean]] =
+  ): ET[domain.SyncResponse[spray.json.JsObject]] =
     proxyWithCommandET { (jwt, deleteUserRequest: domain.DeleteUserRequest) =>
       for {
         userId <- parseUserId(deleteUserRequest.userId)
         _ <- EitherT.rightT(userManagementClient.deleteUser(userId, Some(jwt.value)))
-      } yield domain.OkResponse(true): domain.SyncResponse[Boolean]
+      } yield emptyObjectResponse
     }(req)
 
   def listUsers(req: HttpRequest)(implicit
@@ -596,7 +596,7 @@ class Endpoints(
 
   def createUser(req: HttpRequest)(implicit
       lc: LoggingContextOf[InstanceUUID with RequestID]
-  ): ET[domain.SyncResponse[Boolean]] =
+  ): ET[domain.SyncResponse[spray.json.JsObject]] =
     proxyWithCommand { (jwt, createUserRequest: domain.CreateUserRequest) =>
       {
         import scalaz.std.option._
@@ -623,7 +623,7 @@ class Endpoints(
               Some(jwt.value),
             )
           )
-        } yield domain.OkResponse(true): domain.SyncResponse[Boolean]
+        } yield emptyObjectResponse
       }.run
     }(req)
 
@@ -926,6 +926,9 @@ class Endpoints(
       UserId.fromString(rawUserId).disjunction.leftMap(InvalidUserInput)
     )
   }
+
+  private val emptyObjectResponse: domain.SyncResponse[spray.json.JsObject] =
+    domain.OkResponse(spray.json.JsObject())
 }
 
 object Endpoints {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -609,7 +609,9 @@ class Endpoints(
             primaryParty <- createUserRequest.primaryParty.traverse(it =>
               Ref.Party.fromString(it).disjunction
             )
-            rights <- domain.UserRights.toLedgerUserRights(createUserRequest.rights)
+            rights <- domain.UserRights.toLedgerUserRights(
+              createUserRequest.rights.getOrElse(List.empty)
+            )
           } yield (username, primaryParty, rights)
         for {
           info <- EitherT.either(input.leftMap(InvalidUserInput)): ET[

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -174,7 +174,7 @@ object domain extends com.daml.fetchcontracts.domain.Aliases {
   final case class CreateUserRequest(
       userId: String,
       primaryParty: Option[String],
-      rights: List[UserRight],
+      rights: Option[List[UserRight]],
   )
 
   final case class ListUserRightsRequest(userId: String)


### PR DESCRIPTION
Adjusts the return of the createUser & deleteUser endpoints to be an empty object (instead of true). Furthermore the rights field for creating a user was made optional such that a payload `{ "userId": "nice.user" }` is enough to create a user.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
