### PR TITLE
Update RELEASE.md

### DIFF
--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -187,15 +187,14 @@ patches we backport to the 1.0 release branch).
 
     1. Make `Alice` follow `Bob`.
 
-    1. From `Bob`, select the only available party (currently a long random-looking string) in the `Select a follower` drop down,
+    1. From `Bob`, select Alice in the `Select a follower` drop down,
        insert `hi alice` in the message field and click on `Send`.
 
     1. Verify that `Alice` has received the message in the other window.
 
     1. Make `Bob` follow `Alice`.
 
-    1. From `Alice`, select the only available party (currently a long
-       random-looking string) in the `Select a follower` drop down,
+    1. From `Alice`, select Bob in the `Select a follower` drop down,
        insert `hi bob` in the message field and click on `Send`.
 
     1. Verify that `Bob` has received the message in the other window.


### PR DESCRIPTION
I suppose whoever fixed this forgot to update these instructions, but as of `2.0.0-snapshot.20220204.9165.0.225c58f4` I observed well-formed "Bob" and "Alice" values in the messaging dropdowns.