### PR TITLE
Fix Window linker errors

### DIFF
--- a/bazel_tools/fat_cc_library.bzl
+++ b/bazel_tools/fat_cc_library.bzl
@@ -55,8 +55,8 @@ def _fat_cc_library_impl(ctx):
             # Some libs seems to depend on libstdc++ implicitely
             ["-lstdc++"] +
             (["-framework", "CoreFoundation"] if is_darwin else []) +
-            # On Windows some libs seems to depend on Windows sockets
-            (["-lws2_32"] if is_windows else []),
+            # On Windows we have some extra deps.
+            (["-lbcrypt", "-lDbgHelp", "-lws2_32"] if is_windows else []),
         inputs = static_libs,
         env = {"PATH": ""},
     )


### PR DESCRIPTION
Apparently https://github.com/digital-asset/daml/pull/13066 resulted
in linker errors but only on clean builds (I think). I don’t fully
understand why. The requirement from bcrypt seems to come from the
grpc upgrade but reverting that still leaves undefined symbol errors
to DbgHelp. Don’t really care enough to track it down given that this
fixes it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
