### PR TITLE
Fixing idempotent insert for Oracle (second attempt) [DPP-562]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleTable.scala
@@ -24,9 +24,8 @@ private[oracle] object OracleTable {
                     data(fieldIndex)(dataIndex),
                   )
                 }
-                preparedStatement.addBatch()
+                preparedStatement.execute()
               }
-              preparedStatement.executeBatch()
               preparedStatement.close()
             }
     }


### PR DESCRIPTION
The original solution turned out to reveal a bug in Oracle DB:
the batch insert with IGNORE_ROW_ON_DUPKEY_INDEX with rows containing
significant amount of varying payload can run on Oracle JDBC
driver exceptions.

* Fixes with switching to single insert instead of multi-insert for package upload
for Oracle
* Enhances unit test to uncover the aforementioned issue

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
