### PR TITLE
Use Seq instead of Vector in user mgmt apis

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
@@ -74,7 +74,7 @@ object EndpointsCompanion {
   trait CreateFromUserToken[A] {
     def apply(
         jwt: DecodedJwt[String],
-        listUserRights: UserId => Future[Vector[UserRight]],
+        listUserRights: UserId => Future[Seq[UserRight]],
         getLedgerId: () => Future[String],
     ): ET[A]
   }
@@ -117,7 +117,7 @@ object EndpointsCompanion {
 
     private def transformUserTokenTo[B](
         jwt: DecodedJwt[String],
-        listUserRights: UserId => Future[Vector[UserRight]],
+        listUserRights: UserId => Future[Seq[UserRight]],
         getLedgerId: () => Future[String],
     )(
         fromUser: FromUser[Unauthorized, B]

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -153,7 +153,7 @@ object domain extends com.daml.fetchcontracts.domain.Aliases {
           Ref.Party.fromString(party.unwrap).map(LedgerUserRight.CanReadAs).disjunction
       }
 
-    def fromLedgerUserRights(input: Vector[LedgerUserRight]): List[UserRight] = input
+    def fromLedgerUserRights(input: Seq[LedgerUserRight]): List[UserRight] = input
       .map[domain.UserRight] {
         case LedgerUserRight.ParticipantAdmin => ParticipantAdmin
         case LedgerUserRight.CanActAs(party) =>

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/UserManagementClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/admin/UserManagementClient.scala
@@ -52,49 +52,49 @@ final class UserManagementClient(service: UserManagementServiceStub)(implicit
       .deleteUser(proto.DeleteUserRequest(userId.toString))
       .map(_ => ())
 
-  def listUsers(token: Option[String] = None): Future[Vector[User]] =
+  def listUsers(token: Option[String] = None): Future[Seq[User]] =
     LedgerClient
       .stub(service, token)
       .listUsers(proto.ListUsersRequest())
-      .map(_.users.view.map(fromProtoUser).toVector)
+      .map(_.users.view.map(fromProtoUser).toSeq)
 
   def grantUserRights(
       userId: UserId,
       rights: Seq[UserRight],
       token: Option[String] = None,
-  ): Future[Vector[UserRight]] =
+  ): Future[Seq[UserRight]] =
     LedgerClient
       .stub(service, token)
       .grantUserRights(proto.GrantUserRightsRequest(userId.toString, rights.map(toProtoRight)))
-      .map(_.newlyGrantedRights.view.collect(fromProtoRight.unlift).toVector)
+      .map(_.newlyGrantedRights.view.collect(fromProtoRight.unlift).toSeq)
 
   def revokeUserRights(
       userId: UserId,
       rights: Seq[UserRight],
       token: Option[String] = None,
-  ): Future[Vector[UserRight]] =
+  ): Future[Seq[UserRight]] =
     LedgerClient
       .stub(service, token)
       .revokeUserRights(proto.RevokeUserRightsRequest(userId.toString, rights.map(toProtoRight)))
-      .map(_.newlyRevokedRights.view.collect(fromProtoRight.unlift).toVector)
+      .map(_.newlyRevokedRights.view.collect(fromProtoRight.unlift).toSeq)
 
   /** List the rights of the given user.
     * Unknown rights are ignored.
     */
-  def listUserRights(userId: UserId, token: Option[String] = None): Future[Vector[UserRight]] =
+  def listUserRights(userId: UserId, token: Option[String] = None): Future[Seq[UserRight]] =
     LedgerClient
       .stub(service, token)
       .listUserRights(proto.ListUserRightsRequest(userId.toString))
-      .map(_.rights.view.collect(fromProtoRight.unlift).toVector)
+      .map(_.rights.view.collect(fromProtoRight.unlift).toSeq)
 
   /** Retrieve the rights of the user authenticated by the token(s) on the call .
     * Unknown rights are ignored.
     */
-  def listAuthenticatedUserRights(token: Option[String] = None): Future[Vector[UserRight]] =
+  def listAuthenticatedUserRights(token: Option[String] = None): Future[Seq[UserRight]] =
     LedgerClient
       .stub(service, token)
       .listUserRights(proto.ListUserRightsRequest())
-      .map(_.rights.view.collect(fromProtoRight.unlift).toVector)
+      .map(_.rights.view.collect(fromProtoRight.unlift).toSeq)
 }
 
 object UserManagementClient {


### PR DESCRIPTION
For consistency with other APIs in this area.
Note that some pre-existing APIs use `List` instead of `Seq`,
but at least those use the same underlying implementation.

This was originally developed (and reviewed) as part of #12187

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
