### PR TITLE
Move ExecutionContext to the CommandExecutor implementing classes [DPP-945]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutor.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.configuration.Configuration
 import com.daml.lf.crypto
 import com.daml.logging.LoggingContext
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 private[apiserver] trait CommandExecutor {
   def execute(
@@ -17,7 +17,6 @@ private[apiserver] trait CommandExecutor {
       submissionSeed: crypto.Hash,
       ledgerConfiguration: Configuration,
   )(implicit
-      ec: ExecutionContext,
-      loggingContext: LoggingContext,
+      loggingContext: LoggingContext
   ): Future[Either[ErrorCause, CommandExecutionResult]]
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
@@ -21,6 +21,8 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
     contractStore: ContractStore,
     maxRetries: Int,
     metrics: Metrics,
+)(implicit
+    ec: ExecutionContext
 ) extends CommandExecutor {
 
   private val logger = ContextualizedLogger.get(this.getClass)
@@ -35,8 +37,7 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
       submissionSeed: crypto.Hash,
       ledgerConfiguration: Configuration,
   )(implicit
-      executionContext: ExecutionContext,
-      loggingContext: LoggingContext,
+      loggingContext: LoggingContext
   ): Future[Either[ErrorCause, CommandExecutionResult]] =
     loop(commands, submissionSeed, ledgerConfiguration, maxRetries)
 
@@ -46,8 +47,7 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
       ledgerConfiguration: Configuration,
       retriesLeft: Int,
   )(implicit
-      executionContext: ExecutionContext,
-      loggingContext: LoggingContext,
+      loggingContext: LoggingContext
   ): Future[Either[ErrorCause, CommandExecutionResult]] =
     delegate
       .execute(commands, submissionSeed, ledgerConfiguration)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -37,6 +37,8 @@ private[apiserver] final class StoreBackedCommandExecutor(
     packagesService: IndexPackagesService,
     contractStore: ContractStore,
     metrics: Metrics,
+)(implicit
+    ec: ExecutionContext
 ) extends CommandExecutor {
 
   private[this] val packageLoader = new DeduplicatingPackageLoader()
@@ -46,8 +48,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
       submissionSeed: crypto.Hash,
       ledgerConfiguration: Configuration,
   )(implicit
-      ec: ExecutionContext,
-      loggingContext: LoggingContext,
+      loggingContext: LoggingContext
   ): Future[Either[ErrorCause, CommandExecutionResult]] = {
     val interpretationTimeNanos = new AtomicLong(0L)
     val start = System.nanoTime()
@@ -119,8 +120,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
       submissionSeed: crypto.Hash,
       interpretationTimeNanos: AtomicLong,
   )(implicit
-      ec: ExecutionContext,
-      loggingContext: LoggingContext,
+      loggingContext: LoggingContext
   ): Future[Result[(SubmittedTransaction, Transaction.Metadata)]] =
     Timed.trackedFuture(
       metrics.daml.execution.engineRunning,
@@ -148,8 +148,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
       result: Result[A],
       interpretationTimeNanos: AtomicLong,
   )(implicit
-      ec: ExecutionContext,
-      loggingContext: LoggingContext,
+      loggingContext: LoggingContext
   ): Future[Either[DamlLfError, A]] = {
     val readers = actAs ++ readAs
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -31,6 +31,9 @@ import scalaz.syntax.tag._
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/** @param ec [[scala.concurrent.ExecutionContext]] that will be used for scheduling CPU-intensive computations
+  *           performed by an [[com.daml.lf.engine.Engine]].
+  */
 private[apiserver] final class StoreBackedCommandExecutor(
     engine: Engine,
     participant: Ref.ParticipantId,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/TimedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/TimedCommandExecutor.scala
@@ -10,7 +10,7 @@ import com.daml.lf.crypto
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 private[apiserver] class TimedCommandExecutor(
     delegate: CommandExecutor,
@@ -22,8 +22,7 @@ private[apiserver] class TimedCommandExecutor(
       submissionSeed: crypto.Hash,
       ledgerConfiguration: Configuration,
   )(implicit
-      ec: ExecutionContext,
-      loggingContext: LoggingContext,
+      loggingContext: LoggingContext
   ): Future[Either[ErrorCause, CommandExecutionResult]] =
     Timed.timedAndTrackedFuture(
       metrics.daml.execution.total,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
@@ -26,7 +26,7 @@ import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 class LedgerTimeAwareCommandExecutorSpec
     extends AsyncWordSpec
@@ -86,8 +86,7 @@ class LedgerTimeAwareCommandExecutorSpec
     val mockExecutor = mock[CommandExecutor]
     when(
       mockExecutor.execute(any[Commands], any[Hash], any[Configuration])(
-        any[ExecutionContext],
-        any[LoggingContext],
+        any[LoggingContext]
       )
     )
       .thenAnswer((c: Commands) =>
@@ -153,7 +152,7 @@ class LedgerTimeAwareCommandExecutorSpec
           any[Commands],
           any[Hash],
           any[Configuration],
-        )(any[ExecutionContext], any[LoggingContext])
+        )(any[LoggingContext])
         verify(mockContractStore, times(contractStoreResults.size))
           .lookupMaximumLedgerTimeAfterInterpretation(Set(cid))
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
@@ -291,7 +291,7 @@ class ApiSubmissionServiceSpec
             eqTo(submitRequest.commands),
             any[Hash],
             any[Configuration],
-          )(any[ExecutionContext], any[LoggingContext])
+          )(any[LoggingContext])
         ).thenReturn(Future.successful(Left(error)))
         service
           .submit(submitRequest)


### PR DESCRIPTION
Move the `ExecutionContext` to class parameters.
This is a follow-up to #13138 

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
