### PR TITLE
Move some daml-script compat tests to sandbox-on-x

### DIFF
--- a/bazel_tools/client_server/client_server_test.bzl
+++ b/bazel_tools/client_server/client_server_test.bzl
@@ -13,6 +13,8 @@ def client_server_test(
         name,
         runner = "//bazel_tools/client_server/runner_with_port_file",
         runner_args = [],
+        runner_files = [],
+        runner_files_prefix = "",
         client = None,
         client_args = [],
         client_files = [],
@@ -62,6 +64,9 @@ def client_server_test(
         cmd = """\
 runner=$$(canonicalize_rlocation $$(get_exe $(rootpaths {runner})))
 runner_args="{runner_args}"
+for file in {runner_files}; do
+    runner_args+=" {runner_files_prefix}$$(canonicalize_rlocation $$file)"
+done
 client=$$(canonicalize_rlocation $$(get_exe $(rootpaths {client})))
 server=$$(canonicalize_rlocation $$(get_exe $(rootpaths {server})))
 server_args="{server_args}"
@@ -81,6 +86,8 @@ $$runner $$client "$$client_args" $$server "$$server_args" "$$runner_args"
 """.format(
             runner = runner,
             runner_args = _escape_args(runner_args),
+            runner_files = _escape_args(runner_files),
+            runner_files_prefix = runner_files_prefix,
             client = client,
             client_args = _escape_args(client_args),
             client_files = _escape_args(client_files),

--- a/compatibility/bazel_tools/client_server/with-upload-dar/BUILD
+++ b/compatibility/bazel_tools/client_server/with-upload-dar/BUILD
@@ -1,0 +1,15 @@
+load("@daml//bazel_tools:haskell.bzl", "da_haskell_binary")
+
+da_haskell_binary(
+    name = "runner",
+    srcs = ["Main.hs"],
+    hackage_deps = [
+        "base",
+        "monad-loops",
+        "network",
+        "process",
+        "safe-exceptions",
+        "split",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/compatibility/bazel_tools/client_server/with-upload-dar/Main.hs
+++ b/compatibility/bazel_tools/client_server/with-upload-dar/Main.hs
@@ -1,0 +1,45 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+module Main(main) where
+
+import System.Environment
+import Control.Exception.Safe
+import Control.Monad.Loops (untilJust)
+import Data.List (stripPrefix)
+import Data.Maybe (mapMaybe)
+import System.Process
+import Data.List.Split (splitOn)
+import Control.Monad (forM_)
+import Network.Socket
+import Control.Concurrent
+
+main :: IO ()
+main = do
+  [clientExe, clientArgs, serverExe, serverArgs, runnerArgs] <- getArgs
+  let splitArgs = filter (/= "") . splitOn " "
+  let serverProc = proc serverExe (splitArgs serverArgs)
+
+  let splitRunnerArgs = splitArgs runnerArgs
+  let ports = map read $ mapMaybe (stripPrefix "--port=") splitRunnerArgs
+  let dars = mapMaybe (stripPrefix "--dar=") splitRunnerArgs
+  (ledgerApiPort:_) <- pure ports
+
+  withCreateProcess serverProc $ \_stdin _stdout _stderr _ph -> do
+    forM_ ports $ \port -> waitForConnectionOnPort (threadDelay 500000) port
+    forM_ dars $ \dar -> callProcess clientExe ["ledger", "upload-dar", "--host", "localhost", "--port", show ledgerApiPort, dar]
+    callProcess clientExe (splitArgs clientArgs)
+
+waitForConnectionOnPort :: IO () -> Int -> IO ()
+waitForConnectionOnPort sleep port = do
+    let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV], addrSocketType = Stream }
+    addr : _ <- getAddrInfo (Just hints) (Just "127.0.0.1") (Just $ show port)
+    untilJust $ do
+        r <- tryIO $ checkConnection addr
+        case r of
+            Left _ -> sleep *> pure Nothing
+            Right _ -> pure $ Just ()
+    where
+        checkConnection addr = bracket
+              (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+              close
+              (\s -> connect s (addrAddress addr))

--- a/compatibility/bazel_tools/daml_script/daml_script.bzl
+++ b/compatibility/bazel_tools/daml_script/daml_script.bzl
@@ -57,6 +57,7 @@ def daml_script_test(compiler_version, runner_version):
     daml_runner = "@daml-sdk-{version}//:daml".format(
         version = runner_version,
     )
+    # 1.16.0 is the first SDK version that defaulted to LF 1.14, which is the earliest LF version that Canton supports
     use_canton = versions.is_at_least("2.0.0", runner_version) and versions.is_at_least("1.16.0", compiler_version)
     use_sandbox_on_x = versions.is_at_least("2.0.0", runner_version) and not use_canton
 

--- a/compatibility/bazel_tools/daml_script/daml_script.bzl
+++ b/compatibility/bazel_tools/daml_script/daml_script.bzl
@@ -57,6 +57,7 @@ def daml_script_test(compiler_version, runner_version):
     daml_runner = "@daml-sdk-{version}//:daml".format(
         version = runner_version,
     )
+
     # 1.16.0 is the first SDK version that defaulted to LF 1.14, which is the earliest LF version that Canton supports
     use_canton = versions.is_at_least("2.0.0", runner_version) and versions.is_at_least("1.16.0", compiler_version)
     use_sandbox_on_x = versions.is_at_least("2.0.0", runner_version) and not use_canton

--- a/compatibility/bazel_tools/daml_script/daml_script.bzl
+++ b/compatibility/bazel_tools/daml_script/daml_script.bzl
@@ -57,6 +57,20 @@ def daml_script_test(compiler_version, runner_version):
     daml_runner = "@daml-sdk-{version}//:daml".format(
         version = runner_version,
     )
+    use_canton = versions.is_at_least("2.0.0", runner_version) and versions.is_at_least("1.16.0", compiler_version)
+    use_sandbox_on_x = versions.is_at_least("2.0.0", runner_version) and not use_canton
+
+    if use_sandbox_on_x:
+        server = "@daml-sdk-{version}//:sandbox-on-x".format(version = runner_version)
+        server_args = ["--participant", "participant-id=sandbox,port=6865"]
+        server_files = []
+        runner_files = ["$(rootpath {})".format(compiled_dar)]
+    else:
+        server = daml_runner
+        server_args = ["sandbox"]
+        server_files = ["$(rootpath {})".format(compiled_dar)]
+        runner_files = []
+
     client_server_test(
         name = "daml-script-test-compiler-{compiler_version}-runner-{runner_version}".format(
             compiler_version = version_to_name(compiler_version),
@@ -80,13 +94,13 @@ def daml_script_test(compiler_version, runner_version):
         data = [
             compiled_dar,
         ],
-        runner = "//bazel_tools/client_server:runner",
-        runner_args = ["6865"],
-        server = daml_runner,
-        server_args = ["sandbox"],
-        server_files = [
-            "$(rootpath {})".format(compiled_dar),
-        ],
-        server_files_prefix = "--dar=" if versions.is_at_least("2.0.0", runner_version) else "",
+        runner = "//bazel_tools/client_server/with-upload-dar:runner",
+        runner_args = ["--port=6865"],
+        runner_files = runner_files,
+        runner_files_prefix = "--dar=",
+        server = server,
+        server_args = server_args,
+        server_files = server_files,
+        server_files_prefix = "--dar=" if use_canton else "",
         tags = ["exclusive"],
     )


### PR DESCRIPTION
The new sandbox doesn't accept LF < 1.14, so move those cases to
sandbox-on-x.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
