### PR TITLE
[User management] Return empty users' next page token early [DPP-840]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/UserManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/UserManagementServiceIT.scala
@@ -333,10 +333,6 @@ final class UserManagementServiceIT extends LedgerTestSuite {
       res3 <- ledger.userManagement.listUsers(
         ListUsersRequest(pageSize = 1000, pageToken = res2.nextPageToken)
       )
-      // Requesting last page that is empty
-      res4 <- ledger.userManagement.listUsers(
-        ListUsersRequest(pageSize = 100, pageToken = res3.nextPageToken)
-      )
       // Using not base64 encoded string as a page token
       onBadTokenError <- ledger.userManagement
         .listUsers(
@@ -360,15 +356,9 @@ final class UserManagementServiceIT extends LedgerTestSuite {
       assert(res2.nextPageToken.nonEmpty, s"Second next page token should be non-empty")
       assertLength("second page", 3, res2.users)
 
-      assert(res3.nextPageToken.nonEmpty, s"Third next page token should be non-empty")
+      assert(res3.nextPageToken.isEmpty, s"Third next page token should be non-empty")
       assert(res2.users.nonEmpty, s"Third page should be non-empty")
 
-      assertEquals(
-        s"Last next page token should be empty but was: ${res4.nextPageToken}",
-        res4.nextPageToken,
-        "",
-      )
-      assert(res4.users.isEmpty, s"Last page should be empty but was: ${res4.users}")
       assertGrpcError(
         participant = ledger,
         t = onBadTokenError,
@@ -384,8 +374,8 @@ final class UserManagementServiceIT extends LedgerTestSuite {
         exceptionMessageSubstring = None,
       )
       assert(
-        responseZeroPageSize.nextPageToken.nonEmpty,
-        "Non-empty page token when pageSize is 0 (and there are some users)",
+        responseZeroPageSize.users.nonEmpty,
+        "First page with requested pageSize zero should return some users",
       )
     }
   })

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/UserManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/UserManagementServiceIT.scala
@@ -356,7 +356,7 @@ final class UserManagementServiceIT extends LedgerTestSuite {
       assert(res2.nextPageToken.nonEmpty, s"Second next page token should be non-empty")
       assertLength("second page", 3, res2.users)
 
-      assert(res3.nextPageToken.isEmpty, s"Third next page token should be non-empty")
+      assert(res3.nextPageToken.isEmpty, "Third next page token should be empty")
       assert(res2.users.nonEmpty, s"Third page should be non-empty")
 
       assertGrpcError(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiUserManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiUserManagementService.scala
@@ -15,7 +15,6 @@ import com.daml.error.{
 import com.daml.ledger.api.domain._
 import com.daml.ledger.api.v1.admin.{user_management_service => proto}
 import com.daml.ledger.participant.state.index.v2.UserManagementStore
-import com.daml.ledger.participant.state.index.v2.UserManagementStore.UsersPage
 import com.daml.lf.data.Ref
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.platform.api.grpc.GrpcApiService
@@ -114,7 +113,10 @@ private[apiserver] final class ApiUserManagementService(
         .flatMap(handleResult("listing users"))
         .map { page: UserManagementStore.UsersPage =>
           val protoUsers = page.users.map(toProtoUser)
-          proto.ListUsersResponse(protoUsers, encodeNextPageToken(page))
+          proto.ListUsersResponse(
+            protoUsers,
+            encodeNextPageToken(if (page.users.size < pageSize) None else page.lastUserIdOption),
+          )
         }
     }
   }
@@ -238,8 +240,8 @@ object ApiUserManagementService {
       proto.Right(proto.Right.Kind.CanReadAs(proto.Right.CanReadAs(party)))
   }
 
-  def encodeNextPageToken(page: UsersPage): String =
-    page.lastUserIdOption
+  def encodeNextPageToken(token: Option[Ref.UserId]): String =
+    token
       .map { id =>
         val bytes = Base64.getUrlEncoder.encode(id.getBytes(StandardCharsets.UTF_8))
         new String(bytes, StandardCharsets.UTF_8)

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/admin/ApiUserManagementServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/admin/ApiUserManagementServiceSpec.scala
@@ -8,8 +8,6 @@ import java.util.Base64
 
 import com.daml.error.definitions.LedgerApiErrors
 import com.daml.error.{DamlContextualizedErrorLogger, ErrorsAssertions}
-import com.daml.ledger.api.domain.User
-import com.daml.ledger.participant.state.index.v2.UserManagementStore.UsersPage
 import com.daml.lf.data.Ref
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
@@ -25,19 +23,15 @@ class ApiUserManagementServiceSpec
 
   it should "test users page token encoding and decoding" in {
     val id2 = Ref.UserId.assertFromString("user2")
-    val page = UsersPage(
-      users = Seq(User(Ref.UserId.assertFromString("user1"), None), User(id2, None))
-    )
-    val actualNextPageToken = ApiUserManagementService.encodeNextPageToken(page)
+    val actualNextPageToken = ApiUserManagementService.encodeNextPageToken(Some(id2))
     actualNextPageToken shouldBe "dXNlcjI="
     ApiUserManagementService.decodePageToken(actualNextPageToken)(errorLogger) shouldBe Right(
       Some(id2)
     )
   }
 
-  it should "test users page token encoding and decoding for an empty page" in {
-    val page = UsersPage(users = Seq.empty)
-    val actualNextPageToken = ApiUserManagementService.encodeNextPageToken(page)
+  it should "test users empty page token encoding and decoding" in {
+    val actualNextPageToken = ApiUserManagementService.encodeNextPageToken(None)
     actualNextPageToken shouldBe ("")
     ApiUserManagementService.decodePageToken(actualNextPageToken)(errorLogger) shouldBe Right(None)
   }


### PR DESCRIPTION
If user management stored returns fewer than pageSize , then set next page token to the empty string

