### PR TITLE
Make Oracle StorageBackend tests 10 times faster

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleResetStorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleResetStorageBackend.scala
@@ -27,6 +27,8 @@ object OracleResetStorageBackend extends ResetStorageBackend {
       "participant_users",
       "participant_user_rights",
       "transaction_metering",
-    ).map(table => SQL"truncate table #$table cascade").foreach(_.execute()(connection))
+    ) foreach { table =>
+      SQL"delete from #$table".execute()(connection)
+    }
 
 }


### PR DESCRIPTION
As it turns out for our usage truncation is much slower than deletion

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
