### PR TITLE
Pipe hpp through package_app

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -16,7 +16,7 @@ damlc_data = [
     "@static_asset_d3plus//:js/d3plus.min.js",
     ghc_pkg,
     "//compiler/damlc:ghcversion",
-    "//compiler/damlc:hpp",
+    "@stackage-exe//hpp",
     "//compiler/damlc/pkg-db",
     "//compiler/damlc/stable-packages",
     "//compiler/repl-service/server:repl_service_jar",
@@ -28,8 +28,8 @@ add_data(
     data = [
         ghc_pkg,
         "//compiler/damlc:ghcversion",
-        "//compiler/damlc:hpp",
         "//compiler/damlc/pkg-db",
+        "@stackage-exe//hpp",
     ],
     executable = ":damlc-bootstrap",
     visibility = ["//visibility:public"],
@@ -61,17 +61,6 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
-genrule(
-    name = "hpp-rule",
-    srcs = ["@stackage-exe//hpp"],
-    outs = ["hpp"],
-    cmd = """
-        cp $(location @stackage-exe//hpp) $(OUTS)
-    """,
-    tools = [],
-    visibility = ["//visibility:public"],
-)
-
 # damlc without runfiles. We use that to build the daml-prim and daml-stdlib
 # package databases.
 da_haskell_binary(
@@ -86,8 +75,8 @@ da_haskell_binary(
     ] if is_windows else [],
     data = [
         "//compiler/damlc:ghcversion",
-        "//compiler/damlc:hpp",
         "//compiler/damlc/stable-packages",
+        "@stackage-exe//hpp",
     ],
     hackage_deps = [
         "base",
@@ -106,7 +95,7 @@ package_app(
         ":daml-base-anchors.json",
         ":ghc-pkg-dist",
         "//compiler/damlc:ghcversion",
-        "//compiler/damlc:hpp",
+        "//compiler/damlc:hpp-dist",
         "//compiler/damlc/daml-ide-core:dlint.yaml",
         "//compiler/damlc/pkg-db",
         "//compiler/damlc/stable-packages",
@@ -148,6 +137,11 @@ package_app(
       $$MKTGZ $$OUT ghc-pkg
     """,
     tools = ["//bazel_tools/sh:mktgz"],
+)
+
+package_app(
+    name = "hpp-dist",
+    binary = "@stackage-exe//hpp",
 )
 
 da_haskell_library(

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -447,10 +447,8 @@ locateGhcVersionHeader = GhcVersionHeader <$> do
 
 locateCppPath :: IO (Maybe FilePath)
 locateCppPath = do
-    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "hpp")
-    isDirectory <- doesDirectoryExist resourcesDir
-    let path | isDirectory = resourcesDir </> "hpp"
-             | otherwise = resourcesDir
+    resourcesDir <- locateRunfiles $ "stackage" </> "hpp-0.6.4" </> "_install" </> "bin"
+    let path  = resourcesDir </> exe "hpp"
     exists <- doesFileExist path
     pure (guard exists >> Just path)
 


### PR DESCRIPTION
This is needed so shared libraries are properly resolved and this
actually works outside of our build. Same issue that broke
damlc_legacy originally and we had someone trying to use cpp on their
own project (whether they should is another question but having it
half working is even worse).

I don’t know how to write a test for this unfortunately. It would only
fail if our nix store is not available which is pretty hard to
simulate. I could spin up a docker image or something but that doesn’t
seem worth the trouble.

fixes #13100

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
