### PR TITLE
ledger-on-memory: Do not create iterators on a mutable log.

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReader.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReader.scala
@@ -33,7 +33,10 @@ class InMemoryLedgerReader(
               metrics.daml.ledger.log.read,
               state
                 .readLog(
-                  _.view.zipWithIndex.map(_.swap).slice(startExclusive + 1, endInclusive + 1)
+                  _.view.zipWithIndex
+                    .map(_.swap)
+                    .slice(startExclusive + 1, endInclusive + 1)
+                    .toVector // ensure we copy the results so we don't keep a reference to the log
                 )
                 .iterator,
             )


### PR DESCRIPTION
We must copy the slice of the log that we are reading, to ensure that we are not iterating over the log while we mutate it in a separate transaction. (In other words, objects must not escape the `readLog` function.)

This is most likely the cause of a flaky test run that we saw recently.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
