### PR TITLE
VersionClient supports getApiFeatures

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/version/VersionClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/version/VersionClient.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.client.services.version
 
-import com.daml.ledger.api.domain.LedgerId
+import com.daml.ledger.api.domain.{LedgerId, Feature}
 import com.daml.ledger.api.v1.version_service.VersionServiceGrpc.VersionServiceStub
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -15,5 +15,11 @@ final class VersionClient(ledgerId: LedgerId, service: VersionServiceStub) {
       token: Option[String] = None
   )(implicit executionContext: ExecutionContext): Future[String] =
     it.getApiVersion(ledgerId, token)
+
+  def getApiFeatures(
+      ledgerIdToUse: LedgerId,
+      token: Option[String] = None,
+  )(implicit executionContext: ExecutionContext): Future[Seq[Feature]] =
+    it.getApiFeatures(ledgerIdToUse, token)
 
 }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/version/withoutledgerid/VersionClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/version/withoutledgerid/VersionClient.scala
@@ -3,8 +3,21 @@
 
 package com.daml.ledger.client.services.version.withoutledgerid
 
-import com.daml.ledger.api.domain.LedgerId
-import com.daml.ledger.api.v1.version_service.GetLedgerApiVersionRequest
+import com.daml.ledger.api.domain.{Feature, LedgerId}
+import com.daml.ledger.api.v1.experimental_features.CommandDeduplicationPeriodSupport.{
+  DurationSupport,
+  OffsetSupport,
+}
+import com.daml.ledger.api.v1.experimental_features.ExperimentalContractIds.ContractIdV1Support
+import com.daml.ledger.api.v1.experimental_features.{
+  CommandDeduplicationFeatures,
+  CommandDeduplicationPeriodSupport,
+  CommandDeduplicationType,
+  ExperimentalContractIds,
+  ExperimentalFeatures,
+  ExperimentalStaticTime,
+}
+import com.daml.ledger.api.v1.version_service.{FeaturesDescriptor, GetLedgerApiVersionRequest}
 import com.daml.ledger.api.v1.version_service.VersionServiceGrpc.VersionServiceStub
 import com.daml.ledger.client.LedgerClient
 import scalaz.syntax.tag._
@@ -22,4 +35,87 @@ private[daml] final class VersionClient(service: VersionServiceStub) {
         new GetLedgerApiVersionRequest(ledgerIdToUse.unwrap)
       )
       .map(_.version)
+
+  def getApiFeatures(
+      ledgerIdToUse: LedgerId,
+      token: Option[String] = None,
+  )(implicit executionContext: ExecutionContext): Future[Seq[Feature]] =
+    LedgerClient
+      .stub(service, token)
+      .getLedgerApiVersion(
+        new GetLedgerApiVersionRequest(ledgerIdToUse.unwrap)
+      )
+      .map(_.features.toList.flatMap(VersionClient.fromProto))
+}
+
+private[daml] object VersionClient {
+  // see also com.daml.platform.apiserver.services.ApiVersionService.featuresDescriptor
+  def fromProto(featuresDescriptor: FeaturesDescriptor): Seq[Feature] =
+    featuresDescriptor match {
+      case FeaturesDescriptor(userManagement, experimentalFeatures) =>
+        (userManagement.toList map (_ => Feature.UserManagement)) ++
+          (experimentalFeatures.toList flatMap fromProto)
+    }
+
+  def fromProto(experimentalFeatures: ExperimentalFeatures): Seq[Feature] =
+    experimentalFeatures match {
+      case ExperimentalFeatures(
+            selfServiceErrorCodes,
+            maybeStaticTime,
+            maybeCommandDeduplicationFeatures,
+            optionalLedgerId,
+            contractIds,
+          ) =>
+        (selfServiceErrorCodes.toList map (_ => Feature.SelfServiceErrorCodes)) ++
+          (maybeStaticTime collect { case ExperimentalStaticTime(true) => Feature.StaticTime }) ++
+          (maybeCommandDeduplicationFeatures.toList flatMap fromProto) ++
+          (optionalLedgerId map { _ => Feature.ExperimentalOptionalLedgerId }) ++
+          (contractIds flatMap { case ExperimentalContractIds(v1) =>
+            v1 match {
+              case ContractIdV1Support.SUFFIXED => Some(Feature.ContractIds(true))
+              case ContractIdV1Support.NON_SUFFIXED => Some(Feature.ContractIds(false))
+              case _ => None
+            }
+          })
+    }
+
+  def fromProto(commandDeduplicationFeatures: CommandDeduplicationFeatures): Seq[Feature] = {
+    commandDeduplicationFeatures match {
+      case CommandDeduplicationFeatures(
+            deduplicationPeriodSupport,
+            deduplicationType,
+            maxDeduplicationDurationEnforced,
+          ) =>
+        import Feature.CommandDeduplication.{OffsetSupport => OS, DurationSupport => DS, Type => DT}
+        val (os, ds) = deduplicationPeriodSupport match {
+          case Some(CommandDeduplicationPeriodSupport(offsetSupport, durationSupport)) =>
+            (
+              offsetSupport match {
+                case OffsetSupport.OFFSET_NOT_SUPPORTED => Some(OS.OFFSET_NOT_SUPPORTED)
+                case OffsetSupport.OFFSET_NATIVE_SUPPORT => Some(OS.OFFSET_NATIVE_SUPPORT)
+                case OffsetSupport.OFFSET_CONVERT_TO_DURATION => Some(OS.OFFSET_CONVERT_TO_DURATION)
+                case _ => None
+              },
+              durationSupport match {
+                case DurationSupport.DURATION_NATIVE_SUPPORT => Some(DS.DURATION_NATIVE_SUPPORT)
+                case DurationSupport.DURATION_CONVERT_TO_OFFSET =>
+                  Some(DS.DURATION_CONVERT_TO_OFFSET)
+                case _ => None
+              },
+            )
+          case _ => (None, None)
+        }
+
+        val dt = deduplicationType match {
+          case CommandDeduplicationType.ASYNC_ONLY => Some(DT.ASYNC_ONLY)
+          case CommandDeduplicationType.ASYNC_AND_CONCURRENT_SYNC =>
+            Some(DT.ASYNC_AND_CONCURRENT_SYNC)
+          case CommandDeduplicationType.SYNC_ONLY => Some(DT.SYNC_ONLY)
+          case _ => None
+        }
+
+        Seq(Feature.CommandDeduplication(os, ds, dt, maxDeduplicationDurationEnforced))
+    }
+  }
+
 }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/version/withoutledgerid/VersionClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/version/withoutledgerid/VersionClient.scala
@@ -40,7 +40,9 @@ private[daml] object VersionClient {
   // see also com.daml.platform.apiserver.services.ApiVersionService.featuresDescriptor
   def fromProto(featuresDescriptor: FeaturesDescriptor): Seq[Feature] =
     featuresDescriptor match {
-      case FeaturesDescriptor(userManagement, _ /* TODO: expose experimentalFeatures */ ) =>
+      // Note that we do not expose experimental features here, as they are used for internal testing only
+      // and do not have backwards compatibility guarantees. (They should probably be named 'internalFeatures' ;-)
+      case FeaturesDescriptor(userManagement, _) =>
         (userManagement.toList map (_ => Feature.UserManagement))
     }
 }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/version/withoutledgerid/VersionClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/version/withoutledgerid/VersionClient.scala
@@ -4,19 +4,7 @@
 package com.daml.ledger.client.services.version.withoutledgerid
 
 import com.daml.ledger.api.domain.{Feature, LedgerId}
-import com.daml.ledger.api.v1.experimental_features.CommandDeduplicationPeriodSupport.{
-  DurationSupport,
-  OffsetSupport,
-}
-import com.daml.ledger.api.v1.experimental_features.ExperimentalContractIds.ContractIdV1Support
-import com.daml.ledger.api.v1.experimental_features.{
-  CommandDeduplicationFeatures,
-  CommandDeduplicationPeriodSupport,
-  CommandDeduplicationType,
-  ExperimentalContractIds,
-  ExperimentalFeatures,
-  ExperimentalStaticTime,
-}
+
 import com.daml.ledger.api.v1.version_service.{FeaturesDescriptor, GetLedgerApiVersionRequest}
 import com.daml.ledger.api.v1.version_service.VersionServiceGrpc.VersionServiceStub
 import com.daml.ledger.client.LedgerClient
@@ -52,70 +40,7 @@ private[daml] object VersionClient {
   // see also com.daml.platform.apiserver.services.ApiVersionService.featuresDescriptor
   def fromProto(featuresDescriptor: FeaturesDescriptor): Seq[Feature] =
     featuresDescriptor match {
-      case FeaturesDescriptor(userManagement, experimentalFeatures) =>
-        (userManagement.toList map (_ => Feature.UserManagement)) ++
-          (experimentalFeatures.toList flatMap fromProto)
+      case FeaturesDescriptor(userManagement, _ /* TODO: expose experimentalFeatures */ ) =>
+        (userManagement.toList map (_ => Feature.UserManagement))
     }
-
-  def fromProto(experimentalFeatures: ExperimentalFeatures): Seq[Feature] =
-    experimentalFeatures match {
-      case ExperimentalFeatures(
-            selfServiceErrorCodes,
-            maybeStaticTime,
-            maybeCommandDeduplicationFeatures,
-            optionalLedgerId,
-            contractIds,
-          ) =>
-        (selfServiceErrorCodes.toList map (_ => Feature.SelfServiceErrorCodes)) ++
-          (maybeStaticTime collect { case ExperimentalStaticTime(true) => Feature.StaticTime }) ++
-          (maybeCommandDeduplicationFeatures.toList flatMap fromProto) ++
-          (optionalLedgerId map { _ => Feature.ExperimentalOptionalLedgerId }) ++
-          (contractIds flatMap { case ExperimentalContractIds(v1) =>
-            v1 match {
-              case ContractIdV1Support.SUFFIXED => Some(Feature.ContractIds(true))
-              case ContractIdV1Support.NON_SUFFIXED => Some(Feature.ContractIds(false))
-              case _ => None
-            }
-          })
-    }
-
-  def fromProto(commandDeduplicationFeatures: CommandDeduplicationFeatures): Seq[Feature] = {
-    commandDeduplicationFeatures match {
-      case CommandDeduplicationFeatures(
-            deduplicationPeriodSupport,
-            deduplicationType,
-            maxDeduplicationDurationEnforced,
-          ) =>
-        import Feature.CommandDeduplication.{OffsetSupport => OS, DurationSupport => DS, Type => DT}
-        val (os, ds) = deduplicationPeriodSupport match {
-          case Some(CommandDeduplicationPeriodSupport(offsetSupport, durationSupport)) =>
-            (
-              offsetSupport match {
-                case OffsetSupport.OFFSET_NOT_SUPPORTED => Some(OS.OFFSET_NOT_SUPPORTED)
-                case OffsetSupport.OFFSET_NATIVE_SUPPORT => Some(OS.OFFSET_NATIVE_SUPPORT)
-                case OffsetSupport.OFFSET_CONVERT_TO_DURATION => Some(OS.OFFSET_CONVERT_TO_DURATION)
-                case _ => None
-              },
-              durationSupport match {
-                case DurationSupport.DURATION_NATIVE_SUPPORT => Some(DS.DURATION_NATIVE_SUPPORT)
-                case DurationSupport.DURATION_CONVERT_TO_OFFSET =>
-                  Some(DS.DURATION_CONVERT_TO_OFFSET)
-                case _ => None
-              },
-            )
-          case _ => (None, None)
-        }
-
-        val dt = deduplicationType match {
-          case CommandDeduplicationType.ASYNC_ONLY => Some(DT.ASYNC_ONLY)
-          case CommandDeduplicationType.ASYNC_AND_CONCURRENT_SYNC =>
-            Some(DT.ASYNC_AND_CONCURRENT_SYNC)
-          case CommandDeduplicationType.SYNC_ONLY => Some(DT.SYNC_ONLY)
-          case _ => None
-        }
-
-        Seq(Feature.CommandDeduplication(os, ds, dt, maxDeduplicationDurationEnforced))
-    }
-  }
-
 }

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -403,33 +403,5 @@ object domain {
   sealed abstract class Feature extends Product with Serializable
   object Feature {
     case object UserManagement extends Feature
-    case object SelfServiceErrorCodes extends Feature
-    case object StaticTime extends Feature
-    case object ExperimentalOptionalLedgerId extends Feature
-
-    sealed case class CommandDeduplication(
-        offsetSupport: Option[CommandDeduplication.OffsetSupport.Value],
-        durationSupport: Option[CommandDeduplication.DurationSupport.Value],
-        deduplicationType: Option[CommandDeduplication.Type.Value],
-        maxDeduplicationDurationEnforced: Boolean,
-    ) extends Feature
-    object CommandDeduplication {
-      @SuppressWarnings(Array("org.wartremover.warts.Enumeration"))
-      object OffsetSupport extends Enumeration {
-        val OFFSET_NOT_SUPPORTED, OFFSET_NATIVE_SUPPORT, OFFSET_CONVERT_TO_DURATION = Value
-      }
-
-      @SuppressWarnings(Array("org.wartremover.warts.Enumeration"))
-      object DurationSupport extends Enumeration {
-        val DURATION_NATIVE_SUPPORT, DURATION_CONVERT_TO_OFFSET = Value
-      }
-
-      @SuppressWarnings(Array("org.wartremover.warts.Enumeration"))
-      object Type extends Enumeration {
-        val ASYNC_ONLY, ASYNC_AND_CONCURRENT_SYNC, SYNC_ONLY = Value
-      }
-    }
-
-    sealed case class ContractIds(suffixed: Boolean) extends Feature
   }
 }

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -399,4 +399,37 @@ object domain {
     final case class CanActAs(party: Ref.Party) extends UserRight
     final case class CanReadAs(party: Ref.Party) extends UserRight
   }
+
+  sealed abstract class Feature extends Product with Serializable
+  object Feature {
+    case object UserManagement extends Feature
+    case object SelfServiceErrorCodes extends Feature
+    case object StaticTime extends Feature
+    case object ExperimentalOptionalLedgerId extends Feature
+
+    sealed case class CommandDeduplication(
+        offsetSupport: Option[CommandDeduplication.OffsetSupport.Value],
+        durationSupport: Option[CommandDeduplication.DurationSupport.Value],
+        deduplicationType: Option[CommandDeduplication.Type.Value],
+        maxDeduplicationDurationEnforced: Boolean,
+    ) extends Feature
+    object CommandDeduplication {
+      @SuppressWarnings(Array("org.wartremover.warts.Enumeration"))
+      object OffsetSupport extends Enumeration {
+        val OFFSET_NOT_SUPPORTED, OFFSET_NATIVE_SUPPORT, OFFSET_CONVERT_TO_DURATION = Value
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.Enumeration"))
+      object DurationSupport extends Enumeration {
+        val DURATION_NATIVE_SUPPORT, DURATION_CONVERT_TO_OFFSET = Value
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.Enumeration"))
+      object Type extends Enumeration {
+        val ASYNC_ONLY, ASYNC_AND_CONCURRENT_SYNC, SYNC_ONLY = Value
+      }
+    }
+
+    sealed case class ContractIds(suffixed: Boolean) extends Feature
+  }
 }


### PR DESCRIPTION
This exposes the `features` part of the version service's
`GetLedgerApiVersionResponse` protobuf.

Map the protobuf to user-friendly subclasses of `Feature`,
defined in `c.d.ledger.api.domain`.

This was originally developed (and reviewed) as part of #12187

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
