### PR TITLE
DEV all caps needed to exclude dev dependencies

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -420,8 +420,8 @@ jobs:
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=YARN,NPM,CLANG \
-          --detect.npm.dependency.types.excluded=dev \
-          --detect.yarn.dependency.types.excluded=dev \
+          --detect.npm.dependency.types.excluded=DEV \
+          --detect.yarn.dependency.types.excluded=DEV \
           --detect.follow.symbolic.links=false \
           --detect.excluded.directories=language-support/ts/daml-ledger,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/codegen/tests/ts,bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env,result-*\
           --detect.blackduck.signature.scanner.exclusion.name.patterns=language-support/ts/daml-ledger,language-support/ts/daml-types,language-support/ts/daml-react.bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env,result-* \


### PR DESCRIPTION
All caps DEV needed to exclude yarn and npm dev dependencies from scan and bill of materials

<img width="721" alt="image" src="https://user-images.githubusercontent.com/25179017/151820621-7d57877f-1938-4bf4-8134-1852d6d92044.png">

<img width="736" alt="image" src="https://user-images.githubusercontent.com/25179017/151820701-980db29c-d5f9-4a22-977b-d315d25e16c7.png">
