### PR TITLE
Do not run oracle migration tests on macOS

### DIFF
--- a/compatibility/sandbox-migration/util.bzl
+++ b/compatibility/sandbox-migration/util.bzl
@@ -40,7 +40,8 @@ def migration_test(name, versions, tags, quick_tags, **kwargs):
         **kwargs
     )
 
-    # Oracle was introduced after the switch to the append-only schema
+    # Oracle was introduced after the switch to the append-only schema, no need to run with --append-only.
+    # Oracle tests only run on Linux because we don't have docker on macOS or Windows.
     native.sh_test(
         name = "{}-oracle".format(name),
         srcs = ["//sandbox-migration:test.sh"],
@@ -53,4 +54,4 @@ def migration_test(name, versions, tags, quick_tags, **kwargs):
         ] + [dep for ver in oracle_versions(versions) for dep in runfiles(ver)],
         args = ["--oracle"] + oracle_versions(versions),
         **kwargs
-    ) if len(oracle_versions(versions)) > 1 else None
+    ) if len(oracle_versions(versions)) > 1 and is_linux else None

--- a/compatibility/sandbox-migration/util.bzl
+++ b/compatibility/sandbox-migration/util.bzl
@@ -46,7 +46,7 @@ def migration_test(name, versions, tags, quick_tags, **kwargs):
         name = "{}-oracle".format(name),
         srcs = ["//sandbox-migration:test.sh"],
         deps = ["@bazel_tools//tools/bash/runfiles"],
-        tags = tags + ["manual"] if not is_linux else [],
+        tags = tags + (["manual"] if not is_linux else []),
         data = [
             "//sandbox-migration:sandbox-migration-runner",
             "//sandbox-migration:migration-model.dar",

--- a/compatibility/sandbox-migration/util.bzl
+++ b/compatibility/sandbox-migration/util.bzl
@@ -41,12 +41,12 @@ def migration_test(name, versions, tags, quick_tags, **kwargs):
     )
 
     # Oracle was introduced after the switch to the append-only schema, no need to run with --append-only.
-    # Oracle tests only run on Linux because we don't have docker on macOS or Windows.
+    # Oracle tests only run on Linux by default, because we don't have docker on macOS or Windows CI nodes.
     native.sh_test(
         name = "{}-oracle".format(name),
         srcs = ["//sandbox-migration:test.sh"],
         deps = ["@bazel_tools//tools/bash/runfiles"],
-        tags = tags,
+        tags = tags + ["manual"] if not is_linux else [],
         data = [
             "//sandbox-migration:sandbox-migration-runner",
             "//sandbox-migration:migration-model.dar",
@@ -54,4 +54,4 @@ def migration_test(name, versions, tags, quick_tags, **kwargs):
         ] + [dep for ver in oracle_versions(versions) for dep in runfiles(ver)],
         args = ["--oracle"] + oracle_versions(versions),
         **kwargs
-    ) if len(oracle_versions(versions)) > 1 and is_linux else None
+    ) if len(oracle_versions(versions)) > 1 else None


### PR DESCRIPTION
Changes:
- Only start dockerized Oracle if there is docker
- Only run Oracle migration tests on Linux (because we don't use docker on macOS and Windows)