### PR TITLE
LF: Use template parameter (`this`) in method bodies.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -965,7 +965,7 @@ convertImplements env tpl = NM.fromList <$>
       pure (TemplateImplements con methods inheritedChoiceNames)
 
     convertMethods ms = fmap NM.fromList . sequence $
-      [ TemplateImplementsMethod (MethodName k) <$> convertExpr env v
+      [ TemplateImplementsMethod (MethodName k) . (`ETmApp` EVar this) <$> convertExpr env v
       | (k, v) <- ms
       ]
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -329,7 +329,7 @@ private[lf] final class Compiler(
         addDef(compileCreateByInterface(identifier, tmpl, impl.interfaceId))
         addDef(compileImplements(identifier, impl.interfaceId))
         impl.methods.values.foreach(method =>
-          addDef(compileImplementsMethod(identifier, impl.interfaceId, method))
+          addDef(compileImplementsMethod(tmpl.param, identifier, impl.interfaceId, method))
         )
       }
 
@@ -726,12 +726,14 @@ private[lf] final class Compiler(
 
   // Compile the implementation of an interface method.
   private[this] def compileImplementsMethod(
+      tmplParam: Name,
       tmplId: Identifier,
       ifaceId: Identifier,
       method: TemplateImplementsMethod,
   ): (t.SDefinitionRef, SDefinition) = {
-    val ref = t.ImplementsMethodDefRef(tmplId, ifaceId, method.name)
-    ref -> SDefinition(withLabelT(ref, compileExp(method.value)))
+    topLevelFunction1(t.ImplementsMethodDefRef(tmplId, ifaceId, method.name)) { (tmplArgPos, env) =>
+      translateExp(env.bindExprVar(tmplParam, tmplArgPos), method.value)
+    }
   }
 
   private[this] def translateCreateBody(

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -1727,9 +1727,9 @@ for the ``DefTemplate`` rule). ::
         }  ∈ 〚Ξ〛Mod'
     'tpl' (x : T) ↦ { …, 'implements' Mod₁:I₁ { … }, …, 'implements' Modₖ:Iₖ { … } }  ∈ 〚Ξ〛Mod
     R  ⊆  { Mod₁:I₁, …, Modₖ:Iₖ }
-    τ₁  ↠  τ₁'      ⊢  e₁  :  Mod:T -> τ₁'
+    τ₁  ↠  τ₁'      x : Mod:T  ⊢  e₁  :  τ₁'
       ⋮
-    τₘ  ↠  τₘ'      ⊢  eₘ  :  Mod:T -> τₘ'
+    τₘ  ↠  τₘ'      x : Mod:T  ⊢  eₘ  :  τₘ'
   ——————————————————————————————————————————————————————————————— ImplDef
     x : Mod:T  ⊢  'implements' Mod':I
                       { 'methods' { f₁ = e₁, …, fₙ = eₙ }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -443,13 +443,13 @@ private[validation] object Typing {
       env.checkExpr(observers, TParties)
       env.checkExpr(agreementText, TText)
       choices.values.foreach(env.checkChoice(tplName, _))
+      env.checkIfaceImplementations(tplName, implementations)
       mbKey.foreach { key =>
         checkType(key.typ, KStar)
         env.checkExpr(key.body, key.typ)
         checkExpr(key.maintainers, TFun(key.typ, TParties))
         ()
       }
-      env.checkIfaceImplementations(tplName, implementations)
     }
 
     def checkDefIface(ifaceName: TypeConName, iface: DefInterface): Unit =
@@ -509,7 +509,7 @@ private[validation] object Typing {
             case None =>
               throw EUnknownInterfaceMethod(ctx, tplTcon, impl.interfaceId, tplMethod.name)
             case Some(method) =>
-              checkExpr(tplMethod.value, TFun(TTyCon(tplTcon), method.returnType))
+              checkExpr(tplMethod.value, method.returnType)
           }
         }
       }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -1000,7 +1000,7 @@ class TypingSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matcher
                   , observers Nil @Party
                   to upure @Unit ();
               implements Mod:I {
-                method getParties = \(self: NegativeTestCase:T) -> Cons @Party [NegativeTestCase:T {person} self] (Nil @Party);
+                method getParties = Cons @Party [NegativeTestCase:T {person} this] (Nil @Party);
               };
               key @Mod:Key
                   (Mod:Key { person = (NegativeTestCase:T {name} this), party = (NegativeTestCase:T {person} this) })
@@ -1240,7 +1240,7 @@ class TypingSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matcher
                   , controllers Nil @Party
                   to upure @Unit ();
               implements Mod:I {
-                method getParties = \(self: PositiveCase_InterfaceMethodShouldBeProperType:T) -> (); // should Be of type
+                method getParties = (); // should be of type List Party
               };
             };
           }
@@ -1273,9 +1273,9 @@ class TypingSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matcher
                   , controllers Nil @Party
                   to upure @Unit ();
               implements Mod:I {
-                method getParties = \(self: PositiveCase_ImplementsShouldOverrideOnlyMethods:T) ->
+                method getParties =
                   Cons @Party [(PositiveCase_ImplementsShouldOverrideOnlyMethods:T {person} this)] (Nil @Party);
-                method getName = \(self: PositiveCase_ImplementsShouldOverrideOnlyMethods:T) ->
+                method getName =
                   PositiveCase_ImplementsShouldOverrideOnlyMethods:T {name} this;
               };
             };


### PR DESCRIPTION
Instead of having method bodies be functions from the template type to the method type, have them just be expressions of the method type that reuse the existing template parameter (`this`).

Fixes #13123

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
