### PR TITLE
Log stream termination [DPP-880]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
@@ -53,6 +53,7 @@ private[apiserver] final class ApiActiveContractsService private (
       )
       .via(logger.logErrorsOnStream)
       .via(StreamMetrics.countElements(metrics.daml.lapi.streams.acs))
+      .watchTermination()(logger.logTermination)
 
   override def bindService(): ServerServiceDefinition =
     ActiveContractsServiceGrpc.bindService(this, executionContext)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
@@ -53,7 +53,7 @@ private[apiserver] final class ApiActiveContractsService private (
       )
       .via(logger.logErrorsOnStream)
       .via(StreamMetrics.countElements(metrics.daml.lapi.streams.acs))
-      .watchTermination()(logger.logTermination)
+      .via(logger.logTermination)
 
   override def bindService(): ServerServiceDefinition =
     ActiveContractsServiceGrpc.bindService(this, executionContext)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -75,7 +75,7 @@ private[apiserver] final class ApiCommandCompletionService private (
                 )
                 .via(logger.logErrorsOnStream)
                 .via(StreamMetrics.countElements(metrics.daml.lapi.streams.completions))
-                .watchTermination()(logger.logTermination)
+                .via(logger.logTermination)
             },
         )
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -75,6 +75,7 @@ private[apiserver] final class ApiCommandCompletionService private (
                 )
                 .via(logger.logErrorsOnStream)
                 .via(StreamMetrics.countElements(metrics.daml.lapi.streams.completions))
+                .watchTermination()(logger.logTermination)
             },
         )
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
@@ -46,7 +46,7 @@ private[apiserver] final class ApiLedgerConfigurationService private (
         )
       )
       .via(logger.logErrorsOnStream)
-      .watchTermination()(logger.logTermination)
+      .via(logger.logTermination)
   }
 
   override def bindService(): ServerServiceDefinition =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
@@ -46,6 +46,7 @@ private[apiserver] final class ApiLedgerConfigurationService private (
         )
       )
       .via(logger.logErrorsOnStream)
+      .watchTermination()(logger.logTermination)
   }
 
   override def bindService(): ServerServiceDefinition =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
@@ -78,7 +78,7 @@ private[apiserver] final class ApiTimeService private (
             case Some(t) => List(GetTimeResponse(Some(fromInstant(t))))
           }
           .via(logger.logErrorsOnStream)
-          .watchTermination()(logger.logTermination)
+          .via(logger.logTermination)
       },
     )
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
@@ -78,6 +78,7 @@ private[apiserver] final class ApiTimeService private (
             case Some(t) => List(GetTimeResponse(Some(fromInstant(t))))
           }
           .via(logger.logErrorsOnStream)
+          .watchTermination()(logger.logTermination)
       },
     )
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -87,7 +87,7 @@ private[apiserver] final class ApiTransactionService private (
       .via(logger.enrichedDebugStream("Responding with transactions.", transactionsLoggable))
       .via(logger.logErrorsOnStream)
       .via(StreamMetrics.countElements(metrics.daml.lapi.streams.transactions))
-      .watchTermination()(logger.logTermination)
+      .via(logger.logTermination)
   }
 
   override def getTransactionTrees(
@@ -115,7 +115,7 @@ private[apiserver] final class ApiTransactionService private (
       )
       .via(logger.logErrorsOnStream)
       .via(StreamMetrics.countElements(metrics.daml.lapi.streams.transactionTrees))
-      .watchTermination()(logger.logTermination)
+      .via(logger.logTermination)
   }
 
   override def getTransactionByEventId(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -87,6 +87,7 @@ private[apiserver] final class ApiTransactionService private (
       .via(logger.enrichedDebugStream("Responding with transactions.", transactionsLoggable))
       .via(logger.logErrorsOnStream)
       .via(StreamMetrics.countElements(metrics.daml.lapi.streams.transactions))
+      .watchTermination()(logger.logTermination)
   }
 
   override def getTransactionTrees(
@@ -114,6 +115,7 @@ private[apiserver] final class ApiTransactionService private (
       )
       .via(logger.logErrorsOnStream)
       .via(StreamMetrics.countElements(metrics.daml.lapi.streams.transactionTrees))
+      .watchTermination()(logger.logTermination)
   }
 
   override def getTransactionByEventId(

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/ContextualizedLogger.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/ContextualizedLogger.scala
@@ -4,7 +4,7 @@
 package com.daml.logging
 
 import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
-import akka.{Done, NotUsed}
+import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import com.daml.grpc.GrpcException
@@ -13,8 +13,7 @@ import io.grpc.Status
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 
 object ContextualizedLogger {

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/ContextualizedLogger.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/ContextualizedLogger.scala
@@ -37,7 +37,9 @@ object ContextualizedLogger {
   def get(clazz: Class[_]): ContextualizedLogger =
     createFor(clazz.getName.stripSuffix("$"))
 
-  private[logging] class TerminationLogger[T](leveledLogger: LeveledLogger)(implicit loggingContext: LoggingContext) extends GraphStage[FlowShape[T, T]] {
+  private[logging] class TerminationLogger[T](leveledLogger: LeveledLogger)(implicit
+      loggingContext: LoggingContext
+  ) extends GraphStage[FlowShape[T, T]] {
 
     val in: Inlet[T] = Inlet[T]("in")
     val out: Outlet[T] = Outlet[T]("out")
@@ -128,7 +130,7 @@ final class ContextualizedLogger private (val withoutContext: Logger) {
       }
     }
 
-  def logTermination[T](implicit loggingContext: LoggingContext): GraphStage[FlowShape[T,T]] =
+  def logTermination[T](implicit loggingContext: LoggingContext): GraphStage[FlowShape[T, T]] =
     new ContextualizedLogger.TerminationLogger[T](info)
 
 }


### PR DESCRIPTION
A bit heavy handed implementation of stream termination logging.
Unfortunately, implementing a custom akka flow seems to be the only way to distinguish between up- and downstream termination of a stream.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
