### PR TITLE
Shorten contract and party identifiers in Navigator

### DIFF
--- a/navigator/frontend/src/applets/contract/ContractComponent.tsx
+++ b/navigator/frontend/src/applets/contract/ContractComponent.tsx
@@ -4,11 +4,16 @@
 import {
   ArgumentDisplay,
   Breadcrumbs,
+  LongIdentifier,
   Strong,
   styled,
   Truncate,
 } from "@da/ui-core";
 import { DamlLfValue } from "@da/ui-core/lib/api/DamlLfValue";
+import {
+  shortenContractId,
+  shortenPartyId,
+} from "@da/ui-core/lib/api/IdentifierShortening";
 import * as React from "react";
 import Link, { OwnProps } from "../../components/Link";
 import * as Routes from "../../routes";
@@ -95,7 +100,13 @@ const Parties = ({ title, parties }: { title: string; parties: string[] }) => (
     <SubHeader>
       <Strong>{title}</Strong>
     </SubHeader>
-    <span>{parties.join(", ")}</span>
+    {parties.map(party => (
+      <LongIdentifier
+        key={party}
+        text={shortenPartyId(party)}
+        identifier={party}
+      />
+    ))}
   </span>
 );
 
@@ -147,7 +158,11 @@ export default (props: Props): JSX.Element => {
   return (
     <Wrapper>
       <Header>
-        Contract {contract.id} {choicesEl}
+        <LongIdentifier
+          text={`Contract ${shortenContractId(contract.id)}`}
+          identifier={contract.id}
+        />{" "}
+        {choicesEl}
       </Header>
       <Content>
         <div>

--- a/navigator/frontend/src/ui-core/src/ArgumentDisplay/index.tsx
+++ b/navigator/frontend/src/ui-core/src/ArgumentDisplay/index.tsx
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from "react";
+import { shortenContractId, shortenPartyId } from "../api/IdentifierShortening";
 import { DamlLfValue } from "../api/DamlLfValue";
 import * as DamlLfValueF from "../api/DamlLfValue";
 import { LabeledElement } from "../Label";
+import LongIdentifier from "../LongIdentifier";
 import NestedForm from "../NestedForm";
 import { hardcodedStyle } from "../theme";
 import { NonExhaustiveMatch } from "../util";
@@ -84,9 +86,19 @@ const ArgumentDisplay = (props: Props): JSX.Element => {
     case "text":
       return <span>{argument.value}</span>;
     case "party":
-      return <span>{argument.value}</span>;
+      return (
+        <LongIdentifier
+          text={shortenPartyId(argument.value)}
+          identifier={argument.value}
+        />
+      );
     case "contractid":
-      return <span>{argument.value}</span>;
+      return (
+        <LongIdentifier
+          text={shortenContractId(argument.value)}
+          identifier={argument.value}
+        />
+      );
     case "numeric":
       return <span>{argument.value}</span>;
     case "int64":

--- a/navigator/frontend/src/ui-core/src/LongIdentifier/index.tsx
+++ b/navigator/frontend/src/ui-core/src/LongIdentifier/index.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from "react";
+import { default as styled } from "../theme";
+
+const Identifier = styled.span`
+  cursor: pointer;
+  justify-content: space-between;
+  padding: 0.5em 1em;
+  align-items: center;
+  text-decoration: none;
+  margin-right: 1rem;
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2);
+  color: ${({ theme }) => theme.colorPrimary[1]};
+  &,
+  &:hover {
+    color: ${({ theme }) => theme.colorSecondary[1]};
+  }
+  border-radius: ${_ => "999rem"};
+  background-color: ${({ theme }) => theme.colorPrimary[0]};
+  &:hover {
+    background-color: ${({ theme }) => theme.colorSecondary[0]};
+  }
+`;
+
+const LongIdentifier: React.JSXElementConstructor<any> = ({
+  text,
+  identifier,
+}: {
+  text: string;
+  identifier: string;
+}) => (
+  <Identifier
+    onClick={() => navigator.clipboard.writeText(identifier)}
+    title="Click to copy the full identifier to the clipboard">
+    {text}
+  </Identifier>
+);
+
+export default LongIdentifier;

--- a/navigator/frontend/src/ui-core/src/api/IdentifierShortening.ts
+++ b/navigator/frontend/src/ui-core/src/api/IdentifierShortening.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+// All rights reserved.
+
+// --------------------------------------------------------------------------------------------------------------------
+// Identifier shortening
+// --------------------------------------------------------------------------------------------------------------------
+
+// The following definitions replicate (to a certain extent) the way in which Canton shortens identifiers.
+// Specific pointers to the code we are referring to is provided alongside each definition.
+// The replication is slightly unfortunate but this should be good enough for Navigator.
+//
+// See: https://github.com/digital-asset/canton/blob/6f75f64c4fbe054f9e2ec665a5f864d087782144/community/common/src/main/scala/com/digitalasset/canton/logging/pretty/PrettyInstances.scala
+
+// See: https://github.com/digital-asset/canton/blob/6f75f64c4fbe054f9e2ec665a5f864d087782144/community/common/src/main/scala/com/digitalasset/canton/util/ShowUtil.scala#L31
+const hashMaxLength: number = 12;
+
+// See: https://github.com/digital-asset/canton/blob/6f75f64c4fbe054f9e2ec665a5f864d087782144/community/common/src/main/scala/com/digitalasset/canton/util/ShowUtil.scala#L62-L63
+function shortenHash(str: string): string {
+  return str.length > hashMaxLength
+    ? `${str.substr(0, hashMaxLength)}...`
+    : str;
+}
+
+// Contract identifiers are assumed to be either a hash or some sort of opaque string
+export const shortenContractId = shortenHash;
+
+// The assumption is that party identifiers are either:
+// - a participant-unique, readable identifier and an opaque string representing the namespace
+//     - this is what happens in Canton
+//     - keep the first part whole and shorten the namespace to 12 characters
+// - some other opaque string
+//     - just shorten the entire identifier to 12 characters
+export function shortenPartyId(id: string): string {
+  const parts = id.split("::");
+  return parts.length === 2
+    ? `${parts[0]}::${shortenHash(parts[1])}`
+    : shortenHash(id);
+}

--- a/navigator/frontend/src/ui-core/src/index.ts
+++ b/navigator/frontend/src/ui-core/src/index.ts
@@ -10,6 +10,7 @@ export { default as Link } from "./Link";
 export { makeSidebarLink } from "./SidebarLink";
 export { default as ParameterForm } from "./ParameterForm";
 export { default as Popover } from "./Popover";
+export { default as LongIdentifier } from "./LongIdentifier";
 export { default as ArgumentDisplay } from "./ArgumentDisplay";
 export { default as Autosuggest } from "./Autosuggest";
 export { default as AdvanceTime } from "./AdvanceTime";
@@ -48,6 +49,9 @@ export { SortDirection } from "./Table";
 
 export { NonExhaustiveMatch } from "./util";
 export { utcStringToMoment, momentToUtcString } from "./util";
+
+import * as IdentifierShortening from "./api/IdentifierShortening";
+export { IdentifierShortening };
 
 import * as DamlLfValue from "./api/DamlLfValue";
 export { DamlLfValue };


### PR DESCRIPTION
As we transition to Canton, we use a new format of contract and party
identifiers that can break the UI of Navigator here and there. In
order to prevent this, we use the same rules as Canton does to shorten
identifiers (basically, elide any hash longer than 12 characters).
Full identifiers are still shown as part of the tooltip.

Furthermore, a tooltip suggests that clicking on the shortened
identifier copies it in full length on the clipboard (which is indeed
what happens). There are a couple of possible improvements to this
interaction, which cannot be handled as part of this PR due to time
constraint:

- the visual cue suggesting that the identifier can be copied can be
improved by adding a clipboard icon besides the label
- there is no visual feedback from copying the identifier, ideally the
user should somehow see that the copying took place (e.g. by turning the
clipboard icon suggested in the point above into a checkmark for a
couple of seconds)

changelog_begin
[Navigator] Contract and party identifiers are shortened on the UI
but can be copied in full by clicking on their label.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
