### PR TITLE
Fix a bug in user management caching

### DIFF
--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -446,6 +446,9 @@ getParticipantAdmin () = do
   participant_admin <- validateUserId "participant_admin"
   pure $ User participant_admin None
 
+userExists : UserId -> Script Bool
+userExists u = do try do _ <- getUser u; pure True catch UserNotFound _ -> pure False
+
 testUserManagement = do
   participantAdmin <- getParticipantAdmin ()
   users <- listUsers
@@ -454,7 +457,9 @@ testUserManagement = do
   u2 <- validateUserId "u2"
   let user1 = User u1 None
   let user2 = User u2 None
+  False <- userExists u1
   createUser user1 []
+  True <- userExists u1
   createUser user2 []
   u <- getUser u1
   u === user1

--- a/ledger/participant-integration-api/src/main/scala/platform/usermanagement/CachedUserManagementStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/usermanagement/CachedUserManagementStore.scala
@@ -57,7 +57,9 @@ class CachedUserManagementStore(
   }
 
   override def createUser(user: User, rights: Set[domain.UserRight]): Future[Result[Unit]] =
-    delegate.createUser(user, rights)
+    delegate
+      .createUser(user, rights)
+      .andThen(invalidateOnSuccess(user.id))
 
   override def deleteUser(id: UserId): Future[Result[Unit]] = {
     delegate


### PR DESCRIPTION
Fix a bug in user management caching.

To provoke the bug is quite subtle:
- First a nonexistent user is queried with `getUser`.
- Then that user is created using `createUser`.
- Then we query again with `getUser` -- but the user is incorrectly reported as not being found.
