### PR TITLE
ledger-api-bench-tool - do not require using ledgers with UserManagementService implemented [DPP-846]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/CommandCompletionService.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/CommandCompletionService.scala
@@ -42,10 +42,12 @@ class CommandCompletionService(
       ledgerId: String,
       config: WorkflowConfig.StreamConfig.CompletionsStreamConfig,
   ): CompletionStreamRequest = {
-    assert(
-      authorizationToken.isDefined && userId == config.applicationId,
-      s"When using user based authorization applicationId (${config.applicationId}) must be equal to userId ($userId)",
-    )
+    if (authorizationToken.isDefined) {
+      assert(
+        userId == config.applicationId,
+        s"When using user based authorization applicationId (${config.applicationId}) must be equal to userId ($userId)",
+      )
+    }
     val request = CompletionStreamRequest.defaultInstance
       .withLedgerId(ledgerId)
       .withParties(List(config.party))

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/LedgerApiServices.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/LedgerApiServices.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.api.benchtool.services
 
 import com.daml.ledger.api.benchtool.AuthorizationHelper
-import com.daml.ledger.api.v1.admin.user_management_service.UserManagementServiceGrpc
 import com.daml.ledger.participant.state.index.v2.UserManagementStore
 import io.grpc.Channel
 
@@ -35,11 +34,7 @@ class LedgerApiServices(
     new PartyManagementService(channel, authorizationToken = authorizationToken)
   val transactionService =
     new TransactionService(channel, ledgerId, authorizationToken = authorizationToken)
-  val userManagementService: UserManagementServiceGrpc.UserManagementServiceStub =
-    AuthorizationHelper.maybeAuthedService(authorizationToken)(
-      UserManagementServiceGrpc.stub(channel)
-    )
-
+  val userManagementService = new UserManagementService(channel, authorizationToken)
 }
 
 object LedgerApiServices {

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/UserManagementService.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/services/UserManagementService.scala
@@ -1,0 +1,85 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.services
+
+import com.daml.error.definitions.LedgerApiErrors
+import com.daml.ledger.api.benchtool.AuthorizationHelper
+import com.daml.ledger.api.v1.admin.user_management_service.{
+  CreateUserRequest,
+  GrantUserRightsRequest,
+  User,
+  UserManagementServiceGrpc,
+  Right => UserRight,
+}
+import io.grpc.{Channel, StatusRuntimeException}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class UserManagementService(channel: Channel, authorizationToken: Option[String]) {
+  private val logger: Logger = LoggerFactory.getLogger(getClass)
+  private val service: UserManagementServiceGrpc.UserManagementServiceStub =
+    AuthorizationHelper.maybeAuthedService(authorizationToken)(
+      UserManagementServiceGrpc.stub(channel)
+    )
+
+  def createUserOrGrantRightsToExisting(
+      userId: String,
+      observerPartyNames: Seq[String],
+      signatoryPartyName: String,
+  )(implicit ec: ExecutionContext): Future[Unit] = {
+    val rights = userRights(observerPartyNames, signatoryPartyName)
+    createUser(userId, rights).recoverWith {
+      case e: StatusRuntimeException
+          if e.getStatus.getDescription.startsWith(
+            LedgerApiErrors.AdminServices.UserAlreadyExists.id
+          ) =>
+        logger.info(
+          s"Benchmark user already exists (received error: ${e.getStatus.getDescription}) so granting rights the existing user."
+        )
+        grantUserRights(userId, rights)
+    }
+  }
+
+  private def createUser(
+      userId: String,
+      rights: Seq[UserRight],
+  )(implicit ec: ExecutionContext): Future[Unit] = {
+    logger.info(s"Creating a user: '$userId' with rights: ${rights.mkString(", ")}")
+    service
+      .createUser(
+        CreateUserRequest(
+          user = Some(User(id = userId, primaryParty = "")),
+          rights = rights,
+        )
+      )
+      .map(_ => ())
+  }
+
+  private def grantUserRights(
+      userId: String,
+      rights: Seq[UserRight],
+  )(implicit ec: ExecutionContext): Future[Unit] = {
+    logger.info(s"Granting rights: ${rights.mkString(", ")} to the user: $userId")
+    service
+      .grantUserRights(
+        GrantUserRightsRequest(
+          userId = userId,
+          rights = rights,
+        )
+      )
+      .map(_ => ())
+  }
+
+  private def userRights(
+      observerPartyNames: Seq[String],
+      signatoryPartyName: String,
+  ): Seq[UserRight] = {
+    val actAs = UserRight(UserRight.Kind.CanActAs(UserRight.CanActAs(signatoryPartyName)))
+    val readAs = observerPartyNames.map(observerPartyName =>
+      UserRight(UserRight.Kind.CanReadAs(UserRight.CanReadAs(observerPartyName)))
+    )
+    actAs +: readAs
+  }
+}


### PR DESCRIPTION
### Motivation
This is a follow-up PR to #12871 .
This change restores the possibility to connect to ledgers that don't implement the `UserManagementService` with the `ledger-api-bench-tool`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
