### PR TITLE
Drop dummy token from JSON API check

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -142,22 +142,8 @@ withJsonApi (SandboxPort sandboxPort) (JsonApiPort jsonApiPort) extraArgs a = do
             ] ++ extraArgs
     withSdkJar args "json-api-logback.xml" $ \ph -> do
         putStrLn "Waiting for JSON API to start: "
-        -- The secret doesn’t matter here
-        let token = JWT.encodeSigned (JWT.HMACSecret "secret") mempty mempty
-                { JWT.unregisteredClaims = JWT.ClaimsMap $
-                      Map.fromList [("https://daml.com/ledger-api", Object $ HashMap.fromList
-                        [("actAs", toJSON ["Alice" :: T.Text]), ("ledgerId", "sandbox"), ("applicationId", "foobar")])]
-                        -- TODO https://github.com/digital-asset/daml/issues/12145
-                        --   Drop the ledgerId field once it becomes optional.
-                }
-        -- For now, we have a dummy authorization header here to wait for startup since we cannot get a 200
-        -- response otherwise. We probably want to add some method to detect successful startup without
-        -- any authorization
-        let headers =
-                [ ("Authorization", "Bearer " <> T.encodeUtf8 token)
-                ] :: HTTP.RequestHeaders
         waitForHttpServer 240 (unsafeProcessHandle ph) (putStr "." *> threadDelay 500000)
-            ("http://localhost:" <> show jsonApiPort <> "/v1/query") headers
+            ("http://localhost:" <> show jsonApiPort <> "/readyz") []
         a ph
 
 data JsonApiConfig = JsonApiConfig

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -22,13 +22,9 @@ import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Monad
 import Control.Monad.Extra hiding (fromMaybeM)
-import qualified Data.HashMap.Strict as HashMap
 import Data.Maybe
-import qualified Data.Map.Strict as Map
 import DA.PortFile
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import qualified Network.HTTP.Simple as HTTP
 import Network.Socket.Extended (getFreePort)
 import System.Console.ANSI
 import System.FilePath
@@ -36,8 +32,6 @@ import System.Process.Typed
 import System.IO.Extra
 import System.Info.Extra
 import Web.Browser
-import qualified Web.JWT as JWT
-import Data.Aeson
 
 import Options.Applicative.Extended (YesNoAuto, determineAutoM)
 


### PR DESCRIPTION
That token is broken in a number of ways, e.g. broken ledger ids,
parties that may not exist, ….

When we created that there was no healthcheck endpoint on the JSON API
but now that there is one, we can just use that one and it doesn’t
need any token so things get a lot simpler.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
