### PR TITLE
Speedy: Fix computation of Node version

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -153,6 +153,7 @@ private[lf] object PartialTransaction {
       parent: Context,
       byKey: Boolean,
       byInterface: Option[TypeConName],
+      version: TxVersion,
   ) extends ContextInfo {
     val actionNodeSeed = parent.nextActionChildSeed
     val actionChildSeed = crypto.Hash.deriveNodeSeed(actionNodeSeed, _)
@@ -178,13 +179,11 @@ private[lf] object PartialTransaction {
   }
 
   def initial(
-      pkg2TxVersion: Ref.PackageId => TxVersion,
       contractKeyUniqueness: ContractKeyUniquenessMode,
       submissionTime: Time.Timestamp,
       initialSeeds: InitialSeeding,
       committers: Set[Party],
   ) = PartialTransaction(
-    pkg2TxVersion,
     contractKeyUniqueness = contractKeyUniqueness,
     submissionTime = submissionTime,
     nextNodeIdx = 0,
@@ -266,7 +265,6 @@ private[lf] object PartialTransaction {
   *   Used by 'locationInfo()', called by 'finish()' and 'finishIncomplete()'
   */
 private[speedy] case class PartialTransaction(
-    packageToTransactionVersion: Ref.PackageId => TxVersion,
     contractKeyUniqueness: ContractKeyUniquenessMode,
     submissionTime: Time.Timestamp,
     nextNodeIdx: Int,
@@ -341,14 +339,6 @@ private[speedy] case class PartialTransaction(
     }.toMap
   }
 
-  /** normValue: converts a speedy value into a normalized regular value,
-    * suitable for a transaction node of 'version' determined by 'templateId'
-    */
-  def normValue(templateId: TypeConName, svalue: SValue): Value = {
-    val version = packageToTransactionVersion(templateId.packageId)
-    svalue.toNormalizedValue(version)
-  }
-
   private def normByKey(version: TxVersion, byKey: Boolean): Boolean = {
     if (version < TxVersion.minByKey) {
       false
@@ -409,12 +399,12 @@ private[speedy] case class PartialTransaction(
       stakeholders: Set[Party],
       key: Option[Node.KeyWithMaintainers],
       byInterface: Option[TypeConName],
+      version: TxVersion,
   ): (Value.ContractId, PartialTransaction) = {
     val actionNodeSeed = context.nextActionChildSeed
     val discriminator =
       crypto.Hash.deriveContractDiscriminator(actionNodeSeed, submissionTime, stakeholders)
     val cid = Value.ContractId.V1(discriminator)
-    val version = packageToTransactionVersion(templateId.packageId)
     val createNode = Node.Create(
       cid,
       templateId,
@@ -503,9 +493,9 @@ private[speedy] case class PartialTransaction(
       key: Option[Node.KeyWithMaintainers],
       byKey: Boolean,
       byInterface: Option[TypeConName],
+      version: TxVersion,
   ): PartialTransaction = {
     val nid = NodeId(nextNodeIdx)
-    val version = packageToTransactionVersion(templateId.packageId)
     val node = Node.Fetch(
       coid,
       templateId,
@@ -530,9 +520,9 @@ private[speedy] case class PartialTransaction(
       optLocation: Option[Location],
       key: Node.KeyWithMaintainers,
       result: Option[Value.ContractId],
+      version: TxVersion,
   ): PartialTransaction = {
     val nid = NodeId(nextNodeIdx)
-    val version = packageToTransactionVersion(templateId.packageId)
     val node = Node.LookupByKey(
       templateId,
       key,
@@ -561,6 +551,7 @@ private[speedy] case class PartialTransaction(
       byKey: Boolean,
       chosenValue: Value,
       byInterface: Option[TypeConName],
+      version: TxVersion,
   ): PartialTransaction = {
     val nid = NodeId(nextNodeIdx)
     val ec =
@@ -579,6 +570,7 @@ private[speedy] case class PartialTransaction(
         parent = context,
         byKey = byKey,
         byInterface = byInterface,
+        version = version,
       )
 
     mustBeActive(
@@ -613,12 +605,14 @@ private[speedy] case class PartialTransaction(
   /** Close normally an exercise context.
     * Must match a `beginExercises`.
     */
-  def endExercises(value: SValue): PartialTransaction =
+  def endExercises(result: TxVersion => Value): PartialTransaction =
     context.info match {
       case ec: ExercisesContextInfo =>
-        val result = normValue(ec.templateId, value)
         val exerciseNode =
-          makeExNode(ec).copy(children = context.children.toImmArray, exerciseResult = Some(result))
+          makeExNode(ec).copy(
+            children = context.children.toImmArray,
+            exerciseResult = Some(result(ec.version)),
+          )
         val nodeId = ec.nodeId
         copy(
           context =
@@ -656,7 +650,6 @@ private[speedy] case class PartialTransaction(
     }
 
   private[this] def makeExNode(ec: ExercisesContextInfo): Node.Exercise = {
-    val version = packageToTransactionVersion(ec.templateId.packageId)
     Node.Exercise(
       targetCoid = ec.targetId,
       templateId = ec.templateId,
@@ -670,9 +663,9 @@ private[speedy] case class PartialTransaction(
       children = ImmArray.Empty,
       exerciseResult = None,
       key = ec.contractKey,
-      byKey = normByKey(version, ec.byKey),
+      byKey = normByKey(ec.version, ec.byKey),
       byInterface = ec.byInterface,
-      version = version,
+      version = ec.version,
     )
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -24,7 +24,6 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   private[this] val committers: Set[data.Ref.Party] = Set.empty
 
   private[this] val initialState = PartialTransaction.initial(
-    _ => TransactionVersion.maxVersion,
     ContractKeyUniquenessMode.On,
     data.Time.Timestamp.Epoch,
     InitialSeeding.TransactionSeed(transactionSeed),
@@ -54,12 +53,13 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
           Set.empty,
           None,
           None,
+          TransactionVersion.maxVersion,
         )
         ._2
 
     def beginExercises_ : PartialTransaction =
       ptx.beginExercises(
-        Authorize(Set(party)),
+        auth = Authorize(Set(party)),
         targetId = cid,
         templateId = templateId,
         choiceId = choiceId,
@@ -73,10 +73,11 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
         byKey = false,
         byInterface = None,
         chosenValue = Value.ValueUnit,
+        version = TransactionVersion.maxVersion,
       )
 
     def endExercises_ : PartialTransaction =
-      ptx.endExercises(SValue.SUnit)
+      ptx.endExercises(_ => Value.ValueNone)
 
     private val dummyException = SArithmeticError("Dummy", ImmArray.Empty)
 


### PR DESCRIPTION
The computation of Node version relies on the
`packageToTransactionVersion` field of the PartialTransaction.  This
is initialized during the Speedy `Machine` construction with the
compiledPackage used to initialized the Machine. However the
compiledPackage is a mutable field and can be udpated during
interpreation, potentially making the 'PartialTransaction''s
`packageToTransactionVersion` out of date.

The problem was not apparent, for all non-development version of LF, the preprocessor ensures the packages are preloading before interpretation. 

We solve the issue by making the computation of the version, outise
the PartialTransaction object.

CHANGELOG_BEGING
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
