### PR TITLE
[JSON-API] Fix duplicate error logging & improve error logs messages

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -314,12 +314,12 @@ object CommandService {
       message: String,
   ) extends Error
   final case class GrpcError(status: io.grpc.Status) extends Error
-  final case class InternalError(id: Option[Symbol], error: Throwable \/ String) extends Error
+  final case class InternalError(id: Option[Symbol], error: Throwable) extends Error
   object InternalError {
     def apply(id: Option[Symbol], message: String): InternalError =
-      InternalError(id, \/.right(message))
+      InternalError(id, new Exception(message))
     def apply(id: Option[Symbol], error: Throwable): InternalError =
-      InternalError(id, \/.left(error))
+      InternalError(id, error)
   }
 
   private type ET[A] = EitherT[Future, Error, A]

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -141,13 +141,11 @@ class CommandService(
     EitherT {
       fa.transformWith {
         case Failure(e) =>
-          logger.error(s"$opName failure", e)
           Future.successful(-\/(e match {
             case Grpc.StatusEnvelope(status) => GrpcError(status)
-            case _ => InternalError(None, e.toString)
+            case _ => InternalError(Some(op), e)
           }))
         case Success(-\/(e)) =>
-          logger.error(s"$opName failure: ${e.e}: ${e.message}")
           import Grpc.Category._
           val tagged = e.e match {
             case PermissionDenied => -\/(PermissionDenied)
@@ -316,7 +314,13 @@ object CommandService {
       message: String,
   ) extends Error
   final case class GrpcError(status: io.grpc.Status) extends Error
-  final case class InternalError(id: Option[Symbol], message: String) extends Error
+  final case class InternalError(id: Option[Symbol], error: Throwable \/ String) extends Error
+  object InternalError {
+    def apply(id: Option[Symbol], message: String): InternalError =
+      InternalError(id, \/.right(message))
+    def apply(id: Option[Symbol], error: Throwable): InternalError =
+      InternalError(id, \/.left(error))
+  }
 
   private type ET[A] = EitherT[Future, Error, A]
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -505,9 +505,12 @@ object Endpoints {
     implicit val id: IntoEndpointsError[Error] = new IntoEndpointsError(identity)
 
     implicit val fromCommands: IntoEndpointsError[CommandService.Error] = new IntoEndpointsError({
-      case CommandService.InternalError(id, message) =>
+      case CommandService.InternalError(id, reason) =>
         ServerError(
-          s"command service error, ${id.cata(sym => s"${sym.name}: ", "")}$message"
+          new Exception(
+            s"command service error, ${id.cata(sym => s"${sym.name}: ", "")}${reason.getMessage}",
+            reason,
+          )
         )
       case CommandService.GrpcError(status) =>
         ParticipantServerError(status.getCode, Option(status.getDescription))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
@@ -49,8 +49,7 @@ object EndpointsCompanion {
 
   object ServerError {
     // We want stack traces also in the case of simple error messages.
-    def apply(message: String): ServerError = ServerError(new Exception(message))
-    def apply(error: Throwable): ServerError = ServerError(error)
+    def fromMsg(message: String): ServerError = ServerError(new Exception(message))
   }
 
   object Error {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -100,10 +100,7 @@ object WebSocketService {
 
     def logHiddenErrors()(implicit lc: LoggingContextOf[InstanceUUID]): Unit =
       errors foreach { case ServerError(reason) =>
-        reason.fold(
-          logger.error(s"while rendering contract (unknown)", _),
-          message => logger.error(s"while rendering contract: ${message: String}"),
-        )
+        logger.error(s"while rendering contract", reason)
       }
 
     def render(implicit lfv: LfVT <~< JsValue, pos: Pos <~< Map[String, JsValue]): JsObject = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -950,12 +950,12 @@ class WebSocketService(
           ae =>
             domain.ArchivedContract
               .fromLedgerApi(ae)
-              .liftErr(ServerError(_)),
+              .liftErr(ServerError.fromMsg),
           ce =>
             domain.ActiveContract
               .fromLedgerApi(ce)
-              .liftErr(ServerError(_))
-              .flatMap(_.traverse(apiValueToLfValue).liftErr(ServerError(_))),
+              .liftErr(ServerError.fromMsg)
+              .flatMap(_.traverse(apiValueToLfValue).liftErr(ServerError.fromMsg)),
         )(Seq)
         StepAndErrors(
           errors ++ aerrors,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/CreateAndExercise.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/CreateAndExercise.scala
@@ -148,5 +148,5 @@ private[http] object CreateAndExercise {
   import util.ErrorOps._
 
   private def lfValueToApiValue(a: LfValue): Error \/ ApiValue =
-    JsValueToApiValueConverter.lfValueToApiValue(a).liftErr(ServerError)
+    JsValueToApiValueConverter.lfValueToApiValue(a).liftErr(ServerError(_): Error)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/CreateAndExercise.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/CreateAndExercise.scala
@@ -148,5 +148,5 @@ private[http] object CreateAndExercise {
   import util.ErrorOps._
 
   private def lfValueToApiValue(a: LfValue): Error \/ ApiValue =
-    JsValueToApiValueConverter.lfValueToApiValue(a).liftErr(ServerError(_): Error)
+    JsValueToApiValueConverter.lfValueToApiValue(a).liftErr(ServerError.fromMsg)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/RouteSetup.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/RouteSetup.scala
@@ -103,7 +103,7 @@ private[http] final class RouteSetup(
       resp <- withJwtPayloadLoggingContext(jwtPayload)(
         fn(jwt, jwtPayload, reqBody, parseAndDecodeTimerCtx)
       )
-      jsVal <- either(SprayJson.encode1(resp).liftErr(ServerError(_): Error)): ET[JsValue]
+      jsVal <- either(SprayJson.encode1(resp).liftErr(ServerError.fromMsg)): ET[JsValue]
     } yield domain.OkResponse(jsVal)
 
   def inputJsValAndJwtPayload[P](req: HttpRequest)(implicit

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/RouteSetup.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/RouteSetup.scala
@@ -204,7 +204,7 @@ private[http] object RouteSetup {
   private[http] def handleFutureFailure[A](fa: Future[A])(implicit
       ec: ExecutionContext
   ): Future[Error \/ A] =
-    fa.map { a => \/-(a) }.recover(Error.fromThrowable andThen (-\/(_)))
+    fa.map(a => \/-(a)).recover(Error.fromThrowable andThen (-\/(_)))
 
   private[endpoints] def handleFutureEitherFailure[A, B](fa: Future[A \/ B])(implicit
       ec: ExecutionContext,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/RouteSetup.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/RouteSetup.scala
@@ -35,7 +35,6 @@ import spray.json._
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
-import scala.util.control.NonFatal
 import com.daml.ledger.api.{domain => LedgerApiDomain}
 import com.daml.ledger.client.services.admin.UserManagementClient
 import com.daml.ledger.client.services.identity.LedgerIdentityClient
@@ -104,7 +103,7 @@ private[http] final class RouteSetup(
       resp <- withJwtPayloadLoggingContext(jwtPayload)(
         fn(jwt, jwtPayload, reqBody, parseAndDecodeTimerCtx)
       )
-      jsVal <- either(SprayJson.encode1(resp).liftErr(ServerError)): ET[JsValue]
+      jsVal <- either(SprayJson.encode1(resp).liftErr(ServerError(_): Error)): ET[JsValue]
     } yield domain.OkResponse(jsVal)
 
   def inputJsValAndJwtPayload[P](req: HttpRequest)(implicit
@@ -191,13 +190,6 @@ private[http] object RouteSetup {
   private val nonHttpsErrorMessage =
     "missing HTTPS reverse-proxy request headers; for development launch with --allow-insecure-tokens"
 
-  def logException(fromWhat: String)(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID]
-  ): Throwable PartialFunction Throwable = { case NonFatal(e) =>
-    logger.error(s"$fromWhat failed", e)
-    e
-  }
-
   def withJwtPayloadLoggingContext[A](jwtPayload: JwtPayloadG)(
       fn: LoggingContextOf[JwtPayloadTag with InstanceUUID with RequestID] => A
   )(implicit lc: LoggingContextOf[InstanceUUID with RequestID]): A =
@@ -210,18 +202,15 @@ private[http] object RouteSetup {
     ).run(fn)
 
   private[http] def handleFutureFailure[A](fa: Future[A])(implicit
-      ec: ExecutionContext,
-      lc: LoggingContextOf[InstanceUUID with RequestID],
+      ec: ExecutionContext
   ): Future[Error \/ A] =
-    fa.map(a => \/-(a)).recover(logException("Future") andThen Error.fromThrowable andThen (-\/(_)))
+    fa.map { a => \/-(a) }.recover(Error.fromThrowable andThen (-\/(_)))
 
   private[endpoints] def handleFutureEitherFailure[A, B](fa: Future[A \/ B])(implicit
       ec: ExecutionContext,
       A: IntoEndpointsError[A],
-      lc: LoggingContextOf[InstanceUUID with RequestID],
   ): Future[Error \/ B] =
-    fa.map(_ leftMap A.run)
-      .recover(logException("Future") andThen Error.fromThrowable andThen (-\/(_)))
+    fa.map(_ leftMap A.run).recover(Error.fromThrowable andThen (-\/(_)))
 
   private def isForwardedForHttps(headers: Seq[HttpHeader]): Boolean =
     headers exists {


### PR DESCRIPTION
That should improve the error logging situation further.

I manually tested:
- Errors from Futures

So a couple things here are changed with me only assuming that they do the right thing, however the code is very clear in this regard so I assume I'm right. Besides, testing all possible branches where errors could be generated is a bit time-consuming.

changelog_begin

- [HTTP-JSON] Fix duplicate logging of errors & improved error messages slightly

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
