### PR TITLE
Simplify subclasses BaseError trait [DPP-606]

### DIFF
--- a/ledger/error/BUILD.bazel
+++ b/ledger/error/BUILD.bazel
@@ -24,6 +24,7 @@ da_scala_library(
         "//daml-lf/transaction",
         "//daml-lf/validation",
         "//ledger-api/grpc-definitions:ledger_api_proto_scala",
+        "//ledger/ledger-grpc",
         "//ledger/participant-integration-api:participant-integration-api-proto_scala",
         "//ledger/participant-state",
         "//libs-scala/contextualized-logging",

--- a/ledger/error/src/main/scala/com/daml/error/BaseError.scala
+++ b/ledger/error/src/main/scala/com/daml/error/BaseError.scala
@@ -100,33 +100,4 @@ object BaseError {
     msg.startsWith(SecuritySensitiveMessageOnApiPrefix)
   }
 
-  abstract class Impl(
-      override val cause: String,
-      override val throwableO: Option[Throwable] = None,
-  )(implicit override val code: ErrorCode)
-      extends BaseError {
-
-    /** The logging context obtained when we created the error, usually passed in as implicit */
-    def loggingContext: ContextualizedErrorLogger
-
-    /** Flag to control if an error should be logged at creation
-      *
-      * Generally, we do want to log upon creation, except in the case of "nested" or combined errors,
-      * where we just nest the error but don't want it to be logged twice.
-      */
-    def logOnCreation: Boolean = true
-
-    def log(): Unit = logWithContext()(loggingContext)
-
-    def asGrpcStatus: Status =
-      code.asGrpcStatus(this)(loggingContext)
-
-    def asGrpcError: StatusRuntimeException =
-      code.asGrpcError(this)(loggingContext)
-
-    // Automatically log the error on generation
-    if (logOnCreation) {
-      log()
-    }
-  }
 }

--- a/ledger/error/src/main/scala/com/daml/error/ErrorCode.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorCode.scala
@@ -4,7 +4,7 @@
 package com.daml.error
 
 import com.daml.error.ErrorCode.{ValidMetadataKeyRegex, truncateResourceForTransport}
-import com.daml.error.definitions.LoggingTransactionErrorImpl
+import com.daml.error.definitions.DamlError
 import com.google.rpc.Status
 import io.grpc.Status.Code
 import io.grpc.StatusRuntimeException
@@ -73,9 +73,7 @@ abstract class ErrorCode(val id: String, val category: ErrorCategory)(implicit
         contextMap.foreach { case (k, v) => errInfoBld.putMetadata(k, v) }
         errInfoBld.setReason(id)
 
-        // TODO error codes: Resolve dependency and use constant
-        //    val definiteAnswerKey = com.daml.ledger.grpc.GrpcStatuses.DefiniteAnswerKey
-        val definiteAnswerKey = "definite_answer"
+        val definiteAnswerKey = com.daml.ledger.grpc.GrpcStatuses.DefiniteAnswerKey
         err.definiteAnswerO.foreach { definiteAnswer =>
           errInfoBld.putMetadata(definiteAnswerKey, definiteAnswer.toString)
         }
@@ -138,16 +136,12 @@ abstract class ErrorCode(val id: String, val category: ErrorCategory)(implicit
   ): StatusRuntimeException = {
     val status = asGrpcStatus(err)
     // Builder methods for metadata are not exposed, so going route via creating an exception
-    val ex = StatusProto.toStatusRuntimeException(status)
-    // Strip stack trace from exception
-    // TODO error codes: Define a generic mechanism (trait or method) to check if errors are logged on creation,
-    //                   instead of checking every implementation.
+    val e = StatusProto.toStatusRuntimeException(status)
+    // Stripping stacktrace
     err match {
-      case _: LoggingTransactionErrorImpl =>
-        new ErrorCode.LoggingApiException(ex.getStatus, ex.getTrailers)
-      case err: BaseError.Impl if err.logOnCreation =>
-        new ErrorCode.LoggingApiException(ex.getStatus, ex.getTrailers)
-      case _ => new ErrorCode.ApiException(ex.getStatus, ex.getTrailers)
+      case _: DamlError =>
+        new ErrorCode.LoggedApiException(e.getStatus, e.getTrailers)
+      case _ => new ErrorCode.ApiException(e.getStatus, e.getTrailers)
     }
   }
 
@@ -161,7 +155,7 @@ abstract class ErrorCode(val id: String, val category: ErrorCategory)(implicit
   /** True if this error may appear on the API */
   protected def exposedViaApi: Boolean = category.grpcCode.nonEmpty
 
-  def getStatusInfo(
+  private def getStatusInfo(
       err: BaseError
   )(implicit loggingContext: ContextualizedErrorLogger): ErrorCode.StatusInfo = {
     val correlationId = loggingContext.correlationId
@@ -229,7 +223,9 @@ object ErrorCode {
       extends StatusRuntimeException(status, metadata)
       with NoStackTrace
 
-  class LoggingApiException(status: io.grpc.Status, metadata: io.grpc.Metadata)
+  /** Exception that has already been logged.
+    */
+  class LoggedApiException(status: io.grpc.Status, metadata: io.grpc.Metadata)
       extends ApiException(status, metadata)
 
   case class StatusInfo(

--- a/ledger/error/src/main/scala/com/daml/error/definitions/IndexErrors.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/IndexErrors.scala
@@ -3,7 +3,7 @@
 
 package com.daml.error.definitions
 
-import com.daml.error.ErrorCode.LoggingApiException
+import com.daml.error.ErrorCode.LoggedApiException
 import com.daml.error._
 import com.daml.error.definitions.ErrorGroups.ParticipantErrorGroup.IndexErrorGroup
 
@@ -73,16 +73,15 @@ object IndexErrors extends IndexErrorGroup {
   )(implicit
       code: ErrorCode,
       loggingContext: ContextualizedErrorLogger,
-  ) extends LoggingTransactionErrorImpl(cause, throwableO) {
-    override def asGrpcErrorFromContext(implicit
-        contextualizedErrorLogger: ContextualizedErrorLogger
-    ): IndexDbException = {
-      val err = super.asGrpcErrorFromContext(contextualizedErrorLogger)
+  ) extends DamlErrorWithDefiniteAnswer(cause, throwableO) {
+
+    override def asGrpcError: IndexDbException = {
+      val err = super.asGrpcError
       IndexDbException(err.getStatus, err.getTrailers)
     }
   }
 
   case class IndexDbException(status: io.grpc.Status, metadata: io.grpc.Metadata)
-      extends LoggingApiException(status, metadata)
+      extends LoggedApiException(status, metadata)
 
 }

--- a/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
@@ -41,7 +41,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       ) {
 
     case class Reject(_message: String)(implicit errorLogger: ContextualizedErrorLogger)
-        extends LoggingTransactionErrorImpl(
+        extends DamlErrorWithDefiniteAnswer(
           cause = s"The request exercised an unsupported operation: ${_message}"
         )
   }
@@ -64,10 +64,9 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
     override def logLevel: Level = Level.WARN
 
     case class Rejection(reason: String)(implicit errorLogger: ContextualizedErrorLogger)
-        extends LoggingTransactionErrorImpl(cause = s"The participant is overloaded: $reason") {
+        extends DamlErrorWithDefiniteAnswer(cause = s"The participant is overloaded: $reason") {
       override def context: Map[String, String] =
         super.context ++ Map("reason" -> reason)
-
     }
   }
 
@@ -84,7 +83,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       ) {
     case class Reject(_message: String, _definiteAnswer: Boolean)(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(
+    ) extends DamlErrorWithDefiniteAnswer(
           cause = _message,
           definiteAnswer = _definiteAnswer,
         )
@@ -109,7 +108,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
       case class Reject(_reason: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause =
               s"The participant failed to determine the max ledger time for this command: ${_reason}"
           )
@@ -142,7 +141,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
             allowedLanguageVersions: VersionRange[language.LanguageVersion],
         )(implicit
             val loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = buildCause(packageId, languageVersion, allowedLanguageVersions)
             )
       }
@@ -158,7 +157,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           ) {
         case class Reject(validationErrorCause: String)(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = validationErrorCause
             )
       }
@@ -179,7 +178,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
             err: LfError.Preprocessing.Error
         )(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = err.message
             )
       }
@@ -199,7 +198,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
         case class Error(override val cause: String)(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = cause
             )
       }
@@ -216,7 +215,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
         case class Error(override val cause: String)(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = cause
             )
 
@@ -237,7 +236,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
             _err: LfInterpretationError.ContractNotActive,
         )(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = cause
             ) {
           override def resources: Seq[(ErrorResource, String)] = Seq(
@@ -266,7 +265,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
               _key: GlobalKey,
           )(implicit
               loggingContext: ContextualizedErrorLogger
-          ) extends LoggingTransactionErrorImpl(
+          ) extends DamlErrorWithDefiniteAnswer(
                 cause = cause
               ) {
             override def resources: Seq[(ErrorResource, String)] = Seq(
@@ -288,7 +287,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
         case class Reject(override val cause: String)(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = cause
             )
       }
@@ -306,7 +305,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       ) {
     case class Reject(_serviceName: String)(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(
+    ) extends DamlErrorWithDefiniteAnswer(
           cause = s"${_serviceName} has been shut down."
         ) {
       override def context: Map[String, String] =
@@ -323,7 +322,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       ) {
     case class Reject()(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(
+    ) extends DamlErrorWithDefiniteAnswer(
           cause = "Server is shutting down"
         )
   }
@@ -344,7 +343,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject()(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl("Stale stream authorization. Retry quickly.") {
+      ) extends DamlErrorWithDefiniteAnswer("Stale stream authorization. Retry quickly.") {
         override def retryable: Option[ErrorCategoryRetry] = Some(
           ErrorCategoryRetry(who = "application", duration = 0.seconds)
         )
@@ -365,13 +364,13 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class MissingJwtToken()(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = "The command is missing a (valid) JWT token"
           )
 
       case class UserBasedAuthenticationIsDisabled()(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = "User based authentication is disabled."
           )
     }
@@ -385,7 +384,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(message: String, throwable: Throwable)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = message,
             throwableO = Some(throwable),
           )
@@ -402,7 +401,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         extends ErrorCode(id = "PERMISSION_DENIED", ErrorCategory.InsufficientPermission) {
       case class Reject(override val cause: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause =
               s"The provided authorization token is not sufficient to authorize the intended command: $cause"
           )
@@ -425,7 +424,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           ) {
         case class Reject(_packageId: String)(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = "Could not find package."
             ) {
 
@@ -439,7 +438,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
             reference: Reference,
         )(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = LookupError.MissingPackage.pretty(packageId, reference)
             )
       }
@@ -458,7 +457,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
         case class Reject(_transactionId: String)(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(cause = "Transaction not found, or not visible.") {
+        ) extends DamlErrorWithDefiniteAnswer(cause = "Transaction not found, or not visible.") {
           override def resources: Seq[(ErrorResource, String)] = Seq(
             (ErrorResource.TransactionId, _transactionId)
           )
@@ -477,13 +476,13 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
         case class Reject()(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = "The ledger configuration could not be retrieved."
             )
 
         case class RejectWithMessage(_message: String)(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(
+        ) extends DamlErrorWithDefiniteAnswer(
               cause = s"The ledger configuration could not be retrieved: ${_message}."
             )
       }
@@ -498,7 +497,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(override val cause: String, _earliestOffset: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(cause = cause) {
+      ) extends DamlErrorWithDefiniteAnswer(cause = cause) {
 
         override def context: Map[String, String] =
           super.context + (EarliestOffsetMetadataKey -> _earliestOffset)
@@ -516,7 +515,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(_offsetType: String, _requestedOffset: String, _ledgerEnd: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause =
               s"${_offsetType} offset (${_requestedOffset}) is after ledger end (${_ledgerEnd})"
           )
@@ -533,7 +532,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(_message: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(cause = _message)
+      ) extends DamlErrorWithDefiniteAnswer(cause = _message)
     }
 
     @Explanation(
@@ -548,7 +547,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(_expectedLedgerId: String, _receivedLegerId: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause =
               s"Ledger ID '${_receivedLegerId}' not found. Actual Ledger ID is '${_expectedLedgerId}'.",
             definiteAnswer = true,
@@ -563,7 +562,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         extends ErrorCode(id = "MISSING_FIELD", ErrorCategory.InvalidIndependentOfSystemState) {
       case class Reject(_missingField: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = s"The submitted command is missing a mandatory field: ${_missingField}"
           ) {
         override def context: Map[String, String] =
@@ -579,7 +578,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         extends ErrorCode(id = "INVALID_ARGUMENT", ErrorCategory.InvalidIndependentOfSystemState) {
       case class Reject(_reason: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = s"The submitted command has invalid arguments: ${_reason}"
           )
     }
@@ -592,7 +591,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         extends ErrorCode(id = "INVALID_FIELD", ErrorCategory.InvalidIndependentOfSystemState) {
       case class Reject(_fieldName: String, _message: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause =
               s"The submitted command has a field with invalid value: Invalid field ${_fieldName}: ${_message}"
           )
@@ -615,7 +614,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           _maxDeduplicationDuration: Option[Duration],
       )(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = s"The submitted command had an invalid deduplication period: ${_reason}"
           ) {
         override def context: Map[String, String] = {
@@ -638,8 +637,8 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           _offsetValue: String,
           _message: String,
       )(implicit
-          override val loggingContext: ContextualizedErrorLogger
-      ) extends BaseError.Impl(
+          val loggingContext: ContextualizedErrorLogger
+      ) extends DamlError(
             cause =
               s"Offset in ${_fieldName} not specified in hexadecimal: ${_offsetValue}: ${_message}"
           )
@@ -656,7 +655,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
     case class UnexpectedOrUnknownException(t: Throwable)(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(
+    ) extends DamlErrorWithDefiniteAnswer(
           cause = "Unexpected or unknown exception occurred.",
           throwableO = Some(t),
         )
@@ -666,7 +665,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         override val throwableO: Option[Throwable] = None,
     )(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(cause = message) {
+    ) extends DamlErrorWithDefiniteAnswer(cause = message) {
       override def context: Map[String, String] =
         super.context ++ Map("throwableO" -> throwableO.toString)
     }
@@ -675,7 +674,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         err: LfError.Package.SelfConsistency
     )(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(
+    ) extends DamlErrorWithDefiniteAnswer(
           cause = err.message
         )
 
@@ -683,7 +682,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         err: LfError.Package.Internal
     )(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(
+    ) extends DamlErrorWithDefiniteAnswer(
           cause = err.message
         )
 
@@ -691,11 +690,11 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         err: LfError.Preprocessing.Internal
     )(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(cause = err.message)
+    ) extends DamlErrorWithDefiniteAnswer(cause = err.message)
 
     case class Validation(reason: ReplayMismatch)(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(
+    ) extends DamlErrorWithDefiniteAnswer(
           cause = s"Observed un-expected replay mismatch: ${reason}"
         )
 
@@ -705,17 +704,17 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         detailMessage: Option[String],
     )(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(
+    ) extends DamlErrorWithDefiniteAnswer(
           cause = s"Daml-Engine interpretation failed with internal error: ${where} / ${message}"
         )
 
     case class VersionService(message: String)(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(cause = message)
+    ) extends DamlErrorWithDefiniteAnswer(cause = message)
 
     case class Buffer(message: String, override val throwableO: Option[Throwable])(implicit
         loggingContext: ContextualizedErrorLogger
-    ) extends LoggingTransactionErrorImpl(cause = message, throwableO = throwableO)
+    ) extends DamlErrorWithDefiniteAnswer(cause = message, throwableO = throwableO)
   }
 
   @Explanation("Errors raised by Ledger API admin services.")
@@ -729,7 +728,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(_message: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = _message
           )
     }
@@ -743,7 +742,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(_message: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = _message
           )
     }
@@ -759,7 +758,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(_operation: String, userId: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = s"${_operation} failed for unknown user \"${userId}\""
           ) {
         override def resources: Seq[(ErrorResource, String)] = Seq(
@@ -778,7 +777,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(_operation: String, userId: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = s"${_operation} failed, as user \"${userId}\" already exists"
           ) {
         override def resources: Seq[(ErrorResource, String)] = Seq(
@@ -802,7 +801,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(_operation: String, userId: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = s"${_operation} failed, as user \"${userId}\" would have too many rights."
           ) {
         override def resources: Seq[(ErrorResource, String)] = Seq(
@@ -836,7 +835,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           _changeId: Option[ChangeId] = None,
       )(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = "A command with the given command id has already been successfully processed",
             definiteAnswer = _definiteAnswer,
           ) {
@@ -862,7 +861,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
       case class Reject(override val cause: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(cause = cause)
+      ) extends DamlErrorWithDefiniteAnswer(cause = cause)
 
     }
 
@@ -881,7 +880,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       case class Reject(
           details: String
       )(implicit loggingContext: ContextualizedErrorLogger)
-          extends LoggingTransactionErrorImpl(
+          extends DamlErrorWithDefiniteAnswer(
             cause = s"Inconsistent: $details"
           )
 
@@ -901,7 +900,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
       case class MultipleContractsNotFound(_notFoundContractIds: Set[String])(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = s"Unknown contracts: ${_notFoundContractIds.mkString("[", ", ", "]")}"
           ) {
         override def resources: Seq[(ErrorResource, String)] = Seq(
@@ -914,7 +913,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           _cid: Value.ContractId,
       )(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = cause
           ) {
         override def resources: Seq[(ErrorResource, String)] = Seq(
@@ -936,7 +935,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
       case class Reject(reason: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(cause = reason)
+      ) extends DamlErrorWithDefiniteAnswer(cause = reason)
 
     }
 
@@ -955,7 +954,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           _key: GlobalKey,
       )(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(
+      ) extends DamlErrorWithDefiniteAnswer(
             cause = cause
           ) {
         override def resources: Seq[(ErrorResource, String)] = Seq(
@@ -967,7 +966,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
 
       case class Reject(override val cause: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(cause = cause)
+      ) extends DamlErrorWithDefiniteAnswer(cause = cause)
 
     }
 
@@ -987,7 +986,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           ledger_time_lower_bound: Instant,
           ledger_time_upper_bound: Instant,
       )(implicit loggingContext: ContextualizedErrorLogger)
-          extends LoggingTransactionErrorImpl(cause = cause) {
+          extends DamlErrorWithDefiniteAnswer(cause = cause) {
         override def context: Map[String, String] = super.context ++ Map(
           "ledger_time" -> ledger_time.toString,
           "ledger_time_lower_bound" -> ledger_time_lower_bound.toString,
@@ -998,7 +997,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       case class RejectSimple(
           override val cause: String
       )(implicit loggingContext: ContextualizedErrorLogger)
-          extends LoggingTransactionErrorImpl(cause = cause)
+          extends DamlErrorWithDefiniteAnswer(cause = cause)
 
     }
 
@@ -1038,7 +1037,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       case class Reject(
           submitter_party: String
       )(implicit loggingContext: ContextualizedErrorLogger)
-          extends LoggingTransactionErrorImpl(
+          extends DamlErrorWithDefiniteAnswer(
             cause = s"Party not known on ledger: Submitting party '$submitter_party' not known"
           ) {
         override def resources: Seq[(ErrorResource, String)] = Seq(
@@ -1059,7 +1058,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
       case class Reject(_parties: Set[String])(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(cause = s"Parties not known on ledger: ${_parties
+      ) extends DamlErrorWithDefiniteAnswer(cause = s"Parties not known on ledger: ${_parties
             .mkString("[", ",", "]")}") {
         override def resources: Seq[(ErrorResource, String)] =
           _parties.map((ErrorResource.Party, _)).toSeq
@@ -1069,7 +1068,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       case class RejectDeprecated(
           description: String
       )(implicit loggingContext: ContextualizedErrorLogger)
-          extends LoggingTransactionErrorImpl(
+          extends DamlErrorWithDefiniteAnswer(
             cause = s"Party not known on ledger: $description"
           )
     }
@@ -1088,7 +1087,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
       case class Reject(
           details: String
       )(implicit loggingContext: ContextualizedErrorLogger)
-          extends LoggingTransactionErrorImpl(
+          extends DamlErrorWithDefiniteAnswer(
             cause = s"Disputed: $details"
           )
     }
@@ -1107,7 +1106,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         extends ErrorCode(id = "OUT_OF_QUOTA", ErrorCategory.ContentionOnSharedResources) {
       case class Reject(reason: String)(implicit
           loggingContext: ContextualizedErrorLogger
-      ) extends LoggingTransactionErrorImpl(cause = reason)
+      ) extends DamlErrorWithDefiniteAnswer(cause = reason)
     }
 
     @Explanation("A submitting party is not authorized to act through the participant.")
@@ -1122,12 +1121,12 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           submitter: String,
           participantId: String,
       )(implicit loggingContext: ContextualizedErrorLogger)
-          extends LoggingTransactionErrorImpl(cause = s"Inconsistent: $details")
+          extends DamlErrorWithDefiniteAnswer(cause = s"Inconsistent: $details")
 
       case class Reject(
           details: String
       )(implicit loggingContext: ContextualizedErrorLogger)
-          extends LoggingTransactionErrorImpl(cause = s"Inconsistent: $details")
+          extends DamlErrorWithDefiniteAnswer(cause = s"Inconsistent: $details")
     }
 
     @Explanation("Errors that arise from an internal system misbehavior.")
@@ -1145,7 +1144,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           ) {
         case class Reject(override val cause: String, _keyO: Option[GlobalKey] = None)(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(cause = cause) {
+        ) extends DamlErrorWithDefiniteAnswer(cause = cause) {
           override def resources: Seq[(ErrorResource, String)] =
             super.resources ++ _keyO.map(key => ErrorResource.ContractKey -> key.toString).toList
         }
@@ -1163,7 +1162,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           ) {
         case class Reject(override val cause: String, _keyO: Option[GlobalKey] = None)(implicit
             loggingContext: ContextualizedErrorLogger
-        ) extends LoggingTransactionErrorImpl(cause = cause) {
+        ) extends DamlErrorWithDefiniteAnswer(cause = cause) {
           override def resources: Seq[(ErrorResource, String)] =
             super.resources ++ _keyO.map(key => ErrorResource.ContractKey -> key.toString).toList
         }

--- a/ledger/error/src/main/scala/com/daml/error/samples/Example.scala
+++ b/ledger/error/src/main/scala/com/daml/error/samples/Example.scala
@@ -3,11 +3,11 @@
 
 package com.daml.error.samples
 
+import com.daml.error.definitions.{DamlError}
+
 object DummmyServer {
 
   import com.daml.error.{
-    BaseError,
-    ContextualizedErrorLogger,
     DamlContextualizedErrorLogger,
     ErrorCategory,
     ErrorCategoryRetry,
@@ -24,12 +24,13 @@ object DummmyServer {
         ErrorClass.root()
       ) {
 
-    case class Error(message: String) extends BaseError.Impl(cause = message) {
-      override def loggingContext: ContextualizedErrorLogger = new DamlContextualizedErrorLogger(
-        ContextualizedLogger.get(getClass),
-        LoggingContext.newLoggingContext(identity),
-        Some("full-correlation-id-123456790"),
-      )
+    implicit val errorLogger: DamlContextualizedErrorLogger = new DamlContextualizedErrorLogger(
+      ContextualizedLogger.get(getClass),
+      LoggingContext.newLoggingContext(identity),
+      Some("full-correlation-id-123456790"),
+    )
+
+    case class Error(_message: String) extends DamlError(cause = _message) {
 
       override def resources: Seq[(ErrorResource, String)] = Seq(
         ErrorResource.ContractId -> "someContractId"

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CompletionResponse.scala
@@ -122,14 +122,14 @@ object CompletionResponse {
             "Timed out while awaiting for a completion corresponding to a command submission.",
             _definiteAnswer = false,
           )
-          .asGrpcStatusFromContext
+          .asGrpcStatus
       case CompletionResponse.NoStatusInResponse(_, _) =>
         LedgerApiErrors.InternalError
           .Generic(
             "Missing status in completion response.",
             throwableO = None,
           )
-          .asGrpcStatusFromContext
+          .asGrpcStatus
 
     }
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/ValidationLogger.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/ValidationLogger.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.server.api
 
-import com.daml.error.ErrorCode.LoggingApiException
+import com.daml.error.ErrorCode.LoggedApiException
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 
 object ValidationLogger {
@@ -13,7 +13,7 @@ object ValidationLogger {
   ): Throwable = {
     logger.debug(s"Request validation failed for $request. Message: ${t.getMessage}")
     t match {
-      case _: LoggingApiException => ()
+      case _: LoggedApiException => ()
       case _ => logger.info(t.getMessage)
     }
     t

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/server/api/validation/ErrorFactoriesSpec.scala
@@ -8,7 +8,7 @@ import java.time.Duration
 import java.util.regex.Pattern
 
 import ch.qos.logback.classic.Level
-import com.daml.error.definitions.{IndexErrors, LedgerApiErrors, LoggingTransactionErrorImpl}
+import com.daml.error.definitions.{DamlError, IndexErrors, LedgerApiErrors}
 import com.daml.error.definitions.LedgerApiErrors.RequestValidation.InvalidDeduplicationPeriodField.ValidMaxDeduplicationFieldKey
 import com.daml.error.utils.ErrorDetails
 import com.daml.error.{
@@ -114,7 +114,7 @@ class ErrorFactoriesSpec
             .Generic("some message", Some(t))(
               contextualizedErrorLogger
             )
-            .asGrpcStatusFromContext
+            .asGrpcStatus
         )(
           code = Code.INTERNAL,
           message = expectedInternalErrorMessage,
@@ -133,7 +133,7 @@ class ErrorFactoriesSpec
         assertStatus(
           LedgerApiErrors.ParticipantBackpressure
             .Rejection("Some buffer is full")(contextualizedErrorLogger)
-            .asGrpcStatusFromContext
+            .asGrpcStatus
         )(
           code = Code.ABORTED,
           message = msg,
@@ -165,7 +165,7 @@ class ErrorFactoriesSpec
             .Reject("Some service")(
               contextualizedErrorLogger
             )
-            .asGrpcStatusFromContext
+            .asGrpcStatus
         )(
           code = Code.UNAVAILABLE,
           message = msg,
@@ -200,7 +200,7 @@ class ErrorFactoriesSpec
             )(
               contextualizedErrorLogger
             )
-            .asGrpcStatusFromContext
+            .asGrpcStatus
         )(
           code = Code.DEADLINE_EXCEEDED,
           message = msg,
@@ -226,7 +226,7 @@ class ErrorFactoriesSpec
               "Missing status in completion response.",
               throwableO = None,
             )
-            .asGrpcStatusFromContext
+            .asGrpcStatus
         )(
           code = Code.INTERNAL,
           message = expectedInternalErrorMessage,
@@ -746,7 +746,7 @@ class ErrorFactoriesSpec
     )
 
   private def assertError(
-      error: LoggingTransactionErrorImpl
+      error: DamlError
   )(
       code: Code,
       message: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -7,7 +7,7 @@ import java.time.{Duration, Instant}
 import java.util.UUID
 
 import com.daml.api.util.TimeProvider
-import com.daml.error.ErrorCode.LoggingApiException
+import com.daml.error.ErrorCode.LoggedApiException
 import com.daml.error.definitions.{ErrorCauseExport, LedgerApiErrors, RejectionGenerators}
 import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger, ErrorCause}
 import com.daml.ledger.api.domain.{LedgerId, SubmissionId, Commands => ApiCommands}
@@ -143,7 +143,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
         Failure(result.exception)
 
       // Do not log again on errors that are logging on creation
-      case Failure(error: LoggingApiException) => Failure(error)
+      case Failure(error: LoggedApiException) => Failure(error)
       case Failure(error) =>
         logger.info(s"Rejected: ${error.getMessage}")
         Failure(error)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -10,7 +10,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.daml.api.util.TimestampConversion
 import com.daml.daml_lf_dev.DamlLf.Archive
-import com.daml.error.definitions.{LedgerApiErrors, LoggingPackageServiceError}
+import com.daml.error.definitions.{LedgerApiErrors, DamlError}
 import com.daml.error.definitions.PackageServiceError.Validation
 import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger}
 import com.daml.ledger.api.domain.{LedgerOffset, PackageEntry}
@@ -137,7 +137,7 @@ private[apiserver] final class ApiPackageManagementService private (
     }
 
   private implicit class ErrorValidations[E, R](result: Either[E, R]) {
-    def handleError(toSelfServiceErrorCode: E => LoggingPackageServiceError): Try[R] =
+    def handleError(toSelfServiceErrorCode: E => DamlError): Try[R] =
       result.left.map { err =>
         toSelfServiceErrorCode(err).asGrpcError
       }.toTry

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
@@ -78,7 +78,7 @@ class SynchronousResponse[Input, Entry, AcceptedEntry](
                       .Reject("Party submission")(
                         errorLogger
                       )
-                      .asGrpcStatusFromContext(errorLogger)
+                      .asGrpcStatus
                   )
                 )
             }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/QueueBackedTracker.scala
@@ -57,19 +57,19 @@ private[services] final class QueueBackedTracker(
               s"Failed to enqueue: ${throwable.getClass.getSimpleName}: ${throwable.getMessage}",
               Some(throwable),
             )
-            .asGrpcStatusFromContext
+            .asGrpcStatus
         )
       case Success(QueueOfferResult.Dropped) =>
         toQueueSubmitFailure(
           LedgerApiErrors.ParticipantBackpressure
             .Rejection("The submission ingress buffer is full")
-            .asGrpcStatusFromContext
+            .asGrpcStatus
         )
       case Success(QueueOfferResult.QueueClosed) =>
         toQueueSubmitFailure(
           LedgerApiErrors.ServiceNotRunning
             .Reject("Command service queue")
-            .asGrpcStatusFromContext
+            .asGrpcStatus
         )
       case Failure(throwable) =>
         toQueueSubmitFailure(
@@ -78,7 +78,7 @@ private[services] final class QueueBackedTracker(
               s"Unexpected `BoundedSourceQueue.offer` exception: ${throwable.getClass.getSimpleName}: ${throwable.getMessage}",
               Some(throwable),
             )
-            .asGrpcStatusFromContext
+            .asGrpcStatus
         )
     }
   }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/error/ErrorInterceptorSpec.scala
@@ -9,10 +9,10 @@ import java.util.concurrent.TimeUnit
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Source}
+import com.daml.error.definitions.DamlError
 import com.daml.error.definitions.LedgerApiErrors
 import com.daml.error.utils.ErrorDetails
 import com.daml.error.{
-  BaseError,
   ContextualizedErrorLogger,
   DamlContextualizedErrorLogger,
   ErrorCategory,
@@ -259,8 +259,8 @@ object ErrorInterceptorSpec {
       )(ErrorClass.root()) {
 
     case class Error(_msg: String)(implicit
-        override val loggingContext: ContextualizedErrorLogger
-    ) extends BaseError.Impl(
+        val loggingContext: ContextualizedErrorLogger
+    ) extends DamlError(
           cause = s"Foo is missing: ${_msg}"
         )
 

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -59,7 +59,6 @@ da_scala_library(
         "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",
         "//libs-scala/crypto",
-        "//libs-scala/grpc-utils",
         "//libs-scala/logging-entries",
         "//libs-scala/resources",
         "//libs-scala/resources-akka",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVLoggingTransactionErrorImpl.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVLoggingTransactionErrorImpl.scala
@@ -3,9 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.errors
 
-import com.daml.error.definitions.LoggingTransactionErrorImpl
+import com.daml.error.definitions.DamlErrorWithDefiniteAnswer
 import com.daml.error.{ContextualizedErrorLogger, ErrorCode}
-import com.daml.grpc.GrpcStatus
 import com.google.rpc.status.Status
 
 class KVLoggingTransactionErrorImpl(
@@ -15,8 +14,8 @@ class KVLoggingTransactionErrorImpl(
 )(implicit
     code: ErrorCode,
     loggingContext: ContextualizedErrorLogger,
-) extends LoggingTransactionErrorImpl(cause, throwable, definiteAnswer) {
+) extends DamlErrorWithDefiniteAnswer(cause, throwable, definiteAnswer) {
   override def context: Map[String, String] = Map.empty
 
-  final def asStatus: Status = GrpcStatus.toProto(asGrpcStatusFromContext)
+  final def asStatus: Status = rpcStatus()
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/updates/TransactionRejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/updates/TransactionRejections.scala
@@ -7,7 +7,6 @@ import com.daml.error.definitions.LedgerApiErrors
 
 import java.time.Instant
 import com.daml.error.ContextualizedErrorLogger
-import com.daml.grpc.GrpcStatus
 import com.daml.ledger.participant.state.kvutils.Conversions.parseCompletionInfo
 import com.daml.ledger.participant.state.kvutils.committer.transaction.Rejection.{
   ExternallyInconsistentTransaction,
@@ -89,22 +88,18 @@ private[kvutils] object TransactionRejections {
       rejection: PartiesNotKnownOnLedger
   )(implicit loggingContext: ContextualizedErrorLogger): Status = {
     val parties = rejection.getPartiesList
-    GrpcStatus.toProto(
-      LedgerApiErrors.WriteServiceRejections.PartyNotKnownOnLedger
-        .Reject(parties.asScala.toSet)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.WriteServiceRejections.PartyNotKnownOnLedger
+      .Reject(parties.asScala.toSet)
+      .rpcStatus()
   }
 
   def submittingPartyNotKnownOnLedgerStatus(
       rejection: SubmittingPartyNotKnownOnLedger
   )(implicit loggingContext: ContextualizedErrorLogger): Status = {
     val submitter = rejection.getSubmitterParty
-    GrpcStatus.toProto(
-      LedgerApiErrors.WriteServiceRejections.SubmittingPartyNotKnownOnLedger
-        .Reject(submitter)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.WriteServiceRejections.SubmittingPartyNotKnownOnLedger
+      .Reject(submitter)
+      .rpcStatus()
   }
 
   def causalMonotonicityViolatedStatus()(implicit
@@ -133,29 +128,23 @@ private[kvutils] object TransactionRejections {
   }
 
   def externallyDuplicateKeysStatus()(implicit loggingContext: ContextualizedErrorLogger): Status =
-    GrpcStatus.toProto(
-      LedgerApiErrors.ConsistencyErrors.DuplicateContractKey
-        .Reject(ExternallyInconsistentTransaction.DuplicateKeys.description)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.ConsistencyErrors.DuplicateContractKey
+      .Reject(ExternallyInconsistentTransaction.DuplicateKeys.description)
+      .rpcStatus()
 
   def externallyInconsistentKeysStatus()(implicit
       loggingContext: ContextualizedErrorLogger
   ): Status =
-    GrpcStatus.toProto(
-      LedgerApiErrors.ConsistencyErrors.InconsistentContractKey
-        .Reject(ExternallyInconsistentTransaction.InconsistentKeys.description)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.ConsistencyErrors.InconsistentContractKey
+      .Reject(ExternallyInconsistentTransaction.InconsistentKeys.description)
+      .rpcStatus()
 
   def externallyInconsistentContractsStatus()(implicit
       loggingContext: ContextualizedErrorLogger
   ): Status =
-    GrpcStatus.toProto(
-      LedgerApiErrors.ConsistencyErrors.InconsistentContracts
-        .Reject(ExternallyInconsistentTransaction.InconsistentContracts.description)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.ConsistencyErrors.InconsistentContracts
+      .Reject(ExternallyInconsistentTransaction.InconsistentContracts.description)
+      .rpcStatus()
 
   def missingInputStateStatus(
       rejection: MissingInputState
@@ -168,19 +157,15 @@ private[kvutils] object TransactionRejections {
 
   def internallyInconsistentKeysStatus(
   )(implicit loggingContext: ContextualizedErrorLogger): Status =
-    GrpcStatus.toProto(
-      LedgerApiErrors.WriteServiceRejections.Internal.InternallyInconsistentKeys
-        .Reject(InternallyInconsistentTransaction.InconsistentKeys.description)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.WriteServiceRejections.Internal.InternallyInconsistentKeys
+      .Reject(InternallyInconsistentTransaction.InconsistentKeys.description)
+      .rpcStatus()
 
   def internallyDuplicateKeysStatus(
   )(implicit loggingContext: ContextualizedErrorLogger): Status =
-    GrpcStatus.toProto(
-      LedgerApiErrors.WriteServiceRejections.Internal.InternallyDuplicateKeys
-        .Reject(InternallyInconsistentTransaction.DuplicateKeys.description)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.WriteServiceRejections.Internal.InternallyDuplicateKeys
+      .Reject(InternallyInconsistentTransaction.DuplicateKeys.description)
+      .rpcStatus()
 
   def validationFailureStatus(
       rejection: ValidationFailure
@@ -206,15 +191,13 @@ private[kvutils] object TransactionRejections {
     val submitter = rejection.getSubmitterParty
     val participantId = rejection.getParticipantId
     val details = rejection.getDetails
-    GrpcStatus.toProto(
-      LedgerApiErrors.WriteServiceRejections.SubmitterCannotActViaParticipant
-        .RejectWithSubmitterAndParticipantId(
-          details,
-          submitter,
-          participantId,
-        )
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.WriteServiceRejections.SubmitterCannotActViaParticipant
+      .RejectWithSubmitterAndParticipantId(
+        details,
+        submitter,
+        participantId,
+      )
+      .rpcStatus()
   }
 
   def invalidLedgerTimeStatus(
@@ -225,28 +208,26 @@ private[kvutils] object TransactionRejections {
     val ledgerTimeLowerBound = rejection.getLowerBound
     val ledgerTimeUpperBound = rejection.getUpperBound
 
-    GrpcStatus.toProto(
-      LedgerApiErrors.ConsistencyErrors.InvalidLedgerTime
-        .RejectEnriched(
-          cause = details,
-          ledger_time = Instant
-            .ofEpochSecond(
-              ledgerTime.getSeconds,
-              ledgerTime.getNanos.toLong,
-            ),
-          ledger_time_lower_bound = Instant
-            .ofEpochSecond(
-              ledgerTimeLowerBound.getSeconds,
-              ledgerTimeLowerBound.getNanos.toLong,
-            ),
-          ledger_time_upper_bound = Instant
-            .ofEpochSecond(
-              ledgerTimeUpperBound.getSeconds,
-              ledgerTimeUpperBound.getNanos.toLong,
-            ),
-        )
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.ConsistencyErrors.InvalidLedgerTime
+      .RejectEnriched(
+        cause = details,
+        ledger_time = Instant
+          .ofEpochSecond(
+            ledgerTime.getSeconds,
+            ledgerTime.getNanos.toLong,
+          ),
+        ledger_time_lower_bound = Instant
+          .ofEpochSecond(
+            ledgerTimeLowerBound.getSeconds,
+            ledgerTimeLowerBound.getNanos.toLong,
+          ),
+        ledger_time_upper_bound = Instant
+          .ofEpochSecond(
+            ledgerTimeUpperBound.getSeconds,
+            ledgerTimeUpperBound.getNanos.toLong,
+          ),
+      )
+      .rpcStatus()
   }
 
   def resourceExhaustedStatus(
@@ -263,11 +244,10 @@ private[kvutils] object TransactionRejections {
       rejection: PartyNotKnownOnLedger
   )(implicit loggingContext: ContextualizedErrorLogger): Status = {
     val details = rejection.getDetails
-    GrpcStatus.toProto(
-      LedgerApiErrors.WriteServiceRejections.PartyNotKnownOnLedger
-        .RejectDeprecated(details)
-        .asGrpcStatusFromContext
-    )
+
+    LedgerApiErrors.WriteServiceRejections.PartyNotKnownOnLedger
+      .RejectDeprecated(details)
+      .rpcStatus()
   }
 
   @deprecated
@@ -275,11 +255,9 @@ private[kvutils] object TransactionRejections {
       rejection: Inconsistent
   )(implicit loggingContext: ContextualizedErrorLogger): Status = {
     val details = rejection.getDetails
-    GrpcStatus.toProto(
-      LedgerApiErrors.ConsistencyErrors.Inconsistent
-        .Reject(details)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.ConsistencyErrors.Inconsistent
+      .Reject(details)
+      .rpcStatus()
   }
 
   @deprecated
@@ -287,22 +265,18 @@ private[kvutils] object TransactionRejections {
       rejection: Disputed
   )(implicit loggingContext: ContextualizedErrorLogger): Status = {
     val details = rejection.getDetails
-    GrpcStatus.toProto(
-      LedgerApiErrors.WriteServiceRejections.Disputed
-        .Reject(details)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.WriteServiceRejections.Disputed
+      .Reject(details)
+      .rpcStatus()
   }
 
   private def duplicateCommandsRejectionStatus(
       definiteAnswer: Boolean = false,
       existingCommandSubmissionId: Option[String],
   )(implicit loggingContext: ContextualizedErrorLogger): Status =
-    GrpcStatus.toProto(
-      LedgerApiErrors.ConsistencyErrors.DuplicateCommand
-        .Reject(definiteAnswer, existingCommandSubmissionId)
-        .asGrpcStatusFromContext
-    )
+    LedgerApiErrors.ConsistencyErrors.DuplicateCommand
+      .Reject(definiteAnswer, existingCommandSubmissionId)
+      .rpcStatus()
 
   private def invalidRecordTimeReason(
       recordTime: Timestamp,

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -49,7 +49,6 @@ da_scala_library(
         "//libs-scala/build-info",
         "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",
-        "//libs-scala/grpc-utils",
         "//libs-scala/logging-entries",
         "//libs-scala/ports",
         "//libs-scala/resources",

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeWriteService.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeWriteService.scala
@@ -205,7 +205,7 @@ object BridgeWriteService {
           SubmissionResult.SynchronousError(
             LedgerApiErrors.ParticipantBackpressure
               .Rejection("Sandbox-on-X ledger bridge submission buffer is full")
-              .rpcStatus(Some(submissionId))
+              .rpcStatus()
           )
         case QueueOfferResult.Failure(throwable) =>
           SubmissionResult.SynchronousError(
@@ -214,13 +214,13 @@ object BridgeWriteService {
                 message = s"Failed to enqueue submission in the Sandbox-on-X ledger bridge",
                 throwableO = Some(throwable),
               )
-              .rpcStatus(Some(submissionId))
+              .rpcStatus()
           )
         case QueueOfferResult.QueueClosed =>
           SubmissionResult.SynchronousError(
             LedgerApiErrors.ServiceNotRunning
               .Reject("Sandbox-on-X ledger bridge")
-              .rpcStatus(None)
+              .rpcStatus()
           )
       }
     )

--- a/libs-scala/grpc-utils/src/main/scala/com/digitalasset/grpc/GrpcStatus.scala
+++ b/libs-scala/grpc-utils/src/main/scala/com/digitalasset/grpc/GrpcStatus.scala
@@ -42,13 +42,6 @@ object GrpcStatus {
     StatusProto(code, description, extractDetails(statusJavaProto))
   }
 
-  def toProto(statusJavaProto: StatusJavaProto): StatusProto =
-    StatusProto(
-      code = statusJavaProto.getCode,
-      message = statusJavaProto.getMessage,
-      details = extractDetails(statusJavaProto),
-    )
-
   def toJavaProto(status: StatusProto): StatusJavaProto = toJavaBuilder(status).build()
 
   def toJavaBuilder(status: StatusProto): StatusJavaProto.Builder =


### PR DESCRIPTION
Changes:

1. Remove `BaseError.Impl`, `LoggingTransactionErrorImpl` and `LoggingPackageServiceError` 
and instead provide more direct `DamlError` and `DamlErrorWithDefiniteAnswer`. 
1. Remove custom implementation of `TransactionError.rpcStatus` and instead provide simpler one in `DamlErr.r.rpcStatus` (which works by first calling `code.asGrpcStatus` and then converting the result to `com.google.rpc.status.Status`).
1. Remove `GrpcStatus.toProto` and instead use `DamlError.rpcStatus`.
1. Use `asGrpcStatus` and `asGrpcError`  instead of `asGrpcStatusFromContext` and `asGrpcErrorFromContext` where possible. 