### PR TITLE
Fix Windows linking issues

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -194,7 +194,7 @@ c2hs_suite(
     compiler_flags = ["-XCPP", "-Wno-unused-imports", "-Wno-unused-record-wildcards"],
     visibility = ["//visibility:public"],
     deps = [
-        "@grpc_haskell_core_cbits//:fat_cbits",
+        "@grpc_haskell_core_cbits//:merged_cbits",
     ],
 )
 """,
@@ -217,7 +217,7 @@ c2hs_suite(
 load("@com_github_digital_asset_daml//bazel_tools:fat_cc_library.bzl", "fat_cc_library")
 
 fat_cc_library(
-  name = "fat_cbits",
+  name = "merged_cbits",
   input_lib = "cbits",
   visibility = ["//visibility:public"],
 )

--- a/bazel_tools/fat_cc_library.bzl
+++ b/bazel_tools/fat_cc_library.bzl
@@ -56,7 +56,7 @@ def _fat_cc_library_impl(ctx):
             ["-lstdc++"] +
             (["-framework", "CoreFoundation"] if is_darwin else []) +
             # On Windows we have some extra deps.
-            (["-lbcrypt", "-lDbgHelp", "-lws2_32"] if is_windows else []),
+            (["-lws2_32"] if is_windows else []),
         inputs = static_libs,
         env = {"PATH": ""},
     )

--- a/bazel_tools/haskell-windows-extra-libraries.patch
+++ b/bazel_tools/haskell-windows-extra-libraries.patch
@@ -2,7 +2,7 @@ diff --git a/haskell/private/actions/package.bzl b/haskell/private/actions/packa
 index fddf30fd..564da872 100644
 --- a/haskell/private/actions/package.bzl
 +++ b/haskell/private/actions/package.bzl
-@@ -105,7 +105,12 @@ def package(
+@@ -105,7 +105,13 @@ def package(
          "library-dirs": [pkgroot_lib_path] + extra_lib_dirs,
          "dynamic-library-dirs": [pkgroot_lib_path] + extra_dynamic_lib_dirs,
          "hs-libraries": [pkg_id.library_name(hs, my_pkg_id)] if has_hs_library else [],
@@ -12,6 +12,7 @@ index fddf30fd..564da872 100644
 +            "crypt32",
 +            "shlwapi",
 +            "ws2_32",
++            "bcrypt",
 +        ] if hs.toolchain.is_windows else []),
          "depends": hs.package_ids,
          # TODO[AH] Add haskell_module modules


### PR DESCRIPTION
I have to admit I still fdon’t fully understand why this sometimes
fails and sometimes doesn’t. It looks like some caching issue is
involved (e.g. currently builds in /d/a/2 succeed while builds in
/d/a/1 succed) but I’m not entirely sure that’s all.

This PR tries to address this in two ways:

1. Add the library when linking the Haskell bits instead of only on
the C library. I think this is required since we the final Haskell
binary is linked against the static cbits which does not carry a
reference to bcrypt but I’m not completely sure.
2. Rename the target to avoid interference with builds from before the
grpc upgrade. I suspect what is happening is that due to the lack of
sandboxing we sometimes end up picking up that library if it is in the
build tree from an older build instead of the new one.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
