### PR TITLE
Speed up Daml repl startup

### DIFF
--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -10,6 +10,7 @@ da_haskell_library(
     name = "daml-compiler",
     srcs = glob(["src/**/*.hs"]),
     hackage_deps = [
+        "async",
         "base",
         "bytestring",
         "conduit",

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -18,9 +18,9 @@ import BasicTypes (Boxity(..), PromotionFlag(..), Origin(..))
 import DynFlags
 import Bag (bagToList, unitBag)
 import Control.Applicative
+import Control.Concurrent.Async
 import Control.Concurrent.Extra
 import Control.Exception.Safe
-import Control.Lens (toListOf)
 import Control.Monad.Except
 import Control.Monad.Extra
 import qualified Control.Monad.State.Strict as State
@@ -31,7 +31,6 @@ import qualified DA.Daml.LF.InferSerializability as Serializability
 import qualified DA.Daml.LF.Completer as LF
 import qualified DA.Daml.LF.Simplifier as LF
 import qualified DA.Daml.LF.TypeChecker as LF
-import DA.Daml.LF.Ast.Optics (packageRefs)
 import qualified DA.Daml.LF.ReplClient as ReplClient
 import DA.Daml.LFConversion (convertModule)
 import DA.Daml.Options.Types
@@ -39,11 +38,11 @@ import qualified DA.Daml.Preprocessor.Records as Preprocessor
 import DA.Daml.UtilGHC
 import DA.Daml.UtilLF (buildPackage)
 import Data.Bifunctor (first)
+import Data.Either.Combinators (whenLeft)
 import Data.Functor.Alt
 import Data.Functor.Bind
 import Data.Foldable
 import Data.Generics.Uniplate.Data (descendBi)
-import Data.Graph
 import Data.IORef
 import Data.List (intercalate)
 import qualified Data.Map.Strict as Map
@@ -226,20 +225,6 @@ stmtBoundVars (LetStatement binding) = case binding of
     FunBinding f _ -> [unLoc f]
     PatBinding pat _ -> collectPatBinders pat
 
--- | Sort DALF packages in topological order.
--- I.e. if @a@ appears before @b@, then @b@ does not depend on @a@.
-topologicalSort :: [LF.DalfPackage] -> [LF.DalfPackage]
-topologicalSort lfPkgs = map toPkg $ topSort $ transposeG graph
-  where
-    (graph, fromVertex, _) = graphFromEdges
-      [ (lfPkg, pkgId, deps)
-      | lfPkg <- lfPkgs
-      , let pkgId = LF.dalfPackageId lfPkg
-      , let astPkg = LF.extPackagePkg (LF.dalfPackagePkg lfPkg)
-      , let deps = [dep | LF.PRImport dep <- toListOf packageRefs astPkg]
-      ]
-    toPkg = (\(pkg, _, _) -> pkg) . fromVertex
-
 -- | Mapping from module name to all imports for that module.
 --
 -- Invariant: Imports for a module should be associated to its module name and
@@ -322,18 +307,16 @@ parseReplInput input dflags =
 -- | Load all packages in the given session.
 --
 -- Returns the list of modules in the specified import packages.
-loadPackages :: [(LF.PackageName, Maybe LF.PackageVersion)] -> ReplClient.Handle -> IdeState -> IO [ImportDecl GhcPs]
+loadPackages :: [(LF.PackageName, Maybe LF.PackageVersion)] -> ReplClient.Handle -> IdeState -> IO ([ImportDecl GhcPs], IO ())
 loadPackages importPkgs replClient ideState = do
     -- Load packages
     Just (PackageMap pkgs) <- runAction ideState (use GeneratePackageMap "Dummy.daml")
     Just stablePkgs <- runAction ideState (useNoFile GenerateStablePackages)
-    for_ (topologicalSort (toList pkgs <> toList stablePkgs)) $ \pkg -> do
-        r <- ReplClient.loadPackage replClient (LF.dalfPackageBytes pkg)
-        case r of
-            Left err -> do
-                hPutStrLn stderr ("Package could not be loaded: " <> show err)
-                exitFailure
-            Right _ -> pure ()
+    t <- async $ do
+      r <- ReplClient.loadPackages replClient (map LF.dalfPackageBytes $ toList pkgs <> toList stablePkgs)
+      whenLeft r $ \err ->  do
+         hPutStrLn stderr ("Package could not be loaded: " <> show err)
+         exitFailure
     -- Determine module names in imported DALFs.
     let unversionedPkgs = Map.mapKeys (fst . LF.splitUnitId) pkgs
         toUnitId (pkgName, mbVersion) = pkgNameVersion pkgName mbVersion
@@ -347,11 +330,12 @@ loadPackages importPkgs replClient ideState = do
                     "Could not find package for import: " <> unitIdString (toUnitId importPkg) <> "\n"
                     <> "Known packages: " <> intercalate ", " (unitIdString <$> Map.keys pkgs)
                 exitFailure
-    pure
-      [ simpleImportDecl . mkModuleName . T.unpack . LF.moduleNameString $ mod
-      | pkg <- importLfPkgs
-      , mod <- NM.names $ LF.packageModules pkg
-      ]
+    let imports =
+          [ simpleImportDecl . mkModuleName . T.unpack . LF.moduleNameString $ mod
+          | pkg <- importLfPkgs
+          , mod <- NM.names $ LF.packageModules pkg
+          ]
+    pure (imports, wait t)
 
 data ReplLogger = ReplLogger
   { withReplLogger :: forall a. ([FileDiagnostic] -> IO ()) -> IO a -> IO a
@@ -389,7 +373,7 @@ runRepl
     -> IdeState
     -> IO ()
 runRepl importPkgs opts replClient logger ideState = do
-    imports <- loadPackages importPkgs replClient ideState
+    (imports, waitForPackages) <- loadPackages importPkgs replClient ideState
     -- Typecheck once to get the GlobalRdrEnv
     let initialLineNumber = 0
     dflags <- liftIO $
@@ -409,8 +393,8 @@ runRepl importPkgs opts replClient logger ideState = do
           }
     let replM = Repl.evalReplOpts Repl.ReplOpts
           { banner = const (pure "daml> ")
-          , command = replLine
-          , options = replOptions
+          , command = replLine waitForPackages
+          , options = replOptions waitForPackages
           , prefix = Just ':'
           , multilineCommand = Nothing
           , tabComplete = Repl.Cursor $ \_ _ -> pure []
@@ -422,12 +406,13 @@ runRepl importPkgs opts replClient logger ideState = do
     State.evalStateT replM initReplState
   where
     handleStmt
-        :: DynFlags
+        :: IO ()
+        -> DynFlags
         -> String
         -> Stmt GhcPs (LHsExpr GhcPs)
         -> ReplClient.ReplResponseType
         -> ExceptT Error ReplM ()
-    handleStmt dflags line stmt rspType = do
+    handleStmt waitForPackages dflags line stmt rspType = do
         ReplState {imports, bindings, lineNumber} <- State.get
         supportedStmt <- maybe (throwError (UnsupportedStatement line)) pure (validateStmt stmt)
         let rendering = renderModule imports lineNumber bindings supportedStmt
@@ -451,6 +436,7 @@ runRepl importPkgs opts replClient logger ideState = do
         stmtTy <- maybe (throwError TypeError) pure (exprTy $ tm_typechecked_source tcMod)
         -- If we get an error we don’t increment lineNumber and we
         -- do not get a new binding
+        liftIO waitForPackages
         result <- withExceptT ScriptBackendError $ ExceptT $ liftIO $
             ReplClient.runScript replClient (optDamlLfVersion opts) lfMod rspType
 
@@ -531,8 +517,8 @@ runRepl importPkgs opts replClient logger ideState = do
         -> ImportDecl GhcPs
         -> ExceptT Error ReplM ()
     handleImport dflags imp = addImports dflags [imp]
-    replLine :: String -> ReplM ()
-    replLine line = do
+    replLine :: IO () -> String -> ReplM ()
+    replLine waitForPackages line = do
         ReplState {lineNumber} <- State.get
         dflags <- liftIO $
             hsc_dflags . hscEnv <$>
@@ -540,7 +526,7 @@ runRepl importPkgs opts replClient logger ideState = do
         r <- runExceptT $ do
             input <- ExceptT $ pure $ parseReplInput line dflags
             case input of
-                ReplStatement stmt -> handleStmt dflags line stmt ReplClient.ReplText
+                ReplStatement stmt -> handleStmt waitForPackages dflags line stmt ReplClient.ReplText
                 ReplImport imp -> handleImport dflags imp
         case r of
             Left err -> liftIO $ renderError dflags err
@@ -558,10 +544,10 @@ runRepl importPkgs opts replClient logger ideState = do
         case r of
             Left err -> liftIO $ renderError dflags err
             Right () -> pure ()
-    replOptions :: Repl.Options ReplM
-    replOptions =
+    replOptions :: IO () -> Repl.Options ReplM
+    replOptions waitForPackages =
       [ ("help", mkReplOption optHelp)
-      , ("json", mkReplOption optJson)
+      , ("json", mkReplOption (optJson waitForPackages))
       , ("module", mkReplOption optModule)
       , ("show", mkReplOption optShow)
       ]
@@ -573,10 +559,10 @@ runRepl importPkgs opts replClient logger ideState = do
       , "   :module [+/-] <mod> ...     add or remove the modules from the import list"
       , "   :show imports               show the current module imports"
       ]
-    optJson dflags (unwords -> line) = do
+    optJson waitForPackages dflags (unwords -> line) = do
         input <- ExceptT $ pure $ parseReplInput line dflags
         case input of
-            ReplStatement stmt -> handleStmt dflags line stmt ReplClient.ReplJson
+            ReplStatement stmt -> handleStmt waitForPackages dflags line stmt ReplClient.ReplJson
             ReplImport _ -> throwError (ExpectedExpression line)
     optModule dflags ("-" : names) =
         removeImports dflags $ map mkModuleName names

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -306,7 +306,7 @@ parseReplInput input dflags =
 
 -- | Load all packages in the given session.
 --
--- Returns the list of modules in the specified import packages.
+-- Returns the list of modules in the specified import packages and an action that waits for them to be loaded by the repl client.
 loadPackages :: [(LF.PackageName, Maybe LF.PackageVersion)] -> ReplClient.Handle -> IdeState -> IO ([ImportDecl GhcPs], IO ())
 loadPackages importPkgs replClient ideState = do
     -- Load packages

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -671,7 +671,7 @@ execRepl dars importPkgs mbLedgerConfig mbAuthToken mbAppId mbSslConf mbMaxInbou
             logger <- getLogger opts "repl"
             runfilesDir <- locateRunfiles (mainWorkspace </> "compiler/repl-service/server")
             let jar = runfilesDir </> "repl-service.jar"
-            ReplClient.withReplClient (ReplClient.Options jar mbLedgerConfig mbAuthToken mbAppId mbSslConf mbMaxInboundMessageSize timeMode Inherit) $ \replHandle _stdout _ph ->
+            ReplClient.withReplClient (ReplClient.Options jar mbLedgerConfig mbAuthToken mbAppId mbSslConf mbMaxInboundMessageSize timeMode Inherit) $ \replHandle ->
                 withTempDir $ \dir ->
                 withCurrentDirectory dir $ do
                 sdkVer <- fromMaybe SdkVersion.sdkVersion <$> lookupEnv sdkVersionEnvVar

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -116,7 +116,7 @@ testConnection damlc scriptDar ledgerPort mbTokenFile mbCaCrt = do
         [ "alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"Alice\")"
         , "debug alice"
         ]
-    let regexString = "^(Client TLS.*\\.\n)?daml> daml>.*: 'Alice'\ndaml> Goodbye.\n$" :: String
+    let regexString = "^.*daml>.*: 'Alice'\ndaml> Goodbye.\n$" :: String
     let regex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexString
     unless (matchTest regex out) $
         assertFailure (show out <> " did not match " <> show regexString <> ".")

--- a/compiler/repl-service/client/src/DA/Daml/LF/ReplClient.hs
+++ b/compiler/repl-service/client/src/DA/Daml/LF/ReplClient.hs
@@ -9,9 +9,11 @@ module DA.Daml.LF.ReplClient
   , MaxInboundMessageSize(..)
   , ReplTimeMode(..)
   , Handle
+  , hTerminate
+  , hStdout
   , ReplResponseType(..)
   , withReplClient
-  , loadPackage
+  , loadPackages
   , runScript
   , clearResults
   , BackendError
@@ -20,7 +22,9 @@ module DA.Daml.LF.ReplClient
   , ScriptResult(..)
   ) where
 
-import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Concurrent.Extra
+import Control.Exception
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.Proto3.EncodeV1 as EncodeV1
 import DA.PortFile
@@ -29,6 +33,7 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.Functor
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import qualified Data.Vector as V
 import Network.GRPC.HighLevel.Client (ClientError, ClientRequest(..), ClientResult(..), GRPCMethodType(..))
 import Network.GRPC.HighLevel.Generated (withGRPCClient)
 import Network.GRPC.LowLevel (ClientConfig(..), ClientSSLConfig(..), ClientSSLKeyCertPair(..), Host(..), Port(..), StatusCode(..))
@@ -62,8 +67,10 @@ data Options = Options
   }
 
 data Handle = Handle
-  { hClient :: Grpc.ReplService ClientRequest ClientResult
+  { hClient :: IO (Grpc.ReplService ClientRequest ClientResult)
   , hOptions :: Options
+  , hStdout :: Maybe IO.Handle
+  , hTerminate :: IO ()
   }
 data BackendError
   = BErrorClient ClientError
@@ -83,7 +90,7 @@ javaProc args =
       let javaExe = javaHome </> "bin" </> "java"
       in proc javaExe args
 
-withReplClient :: Options -> (Handle -> Maybe IO.Handle -> ProcessHandle -> IO a) -> IO a
+withReplClient :: Options -> (Handle -> IO a) -> IO a
 withReplClient opts@Options{..} f = withTempFile $ \portFile -> do
     replServer <- javaProc $ concat
         [ [ "-jar", optServerJar
@@ -113,21 +120,29 @@ withReplClient opts@Options{..} f = withTempFile $ \portFile -> do
         , concat [ ["--max-inbound-message-size", show (getMaxInboundMessageSize size)] | Just size <- [optMaxInboundMessageSize] ]
         ]
     withCreateProcess replServer { std_out = optStdout } $ \_ stdout _ ph -> do
-      port <- readPortFile ph maxRetries portFile
-      let grpcConfig = ClientConfig (Host "127.0.0.1") (Port port) [] Nothing Nothing
-      threadDelay 1000000
-      withGRPCClient grpcConfig $ \client -> do
-          replClient <- Grpc.replServiceClient client
-          f Handle
-              { hClient = replClient
-              , hOptions = opts
-              } stdout ph
+      clientBarrier <- newBarrier
+      terminateBarrier <- newBarrier
+      let handle = Handle
+            { hClient = waitBarrier clientBarrier
+            , hStdout = stdout
+            , hTerminate = terminateProcess ph
+            , hOptions = opts
+            }
+          clientAct = do
+            port <- readPortFile ph maxRetries portFile
+            let grpcConfig = ClientConfig (Host "127.0.0.1") (Port port) [] Nothing Nothing
+            withGRPCClient grpcConfig $ \client -> do
+                replClient <- Grpc.replServiceClient client
+                signalBarrier clientBarrier replClient
+                waitBarrier terminateBarrier
+      withAsync clientAct $ const $ f handle `finally` signalBarrier terminateBarrier ()
 
-loadPackage :: Handle -> BS.ByteString -> IO (Either BackendError ())
-loadPackage Handle{..} package = do
+loadPackages :: Handle -> [BS.ByteString] -> IO (Either BackendError ())
+loadPackages Handle{..} packages = do
+    client <- hClient
     r <- performRequest
-        (Grpc.replServiceLoadPackage hClient)
-        (Grpc.LoadPackageRequest package)
+        (Grpc.replServiceLoadPackages client)
+        (Grpc.LoadPackagesRequest (V.fromList packages))
     pure (() <$ r)
 
 data ScriptResult
@@ -137,8 +152,9 @@ data ScriptResult
 
 runScript :: Handle -> LF.Version -> LF.Module -> ReplResponseType -> IO (Either BackendError ScriptResult)
 runScript Handle{..} version m rspType = do
+    client <- hClient
     r <- performRequest
-        (Grpc.replServiceRunScript hClient)
+        (Grpc.replServiceRunScript client)
         (Grpc.RunScriptRequest bytes (TL.pack $ LF.renderMinorVersion (LF.versionMinor version)) grpcRspType)
     pure $ fmap handleResult r
   where
@@ -156,7 +172,8 @@ runScript Handle{..} version m rspType = do
 
 clearResults :: Handle -> IO (Either BackendError ())
 clearResults Handle{..} = do
-    r <- performRequest (Grpc.replServiceClearResults hClient) Grpc.ClearResultsRequest
+    client <- hClient
+    r <- performRequest (Grpc.replServiceClearResults client) Grpc.ClearResultsRequest
     pure (() <$ r)
 
 performRequest

--- a/compiler/repl-service/protos/repl_service.proto
+++ b/compiler/repl-service/protos/repl_service.proto
@@ -10,16 +10,16 @@ option java_outer_classname = "ReplServiceProto";
 package replservice;
 
 service ReplService {
-  rpc LoadPackage (LoadPackageRequest) returns (LoadPackageResponse);
+  rpc LoadPackages (LoadPackagesRequest) returns (LoadPackagesResponse);
   rpc RunScript (RunScriptRequest) returns (RunScriptResponse);
   rpc ClearResults (ClearResultsRequest) returns (ClearResultsResponse);
 }
 
-message LoadPackageRequest {
-  bytes package = 1;
+message LoadPackagesRequest {
+  repeated bytes packages = 1;
 }
 
-message LoadPackageResponse {
+message LoadPackagesResponse {
 }
 
 message RunScriptRequest {


### PR DESCRIPTION
Daml repl startup is stupidly slow to the point where starting up and
executing 1+1 takes ~7s (piped to stdin so no typing included).

This PR speeds this up to ~4.5s. In addition to that, we also display
the repl process sooner and complete the last bit of setup while the
user is typing.

Specifically, we do the following:

1. Startup the JVM process in parallel with initializing our package
   db and only block on it once it’s started (and remove a stupid 1s
   sleep which doesn’t actually matter).
2. Load all packages in one go instead of one by one. This (roughly)
   matches how the script service works.
3. Only block on packages being loaded once we start running the
   script. Users can type before and we even typecheck their stuff
   before.

We could take this further and do even more in parallel with users
typing but this seems to strike a good balance between implementation
complexity, UX (if startup actually fails you get somewhat sensible
errors) & performance.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
