### PR TITLE
Simplify Nix GHC derivation

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -24,29 +24,6 @@ let
         sha256 = "0hzd6pljc8z5fwins5a05rwpx2w7wmlb6gb8973c676i7i895ps9";
       };
     });
-   haskell = pkgs.haskell // {
-     packages = pkgs.haskell.packages // {
-       integer-simple = pkgs.haskell.packages.integer-simple // {
-        ghc8107 = pkgs.haskell.packages.integer-simple.ghc8107.override {
-          ghc = pkgs.haskell.compiler.integer-simple.ghc8107.overrideAttrs (old: {
-            # We need to include darwin.cctools in PATH to make sure GHC finds
-            # otool.
-            postInstall = ''
-    # Install the bash completion file.
-    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/ghc
-
-    # Patch scripts to include "readelf" and "cat" in $PATH.
-    for i in "$out/bin/"*; do
-      test ! -h $i || continue
-      egrep --quiet '^#!' <(head -n 1 $i) || continue
-      sed -i -e '2i export PATH="$PATH:${pkgs.lib.makeBinPath ([ pkgs.targetPackages.stdenv.cc.bintools pkgs.coreutils ] ++ pkgs.lib.optional pkgs.targetPlatform.isDarwin pkgs.darwin.cctools) }"' $i
-    done
-  '';
-          });
-        };
-       };
-     };
-    };
 
     bazel_4 = pkgs.bazel_4.overrideAttrs(oldAttrs: {
       patches = oldAttrs.patches ++ [


### PR DESCRIPTION
It turns out we don’t need this anymore (according to CI which is good
enough for me). This is great since it means that we don’t need to
build our own GHC anymore and can instead fetch it from the upstream
cache.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
