### PR TITLE
damlc: Don't rely on worker for zero argument polymorphic type constructors

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1704,7 +1704,7 @@ convertDataCon env m con args
     -- In this situation there is no worker function, so we inline
     -- the constructor by introducing some type lambdas.
     | let (conTypes, conTheta, conArgs, _) = dataConSig con
-    , length conTheta + length conArgs == 0 -- no value args
+    , null conTheta && null conArgs -- no value args
     = do
         kinds <- mapM (convertKind . tyVarKind) conTypes
         withTyArgs env kinds args $ \ env' types args' -> do

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1698,6 +1698,25 @@ convertDataCon env m con args
     | Just (tyArgs, tmArgs) <- splitConArgs_maybe con args = do
         tyArgs <- mapM (convertType env) tyArgs
         tmArgs <- mapM (convertExpr env) tmArgs
+        (, []) <$> fullyApplied env tyArgs tmArgs
+
+    -- Partially applied, but the constructor only takes type args.
+    -- In this situation there is no worker function, so we inline
+    -- the constructor by introducing some type lambdas.
+    | let (conTypes, conTheta, conArgs, _) = dataConSig con
+    , length conTheta + length conArgs == 0 -- no value args
+    = do
+        kinds <- mapM (convertKind . tyVarKind) conTypes
+        withTyArgs env kinds args $ \ env' types args' -> do
+            (, args') <$> fullyApplied env' types []
+
+    -- Partially applied
+    | otherwise = do
+        fmap (\op -> (EVal op, args)) (qual mkWorkerName (getOccText con))
+  where
+
+    fullyApplied :: Env -> [LF.Type] -> [LF.Expr] -> ConvertM LF.Expr
+    fullyApplied env tyArgs tmArgs = do
         let tycon = dataConTyCon con
         qTCon <- qual (\x -> mkTypeCon [x]) (getOccText tycon)
         let tcon = TypeConApp qTCon tyArgs
@@ -1705,7 +1724,7 @@ convertDataCon env m con args
             fldNames = ctorLabels con
             xargs = (dataConName con, args)
 
-        fmap (, []) $ case classifyDataCon con of
+        case classifyDataCon con of
             EnumCon -> do
                 unless (null args) $ unhandled "enum constructor with arguments" xargs
                 pure $ EEnumCon qTCon ctorName
@@ -1729,22 +1748,25 @@ convertDataCon env m con args
                     EVariantCon tcon ctorName $
                     ERecCon (TypeConApp recTCon tyArgs) (zipExact fldNames tmArgs)
 
-    -- Partially applied
-    | otherwise = do
-        fmap (\op -> (EVal op, args)) (qual mkWorkerName (getOccText con))
-
-    where
-
-        qual :: (T.Text -> n) -> T.Text -> ConvertM (Qualified n)
-        qual f t
-            | Just xs <- T.stripPrefix "(," t
-            , T.dropWhile (== ',') xs == ")" = qDA_Types env $ f $ "Tuple" <> T.pack (show $ T.length xs + 1)
-            | IgnoreWorkerPrefix t' <- t = qualify env m $ f t'
+    qual :: (T.Text -> n) -> T.Text -> ConvertM (Qualified n)
+    qual f t
+        | Just xs <- T.stripPrefix "(," t
+        , T.dropWhile (== ',') xs == ")" = qDA_Types env $ f $ "Tuple" <> T.pack (show $ T.length xs + 1)
+        | IgnoreWorkerPrefix t' <- t = qualify env m $ f t'
 
 convertArg :: Env -> GHC.Arg Var -> ConvertM LF.Arg
 convertArg env = \case
     Type t -> TyArg <$> convertType env t
     e -> TmArg <$> convertExpr env e
+
+withTyArgs :: Env -> [LF.Kind] -> [LArg Var] -> (Env -> [LF.Type] -> [LArg Var] -> ConvertM (LF.Expr, [LArg Var])) -> ConvertM (LF.Expr, [LArg Var])
+withTyArgs env0 kinds0 args0 cont = go env0 args0 [] kinds0
+  where
+    go !env !args !types [] =
+        cont env (reverse types) args
+    go !env !args !types (kind : kinds) =
+        withTyArg env kind args $ \env' ty args' ->
+            go env' args' (ty : types) kinds
 
 withTyArg :: Env -> LF.Kind -> [LArg Var] -> (Env -> LF.Type -> [LArg Var] -> ConvertM (LF.Expr, [LArg Var])) -> ConvertM (LF.Expr, [LArg Var])
 withTyArg env _ (LType t:args) cont = do

--- a/compiler/damlc/tests/daml-test-files/PolymorphicConstant.daml
+++ b/compiler/damlc/tests/daml-test-files/PolymorphicConstant.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- | Regression test for https://github.com/digital-asset/daml/issues/12166
-module SmartConstructor where
+module PolymorphicConstant where
 
 data Foo t = Baz | Bar t
 

--- a/compiler/damlc/tests/daml-test-files/SmartConstructor.daml
+++ b/compiler/damlc/tests/daml-test-files/SmartConstructor.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Regression test for https://github.com/digital-asset/daml/issues/12166
+module SmartConstructor where
+
+data Foo t = Baz | Bar t
+
+baz : forall t. Foo t
+baz = Baz


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/12166 which was caused by using a constructor worker (`$WBaz`) in a case where GHC doesn't generate them. This only caused a problem with partially applied zero argument constructors, so, it only affected zero argument constructors of polymorphic types in situations where the type argument is eta-reduced, which is probably why it flew under the radar.

The code in the bug report is added as a regression test.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
