### PR TITLE
user react hook

### DIFF
--- a/language-support/ts/daml-react/defaultLedgerContext.ts
+++ b/language-support/ts/daml-react/defaultLedgerContext.ts
@@ -3,7 +3,7 @@
 
 import { createLedgerContext, FetchResult, QueryResult, LedgerProps, FetchByKeysResult } from "./createLedgerContext";
 import { ContractId, Party, Template } from '@daml/types';
-import Ledger, { Query, StreamCloseEvent } from '@daml/ledger';
+import Ledger, { Query, StreamCloseEvent, User } from '@daml/ledger';
 
 /**
  * @internal
@@ -23,6 +23,11 @@ export function DamlLedger(props: React.PropsWithChildren<LedgerProps>): React.R
  * React hook to get the party currently connected to the ledger.
  */
 export function useParty(): Party { return ledgerContext.useParty(); }
+
+/**
+ * React hook to get the user currently connected to the ledger participant.
+ */
+export function useUser(): User { return ledgerContext.useUser(); }
 
 /**
  * React Hook that returns the Ledger instance to interact with the connected Daml ledger.

--- a/language-support/ts/daml-react/index.ts
+++ b/language-support/ts/daml-react/index.ts
@@ -3,6 +3,6 @@
 
 export { createLedgerContext, FetchResult, LedgerContext, QueryResult, FetchByKeysResult } from './createLedgerContext';
 
-import { DamlLedger, useParty, useLedger, useQuery, useFetch, useFetchByKey, useStreamQuery, useStreamQueries, useStreamFetchByKey, useStreamFetchByKeys, useReload } from "./defaultLedgerContext";
-export { useParty, useLedger, useQuery, useFetch, useFetchByKey, useStreamQuery, useStreamQueries, useStreamFetchByKey, useStreamFetchByKeys, useReload };
+import { DamlLedger, useParty, useUser, useLedger, useQuery, useFetch, useFetchByKey, useStreamQuery, useStreamQueries, useStreamFetchByKey, useStreamFetchByKeys, useReload } from "./defaultLedgerContext";
+export { useParty, useUser, useLedger, useQuery, useFetch, useFetchByKey, useStreamQuery, useStreamQueries, useStreamFetchByKey, useStreamFetchByKeys, useReload };
 export default DamlLedger;

--- a/templates/create-daml-app/ui/src/Credentials.ts
+++ b/templates/create-daml-app/ui/src/Credentials.ts
@@ -1,9 +1,13 @@
 // Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { User } from "@daml/ledger";
+
+
 export type Credentials = {
   party: string;
   token: string;
+  user: User;
 }
 
 export default Credentials;

--- a/templates/create-daml-app/ui/src/components/App.tsx
+++ b/templates/create-daml-app/ui/src/components/App.tsx
@@ -20,6 +20,7 @@ const App: React.FC = () => {
     ? <DamlLedger
         token={credentials.token}
         party={credentials.party}
+        user={credentials.user}
       >
       <MainScreen onLogout={() => {
         if (authConfig.provider === 'daml-hub') {

--- a/templates/create-daml-app/ui/src/components/LoginScreen.tsx.template
+++ b/templates/create-daml-app/ui/src/components/LoginScreen.tsx.template
@@ -72,7 +72,8 @@ const LoginScreen: React.FC<Props> = ({onLogin}) => {
         alert(`Failed to login as '${username}':\n${errorMsg}`);
         throw error;
       });
-      await login({party: primaryParty,
+      await login({user: {userId: username, primaryParty: primaryParty},
+                   party: primaryParty,
                    token: auth.makeToken(username)});
     }
 
@@ -99,7 +100,7 @@ const LoginScreen: React.FC<Props> = ({onLogin}) => {
       <DamlHubLoginBtn
         onLogin={creds => {
           if (creds) {
-            login(creds);
+            login({party:creds.party, user: {userId: creds.partyName, primaryParty: creds.party}, token:creds.token});
           }
         }}
         options={{
@@ -118,8 +119,10 @@ const LoginScreen: React.FC<Props> = ({onLogin}) => {
     (async function () {
       if (isLoading === false && isAuthenticated === true) {
         if (user !== undefined) {
+          const party = user["https://daml.com/ledger-api"];
           const creds: Credentials = {
-            party: user["https://daml.com/ledger-api"],
+            user: {userId: user.email ?? user.name ?? party, primaryParty: party},
+            party: party,
             token: (await getAccessTokenSilently({
                      audience: "https://daml.com/ledger-api"}))};
           login(creds);

--- a/templates/create-daml-app/ui/src/components/MainScreen.tsx
+++ b/templates/create-daml-app/ui/src/components/MainScreen.tsx
@@ -4,8 +4,7 @@
 import React from 'react'
 import { Image, Menu } from 'semantic-ui-react'
 import MainView from './MainView';
-import {useLedger} from '@daml/react';
-import {useState, useEffect} from 'react'
+import {useUser} from '@daml/react';
 
 type Props = {
   onLogout: () => void;
@@ -15,14 +14,7 @@ type Props = {
  * React component for the main screen of the `App`.
  */
 const MainScreen: React.FC<Props> = ({onLogout}) => {
-  const ledger = useLedger();
-  const [user, setUser] = useState('');
-  useEffect( () =>{
-    (async () => {
-      const u = await ledger.getUser()
-      setUser(u.userId);
-    } ) ()}
-  , [ledger]);
+  const user = useUser();
 
   return (
     <>
@@ -39,7 +31,7 @@ const MainScreen: React.FC<Props> = ({onLogout}) => {
         </Menu.Item>
         <Menu.Menu position='right' className='test-select-main-menu'>
           <Menu.Item position='right'>
-            You are logged in as {user}.
+            You are logged in as {user.userId}.
           </Menu.Item>
           <Menu.Item
             position='right'


### PR DESCRIPTION
We add a `useUser` hook to daml-react returning the user currently
logged in the ledger participant. create-daml-app is changed
accordingly.

CHANGELOG_BEGIN
[daml-react] A `useUser` react hook is added to the daml-react
TypeScript library. It allows for easy access to the currently logged in
user of a ledger participant node for ledgers supporting user
management.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
