### PR TITLE
[JSON-API] Normalize token parsing & remove custom parsing code

### DIFF
--- a/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json-testing/src/main/scala/com/daml/http/HttpServiceTestFixture.scala
@@ -316,15 +316,15 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
   def jwtForParties(
       actAs: List[String],
       readAs: List[String],
-      ledgerId: String,
-      withoutNamespace: Boolean = false,
-      admin: Boolean = false,
+      ledgerIdOpt: Option[String],
+      withoutNamespace: Boolean,
+      admin: Boolean,
   ): Jwt = {
     import AuthServiceJWTCodec.JsonImplicits._
     val payload =
       if (withoutNamespace)
         s"""{
-               |  "ledgerId": "$ledgerId",
+               |  ${ledgerIdOpt.map(it => s""""ledgerId": "$it",""").getOrElse("")}
                |  "applicationId": "test",
                |  "exp": 0,
                |  "admin": $admin,
@@ -334,7 +334,7 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
               """.stripMargin
       else
         (CustomDamlJWTPayload(
-          ledgerId = Some(ledgerId),
+          ledgerId = ledgerIdOpt,
           applicationId = Some("test"),
           actAs = actAs,
           participantId = None,
@@ -352,6 +352,14 @@ object HttpServiceTestFixture extends LazyLogging with Assertions with Inside {
       )
       .fold(e => throw new IllegalArgumentException(s"cannot sign a JWT: ${e.shows}"), identity)
   }
+
+  def jwtForParties(
+      actAs: List[String],
+      readAs: List[String],
+      ledgerId: String,
+      withoutNamespace: Boolean = false,
+      admin: Boolean = false,
+  ): Jwt = jwtForParties(actAs, readAs, Some(ledgerId), withoutNamespace, admin)
 
   def headersWithPartyAuth(
       actAs: List[String],

--- a/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
+++ b/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
@@ -42,7 +42,7 @@ final class FailureTests
   import WebsocketTestFixture._
 
   private def headersWithParties(actAs: List[String]) =
-    headersWithPartyAuth(actAs, List(), ledgerId().unwrap)
+    headersWithPartyAuth(actAs, List(), Some(ledgerId().unwrap))
 
   "Command submission succeeds after reconnect" in withHttpService[Assertion] {
     (uri, encoder, _, client) =>
@@ -344,7 +344,7 @@ final class FailureTests
       _ = status shouldBe a[StatusCodes.Success]
       cid = getContractId(getResult(r))
       r <- (singleClientQueryStream(
-        jwtForParties(List(p.unwrap), List(), ledgerId().unwrap),
+        jwtForParties(List(p.unwrap), List(), Some(ledgerId().unwrap)),
         uri,
         query,
       ) via parseResp runWith respBefore(cid)).transform(x => Success(x))
@@ -363,7 +363,7 @@ final class FailureTests
       cid = getContractId(getResult(r))
       _ = status shouldBe a[StatusCodes.Success]
       (stop, source) = singleClientQueryStream(
-        jwtForParties(List(p.unwrap), List(), ledgerId().unwrap),
+        jwtForParties(List(p.unwrap), List(), Some(ledgerId().unwrap)),
         uri,
         query,
         Some(offset),

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -782,7 +782,7 @@ trait AbstractHttpServiceIntegrationTestFunsCustomToken
       admin: Boolean = false,
   )(implicit ec: ExecutionContext): Future[Jwt] =
     Future.successful(
-      HttpServiceTestFixture.jwtForParties(actAs, readAs, ledgerId, withoutNamespace)
+      HttpServiceTestFixture.jwtForParties(actAs, readAs, Some(ledgerId), withoutNamespace)
     )
 
   protected def jwt(uri: Uri)(implicit ec: ExecutionContext): Future[Jwt] =
@@ -802,7 +802,12 @@ trait AbstractHttpServiceIntegrationTestFunsCustomToken
       actAs: List[String],
       readAs: List[String] = List(),
   ) =
-    HttpServiceTestFixture.headersWithPartyAuth(actAs, readAs, testId, withoutNamespace = true)
+    HttpServiceTestFixture.headersWithPartyAuth(
+      actAs,
+      readAs,
+      Some(testId),
+      withoutNamespace = true,
+    )
 
   "get all parties using the legacy token format" in withHttpServiceAndClient {
     (uri, _, _, client, _) =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
@@ -173,7 +173,6 @@ object EndpointsCompanion {
   }
 
   object CreateFromCustomToken {
-    @inline def apply[A](implicit ev: CreateFromCustomToken[A]): CreateFromCustomToken[A] = ev
 
     private[http] implicit val jwtWritePayloadFromCustomToken
         : CreateFromCustomToken[JwtWritePayload] =

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
@@ -291,13 +291,13 @@ object EndpointsCompanion {
     for {
       token <- EitherT.either(decodeAndParseJwt(jwt, decodeJwt))
       p <- token match {
-        case standardToken @ StandardJWTPayload(_, _, _) =>
+        case standardToken: StandardJWTPayload =>
           createFromUserToken(
             standardToken,
             userId => userManagementClient.listUserRights(userId, Some(jwt.value)),
             () => ledgerIdentityClient.getLedgerId(Some(jwt.value)),
           ).leftMap(identity[Error])
-        case customToken @ CustomDamlJWTPayload(_, _, _, _, _, _, _) =>
+        case customToken: CustomDamlJWTPayload =>
           EitherT.either(createFromCustomToken(customToken): Error \/ A)
       }
     } yield (jwt, p: A)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
@@ -12,8 +12,12 @@ import com.daml.http.json.SprayJson
 import com.daml.http.util.Logging.{InstanceUUID, RequestID, extendWithRequestIdLogCtx}
 import util.GrpcHttpErrorCodes._
 import com.daml.jwt.domain.{DecodedJwt, Jwt}
-import com.daml.ledger.api.auth.{AuthServiceJWTCodec, CustomDamlJWTPayload, StandardJWTPayload}
-import AuthServiceJWTCodec.{readPayload => readJWTPayload}
+import com.daml.ledger.api.auth.{
+  AuthServiceJWTCodec,
+  AuthServiceJWTPayload,
+  CustomDamlJWTPayload,
+  StandardJWTPayload,
+}
 import com.daml.ledger.api.domain.UserRight
 import UserRight.{CanActAs, CanReadAs}
 import com.daml.ledger.api.refinements.{ApiTypes => lar}
@@ -28,7 +32,6 @@ import scalaz.{-\/, EitherT, Monad, NonEmptyList, Show, \/, \/-}
 import spray.json.JsValue
 import scalaz.syntax.std.either._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
 import scala.util.control.NonFatal
 
 object EndpointsCompanion {
@@ -64,19 +67,19 @@ object EndpointsCompanion {
       case NonFatal(t) => ServerError(t.description)
     }
   }
-  private type ET[A] = EitherT[Future, Unauthorized, A]
-  trait ParsePayload[A] {
-    def parsePayload(
-        jwt: DecodedJwt[String]
-    ): Error \/ A
+
+  trait CreateFromCustomToken[A] {
+    def apply(
+        jwt: CustomDamlJWTPayload
+    ): Unauthorized \/ A
   }
 
   trait CreateFromUserToken[A] {
     def apply(
-        jwt: DecodedJwt[String],
+        jwt: StandardJWTPayload,
         listUserRights: UserId => Future[Seq[UserRight]],
         getLedgerId: () => Future[String],
-    ): ET[A]
+    ): EitherT[Future, Unauthorized, A]
   }
 
   object CreateFromUserToken {
@@ -87,36 +90,16 @@ object EndpointsCompanion {
       def apply(userId: String, actAs: List[String], readAs: List[String], ledgerId: String): A \/ B
     }
 
-    private def parseAndDecodeUserToken(jwt: DecodedJwt[String]) = {
-      import spray.json._
-      for {
-        jsValue <- Try(jwt.payload.parseJson).toEither.disjunction
-          .leftMap(it => Unauthorized(it.getMessage))
-        decodedToken <-
-          \/.attempt(readJWTPayload(jsValue)) {
-            case _: spray.json.DeserializationException => Unauthorized("Invalid token supplied")
-            case e => throw e
-          }
-      } yield decodedToken
-    }
-
-    private[http] def parseUserIdFromToken(
-        jwt: DecodedJwt[String]
+    private[http] def userIdFromToken(
+        jwt: StandardJWTPayload
     ): Unauthorized \/ UserId =
-      for {
-        parsedToken <- parseAndDecodeUserToken(jwt)
-        userId <- (parsedToken match {
-          case d: CustomDamlJWTPayload =>
-            d.applicationId toRight "This user token contains no applicationId/userId"
-          case s: StandardJWTPayload => Right(s.userId)
-        })
-          .flatMap(UserId.fromString)
-          .disjunction
-          .leftMap(Unauthorized)
-      } yield userId
+      UserId
+        .fromString(jwt.userId)
+        .disjunction
+        .leftMap(Unauthorized)
 
     private def transformUserTokenTo[B](
-        jwt: DecodedJwt[String],
+        jwt: StandardJWTPayload,
         listUserRights: UserId => Future[Seq[UserRight]],
         getLedgerId: () => Future[String],
     )(
@@ -125,7 +108,7 @@ object EndpointsCompanion {
         mf: Monad[Future]
     ): EitherT[Future, Unauthorized, B] =
       for {
-        userId <- either(parseUserIdFromToken(jwt))
+        userId <- either(userIdFromToken(jwt))
         rights <- EitherT.rightT(listUserRights(userId))
 
         actAs = rights.collect { case CanActAs(party) =>
@@ -165,16 +148,10 @@ object EndpointsCompanion {
     private[http] implicit def jwtPayloadLedgerIdOnlyFromUserToken(implicit
         mf: Monad[Future]
     ): CreateFromUserToken[JwtPayloadLedgerIdOnly] =
-      (jwt, _, getLedgerId: () => Future[String]) =>
-        for {
-          // Just testing whether this is a valid user token,
-          // to make sure that we don't see the incoming token
-          // as an user token which actually isn't
-          _ <- either(parseAndDecodeUserToken(jwt))
-          res <- EitherT
-            .rightT(getLedgerId())
-            .map(ledgerId => JwtPayloadLedgerIdOnly(lar.LedgerId(ledgerId)))
-        } yield res
+      (_, _, getLedgerId: () => Future[String]) =>
+        EitherT
+          .rightT(getLedgerId())
+          .map(ledgerId => JwtPayloadLedgerIdOnly(lar.LedgerId(ledgerId)))
 
     private[http] implicit def jwtPayloadFromUserToken(implicit
         mf: Monad[Future]
@@ -195,99 +172,52 @@ object EndpointsCompanion {
 
   }
 
-  object ParsePayload {
-    @inline def apply[A](implicit ev: ParsePayload[A]): ParsePayload[A] = ev
+  object CreateFromCustomToken {
+    @inline def apply[A](implicit ev: CreateFromCustomToken[A]): CreateFromCustomToken[A] = ev
 
-    private[http] implicit val jwtWriteParsePayload: ParsePayload[JwtWritePayload] =
+    private[http] implicit val jwtWritePayloadFromCustomToken
+        : CreateFromCustomToken[JwtWritePayload] =
       (
-        jwt: DecodedJwt[String],
-      ) => {
-        // AuthServiceJWTCodec is the JWT reader used by the sandbox and some Daml-on-X ledgers.
-        // Most JWT fields are optional for the sandbox, but not for the JSON API.
-        AuthServiceJWTCodec
-          .readFromString(jwt.payload)
-          .fold(
-            e => -\/ apply Unauthorized(e.getMessage),
-            mPayload =>
-              for {
-                payload <- mPayload match {
-                  case d: CustomDamlJWTPayload => \/-(d)
-                  case _: StandardJWTPayload =>
-                    -\/(Unauthorized("ledgerId and actAs missing in access token"))
-                }
-                ledgerId <- payload.ledgerId
-                  .toRightDisjunction(Unauthorized("ledgerId missing in access token"))
-                applicationId <- payload.applicationId
-                  .toRightDisjunction(Unauthorized("applicationId missing in access token"))
-                actAs <- payload.actAs match {
-                  case p +: ps => \/-(NonEmptyList(p, ps: _*))
-                  case _ =>
-                    -\/(Unauthorized(s"Expected one or more parties in actAs but got none"))
-                }
-              } yield JwtWritePayload(
-                lar.LedgerId(ledgerId),
-                lar.ApplicationId(applicationId),
-                lar.Party.subst(actAs),
-                lar.Party.subst(payload.readAs),
-              ),
-          )
-      }
-
-    private[http] implicit val jwtParsePayloadLedgerIdOnly: ParsePayload[JwtPayloadLedgerIdOnly] =
-      (jwt: DecodedJwt[String]) => {
-        import spray.json._
-        val asJsObject: JsValue => Option[Map[String, JsValue]] = {
-          case JsObject(fields) => Some(fields)
-          case _ => None
-        }
-        val asString: JsValue => Option[String] = {
-          case JsString(value) => Some(value)
-          case _ => None
-        }
-        val ast = jwt.payload.parseJson
+        jwt: CustomDamlJWTPayload,
+      ) =>
         for {
-          obj <- asJsObject(ast).toRightDisjunction(Unauthorized("invalid access token"))
-          namespace = obj
-            .get(AuthServiceJWTCodec.oidcNamespace)
-            .flatMap(asJsObject)
-            .getOrElse(obj)
-          ledgerId <- namespace
-            .get("ledgerId")
-            .flatMap(asString)
+          ledgerId <- jwt.ledgerId
             .toRightDisjunction(Unauthorized("ledgerId missing in access token"))
-        } yield JwtPayloadLedgerIdOnly(lar.LedgerId(ledgerId))
-      }
+          applicationId <- jwt.applicationId
+            .toRightDisjunction(Unauthorized("applicationId missing in access token"))
+          actAs <- jwt.actAs match {
+            case p +: ps => \/-(NonEmptyList(p, ps: _*))
+            case _ =>
+              -\/(Unauthorized(s"Expected one or more parties in actAs but got none"))
+          }
+        } yield JwtWritePayload(
+          lar.LedgerId(ledgerId),
+          lar.ApplicationId(applicationId),
+          lar.Party.subst(actAs),
+          lar.Party.subst(jwt.readAs),
+        )
 
-    private[http] implicit val jwtParsePayload: ParsePayload[JwtPayload] =
-      (jwt: DecodedJwt[String]) => {
-        // AuthServiceJWTCodec is the JWT reader used by the sandbox and some Daml-on-X ledgers.
-        // Most JWT fields are optional for the sandbox, but not for the JSON API.
-        AuthServiceJWTCodec
-          .readFromString(jwt.payload)
-          .fold(
-            e => -\/ apply Unauthorized(e.getMessage),
-            mPayload =>
-              for {
-                lpcr <- mPayload match {
-                  case d: CustomDamlJWTPayload =>
-                    \/-((d.ledgerId, d.applicationId, d.actAs, d.readAs))
-                  case _: StandardJWTPayload =>
-                    -\/(Unauthorized("ledgerId, actAs, readAs missing in access token"))
-                }
-                (mLedgerId, mApplicationId, mActAs, mReadAs) = lpcr
-                ledgerId <- mLedgerId
-                  .toRightDisjunction(Unauthorized("ledgerId missing in access token"))
-                applicationId <- mApplicationId
-                  .toRightDisjunction(Unauthorized("applicationId missing in access token"))
-                payload <- JwtPayload(
-                  lar.LedgerId(ledgerId),
-                  lar.ApplicationId(applicationId),
-                  actAs = lar.Party.subst(mActAs),
-                  readAs = lar.Party.subst(mReadAs),
-                ).toRightDisjunction(Unauthorized("No parties in actAs and readAs"))
-              } yield payload,
-          )
-      }
+    private[http] implicit val jwtPayloadLedgerIdOnlyFromCustomToken
+        : CreateFromCustomToken[JwtPayloadLedgerIdOnly] =
+      (jwt: CustomDamlJWTPayload) =>
+        jwt.ledgerId
+          .toRightDisjunction(Unauthorized("ledgerId missing in access token"))
+          .map(ledgerId => JwtPayloadLedgerIdOnly(lar.LedgerId(ledgerId)))
+
+    private[http] implicit val jwtPayloadFromCustomToken: CreateFromCustomToken[JwtPayload] =
+      (jwt: CustomDamlJWTPayload) =>
+        for {
+          ledgerId <- jwt.ledgerId
+            .toRightDisjunction(Unauthorized("ledgerId missing in access token"))
+          applicationId <- jwt.applicationId
+            .toRightDisjunction(Unauthorized("applicationId missing in access token"))
+          payload <- JwtPayload(
+            lar.LedgerId(ledgerId),
+            lar.ApplicationId(applicationId),
+            actAs = lar.Party.subst(jwt.actAs),
+            readAs = lar.Party.subst(jwt.readAs),
+          ).toRightDisjunction(Unauthorized("No parties in actAs and readAs"))
+        } yield payload
   }
 
   def notFound(implicit lc: LoggingContextOf[InstanceUUID]): Route = (ctx: RequestContext) =>
@@ -334,33 +264,42 @@ object EndpointsCompanion {
 
   private[http] def format(a: JsValue): ByteString = ByteString(a.compactPrint)
 
+  private[http] def decodeAndParseJwt(
+      jwt: Jwt,
+      decodeJwt: ValidateJwt,
+  ): Error \/ AuthServiceJWTPayload =
+    decodeJwt(jwt)
+      .flatMap(a =>
+        AuthServiceJWTCodec
+          .readFromString(a.payload)
+          .toEither
+          .disjunction
+          .leftMap(Error.fromThrowable)
+      )
+
   private[http] def decodeAndParsePayload[A](
       jwt: Jwt,
       decodeJwt: ValidateJwt,
       userManagementClient: UserManagementClient,
       ledgerIdentityClient: LedgerIdentityClient,
   )(implicit
-      lc: LoggingContextOf[InstanceUUID with RequestID],
-      customParse: ParsePayload[A],
+      createFromCustomToken: CreateFromCustomToken[A],
       createFromUserToken: CreateFromUserToken[A],
       fm: Monad[Future],
       ec: ExecutionContext,
-  ): ET[(Jwt, A)] = {
+  ): EitherT[Future, Error, (Jwt, A)] = {
     for {
-      a <- EitherT.either(decodeJwt(jwt): Unauthorized \/ DecodedJwt[String])
-      p <- customParse
-        .parsePayload(a)
-        .fold(
-          { _ =>
-            logger.debug("No custom token found, trying to process the token as user token.")
-            createFromUserToken(
-              a,
-              userId => userManagementClient.listUserRights(userId, Some(jwt.value)),
-              () => ledgerIdentityClient.getLedgerId(Some(jwt.value)),
-            )
-          },
-          EitherT.pure(_): ET[A],
-        )
-    } yield (jwt, p)
+      token <- EitherT.either(decodeAndParseJwt(jwt, decodeJwt))
+      p <- token match {
+        case standardToken @ StandardJWTPayload(_, _, _) =>
+          createFromUserToken(
+            standardToken,
+            userId => userManagementClient.listUserRights(userId, Some(jwt.value)),
+            () => ledgerIdentityClient.getLedgerId(Some(jwt.value)),
+          ).leftMap(identity[Error])
+        case customToken @ CustomDamlJWTPayload(_, _, _, _, _, _, _) =>
+          EitherT.either(createFromCustomToken(customToken): Error \/ A)
+      }
+    } yield (jwt, p: A)
   }
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/UserManagement.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/endpoints/UserManagement.scala
@@ -212,7 +212,7 @@ private[http] object UserManagement {
       mf: Monad[Future]
   ): ET[UserId] =
     EitherT.either(decodeAndParseJwt(rawJwt, decodeJwt).flatMap {
-      case token @ StandardJWTPayload(_, _, _) => userIdFromToken(token)
+      case token: StandardJWTPayload => userIdFromToken(token)
       case _ =>
         -\/(Unauthorized("A user token was expected but a custom token was given"): Error)
     })

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/CommandServiceTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/CommandServiceTest.scala
@@ -83,7 +83,7 @@ object CommandServiceTest {
   private lazy val multiPartyJwt = jwtForParties(
     actAs = domain.Party unsubst multiPartyJwp.submitter.toList,
     readAs = domain.Party unsubst multiPartyJwp.readAs,
-    ledgerId = multiPartyJwp.ledgerId.unwrap,
+    ledgerId = Some(multiPartyJwp.ledgerId.unwrap),
   )
   private val tplId = domain.TemplateId("Foo", "Bar", "Baz")
 


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/13127

No custom parsing code anymore in the json api. With this we will only rely on the ledger code which is already shared with other components too :)

changelog_begin

- [HTTP-JSON] custom claim tokens without ledger id are now correctly recognized as such and not as user tokens

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
