### PR TITLE
Use an error code when AkkaGrpc services get closed [DPP-765]

### DIFF
--- a/ledger-api/sample-service/BUILD.bazel
+++ b/ledger-api/sample-service/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load("//bazel_tools:scala.bzl", "da_scala_library")
 load("//bazel_tools:proto.bzl", "proto_gen")
+load("//bazel_tools:scala.bzl", "scala_source_jar")
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 load("@scala_version//:index.bzl", "scala_major_version_suffix")
 
@@ -22,21 +23,35 @@ proto_gen(
     ],
 )
 
+proto_gen(
+    name = "sample-service-akka-sources",
+    srcs = [":sample-service-proto"],
+    plugin_exec = "//scala-protoc-plugins/scala-akka:protoc-gen-scala-akka",
+    plugin_name = "scala-akka",
+)
+
 scala_library(
     name = "sample-service-scalapb",
-    srcs = [":sample-service-scalapb-sources"],
+    srcs = [
+        ":sample-service-akka-sources",
+        ":sample-service-scalapb-sources",
+    ],
     unused_dependency_checker_mode = "error",
     deps = [
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/rs-grpc-akka",
     ] + [
         "{}_{}".format(dep, scala_major_version_suffix)
         for dep in [
             "@maven//:com_thesamet_scalapb_lenses",
             "@maven//:com_thesamet_scalapb_scalapb_runtime",
             "@maven//:com_thesamet_scalapb_scalapb_runtime_grpc",
+            "@maven//:com_typesafe_akka_akka_actor",
+            "@maven//:com_typesafe_akka_akka_stream",
         ]
     ],
 )

--- a/ledger/error/src/main/scala/com/daml/error/ContextualizedErrorLogger.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ContextualizedErrorLogger.scala
@@ -24,6 +24,17 @@ trait ContextualizedErrorLogger {
 
 object DamlContextualizedErrorLogger {
 
+  def forClass(
+      clazz: Class[_],
+      loggingContext: LoggingContext = LoggingContext.empty,
+      correlationId: Option[String] = None,
+  ): DamlContextualizedErrorLogger =
+    new DamlContextualizedErrorLogger(
+      ContextualizedLogger.get(clazz),
+      loggingContext,
+      correlationId,
+    )
+
   def forTesting(clazz: Class[_], correlationId: Option[String] = None) =
     new DamlContextualizedErrorLogger(
       ContextualizedLogger.get(clazz),

--- a/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
@@ -310,6 +310,20 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
     }
   }
 
+  @Explanation("This rejection is given when the participant server is shutting down.")
+  @Resolution("Contact the participant operator.")
+  object ServerIsShuttingDown
+      extends ErrorCode(
+        id = "SERVER_IS_SHUTTING_DOWN",
+        ErrorCategory.TransientServerFailure,
+      ) {
+    case class Reject()(implicit
+        loggingContext: ContextualizedErrorLogger
+    ) extends LoggingTransactionErrorImpl(
+          cause = "Server is shutting down"
+        )
+  }
+
   @Explanation("Authentication and authorization errors.")
   object AuthorizationChecks extends ErrorGroup() {
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
@@ -6,8 +6,10 @@ package com.daml.platform.apiserver.error
 import java.net.{InetAddress, InetSocketAddress}
 import java.util.concurrent.TimeUnit
 
+import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Source}
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.error.utils.ErrorDetails
 import com.daml.error.{
   BaseError,
@@ -19,17 +21,15 @@ import com.daml.error.{
   ErrorsAssertions,
 }
 import com.daml.grpc.adapter.ExecutionSequencerFactory
-import com.daml.grpc.adapter.server.akka.ServerAdapter
 import com.daml.grpc.sampleservice.HelloServiceResponding
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner, TestResourceContext}
 import com.daml.platform.apiserver.services.GrpcClientResource
 import com.daml.platform.hello.HelloServiceGrpc.HelloService
-import com.daml.platform.hello.{HelloRequest, HelloResponse, HelloServiceGrpc}
+import com.daml.platform.hello.{HelloRequest, HelloResponse, HelloServiceAkkaGrpc, HelloServiceGrpc}
 import com.daml.platform.testing.{LogCollectorAssertions, StreamConsumer}
 import com.daml.ports.Port
 import io.grpc.netty.NettyServerBuilder
-import io.grpc.stub.StreamObserver
 import io.grpc.{BindableService, ServerServiceDefinition, _}
 import org.scalatest.{Assertion, Assertions, Checkpoints}
 import org.scalatest.concurrent.Eventually
@@ -55,19 +55,23 @@ final class ErrorInterceptorSpec
 
   classOf[ErrorInterceptor].getSimpleName - {
 
-    assume(FooMissingErrorCode.category.grpcCode.get != Status.Code.INTERNAL)
+    assert(FooMissingErrorCode.category.grpcCode.get != Status.Code.INTERNAL)
 
     "for a server unary future endpoint" - {
       "when signalling with a non-self-service error should SANITIZE the server response when arising " - {
         "inside a Future" in {
-          exerciseUnaryFutureEndpoint(useSelfService = false, insideFuture = true)
+          exerciseUnaryFutureEndpoint(
+            new HelloServiceFailing(useSelfService = false, errorInsideFutureOrStream = true)
+          )
             .map { t: StatusRuntimeException =>
               assertSecuritySanitizedError(t)
             }
         }
 
         s"outside a Future $bypassMsg" in {
-          exerciseUnaryFutureEndpoint(useSelfService = false, insideFuture = false)
+          exerciseUnaryFutureEndpoint(
+            new HelloServiceFailing(useSelfService = false, errorInsideFutureOrStream = false)
+          )
             .map { t: StatusRuntimeException =>
               assertSecuritySanitizedError(t)
             }
@@ -76,7 +80,9 @@ final class ErrorInterceptorSpec
 
       "when signalling with a self-service error should NOT SANITIZE the server response when arising" - {
         "inside a Future" in {
-          exerciseUnaryFutureEndpoint(useSelfService = true, insideFuture = true)
+          exerciseUnaryFutureEndpoint(
+            new HelloServiceFailing(useSelfService = true, errorInsideFutureOrStream = true)
+          )
             .map { t: StatusRuntimeException =>
               assertFooMissingError(
                 actual = t,
@@ -86,7 +92,9 @@ final class ErrorInterceptorSpec
         }
 
         s"outside a Future $bypassMsg" in {
-          exerciseUnaryFutureEndpoint(useSelfService = true, insideFuture = false)
+          exerciseUnaryFutureEndpoint(
+            new HelloServiceFailing(useSelfService = true, errorInsideFutureOrStream = false)
+          )
             .map { t: StatusRuntimeException =>
               assertFooMissingError(
                 actual = t,
@@ -99,16 +107,30 @@ final class ErrorInterceptorSpec
 
     "for an server streaming Akka endpoint" - {
 
+      "signal server shutting down" in {
+        val service =
+          new HelloServiceFailing(useSelfService = false, errorInsideFutureOrStream = true)
+        service.close()
+        exerciseStreamingAkkaEndpoint(service)
+          .map { t: StatusRuntimeException =>
+            assertMatchesErrorCode(t, LedgerApiErrors.ServerIsShuttingDown)
+          }
+      }
+
       "when signalling with a non-self-service error should SANITIZE the server response when arising" - {
         "inside a Stream" in {
-          exerciseStreamingAkkaEndpoint(useSelfService = false, insideStream = true)
+          exerciseStreamingAkkaEndpoint(
+            new HelloServiceFailing(useSelfService = false, errorInsideFutureOrStream = true)
+          )
             .map { t: StatusRuntimeException =>
               assertSecuritySanitizedError(t)
             }
         }
 
         s"outside a Stream $bypassMsg" in {
-          exerciseStreamingAkkaEndpoint(useSelfService = false, insideStream = false)
+          exerciseStreamingAkkaEndpoint(
+            new HelloServiceFailing(useSelfService = false, errorInsideFutureOrStream = false)
+          )
             .map { t: StatusRuntimeException =>
               assertSecuritySanitizedError(t)
             }
@@ -117,7 +139,9 @@ final class ErrorInterceptorSpec
 
       "when signalling with a self-service error should NOT SANITIZE the server response when arising" - {
         "inside a Stream" in {
-          exerciseStreamingAkkaEndpoint(useSelfService = true, insideStream = true)
+          exerciseStreamingAkkaEndpoint(
+            new HelloServiceFailing(useSelfService = true, errorInsideFutureOrStream = true)
+          )
             .map { t: StatusRuntimeException =>
               assertFooMissingError(
                 actual = t,
@@ -127,7 +151,9 @@ final class ErrorInterceptorSpec
         }
 
         s"outside a Stream $bypassMsg" in {
-          exerciseStreamingAkkaEndpoint(useSelfService = true, insideStream = false)
+          exerciseStreamingAkkaEndpoint(
+            new HelloServiceFailing(useSelfService = true, errorInsideFutureOrStream = false)
+          )
             .map { t: StatusRuntimeException =>
               assertFooMissingError(
                 actual = t,
@@ -141,15 +167,11 @@ final class ErrorInterceptorSpec
   }
 
   private def exerciseUnaryFutureEndpoint(
-      useSelfService: Boolean,
-      insideFuture: Boolean,
+      helloService: BindableService
   ): Future[StatusRuntimeException] = {
     val response: Future[HelloResponse] = server(
       tested = new ErrorInterceptor(),
-      service = new HelloServiceFailing(
-        useSelfService = useSelfService,
-        insideFutureOrStream = insideFuture,
-      ),
+      service = helloService,
     ).use { channel =>
       HelloServiceGrpc.stub(channel).single(HelloRequest(1))
     }
@@ -159,15 +181,11 @@ final class ErrorInterceptorSpec
   }
 
   private def exerciseStreamingAkkaEndpoint(
-      useSelfService: Boolean,
-      insideStream: Boolean,
+      helloService: BindableService
   ): Future[StatusRuntimeException] = {
     val response: Future[Vector[HelloResponse]] = server(
       tested = new ErrorInterceptor(),
-      service = new HelloServiceFailing(
-        useSelfService = useSelfService,
-        insideFutureOrStream = insideStream,
-      ),
+      service = helloService,
     ).use { channel =>
       val streamConsumer = new StreamConsumer[HelloResponse](observer =>
         HelloServiceGrpc.stub(channel).serverStreaming(HelloRequest(1), observer)
@@ -248,7 +266,7 @@ object ErrorInterceptorSpec {
 
   }
 
-  trait HelloService_Base extends BindableService {
+  trait HelloServiceBase extends BindableService {
     self: HelloService =>
 
     implicit protected val damlLogger: DamlContextualizedErrorLogger =
@@ -260,22 +278,20 @@ object ErrorInterceptorSpec {
     override def fails(request: HelloRequest): Future[HelloResponse] = ??? // not used in this test
   }
 
-  /** @param useSelfService      - whether to use self service error codes or a "rogue" exception
-    * @param insideFutureOrStream - whether to signal the exception inside a Future or a Stream, or outside to them
+  /** @param useSelfService - whether to use self service error codes or "rogue" exceptions
+    * @param errorInsideFutureOrStream - whether to signal the exception inside a Future or a Stream, or outside to them
     */
-  // TODO error codes: Extend a HelloService generated by our Akka streaming scalapb plugin. (~HelloServiceAkkaGrpc)
-  class HelloServiceFailing(useSelfService: Boolean, insideFutureOrStream: Boolean)(implicit
-      executionSequencerFactory: ExecutionSequencerFactory,
-      materializer: Materializer,
-  ) extends HelloService
+  class HelloServiceFailing(useSelfService: Boolean, errorInsideFutureOrStream: Boolean)(implicit
+      protected val esf: ExecutionSequencerFactory,
+      protected val mat: Materializer,
+  ) extends HelloServiceAkkaGrpc
       with HelloServiceResponding
-      with HelloService_Base {
+      with HelloServiceBase {
 
-    override def serverStreaming(
-        request: HelloRequest,
-        responseObserver: StreamObserver[HelloResponse],
-    ): Unit = {
-      val where = if (insideFutureOrStream) "inside" else "outside"
+    override protected def serverStreamingSource(
+        request: HelloRequest
+    ): Source[HelloResponse, NotUsed] = {
+      val where = if (errorInsideFutureOrStream) "inside" else "outside"
       val t: Throwable = if (useSelfService) {
         FooMissingErrorCode
           .Error(s"Non-Status.INTERNAL self-service error $where a Stream")
@@ -283,18 +299,17 @@ object ErrorInterceptorSpec {
       } else {
         new IllegalArgumentException(s"Failure $where a Stream")
       }
-      if (insideFutureOrStream) {
-        val _ = Source
+      if (errorInsideFutureOrStream) {
+        Source
           .single(request)
           .via(Flow[HelloRequest].mapConcat(_ => throw t))
-          .runWith(ServerAdapter.toSink(responseObserver))
       } else {
         throw t
       }
     }
 
     override def single(request: HelloRequest): Future[HelloResponse] = {
-      val where = if (insideFutureOrStream) "inside" else "outside"
+      val where = if (errorInsideFutureOrStream) "inside" else "outside"
       val t: Throwable = if (useSelfService) {
         FooMissingErrorCode
           .Error(s"Non-Status.INTERNAL self-service error $where a Future")
@@ -302,7 +317,7 @@ object ErrorInterceptorSpec {
       } else {
         new IllegalArgumentException(s"Failure $where a Future")
       }
-      if (insideFutureOrStream) {
+      if (errorInsideFutureOrStream) {
         Future.failed(t)
       } else {
         throw t

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
@@ -11,6 +11,8 @@ object LoggingContext {
 
   val ForTesting: LoggingContext = new LoggingContext(LoggingEntries.empty)
 
+  val empty: LoggingContext = new LoggingContext(LoggingEntries.empty)
+
   private[logging] def newLoggingContext[A](entries: LoggingEntries)(f: LoggingContext => A): A =
     f(new LoggingContext(entries))
 

--- a/scala-protoc-plugins/scala-akka/AkkaGrpcServicePrinter.scala
+++ b/scala-protoc-plugins/scala-akka/AkkaGrpcServicePrinter.scala
@@ -71,8 +71,7 @@ final class AkkaGrpcServicePrinter(
       .add(s"protected val killSwitch = akka.stream.KillSwitches.shared($killSwitchName)")
       .add("protected val closed = new java.util.concurrent.atomic.AtomicBoolean(false)")
       .add(
-        // TODO error code: Use self service error code
-        "protected def closingError = new io.grpc.StatusRuntimeException(io.grpc.Status.UNAVAILABLE.withDescription(\"Server is shutting down\")) with scala.util.control.NoStackTrace"
+        "protected def closingError = com.daml.grpc.adapter.server.akka.ServerAdapter.closingError()"
       )
       .add("def close(): Unit = {")
       .indent


### PR DESCRIPTION

> Ledger API Specification: Streaming endpoints will use error code 'SERVER_IS_SHUTTING_DOWN' when the server
> is being shut down, whereas before an exception without an error code was used.
> Grpc status code in use remains 'UNAVAILABLE'.
> 