### PR TITLE
daily snapshot: pick better time

### DIFF
--- a/ci/daily-snapshot.yml
+++ b/ci/daily-snapshot.yml
@@ -4,7 +4,7 @@
 pr: none
 trigger: none
 schedules:
-- cron: "0 3 * * *"
+- cron: "30 4 * * *"
   displayName: Daily split snapshot
   branches:
     include:


### PR DESCRIPTION
CI nodes are reset at 4, which means starting at 3 doesn't leave us with
enough time to complete.

CHANGELOG_BEGIN
CHANGELOG_END