### PR TITLE
ci: bump Nix on macOS nodes

### DIFF
--- a/infra/macos/2-common-box/init.sh
+++ b/infra/macos/2-common-box/init.sh
@@ -120,8 +120,8 @@ su -l vsts <<'END'
 set -euo pipefail
 export PATH="/usr/local/bin:/usr/sbin:$PATH"
 bash <(curl -sSfL https://releases.nixos.org/nix/nix-2.3.16/install)
-export PATH="$HOME/.nix-profile/bin:$PATH"
-nix-channel --update && nix-env -iA nixpkgs.nix_2_4
+source /Users/vsts/.nix-profile/etc/profile.d/nix.sh
+nix upgrade-nix
 echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
 END
 


### PR DESCRIPTION
However that happened, we were stuck with Nix 2.3.15 (or 2.3.16 in some
cases) on our macOS nodes. This PR is a minor edition to the Nix
initialization commands to switch from 2.4 to "latest", but I wil lalso
use it to record the changes I just did manually to the cluster.

The cluster is currently composed of two parts:
- 7 machines running Catalina (10.15.7).
- 1 machine running Monterey (12.2).

Unfortunately they use different setup. The Catalina ones are described
by the state of the repo (in theory, though keeping them in sync is
manual); in order to update those, I have:

1. Taken one node off the CI pool (`builder1epjj7`).
2. On that node, run the following commands:
   ```
   cd ~/daml/infra/macos/3-running-box
   vagrant destroy -f
   rm ~/images/*
   vagrant box remove macinbox
   vagrant box remove azure-ci-node
   rm -r ~/.vagrant.d/boxes/macinbox-06032020.tar.gz
   softwareupdate -d --fetch-full-installer --full-installer-version 10.15.7
   cd ~/daml/infra/macos/1-create-box
   sudo macinbox --box-format vmware_desktop --disk 250 --memory 32768 --cpu 10 --user-script user-script.sh
   cd ../2-common-box
   vagrant up
   vagrant package --output ~/images/initialized-$(date +%Y%m%d).box
   vagrant destroy -f
   cd
   ./run-agent.sh
   ```
   This leaves us with that node running an updated box. The new box is
   in `~/images/initialized-$(date)`.
3. Send that file to all the other nodes with `scp`.
4. Reboot all the nodes (after deactivating & waiting for jobs to
   finish).

For the Monterey node, images (steps 1 and 2 in this repo) are currently
created by @nycnewman on another machine I don't have access to, so I
took a slightly different approach: I took the existing image, started
it from the `3-running-box` folder as usual, manually updated Nix there,
then repackaged that.

CHANGELOG_BEGIN
CHANGELOG_END