### PR TITLE
Drop dependency on hosted nodes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,7 +223,8 @@ jobs:
 - job: compat_versions_pr_trigger_daily
   dependsOn: compat_versions_pr
   pool:
-    vmImage: "ubuntu-18.04"
+    name: 'ubuntu_20_04'
+    demands: assignment -equals default
   variables:
     branch: $[ dependencies.compat_versions_pr.outputs['out.branch'] ]
   steps:
@@ -233,6 +234,7 @@ jobs:
       var_name: bash-lib
   - bash: |
       set -euo pipefail
+      eval "$(./dev-env/bin/dade-assist)"
       source $(bash-lib)
       trigger_azure $(System.AccessToken) PRs --branch $(branch)
       trigger_azure $(System.AccessToken) digital-asset.daml-daily-compat --branch $(branch)

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -150,15 +150,16 @@ jobs:
         trigger_sha: '$(trigger_sha)'
     - template: report-end.yml
 
-- template: patch_bazel_windows/compile.yml
-  parameters:
-    final_job_name: patch_bazel_windows
+# TODO https://github.com/digital-asset/daml/issues/12900
+# - template: patch_bazel_windows/compile.yml
+#  parameters:
+#     final_job_name: patch_bazel_windows
 
 - job: Windows
   dependsOn:
     - da_ghc_lib
     - check_for_release
-    - patch_bazel_windows
+    # - patch_bazel_windows
     - git_sha
   variables:
     - name: release_sha

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -500,11 +500,13 @@ jobs:
     condition: and(succeeded(),
                    eq(variables['Build.SourceBranchName'], 'main'))
     pool:
-      vmImage: ubuntu-20.04
+      name: 'ubuntu_20_04'
+      demands: assignment -equals default
     variables:
       need_to_build: $[ dependencies.blackduck_scan.outputs['out.need_to_build'] ]
     steps:
       - bash: |
+          eval "$(./dev-env/bin/dade-assist)"
           if [ "$(need_to_build)" == "true" ]; then
               branch="notices-update-$(Build.BuildId)"
               az extension add --name azure-devops

--- a/ci/cron/tuesday.yml
+++ b/ci/cron/tuesday.yml
@@ -16,7 +16,8 @@ jobs:
 - job: announce_rotation
   timeoutInMinutes: 60
   pool:
-    vmImage: ubuntu-18.04
+    name: 'ubuntu_20_04'
+    demands: assignment -equals default
   steps:
   - checkout: self
     persistCredentials: true
@@ -25,7 +26,7 @@ jobs:
       var_name: bash_lib
   - bash: |
       set -euo pipefail
-
+      eval "$(./dev-env/bin/dade-assist)"
       source "$(bash_lib)"
 
       RELEASE_MANAGER=$(next_in_rotation_slack)

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -16,7 +16,8 @@ jobs:
 - job: open_release_pr
   timeoutInMinutes: 60
   pool:
-    vmImage: ubuntu-18.04
+    name: 'ubuntu_20_04'
+    demands: assignment -equals default
   steps:
   - checkout: self
     persistCredentials: true
@@ -25,7 +26,7 @@ jobs:
       var_name: bash_lib
   - bash: |
       set -euo pipefail
-
+      eval "$(./dev-env/bin/dade-assist)"
       source "$(bash_lib)"
 
       AUTH="$(get_gh_auth_header)"

--- a/ci/prs.yml
+++ b/ci/prs.yml
@@ -176,7 +176,8 @@ jobs:
 
 - job: self_service_compat_test
   pool:
-    vmImage: ubuntu-20.04
+    name: 'ubuntu_20_04'
+    demands: assignment -equals default
   condition: eq(variables['Build.Reason'], 'PullRequest')
   steps:
   - checkout: self
@@ -185,6 +186,7 @@ jobs:
       var_name: bash-lib
   - bash: |
       set -euo pipefail
+      eval "$(./dev-env/bin/dade-assist)"
       source $(bash-lib)
       COMMIT=$(git rev-parse HEAD^2)
       REQUEST=$(git log -n1 --format="%(trailers:key=run-full-compat,valueonly)" $COMMIT)

--- a/dev-env/bin/az
+++ b/dev-env/bin/az
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -199,6 +199,7 @@ in rec {
 
     # Cloud tools
     aws = pkgs.awscli;
+    az = pkgs.azure-cli;
     gcloud = pkgs.google-cloud-sdk;
     bq = gcloud;
     gsutil = gcloud;


### PR DESCRIPTION
This should hopefully get CI working again.

There are two changes in here:

1. We can no longer change our patched Bazel. I didn’t switch away
   from the current patched version for now (we upload it to gcp bucket
   so it still works fine even if we cannot build it) but if we upgrade,
   we need to go to an unpatched version for now.
2. We need to get `az` from dev-env. I tested the self service compat
   job stuff and it works fine with this but there is a chance other
   parts don’t.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
