### PR TITLE
sandbox-classic: Fix the class loader when retrieving the banner.

### DIFF
--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/banner/Banner.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/banner/Banner.scala
@@ -13,13 +13,10 @@ object Banner {
   private val resourceName = "banner.txt"
 
   private def banner: String =
-    if (classLoader.getResource(resourceName) != null)
-      Source
-        .fromResource(resourceName, classLoader)
-        .getLines()
-        .mkString("\n")
-    else
-      "Banner resource missing from classpath."
+    Source
+      .fromResource(resourceName, classLoader)
+      .getLines()
+      .mkString("\n")
 
   def show(out: PrintStream): Unit = out.println(banner)
 }

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/banner/Banner.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/banner/Banner.scala
@@ -8,16 +8,18 @@ import java.io.PrintStream
 import scala.io.Source
 
 object Banner {
-  def show(out: PrintStream): Unit = {
-    val resourceName = "banner.txt"
-    if (getClass.getClassLoader.getResource(resourceName) != null)
-      out.println(
-        Source
-          .fromResource(resourceName)
-          .getLines()
-          .mkString("\n")
-      )
+  private val classLoader = getClass.getClassLoader
+
+  private val resourceName = "banner.txt"
+
+  private def banner: String =
+    if (classLoader.getResource(resourceName) != null)
+      Source
+        .fromResource(resourceName, classLoader)
+        .getLines()
+        .mkString("\n")
     else
-      out.println("Banner resource missing from classpath.")
-  }
+      "Banner resource missing from classpath."
+
+  def show(out: PrintStream): Unit = out.println(banner)
 }


### PR DESCRIPTION
If the classloader is not explicitly provided to `Source.fromResource`, it will use the current thread's class loader, which may not have access to _banner.txt_. To avoid issues, we need to use the correct class loader.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
