### PR TITLE
LF: Gracefully handle serialization error of Values beyond 2GB

### DIFF
--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -58,7 +58,33 @@ da_scala_library(
         "//daml-lf/data",
         "//daml-lf/language",
         "//libs-scala/nameof",
+        "//libs-scala/safe-proto",
         "//libs-scala/scala-utils",
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)
+
+da_scala_test(
+    name = "value-test",
+    srcs = glob([
+        "src/test/**/value/*.scala",
+        "src/test/**/EitherAssertions.scala",
+    ]),
+    max_heap_size = "3g",
+    scala_deps = [
+        "@maven//:com_chuusai_shapeless",
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+        "@maven//:org_scalaz_scalaz_core",
+        "@maven//:org_scalaz_scalaz_scalacheck_binding",
+    ],
+    scalacopts = lf_scalacopts,
+    deps = [
+        ":transaction",
+        ":value_proto_java",
+        "//daml-lf/data",
+        "//daml-lf/interface",
+        "//daml-lf/transaction-test-lib",
         "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
@@ -69,7 +95,6 @@ da_scala_test(
     srcs = glob([
         "src/test/**/EitherAssertions.scala",
         "src/test/**/crypto/*.scala",
-        "src/test/**/value/*.scala",
         "src/test/**/transaction/*.scala",
     ]),
     scala_deps = [
@@ -77,7 +102,6 @@ da_scala_test(
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalatestplus_scalacheck_1_15",
         "@maven//:org_scalaz_scalaz_core",
-        "@maven//:org_scalaz_scalaz_scalacheck_binding",
     ],
     scalacopts = lf_scalacopts,
     deps = [

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf
+package com.daml
+package lf
 package value
 
 import com.daml.lf.data.Ref._
@@ -385,10 +386,10 @@ object ValueCoder {
       value: Value,
   ): Either[EncodeError, proto.VersionedValue] =
     for {
-      protoValue <- encodeValue(encodeCid, version, value)
+      bytes <- encodeValue(encodeCid, version, value)
     } yield {
       val builder = proto.VersionedValue.newBuilder()
-      builder.setVersion(encodeValueVersion(version)).setValue(protoValue).build()
+      builder.setVersion(encodeValueVersion(version)).setValue(bytes).build()
     }
 
   /** Serialize a Value to protobuf
@@ -514,7 +515,7 @@ object ValueCoder {
     }
 
     try {
-      Right(go(0, v0).toByteString)
+      SafeProto.toByteString(go(0, v0)).left.map(EncodeError)
     } catch {
       case Err(msg) => Left(EncodeError(msg))
     }
@@ -526,4 +527,5 @@ object ValueCoder {
   ): Either[DecodeError, Value] = {
     decodeValue(decodeCid, proto.VersionedValue.parseFrom(bytes))
   }
+
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf
+package com.daml
+package lf
 package value
 
 import com.daml.lf.EitherAssertions
@@ -27,6 +28,19 @@ class ValueCoderSpec
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 1000)
+
+  "encode" should {
+    "fail gracefully when serialized message exceeding 2GB" in {
+
+      val ver = TransactionVersion.StableVersions.max
+
+      val value0 = ValueText("a" * (1024 * 1024 * 1024))
+      val value1 = ValueList(FrontStack(value0, value0))
+
+      ValueCoder.encodeValue(ValueCoder.CidEncoder, ver, value0) shouldBe a[Right[_, _]]
+      ValueCoder.encodeValue(ValueCoder.CidEncoder, ver, value1) shouldBe a[Left[_, _]]
+    }
+  }
 
   "encode-decode" should {
     "do Int" in {

--- a/libs-scala/safe-proto/BUILD.bazel
+++ b/libs-scala/safe-proto/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+)
+
+da_scala_library(
+    name = "safe-proto",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    tags = ["maven_coordinates=com.daml:safe-proto:__VERSION__"],
+    visibility = ["//visibility:public"],
+    deps = ["@maven//:com_google_protobuf_protobuf_java"],
+)
+
+da_scala_test_suite(
+    name = "safe-protot-test",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    max_heap_size = "4g",
+    deps = [
+        ":safe-proto",
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)

--- a/libs-scala/safe-proto/src/main/scala/com/daml/SafeProto.scala
+++ b/libs-scala/safe-proto/src/main/scala/com/daml/SafeProto.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml
+
+import com.google.protobuf.{AbstractMessageLite, ByteString, CodedOutputStream}
+
+object SafeProto {
+
+  // `AbstractMessageLite#toByteString` and `AbstractMessageLite#toByteArray` on
+  // messages requiring more than 2GB fails with two different RuntimeExceptions
+  // which are not human readable. The root cause of the failure is that
+  // AbstractMessageLite#getSerializedSize computation does not handle overflow.
+  // We identified two different error cases when `getSerializedSize` overflows:
+  //  - if `getSerializedSize` overflows and outputs a positive int,
+  //    the serialization throws a generic `RuntimeException` with a
+  //    `CodedOutputStream.OutOfSpaceException` as cause.
+  //  - if `getSerializedSize` overflows and outputs a negative int,
+  //    the serialization throws a `NegativeArraySizeException`
+  // This function catches those exceptions.
+  private[this] def safelySerialize[X](
+      message: AbstractMessageLite[_, _],
+      serialize: AbstractMessageLite[_, _] => X,
+  ): Either[String, X] =
+    try {
+      Right(serialize(message))
+    } catch {
+      case e: RuntimeException
+          if e.isInstanceOf[NegativeArraySizeException] ||
+            e.getCause != null && e.getCause.isInstanceOf[CodedOutputStream.OutOfSpaceException] =>
+        Left(s"the ${message.getClass.getName} message is too big to be serialized")
+    }
+
+  def toByteString(message: AbstractMessageLite[_, _]): Either[String, ByteString] =
+    safelySerialize(message, _.toByteString)
+
+  def toByteArray(message: AbstractMessageLite[_, _]): Either[String, Array[Byte]] =
+    safelySerialize(message, _.toByteArray)
+}

--- a/libs-scala/safe-proto/src/test/scala/com/daml/SafeProtoTest.scala
+++ b/libs-scala/safe-proto/src/test/scala/com/daml/SafeProtoTest.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml
+
+import com.google.protobuf._
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SafeProtoTest extends AnyWordSpec with Inside with Matchers {
+
+  private[this] def tuple(v: Value) =
+    Value.newBuilder().setListValue(ListValue.newBuilder().addValues(v).addValues(v)).build()
+
+  private[this] val value0 = Value.newBuilder().setStringValue("a" * 1024 * 1024 * 1024).build()
+  assert(value0.getSerializedSize > 0)
+  private[this] val value1 = tuple(value0)
+  assert(value1.getSerializedSize < 0)
+  private[this] val value2 = tuple(value1)
+  assert(value2.getSerializedSize >= 0)
+
+  "toByteString" should {
+
+    "fail gracefully if the message to serialize exceeds 2GB" in {
+      SafeProto.toByteString(value0) shouldBe a[Right[_, _]]
+      SafeProto.toByteString(value1) shouldBe a[Left[_, _]]
+      SafeProto.toByteString(value2) shouldBe a[Left[_, _]]
+    }
+  }
+
+  "toByteArray" should {
+
+    "fail gracefully if the message to serialize exceeds 2GB" in {
+      SafeProto.toByteArray(value0) shouldBe a[Right[_, _]]
+      SafeProto.toByteArray(value1) shouldBe a[Left[_, _]]
+      SafeProto.toByteArray(value2) shouldBe a[Left[_, _]]
+    }
+  }
+
+}

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -207,6 +207,8 @@
   type: jar-scala
 - target: //libs-scala/resources-grpc:resources-grpc
   type: jar-scala
+- target: //libs-scala/safe-proto:safe-proto
+  type: jar-scala
 - target: //libs-scala/scala-utils:scala-utils
   type: jar-scala
 - target: //libs-scala/scalatest-utils:scalatest-utils


### PR DESCRIPTION
The [Protobuf library](https://github.com/protocolbuffers/protobuf) uses an `int` to represent and computes the number of bytes needed to serialized a message, however it does not  handle at all overflows. Consequently the result of `com.google.protobuf.MessageLite#getSerializedSize: Int` on messages requiring more that 2GB is meaningless. The Protobuf serialization code, which uses this number, then fails in unexpected way by emitted different kinds of `RuntimeException`s when trying to process too big messages.

We identified two different `RuntimeException`s that can be throw in such a case:
- A `NegativeArraySizeException` in case the result of `getSerializedSize` is negative
- A generic `RunTimeException` with a cause of type com.google.protobug.OutOfSpaceException` in case the  result of `getSerializedSize` is positive (but smaller than required spaced needed to store the message).

fixes #12392

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
