### PR TITLE
Fix executor future scheduling [DPP-945]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -106,30 +106,27 @@ private[apiserver] final class ApiSubmissionService private[services] (
       request: SubmitRequest
   )(implicit telemetryContext: TelemetryContext): Future[Unit] =
     withEnrichedLoggingContext(logging.commands(request.commands)) { implicit loggingContext =>
-      // TODO: Replace the workaround below with a proper solution.
-      // Spin up a Future so that all the work is done not on the dispatcher thread
-      // but using the pool provided with the ExecutionContext of this class instance.
-      Future {
-        logger.info("Submitting transaction")
-        logger.trace(s"Commands: ${request.commands.commands.commands}")
+      logger.info("Submitting transaction")
+      logger.trace(s"Commands: ${request.commands.commands.commands}")
+
+      implicit val contextualizedErrorLogger: ContextualizedErrorLogger =
         new DamlContextualizedErrorLogger(
           logger,
           loggingContext,
           request.commands.submissionId.map(SubmissionId.unwrap),
         )
-      }.flatMap { implicit contextualizedErrorLogger: ContextualizedErrorLogger =>
-        val evaluatedCommand = ledgerConfigurationSubscription
-          .latestConfiguration() match {
-          case Some(ledgerConfiguration) =>
-            evaluateAndSubmit(seedService.nextSeed(), request.commands, ledgerConfiguration)
-              .transform(handleSubmissionResult)
-          case None =>
-            Future.failed(
-              errorFactories.missingLedgerConfig()
-            )
-        }
-        evaluatedCommand.andThen(logger.logErrorsOnCall[Unit])
+
+      val evaluatedCommand = ledgerConfigurationSubscription
+        .latestConfiguration() match {
+        case Some(ledgerConfiguration) =>
+          evaluateAndSubmit(seedService.nextSeed(), request.commands, ledgerConfiguration)
+            .transform(handleSubmissionResult)
+        case None =>
+          Future.failed(
+            errorFactories.missingLedgerConfig()
+          )
       }
+      evaluatedCommand.andThen(logger.logErrorsOnCall[Unit])
     }
 
   private def handleSubmissionResult(result: Try[state.SubmissionResult])(implicit


### PR DESCRIPTION
### Changes
- remove the temporary workaround from the `ApiSubmissionService`
- start engine computations asynchronously in a `Future` on the `ExecutionContext` provided as an implicit method parameter in `StoreBackedCommandExecutor`

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
