### PR TITLE
interfaces:ensure that implementations are ordered

### DIFF
--- a/compiler/damlc/tests/daml-test-files/InterfacePrecondition.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfacePrecondition.daml
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- @SINCE-LF-FEATURE DAML_INTERFACE
+-- @ERROR boom head
 
 module InterfacePrecondition where
 
@@ -42,6 +43,10 @@ interface Token2 where
       do
         noopImpl this nothing
 
+interface Token3 where
+  getMessage : Text
+  ensure (error $ getMessage this)
+
 template Asset
   with
     issuer : Party
@@ -51,6 +56,101 @@ template Asset
     signatory issuer, owner
 
     ensure (amount >= 5 && amount <= 8)
+
+    implements Token1 where
+      let getOwner1 = owner
+      let getAmount1 = amount
+      let splitImpl = \splitAmount -> do
+            assert (splitAmount < amount)
+            cid1 <- create this with amount = splitAmount
+            cid2 <- create this with amount = amount - splitAmount
+            pure (toInterfaceContractId @Token1 cid1, toInterfaceContractId @Token1 cid2)
+      let transferImpl = \newOwner -> do
+            cid <- create this with owner = newOwner
+            pure (toInterfaceContractId @Token1 cid)
+
+
+    implements Token2 where
+      let getOwner2 = owner
+      let getAmount2 = amount
+      let noopImpl = \nothing -> do
+            pure ()
+
+-- Same as Asset, but the precondition is different and it implements Token3.
+template Asset2
+  with
+    issuer : Party
+    owner : Party
+    amount : Int
+  where
+    signatory issuer, owner
+
+    ensure (amount > 10)
+
+    implements Token1 where
+      let getOwner1 = owner
+      let getAmount1 = amount
+      let splitImpl = \splitAmount -> do
+            assert (splitAmount < amount)
+            cid1 <- create this with amount = splitAmount
+            cid2 <- create this with amount = amount - splitAmount
+            pure (toInterfaceContractId @Token1 cid1, toInterfaceContractId @Token1 cid2)
+      let transferImpl = \newOwner -> do
+            cid <- create this with owner = newOwner
+            pure (toInterfaceContractId @Token1 cid)
+
+    implements Token2 where
+      let getOwner2 = owner
+      let getAmount2 = amount
+      let noopImpl = \nothing -> do
+            pure ()
+
+    implements Token3 where
+      let getMessage = "boom tail"
+
+template Asset3
+  with
+    issuer : Party
+    owner : Party
+    amount : Int
+  where
+    signatory issuer, owner
+
+    ensure (amount > 10)
+
+    implements Token1 where
+      let getOwner1 = owner
+      let getAmount1 = amount
+      let splitImpl = \splitAmount -> do
+            assert (splitAmount < amount)
+            cid1 <- create this with amount = splitAmount
+            cid2 <- create this with amount = amount - splitAmount
+            pure (toInterfaceContractId @Token1 cid1, toInterfaceContractId @Token1 cid2)
+      let transferImpl = \newOwner -> do
+            cid <- create this with owner = newOwner
+            pure (toInterfaceContractId @Token1 cid)
+
+    implements Token3 where
+      let getMessage = "boom middle"
+
+    implements Token2 where
+      let getOwner2 = owner
+      let getAmount2 = amount
+      let noopImpl = \nothing -> do
+            pure ()
+
+template Asset4
+  with
+    issuer : Party
+    owner : Party
+    amount : Int
+  where
+    signatory issuer, owner
+
+    ensure (amount > 10)
+
+    implements Token3 where
+      let getMessage = "boom head"
 
     implements Token1 where
       let getOwner1 = owner
@@ -108,6 +208,24 @@ main = scenario do
       issuer = p
       owner = p
       amount = 5 -- works for Token1 & Token2 & Asset
+
+  p `submitMustFail` do
+    create Asset2 with
+      issuer = p
+      owner = p
+      amount = 11 -- violates Token1 & Token2 & Token3, but will not explode because the precondition of Token3 is evaluated last
+
+  p `submitMustFail` do
+    create Asset3 with
+      issuer = p
+      owner = p
+      amount = 11 -- violates Token1 & Token2 & Token3, but will not explode because the precondition of Token3 is evalauted after the failing precondition of Token1
+
+  p `submit` do
+    create Asset4 with
+      issuer = p
+      owner = p
+      amount = 11 -- violates Token1 & Token2 & Token3 and will explode, because the precondition of Token3 is evaluated first.
   pure ()
 
 -- @ENABLE-SCENARIOS

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -5,7 +5,7 @@ package com.daml.lf.language
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
-import scala.collection.immutable.ListMap
+import scala.collection.immutable.VectorMap
 
 object Ast {
   //
@@ -746,9 +746,9 @@ object Ast {
       choices: Map[ChoiceName, GenTemplateChoice[E]], // Choices available in the template.
       observers: E, // Observers of the contract.
       key: Option[GenTemplateKey[E]],
-      implements: ListMap[TypeConName, GenTemplateImplements[
+      implements: VectorMap[TypeConName, GenTemplateImplements[
         E
-      ]], // We use a ListMap to preserve insertion order. The order of the implements determines the order in which to evaluate interface preconditions.
+      ]], // We use a VectorMap to preserve insertion order. The order of the implements determines the order in which to evaluate interface preconditions.
   ) {
     lazy val inheritedChoices: Map[ChoiceName, TypeConName] =
       implements.flatMap { case (iface, impl) =>
@@ -779,7 +779,7 @@ object Ast {
         ),
         observers = observers,
         key = key,
-        implements = toListMapWithoutDuplicate(
+        implements = toVectorMapWithoutDuplicate(
           implements.map(i => i.interfaceId -> i),
           (ifaceId: TypeConName) =>
             PackageError(s"repeated interface implementation ${ifaceId.toString}"),
@@ -794,7 +794,7 @@ object Ast {
         choices: Map[ChoiceName, GenTemplateChoice[E]],
         observers: E,
         key: Option[GenTemplateKey[E]],
-        implements: ListMap[TypeConName, GenTemplateImplements[E]],
+        implements: VectorMap[TypeConName, GenTemplateImplements[E]],
     ) = GenTemplate(
       param = param,
       precond = precond,
@@ -815,7 +815,7 @@ object Ast {
           Map[ChoiceName, GenTemplateChoice[E]],
           E,
           Option[GenTemplateKey[E]],
-          ListMap[TypeConName, GenTemplateImplements[E]],
+          VectorMap[TypeConName, GenTemplateImplements[E]],
       )
     ] = Some(
       (
@@ -1009,11 +1009,11 @@ object Ast {
         acc.updated(key, value)
     }
 
-  private[this] def toListMapWithoutDuplicate[Key, Value](
+  private[this] def toVectorMapWithoutDuplicate[Key, Value](
       xs: Iterable[(Key, Value)],
       error: Key => PackageError,
-  ): ListMap[Key, Value] =
-    xs.foldRight(ListMap.empty[Key, Value]) { case ((key, value), acc) =>
+  ): VectorMap[Key, Value] =
+    xs.foldRight(VectorMap.empty[Key, Value]) { case ((key, value), acc) =>
       if (acc.contains(key))
         throw error(key)
       else

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -5,6 +5,7 @@ package com.daml.lf.language
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
+import scala.collection.immutable.ListMap
 
 object Ast {
   //
@@ -745,7 +746,9 @@ object Ast {
       choices: Map[ChoiceName, GenTemplateChoice[E]], // Choices available in the template.
       observers: E, // Observers of the contract.
       key: Option[GenTemplateKey[E]],
-      implements: Map[TypeConName, GenTemplateImplements[E]],
+      implements: ListMap[TypeConName, GenTemplateImplements[
+        E
+      ]], // We use a ListMap to preserve insertion order. The order of the implements determines the order in which to evaluate interface preconditions.
   ) {
     lazy val inheritedChoices: Map[ChoiceName, TypeConName] =
       implements.flatMap { case (iface, impl) =>
@@ -776,7 +779,7 @@ object Ast {
         ),
         observers = observers,
         key = key,
-        implements = toMapWithoutDuplicate(
+        implements = toListMapWithoutDuplicate(
           implements.map(i => i.interfaceId -> i),
           (ifaceId: TypeConName) =>
             PackageError(s"repeated interface implementation ${ifaceId.toString}"),
@@ -791,7 +794,7 @@ object Ast {
         choices: Map[ChoiceName, GenTemplateChoice[E]],
         observers: E,
         key: Option[GenTemplateKey[E]],
-        implements: Map[TypeConName, GenTemplateImplements[E]],
+        implements: ListMap[TypeConName, GenTemplateImplements[E]],
     ) = GenTemplate(
       param = param,
       precond = precond,
@@ -812,7 +815,7 @@ object Ast {
           Map[ChoiceName, GenTemplateChoice[E]],
           E,
           Option[GenTemplateKey[E]],
-          Map[TypeConName, GenTemplateImplements[E]],
+          ListMap[TypeConName, GenTemplateImplements[E]],
       )
     ] = Some(
       (
@@ -1000,6 +1003,17 @@ object Ast {
       error: Key => PackageError,
   ): Map[Key, Value] =
     xs.foldLeft(Map.empty[Key, Value]) { case (acc, (key, value)) =>
+      if (acc.contains(key))
+        throw error(key)
+      else
+        acc.updated(key, value)
+    }
+
+  private[this] def toListMapWithoutDuplicate[Key, Value](
+      xs: Iterable[(Key, Value)],
+      error: Key => PackageError,
+  ): ListMap[Key, Value] =
+    xs.foldRight(ListMap.empty[Key, Value]) { case ((key, value), acc) =>
       if (acc.contains(key))
         throw error(key)
       else

--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
@@ -10,6 +10,7 @@ import com.daml.lf.language.Util._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import scala.collection.immutable.ListMap
 
 // TODO https://github.com/digital-asset/daml/issues/12051
 //  Test Interface logic
@@ -57,7 +58,7 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
       choices = Map.empty,
       observers = eParties,
       key = None,
-      implements = Map.empty,
+      implements = ListMap.empty,
     )
     def exception = DefException(
       message = eText

--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
@@ -10,7 +10,7 @@ import com.daml.lf.language.Util._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import scala.collection.immutable.ListMap
+import scala.collection.immutable.VectorMap
 
 // TODO https://github.com/digital-asset/daml/issues/12051
 //  Test Interface logic
@@ -58,7 +58,7 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
       choices = Map.empty,
       observers = eParties,
       key = None,
-      implements = ListMap.empty,
+      implements = VectorMap.empty,
     )
     def exception = DefException(
       message = eText

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -165,7 +165,7 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
             choices = choices,
             observers = observers,
             key = key,
-            implements = implements,
+            implements = implements.reverse, // we want insertion order here.
           ),
         )
     }

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -13,7 +13,7 @@ import com.daml.lf.testing.parser.Implicits._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import scala.collection.immutable.ListMap
+import scala.collection.immutable.VectorMap
 
 import scala.language.implicitConversions
 
@@ -635,7 +635,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
           ),
           observers = e"Cons @Party [Mod:Person {person} this] (Nil @Party)",
           key = Some(TemplateKey(t"Party", e"(Mod:Person {name} this)", e"""\ (p: Party) -> p""")),
-          implements = ListMap(
+          implements = VectorMap(
             human ->
               TemplateImplements(
                 human,

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -13,6 +13,7 @@ import com.daml.lf.testing.parser.Implicits._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scala.collection.immutable.ListMap
 
 import scala.language.implicitConversions
 
@@ -634,7 +635,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
           ),
           observers = e"Cons @Party [Mod:Person {person} this] (Nil @Party)",
           key = Some(TemplateKey(t"Party", e"(Mod:Person {name} this)", e"""\ (p: Party) -> p""")),
-          implements = Map(
+          implements = ListMap(
             human ->
               TemplateImplements(
                 human,


### PR DESCRIPTION
We make sure that the implementations are ordered by insertion in the
Scala AST. This is important to guarantee an evaluation order of the
interface preconditions that is determined by the order of interface
implementations of a template.

Fixes #11762.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
