### PR TITLE
Drop parties from daml templates

### DIFF
--- a/docs/source/daml/patterns/daml.yaml.template
+++ b/docs/source/daml/patterns/daml.yaml.template
@@ -1,9 +1,6 @@
 sdk-version: __VERSION__
 name: daml-patterns
 source: daml
-parties:
-  - Alice
-  - Bob
 version: 0.0.1
 dependencies:
   - daml-prim

--- a/language-support/scala/examples/quickstart-scala/daml.yaml
+++ b/language-support/scala/examples/quickstart-scala/daml.yaml
@@ -5,11 +5,6 @@ sdk-version: 0.0.0
 name: quickstart
 source: daml
 init-script: Main:initialize
-parties:
-  - Alice
-  - Bob
-  - USD_Bank
-  - EUR_Bank
 version: 0.0.1
 exposed-modules:
   - Main

--- a/templates/copy-trigger/daml.yaml.template
+++ b/templates/copy-trigger/daml.yaml.template
@@ -1,9 +1,6 @@
 sdk-version: __VERSION__
 name: __PROJECT_NAME__
 source: src
-parties:
-  - Alice
-  - Bob
 version: 0.0.1
 # trigger-dependencies-begin
 dependencies:

--- a/templates/empty-skeleton/daml.yaml.template
+++ b/templates/empty-skeleton/daml.yaml.template
@@ -1,9 +1,6 @@
 sdk-version: __VERSION__
 name: __PROJECT_NAME__
 source: daml
-parties:
-  - Alice
-  - Bob
 version: 0.0.1
 dependencies:
   - daml-prim


### PR DESCRIPTION
Complements #12952 which drops it from create-daml-app by also
dropping it from the rest.

Couldn’t find any docs or other stuff that is broken by this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
