### PR TITLE
ifaces: tests: check for iface defs in templates

### DIFF
--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -932,39 +932,45 @@ class DecodeV1Spec
       val ifaceTyConName =
         DamlLf1.TypeConName.newBuilder().setModule(modRef).setNameInternedDname(2)
 
-      val i = DamlLf1.DefTemplate.Implements.newBuilder()
-      i.setInterface(ifaceTyConName)
+      val i = DamlLf1.DefTemplate.Implements
+        .newBuilder()
+        .setInterface(ifaceTyConName)
+        .build()
 
-      val t = DamlLf1.DefTemplate.newBuilder()
-      t.setTyconInternedDname(1)
-      t.setParamInternedStr(0)
-      t.setPrecond(unitExpr)
-      t.setSignatories(unitExpr)
-      t.setAgreement(unitExpr)
-      t.setObservers(unitExpr)
-      t.addImplements(i.build())
+      val t = DamlLf1.DefTemplate
+        .newBuilder()
+        .setTyconInternedDname(1)
+        .setParamInternedStr(0)
+        .setPrecond(unitExpr)
+        .setSignatories(unitExpr)
+        .setAgreement(unitExpr)
+        .setObservers(unitExpr)
+        .addImplements(i)
+        .build()
 
-      val m = DamlLf1.Module.newBuilder()
-      m.setNameInternedDname(0)
-      m.addTemplates(t.build())
-      m.setFlags(
-        DamlLf1.FeatureFlags
-          .newBuilder()
-          .setForbidPartyLiterals(true)
-          .setDontDivulgeContractIdsInCreateArguments(true)
-          .setDontDiscloseNonConsumingChoicesToObservers(true)
-      )
+      val m = DamlLf1.Module
+        .newBuilder()
+        .setNameInternedDname(0)
+        .addTemplates(t)
+        .setFlags(
+          DamlLf1.FeatureFlags
+            .newBuilder()
+            .setForbidPartyLiterals(true)
+            .setDontDivulgeContractIdsInCreateArguments(true)
+            .setDontDiscloseNonConsumingChoicesToObservers(true)
+        )
+        .build()
 
       val ifaceTemplateScala = GenModule(
         Ref.DottedName.assertFromString("Mod"),
-        Map(),
+        Map.empty,
         Map(
           Ref.DottedName.assertFromString("Mod.T") -> GenTemplate(
             Ref.IdString.Name.assertFromString("test"),
             EPrimCon(PCUnit),
             EPrimCon(PCUnit),
             EPrimCon(PCUnit),
-            Map(),
+            Map.empty,
             EPrimCon(PCUnit),
             None,
             VectorMap(
@@ -977,12 +983,11 @@ class DecodeV1Spec
             ),
           )
         ),
-        Map(),
-        Map(),
+        Map.empty,
+        Map.empty,
         FeatureFlags(),
       )
 
-      val mod = m.build()
       forEveryVersion { version =>
         val decoder = moduleDecoder(
           version,
@@ -990,7 +995,7 @@ class DecodeV1Spec
           ImmArraySeq("Mod", "Mod.T", "Mod.I").map(Ref.DottedName.assertFromString),
           typeTable,
         )
-        val result = Try(decoder.decodeModule(mod))
+        val result = Try(decoder.decodeModule(m))
         if (version >= LV.Features.interfaces)
           result shouldBe Success(ifaceTemplateScala)
         else
@@ -1001,29 +1006,32 @@ class DecodeV1Spec
     }
 
     s"Reject interface definitions in modules iff version < ${LV.Features.interfaces}" in {
-      val i = DamlLf1.DefInterface.newBuilder()
+      val i = DamlLf1.DefInterface
+        .newBuilder()
         .setTyconInternedDname(1)
         .setParamInternedStr(0)
         .setPrecond(unitExpr)
         .build()
 
-      val m = DamlLf1.Module.newBuilder()
-      m.setNameInternedDname(0)
-      m.addInterfaces(i.build())
-      m.setFlags(
-        DamlLf1.FeatureFlags
-          .newBuilder()
-          .setForbidPartyLiterals(true)
-          .setDontDivulgeContractIdsInCreateArguments(true)
-          .setDontDiscloseNonConsumingChoicesToObservers(true)
-      )
+      val m = DamlLf1.Module
+        .newBuilder()
+        .setNameInternedDname(0)
+        .addInterfaces(i)
+        .setFlags(
+          DamlLf1.FeatureFlags
+            .newBuilder()
+            .setForbidPartyLiterals(true)
+            .setDontDivulgeContractIdsInCreateArguments(true)
+            .setDontDiscloseNonConsumingChoicesToObservers(true)
+        )
+        .build()
 
       val ifaceTemplateScala =
         GenModule(
           Ref.DottedName.assertFromString("Mod"),
           Map.empty,
-          Map(),
-          Map(),
+          Map.empty,
+          Map.empty,
           Map(
             Ref.DottedName.assertFromString("Mod.I") ->
               GenDefInterface(
@@ -1037,7 +1045,6 @@ class DecodeV1Spec
           FeatureFlags(),
         )
 
-      val mod = m.build()
       forEveryVersion { version =>
         val decoder = moduleDecoder(
           version,
@@ -1045,7 +1052,7 @@ class DecodeV1Spec
           ImmArraySeq("Mod", "Mod.I").map(Ref.DottedName.assertFromString),
           typeTable,
         )
-        val result = Try(decoder.decodeModule(mod))
+        val result = Try(decoder.decodeModule(m))
         if (version >= LV.Features.interfaces)
           result shouldBe Success(ifaceTemplateScala)
         else

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -1026,7 +1026,7 @@ class DecodeV1Spec
           Map(
             Ref.DottedName.assertFromString("Mod.I") ->
               GenDefInterface(
-                Set(),
+                Set.empty,
                 Ref.IdString.Name.assertFromString("test"),
                 Map(),
                 Map(),

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -1020,7 +1020,7 @@ class DecodeV1Spec
       val ifaceTemplateScala =
         GenModule(
           Ref.DottedName.assertFromString("Mod"),
-          Map(),
+          Map.empty,
           Map(),
           Map(),
           Map(

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -1002,9 +1002,10 @@ class DecodeV1Spec
 
     s"Reject interface definitions in modules iff version < ${LV.Features.interfaces}" in {
       val i = DamlLf1.DefInterface.newBuilder()
-      i.setTyconInternedDname(1)
-      i.setParamInternedStr(0)
-      i.setPrecond(unitExpr)
+        .setTyconInternedDname(1)
+        .setParamInternedStr(0)
+        .setPrecond(unitExpr)
+        .build()
 
       val m = DamlLf1.Module.newBuilder()
       m.setNameInternedDname(0)


### PR DESCRIPTION
This adds a test that will fail when an interface definition is present
in a module when daml-lf < 1.dev.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
