### PR TITLE
Re-enable Azure nodes

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -150,16 +150,15 @@ jobs:
         trigger_sha: '$(trigger_sha)'
     - template: report-end.yml
 
-# TODO https://github.com/digital-asset/daml/issues/12900
-# - template: patch_bazel_windows/compile.yml
-#  parameters:
-#     final_job_name: patch_bazel_windows
+- template: patch_bazel_windows/compile.yml
+  parameters:
+    final_job_name: patch_bazel_windows
 
 - job: Windows
   dependsOn:
     - da_ghc_lib
     - check_for_release
-    # - patch_bazel_windows
+    - patch_bazel_windows
     - git_sha
   variables:
     - name: release_sha


### PR DESCRIPTION
This reverts a small part of 9e1e42d27cb3334d0b3741c16314ffb4ee97db27 (#12901).

Microsoft seems to have given us our free parallel jobs back, so we can run the patch_bazel job again.

Fixes #12900.

CHANGELOG_BEGIN
CHANGELOG_END