### PR TITLE
Conflict checking enabled by default [DPP-850]

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -1071,7 +1071,7 @@ def sdk_platform_test(sdk_version, platform_version):
     sandbox_classic_args = ["sandbox-classic", "--contract-id-seeding=testing-weak"]
 
     sandbox_on_x = "@daml-sdk-{}//:sandbox-on-x".format(platform_version)
-    sandbox_on_x_args = ["--contract-id-seeding=testing-weak", "--implicit-party-allocation=false", "--enable-conflict-checking", "--mutable-contract-state-cache"]
+    sandbox_on_x_args = ["--contract-id-seeding=testing-weak", "--implicit-party-allocation=false", "--mutable-contract-state-cache"]
 
     json_api_args = ["json-api"]
 
@@ -1222,7 +1222,7 @@ def sdk_platform_test(sdk_version, platform_version):
         sdk_version = sdk_version,
         daml = daml_assistant,
         sandbox = sandbox_on_x if versions.is_at_least("2.0.0", platform_version) else sandbox,
-        sandbox_args = ["--contract-id-seeding=testing-weak", "--enable-conflict-checking", "--mutable-contract-state-cache", "--participant=participant-id=sandbox,port=0,port-file=__PORTFILE__"] if versions.is_at_least("2.0.0", platform_version) else ["sandbox", "--port=0", "--port-file=__PORTFILE__"],
+        sandbox_args = ["--contract-id-seeding=testing-weak", "--mutable-contract-state-cache", "--participant=participant-id=sandbox,port=0,port-file=__PORTFILE__"] if versions.is_at_least("2.0.0", platform_version) else ["sandbox", "--port=0", "--port-file=__PORTFILE__"],
         size = "large",
         # We see timeouts here fairly regularly so we
         # increase the number of CPUs.

--- a/compatibility/sandbox-migration/runner/Migration/Runner.hs
+++ b/compatibility/sandbox-migration/runner/Migration/Runner.hs
@@ -127,7 +127,7 @@ withSandbox (AppendOnly appendOnly) assistant jdbcUrl f =
     -- we spin it up directly.
     withSandboxOnX portFile f = do
           let args =
-                  [ "--contract-id-seeding=testing-weak", "--enable-conflict-checking", "--mutable-contract-state-cache"
+                  [ "--contract-id-seeding=testing-weak", "--mutable-contract-state-cache"
                   , "--ledger-id=" <> ledgerid
                   , "--participant=participant-id=sandbox-participant,port=0,port-file=" <> portFile <> ",server-jdbc-url=" <> T.unpack jdbcUrl <> ",ledgerid=" <> ledgerid
                   ]

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -350,12 +350,13 @@ SERVERS = {
 }
 
 conformance_test(
-    name = "conformance-test",
+    name = "conformance-test-no-conflict-checking",
     ports = [6865],
     server = ":app",
     server_args = [
         "--contract-id-seeding=testing-weak",
         "--participant participant-id=example,port=6865",
+        "--disable-conflict-checking",
     ],
     test_tool_args = [
         "--verbose",
@@ -374,11 +375,10 @@ conformance_test(
 )
 
 server_conformance_test(
-    name = "conformance-test-conflict-checking",
+    name = "conformance-test",
     server_args = [
         "--contract-id-seeding=testing-weak",
         "--participant participant-id=example,port=6865",
-        "--enable-conflict-checking",
     ],
     servers = SERVERS,
     test_tool_args = [
@@ -387,13 +387,12 @@ server_conformance_test(
 )
 
 conformance_test(
-    name = "conformance-test-conflict-checking-static-time",
+    name = "conformance-test-static-time",
     ports = [6865],
     server = ":app",
     server_args = [
         "--contract-id-seeding=testing-weak",
         "--participant participant-id=example,port=6865",
-        "--enable-conflict-checking",
         "--static-time",
     ],
     test_tool_args = [
@@ -408,7 +407,6 @@ conformance_test(
     server_args = [
         "--contract-id-seeding=testing-weak",
         "--participant participant-id=example,port=6865,ledger-api-transactions-buffer-max-size=10",
-        "--enable-conflict-checking",
         "--buffered-ledger-api-streams-unsafe",
     ],
     test_tool_args = [

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeConfig.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeConfig.scala
@@ -23,9 +23,10 @@ object BridgeConfigProvider extends ConfigProvider[BridgeConfig] {
       .action((p, c) => c.copy(extra = c.extra.copy(submissionBufferSize = p)))
 
     parser
-      .opt[Unit]("enable-conflict-checking")
-      .text("Enables the ledger-side submission conflict checking.")
-      .action((_, c) => c.copy(extra = c.extra.copy(conflictCheckingEnabled = true)))
+      .opt[Unit]("disable-conflict-checking")
+      .hidden()
+      .text("Disable ledger-side submission conflict checking.")
+      .action((_, c) => c.copy(extra = c.extra.copy(conflictCheckingEnabled = false)))
 
     parser
       .opt[Boolean](name = "implicit-party-allocation")
@@ -35,6 +36,7 @@ object BridgeConfigProvider extends ConfigProvider[BridgeConfig] {
         s"When referring to a party that doesn't yet exist on the ledger, the participant will implicitly allocate that party."
           + s" You can optionally disable this behavior to bring participant into line with other ledgers."
       )
+
     parser.checkConfig(c =>
       Either.cond(
         c.maxDeduplicationDuration.forall(_.compareTo(Duration.ofHours(1L)) <= 0),
@@ -53,8 +55,7 @@ object BridgeConfigProvider extends ConfigProvider[BridgeConfig] {
   }
 
   override val defaultExtraConfig: BridgeConfig = BridgeConfig(
-    // TODO SoX: Enabled by default
-    conflictCheckingEnabled = false,
+    conflictCheckingEnabled = true,
     submissionBufferSize = 500,
     implicitPartyAllocation = false,
   )

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/LedgerBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/LedgerBridge.scala
@@ -39,7 +39,6 @@ object LedgerBridge {
       timeProvider: TimeProvider,
   )(implicit
       loggingContext: LoggingContext,
-      // TODO SoX: Consider using a dedicated thread-pool for the ledger bridge
       servicesExecutionContext: ExecutionContext,
   ): ResourceOwner[LedgerBridge] =
     if (config.extra.conflictCheckingEnabled)
@@ -65,7 +64,6 @@ object LedgerBridge {
       timeProvider: TimeProvider,
   )(implicit
       loggingContext: LoggingContext,
-      // TODO SoX: Consider using a dedicated thread-pool for the ledger bridge
       servicesExecutionContext: ExecutionContext,
   ) =
     for {

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/validate/TagWithLedgerEndImpl.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/validate/TagWithLedgerEndImpl.scala
@@ -24,7 +24,6 @@ private[validate] class TagWithLedgerEndImpl(
     case Left(rejection) => Future.successful(Left(rejection))
     case Right(preparedSubmission) =>
       Timed.future(
-        // TODO SoX: Remove as this should be instantaneous
         bridgeMetrics.Stages.TagWithLedgerEnd.timer,
         indexService
           .currentLedgerEnd()(preparedSubmission.submission.loggingContext)


### PR DESCRIPTION
This PR enables conflict-checking by default in Sandbox-on-X:
* `enable-conflict-checking` CLI flag is removed
* `disable-conflict-checking` CLI flag is added

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
