### PR TITLE
split-release: add non-repudiation artifacts

### DIFF
--- a/ci/publish-artifactory.sh
+++ b/ci/publish-artifactory.sh
@@ -73,4 +73,10 @@ else
         done
         )
     done
+    for base in non-repudiation-core non-repudiation-client; do
+        for end in .jar .pom -sources.jar -javadoc.jar; do
+            push assembly/daml $base-${RELEASE_TAG}${end}${sign}
+        done
+    done
+    push assembly/daml $NON_REPUDIATION
 fi

--- a/ci/publish-artifactory.sh
+++ b/ci/publish-artifactory.sh
@@ -79,4 +79,8 @@ else
         done
     done
     push assembly/daml $NON_REPUDIATION
+    push assembly/daml $TRIGGER_SERVICE
+    push assembly/daml $HTTP_JSON
+    push assembly/daml $TRIGGER_RUNNER
+    push assembly/daml $SCRIPT_RUNNER
 fi


### PR DESCRIPTION
All these are currently saved by the release process under
`gs://daml-data/releases/$version/artifactory`; since creating entries
under `daml-data/releases` will be done from the assembly repo in the
new process, the assembly build needs access to them.

Alternatively, the assembly build could get these from their Maven repo
on Artifactory, but I think it's cleaner if everything the assembly repo
needs from the daml repo goes through the same place (assembly/daml on
Artifactory) so it's easier to keep track of.

CHANGELOG_BEGIN
CHANGELOG_END