### PR TITLE
Removing applicationId config option from bench-tool's 'streams: type: completions' config. [DPP-846]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/Cli.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/Cli.scala
@@ -268,14 +268,12 @@ object Cli {
           for {
             name <- stringField("name")
             party <- stringField("party")
-            applicationId <- stringField("application-id")
             beginOffset <- optionalStringField("begin-offset").map(_.map(offset))
             minItemRate <- optionalDoubleField("min-item-rate")
             maxItemRate <- optionalDoubleField("max-item-rate")
           } yield WorkflowConfig.StreamConfig.CompletionsStreamConfig(
             name = name,
             party = party,
-            applicationId = applicationId,
             beginOffset = beginOffset,
             objectives = rateObjectives(minItemRate, maxItemRate),
           )

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfig.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfig.scala
@@ -58,7 +58,6 @@ object WorkflowConfig {
     final case class CompletionsStreamConfig(
         name: String,
         party: String,
-        applicationId: String,
         beginOffset: Option[LedgerOffset],
         objectives: Option[StreamConfig.RateObjectives],
     ) extends StreamConfig

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParser.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParser.scala
@@ -78,10 +78,9 @@ object WorkflowConfigParser {
       )(StreamConfig.ActiveContractsStreamConfig.apply)
 
     implicit val completionsStreamDecoder: Decoder[StreamConfig.CompletionsStreamConfig] =
-      Decoder.forProduct5(
+      Decoder.forProduct4(
         "name",
         "party",
-        "application_id",
         "begin_offset",
         "objectives",
       )(StreamConfig.CompletionsStreamConfig.apply)

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/CommandCompletionService.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/CommandCompletionService.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.api.benchtool.services
 
 import com.daml.ledger.api.benchtool.config.WorkflowConfig
+import com.daml.ledger.api.benchtool.submission.CommandSubmitter
 import com.daml.ledger.api.benchtool.util.ObserverWithResult
 import com.daml.ledger.api.v1.command_completion_service.{
   CommandCompletionServiceGrpc,
@@ -40,7 +41,7 @@ class CommandCompletionService(
     val request = CompletionStreamRequest.defaultInstance
       .withLedgerId(ledgerId)
       .withParties(List(config.party))
-      .withApplicationId(config.applicationId)
+      .withApplicationId(CommandSubmitter.ApplicationId)
 
     config.beginOffset match {
       case Some(offset) => request.withOffset(offset)

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/CommandSubmitter.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/CommandSubmitter.scala
@@ -23,8 +23,7 @@ case class CommandSubmitter(services: LedgerApiServices) {
   private val logger = LoggerFactory.getLogger(getClass)
 
   private val identifierSuffix = f"${System.nanoTime}%x"
-  private val applicationId = "benchtool"
-  private val workflowId = s"$applicationId-$identifierSuffix"
+  private val workflowId = s"${CommandSubmitter.ApplicationId}-$identifierSuffix"
   private val signatoryName = s"signatory-$identifierSuffix"
   private def observerName(index: Int, uniqueParties: Boolean): String = {
     if (uniqueParties) s"Obs-$index-$identifierSuffix"
@@ -101,7 +100,7 @@ case class CommandSubmitter(services: LedgerApiServices) {
   ): Future[Unit] = {
     val result = new Commands(
       ledgerId = services.ledgerId,
-      applicationId = applicationId,
+      applicationId = CommandSubmitter.ApplicationId,
       commandId = id,
       party = party.unwrap,
       commands = commands,
@@ -191,6 +190,9 @@ case class CommandSubmitter(services: LedgerApiServices) {
 }
 
 object CommandSubmitter {
+
+  val ApplicationId = "benchtool"
+
   case class CommandSubmitterError(msg: String) extends RuntimeException(msg)
 
   case class SubmissionSummary(observers: List[Primitive.Party])

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/CliSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/CliSpec.scala
@@ -82,7 +82,6 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
       import WorkflowConfig.StreamConfig._
       val name = "streamname"
       val party = "dummy"
-      val appId = "appid"
       val cases = Table(
         "cli argument" -> "stream config",
         s"stream-type=transactions,name=$name,filters=$party" -> TransactionsStreamConfig(
@@ -104,10 +103,9 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           filters = List(PartyFilter(party, Nil)),
           objectives = None,
         ),
-        s"stream-type=completions,name=$name,party=$party,application-id=$appId" -> CompletionsStreamConfig(
+        s"stream-type=completions,name=$name,party=$party" -> CompletionsStreamConfig(
           name = name,
           party = party,
-          applicationId = appId,
           beginOffset = None,
           objectives = None,
         ),

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParserSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParserSpec.scala
@@ -337,7 +337,6 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
           |    name: stream-1
           |    party: Obs-2
           |    begin_offset: foo
-          |    application_id: foobar
           |    objectives:
           |      min_item_rate: 12
           |      max_item_rate: 345""".stripMargin
@@ -349,7 +348,6 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
               name = "stream-1",
               party = "Obs-2",
               beginOffset = Some(offset("foo")),
-              applicationId = "foobar",
               objectives = Some(
                 WorkflowConfig.StreamConfig.RateObjectives(
                   minItemRate = Some(12),


### PR DESCRIPTION
For producing data benchtool has been using a hardcoded applicationId.
Exposing a configurable applicationid only for one kind of streams seems arbitrary and is probably not used as the following gave no hits in eom-kit repo:
```
git grep 'application-id='
git grep 'type:completions'
git grep 'type: completions'
git grep 'type:  completions'
```

Removing this configuration options makes it cleaner to subsequently add user based authorization support to the bench-tool.
