### PR TITLE
Fix daml script reference in copy-unix-release-artifacts

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -86,9 +86,6 @@ steps:
     env:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
     name: publish
-    condition: and(succeeded(),
-                   eq(${{parameters.is_release}}, 'true'),
-                   eq(variables['Build.SourceBranchName'], 'main'))
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: $(Build.StagingDirectory)/release

--- a/ci/copy-unix-release-artifacts.sh
+++ b/ci/copy-unix-release-artifacts.sh
@@ -56,8 +56,8 @@ if [[ "$NAME" == "linux" ]]; then
     cp bazel-bin/triggers/runner/trigger-runner_deploy.jar $OUTPUT_DIR/artifactory/$TRIGGER
 
     SCRIPT=daml-script-$RELEASE_TAG.jar
-    bazel build //daml-script/runner:script-runner_deploy.jar
-    cp bazel-bin/daml-script/runner/script-runner_deploy.jar $OUTPUT_DIR/artifactory/$SCRIPT
+    bazel build //daml-script/runner:daml-script-binary_deploy.jar
+    cp bazel-bin/daml-script/runner/daml-script-binary_deploy.jar $OUTPUT_DIR/artifactory/$SCRIPT
 
     NON_REPUDIATION=non-repudiation-$RELEASE_TAG-ee.jar
     bazel build //runtime-components/non-repudiation-app:non-repudiation-app_deploy.jar


### PR DESCRIPTION
I also changed CI config so we run this on every build but only upload
on releases. That should hopefully make sure we catch this immediately
next time. The script is fast enough that this shouldn’t slow this
down meaningfully.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
