### PR TITLE
add release instructions to release notification

### DIFF
--- a/ci/cron/tuesday.yml
+++ b/ci/cron/tuesday.yml
@@ -31,4 +31,4 @@ jobs:
 
       RELEASE_MANAGER=$(next_in_rotation_slack)
 
-      tell_slack "$(echo -e "Hi <@$RELEASE_MANAGER>! According to the <https://github.com/digital-asset/daml/blob/main/release/rotation|rotation>, you are in charge of the release tomorrow. Please make sure you plan accordingly, or find a replacement.")"
+      tell_slack "$(echo -e "Hi <@$RELEASE_MANAGER>! According to the <https://github.com/digital-asset/daml/blob/main/release/rotation|rotation>, you are in charge of the release tomorrow. Please make sure you plan accordingly, or find a replacement. See the <https://github.com/digital-asset/daml/blob/main/release/RELEASE.md|release instructions> for details.")"

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -88,4 +88,4 @@ jobs:
       rotate
       open_pr "rotate-after-release-$(date -I)" \
               "rotate release duty after $(date -I)" \
-              "@$NEXT_GH is taking care of testing today's release, so they get pushed back to the end of the line.\n\nPlease do not merge this before the release is fully tested."
+              "@$NEXT_GH is taking care of [testing](https://github.com/digital-asset/daml/blob/main/release/RELEASE.md) today's release, so they get pushed back to the end of the line.\n\nPlease do not merge this before the release is fully tested."

--- a/release/RELEASE_SNAPSHOT_1.0.md
+++ b/release/RELEASE_SNAPSHOT_1.0.md
@@ -30,3 +30,5 @@
 
 1. Merge the PR and wait for the corresponding `main` build to finish. You
    will be notified on `#team-daml`.
+
+1. Go back to the general [release instructions](RELEASE.md).

--- a/release/RELEASE_SNAPSHOT_2.0.md
+++ b/release/RELEASE_SNAPSHOT_2.0.md
@@ -6,4 +6,6 @@
 
 1. Merge the PR and wait for the corresponding `main` build to finish.
 
+1. Go back to the general [release instructions](RELEASE.md).
+
 [DACH-NY/assembly]: https://github.com/DACH-NY/assembly

--- a/release/RELEASE_STABLE_1.0.md
+++ b/release/RELEASE_STABLE_1.0.md
@@ -19,4 +19,6 @@
 1. Merge the PR and wait for the corresponding `main` build to finish. You
    will be notified on `#team-daml`.
 
+1. Go back to the general [release instructions](RELEASE.md).
+
 [checklist]: https://docs.google.com/document/d/1RY2Qe9GwAUiiSJmq1lTzy6wu1N2ZSEILQ68M9n8CHgg

--- a/release/RELEASE_STABLE_2.0.md
+++ b/release/RELEASE_STABLE_2.0.md
@@ -27,6 +27,8 @@
 
 1. Merge the PR and wait for the corresponding `main` build to finish.
 
+1. Go back to the general [release instructions](RELEASE.md).
+
 [checklist]: https://docs.google.com/document/d/1RY2Qe9GwAUiiSJmq1lTzy6wu1N2ZSEILQ68M9n8CHgg
 [DACH-NY/assembly]: https://github.com/DACH-NY/assembly
 [digital-asset/daml]: https://github.com/digital-asset/daml


### PR DESCRIPTION
Because we can't expect people to magically know where to find them.

CHANGELOG_BEGIN
CHANGELOG_END