### PR TITLE
Upgrade canton to 20220209

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -356,7 +356,7 @@ java_import(
     jars = glob(["lib/**/*.jar"]),
 )
         """,
-            sha256 = "529bcb185b0fec8e74652a7589b37c22f5700d765edd2467375655eb3e656c29",
+            sha256 = "e72c2ecd613a868ec3eb5654258527cbaed17b15b8c260a0a3de49841355af12",
             strip_prefix = "canton-community-1.0.0-SNAPSHOT",
-            urls = ["https://www.canton.io/releases/canton-community-20220202.tar.gz"],
+            urls = ["https://www.canton.io/releases/canton-community-20220209.tar.gz"],
         )

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -81,12 +81,7 @@ conformance_test(
             "ParticipantPruningIT",  # see "conformance-test-participant-pruning" below
             "ClosedWorldIT",  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
             "CommandServiceIT:CSsubmitAndWaitCompletionOffset",  # Canton does not fill the offsets
-            "CommandDeduplicationIT:SimpleDeduplicationBasic",  # sync vs async error (part of canton #6301)
-            "CommandDeduplicationIT:DeduplicateSubmitterBasic",
-            "CommandDeduplicationIT:DeduplicateUsingDurations",  # disabled while Canton does not support the feature descriptors
-            "CommandDeduplicationIT:DeduplicateUsingOffsets",  # disabled while Canton does not support the feature descriptors
-            "CommandDeduplicationParallelIT",  # can be re-enabled once canton exposes the feature descriptors
-            "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # TODO https://github.com/DACH-NY/canton/issues/6301
+            "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # requires pruning not available in canton community
             "DeeplyNestedValueIT",  # FIXME: Too deeply nested values flake with a time out (half of the time)
             "RaceConditionIT:RWArchiveVsFailedLookupByKey",  # finding a lookup failure after contract creation
             # dynamic config management not supported by Canton
@@ -151,42 +146,5 @@ conformance_test(
             "ExceptionsIT",
             "RaceConditionIT",
         ]),
-    ],
-) if not is_windows else None
-
-conformance_test(
-    name = "conformance-test-participant-pruning",
-    extra_data = [
-        ":bootstrap.canton",
-        ":canton_deploy.jar",
-        ":canton.conf",
-        ":enable-faster-pruning.conf",  # needed to prevent timing out on prune requests
-        ":logback-debug.xml",
-        "@coreutils_nix//:bin/base64",
-        "@curl_nix//:bin/curl",
-        "@grpcurl_nix//:bin/grpcurl",
-        "@jq_dev_env//:jq",
-        "@bazel_tools//tools/jdk",
-    ],
-    lf_versions = [
-        "default",
-        "latest",
-    ],
-    ports = [
-        5011,
-        5021,
-        5031,
-        5041,
-    ],
-    runner = "@//bazel_tools/client_server/runner_with_port_check",
-    server = ":canton-test-runner-with-dependencies",
-    tags = [
-        "manual",  # pruning test is flaky on canton because of safe-pruning offset reconciliation checks
-    ],
-    test_tool_args = [
-        "--verbose",
-        "--concurrent-test-runs=1",  # lowered from default #procs to reduce flakes - details in https://github.com/digital-asset/daml/issues/7316
-        "--timeout-scale-factor=4",  # increased to match setting in canton repo
-        "--include=ParticipantPruningIT",
     ],
 ) if not is_windows else None

--- a/ledger/ledger-api-test-tool-on-canton/enable-faster-pruning.conf
+++ b/ledger/ledger-api-test-tool-on-canton/enable-faster-pruning.conf
@@ -1,3 +1,0 @@
-canton.domains.test_domain.domain-parameters.reconciliation-interval = 2s
-canton.domains.test_domain.domain-parameters.participant-response-timeout = 2s
-canton.domains.test_domain.domain-parameters.mediator-reaction-timeout = 2s


### PR DESCRIPTION
Also:
- enabled deduplication tests
- removes pruning tests as canton no longer even pretends to support pruning (i.e. by now no longer pruning the ledger-api index either)

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
