### PR TITLE
Backport: Fix activeness display in script service

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -497,7 +497,7 @@ final class Conversions(
     nodeInfo.consumedBy
       .map(eventId => builder.setConsumedBy(convertEventId(eventId)))
     nodeInfo.rolledbackBy
-      .map(eventId => builder.setRolledbackBy(convertEventId(eventId)))
+      .map(nodeId => builder.setRolledbackBy(convertNodeId(eventId.transactionId, nodeId)))
     nodeInfo.parent
       .map(eventId => builder.setParent(convertEventId(eventId)))
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -157,7 +157,7 @@ object ScenarioLedger {
     *                       node exists. Consumption under a rollback
     *                       is not included here even for contracts created
     *                       under a rollback node.
-    * @param rolledbackBy   The nearest parent rollback node, provided such a
+    * @param rolledbackBy   The nearest ancestor rollback node, provided such a
     *                       node exists.
     * @param parent         If the node is part of a sub-transaction, then
     *                       this is the immediate parent, which must be an
@@ -171,7 +171,7 @@ object ScenarioLedger {
       disclosures: Map[Party, Disclosure],
       referencedBy: Set[EventId],
       consumedBy: Option[EventId],
-      rolledbackBy: Option[EventId],
+      rolledbackBy: Option[NodeId],
       parent: Option[EventId],
   ) {
 
@@ -397,13 +397,16 @@ object ScenarioLedger {
   ): Either[UniqueKeyViolation, LedgerData] = {
 
     final case class RollbackBeginState(
-        rollbackId: EventId,
         activeContracts: Set[ContractId],
         activeKeys: Map[GlobalKey, ContractId],
     )
 
     final case class ProcessingNode(
+        // The id of the direct parent or None.
         mbParentId: Option[NodeId],
+        // The id of the nearest rollback ancestor. If this is
+        // a rollback node itself, it points to itself.
+        mbRollbackAncestorId: Option[NodeId],
         children: List[NodeId],
         // For rollback nodes, we store the previous state here and restore it.
         // For exercise nodes, we don’t need to restore anything.
@@ -420,7 +423,7 @@ object ScenarioLedger {
         case Right(cache0) =>
           enps match {
             case Nil => Right(cache0)
-            case ProcessingNode(_, Nil, optPrevState) :: restENPs => {
+            case ProcessingNode(_, _, Nil, optPrevState) :: restENPs => {
               val cache1 = optPrevState.fold(cache0) { case prevState =>
                 cache0.copy(
                   activeContracts = prevState.activeContracts,
@@ -431,6 +434,7 @@ object ScenarioLedger {
             }
             case (processingNode @ ProcessingNode(
                   mbParentId,
+                  mbRollbackAncestorId,
                   nodeId :: restOfNodeIds,
                   optPrevState,
                 )) :: restENPs =>
@@ -447,7 +451,7 @@ object ScenarioLedger {
                     disclosures = Map.empty,
                     referencedBy = Set.empty,
                     consumedBy = None,
-                    rolledbackBy = optPrevState.map(_.rollbackId),
+                    rolledbackBy = mbRollbackAncestorId,
                     parent = mbParentId.map(EventId(trId.id, _)),
                   )
                   val newCache =
@@ -457,10 +461,11 @@ object ScenarioLedger {
                   node match {
                     case rollback: Node.Rollback =>
                       val rollbackState =
-                        RollbackBeginState(eventId, newCache.activeContracts, newCache.activeKeys)
+                        RollbackBeginState(newCache.activeContracts, newCache.activeKeys)
                       processNodes(
                         Right(newCache),
                         ProcessingNode(
+                          Some(nodeId),
                           Some(nodeId),
                           rollback.children.toList,
                           Some(rollbackState),
@@ -521,7 +526,12 @@ object ScenarioLedger {
 
                       processNodes(
                         Right(newCache1),
-                        ProcessingNode(Some(nodeId), ex.children.toList, None) :: idsToProcess,
+                        ProcessingNode(
+                          Some(nodeId),
+                          mbRollbackAncestorId,
+                          ex.children.toList,
+                          None,
+                        ) :: idsToProcess,
                       )
 
                     case nlkup: Node.LookupByKey =>
@@ -546,7 +556,7 @@ object ScenarioLedger {
     val mbCacheAfterProcess =
       processNodes(
         Right(ledgerData),
-        List(ProcessingNode(None, richTr.transaction.roots.toList, None)),
+        List(ProcessingNode(None, None, richTr.transaction.roots.toList, None)),
       )
 
     mbCacheAfterProcess.map { cacheAfterProcess =>


### PR DESCRIPTION
Backport from #13059

changelog_begin

- [Daml Studio] Fix a bug where contracts that have been rolled back
  would still show up as active in the table view and in the list of
  active contracts at the end of the transaction view. This only
  affected display. Fetching those contracts failed and `query` also
  did not return those contracts.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
