### PR TITLE
Remove option to spin up ledger in-process in daml test-script

### DIFF
--- a/daml-assistant/daml-sdk/util.bzl
+++ b/daml-assistant/daml-sdk/util.bzl
@@ -4,10 +4,9 @@
 def deps(edition):
     return [
         "//daml-script/runner:script-runner-lib",
-        "//daml-script/runner:script-test-lib-{}".format(edition),
+        "//daml-script/runner:script-test-lib",
         "//language-support/codegen-main:codegen-main-lib",
         "//ledger-service/http-json:http-json-{}".format(edition),
-        "//ledger/sandbox:sandbox-{}".format(edition),
         "//navigator/backend:navigator-library",
         "//daml-script/export",
         "//triggers/runner:trigger-runner-lib",

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -73,47 +73,30 @@ da_scala_test(
     ],
 )
 
-# Spun out into a separate library to avoid pulling in a sandbox
-# dependency where we don’t need it.
-[
-    da_scala_library(
-        name = "script-test-lib-{}".format(edition),
-        srcs = test_script_sources,
-        scala_deps = [
-            "@maven//:com_typesafe_akka_akka_stream",
-            "@maven//:io_spray_spray_json",
-            "@maven//:org_scalaz_scalaz_core",
-        ],
-        scalacopts = script_scalacopts,
-        visibility = ["//visibility:public"],
-        deps = [
-            ":script-runner-lib",
-            "//daml-lf/archive:daml_lf_archive_reader",
-            "//daml-lf/data",
-            "//daml-lf/interpreter",
-            "//daml-lf/language",
-            "//daml-lf/transaction",
-            "//language-support/scala/bindings",
-            "//language-support/scala/bindings-akka",
-            "//ledger-api/rs-grpc-bridge",
-            "//ledger/caching",
-            "//ledger/ledger-api-auth",
-            "//ledger/ledger-api-client",
-            "//ledger/ledger-api-common",
-            "//ledger/ledger-configuration",
-            "//ledger/ledger-resources",
-            "//ledger/participant-integration-api",
-            "//ledger/sandbox:sandbox-{}".format(edition),
-            "//ledger/sandbox-common",
-            "//libs-scala/ports",
-            "//libs-scala/resources",
-        ],
-    )
-    for edition in [
-        "ce",
-        "ee",
-    ]
-]
+da_scala_library(
+    name = "script-test-lib",
+    srcs = test_script_sources,
+    scala_deps = [
+        "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:io_spray_spray_json",
+        "@maven//:org_scalaz_scalaz_core",
+    ],
+    scalacopts = script_scalacopts,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":script-runner-lib",
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/data",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
+        "//daml-lf/transaction",
+        "//language-support/scala/bindings",
+        "//language-support/scala/bindings-akka",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger/ledger-api-client",
+        "//ledger/ledger-api-common",
+    ],
+)
 
 da_scala_binary(
     name = "script-runner",
@@ -130,7 +113,7 @@ da_scala_binary(
     resources = glob(["src/main/resources/**/*"]),
     scalacopts = script_scalacopts,
     visibility = ["//visibility:public"],
-    deps = [":script-test-lib-ce"],
+    deps = [":script-test-lib"],
 )
 
 exports_files(["src/main/resources/logback.xml"])

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
@@ -69,6 +69,8 @@ object TestConfig {
         failure("Must specify both --ledger-host and --ledger-port")
       } else if (c.ledgerHost.isDefined && c.participantConfig.isDefined) {
         failure("Cannot specify both --ledger-host and --participant-config")
+      } else if (!c.ledgerHost.isDefined && !c.participantConfig.isDefined) {
+        failure("Must specify either --ledger-host or --participant-config")
       } else {
         success
       }

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -243,10 +243,12 @@ sh_test(
         "$(POSIX_DIFF)",
         "$(POSIX_GREP)",
         "$(POSIX_SED)",
+        "$(rootpath //ledger/sandbox-classic:sandbox-classic-binary)",
     ],
     data = [
         ":script-test.dar",
         "//daml-script/runner:test-runner",
+        "//ledger/sandbox-classic:sandbox-classic-binary",
     ],
     toolchains = ["@rules_sh//sh/posix:make_variables"],
     deps = ["@bazel_tools//tools/bash/runfiles"],


### PR DESCRIPTION
This drops the dependency on the kv sandbox which we need to kill for
2.0.

part of #12837

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
