### PR TITLE
ci: pin Windows folders, step 1

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -184,6 +184,16 @@ jobs:
     - checkout: self
     - bash: |
         set -euo pipefail
+
+        for f in $(find /d/a/SourceRootMapping); do
+          echo "-----"
+          echo $f
+          echo "-----"
+          cat $f
+          echo "-----"
+        done
+    - bash: |
+        set -euo pipefail
         git checkout $(release_sha)
       name: checkout_release
       condition: and(succeeded(), eq(variables.is_release, 'true'))


### PR DESCRIPTION
The mapping from Azure job to local folder is managed by a handful of
JSON files under `$WORKDIR/SourceRootMapping`. Based on the sketchy
[documentation] that screams "don't mess with these definitely internal,
subject-to-change files" that our best bet for pinning Windows work
folders is to mess with these files. Specifically, take a "version" of
these files we like from a live CI machine and add those specific files
to the init script of our Windows nodes.

[documentation]: https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/jobdirectories.md

So the first step is to collect these files, which is what this PR aims
to accomplish.

CHANGELOG_BEGIN
CHANGELOG_END