### PR TITLE
Make gsg-trigger docs work with Canton

### DIFF
--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -172,11 +172,11 @@ with:
 
 .. code-block:: bash
 
-    daml trigger --dar .daml/dist/create-daml-app-0.1.0.dar \
+    daml trigger --dar .daml/dist/gsg-trigger-0.1.0.dar \
                  --trigger-name NoOp:noOp \
                  --ledger-host localhost \
                  --ledger-port 6865 \
-                 --ledger-party "bob"
+                 --ledger-user "bob"
 
 and then play with the app as ``alice`` and ``bob`` just like you did for
 :doc:`/getting-started/first-feature`, you should see the trigger command
@@ -239,11 +239,11 @@ its terminal, then start the trigger with:
 
 .. code-block:: bash
 
-    daml trigger --dar .daml/dist/create-daml-app-0.1.0.dar \
+    daml trigger --dar .daml/dist/gsg-trigger-0.1.0.dar \
                  --trigger-name ChatBot:autoReply \
                  --ledger-host localhost \
                  --ledger-port 6865 \
-                 --ledger-party "bob"
+                 --ledger-user "bob"
 
 Play a bit with ``alice`` and ``bob`` in your browser, to get a feel for how
 the trigger works. Watch both the messages in-browser and the debug statements

--- a/templates/gsg-trigger.patch
+++ b/templates/gsg-trigger.patch
@@ -1,6 +1,6 @@
-diff -Naur create-daml-app/daml/ChatBot.daml gsg-trigger/daml/ChatBot.daml
+diff --git create-daml-app/daml/ChatBot.daml create-daml-app/daml/ChatBot.daml
 --- create-daml-app/daml/ChatBot.daml	1970-01-01 01:00:00.000000000 +0100
-+++ gsg-trigger/daml/ChatBot.daml	2022-01-12 17:55:45.838308273 +0100
++++ create-daml-app/daml/ChatBot.daml	2022-01-12 17:55:45.838308273 +0100
 @@ -0,0 +1,29 @@
 +module ChatBot where
 +
@@ -31,9 +31,9 @@ diff -Naur create-daml-app/daml/ChatBot.daml gsg-trigger/daml/ChatBot.daml
 +  , registeredTemplates = T.AllInDar
 +  , heartbeat = None
 +  }
-diff -Naur create-daml-app/daml/NoOp.daml gsg-trigger/daml/NoOp.daml
+diff --git create-daml-app/daml/NoOp.daml create-daml-app/daml/NoOp.daml
 --- create-daml-app/daml/NoOp.daml	1970-01-01 01:00:00.000000000 +0100
-+++ gsg-trigger/daml/NoOp.daml	2022-01-12 17:55:45.838308273 +0100
++++ create-daml-app/daml/NoOp.daml	2022-01-12 17:55:45.838308273 +0100
 @@ -0,0 +1,13 @@
 +module NoOp where
 +
@@ -48,17 +48,9 @@ diff -Naur create-daml-app/daml/NoOp.daml gsg-trigger/daml/NoOp.daml
 +    pure ()
 +  registeredTemplates = T.AllInDar
 +  heartbeat = None
-diff -Naur create-daml-app/daml/User.daml gsg-trigger/daml/User.daml
+diff --git create-daml-app/daml/User.daml create-daml-app/daml/User.daml
 --- create-daml-app/daml/User.daml	2022-01-12 17:55:49.754285111 +0100
-+++ gsg-trigger/daml/User.daml	2022-01-12 17:55:45.838308273 +0100
-@@ -6,7 +6,6 @@
- -- MAIN_TEMPLATE_BEGIN
- template User with
-     username: Party
--    public: Party
-     following: [Party]
-   where
-     signatory username
++++ create-daml-app/daml/User.daml	2022-01-12 17:55:45.838308273 +0100
 @@ -26,6 +25,17 @@
          archive self
          create this with following = userToFollow :: following
@@ -92,7 +84,7 @@ diff -Naur create-daml-app/daml/User.daml gsg-trigger/daml/User.daml
 +    signatory sender, receiver
 +-- MESSAGE_END
 --- create-daml-app/daml.yaml.template	2022-01-26 17:29:37.149557361 +0100
-+++ gsg-trigger/daml.yaml.template	2022-01-26 17:29:27.749276386 +0100
++++ create-daml-app/daml.yaml.template	2022-01-26 17:29:27.749276386 +0100
 @@ -6,10 +6,12 @@
  - Alice
  - Bob
@@ -106,13 +98,25 @@ diff -Naur create-daml-app/daml/User.daml gsg-trigger/daml/User.daml
  start-navigator: false
  codegen:
    js:
-diff -Naur create-daml-app/ui/src/components/MainView.tsx.template gsg-trigger/ui/src/components/MainView.tsx.template
---- create-daml-app/ui/src/components/MainView.tsx.template	2022-01-12 18:39:11.584886272 +0100
-+++ gsg-trigger/ui/src/components/MainView.tsx.template	2022-01-12 18:17:12.021819139 +0100
-@@ -83,6 +83,15 @@
+diff --git create-daml-app/ui/src/components/MainView.tsx.template create-daml-app/ui/src/components/MainView.tsx.template
+--- create-daml-app/ui/src/components/MainView.tsx.template
++++ create-daml-app/ui/src/components/MainView.tsx.template
+@@ -8,6 +8,10 @@ import { User } from '@daml.js/create-daml-app';
+ import { useParty, useLedger, useStreamFetchByKey, useStreamQueries } from '@daml/react';
+ import UserList from './UserList';
+ import PartyListEdit from './PartyListEdit';
++// IMPORTS_BEGIN
++import MessageEdit from './MessageEdit';
++import MessageList from './MessageList';
++// IMPORTS_END
+
+ // USERS_BEGIN
+ const MainView: React.FC = () => {
+@@ -78,6 +82,22 @@ const MainView: React.FC = () => {
                />
                {/* USERLIST_END */}
              </Segment>
++            {/* MESSAGES_SEGMENT_BEGIN */}
 +            <Segment>
 +              <Header as='h2'>
 +                <Icon name='pencil square' />
@@ -121,14 +125,24 @@ diff -Naur create-daml-app/ui/src/components/MainView.tsx.template gsg-trigger/u
 +                  <Header.Subheader>Send a message to a follower</Header.Subheader>
 +                </Header.Content>
 +              </Header>
++              <MessageEdit
++                followers={followers.map(follower => follower.username)}
++              />
++              <Divider />
++              <MessageList />
 +            </Segment>
++            {/* MESSAGES_SEGMENT_END */}
            </Grid.Column>
          </Grid.Row>
        </Grid>
-diff -Naur create-daml-app/ui/src/components/MessageEdit.tsx.template gsg-trigger/ui/src/components/MessageEdit.tsx.template
---- create-daml-app/ui/src/components/MessageEdit.tsx.template	1970-01-01 01:00:00.000000000 +0100
-+++ gsg-trigger/ui/src/components/MessageEdit.tsx.template	2022-01-12 17:55:45.838308273 +0100
-@@ -0,0 +1,65 @@
+diff --git create-daml-app/ui/src/components/MessageEdit.tsx.template create-daml-app/ui/src/components/MessageEdit.tsx.template
+--- /dev/null
++++ create-daml-app/ui/src/components/MessageEdit.tsx.template
+@@ -0,0 +1,70 @@
++// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
++// SPDX-License-Identifier: Apache-2.0
++
++// MESSAGEEDIT_BEGIN
 +import React from 'react'
 +import { Form, Button } from 'semantic-ui-react';
 +import { Party } from '@daml/types';
@@ -194,10 +208,15 @@ diff -Naur create-daml-app/ui/src/components/MessageEdit.tsx.template gsg-trigge
 +};
 +
 +export default MessageEdit;
-diff -Naur create-daml-app/ui/src/components/MessageList.tsx.template gsg-trigger/ui/src/components/MessageList.tsx.template
---- create-daml-app/ui/src/components/MessageList.tsx.template	1970-01-01 01:00:00.000000000 +0100
-+++ gsg-trigger/ui/src/components/MessageList.tsx.template	2022-01-12 17:55:45.834308296 +0100
-@@ -0,0 +1,28 @@
++// MESSAGEEDIT_END
+diff --git create-daml-app/ui/src/components/MessageList.tsx.template create-daml-app/ui/src/components/MessageList.tsx.template
+--- /dev/null
++++ create-daml-app/ui/src/components/MessageList.tsx.template	2022-01-12 17:55:45.834308296 +0100
+@@ -0,0 +1,33 @@
++// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
++// SPDX-License-Identifier: Apache-2.0
++
++// MESSAGELIST_BEGIN
 +import React from 'react'
 +import { List, ListItem } from 'semantic-ui-react';
 +import { User } from '@daml.js/__PROJECT_NAME__';
@@ -226,3 +245,4 @@ diff -Naur create-daml-app/ui/src/components/MessageList.tsx.template gsg-trigge
 +};
 +
 +export default MessageList;
++// MESSAGELIST_END


### PR DESCRIPTION
Sadly most of these changes are not actually related to Canton but the
previous docs were already broken primarily because of the patch file
not making all the required changes.

I got the patch file as close as possible to the `messaging.patch` to
make it easier to keep them in sync. The fact that we have two patch
files that duplicate most of the code is something that we really need
to fix but not in this PR.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
