### PR TITLE
ci: temporarily increase Windows capacity

### DIFF
--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -17,7 +17,7 @@ locals {
     },
     {
       name       = "ci-w2"
-      size       = 0,
+      size       = 6,
       assignment = "default",
       disk_size  = 400,
     },


### PR DESCRIPTION
Our Windows CI nodes seem completely overwhelmed today, with typical
wait times above half an hour before jobs even start. This isn't fun, so
I'd like to double our capacity for a few hours.

CHANGELOG_BEGIN
CHANGELOG_END