### PR TITLE
Fix parsing of java codegen module prefixes

### DIFF
--- a/language-support/codegen-common/BUILD.bazel
+++ b/language-support/codegen-common/BUILD.bazel
@@ -32,6 +32,7 @@ da_scala_test(
     deps = [
         ":codegen-common",
         "//daml-assistant/scala-daml-project-config",
+        "//daml-lf/data",
         "@maven//:ch_qos_logback_logback_classic",
     ],
 )

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
@@ -160,9 +160,7 @@ object CodegenConfigReader {
       // TODO (MK) https://github.com/digital-asset/daml/issues/9934
       // For now we only allow name-version pairs to match the compiler. Once the compiler
       // accepts package ids we can allow for those here as well.
-      final def apply(key: String): Option[PackageReference] = nameVersion(key)
-
-      private def nameVersion(key: String): Option[PackageReference] = {
+      final def apply(key: String): Option[PackageReference] = {
         val dashIndex = key.lastIndexWhere(_ == '-')
         if (dashIndex < 0) {
           None

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
@@ -157,13 +157,15 @@ object CodegenConfigReader {
 
   implicit val decodePackageReference: KeyDecoder[PackageReference] =
     new KeyDecoder[PackageReference] {
+      // This regex matches IdString.PackageVersion.
+      private val refRegex = """^(.*)-((0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*)$""".r
       // TODO (MK) https://github.com/digital-asset/daml/issues/9934
-      // For now we only allow name-vesion pairs to match the compiler. Once the compiler
+      // For now we only allow name-version pairs to match the compiler. Once the compiler
       // accepts package ids we can allow for those here as well.
       final def apply(key: String): Option[PackageReference] = nameVersion(key)
 
-      private def nameVersion(key: String): Option[PackageReference] = key.split("-") match {
-        case Array(name, version) =>
+      private def nameVersion(key: String): Option[PackageReference] = key match {
+        case refRegex(name, version, _*) =>
           for {
             name <- PackageName.fromString(name).toOption
             version <- PackageVersion.fromString(version).toOption

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
@@ -160,16 +160,16 @@ object CodegenConfigReader {
       // TODO (MK) https://github.com/digital-asset/daml/issues/9934
       // For now we only allow name-version pairs to match the compiler. Once the compiler
       // accepts package ids we can allow for those here as well.
-      final def apply(key: String): Option[PackageReference] = {
-        val dashIndex = key.lastIndexWhere(_ == '-')
-        if (dashIndex < 0) {
-          None
-        } else {
-          for {
-            name <- PackageName.fromString(key.slice(0, dashIndex)).toOption
-            version <- PackageVersion.fromString(key.slice(dashIndex + 1, key.length)).toOption
-          } yield PackageReference.NameVersion(name, version)
+      final def apply(key: String): Option[PackageReference] =
+        key.splitAt(key.lastIndexOf('-')) match {
+          case (rawPackageName, rawPackageVersion)
+              if rawPackageName.nonEmpty && rawPackageVersion.nonEmpty =>
+            for {
+              name <- PackageName.fromString(rawPackageName).toOption
+              version <- PackageVersion.fromString(rawPackageVersion.tail).toOption
+            } yield PackageReference.NameVersion(name, version)
+          case _ =>
+            None
         }
-      }
     }
 }


### PR DESCRIPTION
I admit I have no idea what I thought when I wrote that split but it
was clearly nothing sensible.

changelog_begin

- [Java Codegen] Fix parsing of `module-prefixes` to support package
  names containing dashes.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
