### PR TITLE
test middleware user tokens with oauth2 server user tokens

### DIFF
--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -70,6 +70,7 @@ trait TestFixture
   }
   lazy protected val middlewareClientRoutes: Client.Routes =
     middlewareClient.routes(middlewareClientCallbackUri)
+  protected def oauthYieldsUserTokens: Boolean = true
   override protected lazy val suiteResource: Resource[TestResources] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
     new OwnedResource[ResourceContext, TestResources](
@@ -81,7 +82,7 @@ trait TestFixture
             ledgerId = ledgerId,
             jwtSecret = jwtSecret,
             clock = Some(clock),
-            yieldUserTokens = false, // TODO parameterize (#12989)
+            yieldUserTokens = oauthYieldsUserTokens,
           )
         )
         serverBinding <- Resources.authServerBinding(server)

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
@@ -324,35 +324,16 @@ class TestMiddlewareClaimsToken extends TestMiddleware {
     "not authorize unauthorized parties" in {
       server.revokeParty(Party("Eve"))
       val claims = Request.Claims(actAs = List(Party("Eve")))
-      val req = HttpRequest(uri = middlewareClientRoutes.loginUri(claims, None))
-      for {
-        resp <- Http().singleRequest(req)
-        // Redirect to /authorize on authorization server
-        resp <- {
-          assert(resp.status == StatusCodes.Found)
-          val req = HttpRequest(uri = resp.header[Location].get.uri)
-          Http().singleRequest(req)
-        }
-        // Redirect to /cb on middleware
-        resp <- {
-          assert(resp.status == StatusCodes.Found)
-          val req = HttpRequest(uri = resp.header[Location].get.uri)
-          Http().singleRequest(req)
-        }
-      } yield {
-        // Redirect to client callback
-        assert(resp.status == StatusCodes.Found)
-        assert(resp.header[Location].get.uri.withQuery(Uri.Query()) == middlewareClientCallbackUri)
-        // with error parameter set
-        assert(resp.header[Location].get.uri.query().toMap.get("error") == Some("access_denied"))
-        // Without token in cookie
-        val cookie = resp.header[`Set-Cookie`]
-        assert(cookie == None)
-      }
+      ensureDisallowed(claims)
     }
+
     "not authorize disallowed admin claims" in {
       server.revokeAdmin()
       val claims = Request.Claims(admin = true)
+      ensureDisallowed(claims)
+    }
+
+    def ensureDisallowed(claims: Request.Claims) = {
       val req = HttpRequest(uri = middlewareClientRoutes.loginUri(claims, None))
       for {
         resp <- Http().singleRequest(req)

--- a/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/TestFixture.scala
@@ -30,7 +30,7 @@ trait TestFixture
   lazy protected val server: Server = suiteResource.value._2
   lazy protected val serverBinding: ServerBinding = suiteResource.value._3
   lazy protected val clientBinding: ServerBinding = suiteResource.value._4
-  protected def yieldUserTokens: Boolean
+  protected[this] def yieldUserTokens: Boolean
   override protected lazy val suiteResource
       : Resource[(AdjustableClock, Server, ServerBinding, ServerBinding)] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)


### PR DESCRIPTION
`TestMiddlewareUserToken` now uses user tokens from the oauth server as well, courtesy #12929. `TestMiddlewareClaimsToken` is the only middleware-only (non-Client) test that switches the oauth test server back to producing claims tokens, and contains all the tests that depend on claims token semantics.

The token returned by the oauth server is irrelevant for the behavior these tests are exercising, so they are merely ported to always run on user tokens.

* TestMiddlewareCallbackUriOverride
* TestMiddlewareLimitedCallbackStore
* TestMiddlewareClientLimitedCallbackStore
* TestMiddlewareClientNoRedirectToLogin
* TestMiddlewareClientYesRedirectToLogin
* TestMiddlewareClientAutoRedirectToLogin

Fixes #12989.

* [x] move from d1093cb92745ac0db9daade461ce7169b3c1dce5 to main after #12929 merges

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
