### PR TITLE
Fix docs  rendering of \n in interpolated strings in TypeScript

### DIFF
--- a/docs/configs/static/typescript.py
+++ b/docs/configs/static/typescript.py
@@ -124,8 +124,7 @@ class TypeScriptLexer(RegexLexer):
         # there should be reflected here as well.
         'interp': [
             (r'`', String.Backtick, '#pop'),
-            (r'\\\\', String.Backtick),
-            (r'\\`', String.Backtick),
+            (r'\\.', String.Backtick),
             (r'\$\{', String.Interpol, 'interp-inside'),
             (r'\$', String.Backtick),
             (r'[^`\\$]+', String.Backtick),

--- a/docs/theme/docs/typescript.py
+++ b/docs/theme/docs/typescript.py
@@ -55,7 +55,7 @@ class TypeScriptLexer(RegexLexer):
         ],
         'tag': [
             (r'\s+', Text),
-            (",", Punctuation),
+            (r'[,\|]', Punctuation),
             (r'([\w:-]+\s*)(=)(\s*)', bygroups(Name.Attribute, Operator, Text),
              'attr'),
             (r'[\w:-]+', Name.Attribute),
@@ -124,8 +124,7 @@ class TypeScriptLexer(RegexLexer):
         # there should be reflected here as well.
         'interp': [
             (r'`', String.Backtick, '#pop'),
-            (r'\\\\', String.Backtick),
-            (r'\\`', String.Backtick),
+            (r'\\.', String.Backtick),
             (r'\$\{', String.Interpol, 'interp-inside'),
             (r'\$', String.Backtick),
             (r'[^`\\$]+', String.Backtick),


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

Our TypeScript Lexer is a fork of https://github.com/pygments/pygments/blob/master/pygments/lexers/javascript.py.
In the version we were using, the rendering of escaped characters in interpolated strings was not working. See for example https://docs.daml.com/2.0.0-snapshot.20220215.9307.0.55fef9cf/getting-started/first-feature.html#messageedit-component:
<img width="217" alt="image" src="https://user-images.githubusercontent.com/40762178/155108275-97e922a2-d076-4c64-bf82-044a6d0ea39f.png">

This fix updates the `interp` section of our Lexer with that of the latest upstream. It seems to fix the issue. Without breaking new things.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
