### PR TITLE
Return a wrapper `CreateUserResponse` type for the Java bindings

### DIFF
--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/UserManagementClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/UserManagementClient.java
@@ -10,9 +10,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 /** An RxJava version of {@link com.daml.ledger.api.v1.admin.UserManagementServiceGrpc} */
 public interface UserManagementClient {
 
-  Single<User> createUser(@NonNull CreateUserRequest request);
+  Single<CreateUserResponse> createUser(@NonNull CreateUserRequest request);
 
-  Single<User> createUser(@NonNull CreateUserRequest request, String accessToken);
+  Single<CreateUserResponse> createUser(@NonNull CreateUserRequest request, String accessToken);
 
   Single<User> getUser(@NonNull GetUserRequest request);
 

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/UserManagementClientImpl.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/UserManagementClientImpl.java
@@ -30,22 +30,23 @@ public final class UserManagementClientImpl implements UserManagementClient {
     this.sequencerFactory = sequencerFactory;
   }
 
-  private Single<User> createUser(
+  private Single<CreateUserResponse> createUser(
       @NonNull CreateUserRequest request, @NonNull Optional<String> maybeToken) {
     return CreateSingle.fromFuture(
             StubHelper.authenticating(this.serviceFutureStub, maybeToken)
                 .createUser(request.toProto()),
             sequencerFactory)
-        .map(res -> User.fromProto(res.getUser()));
+        .map(CreateUserResponse::fromProto);
   }
 
   @Override
-  public Single<User> createUser(@NonNull CreateUserRequest request) {
+  public Single<CreateUserResponse> createUser(@NonNull CreateUserRequest request) {
     return createUser(request, Optional.empty());
   }
 
   @Override
-  public Single<User> createUser(@NonNull CreateUserRequest request, @NonNull String accessToken) {
+  public Single<CreateUserResponse> createUser(
+      @NonNull CreateUserRequest request, @NonNull String accessToken) {
     return createUser(request, Optional.of(accessToken));
   }
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreateUserResponse.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreateUserResponse.java
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data;
+
+import com.daml.ledger.api.v1.admin.UserManagementServiceOuterClass;
+import java.util.Objects;
+
+public final class CreateUserResponse {
+
+  private final User user;
+
+  public CreateUserResponse(User user) {
+    this.user = user;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public static CreateUserResponse fromProto(
+      UserManagementServiceOuterClass.CreateUserResponse proto) {
+    return new CreateUserResponse(User.fromProto(proto.getUser()));
+  }
+
+  public UserManagementServiceOuterClass.CreateUserResponse toProto() {
+    return UserManagementServiceOuterClass.CreateUserResponse.newBuilder()
+        .setUser(this.user.toProto())
+        .build();
+  }
+
+  @Override
+  public String toString() {
+    return "CreateUserResponse{" + "user=" + user + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CreateUserResponse that = (CreateUserResponse) o;
+    return user.equals(that.user);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(user);
+  }
+}


### PR DESCRIPTION
Fixes #12813, follows up on https://github.com/digital-asset/daml/pull/12682#discussion_r796599150

changelog_begin
[Java bindings] The wrapper type `CreateUserResponse` is now returned when
creating a user instead of the `User` type itself
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
