### PR TITLE
Remove deduplication feature descriptor SYNC_ONLY

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -70,9 +70,6 @@ enum CommandDeduplicationType {
   // Commands that are duplicates of concurrently submitted commands are reported synchronously via a gRPC error on the
   // command submission, while all other duplicate commands are reported asynchronously via completions.
   ASYNC_AND_CONCURRENT_SYNC = 1;
-  // Duplicate commands are always reported synchronously via a synchronous gRPC error on the command submission.
-  // Deprecated: Was used for participant-side command deduplication.
-  SYNC_ONLY = 2 [deprecated=true];
 }
 
 // See `daml-lf/spec/contract-id.rst` for more information on contract ID formats.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -71,7 +71,8 @@ enum CommandDeduplicationType {
   // command submission, while all other duplicate commands are reported asynchronously via completions.
   ASYNC_AND_CONCURRENT_SYNC = 1;
   // Duplicate commands are always reported synchronously via a synchronous gRPC error on the command submission.
-  SYNC_ONLY = 2;
+  // Deprecated: Was used for participant-side command deduplication.
+  SYNC_ONLY = 2 [deprecated=true];
 }
 
 // See `daml-lf/spec/contract-id.rst` for more information on contract ID formats.

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
@@ -75,7 +75,7 @@ final class CommandDeduplicationIT(
         updateSubmissionId(request, firstAcceptedSubmissionId),
         party,
       )
-      _ <- submitRequestAndAssertAsyncDeduplication(
+      _ <- submitRequestAndAssertDeduplication(
         ledger,
         request,
         firstAcceptedSubmissionId,
@@ -294,7 +294,7 @@ final class CommandDeduplicationIT(
           acceptedLedgerOffset,
         ).map(_ => None)
       else
-        submitRequestAndAssertAsyncDeduplication(
+        submitRequestAndAssertDeduplication(
           ledger,
           updateWithFreshSubmissionId(submitRequest),
           acceptedSubmissionId,
@@ -362,7 +362,7 @@ final class CommandDeduplicationIT(
         updateSubmissionId(aliceRequest, aliceAcceptedSubmissionId),
         alice,
       )
-      _ <- submitRequestAndAssertAsyncDeduplication(
+      _ <- submitRequestAndAssertDeduplication(
         ledger,
         updateWithFreshSubmissionId(aliceRequest),
         aliceAcceptedSubmissionId,
@@ -376,7 +376,7 @@ final class CommandDeduplicationIT(
         updateSubmissionId(bobRequest, bobAcceptedSubmissionId),
         bob,
       )
-      _ <- submitRequestAndAssertAsyncDeduplication(
+      _ <- submitRequestAndAssertDeduplication(
         ledger,
         updateWithFreshSubmissionId(bobRequest),
         bobAcceptedSubmissionId,
@@ -471,7 +471,7 @@ final class CommandDeduplicationIT(
             updateSubmissionId(request, firstAcceptedSubmissionId),
             party,
           )
-          deduplicationCompletionResponse <- submitRequestAndAssertAsyncDeduplication(
+          deduplicationCompletionResponse <- submitRequestAndAssertDeduplication(
             ledger,
             updateWithFreshSubmissionId(request),
             firstAcceptedSubmissionId,
@@ -559,7 +559,7 @@ final class CommandDeduplicationIT(
           // This is done so that we can validate that the third command is accepted
           _ <- delayForOffsetIfRequired(ledger)
           // Submit command again using the first offset as the deduplication offset
-          response2 <- submitRequestAndAssertAsyncDeduplication(
+          response2 <- submitRequestAndAssertDeduplication(
             ledger,
             updateWithFreshSubmissionId(
               request.update(
@@ -713,7 +713,7 @@ final class CommandDeduplicationIT(
         )
       )
 
-  protected def submitRequestAndAssertAsyncDeduplication(
+  protected def submitRequestAndAssertDeduplication(
       ledger: ParticipantTestContext,
       request: SubmitRequest,
       acceptedSubmissionId: SubmissionId,


### PR DESCRIPTION
This PR removes the CommandDeduplicationType `SYNC_ONLY` since it's not used since removal of participant-side command deduplication

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
