### PR TITLE
Return all users from `GET /v1/users/`, paginating 1k at a time

### DIFF
--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
@@ -585,6 +585,7 @@ class HttpServiceIntegrationTestUserManagementNoAuth
   ) { (uri, _, _, _, _) =>
     import spray.json._
     import spray.json.DefaultJsonProtocol._
+
     val createdUsers = 20000
 
     val createUserRequests: List[domain.CreateUserRequest] =
@@ -640,7 +641,7 @@ class HttpServiceIntegrationTestUserManagementNoAuth
       status shouldBe StatusCodes.OK
       val userIds = getResult(output).convertTo[List[UserDetails]].map(_.userId)
       val expectedUserIds = "participant_admin" :: createUserRequests.map(_.userId)
-      userIds should contain theSameElementsAs expectedUserIds
+      userIds should contain allElementsOf expectedUserIds
     }
   }
 }


### PR DESCRIPTION
The test runs overall for ~30 seconds, mostly due to the time required to
create 20k users.

changelog_begin
[HTTP-JSON API] Previously, a 10k limit was in place on the number of users returned by
`GET /v1/users/`. This limit has been removed and users are retrieved in chunks from the ledger
changelog_end

As of now, this builds the response in-memory, which is likely not what we want to
support long-term.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
