### PR TITLE
No parties in create-daml-app's daml.yaml template,

### DIFF
--- a/templates/create-daml-app/daml.yaml.template
+++ b/templates/create-daml-app/daml.yaml.template
@@ -2,10 +2,6 @@ sdk-version: __VERSION__
 name: __PROJECT_NAME__
 version: 0.1.0
 source: daml
-parties:
-- Alice
-- Bob
-- Charlie
 dependencies:
 - daml-prim
 - daml-stdlib

--- a/templates/gsg-trigger.patch
+++ b/templates/gsg-trigger.patch
@@ -85,10 +85,10 @@ diff --git create-daml-app/daml/User.daml create-daml-app/daml/User.daml
 +-- MESSAGE_END
 --- create-daml-app/daml.yaml.template	2022-01-26 17:29:37.149557361 +0100
 +++ create-daml-app/daml.yaml.template	2022-01-26 17:29:27.749276386 +0100
-@@ -6,10 +6,12 @@
- - Alice
- - Bob
- - Charlie
+@@ -2,10 +2,12 @@
+ name: __PROJECT_NAME__
+ version: 0.1.0
+ source: daml
 +# trigger-dependencies-begin
  dependencies:
  - daml-prim


### PR DESCRIPTION
... so that Navigator shows users for login by default.

When parties are specified explicitly in daml.yaml,
navigator uses those instead of querying user management
for the list of users a user can log in as.

These days, it actually doesn't make sense to list the
parties in the daml.yaml. Navigator will query party
mgmt for a list of known parties. We don't implicitly
allocate parties (anymore), so unclear why this section
is still here.

The users for the template are created by the init script
(see Setup.daml).

See #12945

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
