### PR TITLE
ledger-on-(memory|sql): Stop publishing to Maven.

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -18,7 +18,6 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
     ],
-    tags = ["maven_coordinates=com.daml:ledger-on-memory:__VERSION__"],
     visibility = [
         "//visibility:public",
     ],
@@ -99,7 +98,6 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_actor",
         "@maven//:com_typesafe_akka_akka_stream",
     ],
-    tags = ["maven_coordinates=com.daml:ledger-on-memory-app:__VERSION__"],
     visibility = ["//visibility:public"],
     deps = [
         ":ledger-on-memory",

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -52,7 +52,6 @@ da_scala_library(
         "@maven//:org_playframework_anorm_anorm_tokenizer",
         "@maven//:org_scalaz_scalaz_core",
     ],
-    tags = ["maven_coordinates=com.daml:ledger-on-sql:__VERSION__"],
     visibility = [
         "//visibility:public",
     ],

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -133,12 +133,6 @@
   type: jar-scala
 - target: //ledger/ledger-offset:ledger-offset
   type: jar-scala
-- target: //ledger/ledger-on-memory:ledger-on-memory
-  type: jar-scala
-- target: //ledger/ledger-on-memory:ledger-on-memory-app
-  type: jar-scala
-- target: //ledger/ledger-on-sql:ledger-on-sql
-  type: jar-scala
 - target: //ledger/ledger-resources:ledger-resources
   type: jar-scala
 - target: //ledger/metrics:metrics


### PR DESCRIPTION
Nothing depends on these any more.

We plan on removing them entirely, but for now we can just make sure they're not published.

### Changelog

- **[Maven]** Two internal components, "ledger-on-memory" and "ledger-on-sql", are no longer published to Maven Central. If you were relying on these components to implement a simple ledger, we encourage you to migrate to the community edition of Canton.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
