### PR TITLE
match Foldable.foldl1's argument order to DA.List.foldl1's order

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Foldable.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Foldable.daml
@@ -50,7 +50,7 @@ class Foldable t where
   foldl1 : (a -> a -> a) -> t a -> a
   foldl1 f xs = O.fromSomeNote "foldl1: empty input" (foldl mf None xs)
     where
-      mf m x = Some (case m of None -> x; Some y -> f x y)
+      mf m x = Some (case m of None -> x; Some y -> f y x)
 
   -- | List of elements of a structure, from left to right.
   toList : t a -> [a]

--- a/compiler/damlc/tests/daml-test-files/List.daml
+++ b/compiler/damlc/tests/daml-test-files/List.daml
@@ -1,19 +1,20 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=127:17-127:32; Use dedup
--- @INFO range=313:10-313:24; Evaluate
--- @INFO range=328:38-328:48; Use sum
--- @INFO range=329:43-329:53; Use sum
--- @INFO range=330:29-330:39; Use sum
--- @INFO range=333:3-333:23; Use head
--- @INFO range=338:29-338:36; Use head
+-- @INFO range=128:17-128:32; Use dedup
+-- @INFO range=314:10-314:24; Evaluate
+-- @INFO range=335:38-335:48; Use sum
+-- @INFO range=336:43-336:53; Use sum
+-- @INFO range=337:29-337:39; Use sum
+-- @INFO range=340:3-340:23; Use head
+-- @INFO range=345:29-345:36; Use head
 
 module List where
 
 import DA.List
 import DA.Assert
 import DA.Optional
+import qualified DA.Foldable as Foldable
 
 data Foo = Foo with x : Int; y : Text
   deriving (Eq, Show)
@@ -323,6 +324,12 @@ testFoldr1 = scenario do
   3.0 === foldr1 (/) ([9.0, 150.0, 50.0] : [Decimal])
   "abc" === foldr1 (<>) ["a", "b", "c"]
   2 === foldr1 (-) [1, 2, 3]
+
+testFoldable = scenario do
+  "abc" === Foldable.foldl1 (<>) ["a", "b", "c"]
+  -4 === Foldable.foldl1 (-) [1, 2, 3]
+  "abc" === Foldable.foldr1 (<>) ["a", "b", "c"]
+  2 === Foldable.foldr1 (-) [1, 2, 3]
 
 testRepeatedly = scenario do
   [15, 12, 5] === repeatedly (\x -> (foldl1 (+) x, drop 2 x)) [1..5]


### PR DESCRIPTION
`List.foldl1` uses the first argument as the accumulator, whereas `Foldable.foldl1` uses the second argument.  I believe the latter is an oversight (though the documentation doesn't suggest one way or the other), so swap them here.

As discovered and reported by @gyorgybalazsi [on the Daml Forum](https://discuss.daml.com/t/in-daml-foldl1-works-differently-from-haskell-is-this-intentional/3819).

The default `Foldable.foldl1` has been like this since the `DA.Foldable` module was written; it may be considered seriously incompatible to fix it (though it will be harmless for any symmetric functions, which I suspect are many of the use cases of `foldl1`), but I don't think the status quo--where it needlessly and invisibly diverges from `List.foldl1`--is reasonable either.

If we can't make this change, I suggest as an alternative the approach from scalaz/scalaz#512, which is both strictly a more useful pair of methods and would have prevented this argument swapping in the first place by type-checking, combined with deprecation of the `foldl1` method.

```rst
CHANGELOG_BEGIN
- [Daml Standard Library] An argument order in the default
  implementation of ``Foldable.foldl1`` was reversed from that of
  ``DA.List.foldl1``; this incompatibly changes the former to match the
  latter.
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
