### PR TITLE
Typecheck experimental primitives in damlc

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -147,6 +147,7 @@ data Error
   | EUnknownInterfaceMethod !TypeConName !(Qualified TypeConName) !MethodName
   | ETemplateDoesNotImplementInterface !(Qualified TypeConName) !(Qualified TypeConName)
   | EWrongInterfaceRequirement !(Qualified TypeConName) !(Qualified TypeConName)
+  | EUnknownExperimental !T.Text !Type
 
 contextLocation :: Context -> Maybe SourceLoc
 contextLocation = \case
@@ -432,6 +433,8 @@ instance Pretty Error where
       "Template " <> pretty tpl <> " does not implement interface " <> pretty iface
     EWrongInterfaceRequirement requiringIface requiredIface ->
       "Interface " <> pretty requiringIface <> " does not require interface " <> pretty requiredIface
+    EUnknownExperimental name ty ->
+      "Unknown experimental primitive " <> string (show name) <> " : " <> pretty ty
 
 prettyConsuming :: Bool -> Doc ann
 prettyConsuming consuming = if consuming then "consuming" else "non-consuming"

--- a/compiler/damlc/tests/daml-test-files/ExperimentalCheck.daml
+++ b/compiler/damlc/tests/daml-test-files/ExperimentalCheck.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2022, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_EXPERIMENTAL
+-- @ERROR Unknown experimental primitive "DOES_NOT_EXIST" : Unit
+
+-- | Check that experimental primitives are verified in damlc.
+module ExperimentalCheck where
+
+test : ()
+test = GHC.Types.primitive @"$DOES_NOT_EXIST"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1850,7 +1850,6 @@ private[lf] object SBuiltin {
       List(
         "ANSWER" -> SBExperimentalAnswer,
         "TO_TYPE_REP" -> SBExperimentalToTypeRep,
-        "RESOLVE_VIRTUAL_CREATE" -> new SBResolveVirtual(CreateDefRef),
         "RESOLVE_VIRTUAL_SIGNATORY" -> new SBResolveVirtual(SignatoriesDefRef),
         "RESOLVE_VIRTUAL_OBSERVER" -> new SBResolveVirtual(ObserversDefRef),
       ).view.map { case (name, builtin) => name -> compileTime.SEBuiltin(builtin) }.toMap


### PR DESCRIPTION
Adds a check that experimental primitives are defined and have the type you expect, in the damlc LF typechecker.

This is only for the Haskell side, and only intended so we can catch bugs in the compiler more easily during development. (This would have caught the bug where `observer` for interfaces wasn't defined correctly in LFConversion.Primitives)

I also removed RESOLVE_VIRTUAL_CREATE from speedy since we're not using it at all, it's been superseded by UCreateInterface.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
