### PR TITLE
Fix the indentation of item four levels down the docs ToC.

### DIFF
--- a/docs/theme/sass/_theme_layout.sass
+++ b/docs/theme/sass/_theme_layout.sass
@@ -133,11 +133,13 @@ html
     > a
       padding: $gutter / 4 $gutter * 2.5 / 0.9 $gutter / 4 $gutter * 2.1 / 0.9
 
-    li.toctree-l3 > a
-      padding: $gutter / 4 $gutter * 2.5 / 0.9 $gutter / 4 $gutter * 2.8 / 0.9
+    li.toctree-l3 
+      > a
+        padding: $gutter / 4 $gutter * 2.5 / 0.9 $gutter / 4 $gutter * 2.8 / 0.9
     
-      li.toctree-l4 > a
-        padding: $gutter / 4 $gutter * 2.5 / 0.9 $gutter / 4 $gutter * 3.5 / 0.9
+      li.toctree-l4
+        > a
+          padding: $gutter / 4 $gutter * 2.5 / 0.9 $gutter / 4 $gutter * 3.5 / 0.9
 
     a:hover span.toctree-expand
       color: $menu-link-medium


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

Fixes this:
<img width="347" alt="image" src="https://user-images.githubusercontent.com/40762178/155112335-91a47d0b-f59a-469b-977b-5eb11788c4fd.png">

After:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/40762178/155112413-1ffa204e-2bf6-489d-ba74-0b4152606b6d.png">

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
