### PR TITLE
Add experimental builtin to convert a template typerep to text

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -787,6 +787,7 @@ typeOf' = \case
 
 checkExperimentalType :: MonadGamma m => T.Text -> Type -> m ()
 checkExperimentalType "ANSWER" (TUnit :-> TInt64) = pure ()
+checkExperimentalType "TYPEREP_TYCON_NAME" (TTypeRep :-> TOptional TText) = pure ()
 checkExperimentalType name ty =
   throwWithContext (EUnknownExperimental name ty)
 

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
@@ -4,6 +4,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 
 -- This is the companion module (is that a word? now it is!) to DA.Internal.Template
 -- which provides functions and typeclasses.
@@ -253,6 +254,21 @@ instance Eq TemplateTypeRep where
   TemplateTypeRep a == TemplateTypeRep b = a == b
 
 deriving instance Ord TemplateTypeRep
+
+#ifdef DAML_EXPERIMENTAL
+
+-- | (experimental, 1.dev only) Get the template id (or interface id)
+-- represented by a TemplateTypeRep, as a string.
+templateTypeRepToText : TemplateTypeRep -> Text
+templateTypeRepToText (TemplateTypeRep x) =
+  case primitive @"$TYPEREP_TYCON_NAME" x of
+    None -> error "Invalid TemplateTypeRep, does not contain a type constructor."
+    Some y -> y
+
+instance Show TemplateTypeRep where
+  show = templateTypeRepToText
+
+#endif
 
 -- | Wrap the template in `AnyTemplate`.
 --

--- a/compiler/damlc/tests/daml-test-files/TemplateTypeRepToText.daml
+++ b/compiler/damlc/tests/daml-test-files/TemplateTypeRepToText.daml
@@ -1,0 +1,28 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @SINCE-LF-FEATURE DAML_EXPERIMENTAL
+module TemplateTypeRepToText where
+
+import DA.Assert ((===), (=/=))
+import qualified TemplateTypeRep as A
+import qualified TemplateTypeRep2 as B
+
+main = scenario do
+    let rep1 = templateTypeRep @A.T1
+    let rep2 = templateTypeRep @A.T2
+    let rep3 = templateTypeRep @B.T1
+
+    rep1 === rep1
+    rep2 === rep2
+    rep3 === rep3
+
+    rep1 =/= rep2
+    rep1 =/= rep3
+    rep2 =/= rep3
+
+    templateTypeRepToText rep1 === "-homePackageId-:TemplateTypeRep:T1"
+    templateTypeRepToText rep2 === "-homePackageId-:TemplateTypeRep:T2"
+    templateTypeRepToText rep3 === "-homePackageId-:TemplateTypeRep2:T1"
+
+-- @ENABLE-SCENARIOS

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -168,6 +168,12 @@ private[speedy] sealed abstract class SBuiltin(val arity: Int) {
       case otherwise => unexpectedType(i, "SAny", otherwise)
     }
 
+  final protected def getSTypeRep(args: util.ArrayList[SValue], i: Int): Ast.Type =
+    args.get(i) match {
+      case STypeRep(ty) => ty
+      case otherwise => unexpectedType(i, "STypeRep", otherwise)
+    }
+
   final protected def getSAnyException(args: util.ArrayList[SValue], i: Int): SRecord =
     args.get(i) match {
       case SAnyException(exception) => exception
@@ -1865,10 +1871,19 @@ private[lf] object SBuiltin {
         machine.returnValue = SInt64(42L)
     }
 
+    private object SBExperimentalTypeRepTyConName extends SBuiltinPure(1) {
+      override private[speedy] def executePure(args: util.ArrayList[SValue]): SOptional =
+        getSTypeRep(args, 0) match {
+          case Ast.TTyCon(name) => SOptional(Some(SText(name.toString)))
+          case _ => SOptional(None)
+        }
+    }
+
     //TODO: move this into the speedy compiler code
     private val mapping: Map[String, compileTime.SExpr] =
       List(
-        "ANSWER" -> SBExperimentalAnswer
+        "ANSWER" -> SBExperimentalAnswer,
+        "TYPEREP_TYCON_NAME" -> SBExperimentalTypeRepTyConName,
       ).view.map { case (name, builtin) => name -> compileTime.SEBuiltin(builtin) }.toMap
 
     def apply(name: String): compileTime.SExpr =


### PR DESCRIPTION
Part of #12792, this is the builtin we need to be able to effectively
store a TemplateTypeRep inside a template (i.e. you store a string
containing the template id, not a typerep).

A nice bonus is that we can use it to implement a Show instance
for TemplateTypeRep, so we can use (===) and (=/=) as well.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
