### PR TITLE
Split out phase1 of speedy compilation

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -4,26 +4,25 @@
 package com.daml.lf
 package speedy
 
-import java.util
 import com.daml.lf.data.Ref._
-import com.daml.lf.data.{ImmArray, Numeric, Ref, Struct, Time}
+import com.daml.lf.data.{ImmArray, Ref, Struct, Time}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{LanguageVersion, LookupError, PackageInterface, StablePackages}
 import com.daml.lf.speedy.Anf.flattenToAnf
+import com.daml.lf.speedy.ClosureConversion.closureConvert
+import com.daml.lf.speedy.PhaseOne.{Env, Position}
 import com.daml.lf.speedy.Profile.LabelModule
 import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.SValue._
-import com.daml.lf.speedy.{SExpr0 => s}
-import com.daml.lf.speedy.{SExpr => t}
-import com.daml.lf.speedy.ClosureConversion.closureConvert
 import com.daml.lf.speedy.ValidateCompilation.validateCompilation
+import com.daml.lf.speedy.{SExpr => t}
+import com.daml.lf.speedy.{SExpr0 => s}
 import com.daml.lf.validation.{EUnknownDefinition, Validation, ValidationError}
 import com.daml.scalautil.Statement.discard
-import com.daml.nameof.NameOf
+
 import org.slf4j.LoggerFactory
 
-import scala.annotation.{nowarn, tailrec}
-import scala.reflect.ClassTag
+import scala.annotation.nowarn
 
 /** Compiles LF expressions into Speedy expressions.
   * This includes:
@@ -88,19 +87,13 @@ private[lf] object Compiler {
     )
   }
 
-  private val SEGetTime = s.SEBuiltin(SBGetTime)
-
-  private val SBEToTextNumeric = s.SEAbs(1, s.SEBuiltin(SBToText))
-
-  private val SENat: Numeric.Scale => Some[s.SEValue] =
-    Numeric.Scale.values.map(n => Some(s.SEValue(STNat(n))))
-
   /** Validates and Compiles all the definitions in the packages provided. Returns them in a Map.
     *
     * The packages do not need to be in any specific order, as long as they and all the packages
     * they transitively reference are in the [[packages]] in the compiler.
     */
-  def compilePackages(
+
+  private[lf] def compilePackages(
       interface: PackageInterface,
       packages: Map[PackageId, Package],
       compilerConfig: Compiler.Config,
@@ -109,7 +102,7 @@ private[lf] object Compiler {
     try {
       Right(packages.foldLeft(Map.empty[t.SDefinitionRef, SDefinition]) {
         case (acc, (pkgId, pkg)) =>
-          acc ++ compiler.unsafeCompilePackage(pkgId, pkg)
+          acc ++ compiler.compilePackage(pkgId, pkg)
       })
     } catch {
       case CompilationError(msg) => Left(s"Compilation Error: $msg")
@@ -117,17 +110,6 @@ private[lf] object Compiler {
         Left(LookupError.MissingPackage.pretty(pkgId, context))
       case e: ValidationError => Left(e.pretty)
     }
-  }
-
-  // Hand-implemented `map` uses less stack.
-  private def mapToArray[A, B: ClassTag](input: ImmArray[A])(f: A => B): List[B] = {
-    val output = Array.ofDim[B](input.length)
-    var i = 0
-    input.foreach { value =>
-      output(i) = f(value)
-      i += 1
-    }
-    output.toList
   }
 
 }
@@ -139,84 +121,43 @@ private[lf] final class Compiler(
 
   import Compiler._
 
+  // Compilation entry points...
+
+  @throws[PackageNotFound]
+  @throws[CompilationError]
+  def unsafeCompile(cmds: ImmArray[Command]): t.SExpr = compileCommands(cmds)
+
+  @throws[PackageNotFound]
+  @throws[CompilationError]
+  def unsafeCompileForReinterpretation(cmd: Command): t.SExpr =
+    compileCommandForReinterpretation(cmd)
+
+  @throws[PackageNotFound]
+  @throws[CompilationError]
+  def unsafeCompile(expr: Expr): t.SExpr = compileExp(expr)
+
+  @throws[PackageNotFound]
+  @throws[CompilationError]
+  def unsafeClosureConvert(sexpr: s.SExpr): t.SExpr = pipeline(sexpr)
+
+  @throws[PackageNotFound]
+  @throws[CompilationError]
+  @throws[ValidationError]
+  def unsafeCompilePackage(
+      pkgId: PackageId,
+      pkg: Package,
+  ): Iterable[(t.SDefinitionRef, SDefinition)] = compilePackage(pkgId, pkg)
+
+  @throws[PackageNotFound]
+  @throws[CompilationError]
+  def unsafeCompileModule( //called by scenario-service
+      pkgId: PackageId,
+      module: Module,
+  ): Iterable[(t.SDefinitionRef, SDefinition)] = compileModule(pkgId, module)
+
   private[this] val stablePackageIds = StablePackages.ids(config.allowedLanguageVersions)
 
-  private[this] def handleLookup[X](location: String, x: Either[LookupError, X]) =
-    x match {
-      case Right(value) => value
-      case Left(err) => throw SError.SErrorCrash(location, err.pretty)
-    }
-
-  // Stack-trace support is disabled by avoiding the construction of SELocation nodes.
-  private[this] def maybeSELocation(loc: Location, sexp: s.SExpr): s.SExpr = {
-    config.stacktracing match {
-      case NoStackTrace => sexp
-      case FullStackTrace => s.SELocation(loc, sexp)
-    }
-  }
-
   private[this] val logger = LoggerFactory.getLogger(this.getClass)
-
-  private[this] abstract class VarRef { def name: Name }
-  // corresponds to Daml-LF expression variable.
-  private[this] case class EVarRef(name: ExprVarName) extends VarRef
-  // corresponds to Daml-LF type variable.
-  private[this] case class TVarRef(name: TypeVarName) extends VarRef
-
-  case class Position(idx: Int)
-
-  private[this] object Env {
-    val Empty = Env(0, Map.empty)
-  }
-
-  private[this] case class Env(
-      position: Int,
-      varIndices: Map[VarRef, Position],
-  ) {
-
-    def toSEVar(p: Position) = s.SEVarLevel(p.idx)
-
-    def nextPosition = Position(position)
-
-    def pushVar: Env = copy(position = position + 1)
-
-    private[this] def bindVar(ref: VarRef, p: Position) =
-      copy(varIndices = varIndices.updated(ref, p))
-
-    def pushVar(ref: VarRef): Env =
-      bindVar(ref, nextPosition).pushVar
-
-    def pushExprVar(name: ExprVarName): Env =
-      pushVar(EVarRef(name))
-
-    def pushExprVar(maybeName: Option[ExprVarName]): Env =
-      maybeName match {
-        case Some(name) => pushExprVar(name)
-        case None => pushVar
-      }
-
-    def pushTypeVar(name: ExprVarName): Env =
-      pushVar(TVarRef(name))
-
-    def hideTypeVar(name: TypeVarName): Env =
-      copy(varIndices = varIndices - TVarRef(name))
-
-    def bindExprVar(name: ExprVarName, p: Position): Env =
-      bindVar(EVarRef(name), p)
-
-    private[this] def vars: List[VarRef] = varIndices.keys.toList
-
-    private[this] def lookupVar(varRef: VarRef): Option[s.SExpr] =
-      varIndices.get(varRef).map(toSEVar)
-
-    def lookupExprVar(name: ExprVarName): s.SExpr =
-      lookupVar(EVarRef(name))
-        .getOrElse(throw CompilationError(s"Unknown variable: $name. Known: ${vars.mkString(",")}"))
-
-    def lookupTypeVar(name: TypeVarName): Option[s.SExpr] =
-      lookupVar(TVarRef(name))
-
-  }
 
   // We add labels before and after flattenning
 
@@ -246,15 +187,6 @@ private[lf] final class Compiler(
       }
     }
 
-  private[this] def withOptLabelS[L: Profile.LabelModule.Allowed](
-      optLabel: Option[L with AnyRef],
-      expr: s.SExpr,
-  ): s.SExpr =
-    optLabel match {
-      case Some(label) => withLabelS(label, expr)
-      case None => expr
-    }
-
   private[this] def app(f: s.SExpr, a: s.SExpr) = s.SEApp(f, List(a))
 
   private[this] def let(env: Env, bound: s.SExpr)(f: (Position, Env) => s.SExpr): s.SELet =
@@ -281,10 +213,8 @@ private[lf] final class Compiler(
 
   private[this] def topLevelFunction[SDefRef <: t.SDefinitionRef: LabelModule.Allowed](
       ref: SDefRef
-  )(
-      body: s.SExpr
-  ): (SDefRef, SDefinition) =
-    ref -> SDefinition(unsafeClosureConvert(withLabelS(ref, body)))
+  )(body: s.SExpr): (SDefRef, SDefinition) =
+    ref -> SDefinition(pipeline(withLabelS(ref, body)))
 
   private val Position1 = Env.Empty.nextPosition
   private val Env1 = Env.Empty.pushVar
@@ -327,35 +257,34 @@ private[lf] final class Compiler(
       s.SEAbs(5, body(Position1, Position2, Position3, Position4, Position5, Env5))
     )
 
-  @throws[PackageNotFound]
-  @throws[CompilationError]
-  def unsafeCompile(cmds: ImmArray[Command]): t.SExpr =
-    validateCompilation(compilationPipeline(compileCommands(Env.Empty, cmds)))
+  val phaseOne = {
+    val config1 =
+      PhaseOne.Config(
+        profiling = config.profiling,
+        stacktracing = config.stacktracing,
+      )
+    new PhaseOne(interface, config1)
+  }
 
-  @throws[PackageNotFound]
-  @throws[CompilationError]
-  def unsafeCompileForReinterpretation(cmd: Command): t.SExpr =
-    validateCompilation(compilationPipeline(compileCommandForReinterpretation(cmd)))
+  // "translate" indicates the first stage of compilation only (producing: SExpr0)
+  // "compile" indicates the full compilation pipeline (producing: SExpr)
+  private[this] def translateExp(env: Env, expr0: Expr): s.SExpr =
+    phaseOne.translateFromLF(env, expr0)
 
-  @throws[PackageNotFound]
-  @throws[CompilationError]
-  def unsafeCompile(expr: Expr): t.SExpr =
-    validateCompilation(compilationPipeline(compile(Env.Empty, expr)))
+  private[this] def compileExp(expr: Expr): t.SExpr =
+    pipeline(translateExp(Env.Empty, expr))
 
-  @throws[PackageNotFound]
-  @throws[CompilationError]
-  def unsafeClosureConvert(sexpr: s.SExpr): t.SExpr =
-    validateCompilation(compilationPipeline(sexpr))
+  private[this] def compileCommands(cmds: ImmArray[Command]): t.SExpr =
+    pipeline(translateCommands(Env.Empty, cmds))
 
-  // Run the compilation pipeline phases:
-  // (1) closure conversion
-  // (2) transform to ANF
-  private[this] def compilationPipeline(sexpr: s.SExpr): t.SExpr =
-    flattenToAnf(closureConvert(sexpr))
+  private[this] def compileCommandForReinterpretation(cmd: Command): t.SExpr =
+    pipeline(translateCommandForReinterpretation(cmd))
 
-  @throws[PackageNotFound]
-  @throws[CompilationError]
-  def unsafeCompileModule(
+  // speedy compilation phases 2,3,4 (i.e post translate-from-LF)
+  private[this] def pipeline(sexpr: s.SExpr): t.SExpr =
+    validateCompilation(flattenToAnf(closureConvert(sexpr)))
+
+  private[this] def compileModule(
       pkgId: PackageId,
       module: Module,
   ): Iterable[(t.SDefinitionRef, SDefinition)] = {
@@ -364,13 +293,13 @@ private[lf] final class Compiler(
 
     module.exceptions.foreach { case (defName, GenDefException(message)) =>
       val ref = t.ExceptionMessageDefRef(Identifier(pkgId, QualifiedName(module.name, defName)))
-      builder += (ref -> SDefinition(withLabelT(ref, unsafeCompile(message))))
+      builder += (ref -> SDefinition(withLabelT(ref, compileExp(message))))
     }
 
     module.definitions.foreach {
       case (defName, DValue(_, body, _)) =>
         val ref = t.LfDefRef(Identifier(pkgId, QualifiedName(module.name, defName)))
-        builder += (ref -> SDefinition(withLabelT(ref, unsafeCompile(body))))
+        builder += (ref -> SDefinition(withLabelT(ref, compileExp(body))))
       case _ =>
     }
 
@@ -419,10 +348,7 @@ private[lf] final class Compiler(
     *
     * @throws ValidationError if the package does not pass validations.
     */
-  @throws[PackageNotFound]
-  @throws[CompilationError]
-  @throws[ValidationError]
-  def unsafeCompilePackage(
+  private def compilePackage(
       pkgId: PackageId,
       pkg: Package,
   ): Iterable[(t.SDefinitionRef, SDefinition)] = {
@@ -452,7 +378,7 @@ private[lf] final class Compiler(
 
     val t1 = Time.Timestamp.now()
 
-    val result = pkg.modules.values.flatMap(unsafeCompileModule(pkgId, _))
+    val result = pkg.modules.values.flatMap(compileModule(pkgId, _))
 
     val t2 = Time.Timestamp.now()
     logger.trace(
@@ -462,606 +388,35 @@ private[lf] final class Compiler(
     result
   }
 
-  private[this] def compile(env: Env, expr0: Expr): s.SExpr =
-    expr0 match {
-      case EVar(name) =>
-        env.lookupExprVar(name)
-      case EVal(ref) =>
-        s.SEVal(t.LfDefRef(ref))
-      case EBuiltin(bf) =>
-        compileBuiltin(env, bf)
-      case EPrimCon(con) =>
-        compilePrimCon(con)
-      case EPrimLit(lit) =>
-        compilePrimLit(lit)
-      case EAbs(_, _, _) | ETyAbs(_, _) =>
-        compileAbss(env, expr0)
-      case EApp(_, _) | ETyApp(_, _) =>
-        compileApps(env, expr0)
-      case ERecCon(tApp, fields) =>
-        compileERecCon(env, tApp, fields)
-      case ERecProj(tapp, field, record) =>
-        SBRecProj(
-          tapp.tycon,
-          handleLookup(
-            NameOf.qualifiedNameOfCurrentFunc,
-            interface.lookupRecordFieldInfo(tapp.tycon, field),
-          ).index,
-        )(compile(env, record))
-      case erecupd: ERecUpd =>
-        compileERecUpd(env, erecupd)
-      case EStructCon(fields) =>
-        val fieldsInputOrder =
-          Struct.assertFromSeq(fields.iterator.map(_._1).zipWithIndex.toSeq)
-        s.SEApp(
-          s.SEBuiltin(SBStructCon(fieldsInputOrder)),
-          mapToArray(fields) { case (_, e) => compile(env, e) },
-        )
-      case EStructProj(field, struct) =>
-        SBStructProj(field)(compile(env, struct))
-      case EStructUpd(field, struct, update) =>
-        SBStructUpd(field)(compile(env, struct), compile(env, update))
-      case ECase(scrut, alts) =>
-        compileECase(env, scrut, alts)
-      case ENil(_) =>
-        s.SEValue.EmptyList
-      case ECons(_, front, tail) =>
-        // TODO(JM): Consider emitting SEValue(SList(...)) for
-        // constant lists?
-        val args = (front.iterator.map(compile(env, _)) ++ Seq(compile(env, tail))).toList
-        if (front.length == 1) {
-          s.SEApp(s.SEBuiltin(SBCons), args)
-        } else {
-          s.SEApp(s.SEBuiltin(SBConsMany(front.length)), args)
-        }
-      case ENone(_) =>
-        s.SEValue.None
-      case ESome(_, body) =>
-        SBSome(compile(env, body))
-      case EEnumCon(tyCon, consName) =>
-        val rank = handleLookup(
-          NameOf.qualifiedNameOfCurrentFunc,
-          interface.lookupEnumConstructor(tyCon, consName),
-        )
-        s.SEValue(SEnum(tyCon, consName, rank))
-      case EVariantCon(tapp, variant, arg) =>
-        val rank = handleLookup(
-          NameOf.qualifiedNameOfCurrentFunc,
-          interface.lookupVariantConstructor(tapp.tycon, variant),
-        ).rank
-        SBVariantCon(tapp.tycon, variant, rank)(compile(env, arg))
-      case let: ELet =>
-        compileELet(env, let)
-      case EUpdate(upd) =>
-        compileEUpdate(env, upd)
-      case ELocation(loc, EScenario(scen)) =>
-        maybeSELocation(loc, compileScenario(env, scen, Some(loc)))
-      case EScenario(scen) =>
-        compileScenario(env, scen, None)
-      case ELocation(loc, e) =>
-        maybeSELocation(loc, compile(env, e))
-      case EToAny(ty, e) =>
-        SBToAny(ty)(compile(env, e))
-      case EFromAny(ty, e) =>
-        SBFromAny(ty)(compile(env, e))
-      case ETypeRep(typ) =>
-        s.SEValue(STypeRep(typ))
-      case EToAnyException(ty, e) =>
-        SBToAny(ty)(compile(env, e))
-      case EFromAnyException(ty, e) =>
-        SBFromAny(ty)(compile(env, e))
-      case EThrow(_, ty, e) =>
-        SBThrow(SBToAny(ty)(compile(env, e)))
-      case EToInterface(iface @ _, tpl @ _, e) =>
-        compile(env, e) // interfaces have the same representation as underlying template
-      case EFromInterface(iface @ _, tpl, e) =>
-        SBFromInterface(tpl)(compile(env, e))
-      case ECallInterface(iface, methodName, e) =>
-        SBCallInterface(iface, methodName)(compile(env, e))
-      case EToRequiredInterface(requiredIfaceId @ _, requiringIfaceId @ _, body @ _) =>
-        compile(env, body)
-      case EFromRequiredInterface(requiredIfaceId @ _, requiringIfaceId, body @ _) =>
-        SBFromRequiredInterface(requiringIfaceId)(compile(env, body))
-      case EInterfaceTemplateTypeRep(ifaceId, body @ _) =>
-        SBInterfaceTemplateTypeRep(ifaceId)(compile(env, body))
-      case ESignatoryInterface(ifaceId, body @ _) =>
-        val arg = compile(env, body)
-        SBSignatoryInterface(ifaceId)(arg, arg)
-      case EObserverInterface(ifaceId, body @ _) =>
-        val arg = compile(env, body)
-        SBObserverInterface(ifaceId)(arg, arg)
-      case EExperimental(name, _) =>
-        SBExperimental(name)
-
-    }
-
   @inline
-  private[this] def compileIdentity(env: Env) = s.SEAbs(1, s.SEVarLevel(env.position))
-
-  @inline
-  private[this] def compileBuiltin(env: Env, bf: BuiltinFunction): s.SExpr = {
-
-    def SBCompareNumeric(b: SBuiltinPure) = {
-      val d = env.position
-      s.SEAbs(3, s.SEApp(s.SEBuiltin(b), List(s.SEVarLevel(d + 1), s.SEVarLevel(d + 2))))
-    }
-
-    val SBLessNumeric = SBCompareNumeric(SBLess)
-    val SBLessEqNumeric = SBCompareNumeric(SBLessEq)
-    val SBGreaterNumeric = SBCompareNumeric(SBGreater)
-    val SBGreaterEqNumeric = SBCompareNumeric(SBGreaterEq)
-    val SBEqualNumeric = SBCompareNumeric(SBEqual)
-
-    bf match {
-      case BCoerceContractId => compileIdentity(env)
-      // Numeric Comparisons
-      case BLessNumeric => SBLessNumeric
-      case BLessEqNumeric => SBLessEqNumeric
-      case BGreaterNumeric => SBGreaterNumeric
-      case BGreaterEqNumeric => SBGreaterEqNumeric
-      case BEqualNumeric => SBEqualNumeric
-      case BNumericToText => SBEToTextNumeric
-
-      case BTextMapEmpty => s.SEValue.EmptyTextMap
-      case BGenMapEmpty => s.SEValue.EmptyGenMap
-      case _ =>
-        s.SEBuiltin(bf match {
-          case BTrace => SBTrace
-
-          // Decimal arithmetic
-          case BAddNumeric => SBAddNumeric
-          case BSubNumeric => SBSubNumeric
-          case BMulNumeric => SBMulNumeric
-          case BDivNumeric => SBDivNumeric
-          case BRoundNumeric => SBRoundNumeric
-          case BCastNumeric => SBCastNumeric
-          case BShiftNumeric => SBShiftNumeric
-
-          // Int64 arithmetic
-          case BAddInt64 => SBAddInt64
-          case BSubInt64 => SBSubInt64
-          case BMulInt64 => SBMulInt64
-          case BModInt64 => SBModInt64
-          case BDivInt64 => SBDivInt64
-          case BExpInt64 => SBExpInt64
-
-          // Conversions
-          case BInt64ToNumeric => SBInt64ToNumeric
-          case BNumericToInt64 => SBNumericToInt64
-          case BDateToUnixDays => SBDateToUnixDays
-          case BUnixDaysToDate => SBUnixDaysToDate
-          case BTimestampToUnixMicroseconds => SBTimestampToUnixMicroseconds
-          case BUnixMicrosecondsToTimestamp => SBUnixMicrosecondsToTimestamp
-
-          // Text functions
-          case BExplodeText => SBExplodeText
-          case BImplodeText => SBImplodeText
-          case BAppendText => SBAppendText
-
-          case BInt64ToText => SBToText
-          case BTextToText => SBToText
-          case BTimestampToText => SBToText
-          case BPartyToText => SBToText
-          case BDateToText => SBToText
-          case BContractIdToText => SBContractIdToText
-          case BPartyToQuotedText => SBPartyToQuotedText
-          case BCodePointsToText => SBCodePointsToText
-          case BTextToParty => SBTextToParty
-          case BTextToInt64 => SBTextToInt64
-          case BTextToNumeric => SBTextToNumeric
-          case BTextToCodePoints => SBTextToCodePoints
-
-          case BSHA256Text => SBSHA256Text
-
-          // List functions
-          case BFoldl => SBFoldl
-          case BFoldr => SBFoldr
-          case BEqualList => SBEqualList
-
-          // Errors
-          case BError => SBError
-
-          // Comparison
-          case BEqualContractId => SBEqual
-          case BEqual => SBEqual
-          case BLess => SBLess
-          case BLessEq => SBLessEq
-          case BGreater => SBGreater
-          case BGreaterEq => SBGreaterEq
-
-          // TextMap
-
-          case BTextMapInsert => SBMapInsert
-          case BTextMapLookup => SBMapLookup
-          case BTextMapDelete => SBMapDelete
-          case BTextMapToList => SBMapToList
-          case BTextMapSize => SBMapSize
-
-          // GenMap
-
-          case BGenMapInsert => SBMapInsert
-          case BGenMapLookup => SBMapLookup
-          case BGenMapDelete => SBMapDelete
-          case BGenMapKeys => SBMapKeys
-          case BGenMapValues => SBMapValues
-          case BGenMapSize => SBMapSize
-
-          case BScaleBigNumeric => SBScaleBigNumeric
-          case BPrecisionBigNumeric => SBPrecisionBigNumeric
-          case BAddBigNumeric => SBAddBigNumeric
-          case BSubBigNumeric => SBSubBigNumeric
-          case BDivBigNumeric => SBDivBigNumeric
-          case BMulBigNumeric => SBMulBigNumeric
-          case BShiftRightBigNumeric => SBShiftRightBigNumeric
-          case BNumericToBigNumeric => SBNumericToBigNumeric
-          case BBigNumericToNumeric => SBBigNumericToNumeric
-          case BBigNumericToText => SBToText
-
-          // Unstable Text Primitives
-          case BTextToUpper => SBTextToUpper
-          case BTextToLower => SBTextToLower
-          case BTextSlice => SBTextSlice
-          case BTextSliceIndex => SBTextSliceIndex
-          case BTextContainsOnly => SBTextContainsOnly
-          case BTextReplicate => SBTextReplicate
-          case BTextSplitOn => SBTextSplitOn
-          case BTextIntercalate => SBTextIntercalate
-
-          // Implemented using normal SExpr
-
-          case BCoerceContractId | BLessNumeric | BLessEqNumeric | BGreaterNumeric |
-              BGreaterEqNumeric | BEqualNumeric | BNumericToText | BTextMapEmpty | BGenMapEmpty =>
-            throw CompilationError(s"unexpected $bf")
-
-          case BAnyExceptionMessage => SBAnyExceptionMessage
-        })
-    }
-  }
-
-  @inline
-  private[this] def compilePrimCon(con: PrimCon): s.SExpr =
-    con match {
-      case PCTrue => s.SEValue.True
-      case PCFalse => s.SEValue.False
-      case PCUnit => s.SEValue.Unit
-    }
-
-  @inline
-  private[this] def compilePrimLit(lit: PrimLit): s.SExpr =
-    s.SEValue(lit match {
-      case PLInt64(i) => SInt64(i)
-      case PLNumeric(d) => SNumeric(d)
-      case PLText(t) => SText(t)
-      case PLTimestamp(ts) => STimestamp(ts)
-      case PLDate(d) => SDate(d)
-      case PLRoundingMode(roundingMode) => SInt64(roundingMode.ordinal.toLong)
-    })
-
-  // ERecUpd(_, f2, ERecUpd(_, f1, e0, e1), e2) => (e0, [f1, f2], [e1, e2])
-  @inline
-  private[this] def collectRecUpds(expr: Expr): (Expr, List[Name], List[Expr]) = {
-    @tailrec
-    def go(expr: Expr, fields: List[Name], updates: List[Expr]): (Expr, List[Name], List[Expr]) =
-      stripLocs(expr) match {
-        case ERecUpd(_, field, record, update) =>
-          go(record, field :: fields, update :: updates)
-        case _ =>
-          (expr, fields, updates)
-      }
-    go(expr, List.empty, List.empty)
-  }
-
-  private def noArgs = new util.ArrayList[SValue](0)
-
-  @inline
-  private[this] def compileERecCon(
-      env: Env,
-      tApp: TypeConApp,
-      fields: ImmArray[(FieldName, Expr)],
-  ): s.SExpr =
-    if (fields.isEmpty)
-      s.SEValue(SRecord(tApp.tycon, ImmArray.Empty, noArgs))
-    else
-      s.SEApp(
-        s.SEBuiltin(SBRecCon(tApp.tycon, fields.map(_._1))),
-        fields.iterator.map(f => compile(env, f._2)).toList,
-      )
-
-  private[this] def compileERecUpd(env: Env, erecupd: ERecUpd): s.SExpr = {
-    val tapp = erecupd.tycon
-    val (record, fields, updates) = collectRecUpds(erecupd)
-    if (fields.length == 1) {
-      val index = handleLookup(
-        NameOf.qualifiedNameOfCurrentFunc,
-        interface.lookupRecordFieldInfo(tapp.tycon, fields.head),
-      ).index
-      SBRecUpd(tapp.tycon, index)(compile(env, record), compile(env, updates.head))
-    } else {
-      val indices =
-        fields.map(name =>
-          handleLookup(
-            NameOf.qualifiedNameOfCurrentFunc,
-            interface.lookupRecordFieldInfo(tapp.tycon, name),
-          ).index
-        )
-      SBRecUpdMulti(tapp.tycon, indices.to(ImmArray))((record :: updates).map(compile(env, _)): _*)
-    }
-  }
-
-  private[this] def compileECase(env: Env, scrut: Expr, alts: ImmArray[CaseAlt]): s.SExpr =
-    s.SECase(
-      compile(env, scrut),
-      mapToArray(alts) { case CaseAlt(pat, expr) =>
-        pat match {
-          case CPVariant(tycon, variant, binder) =>
-            val rank = handleLookup(
-              NameOf.qualifiedNameOfCurrentFunc,
-              interface.lookupVariantConstructor(tycon, variant),
-            ).rank
-            s.SCaseAlt(t.SCPVariant(tycon, variant, rank), compile(env.pushExprVar(binder), expr))
-
-          case CPEnum(tycon, constructor) =>
-            val rank = handleLookup(
-              NameOf.qualifiedNameOfCurrentFunc,
-              interface.lookupEnumConstructor(tycon, constructor),
-            )
-            s.SCaseAlt(t.SCPEnum(tycon, constructor, rank), compile(env, expr))
-
-          case CPNil =>
-            s.SCaseAlt(t.SCPNil, compile(env, expr))
-
-          case CPCons(head, tail) =>
-            s.SCaseAlt(t.SCPCons, compile(env.pushExprVar(head).pushExprVar(tail), expr))
-
-          case CPPrimCon(pc) =>
-            s.SCaseAlt(t.SCPPrimCon(pc), compile(env, expr))
-
-          case CPNone =>
-            s.SCaseAlt(t.SCPNone, compile(env, expr))
-
-          case CPSome(body) =>
-            s.SCaseAlt(t.SCPSome, compile(env.pushExprVar(body), expr))
-
-          case CPDefault =>
-            s.SCaseAlt(t.SCPDefault, compile(env, expr))
-        }
-      },
-    )
-
-  // Compile nested lets using constant stack.
-  @tailrec
-  private[this] def compileELet(
-      env0: Env,
-      eLet0: ELet,
-      bounds0: List[s.SExpr] = List.empty,
-  ): s.SELet = {
-    val binding = eLet0.binding
-    val bounds = withOptLabelS(binding.binder, compile(env0, binding.bound)) :: bounds0
-    val env1 = env0.pushExprVar(binding.binder)
-    eLet0.body match {
-      case eLet1: ELet =>
-        compileELet(env1, eLet1, bounds)
-      case body0 =>
-        compile(env1, body0) match {
-          case s.SELet(bounds1, body1) =>
-            s.SELet(bounds.foldLeft(bounds1)((acc, b) => b :: acc), body1)
-          case otherwise =>
-            s.SELet(bounds.reverse, otherwise)
-        }
-    }
-  }
-
-  @inline
-  private[this] def compileEUpdate(env: Env, update: Update): s.SExpr =
-    update match {
-      case UpdatePure(_, e) =>
-        compilePure(env, e)
-      case UpdateBlock(bindings, body) =>
-        compileBlock(env, bindings, body)
-      case UpdateFetch(tmplId, coidE) =>
-        t.FetchDefRef(tmplId)(compile(env, coidE))
-      case UpdateFetchInterface(ifaceId, coidE) =>
-        t.FetchDefRef(ifaceId)(compile(env, coidE))
-      case UpdateEmbedExpr(_, e) =>
-        compileEmbedExpr(env, e)
-      case UpdateCreate(tmplId, arg) =>
-        t.CreateDefRef(tmplId)(compile(env, arg))
-      case UpdateCreateInterface(iface, arg) =>
-        t.CreateDefRef(iface)(compile(env, arg))
-      case UpdateExercise(tmplId, chId, cidE, argE) =>
-        t.ChoiceDefRef(tmplId, chId)(compile(env, cidE), compile(env, argE))
-      case UpdateExerciseInterface(ifaceId, chId, cidE, argE, typeRepE, guardE) =>
-        t.GuardedChoiceDefRef(ifaceId, chId)(
-          compile(env, cidE),
-          compile(env, argE),
-          compile(env, typeRepE),
-          compile(env, guardE),
-        )
-      case UpdateExerciseByKey(tmplId, chId, keyE, argE) =>
-        t.ChoiceByKeyDefRef(tmplId, chId)(compile(env, keyE), compile(env, argE))
-      case UpdateGetTime =>
-        SEGetTime
-      case UpdateLookupByKey(RetrieveByKey(templateId, key)) =>
-        t.LookupByKeyDefRef(templateId)(compile(env, key))
-      case UpdateFetchByKey(RetrieveByKey(templateId, key)) =>
-        t.FetchByKeyDefRef(templateId)(compile(env, key))
-
-      case UpdateTryCatch(_, body, binder, handler) =>
-        unaryFunction(env) { (tokenPos, env0) =>
-          s.SETryCatch(
-            app(compile(env0, body), env0.toSEVar(tokenPos)), {
-              val env1 = env0.pushExprVar(binder)
-              SBTryHandler(
-                compile(env1, handler),
-                env1.lookupExprVar(binder),
-                env1.toSEVar(tokenPos),
-              )
-            },
-          )
-        }
-    }
-
-  @tailrec
-  private[this] def compileAbss(env: Env, expr0: Expr, arity: Int = 0): s.SExpr =
-    expr0 match {
-      case EAbs((binder, typ @ _), body, ref @ _) =>
-        compileAbss(env.pushExprVar(binder), body, arity + 1)
-      case ETyAbs((binder, KNat), body) =>
-        compileAbss(env.pushTypeVar(binder), body, arity + 1)
-      case ETyAbs((binder, _), body) =>
-        compileAbss(env.hideTypeVar(binder), body, arity)
-      case _ if arity == 0 =>
-        compile(env, expr0)
-      case _ =>
-        withLabelS(t.AnonymousClosure, s.SEAbs(arity, compile(env, expr0)))
-    }
-
-  @tailrec
-  private[this] def compileApps(env: Env, expr0: Expr, args: List[s.SExpr] = List.empty): s.SExpr =
-    expr0 match {
-      case EApp(fun, arg) =>
-        compileApps(env, fun, compile(env, arg) :: args)
-      case ETyApp(fun, arg) =>
-        compileApps(env, fun, translateType(env, arg).fold(args)(_ :: args))
-      case _ if args.isEmpty =>
-        compile(env, expr0)
-      case _ =>
-        s.SEApp(compile(env, expr0), args)
-    }
-
-  private[this] def translateType(env: Env, typ: Type): Option[s.SExpr] =
-    typ match {
-      case TNat(n) => SENat(n)
-      case TVar(name) => env.lookupTypeVar(name)
-      case _ => None
-    }
-
-  private[this] def compileScenario(env: Env, scen: Scenario, optLoc: Option[Location]): s.SExpr =
-    scen match {
-      case ScenarioPure(_, e) =>
-        compilePure(env, e)
-      case ScenarioBlock(bindings, body) =>
-        compileBlock(env, bindings, body)
-      case ScenarioCommit(partyE, updateE, _retType @ _) =>
-        compileCommit(env, partyE, updateE, optLoc, mustFail = false)
-      case ScenarioMustFailAt(partyE, updateE, _retType @ _) =>
-        compileCommit(env, partyE, updateE, optLoc, mustFail = true)
-      case ScenarioGetTime =>
-        SEGetTime
-      case ScenarioGetParty(e) =>
-        compileGetParty(env, e)
-      case ScenarioPass(relTime) =>
-        compilePass(env, relTime)
-      case ScenarioEmbedExpr(_, e) =>
-        compileEmbedExpr(env, e)
-    }
-
-  @inline
-  private[this] def compileCommit(
-      env: Env,
-      partyE: Expr,
-      updateE: Expr,
-      optLoc: Option[Location],
-      mustFail: Boolean,
-  ): s.SExpr =
-    // let party = <partyE>
-    //     update = <updateE>
-    // in $submit(mustFail)(party, update)
-    let(env, compile(env, partyE)) { (partyLoc, env) =>
-      let(env, compile(env, updateE)) { (updateLoc, env) =>
-        SBSSubmit(optLoc, mustFail)(env.toSEVar(partyLoc), env.toSEVar(updateLoc))
-      }
-    }
-
-  @inline
-  private[this] def compileGetParty(env: Env, expr: Expr): s.SExpr =
-    labeledUnaryFunction(Profile.GetPartyLabel, env) { (tokenPos, env) =>
-      SBSGetParty(compile(env, expr), env.toSEVar(tokenPos))
-    }
-
-  @inline
-  private[this] def compilePass(env: Env, time: Expr): s.SExpr =
-    labeledUnaryFunction(Profile.PassLabel, env) { (tokenPos, env) =>
-      SBSPass(compile(env, time), env.toSEVar(tokenPos))
-    }
-
-  @inline
-  private[this] def compileEmbedExpr(env: Env, expr: Expr): s.SExpr =
-    // EmbedExpr's get wrapped into an extra layer of abstraction
-    // to delay evaluation.
-    // e.g.
-    // embed (error "foo") => \token -> error "foo"
-    unaryFunction(env) { (tokenPos, env) =>
-      app(compile(env, expr), env.toSEVar(tokenPos))
-    }
-
-  private[this] def compilePure(env: Env, body: Expr): s.SExpr =
-    // pure <E>
-    // =>
-    // ((\x token -> x) <E>)
-    let(env, compile(env, body)) { (bodyPos, env) =>
-      unaryFunction(env) { (tokenPos, env) =>
-        SBSPure(env.toSEVar(bodyPos), env.toSEVar(tokenPos))
-      }
-    }
-
-  private[this] def compileBlock(env: Env, bindings: ImmArray[Binding], body: Expr): s.SExpr =
-    // do
-    //   x <- f
-    //   y <- g x
-    //   z x y
-    // =>
-    // let f' = f
-    // in \token ->
-    //   let x = f' token
-    //       y = g x token
-    //   in z x y token
-    let(env, compile(env, bindings.head.bound)) { (firstPos, env) =>
-      unaryFunction(env) { (tokenPos, env) =>
-        let(env, app(env.toSEVar(firstPos), env.toSEVar(tokenPos))) { (firstBoundPos, _env) =>
-          val env = bindings.head.binder.fold(_env)(_env.bindExprVar(_, firstBoundPos))
-
-          def loop(env: Env, list: List[Binding]): s.SExpr = list match {
-            case Binding(binder, _, bound) :: tail =>
-              let(env, app(compile(env, bound), env.toSEVar(tokenPos))) { (boundPos, _env) =>
-                val env = binder.fold(_env)(_env.bindExprVar(_, boundPos))
-                loop(env, tail)
-              }
-            case Nil =>
-              app(compile(env, body), env.toSEVar(tokenPos))
-          }
-
-          loop(env, bindings.tail.toList)
-        }
-      }
-    }
+  private[this] def translateIdentity(env: Env) = s.SEAbs(1, s.SEVarLevel(env.position))
 
   private[this] val KeyWithMaintainersStruct =
     SBStructCon(Struct.assertFromSeq(List(keyFieldName, maintainersFieldName).zipWithIndex))
 
-  private[this] def encodeKeyWithMaintainers(
+  private[this] def translateKeyWithMaintainers(
       env: Env,
       keyPos: Position,
       tmplKey: TemplateKey,
   ): s.SExpr =
     KeyWithMaintainersStruct(
       env.toSEVar(keyPos),
-      app(compile(env, tmplKey.maintainers), env.toSEVar(keyPos)),
+      app(translateExp(env, tmplKey.maintainers), env.toSEVar(keyPos)),
     )
 
-  private[this] def compileKeyWithMaintainers(
+  private[this] def translateKeyWithMaintainers(
       env: Env,
       maybeTmplKey: Option[TemplateKey],
   ): s.SExpr =
     maybeTmplKey match {
       case None => s.SEValue.None
       case Some(tmplKey) =>
-        let(env, compile(env, tmplKey.body)) { (keyPos, env) =>
-          SBSome(encodeKeyWithMaintainers(env, keyPos, tmplKey))
+        let(env, translateExp(env, tmplKey.body)) { (keyPos, env) =>
+          SBSome(translateKeyWithMaintainers(env, keyPos, tmplKey))
         }
     }
 
-  private[this] def compileChoiceBody(
+  private[this] def translateChoiceBody(
       env: Env,
       tmplId: TypeConName,
       tmpl: Template,
@@ -1091,23 +446,23 @@ private[lf] final class Compiler(
         )(
           env.toSEVar(choiceArgPos),
           env.toSEVar(cidPos),
-          compile(env, choice.controllers),
+          translateExp(env, choice.controllers),
           choice.choiceObservers match {
-            case Some(observers) => compile(env, observers)
+            case Some(observers) => translateExp(env, observers)
             case None => s.SEValue.EmptyList
           },
         ),
       ) { (_, _env) =>
         val env = _env.bindExprVar(choice.selfBinder, cidPos)
         s.SEScopeExercise(
-          app(compile(env, choice.update), env.toSEVar(tokenPos))
+          app(translateExp(env, choice.update), env.toSEVar(tokenPos))
         )
       }
     }
 
   // TODO https://github.com/digital-asset/daml/issues/12051
   //   Try to factorise this with compileChoiceBody above.
-  private[this] def compileInterfaceChoiceBody(
+  private[this] def translateInterfaceChoiceBody(
       env: Env,
       ifaceId: TypeConName,
       param: ExprVarName,
@@ -1141,15 +496,15 @@ private[lf] final class Compiler(
               env.toSEVar(payloadPos),
               env.toSEVar(choiceArgPos),
               env.toSEVar(cidPos),
-              compile(env, choice.controllers),
+              translateExp(env, choice.controllers),
               choice.choiceObservers match {
-                case Some(observers) => compile(env, observers)
+                case Some(observers) => translateExp(env, observers)
                 case None => s.SEValue.EmptyList
               },
             ),
           ) { (_, _env) =>
             val env = _env.bindExprVar(choice.selfBinder, cidPos)
-            s.SEScopeExercise(app(compile(env, choice.update), env.toSEVar(tokenPos)))
+            s.SEScopeExercise(app(translateExp(env, choice.update), env.toSEVar(tokenPos)))
           }
         }
     }
@@ -1163,7 +518,7 @@ private[lf] final class Compiler(
       (cidPos, choiceArgPos, tokenPos, env) =>
         let(env, s.SEValue(SOptional(None))) { (typeRepPos, env) =>
           let(env, s.SEBuiltin(SBGuardConstTrue)) { (guardPos, env) =>
-            compileInterfaceChoiceBody(env, ifaceId, param, choice)(
+            translateInterfaceChoiceBody(env, ifaceId, param, choice)(
               choiceArgPos,
               cidPos,
               tokenPos,
@@ -1181,7 +536,7 @@ private[lf] final class Compiler(
   ): (t.SDefinitionRef, SDefinition) =
     topLevelFunction5(t.GuardedChoiceDefRef(ifaceId, choice.name)) {
       (cidPos, choiceArgPos, typeRepPos, guardPos, tokenPos, env) =>
-        compileInterfaceChoiceBody(env, ifaceId, param, choice)(
+        translateInterfaceChoiceBody(env, ifaceId, param, choice)(
           choiceArgPos,
           cidPos,
           tokenPos,
@@ -1204,7 +559,7 @@ private[lf] final class Compiler(
     //   in <retValue>
     topLevelFunction3(t.ChoiceDefRef(tmplId, choice.name)) {
       (cidPos, choiceArgPos, tokenPos, env) =>
-        compileChoiceBody(env, tmplId, tmpl, choice)(
+        translateChoiceBody(env, tmplId, tmpl, choice)(
           choiceArgPos,
           cidPos,
           None,
@@ -1230,9 +585,9 @@ private[lf] final class Compiler(
     //   in  <retValue>
     topLevelFunction3(t.ChoiceByKeyDefRef(tmplId, choice.name)) {
       (keyPos, choiceArgPos, tokenPos, env) =>
-        let(env, encodeKeyWithMaintainers(env, keyPos, tmplKey)) { (keyWithMPos, env) =>
+        let(env, translateKeyWithMaintainers(env, keyPos, tmplKey)) { (keyWithMPos, env) =>
           let(env, SBUFetchKey(tmplId)(env.toSEVar(keyWithMPos))) { (cidPos, env) =>
-            compileChoiceBody(env, tmplId, tmpl, choice)(
+            translateChoiceBody(env, tmplId, tmpl, choice)(
               choiceArgPos,
               cidPos,
               Some(keyWithMPos),
@@ -1240,13 +595,6 @@ private[lf] final class Compiler(
             )
           }
         }
-    }
-
-  @tailrec
-  private[this] def stripLocs(expr: Expr): Expr =
-    expr match {
-      case ELocation(_, expr1) => stripLocs(expr1)
-      case _ => expr
     }
 
   @nowarn("msg=parameter value tokenPos in method compileFetchBody is never used")
@@ -1314,7 +662,7 @@ private[lf] final class Compiler(
       expr: Expr,
   ) =
     topLevelFunction1(t.InterfacePrecondDefRef(iface))((argPos, env) =>
-      compile(env.bindExprVar(param, argPos), expr)
+      translateExp(env.bindExprVar(param, argPos), expr)
     )
 
   private[this] def compileKey(
@@ -1322,7 +670,7 @@ private[lf] final class Compiler(
       tmpl: Template,
   ): (t.SDefinitionRef, SDefinition) =
     topLevelFunction1(t.KeyDefRef(tmplId)) { (tmplArgPos, env) =>
-      compileKeyWithMaintainers(env.bindExprVar(tmpl.param, tmplArgPos), tmpl.key)
+      translateKeyWithMaintainers(env.bindExprVar(tmpl.param, tmplArgPos), tmpl.key)
     }
 
   private[this] def compileSignatories(
@@ -1330,7 +678,7 @@ private[lf] final class Compiler(
       tmpl: Template,
   ): (t.SDefinitionRef, SDefinition) =
     topLevelFunction1(t.SignatoriesDefRef(tmplId)) { (tmplArgPos, env) =>
-      compile(env.bindExprVar(tmpl.param, tmplArgPos), tmpl.signatories)
+      translateExp(env.bindExprVar(tmpl.param, tmplArgPos), tmpl.signatories)
     }
 
   private[this] def compileObservers(
@@ -1338,7 +686,7 @@ private[lf] final class Compiler(
       tmpl: Template,
   ): (t.SDefinitionRef, SDefinition) =
     topLevelFunction1(t.ObserversDefRef(tmplId)) { (tmplArgPos, env) =>
-      compile(env.bindExprVar(tmpl.param, tmplArgPos), tmpl.observers)
+      translateExp(env.bindExprVar(tmpl.param, tmplArgPos), tmpl.observers)
     }
 
   // Turn a template value into an interface value. Since interfaces have a
@@ -1350,7 +698,7 @@ private[lf] final class Compiler(
       ifaceId: Identifier,
   ): (t.SDefinitionRef, SDefinition) =
     t.ImplementsDefRef(tmplId, ifaceId) ->
-      SDefinition(unsafeClosureConvert(compileIdentity(Env.Empty)))
+      SDefinition(pipeline(translateIdentity(Env.Empty)))
 
   // Compile the implementation of an interface method.
   private[this] def compileImplementsMethod(
@@ -1359,10 +707,10 @@ private[lf] final class Compiler(
       method: TemplateImplementsMethod,
   ): (t.SDefinitionRef, SDefinition) = {
     val ref = t.ImplementsMethodDefRef(tmplId, ifaceId, method.name)
-    ref -> SDefinition(withLabelT(ref, unsafeCompile(method.value)))
+    ref -> SDefinition(withLabelT(ref, compileExp(method.value)))
   }
 
-  private[this] def compileCreateBody(
+  private[this] def translateCreateBody(
       tmplId: Identifier,
       tmpl: Template,
       byInterface: Option[Identifier],
@@ -1377,7 +725,7 @@ private[lf] final class Compiler(
     // TODO Clean this up as part of changing how we evaluate these
     // https://github.com/digital-asset/daml/issues/11762
     val precondsArray: ImmArray[s.SExpr] =
-      (Iterator(compile(env2, tmpl.precond)) ++ implementsPrecondsIterator ++ Iterator(
+      (Iterator(translateExp(env2, tmpl.precond)) ++ implementsPrecondsIterator ++ Iterator(
         s.SEValue.EmptyList
       )).to(ImmArray)
     val preconds = s.SEApp(s.SEBuiltin(SBConsMany(precondsArray.length - 1)), precondsArray.toList)
@@ -1387,10 +735,10 @@ private[lf] final class Compiler(
     let(env2, SBCheckPrecond(tmplId)(env2.toSEVar(tmplArgPos), preconds)) { (_, env) =>
       SBUCreate(tmplId, byInterface)(
         env.toSEVar(tmplArgPos),
-        compile(env, tmpl.agreementText),
-        compile(env, tmpl.signatories),
-        compile(env, tmpl.observers),
-        compileKeyWithMaintainers(env, tmpl.key),
+        translateExp(env, tmpl.agreementText),
+        translateExp(env, tmpl.signatories),
+        translateExp(env, tmpl.observers),
+        translateKeyWithMaintainers(env, tmpl.key),
       )
     }
   }
@@ -1404,7 +752,7 @@ private[lf] final class Compiler(
     //   let _ = $checkPrecond(tmplId)(<tmplArg> [tmpl.precond ++ [precond | precond <- tmpl.implements]]
     //   in $create <tmplArg> [tmpl.agreementText] [tmpl.signatories] [tmpl.observers] [tmpl.key]
     topLevelFunction2(t.CreateDefRef(tmplId))((tmplArgPos, _, env) =>
-      compileCreateBody(tmplId, tmpl, None, tmplArgPos, env)
+      translateCreateBody(tmplId, tmpl, None, tmplArgPos, env)
     )
   }
 
@@ -1415,7 +763,7 @@ private[lf] final class Compiler(
   ): (t.SDefinitionRef, SDefinition) = {
     // Similar to compileCreate, but sets the 'byInterface' field in the transaction.
     topLevelFunction2(t.CreateByInterfaceDefRef(tmplId, ifaceId))((tmplArgPos, _, env) =>
-      compileCreateBody(tmplId, tmpl, Some(ifaceId), tmplArgPos, env)
+      translateCreateBody(tmplId, tmpl, Some(ifaceId), tmplArgPos, env)
     )
   }
 
@@ -1460,7 +808,7 @@ private[lf] final class Compiler(
     //        _ = $insertLookup(tmplId> <keyWithM> <mbCid>
     //    in <mbCid>
     topLevelFunction2(t.LookupByKeyDefRef(tmplId)) { (keyPos, _, env) =>
-      let(env, encodeKeyWithMaintainers(env, keyPos, tmplKey)) { (keyWithMPos, env) =>
+      let(env, translateKeyWithMaintainers(env, keyPos, tmplKey)) { (keyWithMPos, env) =>
         let(env, SBULookupKey(tmplId)(env.toSEVar(keyWithMPos))) { (maybeCidPos, env) =>
           let(
             env,
@@ -1489,7 +837,7 @@ private[lf] final class Compiler(
     //        _ = $insertFetch <coid> <signatories> <observers> (Some <keyWithM> )
     //    in { contractId: ContractId Foo, contract: Foo }
     topLevelFunction2(t.FetchByKeyDefRef(tmplId)) { (keyPos, tokenPos, env) =>
-      let(env, encodeKeyWithMaintainers(env, keyPos, tmplKey)) { (keyWithMPos, env) =>
+      let(env, translateKeyWithMaintainers(env, keyPos, tmplKey)) { (keyWithMPos, env) =>
         let(env, SBUFetchKey(tmplId)(env.toSEVar(keyWithMPos))) { (cidPos, env) =>
           let(env, compileFetchBody(env, tmplId, tmpl)(cidPos, Some(keyWithMPos), tokenPos)) {
             (contractPos, env) =>
@@ -1531,7 +879,7 @@ private[lf] final class Compiler(
       }
     }
 
-  private[this] def compileCommand(env: Env, cmd: Command): s.SExpr = cmd match {
+  private[this] def translateCommand(env: Env, cmd: Command): s.SExpr = cmd match {
     case Command.Create(templateId, argument) =>
       t.CreateDefRef(templateId)(s.SEValue(argument))
     case Command.CreateByInterface(interfaceId, templateId, argument) =>
@@ -1577,23 +925,23 @@ private[lf] final class Compiler(
       )
     }
 
-  private[this] def compileCommandForReinterpretation(cmd: Command): s.SExpr =
-    catchEverything(compileCommand(Env.Empty, cmd))
+  private[this] def translateCommandForReinterpretation(cmd: Command): s.SExpr =
+    catchEverything(translateCommand(Env.Empty, cmd))
 
-  private[this] def compileCommands(env: Env, bindings: ImmArray[Command]): s.SExpr =
+  private[this] def translateCommands(env: Env, bindings: ImmArray[Command]): s.SExpr =
     // commands are compile similarly as update block
     // see compileBlock
     bindings.toList match {
       case Nil =>
         SEUpdatePureUnit
       case first :: rest =>
-        let(env, compileCommand(env, first)) { (firstPos, env) =>
+        let(env, translateCommand(env, first)) { (firstPos, env) =>
           unaryFunction(env) { (tokenPos, env) =>
             let(env, app(env.toSEVar(firstPos), env.toSEVar(tokenPos))) { (_, _env) =>
               // we cannot process `rest` recursively without exposing ourselves to stack overflow.
               var env = _env
               val exprs = rest.map { cmd =>
-                val expr = app(compileCommand(env, cmd), env.toSEVar(tokenPos))
+                val expr = app(translateCommand(env, cmd), env.toSEVar(tokenPos))
                 env = env.pushVar
                 expr
               }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
@@ -1,0 +1,774 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import java.util
+
+import com.daml.lf.data.Ref._
+import com.daml.lf.data.{ImmArray, Numeric, Struct}
+import com.daml.lf.language.Ast._
+import com.daml.lf.language.{LookupError, PackageInterface}
+import com.daml.lf.speedy.Compiler.{ProfilingMode, StackTraceMode, CompilationError}
+import com.daml.lf.speedy.SBuiltin._
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.{SExpr => t}
+import com.daml.lf.speedy.{SExpr0 => s}
+import com.daml.nameof.NameOf
+
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+
+private[speedy] object PhaseOne {
+
+  case class Config(
+      profiling: ProfilingMode,
+      stacktracing: StackTraceMode,
+  )
+
+  private val SEGetTime = s.SEBuiltin(SBGetTime)
+
+  private val SBEToTextNumeric = s.SEAbs(1, s.SEBuiltin(SBToText))
+
+  private val SENat: Numeric.Scale => Some[s.SEValue] =
+    Numeric.Scale.values.map(n => Some(s.SEValue(STNat(n))))
+
+  // Hand-implemented `map` uses less stack.
+  private def mapToArray[A, B: ClassTag](input: ImmArray[A])(f: A => B): List[B] = {
+    val output = Array.ofDim[B](input.length)
+    var i = 0
+    input.foreach { value =>
+      output(i) = f(value)
+      i += 1
+    }
+    output.toList
+  }
+
+  private[speedy] abstract class VarRef { def name: Name }
+  // corresponds to Daml-LF expression variable.
+  private[this] case class EVarRef(name: ExprVarName) extends VarRef
+  // corresponds to Daml-LF type variable.
+  private[this] case class TVarRef(name: TypeVarName) extends VarRef
+
+  case class Position(idx: Int)
+
+  private[speedy] object Env {
+    val Empty = Env(0, Map.empty)
+  }
+
+  private[speedy] case class Env(
+      position: Int,
+      varIndices: Map[VarRef, Position],
+  ) {
+
+    def toSEVar(p: Position) = s.SEVarLevel(p.idx)
+
+    def nextPosition = Position(position)
+
+    def pushVar: Env = copy(position = position + 1)
+
+    private[this] def bindVar(ref: VarRef, p: Position) =
+      copy(varIndices = varIndices.updated(ref, p))
+
+    def pushVar(ref: VarRef): Env =
+      bindVar(ref, nextPosition).pushVar
+
+    def pushExprVar(name: ExprVarName): Env =
+      pushVar(EVarRef(name))
+
+    def pushExprVar(maybeName: Option[ExprVarName]): Env =
+      maybeName match {
+        case Some(name) => pushExprVar(name)
+        case None => pushVar
+      }
+
+    def pushTypeVar(name: ExprVarName): Env =
+      pushVar(TVarRef(name))
+
+    def hideTypeVar(name: TypeVarName): Env =
+      copy(varIndices = varIndices - TVarRef(name))
+
+    def bindExprVar(name: ExprVarName, p: Position): Env =
+      bindVar(EVarRef(name), p)
+
+    private[this] def vars: List[VarRef] = varIndices.keys.toList
+
+    private[this] def lookupVar(varRef: VarRef): Option[s.SExpr] =
+      varIndices.get(varRef).map(toSEVar)
+
+    def lookupExprVar(name: ExprVarName): s.SExpr =
+      lookupVar(EVarRef(name))
+        .getOrElse(throw CompilationError(s"Unknown variable: $name. Known: ${vars.mkString(",")}"))
+
+    def lookupTypeVar(name: TypeVarName): Option[s.SExpr] =
+      lookupVar(TVarRef(name))
+  }
+
+}
+
+private[lf] final class PhaseOne(
+    interface: PackageInterface,
+    config: PhaseOne.Config,
+) {
+
+  import PhaseOne._
+
+  // Entry point for stage1 of speedy compilation pipeline
+  // TODO https://github.com/digital-asset/daml/issues/11561
+  // - reimplement this function to be stack safe
+  @throws[CompilationError]
+  private[speedy] def translateFromLF(env: Env, expr0: Expr): s.SExpr = {
+    compile(env, expr0)
+  }
+
+  private[this] def handleLookup[X](location: String, x: Either[LookupError, X]) =
+    x match {
+      case Right(value) => value
+      case Left(err) => throw SError.SErrorCrash(location, err.pretty)
+    }
+
+  // Stack-trace support is disabled by avoiding the construction of SELocation nodes.
+  private[this] def maybeSELocation(loc: Location, sexp: s.SExpr): s.SExpr = {
+    config.stacktracing match {
+      case Compiler.NoStackTrace => sexp
+      case Compiler.FullStackTrace => s.SELocation(loc, sexp)
+    }
+  }
+
+  private[this] val withLabelS: (Profile.Label, s.SExpr) => s.SExpr =
+    config.profiling match {
+      case Compiler.NoProfile => { (_, expr) =>
+        expr
+      }
+      case Compiler.FullProfile => { (label, expr) =>
+        expr match {
+          case s.SELabelClosure(_, expr1) => s.SELabelClosure(label, expr1)
+          case _ => s.SELabelClosure(label, expr)
+        }
+      }
+    }
+
+  private[this] def withOptLabelS[L: Profile.LabelModule.Allowed](
+      optLabel: Option[L with AnyRef],
+      expr: s.SExpr,
+  ): s.SExpr =
+    optLabel match {
+      case Some(label) => withLabelS(label, expr)
+      case None => expr
+    }
+
+  private[this] def app(f: s.SExpr, a: s.SExpr) = s.SEApp(f, List(a))
+
+  private[this] def let(env: Env, bound: s.SExpr)(f: (Position, Env) => s.SExpr): s.SELet =
+    f(env.nextPosition, env.pushVar) match {
+      case s.SELet(bounds, body) =>
+        s.SELet(bound :: bounds, body)
+      case otherwise =>
+        s.SELet(List(bound), otherwise)
+    }
+
+  private[this] def unaryFunction(env: Env)(f: (Position, Env) => s.SExpr): s.SEAbs =
+    f(env.nextPosition, env.pushVar) match {
+      case s.SEAbs(n, body) => s.SEAbs(n + 1, body)
+      case otherwise => s.SEAbs(1, otherwise)
+    }
+
+  private[this] def labeledUnaryFunction[L: Profile.LabelModule.Allowed](
+      label: L with AnyRef,
+      env: Env,
+  )(
+      body: (Position, Env) => s.SExpr
+  ): s.SExpr =
+    unaryFunction(env)((positions, env) => withLabelS(label, body(positions, env)))
+
+  private[this] def compile(env: Env, expr0: Expr): s.SExpr =
+    expr0 match {
+      case EVar(name) =>
+        env.lookupExprVar(name)
+      case EVal(ref) =>
+        s.SEVal(t.LfDefRef(ref))
+      case EBuiltin(bf) =>
+        compileBuiltin(env, bf)
+      case EPrimCon(con) =>
+        compilePrimCon(con)
+      case EPrimLit(lit) =>
+        compilePrimLit(lit)
+      case EAbs(_, _, _) | ETyAbs(_, _) =>
+        compileAbss(env, expr0)
+      case EApp(_, _) | ETyApp(_, _) =>
+        compileApps(env, expr0)
+      case ERecCon(tApp, fields) =>
+        compileERecCon(env, tApp, fields)
+      case ERecProj(tapp, field, record) =>
+        SBRecProj(
+          tapp.tycon,
+          handleLookup(
+            NameOf.qualifiedNameOfCurrentFunc,
+            interface.lookupRecordFieldInfo(tapp.tycon, field),
+          ).index,
+        )(compile(env, record))
+      case erecupd: ERecUpd =>
+        compileERecUpd(env, erecupd)
+      case EStructCon(fields) =>
+        val fieldsInputOrder =
+          Struct.assertFromSeq(fields.iterator.map(_._1).zipWithIndex.toSeq)
+        s.SEApp(
+          s.SEBuiltin(SBStructCon(fieldsInputOrder)),
+          mapToArray(fields) { case (_, e) => compile(env, e) },
+        )
+      case EStructProj(field, struct) =>
+        SBStructProj(field)(compile(env, struct))
+      case EStructUpd(field, struct, update) =>
+        SBStructUpd(field)(compile(env, struct), compile(env, update))
+      case ECase(scrut, alts) =>
+        compileECase(env, scrut, alts)
+      case ENil(_) =>
+        s.SEValue.EmptyList
+      case ECons(_, front, tail) =>
+        // TODO(JM): Consider emitting SEValue(SList(...)) for
+        // constant lists?
+        val args =
+          (front.iterator.map(compile(env, _)) ++ Seq(compile(env, tail))).toList
+        if (front.length == 1) {
+          s.SEApp(s.SEBuiltin(SBCons), args)
+        } else {
+          s.SEApp(s.SEBuiltin(SBConsMany(front.length)), args)
+        }
+      case ENone(_) =>
+        s.SEValue.None
+      case ESome(_, body) =>
+        SBSome(compile(env, body))
+      case EEnumCon(tyCon, consName) =>
+        val rank = handleLookup(
+          NameOf.qualifiedNameOfCurrentFunc,
+          interface.lookupEnumConstructor(tyCon, consName),
+        )
+        s.SEValue(SEnum(tyCon, consName, rank))
+      case EVariantCon(tapp, variant, arg) =>
+        val rank = handleLookup(
+          NameOf.qualifiedNameOfCurrentFunc,
+          interface.lookupVariantConstructor(tapp.tycon, variant),
+        ).rank
+        SBVariantCon(tapp.tycon, variant, rank)(compile(env, arg))
+      case let: ELet =>
+        compileELet(env, let)
+      case EUpdate(upd) =>
+        compileEUpdate(env, upd)
+      case ELocation(loc, EScenario(scen)) =>
+        maybeSELocation(loc, compileScenario(env, scen, Some(loc)))
+      case EScenario(scen) =>
+        compileScenario(env, scen, None)
+      case ELocation(loc, e) =>
+        maybeSELocation(loc, compile(env, e))
+      case EToAny(ty, e) =>
+        SBToAny(ty)(compile(env, e))
+      case EFromAny(ty, e) =>
+        SBFromAny(ty)(compile(env, e))
+      case ETypeRep(typ) =>
+        s.SEValue(STypeRep(typ))
+      case EToAnyException(ty, e) =>
+        SBToAny(ty)(compile(env, e))
+      case EFromAnyException(ty, e) =>
+        SBFromAny(ty)(compile(env, e))
+      case EThrow(_, ty, e) =>
+        SBThrow(SBToAny(ty)(compile(env, e)))
+      case EToInterface(iface @ _, tpl @ _, e) =>
+        compile(env, e) // interfaces have the same representation as underlying template
+      case EFromInterface(iface @ _, tpl, e) =>
+        SBFromInterface(tpl)(compile(env, e))
+      case ECallInterface(iface, methodName, e) =>
+        SBCallInterface(iface, methodName)(compile(env, e))
+      case EToRequiredInterface(requiredIfaceId @ _, requiringIfaceId @ _, body @ _) =>
+        compile(env, body)
+      case EFromRequiredInterface(requiredIfaceId @ _, requiringIfaceId, body @ _) =>
+        SBFromRequiredInterface(requiringIfaceId)(compile(env, body))
+      case EInterfaceTemplateTypeRep(ifaceId, body @ _) =>
+        SBInterfaceTemplateTypeRep(ifaceId)(compile(env, body))
+      case ESignatoryInterface(ifaceId, body @ _) =>
+        val arg = compile(env, body)
+        SBSignatoryInterface(ifaceId)(arg, arg)
+      case EObserverInterface(ifaceId, body @ _) =>
+        val arg = compile(env, body)
+        SBObserverInterface(ifaceId)(arg, arg)
+      case EExperimental(name, _) =>
+        SBExperimental(name)
+    }
+
+  @inline
+  private[this] def compileIdentity(env: Env) = s.SEAbs(1, s.SEVarLevel(env.position))
+
+  @inline
+  private[this] def compileBuiltin(env: Env, bf: BuiltinFunction): s.SExpr = {
+
+    def SBCompareNumeric(b: SBuiltinPure) = {
+      val d = env.position
+      s.SEAbs(3, s.SEApp(s.SEBuiltin(b), List(s.SEVarLevel(d + 1), s.SEVarLevel(d + 2))))
+    }
+
+    val SBLessNumeric = SBCompareNumeric(SBLess)
+    val SBLessEqNumeric = SBCompareNumeric(SBLessEq)
+    val SBGreaterNumeric = SBCompareNumeric(SBGreater)
+    val SBGreaterEqNumeric = SBCompareNumeric(SBGreaterEq)
+    val SBEqualNumeric = SBCompareNumeric(SBEqual)
+
+    bf match {
+      case BCoerceContractId => compileIdentity(env)
+      // Numeric Comparisons
+      case BLessNumeric => SBLessNumeric
+      case BLessEqNumeric => SBLessEqNumeric
+      case BGreaterNumeric => SBGreaterNumeric
+      case BGreaterEqNumeric => SBGreaterEqNumeric
+      case BEqualNumeric => SBEqualNumeric
+      case BNumericToText => SBEToTextNumeric
+
+      case BTextMapEmpty => s.SEValue.EmptyTextMap
+      case BGenMapEmpty => s.SEValue.EmptyGenMap
+      case _ =>
+        s.SEBuiltin(bf match {
+          case BTrace => SBTrace
+
+          // Decimal arithmetic
+          case BAddNumeric => SBAddNumeric
+          case BSubNumeric => SBSubNumeric
+          case BMulNumeric => SBMulNumeric
+          case BDivNumeric => SBDivNumeric
+          case BRoundNumeric => SBRoundNumeric
+          case BCastNumeric => SBCastNumeric
+          case BShiftNumeric => SBShiftNumeric
+
+          // Int64 arithmetic
+          case BAddInt64 => SBAddInt64
+          case BSubInt64 => SBSubInt64
+          case BMulInt64 => SBMulInt64
+          case BModInt64 => SBModInt64
+          case BDivInt64 => SBDivInt64
+          case BExpInt64 => SBExpInt64
+
+          // Conversions
+          case BInt64ToNumeric => SBInt64ToNumeric
+          case BNumericToInt64 => SBNumericToInt64
+          case BDateToUnixDays => SBDateToUnixDays
+          case BUnixDaysToDate => SBUnixDaysToDate
+          case BTimestampToUnixMicroseconds => SBTimestampToUnixMicroseconds
+          case BUnixMicrosecondsToTimestamp => SBUnixMicrosecondsToTimestamp
+
+          // Text functions
+          case BExplodeText => SBExplodeText
+          case BImplodeText => SBImplodeText
+          case BAppendText => SBAppendText
+
+          case BInt64ToText => SBToText
+          case BTextToText => SBToText
+          case BTimestampToText => SBToText
+          case BPartyToText => SBToText
+          case BDateToText => SBToText
+          case BContractIdToText => SBContractIdToText
+          case BPartyToQuotedText => SBPartyToQuotedText
+          case BCodePointsToText => SBCodePointsToText
+          case BTextToParty => SBTextToParty
+          case BTextToInt64 => SBTextToInt64
+          case BTextToNumeric => SBTextToNumeric
+          case BTextToCodePoints => SBTextToCodePoints
+
+          case BSHA256Text => SBSHA256Text
+
+          // List functions
+          case BFoldl => SBFoldl
+          case BFoldr => SBFoldr
+          case BEqualList => SBEqualList
+
+          // Errors
+          case BError => SBError
+
+          // Comparison
+          case BEqualContractId => SBEqual
+          case BEqual => SBEqual
+          case BLess => SBLess
+          case BLessEq => SBLessEq
+          case BGreater => SBGreater
+          case BGreaterEq => SBGreaterEq
+
+          // TextMap
+
+          case BTextMapInsert => SBMapInsert
+          case BTextMapLookup => SBMapLookup
+          case BTextMapDelete => SBMapDelete
+          case BTextMapToList => SBMapToList
+          case BTextMapSize => SBMapSize
+
+          // GenMap
+
+          case BGenMapInsert => SBMapInsert
+          case BGenMapLookup => SBMapLookup
+          case BGenMapDelete => SBMapDelete
+          case BGenMapKeys => SBMapKeys
+          case BGenMapValues => SBMapValues
+          case BGenMapSize => SBMapSize
+
+          case BScaleBigNumeric => SBScaleBigNumeric
+          case BPrecisionBigNumeric => SBPrecisionBigNumeric
+          case BAddBigNumeric => SBAddBigNumeric
+          case BSubBigNumeric => SBSubBigNumeric
+          case BDivBigNumeric => SBDivBigNumeric
+          case BMulBigNumeric => SBMulBigNumeric
+          case BShiftRightBigNumeric => SBShiftRightBigNumeric
+          case BNumericToBigNumeric => SBNumericToBigNumeric
+          case BBigNumericToNumeric => SBBigNumericToNumeric
+          case BBigNumericToText => SBToText
+
+          // Unstable Text Primitives
+          case BTextToUpper => SBTextToUpper
+          case BTextToLower => SBTextToLower
+          case BTextSlice => SBTextSlice
+          case BTextSliceIndex => SBTextSliceIndex
+          case BTextContainsOnly => SBTextContainsOnly
+          case BTextReplicate => SBTextReplicate
+          case BTextSplitOn => SBTextSplitOn
+          case BTextIntercalate => SBTextIntercalate
+
+          // Implemented using normal SExpr
+
+          case BCoerceContractId | BLessNumeric | BLessEqNumeric | BGreaterNumeric |
+              BGreaterEqNumeric | BEqualNumeric | BNumericToText | BTextMapEmpty | BGenMapEmpty =>
+            throw CompilationError(s"unexpected $bf")
+
+          case BAnyExceptionMessage => SBAnyExceptionMessage
+        })
+    }
+  }
+
+  @inline
+  private[this] def compilePrimCon(con: PrimCon): s.SExpr =
+    con match {
+      case PCTrue => s.SEValue.True
+      case PCFalse => s.SEValue.False
+      case PCUnit => s.SEValue.Unit
+    }
+
+  @inline
+  private[this] def compilePrimLit(lit: PrimLit): s.SExpr =
+    s.SEValue(lit match {
+      case PLInt64(i) => SInt64(i)
+      case PLNumeric(d) => SNumeric(d)
+      case PLText(t) => SText(t)
+      case PLTimestamp(ts) => STimestamp(ts)
+      case PLDate(d) => SDate(d)
+      case PLRoundingMode(roundingMode) => SInt64(roundingMode.ordinal.toLong)
+    })
+
+  // ERecUpd(_, f2, ERecUpd(_, f1, e0, e1), e2) => (e0, [f1, f2], [e1, e2])
+  @inline
+  private[this] def collectRecUpds(expr: Expr): (Expr, List[Name], List[Expr]) = {
+    @tailrec
+    def go(expr: Expr, fields: List[Name], updates: List[Expr]): (Expr, List[Name], List[Expr]) =
+      stripLocs(expr) match {
+        case ERecUpd(_, field, record, update) =>
+          go(record, field :: fields, update :: updates)
+        case _ =>
+          (expr, fields, updates)
+      }
+    go(expr, List.empty, List.empty)
+  }
+
+  private def noArgs = new util.ArrayList[SValue](0)
+
+  @inline
+  private[this] def compileERecCon(
+      env: Env,
+      tApp: TypeConApp,
+      fields: ImmArray[(FieldName, Expr)],
+  ): s.SExpr =
+    if (fields.isEmpty)
+      s.SEValue(SRecord(tApp.tycon, ImmArray.Empty, noArgs))
+    else
+      s.SEApp(
+        s.SEBuiltin(SBRecCon(tApp.tycon, fields.map(_._1))),
+        fields.iterator.map(f => compile(env, f._2)).toList,
+      )
+
+  private[this] def compileERecUpd(env: Env, erecupd: ERecUpd): s.SExpr = {
+    val tapp = erecupd.tycon
+    val (record, fields, updates) = collectRecUpds(erecupd)
+    if (fields.length == 1) {
+      val index = handleLookup(
+        NameOf.qualifiedNameOfCurrentFunc,
+        interface.lookupRecordFieldInfo(tapp.tycon, fields.head),
+      ).index
+      SBRecUpd(tapp.tycon, index)(compile(env, record), compile(env, updates.head))
+    } else {
+      val indices =
+        fields.map(name =>
+          handleLookup(
+            NameOf.qualifiedNameOfCurrentFunc,
+            interface.lookupRecordFieldInfo(tapp.tycon, name),
+          ).index
+        )
+      SBRecUpdMulti(tapp.tycon, indices.to(ImmArray))(
+        (record :: updates).map(compile(env, _)): _*
+      )
+    }
+  }
+
+  private[this] def compileECase(env: Env, scrut: Expr, alts: ImmArray[CaseAlt]): s.SExpr =
+    s.SECase(
+      compile(env, scrut),
+      mapToArray(alts) { case CaseAlt(pat, expr) =>
+        pat match {
+          case CPVariant(tycon, variant, binder) =>
+            val rank = handleLookup(
+              NameOf.qualifiedNameOfCurrentFunc,
+              interface.lookupVariantConstructor(tycon, variant),
+            ).rank
+            s.SCaseAlt(
+              t.SCPVariant(tycon, variant, rank),
+              compile(env.pushExprVar(binder), expr),
+            )
+
+          case CPEnum(tycon, constructor) =>
+            val rank = handleLookup(
+              NameOf.qualifiedNameOfCurrentFunc,
+              interface.lookupEnumConstructor(tycon, constructor),
+            )
+            s.SCaseAlt(t.SCPEnum(tycon, constructor, rank), compile(env, expr))
+
+          case CPNil =>
+            s.SCaseAlt(t.SCPNil, compile(env, expr))
+
+          case CPCons(head, tail) =>
+            s.SCaseAlt(t.SCPCons, compile(env.pushExprVar(head).pushExprVar(tail), expr))
+
+          case CPPrimCon(pc) =>
+            s.SCaseAlt(t.SCPPrimCon(pc), compile(env, expr))
+
+          case CPNone =>
+            s.SCaseAlt(t.SCPNone, compile(env, expr))
+
+          case CPSome(body) =>
+            s.SCaseAlt(t.SCPSome, compile(env.pushExprVar(body), expr))
+
+          case CPDefault =>
+            s.SCaseAlt(t.SCPDefault, compile(env, expr))
+        }
+      },
+    )
+
+  // Compile nested lets using constant stack.
+  @tailrec
+  private[this] def compileELet(
+      env0: Env,
+      eLet0: ELet,
+      bounds0: List[s.SExpr] = List.empty,
+  ): s.SELet = {
+    val binding = eLet0.binding
+    val bounds = withOptLabelS(binding.binder, compile(env0, binding.bound)) :: bounds0
+    val env1 = env0.pushExprVar(binding.binder)
+    eLet0.body match {
+      case eLet1: ELet =>
+        compileELet(env1, eLet1, bounds)
+      case body0 =>
+        compile(env1, body0) match {
+          case s.SELet(bounds1, body1) =>
+            s.SELet(bounds.foldLeft(bounds1)((acc, b) => b :: acc), body1)
+          case otherwise =>
+            s.SELet(bounds.reverse, otherwise)
+        }
+    }
+  }
+
+  @inline
+  private[this] def compileEUpdate(env: Env, update: Update): s.SExpr =
+    update match {
+      case UpdatePure(_, e) =>
+        compilePure(env, e)
+      case UpdateBlock(bindings, body) =>
+        compileBlock(env, bindings, body)
+      case UpdateFetch(tmplId, coidE) =>
+        t.FetchDefRef(tmplId)(compile(env, coidE))
+      case UpdateFetchInterface(ifaceId, coidE) =>
+        t.FetchDefRef(ifaceId)(compile(env, coidE))
+      case UpdateEmbedExpr(_, e) =>
+        compileEmbedExpr(env, e)
+      case UpdateCreate(tmplId, arg) =>
+        t.CreateDefRef(tmplId)(compile(env, arg))
+      case UpdateCreateInterface(iface, arg) =>
+        t.CreateDefRef(iface)(compile(env, arg))
+      case UpdateExercise(tmplId, chId, cidE, argE) =>
+        t.ChoiceDefRef(tmplId, chId)(compile(env, cidE), compile(env, argE))
+      case UpdateExerciseInterface(ifaceId, chId, cidE, argE, typeRepE, guardE) =>
+        t.GuardedChoiceDefRef(ifaceId, chId)(
+          compile(env, cidE),
+          compile(env, argE),
+          compile(env, typeRepE),
+          compile(env, guardE),
+        )
+      case UpdateExerciseByKey(tmplId, chId, keyE, argE) =>
+        t.ChoiceByKeyDefRef(tmplId, chId)(compile(env, keyE), compile(env, argE))
+      case UpdateGetTime =>
+        SEGetTime
+      case UpdateLookupByKey(RetrieveByKey(templateId, key)) =>
+        t.LookupByKeyDefRef(templateId)(compile(env, key))
+      case UpdateFetchByKey(RetrieveByKey(templateId, key)) =>
+        t.FetchByKeyDefRef(templateId)(compile(env, key))
+
+      case UpdateTryCatch(_, body, binder, handler) =>
+        unaryFunction(env) { (tokenPos, env0) =>
+          s.SETryCatch(
+            app(compile(env0, body), env0.toSEVar(tokenPos)), {
+              val env1 = env0.pushExprVar(binder)
+              SBTryHandler(
+                compile(env1, handler),
+                env1.lookupExprVar(binder),
+                env1.toSEVar(tokenPos),
+              )
+            },
+          )
+        }
+    }
+
+  @tailrec
+  private[this] def compileAbss(env: Env, expr0: Expr, arity: Int = 0): s.SExpr =
+    expr0 match {
+      case EAbs((binder, typ @ _), body, ref @ _) =>
+        compileAbss(env.pushExprVar(binder), body, arity + 1)
+      case ETyAbs((binder, KNat), body) =>
+        compileAbss(env.pushTypeVar(binder), body, arity + 1)
+      case ETyAbs((binder, _), body) =>
+        compileAbss(env.hideTypeVar(binder), body, arity)
+      case _ if arity == 0 =>
+        compile(env, expr0)
+      case _ =>
+        withLabelS(t.AnonymousClosure, s.SEAbs(arity, compile(env, expr0)))
+    }
+
+  @tailrec
+  private[this] def compileApps(
+      env: Env,
+      expr0: Expr,
+      args: List[s.SExpr] = List.empty,
+  ): s.SExpr =
+    expr0 match {
+      case EApp(fun, arg) =>
+        compileApps(env, fun, compile(env, arg) :: args)
+      case ETyApp(fun, arg) =>
+        compileApps(env, fun, translateType(env, arg).fold(args)(_ :: args))
+      case _ if args.isEmpty =>
+        compile(env, expr0)
+      case _ =>
+        s.SEApp(compile(env, expr0), args)
+    }
+
+  private[this] def translateType(env: Env, typ: Type): Option[s.SExpr] =
+    typ match {
+      case TNat(n) => SENat(n)
+      case TVar(name) => env.lookupTypeVar(name)
+      case _ => None
+    }
+
+  private[this] def compileScenario(env: Env, scen: Scenario, optLoc: Option[Location]): s.SExpr =
+    scen match {
+      case ScenarioPure(_, e) =>
+        compilePure(env, e)
+      case ScenarioBlock(bindings, body) =>
+        compileBlock(env, bindings, body)
+      case ScenarioCommit(partyE, updateE, _retType @ _) =>
+        compileCommit(env, partyE, updateE, optLoc, mustFail = false)
+      case ScenarioMustFailAt(partyE, updateE, _retType @ _) =>
+        compileCommit(env, partyE, updateE, optLoc, mustFail = true)
+      case ScenarioGetTime =>
+        SEGetTime
+      case ScenarioGetParty(e) =>
+        compileGetParty(env, e)
+      case ScenarioPass(relTime) =>
+        compilePass(env, relTime)
+      case ScenarioEmbedExpr(_, e) =>
+        compileEmbedExpr(env, e)
+    }
+
+  @inline
+  private[this] def compileCommit(
+      env: Env,
+      partyE: Expr,
+      updateE: Expr,
+      optLoc: Option[Location],
+      mustFail: Boolean,
+  ): s.SExpr =
+    // let party = <partyE>
+    //     update = <updateE>
+    // in $submit(mustFail)(party, update)
+    let(env, compile(env, partyE)) { (partyLoc, env) =>
+      let(env, compile(env, updateE)) { (updateLoc, env) =>
+        SBSSubmit(optLoc, mustFail)(env.toSEVar(partyLoc), env.toSEVar(updateLoc))
+      }
+    }
+
+  @inline
+  private[this] def compileGetParty(env: Env, expr: Expr): s.SExpr =
+    labeledUnaryFunction(Profile.GetPartyLabel, env) { (tokenPos, env) =>
+      SBSGetParty(compile(env, expr), env.toSEVar(tokenPos))
+    }
+
+  @inline
+  private[this] def compilePass(env: Env, time: Expr): s.SExpr =
+    labeledUnaryFunction(Profile.PassLabel, env) { (tokenPos, env) =>
+      SBSPass(compile(env, time), env.toSEVar(tokenPos))
+    }
+
+  @inline
+  private[this] def compileEmbedExpr(env: Env, expr: Expr): s.SExpr =
+    // EmbedExpr's get wrapped into an extra layer of abstraction
+    // to delay evaluation.
+    // e.g.
+    // embed (error "foo") => \token -> error "foo"
+    unaryFunction(env) { (tokenPos, env) =>
+      app(compile(env, expr), env.toSEVar(tokenPos))
+    }
+
+  private[this] def compilePure(env: Env, body: Expr): s.SExpr =
+    // pure <E>
+    // =>
+    // ((\x token -> x) <E>)
+    let(env, compile(env, body)) { (bodyPos, env) =>
+      unaryFunction(env) { (tokenPos, env) =>
+        SBSPure(env.toSEVar(bodyPos), env.toSEVar(tokenPos))
+      }
+    }
+
+  private[this] def compileBlock(env: Env, bindings: ImmArray[Binding], body: Expr): s.SExpr =
+    // do
+    //   x <- f
+    //   y <- g x
+    //   z x y
+    // =>
+    // let f' = f
+    // in \token ->
+    //   let x = f' token
+    //       y = g x token
+    //   in z x y token
+    let(env, compile(env, bindings.head.bound)) { (firstPos, env) =>
+      unaryFunction(env) { (tokenPos, env) =>
+        let(env, app(env.toSEVar(firstPos), env.toSEVar(tokenPos))) { (firstBoundPos, _env) =>
+          val env = bindings.head.binder.fold(_env)(_env.bindExprVar(_, firstBoundPos))
+
+          def loop(env: Env, list: List[Binding]): s.SExpr = list match {
+            case Binding(binder, _, bound) :: tail =>
+              let(env, app(compile(env, bound), env.toSEVar(tokenPos))) { (boundPos, _env) =>
+                val env = binder.fold(_env)(_env.bindExprVar(_, boundPos))
+                loop(env, tail)
+              }
+            case Nil =>
+              app(compile(env, body), env.toSEVar(tokenPos))
+          }
+
+          loop(env, bindings.tail.toList)
+        }
+      }
+    }
+
+  @tailrec
+  private[this] def stripLocs(expr: Expr): Expr =
+    expr match {
+      case ELocation(_, expr1) => stripLocs(expr1)
+      case _ => expr
+    }
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -20,7 +20,7 @@ package speedy
   * 3: transform to ANF
   * 4: validate the final expression which will run on the speedy machine
   *
-  * Stage 1 is in Compiler.scala
+  * Stage 1 is in PhaseOne.scala
   * Stage 2 is in ClosureConversion.scala
   * Stage 3 is in Anf.scala
   * Stage 4 is in ValidateCompilation.scala

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PhaseOneTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PhaseOneTest.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+import com.daml.lf.data.Ref.PackageId
+import com.daml.lf.language.Ast._
+import com.daml.lf.speedy.SExpr0._
+import com.daml.lf.language.PackageInterface
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+import scala.annotation.tailrec
+
+class PhaseOneTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks {
+
+  // Construct one level of source-expression at various 'recursion-points'.
+  private val app1 = (x: Expr) => EApp(x, leaf)
+  private val app2 = (x: Expr) => EApp(leaf, x)
+
+  "compilation phase #1 (stack-safety)" - {
+
+    val phase1 = {
+      def signatures: PartialFunction[PackageId, PackageSignature] = Map.empty
+      def interface = new PackageInterface(signatures)
+      def config =
+        PhaseOne.Config(
+          profiling = Compiler.NoProfile,
+          stacktracing = Compiler.FullStackTrace,
+        )
+      new PhaseOne(interface, config)
+    }
+
+    // This is the code under test...
+    def transform(e: Expr): SExpr = {
+      phase1.translateFromLF(PhaseOne.Env.Empty, e)
+    }
+
+    /* We test stack-safety by building deep expressions through each of the different
+     * recursion points of an expression, using one of the builder functions above, and
+     * then ensuring we can 'transform' the expression using the phase1 compilation step.
+     */
+    def runTest(depth: Int, cons: Expr => Expr) = {
+      // Make an expression by iterating the 'cons' function, 'depth' times
+      @tailrec def loop(x: Expr, n: Int): Expr = if (n == 0) x else loop(cons(x), n - 1)
+      val exp: Expr = loop(leaf, depth)
+      val _: SExpr = transform(exp)
+      true
+    }
+
+    // TODO https://github.com/digital-asset/daml/issues/11561
+    // - add testcases for all Ast.Expr recursion points
+    val testCases = {
+      Table[String, Expr => Expr](
+        ("name", "recursion-point"),
+        ("app1", app1),
+        ("app2", app2),
+      )
+    }
+
+    {
+      // TODO https://github.com/digital-asset/daml/issues/11561
+      // -- tests should run to a depth of 10000 (currently this causes stack overflow)
+      val depth = 100
+      s"depth = $depth" - {
+        forEvery(testCases) { (name: String, recursionPoint: Expr => Expr) =>
+          name in {
+            runTest(depth, recursionPoint)
+          }
+        }
+      }
+    }
+  }
+
+  private def leaf: Expr = EPrimLit(PLText("leaf"))
+
+}


### PR DESCRIPTION
Split` out phase1 of speedy compilation in preparation for making it stack-safe.
- `PhaseOne.scala` split from `Compiler.scala`
- entry point: `phase1.translateFromLF`
- some renaming in `Compiler.scala` for clarity
- Setup placeholder for the the phase1 stack-safety tests.

For issue: #11561
