### PR TITLE
Fix ledger-api-bench-tool reporting NaN result [DPP-989]

### DIFF
--- a/ledger/ledger-api-bench-tool/BUILD.bazel
+++ b/ledger/ledger-api-bench-tool/BUILD.bazel
@@ -96,6 +96,7 @@ da_scala_test_suite(
         "//language-support/scala/bindings",
         "//ledger/ledger-api-common",
         "//ledger/metrics",
+        "//libs-scala/adjustable-clock",
         "@maven//:com_typesafe_config",
         "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_grpc_grpc_api",

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/util/TimeUtil.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/util/TimeUtil.scala
@@ -17,4 +17,8 @@ object TimeUtil {
 
   def durationBetween(before: Instant, after: Instant): Duration =
     Duration.between(before, after)
+
+  /** Returns `true` if `a` is longer or equal to `b`. */
+  def isAtLeast(a: Duration, b: Duration): Boolean =
+    a.compareTo(b) >= 0
 }


### PR DESCRIPTION
### Motivation
`ledger-api-bench-tool` can incorrectly report `NaN` as a metric value in cases when the distance between subsequent periodic report requests is not positive. This PR ensures that that cannot happen.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
