### PR TITLE
ifaces: tests: check for interface collisions in ast

### DIFF
--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
@@ -172,7 +172,7 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
             defName("defName1") -> interface,
             defName("defName1") -> interface,
           ),
-          templates = List(),
+          templates = List.empty,
           exceptions = List.empty,
           featureFlags = FeatureFlags.default,
         )

--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
@@ -60,6 +60,14 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
       key = None,
       implements = VectorMap.empty,
     )
+    def interface = DefInterface(
+      param = Name.assertFromString("x"),
+      precond = ETrue,
+      fixedChoices = Map.empty,
+      methods = Map.empty,
+      requires = Set.empty,
+    )
+
     def exception = DefException(
       message = eText
     )
@@ -132,6 +140,40 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
           ),
           exceptions = List.empty,
           interfaces = List.empty,
+          featureFlags = FeatureFlags.default,
+        )
+      )
+    }
+
+    "catch interface collisions" in {
+
+      Module.build(
+        name = modName1,
+        definitions = List(
+          defName("defName1") -> recordDef,
+          defName("defName2") -> recordDef,
+        ),
+        interfaces = List(
+          defName("defName1") -> interface
+        ),
+        exceptions = List.empty,
+        templates = List.empty,
+        featureFlags = FeatureFlags.default,
+      )
+
+      a[PackageError] shouldBe thrownBy(
+        Module.build(
+          name = modName1,
+          definitions = List(
+            defName("defName1") -> recordDef,
+            defName("defName2") -> recordDef,
+          ),
+          interfaces = List(
+            defName("defName1") -> interface,
+            defName("defName1") -> interface,
+          ),
+          templates = List(),
+          exceptions = List.empty,
           featureFlags = FeatureFlags.default,
         )
       )


### PR DESCRIPTION
We add a test to check for interface name collisions in the daml-lf AST.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
