### PR TITLE
Backport: Enable html4 writer in sphinx

### DIFF
--- a/docs/configs/html/conf.py
+++ b/docs/configs/html/conf.py
@@ -120,6 +120,8 @@ html_scaled_image_link = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'DigitalAssetSDKdoc'
 
+html4_writer = True
+
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
Backport from #13056

The sphinx update switched to an html 5 writer by default which broke
a bunch of our CSS which I unfortunately missed. While that is
definitely fixable, a few days before our 2.0 release this doesn’t
seem sensible to focus on so for now let’s force the html4 writer.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
