### PR TITLE
Drop profile-dir validation for sandbox-kv

### DIFF
--- a/daml-assistant/daml-sdk/validate.sh
+++ b/daml-assistant/daml-sdk/validate.sh
@@ -19,19 +19,6 @@ JAVA=$(rlocation "$TEST_WORKSPACE/$1")
 SDK_CE=$(rlocation "$TEST_WORKSPACE/$2")
 SDK_EE=$(rlocation "$TEST_WORKSPACE/$3")
 
-for cmd in sandbox-kv; do
-    ret=0
-    $JAVA -jar $SDK_CE $cmd --help | grep -q profile-dir || ret=$?
-    if [[ $ret -eq 0 ]]; then
-        echo "Unexpected profile-dir option in CE"
-        exit 1
-    fi
-done
-
-for cmd in sandbox-kv; do
-    $JAVA -jar $SDK_EE $cmd --help | grep -q profile-dir
-done
-
 if ! ($JAVA -jar $SDK_EE trigger-service --help | grep -q oracle); then
   exit 1
 fi


### PR DESCRIPTION
Given that we’re killing that in 2.0 it doesn’t make sense to keep
this. I’ll create an issue on the assembly repo to add corresponding
tests for the Sandbox tests. https://github.com/DACH-NY/assembly/issues/57

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
