### PR TITLE
Engine: fix compilation exception catch

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -151,7 +151,10 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
   ): Result[(SubmittedTransaction, Tx.Metadata)] =
     for {
       speedyCommand <- preprocessor.preprocessCommand(command)
-      sexpr = compiledPackages.compiler.unsafeCompileForReinterpretation(speedyCommand)
+      sexpr <- runCompilerSafely(
+        NameOf.qualifiedNameOfCurrentFunc,
+        compiledPackages.compiler.unsafeCompileForReinterpretation(speedyCommand),
+      )
       // reinterpret is never used for submission, only for validation.
       result <- interpretExpression(
         validating = true,
@@ -242,27 +245,22 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
     )
 
   @inline
-  private[lf] def runSafely[X](
-      funcName: String
-  )(run: => Result[X]): Result[X] = {
-    def start: Result[X] =
-      try {
-        run
-      } catch {
-        // The two following error should be prevented by the type checking does by translateCommand
-        // so it’s an internal error.
-        case speedy.Compiler.PackageNotFound(pkgId, context) =>
-          ResultError(
-            Error.Preprocessing.Internal(
-              funcName,
-              s"CompilationError: " + LookupError.MissingPackage.pretty(pkgId, context),
-            )
+  private[this] def runCompilerSafely[X](funcName: => String, run: => X): Result[X] =
+    try {
+      ResultDone(run)
+    } catch {
+      // The two following error should be prevented by the type checking does by translateCommand
+      // so it’s an internal error.
+      case speedy.Compiler.PackageNotFound(pkgId, context) =>
+        ResultError(
+          Error.Preprocessing.Internal(
+            funcName,
+            s"CompilationError: " + LookupError.MissingPackage.pretty(pkgId, context),
           )
-        case speedy.Compiler.CompilationError(error) =>
-          ResultError(Error.Preprocessing.Internal(funcName, s"CompilationError: $error"))
-      }
-    start
-  }
+        )
+      case speedy.Compiler.CompilationError(error) =>
+        ResultError(Error.Preprocessing.Internal(funcName, s"CompilationError: $error"))
+    }
 
   // command-list compilation, followed by interpretation
   private[engine] def interpretCommands(
@@ -274,16 +272,21 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       submissionTime: Time.Timestamp,
       seeding: speedy.InitialSeeding,
   ): Result[(SubmittedTransaction, Tx.Metadata)] = {
-    val sexpr = compiledPackages.compiler.unsafeCompile(commands)
-    interpretExpression(
-      validating,
-      submitters,
-      readAs,
-      sexpr,
-      ledgerTime,
-      submissionTime,
-      seeding,
-    )
+    for {
+      sexpr <- runCompilerSafely(
+        NameOf.qualifiedNameOfCurrentFunc,
+        compiledPackages.compiler.unsafeCompile(commands),
+      )
+      result <- interpretExpression(
+        validating,
+        submitters,
+        readAs,
+        sexpr,
+        ledgerTime,
+        submissionTime,
+        seeding,
+      )
+    } yield result
   }
 
   /** Interprets the given commands under the authority of @submitters, with additional readers @readAs
@@ -302,21 +305,20 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       ledgerTime: Time.Timestamp,
       submissionTime: Time.Timestamp,
       seeding: speedy.InitialSeeding,
-  ): Result[(SubmittedTransaction, Tx.Metadata)] =
-    runSafely(NameOf.qualifiedNameOfCurrentFunc) {
-      val machine = Machine(
-        compiledPackages = compiledPackages,
-        submissionTime = submissionTime,
-        initialSeeding = seeding,
-        expr = SEApp(sexpr, Array(SEValue.Token)),
-        committers = submitters,
-        readAs = readAs,
-        validating = validating,
-        contractKeyUniqueness = config.contractKeyUniqueness,
-        limits = config.limits,
-      )
-      interpretLoop(machine, ledgerTime)
-    }
+  ): Result[(SubmittedTransaction, Tx.Metadata)] = {
+    val machine = Machine(
+      compiledPackages = compiledPackages,
+      submissionTime = submissionTime,
+      initialSeeding = seeding,
+      expr = SEApp(sexpr, Array(SEValue.Token)),
+      committers = submitters,
+      readAs = readAs,
+      validating = validating,
+      contractKeyUniqueness = config.contractKeyUniqueness,
+      limits = config.limits,
+    )
+    interpretLoop(machine, ledgerTime)
+  }
 
   // TODO SC remove 'return', notwithstanding a love of unhandled exceptions
   @SuppressWarnings(Array("org.wartremover.warts.Return"))

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -165,8 +165,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
         submissionTime = submissionTime,
         seeding = InitialSeeding.RootNodeSeeds(ImmArray(nodeSeed)),
       )
-      (tx, meta) = result
-    } yield (tx, meta)
+    } yield result
 
   def replay(
       submitters: Set[Party],
@@ -271,7 +270,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       ledgerTime: Time.Timestamp,
       submissionTime: Time.Timestamp,
       seeding: speedy.InitialSeeding,
-  ): Result[(SubmittedTransaction, Tx.Metadata)] = {
+  ): Result[(SubmittedTransaction, Tx.Metadata)] =
     for {
       sexpr <- runCompilerSafely(
         NameOf.qualifiedNameOfCurrentFunc,
@@ -287,7 +286,6 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
         seeding,
       )
     } yield result
-  }
 
   /** Interprets the given commands under the authority of @submitters, with additional readers @readAs
     *


### PR DESCRIPTION
During refacotring of #9993, the "unsafe" compilation of the seedy command
has been moved out of the scope of `Engine.runSafely`, whose only purpose
was to catch exceptions thrown by the Speedy compiler.

This fixes the issue and renames the function `runSafely` to
`runCompilkerSafely` to make its purpose more obvious.

This is not a critical bug, as the command preprocessing should ensure
that (1)  the command are properly typed and (2) all the dependencies 
have been loaded. 

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
