### PR TITLE
Fix performance regression in the ApiSubmissionService

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -106,6 +106,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
       request: SubmitRequest
   )(implicit telemetryContext: TelemetryContext): Future[Unit] =
     withEnrichedLoggingContext(logging.commands(request.commands)) { implicit loggingContext =>
+      // TODO: Replace the workaround below with a proper solution.
       // Spin up a Future so that all the work is done not on the dispatcher thread
       // but using the pool provided with the ExecutionContext of this class instance.
       Future {


### PR DESCRIPTION
### Motivation
We have observed performance regression when using `submitAndWait` functionality of the Ledger API. The regression was triggered by removed participant-side deduplication which changed dispatching `Future` executions into the main thread pool and the thread pool used by API services.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
