### PR TITLE
Delete vestigial InterfaceChoice from AST

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -951,15 +951,6 @@ data DefInterface = DefInterface
   }
   deriving (Eq, Data, Generic, NFData, Show)
 
-data InterfaceChoice = InterfaceChoice
-  { ifcLocation :: !(Maybe SourceLoc)
-  , ifcName :: !ChoiceName
-  , ifcConsuming :: !Bool
-  , ifcArgType :: !Type
-  , ifcRetType :: !Type
-  }
-  deriving (Eq, Data, Generic, NFData, Show)
-
 data InterfaceMethod = InterfaceMethod
   { ifmLocation :: !(Maybe SourceLoc)
   , ifmName :: !MethodName
@@ -1052,10 +1043,6 @@ instance Hashable a => Hashable (Qualified a)
 instance NM.Named TemplateChoice where
   type Name TemplateChoice = ChoiceName
   name = chcName
-
-instance NM.Named InterfaceChoice where
-  type Name InterfaceChoice = ChoiceName
-  name = ifcName
 
 instance NM.Named InterfaceMethod where
   type Name InterfaceMethod = MethodName

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -188,7 +188,6 @@ instance MonoTraversable ModuleRef DefDataType
 instance MonoTraversable ModuleRef DefTypeSyn
 instance MonoTraversable ModuleRef DefException
 
-instance MonoTraversable ModuleRef InterfaceChoice
 instance MonoTraversable ModuleRef InterfaceMethod
 instance MonoTraversable ModuleRef DefInterface
 

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -140,9 +140,6 @@ data Error
   | EMissingRequiredInterface { emriTemplate :: !TypeConName, emriRequiringInterface :: !(Qualified TypeConName), emriRequiredInterface :: !(Qualified TypeConName) }
   | EBadInheritedChoices { ebicInterface :: !(Qualified TypeConName), ebicExpected :: ![ChoiceName], ebicGot :: ![ChoiceName] }
   | EMissingInterfaceChoice !ChoiceName
-  | EBadInterfaceChoiceImplConsuming !ChoiceName !Bool !Bool
-  | EBadInterfaceChoiceImplArgType !ChoiceName !Type !Type
-  | EBadInterfaceChoiceImplRetType !ChoiceName !Type !Type
   | EMissingInterfaceMethod !TypeConName !(Qualified TypeConName) !MethodName
   | EUnknownInterfaceMethod !TypeConName !(Qualified TypeConName) !MethodName
   | ETemplateDoesNotImplementInterface !(Qualified TypeConName) !(Qualified TypeConName)
@@ -407,24 +404,6 @@ instance Pretty Error where
       , "But got: " <> pretty ebicGot
       ]
     EMissingInterfaceChoice ch -> "Missing interface choice implementation for " <> pretty ch
-    EBadInterfaceChoiceImplConsuming ch ifaceConsuming tplConsuming ->
-      vcat
-      [ "Choice implementation and interface definition for " <> pretty ch <> " differ in consuming/non-consuming behaviour."
-      , "Expected: " <> prettyConsuming ifaceConsuming
-      , "But got: " <> prettyConsuming tplConsuming
-      ]
-    EBadInterfaceChoiceImplArgType ch ifaceArgType tplArgType ->
-      vcat
-      [ "Choice implementation and interface definition for " <> pretty ch <> " differ in argument type."
-      , "Expected: " <> pretty ifaceArgType
-      , "But got: " <> pretty tplArgType
-      ]
-    EBadInterfaceChoiceImplRetType ch ifaceRetType tplRetType ->
-      vcat
-      [ "Choice implementation and interface definition for " <> pretty ch <> " differ in return type."
-      , "Expected: " <> pretty ifaceRetType
-      , "But got: " <> pretty tplRetType
-      ]
     EMissingInterfaceMethod tpl iface method ->
       "Template " <> pretty tpl <> " is missing method " <> pretty method <> " for interface " <> pretty iface
     EUnknownInterfaceMethod tpl iface method ->
@@ -435,9 +414,6 @@ instance Pretty Error where
       "Interface " <> pretty requiringIface <> " does not require interface " <> pretty requiredIface
     EUnknownExperimental name ty ->
       "Unknown experimental primitive " <> string (show name) <> " : " <> pretty ty
-
-prettyConsuming :: Bool -> Doc ann
-prettyConsuming consuming = if consuming then "consuming" else "non-consuming"
 
 instance Pretty Context where
   pPrint = \case

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -732,14 +732,6 @@ object Ast {
   type DefInterfaceSignature = GenDefInterface[Unit]
   val DefInterfaceSignature = new GenDefInterfaceCompanion[Unit]
 
-  final case class InterfaceChoice(
-      name: ChoiceName,
-      consuming: Boolean,
-      argType: Type,
-      returnType: Type,
-      // TODO interfaces Should observers or controllers be part of the interface?
-  )
-
   final case class InterfaceMethod(
       name: MethodName,
       returnType: Type,

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -330,12 +330,6 @@ private[daml] class AstRewriter(
       case DefException(message) => DefException(apply(message))
     }
 
-  def apply(x: InterfaceChoice): InterfaceChoice =
-    x match {
-      case InterfaceChoice(name, consuming, argType, returnType) =>
-        InterfaceChoice(name, consuming, apply(argType), returnType = apply(returnType))
-    }
-
   def apply(x: InterfaceMethod): InterfaceMethod =
     x match {
       case InterfaceMethod(name, returnType) =>

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -434,47 +434,6 @@ final case class EBadInheritedChoices(
     s"Inherited choices for template $template implementation of interface $iface does not match interface definition.\n Expected: $expected\n But got: $got"
 }
 
-final case class EBadInterfaceChoiceImplConsuming(
-    context: Context,
-    iface: TypeConName,
-    template: TypeConName,
-    choice: ChoiceName,
-    ifaceConsuming: Boolean,
-    tplConsuming: Boolean,
-) extends ValidationError {
-
-  def prettyConsuming(consuming: Boolean): String = if (consuming) "consuming" else "non-consuming"
-
-  override protected def prettyInternal: String =
-    s"The implementation of the choice $choice of interface $iface in template $template differs from the interface definition in the consuming/non-consuming behaviour.\nExpected: ${prettyConsuming(ifaceConsuming)}\n But got: ${prettyConsuming(tplConsuming)}"
-}
-
-final case class EBadInterfaceChoiceImplArgType(
-    context: Context,
-    iface: TypeConName,
-    template: TypeConName,
-    choice: ChoiceName,
-    ifaceArgType: Type,
-    tplArgType: Type,
-) extends ValidationError {
-
-  override protected def prettyInternal: String =
-    s"The implementation of the choice $choice of interface $iface in template $template differs from the interface definition in the argument type.\nExpected: $ifaceArgType\n But got: $tplArgType"
-}
-
-final case class EBadInterfaceChoiceImplRetType(
-    context: Context,
-    iface: TypeConName,
-    template: TypeConName,
-    choice: ChoiceName,
-    ifaceRetType: Type,
-    tplRetType: Type,
-) extends ValidationError {
-
-  override protected def prettyInternal: String =
-    s"The implementation of the choice $choice of interface $iface in template $template differs from the interface definition in the return type.\nExpected: $ifaceRetType\n But got: $tplRetType"
-}
-
 final case class EMissingInterfaceMethod(
     context: Context,
     template: TypeConName,

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
@@ -260,12 +260,6 @@ private[validation] object TypeIterable {
           methods.values.iterator.flatMap(iterator)
     }
 
-  private[validation] def iterator(ichoice: InterfaceChoice): Iterator[Type] =
-    ichoice match {
-      case InterfaceChoice(name @ _, consuming @ _, argType, retType) =>
-        Iterator(argType, retType)
-    }
-
   private[validation] def iterator(imethod: InterfaceMethod): Iterator[Type] =
     imethod match {
       case InterfaceMethod(name @ _, retType) =>


### PR DESCRIPTION
This is a leftover from when interfaces had virtual choices.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
