### PR TITLE
Changed product names in the documentation

### DIFF
--- a/docs/source/app-dev/bindings-java/quickstart.rst
+++ b/docs/source/app-dev/bindings-java/quickstart.rst
@@ -497,7 +497,7 @@ Integrate with the ledger
 
 A distributed ledger only forms the core of a full Daml application.
 
-To build automations and integrations around the ledger, Daml Connect has :doc:`language bindings </app-dev/bindings-java/index>` for the Ledger API in several programming languages.
+To build automations and integrations around the ledger, Daml has :doc:`language bindings </app-dev/bindings-java/index>` for the Ledger API in several programming languages.
 
 
 To compile the Java integration for the quickstart application, we first need to run the Java codegen on the DAR we built before::

--- a/docs/source/app-dev/command-deduplication.rst
+++ b/docs/source/app-dev/command-deduplication.rst
@@ -88,7 +88,7 @@ Independently of how the outcome is communicated, command deduplication generate
 
 For deduplication to work as intended, all submissions for the same ledger change must be submitted via the same participant.
 Whether a submission is considered a duplicate is determined by completion events, and by default a participant outputs only the completion events for submissions that were requested via the very same participant.
-At this time, only `Daml Driver for VMware Blockchain <https://www.digitalasset.com/daml-for-vmware-blockchain/>`__ supports command deduplication across participants.
+At this time, only `Daml driver for VMware Blockchain <https://www.digitalasset.com/daml-for-vmware-blockchain/>`__ supports command deduplication across participants.
 
 .. _command-dedup-usage:
 

--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -9,7 +9,7 @@ Daml Studio is an integrated development environment (IDE) for Daml. It is an ex
 Installing
 **********
 
-Daml Studio is included in :doc:`the Daml Connect SDK </getting-started/installation>`.
+Daml Studio is included in :doc:`the Daml SDK </getting-started/installation>`.
 
 Creating your first Daml file
 *****************************

--- a/docs/source/daml/intro/0_Intro.rst
+++ b/docs/source/daml/intro/0_Intro.rst
@@ -6,13 +6,13 @@ An introduction to Daml
 
 Daml is a smart contract language designed to build composable applications on an abstract :ref:`da-ledgers`.
 
-In this introduction, you will learn about the structure of a Daml Ledger, and how to write Daml applications that run on any Daml Ledger implementation, by building an asset-holding and -trading application. You will gain an overview over most important language features, how they relate to the :ref:`da-ledgers` and how to use Daml Connect's developer tools to write, test, compile, package and ship your application.
+In this introduction, you will learn about the structure of a Daml Ledger, and how to write Daml applications that run on any Daml Ledger implementation, by building an asset-holding and -trading application. You will gain an overview over most important language features, how they relate to the :ref:`da-ledgers` and how to use Daml's developer tools to write, test, compile, package and ship your application.
 
 This introduction is structured such that each section presents a new self-contained application with more functionality than that from the previous section. You can find the Daml code for each section `here <https://github.com/digital-asset/daml/tree/main/docs/source/daml/intro/daml>`_ or download them using the Daml assistant. For example, to load the sources for section 1 into a folder called ``1_Token``, run ``daml new 1_Token --template daml-intro-1``.
 
 Prerequisites:
 
-- You have installed the :doc:`Daml Connect SDK </getting-started/installation>`
+- You have installed the :doc:`Daml SDK </getting-started/installation>`
 
 Next: :doc:`1_Token`.
 

--- a/docs/source/deploy/index.rst
+++ b/docs/source/deploy/index.rst
@@ -21,7 +21,7 @@ for production use today.
    * - Product
      - Ledger
      - Vendor
-   * - `Daml Driver for VMware Blockchain <https://www.digitalasset.com/daml-for-vmware-blockchain/>`__
+   * - `Daml driver for VMware Blockchain <https://www.digitalasset.com/daml-for-vmware-blockchain/>`__
      - `VMware Blockchain <https://www.vmware.com/products/blockchain.html/>`__
      - `VMware <https://vmware.com/>`__
    * - `Daml on Corda <#>`__
@@ -64,7 +64,7 @@ The following table lists open source Daml integrations.
      - `Github Repo <https://github.com/digital-asset/daml-on-fabric>`__
    * - `PostgreSQL <https://www.postgresql.org/>`__
      - `Digital Asset <https://digitalasset.com/>`__
-     - `Daml Driver for PostgreSQL Docs <https://docs.daml.com/daml-driver-for-postgresql/>`__
+     - `Daml driver for PostgreSQL Docs <https://docs.daml.com/daml-driver-for-postgresql/>`__
 
 .. _deploy-ref_in_development:
 

--- a/docs/source/getting-started/app-architecture.rst
+++ b/docs/source/getting-started/app-architecture.rst
@@ -25,7 +25,7 @@ In your terminal, navigate to the root ``create-daml-app`` directory and run::
   daml studio
 
 This should open the Visual Studio Code editor at the root of the project.
-(You may get a new tab pop up with release notes for the latest version of Daml Connect - just close this.)
+(You may get a new tab pop up with release notes for the latest version of Daml - just close this.)
 Using the file *Explorer* on the left sidebar, navigate to the ``daml`` folder and double-click on the ``User.daml`` file.
 
 The Daml code defines the *data* and *workflow* of the application.

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -27,7 +27,7 @@ With that, let's get started!
 Prerequisites
 *************
 
-Please make sure that you have the Daml Connect SDK, Java 8 or higher, and Visual Studio Code (the only supported IDE) installed as per instructions from our :doc:`installation` page.
+Please make sure that you have the Daml SDK, Java 8 or higher, and Visual Studio Code (the only supported IDE) installed as per instructions from our :doc:`installation` page.
 
 You will also need some common software tools to build and interact with the template project.
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -39,7 +39,7 @@ The installer will setup the ``PATH`` variable for you. In order for it to take 
 log out and log in again.
 
 Installing Daml Enterprise
-*********************************
+**************************
 
 If you have a license for Daml Enterprise, you
 can install it as follows:

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -7,7 +7,7 @@ Installing the SDK
 1. Install the dependencies
 ***************************
 
-The Daml Connect SDK currently runs on Windows, macOS and Linux.
+The Daml SDK currently runs on Windows, macOS and Linux.
 
 You need to install:
 
@@ -38,10 +38,10 @@ To install the SDK on Mac or Linux open a terminal and run:
 The installer will setup the ``PATH`` variable for you. In order for it to take effect, you will have to
 log out and log in again.
 
-Installing the Enterprise Edition
+Installing Daml Enterprise
 *********************************
 
-If you have a license for the enterprise edition of Daml Connect, you
+If you have a license for Daml Enterprise, you
 can install it as follows:
 
 On Windows, download the installer from Artifactory_ instead of Github
@@ -59,7 +59,7 @@ This will be used by the assistant to download other versions automatically from
 
 If you already have an existing installation, you only need to add
 this entry to ``daml-config.yaml``. To overwrite a previously
-installed version with the corresponding enterprise edition, use
+installed version with the corresponding Daml Enterprise version, use
 ``daml install --force VERSION``.
 
 Next steps

--- a/docs/source/getting-started/manual-download.rst
+++ b/docs/source/getting-started/manual-download.rst
@@ -4,7 +4,7 @@
 Manually installing the SDK
 ***************************
 
-If you require a higher level of security, you can instead install the Daml Connect SDK by manually downloading the compressed tarball, verifying its signature, extracting it and manually running the install script.
+If you require a higher level of security, you can instead install the Daml SDK by manually downloading the compressed tarball, verifying its signature, extracting it and manually running the install script.
 
 Note that the Windows installer is already signed (within the binary itself), and that signature is checked by Windows before starting it. Nevertheless, you can still follow the steps below to check its external signature file.
 

--- a/docs/source/json-api/production-setup.rst
+++ b/docs/source/json-api/production-setup.rst
@@ -20,11 +20,11 @@ query performance. Details for enabling a query store are highlighted below.
 Query store
 ***********
 
-.. note:: The Community Edition of Daml Connect only supports PostgreSQL backends for the *HTTP JSON API* server, but the Enterprise Edition also supports Oracle backends.
+.. note:: Daml Open Source only supports PostgreSQL backends for the *HTTP JSON API* server, but Daml Enterprise also supports Oracle backends.
 
 The query store is a cached search index and is useful for use cases
 where the application needs to query large active contract sets (ACS). The *HTTP JSON API* server can be
-configured with PostgreSQL/Oracle (Enterprise Edition only) as the query store backend.
+configured with PostgreSQL/Oracle (Daml Enterprise only) as the query store backend.
 
 The query store is built by saving the state of the ACS up to the current ledger
 offset. This allows the *HTTP JSON API* to only request the delta on subsequent queries,

--- a/docs/source/json-api/search-query-language.rst
+++ b/docs/source/json-api/search-query-language.rst
@@ -133,7 +133,7 @@ Appendix: Known issues
 When using Oracle, queries fail if a token is too large
 =======================================================
 
-This limitation is exclusive to users of the HTTP JSON API using the Enterprise Edition support for Oracle. Due to a known limitation in Oracle, the full-test JSON search index on the contract payloads rejects query tokens larger than 256 bytes. This limitations shouldn't impact most workloads, but if this needs to be worked around, the HTTP JSON API server can be started passing the additional ``disableContractPayloadIndexing=true`` (after wiping an existing query store database, if necessary).
+This limitation is exclusive to users of the HTTP JSON API using Daml Enterprise support for Oracle. Due to a known limitation in Oracle, the full-test JSON search index on the contract payloads rejects query tokens larger than 256 bytes. This limitations shouldn't impact most workloads, but if this needs to be worked around, the HTTP JSON API server can be started passing the additional ``disableContractPayloadIndexing=true`` (after wiping an existing query store database, if necessary).
 
 `Issue on GitHub <https://github.com/digital-asset/daml/issues/10780>`__
 

--- a/docs/source/ops/connect/auth0.rst
+++ b/docs/source/ops/connect/auth0.rst
@@ -673,7 +673,7 @@ running. You should be able to log in with Auth0, exchange messages, and set up
 an auto-reply trigger, all by connecting your browser to ``https://$DOMAIN/``.
 
 Manually Setting Up the Daml Components
-******************************************
+***************************************
 
 For simplicity, we assume that all of the Daml components will run on a single
 machine (they can find each other on ``localhost``) and that this machine has

--- a/docs/source/ops/connect/auth0.rst
+++ b/docs/source/ops/connect/auth0.rst
@@ -598,7 +598,7 @@ We document two paths forward here: one that relies on the Helm chart included
 in Daml Enterprise, and a manual setup using only the Open Source SDK.
 
 Using the Daml Helm Chart
-****************************
+*************************
 
 For simplicity, we assume that you have access to a server with a public IP
 address that both you and Auth0 can reach. Furthermore, we assume that you have

--- a/docs/source/ops/connect/auth0.rst
+++ b/docs/source/ops/connect/auth0.rst
@@ -7,7 +7,7 @@ Setting Up Auth0
 ================
 
 In this section, we will walk through a complete setup of an entire Daml
-Connect system using Auth0 as its authentication provider.
+system using Auth0 as its authentication provider.
 
 .. note::
 
@@ -65,7 +65,7 @@ In order to follow along this guide, you will need:
 - An application you want to deploy on your Daml system. This is not, strictly
   speaking, required, but the whole experience is going to be a lot less
   satisfying if you don't end up with something actually running on your Daml
-  Connect system. In this guide, we'll use the `create-daml-app` template,
+  system. In this guide, we'll use the `create-daml-app` template,
   which as of Daml SDK 1.17.0 supports Auth0 out-of-the-box on its UI side.
 
 Generating Party Allocation Credentials
@@ -593,17 +593,16 @@ in the folder that contains both ``nginx`` and ``my-project``:
 
 And that's it for building the application. We now have a DAR file that is
 ready to be deployed to a ledger, as well as a Docker container ready to serve
-our frontend. All we need now is to get a Daml Connect system up and running.
+our frontend. All we need now is to get a Daml system up and running.
 We document two paths forward here: one that relies on the Helm chart included
-in Daml Connect Enterprise Edition, and a manual setup using only the Community
-Edition SDK.
+in Daml Enterprise, and a manual setup using only the Open Source SDK.
 
-Using the Connect Helm Chart
+Using the Daml Helm Chart
 ****************************
 
 For simplicity, we assume that you have access to a server with a public IP
 address that both you and Auth0 can reach. Furthermore, we assume that you have
-access to Enterprise Edition credentials to download the Docker images.  We
+access to Daml Enterprise credentials to download the Docker images.  We
 also assume you can create a local cluster with ``minikube`` on the remote
 machine. Finally, we assume that you have downloaded the Helm chart in a folder
 called ``daml-connect``.
@@ -673,7 +672,7 @@ domain on which your server is exposed. And voilà! Your application is up and
 running. You should be able to log in with Auth0, exchange messages, and set up
 an auto-reply trigger, all by connecting your browser to ``https://$DOMAIN/``.
 
-Manually Setting Up the Connect Components
+Manually Setting Up the Daml Components
 ******************************************
 
 For simplicity, we assume that all of the Daml components will run on a single

--- a/docs/source/ops/connect/helm.rst
+++ b/docs/source/ops/connect/helm.rst
@@ -3,8 +3,8 @@
 
 .. _connect-helm-chart:
 
-Helm Chart
-==================
+Daml Helm Chart
+===============
 
 As of 1.18.0, we provide an Early Access version of the Helm Chart for
 Daml Enterprise customers. This page contains documentation for that Helm

--- a/docs/source/ops/connect/helm.rst
+++ b/docs/source/ops/connect/helm.rst
@@ -253,7 +253,7 @@ easy-to-reconstruct cache. This assume that, in this setup, the data store of
 the Ledger API server is, itself, properly backed up.
 
 Securing Daml
----------------------
+-------------
 
 The Helm chart assumes that the Kubernetes environment itself is trusted, and
 as such does not encrypt connections between components. Full TLS encryption

--- a/docs/source/ops/connect/helm.rst
+++ b/docs/source/ops/connect/helm.rst
@@ -3,17 +3,17 @@
 
 .. _connect-helm-chart:
 
-Connect Helm Chart
+Helm Chart
 ==================
 
-As of 1.18.0, we provide an Early Access version of the Connect Helm Chart for
-Enterprise Edition customers. This page contains documentation for that Helm
+As of 1.18.0, we provide an Early Access version of the Helm Chart for
+Daml Enterprise customers. This page contains documentation for that Helm
 chart.
 
 Credentials
 -----------
 
-Like all Enterprise Edition components, the Helm Chart is hosted on
+Like all Daml Enterprise components, the Helm Chart is hosted on
 Artifactory. To get both the Helm chart itself and the Docker images it relies
 on, you will need Artifactory credentials. In the rest of this document, we
 assume that ``$ARTIFACTORY_USERNAME`` refers to your Artifactory user name,
@@ -22,7 +22,7 @@ whereas ``$ARTIFACTORY_PASSWORD`` refers to your Artifactory API key.
 Installing the Helm Chart Repository
 ------------------------------------
 
-To let your local Helm installation know about the Daml Connect Helm chart, you
+To let your local Helm installation know about the Daml Helm chart, you
 need to add the repository with::
 
   helm repo add daml \
@@ -57,7 +57,7 @@ Setting Up the ``imagePullSecret``
 ----------------------------------
 
 The Helm chart relies on the production-ready Docker images for individual
-components that are part of the Enterprise Edition. Specifically, it expects a
+components that are part of Daml Enterprise. Specifically, it expects a
 Kubernetes secret given as the ``imagePullSecret`` argument with the relevant
 Docker credentials in it.
 
@@ -116,12 +116,12 @@ To get started against a development cluster, you can just run::
 
 This assumes you have used the above script to setup your credentials, or
 otherwise created the secret ``daml-docker-credentials``. It also assumes you
-run this command after having added the Daml Connect Helm chart repository as
+run this command after having added the Daml Helm chart repository as
 explained above.
 
 This is going to start the following:
 
-- For each of the state-keeping components (Daml Driver for PostgreSQL, HTTP
+- For each of the state-keeping components (Daml driver for PostgreSQL, HTTP
   JSON API Service), an "internal" PostgreSQL database server. These are
   decidedly not production-ready. For a production setup, you'll need to
   provide your own databases here.
@@ -129,7 +129,7 @@ This is going to start the following:
   should be replaced with a real authentication server for production use. See
   the :ref:`auth0` section for an example of using an external authentication
   infrastructure.
-- A single instance of each of the following services: Daml Driver for
+- A single instance of each of the following services: Daml driver for
   PostgreSQL, HTTP JSON API Service.
 - An nginx server exposing the ``/v1`` endpoints of the HTTP JSON API Service
   on a ``NodePort`` service type, for easy access from outside the Kubernetes
@@ -152,11 +152,11 @@ need to set the following:
   are most definitely not meant for production use. Specifically, this will
   disable the internal PostgreSQL instances, the mock auth server, and the
   reverse proxy.
-- ``ledger.db``: If you want the Helm char to start a Daml Driver For
+- ``ledger.db``: If you want the Helm char to start a Daml driver For
   PostgreSQL instance for you, you need to set this. See reference section at
   the end of this page for details.
 - ``ledger.host`` and ``ledger.port``: If you **do not** want the Helm chart to
-  setup a Daml Driver isntance for you, but instead want the components started
+  setup a Daml driver isntance for you, but instead want the components started
   by it to connect to an existing Ledger API server, fill in these options
   instead of the ``ledger.db`` object.
 - ``jsonApi.db``: If you want the Helm chart to start the HTTP JSON API Service
@@ -165,7 +165,7 @@ need to set the following:
 - ``triggerService.db``: If you want the Helm chart to start the Trigger
   Service for you, you need to set this. See reference section at the end of
   this page for details.
-- ``authUrl``: If you want the Helm chart to provide either a Daml Driver for
+- ``authUrl``: If you want the Helm chart to provide either a Daml driver for
   PostgreSQL or a OAuth2 Middleware instance, you will need to set this to the
   JWKS URL of your token provider.
 
@@ -198,7 +198,7 @@ JSON-encoded logs. Other components log as unstructured text.
 Daml Metrics Options
 --------------------
 
-The Daml Driver for PostgreSQL instance and the HTTP JSON API instances started
+The Daml driver for PostgreSQL instance and the HTTP JSON API instances started
 by the Helm chart are configured to expose Prometheus metrics on a port named
 ``metrics``, using the appropriate annotations. This means that, if you are
 running a cluster-wide Prometheus instance, the relevant metrics should be
@@ -206,7 +206,7 @@ collected automatically.
 
 See each component's documentation for details on the metrics exposed:
 
-- `Daml Driver for PostgreSQL </daml-driver-for-postgresql/#types-of-metrics>`_
+- `Daml driver for PostgreSQL </daml-driver-for-postgresql/#types-of-metrics>`_
 - :ref:`JSON API metrics <json-api-metrics>`
 
 Upgrading
@@ -216,7 +216,7 @@ Upgrading
 
    This section only makes sense with the ``production`` flag set to ``true``.
 
-Upgrading the Daml Connect version should be done by uninstalling the existing
+Upgrading the Daml version should be done by uninstalling the existing
 Helm chart, waiting for all of the pods to stop, and then installing a higher
 version. Destroying all of the components is a safe operation because all of
 the state is stored in the provided database coordinates. There is no
@@ -244,7 +244,7 @@ those databases as a whole, just like you would any other database.
 If you want to be more fine-grained, you *may* decide to **not** backup the
 database used by the HTTP JSON API Service instances. Note that it is
 imperative that you still backup the databases for the other components (Trigger
-Service and Daml Driver for PostgreSQL) if you are running them.
+Service and Daml driver for PostgreSQL) if you are running them.
 
 If you are running the Helm chart solely for the HTTP JSON API Service
 (connected to an external Ledger API server), then you can eschew backing up
@@ -252,7 +252,7 @@ entirely, as the database for the HTTP JSON API Service is an
 easy-to-reconstruct cache. This assume that, in this setup, the data store of
 the Ledger API server is, itself, properly backed up.
 
-Securing Daml Connect
+Securing Daml
 ---------------------
 
 The Helm chart assumes that the Kubernetes environment itself is trusted, and
@@ -488,7 +488,7 @@ ledger.create
 - **Default**: true
 - **Required**: false
 
-If true, the Helm chart will create a Daml Driver for PostgreSQL instance. If
+If true, the Helm chart will create a Daml driver for PostgreSQL instance. If
 false, you will need to provide ``ledger.host`` and ``ledger.port`` (see
 below).
 
@@ -498,7 +498,7 @@ ledger.db.host
 - **Type**: string
 - **Required**: if enabled & production
 
-The hostname of the database server for the Daml Driver for PostgreSQL, if one
+The hostname of the database server for the Daml driver for PostgreSQL, if one
 is started by the Helm chart.
 
 ledger.db.port
@@ -507,7 +507,7 @@ ledger.db.port
 - **Type**: integer
 - **Required**: if enabled & production
 
-The exposed port of the database server for the Daml Driver for PostgreSQL, if
+The exposed port of the database server for the Daml driver for PostgreSQL, if
 one is started by the Helm chart.
 
 ledger.db.postgres.database
@@ -516,9 +516,9 @@ ledger.db.postgres.database
 - **Type**: string
 - **Required**: if enabled & production
 
-The database the Daml Driver for PostgreSQL should use when connecting to the
+The database the Daml driver for PostgreSQL should use when connecting to the
 database server. Note that, unlike the Trigger Service and HTTP JSON API
-Service, the Daml Driver for PostgreSQL started by the Helm chart only supports
+Service, the Daml driver for PostgreSQL started by the Helm chart only supports
 PostgreSQL database servers.
 
 ledger.db.secret
@@ -551,7 +551,7 @@ ledger.db.setupSecret
 - **Default**: none
 - **Required**: false
 
-The Daml Driver for PostgreSQL supports two start modes: ``--migrate-only`` and
+The Daml driver for PostgreSQL supports two start modes: ``--migrate-only`` and
 ``--migrate-and-start``. The long-running instance always starts with
 ``--migrate-and-start``, but if you supply this option, the Helm chart will
 start a separate, one-time job with ``--migrate-only``.
@@ -570,7 +570,7 @@ ledger.healthCheck
 - **Default**: see below
 - **Required**: false
 
-Overrides the probes for the long-running Daml Driver for PostgreSQL instance.
+Overrides the probes for the long-running Daml driver for PostgreSQL instance.
 Defaults:
 
 .. code-block:: yaml
@@ -595,7 +595,7 @@ ledger.host
 - **Type**: string
 - **Required**: if ledger.create is false
 
-If the Helm chart should not create its own Daml Driver for PostgreSQL instance
+If the Helm chart should not create its own Daml driver for PostgreSQL instance
 (i.e. you want to connect to other components to an existing gRPC Ledger API
 provider), this option should be set to the hostname of the gRPC Ledger API
 Server to connect to.
@@ -607,7 +607,7 @@ ledger.podAnnotations
 - **Default**: {}
 - **Required**: false
 
-The annotations which should be attached to the metadata of the Daml Driver for
+The annotations which should be attached to the metadata of the Daml driver for
 PostgreSQL pod.
 
 ledger.port
@@ -626,7 +626,7 @@ ledger.resources
 - **Default**: see below
 - **Required**: false
 
-Overrides the ``resources`` field of the Daml Driver for PostgreSQL pod.
+Overrides the ``resources`` field of the Daml driver for PostgreSQL pod.
 Defaults:
 
 .. code-block:: yaml
@@ -645,7 +645,7 @@ ledger.serviceAccount
 - **Default**: null
 - **Required**: false
 
-The service account which should be attached to the Daml Driver for PostgreSQL
+The service account which should be attached to the Daml driver for PostgreSQL
 pod.
 
 oauthMiddleware.callback

--- a/docs/source/ops/connect/index.rst
+++ b/docs/source/ops/connect/index.rst
@@ -3,7 +3,7 @@
 
 .. _ops-connect_index:
 
-Operating Daml Connect
+Operating Daml
 ======================
 
 

--- a/docs/source/ops/connect/index.rst
+++ b/docs/source/ops/connect/index.rst
@@ -4,7 +4,7 @@
 .. _ops-connect_index:
 
 Operating Daml
-======================
+==============
 
 
 .. toctree::

--- a/docs/source/ops/pruning.rst
+++ b/docs/source/ops/pruning.rst
@@ -10,7 +10,7 @@ In addition, privacy demands [1]_ may require removing Personally Identifiable I
 
 To satisfy these requirements, the :ref:`Pruning Service <com.daml.ledger.api.v1.admin.ParticipantPruningService>` Ledger API endpoint [2]_ allows Daml Participants to support pruning of Daml contracts and transactions that were respectively archived and submitted before or at a given ledger offset.
 
-Please refer to the specific Daml Driver information for details about its pruning support.
+Please refer to the specific Daml driver information for details about its pruning support.
 
 .. [1] For example, as enabled by provisions about the "right to be forgotten" of legislation such as
        `EU's GDPR <https://gdpr-info.eu/>`_.

--- a/docs/source/support/compatibility.rst
+++ b/docs/source/support/compatibility.rst
@@ -87,7 +87,7 @@ Given the Ledger API Compatibility above, network upgrades are seamless if they 
 As an example, from an application standpoint, the only effect of upgrading Daml for Postgres 1.4.0 to Daml for Postgres 1.6.0 is an uptick in the Ledger API version. There may be significant changes to components or database schemas, but these are not public APIs. 
 
 SDK, Runtime Component, and Library Compatibility: Daml Upgradeability
-******************************************************************************
+**********************************************************************
 
 As long as a major Ledger API version is supported (see :ref:`ledger-api-support`), there will be supported version of Daml able to target all minor versions of that major version. This has the obvious caveat that new features may not be available with old Ledger API versions.
 

--- a/docs/source/support/compatibility.rst
+++ b/docs/source/support/compatibility.rst
@@ -34,7 +34,7 @@ Participant Nodes advertise the Ledger API version they support via the :ref:`ve
 As a concrete example, Daml for Postgres 1.4.0 has the Participant Node integrated, and exposes Ledger API version 1.4.0 and the Daml for VMware Blockchain 1.0 Participant Nodes expose Ledger API version 1.6.0. So any application that runs on Daml for Postgres 1.4.0 will also run on Daml for VMware Blockchain 1.0.
 
 List of Ledger API Versions supported by Daml
-=====================================================
+=============================================
 
 The below lists with which Daml version a new Ledger API version was introduced.
 

--- a/docs/source/support/compatibility.rst
+++ b/docs/source/support/compatibility.rst
@@ -14,7 +14,7 @@ Network Upgradeability
 
   Ledger Operators should be able to upgrade Daml network or Participant Nodes seamlessly to stay up to date with the latest features and fixes. A Daml application should be able to operate without significant change across such Network Upgrades.
 
-Daml Connect Upgradeability
+Daml Upgradeability
 
   Application Developers should be able to update their developer tools seamlessly to stay up to date with the latest features and fixes, and stay able to maintain and develop their existing applications.
 
@@ -33,16 +33,16 @@ Participant Nodes advertise the Ledger API version they support via the :ref:`ve
 
 As a concrete example, Daml for Postgres 1.4.0 has the Participant Node integrated, and exposes Ledger API version 1.4.0 and the Daml for VMware Blockchain 1.0 Participant Nodes expose Ledger API version 1.6.0. So any application that runs on Daml for Postgres 1.4.0 will also run on Daml for VMware Blockchain 1.0.
 
-List of Ledger API Versions supported by Daml Connect
+List of Ledger API Versions supported by Daml
 =====================================================
 
-The below lists with which Daml Connect version a new Ledger API version was introduced.
+The below lists with which Daml version a new Ledger API version was introduced.
 
 .. list-table::   
    :header-rows: 1
 
    * - Ledger API Version
-     - Daml Connect Version
+     - Daml Version
    * - 1.12
      - 1.15
    * - 1.11
@@ -54,7 +54,7 @@ The below lists with which Daml Connect version a new Ledger API version was int
    * - 1.8
      - 1.9
    * - <= 1.7
-     - Introduced with the same Daml Connect / SDK version
+     - Introduced with the same Daml SDK version
 
 Summary of Ledger API Changes
 =============================
@@ -77,7 +77,7 @@ Summary of Ledger API Changes
    * - 1.8
      - Introduce Multi-Party Submissions
    * - <= 1.7
-     - See Daml Connect (/SDK) `release notes <https://daml.com/release-notes>`_ of same version number.
+     - See Daml (SDK) `release notes <https://daml.com/release-notes>`_ of same version number.
 
 Driver and Participant Compatibility: Network Upgradeability
 ************************************************************
@@ -86,22 +86,22 @@ Given the Ledger API Compatibility above, network upgrades are seamless if they 
 
 As an example, from an application standpoint, the only effect of upgrading Daml for Postgres 1.4.0 to Daml for Postgres 1.6.0 is an uptick in the Ledger API version. There may be significant changes to components or database schemas, but these are not public APIs. 
 
-SDK, Runtime Component, and Library Compatibility: Daml Connect Upgradeability
+SDK, Runtime Component, and Library Compatibility: Daml Upgradeability
 ******************************************************************************
 
-As long as a major Ledger API version is supported (see :ref:`ledger-api-support`), there will be supported version of Daml Connect able to target all minor versions of that major version. This has the obvious caveat that new features may not be available with old Ledger API versions.
+As long as a major Ledger API version is supported (see :ref:`ledger-api-support`), there will be supported version of Daml able to target all minor versions of that major version. This has the obvious caveat that new features may not be available with old Ledger API versions.
 
-For example, an application built and compiled with Daml Connect 1.4.0 against Ledger API 1.4.0, it can still be compiled using SDK 1.6.0 and can be run against Ledger API 1.4.0 using 1.6.0 libraries and runtime components. 
+For example, an application built and compiled with Daml SDK 1.4.0 against Ledger API 1.4.0, it can still be compiled using SDK 1.6.0 and can be run against Ledger API 1.4.0 using 1.6.0 libraries and runtime components. 
 
 .. _ledger-api-support:
 
 Ledger API Support Duration
 ***************************
 
-Major Ledger API versions behave like stable features in :doc:`status-definitions`. They are supported from the time they are first released as "stable" to the point where they are removed from Integration Components and Daml Connect following a 12 month deprecation cycle. The earliest point a major Ledger API version can be deprecated is with the release of the next major version. The earliest it can be removed is 12 months later with a major version release of the Integration Components.
+Major Ledger API versions behave like stable features in :doc:`status-definitions`. They are supported from the time they are first released as "stable" to the point where they are removed from Integration Components and Daml following a 12 month deprecation cycle. The earliest point a major Ledger API version can be deprecated is with the release of the next major version. The earliest it can be removed is 12 months later with a major version release of the Integration Components.
 
 Other than for hotfix releases, new releases of the Integration Components will only support the latest minor/patch version of each major Ledger API version.
 
 As a result we can make this overall statement:
 
-**An application built using Daml Connect U.V.W against Ledger API X.Y.Z can be maintained using any Daml Connect version U2.V2.W2 >= U.V.W as long as Ledger API major version X is still supported at the time of release of U2.V2.W2, and run against any Daml Network with Participant Nodes exposing Ledger API X.Y2.Z2 >= X.Y.Z.**
+**An application built using Daml SDK U.V.W against Ledger API X.Y.Z can be maintained using any Daml SDK version U2.V2.W2 >= U.V.W as long as Ledger API major version X is still supported at the time of release of U2.V2.W2, and run against any Daml Network with Participant Nodes exposing Ledger API X.Y2.Z2 >= X.Y.Z.**

--- a/docs/source/support/overview.rst
+++ b/docs/source/support/overview.rst
@@ -45,7 +45,7 @@ Ledger API
 The Ledger API is the primary interface that offers forward and backward compatibility between Daml Networks and Applications (including Daml components). As you can see in the diagram above, all interaction between components above the Participant Node and the Participant Node or Daml Network happen through the Ledger API. The Ledger API is a public API and offers the lowest level of access to Daml Ledgers supported for application use.
 
 Daml Components
-************
+***************
 
 Runtime Components
 ==================

--- a/docs/source/support/overview.rst
+++ b/docs/source/support/overview.rst
@@ -23,7 +23,7 @@ A high level view of the architecture of a Daml application or solution is helpf
 
 .. figure:: architecture.png
 
-The stack is segmented into two parts. Daml Drivers encompass those components which enable an infrastructure to run Daml Smart Contracts, turning it into a **Daml Network**. **Daml Connect** consists of everything developers and users need to connect to a Daml Network: the tools to build, deploy, integrate, and maintain a Daml Application. 
+The stack is segmented into two parts. Daml drivers encompass those components which enable an infrastructure to run Daml Smart Contracts, turning it into a **Daml Network**. **Daml Components** consists of everything developers and users need to connect to a Daml Network: the tools to build, deploy, integrate, and maintain a Daml Application. 
 
 Daml Networks
 *************
@@ -37,14 +37,14 @@ At the bottom of every Daml Application is a Daml network, a distributed, or pos
 Participant Nodes
 *****************
 
-On top of, or integrated into the Daml Drivers sits a Participant Node, that has the primary purpose of exposing the Daml Ledger API. In the case of *integrated* Daml Drivers, the Participant Node usually interacts with the Daml Drivers through solution-specific APIs. In this case, Participant Nodes can only communicate with Daml Drivers of one Daml Network. In the case of *interoperable* Daml Drivers, the Participant Node communicates with the Daml Drivers through the uniform `Canton Protocol <https://www.canton.io/docs/stable/user-manual/index.html>`_. The Canton Protocol is versioned and has some cross-version compatibility guarantees, but is not a public API. So participant nodes may have public APIs like monitoring and logging, command line interfaces or similar, but the only *uniform* public API exposed by all Participant Nodes is the Ledger API.
+On top of, or integrated into the Daml drivers sits a Participant Node, that has the primary purpose of exposing the Daml Ledger API. In the case of *integrated* Daml drivers, the Participant Node usually interacts with the Daml drivers through solution-specific APIs. In this case, Participant Nodes can only communicate with Daml drivers of one Daml Network. In the case of *interoperable* Daml drivers, the Participant Node communicates with the Daml drivers through the uniform `Canton Protocol <https://www.canton.io/docs/stable/user-manual/index.html>`_. The Canton Protocol is versioned and has some cross-version compatibility guarantees, but is not a public API. So participant nodes may have public APIs like monitoring and logging, command line interfaces or similar, but the only *uniform* public API exposed by all Participant Nodes is the Ledger API.
 
 Ledger API
 **********
 
-The Ledger API is the primary interface that offers forward and backward compatibility between Daml Networks and Applications (including Daml Connect components). As you can see in the diagram above, all interaction between components above the Participant Node and the Participant Node or Daml Network happen through the Ledger API. The Ledger API is a public API and offers the lowest level of access to Daml Ledgers supported for application use.
+The Ledger API is the primary interface that offers forward and backward compatibility between Daml Networks and Applications (including Daml components). As you can see in the diagram above, all interaction between components above the Participant Node and the Participant Node or Daml Network happen through the Ledger API. The Ledger API is a public API and offers the lowest level of access to Daml Ledgers supported for application use.
 
-Daml Connect
+Daml Components
 ************
 
 Runtime Components
@@ -60,9 +60,9 @@ Libraries naturally provide public APIs in their target language, be it Daml, or
 Generated Code
 ==============
 
-The SDK allows the generation of code for some languages from a Daml Model. This generated code has public APIs, which are not independently versioned, but depend on the Daml Connect version and source of the generated code, like a Daml package. In this case, the version of the Daml Connect SDK used covers changes to the public API of the generated code.
+The SDK allows the generation of code for some languages from a Daml Model. This generated code has public APIs, which are not independently versioned, but depend on the Daml version and source of the generated code, like a Daml package. In this case, the version of the Daml SDK used covers changes to the public API of the generated code.
 
 Developer Tools / SDK
 =====================
 
-The Daml Connect SDK consists of the developer tools used to develop user code, both Daml and in secondary languages, to generate code, and to interact with running applications via Runtime, and Ledger API. The SDK has a broad public API covering the Daml Language, CLIs, IDE, and Developer tools, but few of those APIs are intended for runtime use in a production environment. Exceptions to that are called out on :doc:`component-statuses`.
+The Daml SDK consists of the developer tools used to develop user code, both Daml and in secondary languages, to generate code, and to interact with running applications via Runtime, and Ledger API. The SDK has a broad public API covering the Daml Language, CLIs, IDE, and Developer tools, but few of those APIs are intended for runtime use in a production environment. Exceptions to that are called out on :doc:`component-statuses`.

--- a/docs/source/support/releases.rst
+++ b/docs/source/support/releases.rst
@@ -22,7 +22,7 @@ Daml's "public API" is laid out in the :doc:`overview`.
 Cadence
 *******
 
-Regular snapshot releases are made every Wednesday, with additional snapshots released as needed. These releases contain Daml Connect and Integration Components, both from the `daml repository <https://github.com/digital-asset/daml>`_ as well as some others.
+Regular snapshot releases are made every Wednesday, with additional snapshots released as needed. These releases contain Daml Components, both from the `daml repository <https://github.com/digital-asset/daml>`_ as well as some others.
 
 Stable versions are released once a month. See :ref:`release_process` below for the usual schedule. This schedule is a guide, not a guarantee, and additional releases may be made, or releases may be delayed for skipped entirely.
 

--- a/docs/source/support/support.rst
+++ b/docs/source/support/support.rst
@@ -20,7 +20,7 @@ When you're in the community Forum or on Stack Overflow, please keep to our `Cod
 Support expectations
 ********************
 
-For community users (ie on our Forum and Stack Overflow):
+For Daml Open Source users:
 
 - **Timing**: You can enjoy the support of the community, which is provided for you out of their own good will and free time. On top of that, a Digital Asset employee will try to reply to unanswered questions within two business days.
 

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -13,7 +13,7 @@ Daml Assistant (``daml``)
 
   This builds the Daml project according to the project config file ``daml.yaml`` (see `Configuration files`_ below).
 
-  In particular, it will download and install the specified version of the Daml Connect SDK (the ``sdk-version`` field in ``daml.yaml``) if missing, and use that SDK version to resolve dependencies and compile the Daml project.
+  In particular, it will download and install the specified version of the Daml SDK (the ``sdk-version`` field in ``daml.yaml``) if missing, and use that SDK version to resolve dependencies and compile the Daml project.
 
 - Launch the tools in the SDK:
 
@@ -61,7 +61,7 @@ By default it's blank, and you usually won't need to edit it. It recognizes the 
    This setting is only used to inform you when an update is available.
 
    Set ``update-check: <number>`` to check for new versions every N seconds. Set ``update-check: never`` to never check for new versions.
-- ``artifactory-api-key``: If you have a license for Daml Connect EE,
+- ``artifactory-api-key``: If you have a license for Daml EE,
   you can use this to specify the Artifactory API key displayed in
   your user profile. The assistant will use this to download the EE
   edition.
@@ -211,7 +211,7 @@ Managing releases
 
 You can manage SDK versions manually by using ``daml install``.
 
-To download and install SDK of the latest stable Daml Connect version::
+To download and install SDK of the latest stable Daml version::
 
   daml install latest
 

--- a/docs/source/tools/auth-middleware/index.rst
+++ b/docs/source/tools/auth-middleware/index.rst
@@ -12,7 +12,7 @@ Auth Middleware
 Daml ledgers only validate authorization tokens. The issuance of those tokens however is something defined by the ledger operator and can vary significantly even if the same ledger is being used. This poses a challenge for application developers aiming to develop applications that need to be able to acquire and refresh authorization tokens but don’t want to tie themselves to any particular mechanism for token issuance.
 The auth middleware aims to address this problem by providing an API that decouples Daml applications from these details.
 The ledger operator can provide an auth middleware that is suitable for their authentication and authorization mechanism.
-Daml Connect includes an implementation of an auth middleware that supports `OAuth 2.0 Authorization Code Grant <https://oauth.net/2/grant-types/authorization-code/>`_. If this implementation is not compatible with your mechanism for token issuance, you can implement your own auth middleware provided it conforms to the same API.
+Daml includes an implementation of an auth middleware that supports `OAuth 2.0 Authorization Code Grant <https://oauth.net/2/grant-types/authorization-code/>`_. If this implementation is not compatible with your mechanism for token issuance, you can implement your own auth middleware provided it conforms to the same API.
 
 Features
 ~~~~~~~~
@@ -71,7 +71,7 @@ Request Authorization
 
 The application directs the user to this endoint if the ``/auth`` endpoint returned 401 Unauthorized.
 This will request authentication and authorization of the user from the IAM for the given claims.
-E.g. in the OAuth 2.0 based implementation included in DAML Connect, this will start an Authorization Code Grant flow.
+E.g. in the OAuth 2.0 based implementation included in DAML, this will start an Authorization Code Grant flow.
 
 If authorization is granted this will store the access and optional refresh token in a cookie. The request can define a callback URI, if specified this endpoint will redirect to the callback URI at the end of the flow. Otherwise, it will respond with a status code that indicates whether authorization was successful or not.
 

--- a/docs/source/tools/auth-middleware/oauth2.rst
+++ b/docs/source/tools/auth-middleware/oauth2.rst
@@ -6,7 +6,7 @@
 OAuth 2.0 Auth Middleware
 #########################
 
-Daml Connect includes an implementation of an auth middleware that supports `OAuth 2.0 Authorization Code Grant <https://oauth.net/2/grant-types/authorization-code/>`_.
+Daml includes an implementation of an auth middleware that supports `OAuth 2.0 Authorization Code Grant <https://oauth.net/2/grant-types/authorization-code/>`_.
 The implementation aims to be configurable to support different OAuth 2.0 providers and to allow custom mappings from Daml ledger claims to OAuth 2.0 scopes.
 
 OAuth 2.0 Configuration

--- a/docs/source/tools/export/index.rst
+++ b/docs/source/tools/export/index.rst
@@ -45,7 +45,7 @@ cause references to :ref:`unknown contract ids <export-unknown-cids>`.
 
 The ``--output`` flag defines the directory prefix under which to generate the
 Daml project that contains the Daml script that represents the ledger export.
-The flag ``--sdk-version`` defines which Daml Connect version to configure in
+The flag ``--sdk-version`` defines which Daml SDK version to configure in
 the generated ``daml.yaml`` configuration file.
 
 By default an export will reproduce all transactions in the ledger history. The

--- a/docs/source/tools/navigator/index.rst
+++ b/docs/source/tools/navigator/index.rst
@@ -11,7 +11,7 @@ The first sections of this guide cover use of the Navigator with the SDK. Refer 
 Navigator functionality
 ***********************
 
-Connect Navigator to any Daml Ledger and use it to:
+Connect the Navigator to any Daml Ledger and use it to:
 
 - View templates
 - View active and archived contracts

--- a/docs/source/tools/non-repudiation.rst
+++ b/docs/source/tools/non-repudiation.rst
@@ -4,20 +4,20 @@
 Non-repudiation
 ###############
 
-The non-repudiation middleware, API and client library are only available in the
-`Daml Connect Enterprise Edition <https://www.digitalasset.com/products/daml-connect>`_ and are currently an
+The non-repudiation middleware, API and client library are only available in
+`Daml Enterprise <https://www.digitalasset.com/products/daml-connect>`_ and are currently an
 :doc:`Early Access Feature in Alpha status </support/status-definitions>`.
 
 When you are issuing a command over the Ledger API, there is an implicit trust assumption between the issuer of the command and the operator of the participant
 that the latter will not issue commands on behalf of the former.
 
-The non-repudiation middleware and its client library are a Daml Connect Enterprise Edition exclusive feature that allows ledger operators to run
+The non-repudiation middleware and its client library are a Daml Enterprise exclusive feature that allows ledger operators to run
 participant nodes that will require each command to come with a verifiable cryptographic signature, which will persisted by the operator. As the
 sole owner of the private key used to sign the command, the authenticity of the command is thus verified and preserved, ensuring that an operator
 cannot issue a command on behalf of the user and that the user cannot repudiate the command.
 
 Note that this is an early access feature: its status is currently under development and further feedback can change how certain details might work
-once the feature is declared a stable part of Daml Connect Enterprise Edition. If you are interested in this feature, you are welcome to use it and
+once the feature is declared a stable part of Daml Enterprise. If you are interested in this feature, you are welcome to use it and
 give us feedback that will shape how this feature will ultimately come to be.
 
 Architecture
@@ -32,7 +32,7 @@ The non-repudiation system consists of three components:
 Running the server-side components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The server-side components are the middleware and the API. Both can be run as a single process by running the non-repudiation fat JAR provided as part of Daml Connect Enterprise Edition.
+The server-side components are the middleware and the API. Both can be run as a single process by running the non-repudiation fat JAR provided as part of Daml Enterprise.
 
 Note that at the current stage you need to also have a PostgreSQL server running where signed commands will be persisted.
 
@@ -47,7 +47,7 @@ For details on how to run them, please run the fat JAR with the ``--help`` comma
 Using the client
 ~~~~~~~~~~~~~~~~
 
-The client is a gRPC interceptor which is available to Daml Connect Enterprise Edition users (hence, it's not available on Maven Central).
+The client is a gRPC interceptor which is available to Daml Enterprise users (hence, it's not available on Maven Central).
 
 The Maven coordinates for the library are `com.daml:non-repudiation-client`.
 
@@ -68,7 +68,7 @@ Non-repudiation over the HTTP JSON API
 The non-repudiation middleware acts *exclusively* as a reverse proxy in front of the Ledger API server: if you want to use the HTTP JSON API you will need to
 run your own HTTP JSON API server and start it with a certificate that will be used to sign every command issued by the HTTP JSON API to the participant.
 
-The HTTP JSON API bundled with the Daml Connect Enterprise Edition has the following extra command line options that *must* be used to run an HTTP JSON API
+The HTTP JSON API bundled with Daml Enterprise has the following extra command line options that *must* be used to run an HTTP JSON API
 server against the non-repudiation middleware:
 
 - `--non-repudiation-certificate-path`: the path to the X.509 certificate containing the public counterpart to the private key that will be used to sign the commands

--- a/docs/source/tools/profiler.rst
+++ b/docs/source/tools/profiler.rst
@@ -4,8 +4,8 @@
 Daml Profiler
 #############
 
-The Daml Profiler is only available in the
-`Daml Connect Enterprise Edition <https://www.digitalasset.com/products/daml-connect>`_.
+The Daml Profiler is only available in
+`Daml Enterprise <https://www.digitalasset.com/products/daml-connect>`_.
 
 The Daml Profiler allows you to to profile execution of your Daml code
 which can help spot bottlenecks and opportunities for optimization.

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -73,7 +73,7 @@ Running with persistence
 ************************
 
 Note: Running Sandbox with persistence is deprecated as of SDK 1.8.0 (16th Dec 2020). You can use the
-Daml Driver for PostgreSQL instead.
+Daml driver for PostgreSQL instead.
 
 By default, Sandbox uses an in-memory store, which means it loses its state when stopped or restarted. If you want to keep the state, you can use a Postgres database for persistence. This allows you to shut down Sandbox and start it up later, continuing where it left off.
 

--- a/docs/source/tools/trigger-service/auth0_example.rst
+++ b/docs/source/tools/trigger-service/auth0_example.rst
@@ -5,7 +5,7 @@ Auth0 Example Configuration
 ###########################
 
 This section describes a minimal example configuration of the trigger service with authorization enabled
-using `Auth0 <auth0_>`_ as the OAuth 2.0 provider together with the OAuth 2.0 middleware included in Daml Connect.
+using `Auth0 <auth0_>`_ as the OAuth 2.0 provider together with the OAuth 2.0 middleware included in Daml.
 It uses the sandbox as the Daml ledger.
 
 Configure Auth0
@@ -142,10 +142,10 @@ Enter the `details page <auth0-user-details_>`_ of the newly created user.
 .. _auth0-create-user: https://auth0.com/docs/users/create-users
 .. _auth0-user-details: https://auth0.com/docs/users/view-user-details
 
-Start Daml Connect
+Start Daml
 ~~~~~~~~~~~~~~~~~~
 
-Next, configure the relevant Daml Connect components to use Auth0 as the IAM.
+Next, configure the relevant Daml components to use Auth0 as the IAM.
 
 Sandbox
 *******

--- a/docs/source/tools/trigger-service/auth0_example.rst
+++ b/docs/source/tools/trigger-service/auth0_example.rst
@@ -143,7 +143,7 @@ Enter the `details page <auth0-user-details_>`_ of the newly created user.
 .. _auth0-user-details: https://auth0.com/docs/users/view-user-details
 
 Start Daml
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
 Next, configure the relevant Daml components to use Auth0 as the IAM.
 


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

Terminology changes made:
- Removing reference to 'Connect'
- Changing the product names