### PR TITLE
Point out to run release manual tests on Windows with the KV sandbox

### DIFF
--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -211,7 +211,7 @@ patches we backport to the 1.0 release branch).
 
    1. Run `daml new myproject` to create a new project and switch to it using
       `cd myproject`.
-   1. Run `daml start`.
+   1. Run `daml start --sandbox-kv`.
    1. Open your browser at `http://localhost:7500`, verify that you can login as
       Alice and there is one contract, and that the template list contains
       `Main:Asset` among other templates.


### PR DESCRIPTION
The Canton sandbox currently has a startup issue that has to be fixed that causes an unusually long startup time on Windows that ends up triggering a timeout.

Can be reverted once https://github.com/DACH-NY/canton/issues/8331 is fixed.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
