### PR TITLE
Update bg color on docs sections

### DIFF
--- a/docs/theme/sass/_theme_layout.sass
+++ b/docs/theme/sass/_theme_layout.sass
@@ -1304,6 +1304,7 @@ body
     z-index: 200
     width: 100%
     height: 100%
+    background: $white
 
     +media($tablet)
       -webkit-box-shadow: -2px 2px 3px 0px $gray-lighter


### PR DESCRIPTION
Adds a background color to the floating section. I accidentally removed it in the last round of style edits.

<img width="707" alt="Screen Shot 2022-02-16 at 11 56 15 AM" src="https://user-images.githubusercontent.com/42810081/154316136-d32f71c2-59bb-442c-9819-427c3d62b76c.png">

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
