### PR TITLE
[Sandbox-on-X] Duplicate party allocations explicit rejection [DPP-893]

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -745,6 +745,18 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        # Sandbox-on-X starts forwarding rejections on duplicate party allocation starting with next release
+        "start": "2.0.0-snapshot.20220201.9108.1",
+        "platform_ranges": [
+            {
+                "end": "2.0.0-snapshot.20220201.9108.0.aa2494f1",
+                "exclusions": [
+                    "PartyManagementServiceIT:PMRejectionDuplicateHint",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
@@ -15,6 +15,7 @@ import io.grpc.Status
 import scalaz.Tag
 import scalaz.syntax.tag.ToTagOps
 
+import java.util.regex.Pattern
 import scala.util.Random
 
 final class PartyManagementServiceIT extends LedgerTestSuite {
@@ -90,6 +91,32 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
       assert(Tag.unwrap(p1).nonEmpty, "The first allocated party identifier is an empty string")
       assert(Tag.unwrap(p2).nonEmpty, "The second allocated party identifier is an empty string")
       assert(p1 != p2, "The two parties have the same party identifier")
+    }
+  })
+
+  test(
+    "PMRejectionDuplicateHint",
+    "A party allocation request with a duplicate party hint should be rejected",
+    allocate(NoParties),
+  )(implicit ec => { case Participants(Participant(ledger)) =>
+    val hint = "party_hint" + "_" + Random.alphanumeric.take(10).mkString
+    for {
+      party <- ledger.allocateParty(partyIdHint = Some(hint), displayName = None)
+      error <- ledger
+        .allocateParty(partyIdHint = Some(hint), displayName = None)
+        .mustFail("allocating a party with a duplicate hint")
+    } yield {
+      assert(
+        Tag.unwrap(party).nonEmpty,
+        "The allocated party identifier is an empty string",
+      )
+      assertGrpcErrorRegex(
+        ledger,
+        error,
+        Status.Code.INVALID_ARGUMENT,
+        LedgerApiErrors.RequestValidation.InvalidArgument,
+        Some(Pattern.compile("Party already exists|PartyToParticipant")),
+      )
     }
   })
 

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -373,6 +373,7 @@ conformance_test(
         "--exclude=ConfigManagementServiceIT:CMConcurrentSetConflicting",
         "--exclude=CommandDeduplication",
         "--exclude=CommandServiceIT:CSduplicate",
+        "--exclude=PartyManagementServiceIT:PMRejectionDuplicateHint",
     ],
 )
 

--- a/ledger/sandbox-on-x/src/test/suite/scala/com/daml/ledger/sandbox/bridge/validate/SequenceSpec.scala
+++ b/ledger/sandbox-on-x/src/test/suite/scala/com/daml/ledger/sandbox/bridge/validate/SequenceSpec.scala
@@ -53,8 +53,15 @@ class SequenceSpec extends AnyFlatSpec with MockitoSugar with Matchers with Argu
       )
     )
 
-    // Assert no update forwarded on duplicate party allocation
-    sequence(partyUploadInput) shouldBe Iterable.empty
+    // Assert duplicate party allocation is rejected
+    sequence(partyUploadInput) shouldBe Iterable(
+      toOffset(2L) -> Update.PartyAllocationRejected(
+        submissionId = submissionId,
+        participantId = Ref.ParticipantId.assertFromString(participantName),
+        recordTime = currentRecordTime,
+        rejectionReason = "Party already exists",
+      )
+    )
   }
 
   it should "validate configuration upload submission" in new TestContext {


### PR DESCRIPTION
This PR:
* Implements generation of an explicit rejection on party allocations with duplicate party id hint
* Adds test case in `PartyManagementServiceIT`

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
