### PR TITLE
interfaces: tests: no interfaces below 1.dev

### DIFF
--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -1567,7 +1567,7 @@ message DefTemplate {
 
   Location location = 9;
 
-  // They key definition for the template, if present
+  // The key definition for the template, if present
   DefKey key = 10; // optional
 
   // Interfaces that this template implements.

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -15,6 +15,12 @@ import com.daml.lf.language.Ast.{
   EInterfaceTemplateTypeRep,
   EObserverInterface,
   EPrimLit,
+  EPrimCon,
+  PCUnit,
+  GenTemplate,
+  GenModule,
+  GenTemplateImplements,
+  FeatureFlags,
   ESignatoryInterface,
   PLRoundingMode,
 }
@@ -26,6 +32,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import scala.Ordering.Implicits.infixOrderingOps
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
+import scala.collection.immutable.VectorMap
 
 class DecodeV1Spec
     extends AnyWordSpec
@@ -909,6 +916,82 @@ class DecodeV1Spec
         val result = Try(decoder.decodeExpr(tryCatchExprProto, "test"))
         if (version >= LV.Features.exceptions)
           result shouldBe Success(tryCatchExprScala)
+        else
+          inside(result) { case Failure(error) =>
+            error shouldBe an[Error.Parsing]
+          }
+      }
+    }
+
+    s"Reject interface implementations in templates iff version < ${LV.Features.interfaces}" in {
+      val unit = DamlLf1.Unit.newBuilder().build()
+      val pkgRef = DamlLf1.PackageRef.newBuilder().setSelf(unit).build
+      val modRef =
+        DamlLf1.ModuleRef.newBuilder().setPackageRef(pkgRef).setModuleNameInternedDname(0).build()
+      val ifaceTyConName =
+        DamlLf1.TypeConName.newBuilder().setModule(modRef).setNameInternedDname(2)
+
+      val i = DamlLf1.DefTemplate.Implements.newBuilder()
+      i.setInterface(ifaceTyConName)
+
+      val t = DamlLf1.DefTemplate.newBuilder()
+      t.setTyconInternedDname(1)
+      t.setParamInternedStr(0)
+      t.setPrecond(unitExpr)
+      t.setSignatories(unitExpr)
+      t.setAgreement(unitExpr)
+      t.setObservers(unitExpr)
+      t.addImplements(i.build())
+
+      val m = DamlLf1.Module.newBuilder()
+      m.setNameInternedDname(0)
+      m.addTemplates(t.build())
+      m.setFlags(
+        DamlLf1.FeatureFlags
+          .newBuilder()
+          .setForbidPartyLiterals(true)
+          .setDontDivulgeContractIdsInCreateArguments(true)
+          .setDontDiscloseNonConsumingChoicesToObservers(true)
+      )
+
+      val ifaceTemplateScala = GenModule(
+        Ref.DottedName.assertFromString("Mod"),
+        Map(),
+        Map(
+          Ref.DottedName.assertFromString("Mod.T") -> GenTemplate(
+            Ref.IdString.Name.assertFromString("test"),
+            EPrimCon(PCUnit),
+            EPrimCon(PCUnit),
+            EPrimCon(PCUnit),
+            Map(),
+            EPrimCon(PCUnit),
+            None,
+            VectorMap(
+              Ref.TypeConName
+                .assertFromString("noPkgId:Mod:Mod.I") -> GenTemplateImplements[EPrimCon](
+                Ref.TypeConName.assertFromString("noPkgId:Mod:Mod.I"),
+                Map(),
+                Set(),
+              )
+            ),
+          )
+        ),
+        Map(),
+        Map(),
+        FeatureFlags(),
+      )
+
+      val mod = m.build()
+      forEveryVersion { version =>
+        val decoder = moduleDecoder(
+          version,
+          ImmArraySeq("test"),
+          ImmArraySeq("Mod", "Mod.T", "Mod.I").map(Ref.DottedName.assertFromString),
+          typeTable,
+        )
+        val result = Try(decoder.decodeModule(mod))
+        if (version >= LV.Features.interfaces)
+          result shouldBe Success(ifaceTemplateScala)
         else
           inside(result) { case Failure(error) =>
             error shouldBe an[Error.Parsing]


### PR DESCRIPTION
We add a check for the decoder that tests that implementations in
templates are only accepted in 1.dev.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
