### PR TITLE
Raise akka log-lveel for CoordinatedShutdown in daml-script

### DIFF
--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -76,8 +76,14 @@ da_scala_binary(
     name = "daml-script-binary",
     main_class = "com.daml.lf.engine.script.ScriptMain",
     resources = glob(["src/main/resources/**/*"]),
+    scala_runtime_deps = [
+        "@maven//:com_typesafe_akka_akka_slf4j",
+    ],
     scalacopts = script_scalacopts,
     visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@maven//:ch_qos_logback_logback_classic",
+    ],
     deps = [":script-runner-lib"],
 )
 

--- a/daml-script/runner/src/main/resources/application.conf
+++ b/daml-script/runner/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+akka {
+     event-handlers = ["akka.event.slf4j.Slf4jLogger"]
+     loglevel = "INFO"
+     logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+}

--- a/daml-script/runner/src/main/resources/logback.xml
+++ b/daml-script/runner/src/main/resources/logback.xml
@@ -9,6 +9,7 @@
     <logger name="io.netty" level="WARN" />
     <logger name="io.grpc.netty" level="WARN" />
     <logger name="akka.event.slf4j" level="WARN" />
+    <logger name="akka.actor.CoordinatedShutdown" level="WARN" />
     <logger name="daml.tracelog" level="DEBUG" />
     <logger name="daml.warnings" level="WARN" />
 


### PR DESCRIPTION
Trying to work around https://github.com/akka/akka/pull/30944/files
having introduced rather confusing log messages in Daml script.

There are probably some other tools where we might want to do this but
I think daml script is the main one as the other ones are long-running
services where you don’t expect to shutdown the actor system during
regular operatino.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
