### PR TITLE
Add tests and refactor package reference decoding

### DIFF
--- a/language-support/codegen-common/BUILD.bazel
+++ b/language-support/codegen-common/BUILD.bazel
@@ -29,6 +29,10 @@ da_scala_test(
     name = "test",
     srcs = glob(["src/test/**/*.scala"]),
     resources = glob(["src/test/resources/**/*"]),
+    scala_deps = [
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatestplus_scalacheck_1_15",
+    ],
     deps = [
         ":codegen-common",
         "//daml-assistant/scala-daml-project-config",


### PR DESCRIPTION
Specifically for the Java codegen, builds on top of #12977.

Makes sure we don't rely on `PackageName.fromString` and `PackageVersion.fromString`
to blow up when passed an empty string.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
