### PR TITLE
[User management][DB] Use binary collation when listing users [DPP-908] [DO NOT MERGE]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackendFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/CommonStorageBackendFactory.scala
@@ -5,8 +5,19 @@ package com.daml.platform.store.backend.common
 
 import com.daml.platform.store.backend._
 import com.daml.platform.store.cache.LedgerEndCache
+import com.daml.platform.store.interning.StringInterning
 
 trait CommonStorageBackendFactory extends StorageBackendFactory {
+
+  protected def queryStrategy: QueryStrategy
+
+  override def createCompletionStorageBackend(
+      stringInterning: StringInterning
+  ): CompletionStorageBackend =
+    new CompletionStorageBackendTemplate(queryStrategy, stringInterning)
+
+  override def createPartyStorageBackend(ledgerEndCache: LedgerEndCache): PartyStorageBackend =
+    new PartyStorageBackendTemplate(queryStrategy, ledgerEndCache)
 
   override def createPackageStorageBackend(ledgerEndCache: LedgerEndCache): PackageStorageBackend =
     new PackageStorageBackendTemplate(ledgerEndCache)
@@ -29,7 +40,7 @@ trait CommonStorageBackendFactory extends StorageBackendFactory {
     StringInterningStorageBackendTemplate
 
   override val createUserManagementStorageBackend: UserManagementStorageBackend =
-    UserManagementStorageBackendTemplate
+    new UserManagementStorageBackendTemplate(queryStrategy)
 
   override def createMeteringStorageReadBackend(
       ledgerEndCache: LedgerEndCache

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
@@ -66,4 +66,8 @@ trait QueryStrategy {
       longs.view.map(Long.box).toArray
     cSQL"= ANY($longArray)"
   }
+
+  /** A collation where strings are ordered based on their binary representation
+    */
+  def binaryCollation: String
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/UserManagementStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/UserManagementStorageBackendTemplate.scala
@@ -18,7 +18,8 @@ import com.daml.platform.store.backend.UserManagementStorageBackend
 
 import scala.util.Try
 
-object UserManagementStorageBackendTemplate extends UserManagementStorageBackend {
+class UserManagementStorageBackendTemplate(queryStrategy: QueryStrategy)
+    extends UserManagementStorageBackend {
 
   private val ParticipantUserParser: RowParser[(Int, String, Option[String], Long)] =
     int("internal_id") ~ str("user_id") ~ str("primary_party").? ~ long("created_at") map {
@@ -83,7 +84,7 @@ object UserManagementStorageBackendTemplate extends UserManagementStorageBackend
     SQL"""SELECT user_id, primary_party
           FROM participant_users
           $whereClause
-          ORDER BY user_id
+          ORDER BY user_id #${queryStrategy.binaryCollation}
           ${QueryStrategy.limitClause(Some(maxResults))}"""
       .asVectorOf(ParticipantUserParser2)(connection)
       .map { case (userId, primaryPartyRaw) =>

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2QueryStrategy.scala
@@ -22,4 +22,6 @@ object H2QueryStrategy extends QueryStrategy {
     s"array_contains($arrayColumnName, $elementColumnName)"
 
   override def isTrue(booleanColumnName: String): String = booleanColumnName
+
+  override def binaryCollation: String = ""
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackendFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackendFactory.scala
@@ -5,18 +5,15 @@ package com.daml.platform.store.backend.h2
 
 import com.daml.platform.store.backend.common.{
   CommonStorageBackendFactory,
-  CompletionStorageBackendTemplate,
   IngestionStorageBackendTemplate,
-  PartyStorageBackendTemplate,
+  QueryStrategy,
 }
 import com.daml.platform.store.backend.{
-  CompletionStorageBackend,
   ContractStorageBackend,
   DBLockStorageBackend,
   DataSourceStorageBackend,
   EventStorageBackend,
   IngestionStorageBackend,
-  PartyStorageBackend,
   ResetStorageBackend,
   StorageBackendFactory,
 }
@@ -27,14 +24,6 @@ object H2StorageBackendFactory extends StorageBackendFactory with CommonStorageB
 
   override val createIngestionStorageBackend: IngestionStorageBackend[_] =
     new IngestionStorageBackendTemplate(H2Schema.schema)
-
-  override def createPartyStorageBackend(ledgerEndCache: LedgerEndCache): PartyStorageBackend =
-    new PartyStorageBackendTemplate(H2QueryStrategy, ledgerEndCache)
-
-  override def createCompletionStorageBackend(
-      stringInterning: StringInterning
-  ): CompletionStorageBackend =
-    new CompletionStorageBackendTemplate(H2QueryStrategy, stringInterning)
 
   override def createContractStorageBackend(
       ledgerEndCache: LedgerEndCache,
@@ -56,4 +45,6 @@ object H2StorageBackendFactory extends StorageBackendFactory with CommonStorageB
 
   override val createResetStorageBackend: ResetStorageBackend =
     H2ResetStorageBackend
+
+  override protected def queryStrategy: QueryStrategy = H2QueryStrategy
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleQueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleQueryStrategy.scala
@@ -32,4 +32,6 @@ object OracleQueryStrategy extends QueryStrategy {
       longs.view.map(Long.box).toVector
     cSQL"= ANY($longArray)"
   }
+
+  override def binaryCollation: String = "COLLATE BINARY"
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackendFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackendFactory.scala
@@ -5,19 +5,16 @@ package com.daml.platform.store.backend.oracle
 
 import com.daml.platform.store.backend.common.{
   CommonStorageBackendFactory,
-  CompletionStorageBackendTemplate,
   ContractStorageBackendTemplate,
   IngestionStorageBackendTemplate,
-  PartyStorageBackendTemplate,
+  QueryStrategy,
 }
 import com.daml.platform.store.backend.{
-  CompletionStorageBackend,
   ContractStorageBackend,
   DBLockStorageBackend,
   DataSourceStorageBackend,
   EventStorageBackend,
   IngestionStorageBackend,
-  PartyStorageBackend,
   ResetStorageBackend,
   StorageBackendFactory,
 }
@@ -29,19 +26,11 @@ object OracleStorageBackendFactory extends StorageBackendFactory with CommonStor
   override val createIngestionStorageBackend: IngestionStorageBackend[_] =
     new IngestionStorageBackendTemplate(OracleSchema.schema)
 
-  override def createPartyStorageBackend(ledgerEndCache: LedgerEndCache): PartyStorageBackend =
-    new PartyStorageBackendTemplate(OracleQueryStrategy, ledgerEndCache)
-
-  override def createCompletionStorageBackend(
-      stringInterning: StringInterning
-  ): CompletionStorageBackend =
-    new CompletionStorageBackendTemplate(OracleQueryStrategy, stringInterning)
-
   override def createContractStorageBackend(
       ledgerEndCache: LedgerEndCache,
       stringInterning: StringInterning,
   ): ContractStorageBackend =
-    new ContractStorageBackendTemplate(OracleQueryStrategy, ledgerEndCache, stringInterning)
+    new ContractStorageBackendTemplate(queryStrategy, ledgerEndCache, stringInterning)
 
   override def createEventStorageBackend(
       ledgerEndCache: LedgerEndCache,
@@ -58,4 +47,5 @@ object OracleStorageBackendFactory extends StorageBackendFactory with CommonStor
   override val createResetStorageBackend: ResetStorageBackend =
     OracleResetStorageBackend
 
+  override protected def queryStrategy: QueryStrategy = OracleQueryStrategy
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresQueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresQueryStrategy.scala
@@ -29,4 +29,6 @@ object PostgresQueryStrategy extends QueryStrategy {
       longs.view.map(Long.box).toArray
     cSQL"= ANY($longArray::bigint[])"
   }
+
+  override def binaryCollation: String = "COLLATE \"C\""
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackendFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackendFactory.scala
@@ -15,19 +15,11 @@ object PostgresStorageBackendFactory
   override val createIngestionStorageBackend: IngestionStorageBackend[_] =
     new IngestionStorageBackendTemplate(PGSchema.schema)
 
-  override def createPartyStorageBackend(ledgerEndCache: LedgerEndCache): PartyStorageBackend =
-    new PartyStorageBackendTemplate(PostgresQueryStrategy, ledgerEndCache)
-
-  override def createCompletionStorageBackend(
-      stringInterning: StringInterning
-  ): CompletionStorageBackend =
-    new CompletionStorageBackendTemplate(PostgresQueryStrategy, stringInterning)
-
   override def createContractStorageBackend(
       ledgerEndCache: LedgerEndCache,
       stringInterning: StringInterning,
   ): ContractStorageBackend =
-    new ContractStorageBackendTemplate(PostgresQueryStrategy, ledgerEndCache, stringInterning)
+    new ContractStorageBackendTemplate(queryStrategy, ledgerEndCache, stringInterning)
 
   override def createEventStorageBackend(
       ledgerEndCache: LedgerEndCache,
@@ -44,4 +36,5 @@ object PostgresStorageBackendFactory
   override val createResetStorageBackend: ResetStorageBackend =
     PostgresResetStorageBackend
 
+  override protected def queryStrategy: QueryStrategy = PostgresQueryStrategy
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsUserManagement.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsUserManagement.scala
@@ -164,6 +164,19 @@ private[backend] trait StorageBackendTestsUserManagement
     )
   }
 
+  it should "get all users (getUsers) ordered by id using binary collation" in {
+    val user1 = newUniqueUser(userId = "a")
+    val user2 = newUniqueUser(userId = "a!")
+    val user3 = newUniqueUser(userId = "b")
+    val user4 = newUniqueUser(userId = "a_")
+    val user5 = newUniqueUser(userId = "!a")
+    val user6 = newUniqueUser(userId = "_a")
+    val users = Seq(user1, user2, user3, user4, user5, user6)
+    users.foreach(user => executeSql(tested.createUser(user, createdAt = zeroMicros)))
+    executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 10))
+      .map(_.id) shouldBe Seq("!a", "_a", "a", "a!", "a_", "b")
+  }
+
   it should "get a page of users (getUsers) ordered by id" in {
     val user1 = newUniqueUser(userId = "user_id_1")
     val user2 = newUniqueUser(userId = "user_id_2")


### PR DESCRIPTION
Using `COLLATE "C"` in Postgres and `COLLATE BINARY` in Oracle when querying users by `user_id`.
H2 virtually doesn't support collation and seems that by default it does want we want.

Orignally I had planned to specify collation on column level, which worked in Postgres, but in Oracle it'd require changing `MAX_STRING_SIZE=STANDARD` to `MAX_STRING_SIZE=EXTENDED` detailed impact of which is unclear and would require thorough analysis.




### More info on Oracle

When attempting to create a table with column collation:
```
SQL> CREATE TABLE id_table
  2    (name VARCHAR2(64) COLLATE BINARY_AI,
  3*    id VARCHAR2(8) COLLATE BINARY_CI);

Error starting at line : 1 in command -
CREATE TABLE id_table
  (name VARCHAR2(64) COLLATE BINARY_AI,
   id VARCHAR2(8) COLLATE BINARY_CI)
Error report -
ORA-43929: Collation cannot be specified if parameter MAX_STRING_SIZE=STANDARD is set.
43929. 0000 -  "Collation cannot be specified if parameter MAX_STRING_SIZE=STANDARD is set."
*Document: YES
*Cause:    The COLLATE or DEFAULT COLLATION clause was specified in a DDL
           statement or the DEFAULT_COLLATION parameter was specified in an
           ALTER SESSION statement, but the value of the initialization
           parameter MAX_STRING_SIZE was STANDARD. The data-bound collation
           feature is disabled if the value of this parameter is STANDARD.
*Action:   Set MAX_STRING_SIZE to EXTENDED by following the procedure
           documented in the Oracle Database Reference.
SQL>
```

From https://docs.oracle.com/database/121/REFRN/GUID-D424D23B-0933-425F-BC69-9C0E6724693C.htm#REFRN10321:

> MAX_STRING_SIZE controls the maximum size of VARCHAR2, NVARCHAR2, and RAW data types in SQL.
> STANDARD means that the length limits for Oracle Database releases prior to Oracle Database 12c apply (for example, 4000 bytes for VARCHAR2 and NVARCHAR2, and 2000 bytes for RAW).
> EXTENDED means that the 32767 byte limit introduced in Oracle Database 12c applies.
> 
