### PR TITLE
Make http.domain a package

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -22,7 +22,32 @@ import spray.json.JsValue
 
 import scala.annotation.tailrec
 
-object domain extends com.daml.fetchcontracts.domain.Aliases {
+package object domain extends com.daml.fetchcontracts.domain.Aliases {
+  type InputContractRef[LfV] =
+    (TemplateId.OptionalPkg, LfV) \/ (Option[TemplateId.OptionalPkg], ContractId)
+
+  type ResolvedContractRef[LfV] =
+    (TemplateId.RequiredPkg, LfV) \/ (TemplateId.RequiredPkg, ContractId)
+
+  type LedgerIdTag = lar.LedgerIdTag
+  type LedgerId = lar.LedgerId
+  val LedgerId = lar.LedgerId
+
+  type ApplicationIdTag = lar.ApplicationIdTag
+  type ApplicationId = lar.ApplicationId
+  val ApplicationId = lar.ApplicationId
+
+  type Choice = lar.Choice
+  val Choice = lar.Choice
+
+  type CommandIdTag = lar.CommandIdTag
+  type CommandId = lar.CommandId
+  val CommandId = lar.CommandId
+
+  type LfType = iface.Type
+}
+
+package domain {
 
   import com.daml.fetchcontracts.domain.`fc domain ErrorOps`
 
@@ -80,12 +105,6 @@ object domain extends com.daml.fetchcontracts.domain.Aliases {
   }
 
   case class Contract[LfV](value: ArchivedContract \/ ActiveContract[LfV])
-
-  type InputContractRef[LfV] =
-    (TemplateId.OptionalPkg, LfV) \/ (Option[TemplateId.OptionalPkg], ContractId)
-
-  type ResolvedContractRef[LfV] =
-    (TemplateId.RequiredPkg, LfV) \/ (TemplateId.RequiredPkg, ContractId)
 
   case class ArchivedContract(contractId: ContractId, templateId: TemplateId.RequiredPkg)
 
@@ -238,21 +257,6 @@ object domain extends com.daml.fetchcontracts.domain.Aliases {
   }
 
   final case class StartingOffset(offset: Offset)
-
-  type LedgerIdTag = lar.LedgerIdTag
-  type LedgerId = lar.LedgerId
-  val LedgerId = lar.LedgerId
-
-  type ApplicationIdTag = lar.ApplicationIdTag
-  type ApplicationId = lar.ApplicationId
-  val ApplicationId = lar.ApplicationId
-
-  type Choice = lar.Choice
-  val Choice = lar.Choice
-
-  type CommandIdTag = lar.CommandIdTag
-  type CommandId = lar.CommandId
-  val CommandId = lar.CommandId
 
   object Contract {
 
@@ -449,8 +453,6 @@ object domain extends com.daml.fetchcontracts.domain.Aliases {
     implicit def hasTemplateId[Off]: HasTemplateId[ContractKeyStreamRequest[Off, *]] =
       HasTemplateId.by[ContractKeyStreamRequest[Off, *]](_.ekey)
   }
-
-  type LfType = iface.Type
 
   trait HasTemplateId[F[_]] {
     def templateId(fa: F[_]): TemplateId.OptionalPkg


### PR DESCRIPTION
Use a package instead of object for organization so the namespace remains open. Note that in Scala 3, the val/type aliases in this diff can be replaced with [export statements](https://docs.scala-lang.org/scala3/reference/other-new-features/export.html).

Fixes #11151

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
