### PR TITLE
Remove the possibility to turn on legacy error codes [DPP-773]

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -746,6 +746,38 @@ excluded_test_tool_tests = [
         ],
     },
     {
+        # Self-service error codes are deprecated as an experimental feature.
+        # Switching to the legacy codes is no longer available.
+        "start": "2.0.0-snapshot.20220127.9042.0.4038d0a7.1",
+        "platform_ranges": [
+            {
+                "end": "1.17.1",
+                "exclusions": [
+                    "ActiveContractsServiceIT",
+                    "ClosedWorldIT",
+                    "CommandServiceIT",
+                    "CommandSubmissionCompletionIT",
+                    "ConfigManagementServiceIT",
+                    "ContractKeysIT",
+                    "DeeplyNestedValueIT",
+                    "ExceptionsIT",
+                    "LedgerConfigurationServiceIT",
+                    "MultiPartySubmissionIT",
+                    "PackageManagementServiceIT",
+                    "PackageServiceIT",
+                    "PartyManagementServiceIT",
+                    "SemanticTests",
+                    "TransactionServiceAuthorizationIT",
+                    "TransactionServiceExerciseIT",
+                    "TransactionServiceQueryIT",
+                    "TransactionServiceStreamsIT",
+                    "TransactionServiceValidationIT",
+                    "WronglyTypedContractIdIT",
+                ],
+            },
+        ],
+    },
+    {
         # Sandbox-on-X starts forwarding rejections on duplicate party allocation starting with next release
         "start": "2.0.0-snapshot.20220201.9108.1",
         "platform_ranges": [

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -16,11 +16,15 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 
 // See the feature message definitions for descriptions.
 message ExperimentalFeatures {
-  reserved 1;
+  ExperimentalSelfServiceErrorCodes self_service_error_codes = 1;
   ExperimentalStaticTime static_time = 2;
   CommandDeduplicationFeatures command_deduplication = 3;
   ExperimentalOptionalLedgerId optional_ledger_id = 4;
   ExperimentalContractIds contract_ids = 5;
+}
+
+// GRPC self-service error codes are returned by the Ledger API.
+message ExperimentalSelfServiceErrorCodes {
 }
 
 // Ledger is in the static time mode and exposes a time service.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -16,15 +16,11 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 
 // See the feature message definitions for descriptions.
 message ExperimentalFeatures {
-  ExperimentalSelfServiceErrorCodes self_service_error_codes = 1;
+  reserved 1;
   ExperimentalStaticTime static_time = 2;
   CommandDeduplicationFeatures command_deduplication = 3;
   ExperimentalOptionalLedgerId optional_ledger_id = 4;
   ExperimentalContractIds contract_ids = 5;
-}
-
-// GRPC self-service error codes are returned by the Ledger API.
-message ExperimentalSelfServiceErrorCodes {
 }
 
 // Ledger is in the static time mode and exposes a time service.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/experimental_features.proto
@@ -16,7 +16,7 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 
 // See the feature message definitions for descriptions.
 message ExperimentalFeatures {
-  ExperimentalSelfServiceErrorCodes self_service_error_codes = 1;
+  ExperimentalSelfServiceErrorCodes self_service_error_codes = 1 [deprecated=true];
   ExperimentalStaticTime static_time = 2;
   CommandDeduplicationFeatures command_deduplication = 3;
   ExperimentalOptionalLedgerId optional_ledger_id = 4;
@@ -25,6 +25,7 @@ message ExperimentalFeatures {
 
 // GRPC self-service error codes are returned by the Ledger API.
 message ExperimentalSelfServiceErrorCodes {
+  option deprecated = true;
 }
 
 // Ledger is in the static time mode and exposes a time service.

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -89,7 +89,6 @@ da_scala_binary(
                 "//ledger/ledger-api-common",
                 "//libs-scala/build-info",
                 "//libs-scala/contextualized-logging",
-                "//libs-scala/grpc-utils",
                 "//libs-scala/resources",
                 "//libs-scala/resources-akka",
                 "//libs-scala/resources-grpc",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -64,7 +64,7 @@ object Assertions {
     )
   }
 
-  //KTODO: remove this two-level function
+  //TODO error codes daml 2.0: remove this two-level function
   /** Asserts GRPC error codes depending on the self-service error codes feature in the Ledger API. */
   def assertGrpcError(
       t: Throwable,
@@ -90,7 +90,7 @@ object Assertions {
   @tailrec
   def assertGrpcErrorRegex(
       t: Throwable,
-      selfServiceErrorCode: ErrorCode, //KTODO: rename to errorCode
+      selfServiceErrorCode: ErrorCode, //TODO error codes daml 2.0: rename to errorCode
       optPattern: Option[Pattern],
       checkDefiniteAnswerMetadata: Boolean = false,
       additionalErrorAssertions: Throwable => Unit = _ => (),
@@ -156,7 +156,7 @@ object Assertions {
       }
   }
 
-  //KTODO: rename this
+  //TODO error codes daml 2.0: rename this
   def assertSelfServiceErrorCode(
       statusRuntimeException: StatusRuntimeException,
       expectedErrorCode: ErrorCode,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/Features.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/Features.scala
@@ -11,7 +11,6 @@ import com.daml.ledger.api.v1.version_service.{GetLedgerApiVersionResponse, User
 
 final case class Features(
     userManagement: UserManagementFeature,
-    selfServiceErrorCodes: Boolean,
     staticTime: Boolean,
     commandDeduplicationFeatures: CommandDeduplicationFeatures,
     optionalLedgerId: Boolean = false,
@@ -21,7 +20,6 @@ final case class Features(
 object Features {
   val defaultFeatures: Features = Features(
     userManagement = UserManagementFeature.defaultInstance,
-    selfServiceErrorCodes = false,
     staticTime = false,
     commandDeduplicationFeatures = CommandDeduplicationFeatures.defaultInstance,
     contractIds = ExperimentalContractIds.defaultInstance,
@@ -33,7 +31,6 @@ object Features {
 
     Features(
       userManagement = features.getUserManagement,
-      selfServiceErrorCodes = experimental.selfServiceErrorCodes.isDefined,
       staticTime = experimental.getStaticTime.supported,
       commandDeduplicationFeatures = experimental.getCommandDeduplication,
       optionalLedgerId = experimental.optionalLedgerId.isDefined,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ActiveContractsServiceIT.scala
@@ -29,7 +29,6 @@ import com.daml.ledger.test.model.Test.{
   WithObservers,
   Witnesses => TestWitnesses,
 }
-import io.grpc.Status
 import scalaz.syntax.tag._
 
 import scala.collection.immutable.Seq
@@ -50,9 +49,7 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       failure <- ledger.activeContracts(invalidRequest).mustFail("retrieving active contracts")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.LedgerIdMismatch,
         Some("not found. Actual Ledger ID"),
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ClosedWorldIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ClosedWorldIT.scala
@@ -9,7 +9,6 @@ import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.client.binding
 import com.daml.ledger.test.semantic.SemanticTests.{Amount, Iou}
-import io.grpc.Status
 
 import java.util.regex.Pattern
 
@@ -32,9 +31,7 @@ class ClosedWorldIT extends LedgerTestSuite {
         .mustFail("referencing an unallocated party")
     } yield {
       assertGrpcErrorRegex(
-        alpha,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.WriteServiceRejections.PartyNotKnownOnLedger,
         Some(Pattern.compile("Part(y|ies) not known on ledger")),
         checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationIT.scala
@@ -678,9 +678,7 @@ final class CommandDeduplicationIT(
       .mustFail(s"Request expected to fail with code $code")
       .map(
         assertGrpcError(
-          ledger,
           _,
-          code,
           selfServiceErrorCode,
           exceptionMessageSubstring = None,
           checkDefiniteAnswerMetadata = true,
@@ -699,9 +697,7 @@ final class CommandDeduplicationIT(
       .mustFail("Request was accepted but we were expecting it to fail with a duplicate error")
       .map(
         assertGrpcError(
-          ledger,
           _,
-          expectedCode = Code.ALREADY_EXISTS,
           selfServiceErrorCode = LedgerApiErrors.ConsistencyErrors.DuplicateCommand,
           exceptionMessageSubstring = None,
           checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandServiceIT.scala
@@ -18,7 +18,6 @@ import com.daml.ledger.test.model.Test.Dummy._
 import com.daml.ledger.test.model.Test.DummyFactory._
 import com.daml.ledger.test.model.Test.WithObservers._
 import com.daml.ledger.test.model.Test._
-import io.grpc.Status
 import scalaz.syntax.tag._
 import java.util.regex.Pattern
 
@@ -182,9 +181,7 @@ final class CommandServiceIT extends LedgerTestSuite {
       failure <- ledger.submitAndWait(request).mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.ALREADY_EXISTS,
         LedgerApiErrors.ConsistencyErrors.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
@@ -205,9 +202,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.ALREADY_EXISTS,
         LedgerApiErrors.ConsistencyErrors.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
@@ -228,9 +223,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.ALREADY_EXISTS,
         LedgerApiErrors.ConsistencyErrors.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
@@ -251,9 +244,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a duplicate request")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.ALREADY_EXISTS,
         LedgerApiErrors.ConsistencyErrors.DuplicateCommand,
         None,
         checkDefiniteAnswerMetadata = true,
@@ -275,9 +266,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .submitAndWaitForTransactionId(request)
         .mustFail("submitting a request with an invalid ledger ID")
     } yield assertGrpcError(
-      ledger,
       failure,
-      Status.Code.NOT_FOUND,
       LedgerApiErrors.RequestValidation.LedgerIdMismatch,
       Some(s"Ledger ID '$invalidLedgerId' not found."),
       checkDefiniteAnswerMetadata = true,
@@ -298,9 +287,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .submitAndWaitForTransaction(request)
         .mustFail("submitting a request with an invalid ledger ID")
     } yield assertGrpcError(
-      ledger,
       failure,
-      Status.Code.NOT_FOUND,
       LedgerApiErrors.RequestValidation.LedgerIdMismatch,
       Some(s"Ledger ID '$invalidLedgerId' not found."),
       checkDefiniteAnswerMetadata = true,
@@ -321,9 +308,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .submitAndWaitForTransactionTree(request)
         .mustFail("submitting a request with an invalid ledger ID")
     } yield assertGrpcError(
-      ledger,
       failure,
-      Status.Code.NOT_FOUND,
       LedgerApiErrors.RequestValidation.LedgerIdMismatch,
       Some(s"Ledger ID '$invalidLedgerId' not found."),
       checkDefiniteAnswerMetadata = true,
@@ -344,9 +329,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with a bad parameter label")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
         Some(Pattern.compile(s"Missing record (label|field)")),
         checkDefiniteAnswerMetadata = true,
@@ -369,9 +352,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with an interpretation error")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.GenericInterpretationError,
         Some(
           Pattern.compile(
@@ -528,25 +509,19 @@ final class CommandServiceIT extends LedgerTestSuite {
           .mustFail("submitting a request with a negative number out of bounds")
       } yield {
         assertGrpcError(
-          ledger,
           e1,
-          Status.Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
           Some("Cannot represent"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
-          ledger,
           e2,
-          Status.Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
           Some("Out-of-bounds (Numeric 10)"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
-          ledger,
           e3,
-          Status.Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
           Some("Out-of-bounds (Numeric 10)"),
           checkDefiniteAnswerMetadata = true,
@@ -599,9 +574,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with bad create arguments")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
         Some("Expecting 1 field for record"),
         checkDefiniteAnswerMetadata = true,
@@ -625,9 +598,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with bad choice arguments")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
         Some("mismatching type"),
         checkDefiniteAnswerMetadata = true,
@@ -652,9 +623,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         .mustFail("submitting a request with an invalid choice")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
         Some(
           Pattern.compile(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandSubmissionCompletionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandSubmissionCompletionIT.scala
@@ -10,7 +10,6 @@ import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.test.model.Test.Dummy
 import com.daml.ledger.test.model.Test.Dummy._
 import com.daml.platform.testing.{TimeoutException, WithTimeout}
-import io.grpc.Status
 
 import java.util.regex.Pattern
 import scala.concurrent.duration.DurationInt
@@ -71,9 +70,7 @@ final class CommandSubmissionCompletionIT extends LedgerTestSuite {
         .mustFail("subscribing to completions past the ledger end")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.OUT_OF_RANGE,
         LedgerApiErrors.RequestValidation.OffsetAfterLedgerEnd,
         Some("is after ledger end"),
       )
@@ -109,9 +106,7 @@ final class CommandSubmissionCompletionIT extends LedgerTestSuite {
       failure <- ledger.submit(wrongRequest).mustFail("submitting an invalid choice")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Preprocessing.PreprocessingFailed,
         Some(
           Pattern.compile(
@@ -135,9 +130,7 @@ final class CommandSubmissionCompletionIT extends LedgerTestSuite {
     for {
       failure <- ledger.submit(request).mustFail("submitting with an invalid ledger ID")
     } yield assertGrpcError(
-      ledger,
       failure,
-      Status.Code.NOT_FOUND,
       LedgerApiErrors.RequestValidation.LedgerIdMismatch,
       Some(s"Ledger ID '$invalidLedgerId' not found."),
       checkDefiniteAnswerMetadata = true,
@@ -154,9 +147,7 @@ final class CommandSubmissionCompletionIT extends LedgerTestSuite {
       failure <- ledger.submit(emptyRequest).mustFail("submitting an empty command")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.MissingField,
         Some("commands"),
         checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
@@ -120,9 +120,7 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
         .mustFail("setting Time Model with an outdated generation")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.InvalidArgument,
         exceptionMessageSubstring = None,
       )
@@ -170,18 +168,14 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
       Try {
         // if the "looser" command fails already on command submission (the winner completed before looser submission is over)
         assertGrpcError(
-          ledger,
           failure,
-          Status.Code.INVALID_ARGUMENT,
           LedgerApiErrors.RequestValidation.InvalidArgument,
           Some("Mismatching configuration generation"),
         )
       }.recover { case _ =>
         // if the "looser" command fails after command submission (the winner completed after looser did submit the configuration change)
         assertGrpcError(
-          ledger,
           failure,
-          Status.Code.ABORTED,
           LedgerApiErrors.AdminServices.ConfigurationEntryRejected,
           Some("Generation mismatch"),
         )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractKeysIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ContractKeysIT.scala
@@ -15,7 +15,6 @@ import com.daml.ledger.client.binding.Primitive.ContractId
 import com.daml.ledger.test.model.DA.Types.Tuple2
 import com.daml.ledger.test.model.Test
 import com.daml.ledger.test.model.Test.CallablePayout
-import io.grpc.Status
 import scalaz.Tag
 
 import java.util.regex.Pattern
@@ -74,16 +73,12 @@ final class ContractKeysIT extends LedgerTestSuite {
         .mustFail("looking up by key with a party that cannot see the contract")
     } yield {
       assertGrpcError(
-        beta,
         fetchFailure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.LookupErrors.ContractKeyNotFound,
         Some("couldn't find key"),
       )
       assertGrpcErrorRegex(
-        beta,
         lookupByKeyFailure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.InconsistentContractKey,
         Some(Pattern.compile("Inconsistent|Contract key lookup with different results")),
         checkDefiniteAnswerMetadata = true,
@@ -125,24 +120,18 @@ final class ContractKeysIT extends LedgerTestSuite {
         .mustFail("looking up a contract by key with a party that cannot see it")
     } yield {
       assertGrpcError(
-        beta,
         fetchFailure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.ContractNotFound,
         Some("Contract could not be found"),
         checkDefiniteAnswerMetadata = true,
       )
       assertGrpcError(
-        beta,
         fetchByKeyFailure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.LookupErrors.ContractKeyNotFound,
         Some("couldn't find key"),
       )
       assertGrpcErrorRegex(
-        beta,
         lookupByKeyFailure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.InconsistentContractKey,
         Some(Pattern.compile("Inconsistent|Contract key lookup with different results")),
         checkDefiniteAnswerMetadata = true,
@@ -215,41 +204,31 @@ final class ContractKeysIT extends LedgerTestSuite {
         .mustFail("creating a contract where a maintainer is not a signatory")
     } yield {
       assertGrpcErrorRegex(
-        alpha,
         duplicateKeyFailure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.DuplicateContractKey,
         Some(Pattern.compile("Inconsistent|contract key is not unique")),
         checkDefiniteAnswerMetadata = true,
       )
       assertGrpcError(
-        beta,
         bobLooksUpTextKeyFailure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
         Some("requires authorizers"),
         checkDefiniteAnswerMetadata = true,
       )
       assertGrpcError(
-        beta,
         bobLooksUpBogusTextKeyFailure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
         Some("requires authorizers"),
         checkDefiniteAnswerMetadata = true,
       )
       assertGrpcError(
-        alpha,
         aliceFailedFetch,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.LookupErrors.ContractKeyNotFound,
         Some("couldn't find key"),
         checkDefiniteAnswerMetadata = true,
       )
       assertGrpcError(
-        alpha,
         maintainerNotSignatoryFailed,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
         Some("are not a subset of the signatories"),
         checkDefiniteAnswerMetadata = true,
@@ -312,9 +291,7 @@ final class ContractKeysIT extends LedgerTestSuite {
 
     } yield {
       assertGrpcError(
-        ledger,
         failedFetch,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.LookupErrors.ContractKeyNotFound,
         Some("couldn't find key"),
         checkDefiniteAnswerMetadata = true,
@@ -391,17 +368,13 @@ final class ContractKeysIT extends LedgerTestSuite {
         .mustFail("exercising after consuming")
     } yield {
       assertGrpcError(
-        ledger,
         failureBeforeCreation,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.LookupErrors.ContractKeyNotFound,
         Some("dependency error: couldn't find key"),
         checkDefiniteAnswerMetadata = true,
       )
       assertGrpcError(
-        ledger,
         failureAfterConsuming,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.LookupErrors.ContractKeyNotFound,
         Some("dependency error: couldn't find key"),
         checkDefiniteAnswerMetadata = true,
@@ -437,17 +410,13 @@ final class ContractKeysIT extends LedgerTestSuite {
         )
       } yield {
         assertGrpcError(
-          ledger2,
           failedLookup,
-          Status.Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Interpreter.GenericInterpretationError,
           Some("not visible"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
-          ledger2,
           failedFetch,
-          Status.Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Interpreter.GenericInterpretationError,
           Some("not visible"),
           checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/DeeplyNestedValueIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/DeeplyNestedValueIT.scala
@@ -12,7 +12,6 @@ import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 import com.daml.ledger.test.semantic.DeeplyNestedValue._
 import com.daml.ledger.client.binding.Primitive
-import io.grpc.Status
 
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
@@ -72,9 +71,7 @@ final class DeeplyNestedValueIT extends LedgerTestSuite {
           case Right(_) if accepted => ()
           case Left(err: Throwable) if !accepted =>
             assertGrpcError(
-              alpha,
               err,
-              Status.Code.INVALID_ARGUMENT,
               errorCodeIfExpected,
               None,
               checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionsIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ExceptionsIT.scala
@@ -10,8 +10,6 @@ import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.test.semantic.Exceptions._
-import io.grpc.Status
-
 import java.util.regex.Pattern
 
 final class ExceptionsIT extends LedgerTestSuite {
@@ -25,9 +23,7 @@ final class ExceptionsIT extends LedgerTestSuite {
       failure <- ledger.exercise(party, t.exerciseThrowUncaught(_)).mustFail("Unhandled exception")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.GenericInterpretationError,
         Some(Pattern.compile("Unhandled (Daml )?exception")),
         checkDefiniteAnswerMetadata = true,
@@ -78,9 +74,7 @@ final class ExceptionsIT extends LedgerTestSuite {
         .mustFail("contract is archived")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.ContractNotFound,
         Some("Contract could not be found"),
         checkDefiniteAnswerMetadata = true,
@@ -103,9 +97,7 @@ final class ExceptionsIT extends LedgerTestSuite {
         .mustFail("contract is archived")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.ContractNotFound,
         Some("Contract could not be found"),
         checkDefiniteAnswerMetadata = true,
@@ -128,9 +120,7 @@ final class ExceptionsIT extends LedgerTestSuite {
         .mustFail("contract is archived")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.ContractNotFound,
         Some("Contract could not be found"),
         checkDefiniteAnswerMetadata = true,
@@ -185,9 +175,7 @@ final class ExceptionsIT extends LedgerTestSuite {
       failure <- ledger.exercise(party, t.exerciseDuplicateKey(_)).mustFail("duplicate key")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.DuplicateContractKey,
         Some("DuplicateKey"),
         checkDefiniteAnswerMetadata = true,
@@ -205,9 +193,7 @@ final class ExceptionsIT extends LedgerTestSuite {
       withKey <- ledger.create(party, WithSimpleKey(party))
       failure <- ledger.exercise(party, t.exerciseDuplicateKey(_)).mustFail("duplicate key")
       _ = assertGrpcError(
-        ledger,
         failure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.DuplicateContractKey,
         Some("DuplicateKey"),
         checkDefiniteAnswerMetadata = true,
@@ -230,9 +216,7 @@ final class ExceptionsIT extends LedgerTestSuite {
       failure <- ledger.exercise(party, t.exerciseFetchKey(_)).mustFail("couldn't find key")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.LookupErrors.ContractKeyNotFound,
         Some("couldn't find key"),
         checkDefiniteAnswerMetadata = true,
@@ -250,9 +234,7 @@ final class ExceptionsIT extends LedgerTestSuite {
       t <- ledger.create(party, ExceptionTester(party))
       failure <- ledger.exercise(party, t.exerciseFetchKey(_)).mustFail("contract not found")
       _ = assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.LookupErrors.ContractKeyNotFound,
         Some("couldn't find key"),
         checkDefiniteAnswerMetadata = true,
@@ -295,9 +277,7 @@ final class ExceptionsIT extends LedgerTestSuite {
           .exercise(aParty, fetcher.exerciseFetch(_, t))
           .mustFail("contract could not be found")
         _ = assertGrpcError(
-          aLedger,
           fetchFailure,
-          Status.Code.ABORTED,
           LedgerApiErrors.ConsistencyErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
@@ -324,9 +304,7 @@ final class ExceptionsIT extends LedgerTestSuite {
           .exercise(bParty, fetcher.exerciseFetch_(_, withKey0))
           .mustFail("contract could not be found")
         _ = assertGrpcError(
-          bLedger,
           fetchFailure,
-          Status.Code.ABORTED,
           LedgerApiErrors.ConsistencyErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
@@ -335,9 +313,7 @@ final class ExceptionsIT extends LedgerTestSuite {
           .exercise(bParty, fetcher.exerciseFetch_(_, withKey1))
           .mustFail("contract could not be found")
         _ = assertGrpcError(
-          bLedger,
           fetchFailure,
-          Status.Code.ABORTED,
           LedgerApiErrors.ConsistencyErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/LedgerConfigurationServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/LedgerConfigurationServiceIT.scala
@@ -7,7 +7,6 @@ import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
-import io.grpc.Status
 
 class LedgerConfigurationServiceIT extends LedgerTestSuite {
   test("ConfigSucceeds", "Return a valid configuration for a valid request", allocate(NoParties))(
@@ -32,9 +31,7 @@ class LedgerConfigurationServiceIT extends LedgerTestSuite {
           .mustFail("retrieving ledger configuration with an invalid ledger ID")
       } yield {
         assertGrpcError(
-          ledger,
           failure,
-          Status.Code.NOT_FOUND,
           LedgerApiErrors.RequestValidation.LedgerIdMismatch,
           Some(s"Ledger ID '$invalidLedgerId' not found."),
         )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/MultiPartySubmissionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/MultiPartySubmissionIT.scala
@@ -14,7 +14,6 @@ import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestCo
 import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.client.binding.Primitive.{Party, List => PList}
 import com.daml.ledger.test.model.Test._
-import io.grpc.Status
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -73,9 +72,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("submitting a contract with a missing authorizers")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
         None,
         checkDefiniteAnswerMetadata = true,
@@ -123,9 +120,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice with a missing authorizers")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
         None,
         checkDefiniteAnswerMetadata = true,
@@ -177,9 +172,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to fetch another contract")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
         Some(Pattern.compile("of the fetched contract to be an authorizer, but authorizers were")),
         checkDefiniteAnswerMetadata = true,
@@ -210,9 +203,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to fetch another contract")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.ABORTED,
         LedgerApiErrors.ConsistencyErrors.ContractNotFound,
         Some(Pattern.compile("Contract could not be found")),
         checkDefiniteAnswerMetadata = true,
@@ -264,9 +255,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to fetch another contract by key")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
         Some(Pattern.compile("of the fetched contract to be an authorizer, but authorizers were")),
         checkDefiniteAnswerMetadata = true,
@@ -297,9 +286,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to fetch another contract by key")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.LookupErrors.ContractKeyNotFound,
         Some(Pattern.compile("dependency error: couldn't find key")),
         checkDefiniteAnswerMetadata = true,
@@ -353,9 +340,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to look up another contract by key")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
         Some(Pattern.compile("requires authorizers (.*) for lookup by key, but it only has")),
         checkDefiniteAnswerMetadata = true,
@@ -387,9 +372,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
         .mustFail("exercising a choice without authorization to look up another contract by key")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.GenericInterpretationError,
         Some(
           Pattern.compile(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
@@ -11,7 +11,6 @@ import com.daml.ledger.test.PackageManagementTestDar
 import com.daml.ledger.test.package_management.PackageManagementTest.PackageManagementTestTemplate
 import com.daml.ledger.test.package_management.PackageManagementTest.PackageManagementTestTemplate._
 import com.google.protobuf.ByteString
-import io.grpc.Status
 
 import java.util.regex.Pattern
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,9 +38,7 @@ final class PackageManagementServiceIT extends LedgerTestSuite {
       failure <- ledger.uploadDarFile(ByteString.EMPTY).mustFail("uploading an empty package")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         PackageServiceError.Reading.InvalidDar,
         Some(Pattern.compile("Invalid DAR: package-upload|Dar file is corrupt")),
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageServiceIT.scala
@@ -7,7 +7,6 @@ import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
-import io.grpc.Status
 
 final class PackageServiceIT extends LedgerTestSuite {
 
@@ -56,9 +55,7 @@ final class PackageServiceIT extends LedgerTestSuite {
         .mustFail("getting the contents of an unknown package")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.NotFound.Package,
         None,
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ParticipantPruningIT.scala
@@ -18,7 +18,6 @@ import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.client.binding.Primitive.Party
 import com.daml.ledger.test.model.Test.Dummy
 import com.daml.ledger.test.semantic.DivulgenceTests._
-import io.grpc.Status
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -39,9 +38,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         .mustFail("pruning without specifying an offset")
     } yield {
       assertGrpcError(
-        participant,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.InvalidArgument,
         Some("prune_up_to not specified"),
       )
@@ -59,9 +56,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         .mustFail("pruning, specifying a non-hexadecimal offset")
     } yield {
       assertGrpcError(
-        participant,
         cannotPruneNonHexOffset,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.NonHexOffset,
         Some("prune_up_to needs to be a hexadecimal string and not"),
       )
@@ -82,9 +77,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         .mustFail("pruning, specifying an offset after the ledger end")
     } yield {
       assertGrpcError(
-        participant,
         cannotPruneOffsetBeyondEnd,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.OffsetOutOfRange,
         Some("prune_up_to needs to be before ledger end"),
       )
@@ -126,9 +119,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         s"transaction trees not pruned at expected offset",
       )
       assertGrpcErrorRegex(
-        participant,
         cannotReadAnymore,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.ParticipantPrunedDataAccessed,
         Some(
           Pattern.compile(
@@ -174,9 +165,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         s"flat transactions not pruned at expected offset",
       )
       assertGrpcErrorRegex(
-        participant,
         cannotReadAnymore,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.ParticipantPrunedDataAccessed,
         Some(
           Pattern.compile(
@@ -229,9 +218,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
         s"first checkpoint offset ${firstCheckpointsAfterPrune.offset} after pruning does not match expected offset $offsetOfFirstSurvivingCheckpoint",
       )
       assertGrpcErrorRegex(
-        participant,
         cannotReadAnymore,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.ParticipantPrunedDataAccessed,
         Some(
           Pattern.compile(
@@ -301,9 +288,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
     } yield {
       prunedTransactionTrees.foreach(
         assertGrpcError(
-          participant,
           _,
-          Status.Code.NOT_FOUND,
           LedgerApiErrors.RequestValidation.NotFound.Transaction,
           Some("Transaction not found, or not visible."),
         )
@@ -350,9 +335,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
     } yield {
       prunedFlatTransactions.foreach(
         assertGrpcError(
-          participant,
           _,
-          Status.Code.NOT_FOUND,
           LedgerApiErrors.RequestValidation.NotFound.Transaction,
           Some("Transaction not found, or not visible."),
         )
@@ -395,9 +378,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
     } yield {
       prunedEventsViaTree.foreach(
         assertGrpcError(
-          participant,
           _,
-          Status.Code.NOT_FOUND,
           LedgerApiErrors.RequestValidation.NotFound.Transaction,
           Some("Transaction not found, or not visible."),
         )
@@ -440,9 +421,7 @@ class ParticipantPruningIT extends LedgerTestSuite {
     } yield {
       prunedEventsViaFlat.foreach(
         assertGrpcError(
-          participant,
           _,
-          Status.Code.NOT_FOUND,
           LedgerApiErrors.RequestValidation.NotFound.Transaction,
           Some("Transaction not found, or not visible."),
         )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
@@ -11,7 +11,6 @@ import com.daml.ledger.api.v1.admin.party_management_service.PartyDetails
 import com.daml.ledger.client.binding
 import com.daml.ledger.test.model.Test.Dummy
 import com.daml.lf.data.Ref
-import io.grpc.Status
 import scalaz.Tag
 import scalaz.syntax.tag.ToTagOps
 
@@ -135,9 +134,7 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
         "The allocated party identifier is an empty string",
       )
       assertGrpcErrorRegex(
-        ledger,
         error,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.InvalidArgument,
         Some(Pattern.compile("Party already exists|PartyToParticipant")),
       )
@@ -158,9 +155,7 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
         .mustFail("allocating a party with a very long identifier")
     } yield {
       assertGrpcError(
-        ledger,
         error,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.InvalidArgument,
         Some("Party is too long"),
       )
@@ -182,9 +177,7 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
         .mustFail("allocating a party with invalid characters")
     } yield {
       assertGrpcError(
-        ledger,
         error,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.InvalidArgument,
         Some("non expected character"),
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/SemanticTests.scala
@@ -22,7 +22,6 @@ import com.daml.ledger.test.semantic.SemanticTests.PaintCounterOffer._
 import com.daml.ledger.test.semantic.SemanticTests.PaintOffer._
 import com.daml.ledger.test.semantic.SemanticTests.SharedContract._
 import com.daml.ledger.test.semantic.SemanticTests._
-import io.grpc.Status
 import scalaz.Tag
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -60,9 +59,7 @@ final class SemanticTests extends LedgerTestSuite {
           .mustFail("consuming a contract twice")
       } yield {
         assertGrpcError(
-          alpha,
           failure,
-          Status.Code.ABORTED,
           LedgerApiErrors.ConsistencyErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
@@ -128,9 +125,7 @@ final class SemanticTests extends LedgerTestSuite {
         failure <- alpha.submitAndWait(doubleSpend).mustFail("consuming a contract twice")
       } yield {
         assertGrpcError(
-          alpha,
           failure,
-          Status.Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Interpreter.ContractNotActive,
           Some("Update failed due to fetch of an inactive contract"),
           checkDefiniteAnswerMetadata = true,
@@ -153,9 +148,7 @@ final class SemanticTests extends LedgerTestSuite {
           .mustFail("consuming a contract twice")
       } yield {
         assertGrpcError(
-          beta,
           failure,
-          Status.Code.ABORTED,
           LedgerApiErrors.ConsistencyErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
@@ -248,9 +241,7 @@ final class SemanticTests extends LedgerTestSuite {
         .mustFail("creating a contract on behalf of two parties")
     } yield {
       assertGrpcError(
-        alpha,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
         Some("requires authorizers"),
         checkDefiniteAnswerMetadata = true,
@@ -272,9 +263,7 @@ final class SemanticTests extends LedgerTestSuite {
           .mustFail("exercising a choice without consent")
       } yield {
         assertGrpcError(
-          beta,
           failure,
-          Status.Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
           Some("requires authorizers"),
           checkDefiniteAnswerMetadata = true,
@@ -340,33 +329,25 @@ final class SemanticTests extends LedgerTestSuite {
 
       } yield {
         assertGrpcError(
-          beta,
           iouFetchFailure,
-          Status.Code.ABORTED,
           LedgerApiErrors.ConsistencyErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
-          alpha,
           paintOfferFetchFailure,
-          Status.Code.ABORTED,
           LedgerApiErrors.ConsistencyErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
-          alpha,
           paintAgreeFetchFailure,
-          Status.Code.ABORTED,
           LedgerApiErrors.ConsistencyErrors.ContractNotFound,
           Some("Contract could not be found"),
           checkDefiniteAnswerMetadata = true,
         )
         assertGrpcError(
-          alpha,
           secondIouFetchFailure,
-          Status.Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
           Some("requires one of the stakeholders"),
           checkDefiniteAnswerMetadata = true,
@@ -432,9 +413,7 @@ final class SemanticTests extends LedgerTestSuite {
           }
         } yield {
           assertGrpcError(
-            beta,
             failure,
-            Status.Code.ABORTED,
             LedgerApiErrors.ConsistencyErrors.ContractNotFound,
             Some("Contract could not be found"),
             checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TimeServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TimeServiceIT.scala
@@ -9,7 +9,6 @@ import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.client.binding.{Primitive => P}
 import com.daml.ledger.test.semantic.TimeTests._
-import io.grpc.Status
 import java.time.Instant
 
 import scala.concurrent.Future
@@ -70,9 +69,7 @@ final class TimeServiceIT extends LedgerTestSuite {
         .mustFail("submitting choice prematurely")
     } yield {
       assertGrpcErrorRegex(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.GenericInterpretationError,
         Some(Pattern.compile("Unhandled (Daml )?exception")),
         checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceAuthorizationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceAuthorizationIT.scala
@@ -13,7 +13,6 @@ import com.daml.ledger.test.model.Test.Agreement._
 import com.daml.ledger.test.model.Test.AgreementFactory._
 import com.daml.ledger.test.model.Test.TriProposal._
 import com.daml.ledger.test.model.Test._
-import io.grpc.Status
 
 class TransactionServiceAuthorizationIT extends LedgerTestSuite {
   test(
@@ -95,9 +94,7 @@ class TransactionServiceAuthorizationIT extends LedgerTestSuite {
               .mustFail("exercising with missing authorizers")
           } yield {
             assertGrpcError(
-              beta,
               failure,
-              Status.Code.INVALID_ARGUMENT,
               LedgerApiErrors.CommandExecution.Interpreter.AuthorizationError,
               Some("requires authorizers"),
               checkDefiniteAnswerMetadata = true,
@@ -135,9 +132,7 @@ class TransactionServiceAuthorizationIT extends LedgerTestSuite {
               .mustFail("exercising with failing assertion")
           } yield {
             assertGrpcError(
-              beta,
               failure,
-              Status.Code.INVALID_ARGUMENT,
               LedgerApiErrors.CommandExecution.Interpreter.GenericInterpretationError,
               Some("Assertion failed"),
               checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceExerciseIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceExerciseIT.scala
@@ -16,7 +16,6 @@ import com.daml.ledger.test.model.Test.CreateAndFetch._
 import com.daml.ledger.test.model.Test.Dummy._
 import com.daml.ledger.test.model.Test.DummyFactory._
 import com.daml.ledger.test.model.Test._
-import io.grpc.Status
 import scalaz.Tag
 
 class TransactionServiceExerciseIT extends LedgerTestSuite {
@@ -130,9 +129,7 @@ class TransactionServiceExerciseIT extends LedgerTestSuite {
         .mustFail("exercising with a failing assertion")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.GenericInterpretationError,
         Some("Assertion failed"),
         checkDefiniteAnswerMetadata = true,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceQueryIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceQueryIT.scala
@@ -10,7 +10,6 @@ import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.test.model.Test.Dummy._
 import com.daml.ledger.test.model.Test._
-import io.grpc.Status
 
 class TransactionServiceQueryIT extends LedgerTestSuite {
   test(
@@ -41,9 +40,7 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("subscribing to an invisible transaction tree")
     } yield {
       assertGrpcError(
-        beta,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.NotFound.Transaction,
         Some("Transaction not found, or not visible."),
       )
@@ -61,9 +58,7 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up an non-existent transaction tree")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.NotFound.Transaction,
         Some("Transaction not found, or not visible."),
       )
@@ -97,9 +92,7 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up an invisible flat transaction")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.NotFound.Transaction,
         Some("Transaction not found, or not visible."),
       )
@@ -117,9 +110,7 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up a non-existent flat transaction")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.NotFound.Transaction,
         Some("Transaction not found, or not visible."),
       )
@@ -155,9 +146,7 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up an invisible transaction tree")
     } yield {
       assertGrpcError(
-        beta,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.NotFound.Transaction,
         Some("Transaction not found, or not visible."),
       )
@@ -175,9 +164,7 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up a non-existent transaction tree")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.NotFound.Transaction,
         Some("Transaction not found, or not visible."),
       )
@@ -213,9 +200,7 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up an invisible flat transaction")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.NotFound.Transaction,
         Some("Transaction not found, or not visible."),
       )
@@ -233,9 +218,7 @@ class TransactionServiceQueryIT extends LedgerTestSuite {
         .mustFail("looking up a non-existent flat transaction")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.NotFound.Transaction,
         Some("Transaction not found, or not visible."),
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceStreamsIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceStreamsIT.scala
@@ -9,7 +9,6 @@ import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.test.model.Test._
-import io.grpc.Status
 import scalaz.Tag
 
 import scala.collection.immutable.Seq
@@ -81,9 +80,7 @@ class TransactionServiceStreamsIT extends LedgerTestSuite {
       failure <- ledger.flatTransactions(beyondEnd).mustFail("subscribing past the ledger end")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.OUT_OF_RANGE,
         LedgerApiErrors.RequestValidation.OffsetAfterLedgerEnd,
         Some("is after ledger end"),
       )
@@ -103,9 +100,7 @@ class TransactionServiceStreamsIT extends LedgerTestSuite {
       failure <- ledger.transactionTrees(beyondEnd).mustFail("subscribing past the ledger end")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.OUT_OF_RANGE,
         LedgerApiErrors.RequestValidation.OffsetAfterLedgerEnd,
         Some("is after ledger end"),
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceValidationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/TransactionServiceValidationIT.scala
@@ -8,7 +8,6 @@ import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.test.model.Test._
-import io.grpc.Status
 
 import scala.collection.immutable.Seq
 
@@ -26,9 +25,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with an empty filter")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.InvalidArgument,
         Some("filtersByParty cannot be empty"),
       )
@@ -51,9 +48,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the end before the begin")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.OffsetOutOfRange,
         Some("is before Begin offset"),
       )
@@ -75,9 +70,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
@@ -99,9 +92,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
@@ -123,9 +114,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
@@ -147,9 +136,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
@@ -171,9 +158,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
@@ -195,9 +180,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("subscribing with the wrong ledger ID")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
@@ -216,9 +199,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("requesting with the wrong ledger ID")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.NOT_FOUND,
         LedgerApiErrors.RequestValidation.LedgerIdMismatch,
         Some(s"Ledger ID '$invalidLedgerId' not found."),
       )
@@ -236,9 +217,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up a transaction tree without specifying a party")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.MissingField,
         Some("requesting_parties"),
       )
@@ -256,9 +235,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up a flat transaction without specifying a party")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.MissingField,
         Some("requesting_parties"),
       )
@@ -276,9 +253,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up an transaction tree using an invalid event ID")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.InvalidField,
         Some("Invalid field event_id"),
       )
@@ -296,9 +271,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up a transaction tree without specifying a party")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.MissingField,
         Some("requesting_parties"),
       )
@@ -316,9 +289,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up a flat transaction using an invalid event ID")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.InvalidField,
         Some("Invalid field event_id"),
       )
@@ -336,9 +307,7 @@ class TransactionServiceValidationIT extends LedgerTestSuite {
         .mustFail("looking up a flat transaction without specifying a party")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Status.Code.INVALID_ARGUMENT,
         LedgerApiErrors.RequestValidation.MissingField,
         Some("requesting_parties"),
       )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/WronglyTypedContractIdIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/WronglyTypedContractIdIT.scala
@@ -11,7 +11,6 @@ import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.test.model.Test.Delegation._
 import com.daml.ledger.test.model.Test.DummyWithParam._
 import com.daml.ledger.test.model.Test.{Delegated, Delegation, Dummy, DummyWithParam}
-import io.grpc.Status.Code
 
 final class WronglyTypedContractIdIT extends LedgerTestSuite {
   test("WTExerciseFails", "Exercising on a wrong type fails", allocate(SingleParty))(
@@ -24,9 +23,7 @@ final class WronglyTypedContractIdIT extends LedgerTestSuite {
           .mustFail("exercising on a wrong type")
       } yield {
         assertGrpcError(
-          ledger,
           exerciseFailure,
-          Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError,
           Some("wrongly typed contract id"),
           checkDefiniteAnswerMetadata = true,
@@ -47,9 +44,7 @@ final class WronglyTypedContractIdIT extends LedgerTestSuite {
           .mustFail("fetching the wrong type")
       } yield {
         assertGrpcError(
-          ledger,
           fetchFailure,
-          Code.INVALID_ARGUMENT,
           LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError,
           Some("wrongly typed contract id"),
           checkDefiniteAnswerMetadata = true,
@@ -76,9 +71,7 @@ final class WronglyTypedContractIdIT extends LedgerTestSuite {
         .mustFail("exercising on a wrong type")
     } yield {
       assertGrpcError(
-        ledger,
         failure,
-        Code.INVALID_ARGUMENT,
         LedgerApiErrors.CommandExecution.Interpreter.InvalidArgumentInterpretationError,
         Some("wrongly typed contract id"),
         checkDefiniteAnswerMetadata = true,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
@@ -11,6 +11,7 @@ import com.daml.error.{
 import com.daml.ledger.api.v1.experimental_features.{
   ExperimentalFeatures,
   ExperimentalOptionalLedgerId,
+  ExperimentalSelfServiceErrorCodes,
   ExperimentalStaticTime,
 }
 import com.daml.ledger.api.v1.version_service.VersionServiceGrpc.VersionService
@@ -71,6 +72,8 @@ private[apiserver] final class ApiVersionService private (
       ),
       experimental = Some(
         ExperimentalFeatures.of(
+          selfServiceErrorCodes =
+            Option.when(enableSelfServiceErrorCodes)(ExperimentalSelfServiceErrorCodes()),
           staticTime = Some(ExperimentalStaticTime(supported = ledgerFeatures.staticTime)),
           commandDeduplication = Some(ledgerFeatures.commandDeduplicationFeatures),
           optionalLedgerId = Some(ExperimentalOptionalLedgerId()),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
@@ -11,7 +11,6 @@ import com.daml.error.{
 import com.daml.ledger.api.v1.experimental_features.{
   ExperimentalFeatures,
   ExperimentalOptionalLedgerId,
-  ExperimentalSelfServiceErrorCodes,
   ExperimentalStaticTime,
 }
 import com.daml.ledger.api.v1.version_service.VersionServiceGrpc.VersionService
@@ -72,8 +71,6 @@ private[apiserver] final class ApiVersionService private (
       ),
       experimental = Some(
         ExperimentalFeatures.of(
-          selfServiceErrorCodes =
-            Option.when(enableSelfServiceErrorCodes)(ExperimentalSelfServiceErrorCodes()),
           staticTime = Some(ExperimentalStaticTime(supported = ledgerFeatures.staticTime)),
           commandDeduplication = Some(ledgerFeatures.commandDeduplicationFeatures),
           optionalLedgerId = Some(ExperimentalOptionalLedgerId()),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
@@ -29,6 +29,7 @@ import com.daml.platform.server.api.validation.ErrorFactories
 import com.daml.platform.usermanagement.UserManagementConfig
 import io.grpc.ServerServiceDefinition
 
+import scala.annotation.nowarn
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
 import scala.util.Try
@@ -73,7 +74,9 @@ private[apiserver] final class ApiVersionService private (
       experimental = Some(
         ExperimentalFeatures.of(
           selfServiceErrorCodes =
-            Option.when(enableSelfServiceErrorCodes)(ExperimentalSelfServiceErrorCodes()),
+            Option.when(enableSelfServiceErrorCodes)(ExperimentalSelfServiceErrorCodes()): @nowarn(
+              "cat=deprecation&origin=com\\.daml\\.ledger\\.api\\.v1\\.experimental_features\\..*"
+            ),
           staticTime = Some(ExperimentalStaticTime(supported = ledgerFeatures.staticTime)),
           commandDeduplication = Some(ledgerFeatures.commandDeduplicationFeatures),
           optionalLedgerId = Some(ExperimentalOptionalLedgerId()),

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -628,13 +628,6 @@ object Config {
           )
           .action((_, config) => config.copy(enableInMemoryFanOutForLedgerApi = true))
 
-        opt[Unit]("use-pre-1.18-error-codes")
-          .optional()
-          .text(
-            "Enables gRPC error code compatibility mode to the pre-1.18 behaviour. This option is deprecated and will be removed in a future release."
-          )
-          .action((_, config: Config[Extra]) => config.copy(enableSelfServiceErrorCodes = false))
-
         opt[Boolean]("enable-user-management")
           .optional()
           .text(

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
@@ -66,18 +66,6 @@ final class ConfigSpec
     )
   behavior of "Runner"
 
-  it should "disable self service error codes when compatibility gRPC error codes flag is set" in {
-    val actual = configParser(
-      Seq(
-        dumpIndexMetadataCommand,
-        "some-jdbc-url",
-        "--use-pre-1.18-error-codes",
-      )
-    )
-
-    actual.value.enableSelfServiceErrorCodes shouldBe false
-  }
-
   it should "enable self-service error codes by default" in {
     val actual = configParser(
       Seq(

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -167,27 +167,6 @@ server_conformance_test(
     ],
 )
 
-# Full conformance test with legacy error codes (Postgres)
-server_conformance_test(
-    name = "conformance-test-legacy-error-codes",
-    lf_versions = [
-        "default",
-        "preview",
-    ],
-    server_args = [
-        "--contract-id-seeding=testing-weak",
-        "--use-pre-1.18-error-codes",
-    ],
-    servers = {"postgresql": SERVERS["postgresql"]},
-    test_tool_args = [
-        "--concurrent-test-runs=1",  # sandbox classic doesn't scale well with concurrent tests (almost no effect on overall run time)
-        "--timeout-scale-factor=2",  # sandbox classic is slow in general
-        "--open-world",
-        "--exclude=ClosedWorldIT",
-        "--exclude=CommandDeduplicationPeriodValidationIT",  # The test expects the new error codes.
-    ],
-)
-
 # Full conformance test (H2)
 # Only run a minimal set of tests on H2. The full test suite is very slow on H2, and prone to fail due to timeouts.
 server_conformance_test(

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCliBase.scala
@@ -379,13 +379,6 @@ class CommonCliBase(name: LedgerName) {
           "Maximum command deduplication duration."
         )
 
-      opt[Unit]("use-pre-1.18-error-codes")
-        .optional()
-        .text(
-          "Enables gRPC error code compatibility mode to the pre-1.18 behaviour. This option is deprecated and will be removed in future release versions."
-        )
-        .action((_, config: SandboxConfig) => config.copy(enableSelfServiceErrorCodes = false))
-
       opt[Boolean]("enable-user-management")
         .optional()
         .text(

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
@@ -353,17 +353,6 @@ abstract class CommonCliSpecBase(
       )
     }
 
-    "parse gRPC error codes compatibility mode flag" in {
-      checkOption(
-        Array("--use-pre-1.18-error-codes"),
-        _.copy(enableSelfServiceErrorCodes = false),
-      )
-      checkOption(
-        Array(),
-        _.copy(enableSelfServiceErrorCodes = true),
-      )
-    }
-
     "handle '--enable-user-management' flag correctly" in {
       checkOptionFail(
         Array("--enable-user-management")

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -62,7 +62,7 @@
 - target: //language-support/scala/bindings:bindings
   type: jar-scala
 - target: //language-support/scala/bindings-akka:bindings-akka
-  type: jar-scala
+  type: jar-scalledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationPeriodValidationIT.scalaa
 - target: //language-support/scala/codegen:codegen
   type: jar-scala
 - target: //ledger-api/grpc-definitions:ledger_api_proto_jar

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -62,7 +62,7 @@
 - target: //language-support/scala/bindings:bindings
   type: jar-scala
 - target: //language-support/scala/bindings-akka:bindings-akka
-  type: jar-scalledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/CommandDeduplicationPeriodValidationIT.scalaa
+  type: jar-scala
 - target: //language-support/scala/codegen:codegen
   type: jar-scala
 - target: //ledger-api/grpc-definitions:ledger_api_proto_jar


### PR DESCRIPTION
### Changes
- remove CLI `--use-pre-1.18-error-codes` option
- remove testing legacy codes in the `ledger-api-test-tool`
- deprecate `ExperimentalSelfServiceErrorCodes` experimental feature in proto definitions

CHANGELOG_BEGIN
- Switching to the legacy error codes is not possible.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
