### PR TITLE
ci: try to fix release process

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -198,7 +198,7 @@ jobs:
         # and then splice that in via a template parameter.
         skip_tests: $(skip_tests)
         is_release: variables.is_release
-        is_split_release: variables.is_split_release
+        is_split_release: $(is_split_release)
     - template: upload-bazel-metrics.yml
     - task: PublishBuildArtifacts@1
       condition: succeededOrFailed()
@@ -439,7 +439,7 @@ jobs:
                 setvar release_sha "$(added_line | awk '{print $1}')"
                 RELEASE_TAG="$(added_line | awk '{print $2}')"
                 setvar release_tag "$RELEASE_TAG"
-                if [ $(added_line | awk '{print $3}') == "SPLIT_RELEASE" ]; then
+                if [ "$(added_line | awk '{print $3}')" == "SPLIT_RELEASE" ]; then
                   setvar split_release_process true
                 else
                   setvar split_release_process false

--- a/ci/copy-windows-release-artifacts.sh
+++ b/ci/copy-windows-release-artifacts.sh
@@ -11,7 +11,7 @@ mkdir -p $OUTPUT_DIR/github
 mkdir -p $OUTPUT_DIR/artifactory
 mkdir -p $OUTPUT_DIR/split-release
 
-if [ "$SPLIT_RELEASE" = "false" ]; then
+if ! [ "$SPLIT_RELEASE" = "true" ]; then
     INSTALLER="$OUTPUT_DIR/github/daml-sdk-$RELEASE_TAG-windows.exe"
     EE_INSTALLER="$OUTPUT_DIR/artifactory/daml-sdk-$RELEASE_TAG-windows-ee.exe"
     mv "bazel-bin/release/windows-installer/daml-sdk-installer-ce.exe" "$INSTALLER"


### PR DESCRIPTION
I'm not quite sure what's going wrong here, but this PR:

- Fixes a small bug in the process for determininng that we're _not_ in
  a split release, which worked because the boolean expression crashing
  is the same as the boolean expression returning false. But I'd still
  prefer if it returned false without crashing.
- Changes the condition for skipping the Windows installer so that in
  case of ternary+ logic we default to the harmless behaviour (including
  it).
- Makes a change that might have some impact maybe on the way Azure
  expands templates which may or may not result in the installer being
  excluded when it should be excluded. But this time if it doesn't work
  worst case we get an extra unused binary that uses some disk space,
  instead of crashing the release.

CHANGELOG_BEGIN
CHANGELOG_END