### PR TITLE
use user token for trigger service sandbox test fixture

### DIFF
--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWTPayload.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWTPayload.scala
@@ -11,7 +11,7 @@ import spray.json._
 import scala.util.Try
 
 /** All the JWT payloads that can be used with the JWT auth service. */
-sealed trait AuthServiceJWTPayload
+sealed abstract class AuthServiceJWTPayload extends Product with Serializable
 
 /** A JWT token payload constructed from custom claims specific to Daml ledgers.
   *

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuth.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuth.scala
@@ -14,4 +14,5 @@ class TriggerServiceTestAuthClaims
     with AbstractTriggerServiceTestInMem
     with AbstractTriggerServiceTestAuthMiddleware {
   override protected[this] def oauth2YieldsUserTokens = false
+  override protected[this] def sandboxClientTakesUserToken = false
 }

--- a/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithOracle.scala
+++ b/triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/TriggerServiceTestAuthWithOracle.scala
@@ -16,4 +16,5 @@ class TriggerServiceTestAuthWithOracleClaims
     with TriggerDaoOracleFixture
     with AbstractTriggerServiceTestAuthMiddleware {
   protected[this] override def oauth2YieldsUserTokens = false
+  protected[this] override def sandboxClientTakesUserToken = false
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -99,7 +99,7 @@ trait AbstractTriggerServiceTest
 
     /** Like `in`, but disables tests that would require the oauth test server
       * to grant claims for the user tokens it manufactures; see
-      * https://github.com/digital-asset/daml/issues/12831#issuecomment-1048176312
+      * https://github.com/digital-asset/daml/issues/13076
       */
     def inClaims(testFn: => Future[Assertion])(implicit pos: source.Position) =
       AbstractTriggerServiceTest.this.inClaims(self, testFn)

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -96,6 +96,11 @@ trait AbstractTriggerServiceTest
     self in testFn
 
   protected[this] implicit final class `InClaims syntax`(private val self: ItVerbString) {
+
+    /** Like `in`, but disables tests that would require the oauth test server
+      * to grant claims for the user tokens it manufactures; see
+      * https://github.com/digital-asset/daml/issues/12831#issuecomment-1048176312
+      */
     def inClaims(testFn: => Future[Assertion])(implicit pos: source.Position) =
       AbstractTriggerServiceTest.this.inClaims(self, testFn)
   }


### PR DESCRIPTION
In `SandboxFixture` when mixing in the auth middleware fixture, set up the ledger client with a user token instead of a claims token when not running in the claims-token-specific auth tests.

Fixes #12831.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
