### PR TITLE
correct deprecated options with newest synopsys-detect version

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -420,8 +420,8 @@ jobs:
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=YARN,NPM,CLANG \
-          --detect.npm.include.dev.dependencies=false \
-          --detect.yarn.prod.only=true \
+          --detect.npm.dependency.types.excluded=dev \
+          --detect.yarn.dependency.types.excluded=dev \
           --detect.follow.symbolic.links=false \
           --detect.excluded.directories=language-support/ts/daml-ledger,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/codegen/tests/ts,bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env,result-*\
           --detect.blackduck.signature.scanner.exclusion.name.patterns=language-support/ts/daml-ledger,language-support/ts/daml-types,language-support/ts/daml-react.bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env,result-* \


### PR DESCRIPTION
Correct deprecated options with newest synopsys detect 7.10 version (just merged upgrade tue 25 jan)

The options to only include only prod yarn and npm dependencies have been rationalised so you can exclude `dev` dependencies in a consistent way now

as detailed in release notes https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=releasenotes.html&_LANG=enus