### PR TITLE
Expose documentation for user-management functions in daml-script.

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -766,29 +766,30 @@ submitTreeMulti actAs readAs cmds =
     continue = identity
 
 
--- | HIDE Identifier for a user in the user management service
+-- | Identifier for a user in the user management service.
 newtype UserId = UserId Text deriving (Eq, Ord)
 
 instance Show UserId where show (UserId text) = "'" <> text <> "'"
 
+-- | Extract the name-text from a user identitifer.
 userIdToText : UserId -> Text
 userIdToText (UserId text) = text
 
--- | HIDE User as used in the user management service
+-- | User-info record for a user in the user management service.
 data User = User
   with
     userId : UserId
     primaryParty : Optional Party
   deriving (Show, Eq, Ord)
 
--- | HIDE The rights of a user
+-- | The rights of a user.
 data UserRight
   = ParticipantAdmin
   | CanActAs Party
   | CanReadAs Party
   deriving (Show, Eq)
 
--- | HIDE May be thrown by validateUserId
+-- | Thrown if text for a user identifier does not conform to the format restriction.
 exception InvalidUserId
   with
     m : Text
@@ -801,7 +802,7 @@ mkUserId name validateScript = do
     None -> pure (UserId name)
     Some msg -> throw (InvalidUserId msg)
 
--- | HIDE May be thrown by createUser
+-- | Thrown if a user to be created already exists.
 exception UserAlreadyExists
   with
     userId : UserId
@@ -814,7 +815,7 @@ checkUserAlreadyExists userId script = do
     None -> throw (UserAlreadyExists userId)
     Some x -> pure x
 
--- | HIDE May be thrown by: {get,delete}User, {list,grant,revoke}UserRights
+-- | Thrown if a user cannot be located for a given user identifier.
 exception UserNotFound
   with
     userId : UserId
@@ -827,18 +828,18 @@ checkUserNotFound userId script = do
     None -> throw (UserNotFound userId)
     Some x -> pure x
 
--- | HIDE Convert the text to a user id or fail if it does not conform to the format restriction.
+-- | Construct a user identifer from text. May throw InvalidUserId.
 validateUserId : HasCallStack => Text -> Script UserId
 validateUserId name = mkUserId name $ lift $ Free $ ValidateUserId ValidateUserIdPayload with
   continue = pure
   locations = getCallStack callStack
   name
 
--- | HIDE Create a user with the given rights
+-- | Create a user with the given rights. May throw UserAlreadyExists.
 createUser : HasCallStack => User -> [UserRight] -> Script ()
 createUser user rights = createUser' user rights None
 
--- | HIDE Create a user with the given rights on the given participant.
+-- | Create a user with the given rights on the given participant. May throw UserAlreadyExists.
 createUserOn : HasCallStack => User -> [UserRight] -> ParticipantName -> Script ()
 createUserOn user rights participant = createUser' user rights (Some participant)
 
@@ -850,11 +851,11 @@ createUser' user rights participant = checkUserAlreadyExists user.userId $ lift 
   user
   rights
 
--- | HIDE Fetch a user by user id
+-- | Fetch a user record by user id. May throw UserNotFound.
 getUser : HasCallStack => UserId -> Script User
 getUser userId = getUser' userId None
 
--- | HIDE Fetch a user by user id from the given participant.
+-- | Fetch a user record by user id from the given participant. May throw UserNotFound.
 getUserOn : HasCallStack => UserId -> ParticipantName -> Script User
 getUserOn userId participant = getUser' userId (Some participant)
 
@@ -865,11 +866,11 @@ getUser' userId participant = checkUserNotFound userId $ lift $ Free $ GetUser G
   locations = getCallStack callStack
   userId
 
--- | Hide List all users
+-- | List all users.
 listUsers : Script [User]
 listUsers = listUsers' None
 
--- | Hide List all users on the given participant
+-- | List all users on the given participant.
 listUsersOn : ParticipantName -> Script [User]
 listUsersOn participant = listUsers' (Some participant)
 
@@ -879,11 +880,11 @@ listUsers' participant = lift $ Free $ ListUsers ListUsersPayload with
   continue = pure
   locations = getCallStack callStack
 
--- | HIDE Grant the user the given rights. Returns the rights that have been newly granted.
+-- | Grant rights to a user. Returns the rights that have been newly granted. May throw UserNotFound.
 grantUserRights : HasCallStack => UserId -> [UserRight] -> Script [UserRight]
 grantUserRights userId rights = grantUserRights' userId rights None
 
--- | HIDE Grant the user on the given participant the given rights. Returns the rights that have been newly granted.
+-- | Grant rights to a user on the given participant. Returns the rights that have been newly granted. May throw UserNotFound.
 grantUserRightsOn : HasCallStack => UserId -> [UserRight] -> ParticipantName -> Script [UserRight]
 grantUserRightsOn userId rights participant = grantUserRights' userId rights (Some participant)
 
@@ -895,10 +896,11 @@ grantUserRights' userId rights participant = checkUserNotFound userId $ lift $ F
   userId
   rights
 
--- | HIDE Revoke the rights of the given user. Returns the revoked rights.
+-- | Revoke rights for a user. Returns the revoked rights. May throw UserNotFound.
 revokeUserRights : HasCallStack => UserId -> [UserRight] -> Script [UserRight]
 revokeUserRights userId rights = revokeUserRights' userId rights None
 
+-- | Revoke rights for a user on the given participant. Returns the revoked rights. May throw UserNotFound.
 revokeUserRightsOn : HasCallStack => UserId -> [UserRight] -> ParticipantName -> Script [UserRight]
 revokeUserRightsOn userId rights participant = revokeUserRights' userId rights (Some participant)
 
@@ -910,11 +912,11 @@ revokeUserRights' userId rights participant = checkUserNotFound userId $ lift $ 
   userId
   rights
 
--- | HIDE Delete the given user. Fails if the user does not exist.
+-- | Delete a user. May throw UserNotFound.
 deleteUser : HasCallStack => UserId -> Script ()
 deleteUser userId = deleteUser' userId None
 
--- | HIDE Delete the given user on the given participant. Fails if the user does not exist.
+-- | Delete a user on the given participant. May throw UserNotFound.
 deleteUserOn : HasCallStack => UserId -> ParticipantName -> Script ()
 deleteUserOn userId participant = deleteUser' userId (Some participant)
 
@@ -925,11 +927,11 @@ deleteUser' userId participant = checkUserNotFound userId $ lift $ Free $ Delete
   locations = getCallStack callStack
   userId
 
--- | HIDE List the rights of the given user .
+-- | List the rights of a user. May throw UserNotFound.
 listUserRights : HasCallStack => UserId -> Script [UserRight]
 listUserRights userId = listUserRights' userId None
 
--- | HIDE List the rights of the user on the given participant.
+-- | List the rights of a user on the given participant. May throw UserNotFound.
 listUserRightsOn : HasCallStack => UserId -> ParticipantName -> Script [UserRight]
 listUserRightsOn userId participant = listUserRights' userId (Some participant)
 
@@ -940,12 +942,11 @@ listUserRights' userId participant = checkUserNotFound userId $ lift $ Free $ Li
   locations = getCallStack callStack
   userId
 
--- | HIDE Submit the commands with the actAs and readAs claims granted to the user.
+-- | Submit the commands with the actAs and readAs claims granted to a user. May throw UserNotFound.
 submitUser : HasCallStack => UserId -> Commands a -> Script a
 submitUser userId cmds = submitUser' userId None cmds
 
--- | HIDE Submit the commands with the actAs and readAs claims granted
--- to the user on the given participant
+-- | Submit the commands with the actAs and readAs claims granted to the user on the given participant. May throw UserNotFound.
 submitUserOn : HasCallStack => UserId -> ParticipantName -> Commands a -> Script a
 submitUserOn userId participant cmds = submitUser' userId (Some participant) cmds
 


### PR DESCRIPTION
- remove `HIDE`
- cleanup the text a tiny bit
- be explicit about what `exception`s may be thrown for each function