### PR TITLE
Fixing idempotent insert for Oracle (and H2) [DPP-562]

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsIngestion.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsIngestion.scala
@@ -3,9 +3,14 @@
 
 package com.daml.platform.store.backend
 
+import java.sql.Connection
+
 import org.scalatest.Inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 private[backend] trait StorageBackendTestsIngestion
     extends Matchers
@@ -88,4 +93,46 @@ private[backend] trait StorageBackendTestsIngestion
     partiesAfterLedgerEndUpdate should not be empty
   }
 
+  private val NumberOfUpsertPackagesTests = 100
+  it should s"safely upsert packages concurrently ($NumberOfUpsertPackagesTests)" in withConnections(
+    2
+  ) { connections =>
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    def test() = {
+      val List(connection1, connection2) = connections
+      def packageFor(n: Int): DbDto.Package =
+        dtoPackage(offset(n.toLong))
+          .copy(package_id = s"abc123$n")
+      val conflictingPackageDtos = 11 to 20 map packageFor
+      val packages1 = 21 to 30 map packageFor
+      val packages2 = 31 to 40 map packageFor
+
+      executeSql(backend.parameter.initializeParameters(someIdentityParams))
+
+      def ingestPackagesF(connection: Connection, packages: Iterable[DbDto.Package]): Future[Unit] =
+        Future {
+          connection.setAutoCommit(false)
+          ingest(packages.toVector, connection)
+          connection.commit()
+        }
+
+      val ingestF1 = ingestPackagesF(connection1, packages1 ++ conflictingPackageDtos)
+      val ingestF2 = ingestPackagesF(connection2, packages2 ++ conflictingPackageDtos)
+
+      Await.result(ingestF1, Duration(10, "seconds"))
+      Await.result(ingestF2, Duration(10, "seconds"))
+
+      executeSql(updateLedgerEnd(offset(50), 0))
+
+      executeSql(backend.packageBackend.lfPackages).keySet.map(_.toString) shouldBe (
+        conflictingPackageDtos ++ packages1 ++ packages2
+      ).map(_.package_id).toSet
+    }
+
+    1 to NumberOfUpsertPackagesTests foreach { _ =>
+      test()
+      executeSql(backend.reset.resetAll)
+    }
+  }
 }


### PR DESCRIPTION
The idempotent insert clauses are racy for Oracle and H2, this is
only used for inserting packages idempotently.

* Fixes H2 by manually retrying maximum 10 times the execution in question
* Fixes Oracle by applying a different approach not requireing retrying:
using IGNORE_ROW_ON_DUPKEY_INDEX
* Adding unit tests which ensures racy idempotent insert is not an issue
(this was failing originally)
* Adding withConnections helper to StorageBackendSpec

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
