### PR TITLE
Change mechanism for detecting the index page in the docs theme.

### DIFF
--- a/docs/theme/da_theme_skeleton/layout.html
+++ b/docs/theme/da_theme_skeleton/layout.html
@@ -4,7 +4,7 @@
 {# TEMPLATE VAR SETTINGS #}
 {%- set url_root = pathto('', 1) %}
 {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
-{%- set is_index = theme_index_page_boxes and url_root == './' %}
+{%- set is_index = theme_index_page_boxes and not prev %}
 {%- if not embedded and docstitle %}
 {%- set titlesuffix = " &mdash; "|safe + docstitle|e %}
 {%- else %}


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGLOG_END

This fixes the issue of any page in the root directly (eg https://docs.daml.com/2.0.0-snapshot.20220215.9307.0.55fef9cf/building-applications.html) showing the box index page.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
