### PR TITLE
Tear down daml services gracefully

### DIFF
--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -79,8 +79,8 @@ withDamlServiceIn path command args act = withDevNull $ \devNull -> do
         -- We tear things down gracefully instead of killing
         -- the process group so that waiting for the parent process
         -- ensures that all child processes are all dead too.
-        -- Gonig via closing stdin works on Windows whereas tearing things
-        -- down gracefully
+        -- Going via closing stdin works on Windows whereas tearing things
+        -- down gracefully via SIGTERM isn’t as much of a thing so we use the former.
         _ <- waitForProcess ph
         pure r
 

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -67,14 +67,21 @@ authorizationHeaders alice = [("Authorization", "Bearer " <> T.encodeUtf8 (hardc
 
 withDamlServiceIn :: FilePath -> String -> [String] -> (ProcessHandle -> IO a) -> IO a
 withDamlServiceIn path command args act = withDevNull $ \devNull -> do
-    let proc' = (shell $ unwords $ ["daml", command] <> args)
+    let proc' = (shell $ unwords $ ["daml", command, "--shutdown-stdin-close"] <> args)
           { std_out = UseHandle devNull
-          , create_group = True
+          , std_in = CreatePipe
           , cwd = Just path
           }
-    withCreateProcess proc' $ \_ _ _ ph -> do
+    withCreateProcess proc' $ \stdin _ _ ph -> do
+        Just stdin <- pure stdin
         r <- act ph
-        interruptProcessGroupOf ph
+        hClose stdin
+        -- We tear things down gracefully instead of killing
+        -- the process group so that waiting for the parent process
+        -- ensures that all child processes are all dead too.
+        -- Gonig via closing stdin works on Windows whereas tearing things
+        -- down gracefully
+        _ <- waitForProcess ph
         pure r
 
 data DamlStartResource = DamlStartResource


### PR DESCRIPTION
The integration tests occasionally produce errors of the form

```
daml-helper: /tmp/extra-dir-68844949176204: changeWorkingDirectory:
does not exist (No such file or directory)
```

While these are mostly harmless they are at the very least very
confusing.

This is caused by yet another instance of killing processes without
waiting for them to terminate which causes us to remove a temp dir
before the process reaches the `finally` clause of
`wtihCurrentDirectory`.

This PR fixes this by shutting things down gracefully. Process groups
& graceful shutdowns are a mess on Windows so we go via the shutdown
on stdin close functionality we added for that.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
