### PR TITLE
Fix log string interpolation in AkkaExecutionSequencer

### DIFF
--- a/ledger-api/rs-grpc-akka/src/main/scala/com/digitalasset/grpc/adapter/AkkaExecutionSequencer.scala
+++ b/ledger-api/rs-grpc-akka/src/main/scala/com/digitalasset/grpc/adapter/AkkaExecutionSequencer.scala
@@ -67,7 +67,7 @@ private[grpc] class RunnableSequencingActor extends Actor with ActorLogging {
       try {
         runnable.run()
       } catch {
-        case NonFatal(t) => log.error("Unexpected exception while executing Runnable", t)
+        case NonFatal(t) => log.error("Unexpected exception while executing Runnable: {}", t)
       }
     case ShutdownRequest =>
       context.stop(self) // processing of the current message will continue


### PR DESCRIPTION
```
# sample before
... Unexpected exception while executing Runnable WARNING arguments left: 1
# sample after
... Unexpected exception while executing Runnable: java.lang.IllegalStateException: call already closed
```