### PR TITLE
guard nightly

### DIFF
--- a/ci/daily-snapshot.yml
+++ b/ci/daily-snapshot.yml
@@ -32,13 +32,20 @@ jobs:
         prefix=$(head -1 LATEST | awk '{print $2}' | sed -e 's/\([^-]*\).*/\1/')
         release=$(./release.sh snapshot HEAD $prefix | awk '{print $2}')
 
-        setvar is_release true
-        setvar trigger_sha "$(branch_sha)"
-        setvar release_sha "$(branch_sha)"
-        setvar release_tag "$release"
-        setvar split_release_process true
+        if ! curl -u $AUTH https://digitalasset.jfrog.io/artifactory/api/storage/assembly/daml/$release --fail; then
+            setvar is_release true
+            setvar trigger_sha "$(branch_sha)"
+            setvar release_sha "$(branch_sha)"
+            setvar release_tag "$release"
+            setvar split_release_process true
+        else
+            echo "Version $release already exists on Artifactory, aborting."
+            setvar is_release false
+        fi
         setvar scala_2_13 true
       name: out
+      env:
+        AUTH: $(ARTIFACTORY_USERNAME):$(ARTIFACTORY_PASSWORD)
 - template: build.yml
 - template: split-release-job.yml
 - job: release

--- a/ci/daily-snapshot.yml
+++ b/ci/daily-snapshot.yml
@@ -32,16 +32,37 @@ jobs:
         prefix=$(head -1 LATEST | awk '{print $2}' | sed -e 's/\([^-]*\).*/\1/')
         release=$(./release.sh snapshot HEAD $prefix | awk '{print $2}')
 
-        if ! curl -u $AUTH https://digitalasset.jfrog.io/artifactory/api/storage/assembly/daml/$release --fail; then
+        ERR=$(mktemp)
+        OUT=$(curl https://digitalasset.jfrog.io/artifactory/api/storage/assembly/daml/$release \
+                   -u $AUTH \
+                   -I \
+                   2>$ERR)
+        STATUS=$(echo "$OUT" | head -1 | sed 's:HTTP/1.1 \([^ ]\+\).*:\1:')
+        case "$STATUS" in
+          200)
+            echo "Version $release already exists on Artifactory, aborting."
+            setvar is_release false
+            ;;
+          404)
             setvar is_release true
             setvar trigger_sha "$(branch_sha)"
             setvar release_sha "$(branch_sha)"
             setvar release_tag "$release"
             setvar split_release_process true
-        else
-            echo "Version $release already exists on Artifactory, aborting."
-            setvar is_release false
-        fi
+            ;;
+          *)
+            echo "Unexpected status code: $STATUS"
+            echo "curl stdout:"
+            echo "--"
+            echo "$OUT"
+            echo "--"
+            echo "curl stderr:"
+            echo "--"
+            echo "$ERR"
+            echo "--"
+            exit 1
+            ;;
+        esac
         setvar scala_2_13 true
       name: out
       env:


### PR DESCRIPTION
In some cases we may end up with the tip of the main branch built as a
split release manually. When Azure then tries to run it, the release
fails (typically on the upload to NPM step).

Normally, Azure is set to run this only once per commit, but that only
applies when the run is successful. So if it breaks in a reproducible
way (e.g. because the version already exists on NPM), Azure will keep
trying every day.

This PR adds a simple guard that makes the nightly build _not_ a release
commit if the reelease already exists, which should short-circuit most
of the jobs in the build and finish successfully.

CHANGELOG_BEGIN
CHANGELOG_END