### PR TITLE
Accept a --wall-clock-time option for the Canton sandbox

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -428,7 +428,10 @@ commandParser = subparser $ fold
             cantonDomainAdminApi <- option auto (long "domain-admin-port" <> value 6868)
             cantonPortFileM <- optional $ option str (long "canton-port-file" <> metavar "PATH"
                 <> help "File to write canton participant ports when ready")
-            cantonStaticTime <- StaticTime <$> switch (long "static-time")
+            cantonStaticTime <- StaticTime <$>
+                (flag' True (long "static-time") <|>
+                 flag' False (long "wall-clock-time") <|>
+                 pure False)
             pure CantonOptions{..}
         portFileM <- optional $ option str (long "port-file" <> metavar "PATH"
             <> help "File to write ledger API port when ready")


### PR DESCRIPTION
We have this in so many of our examples that I expect a lot of users
have it as well and we can trivially support it so it seems nice to
not break things more for our users than necessary.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
