### PR TITLE
[Error codes] Remove definite_answer from com.daml.error.definitions.TransactionError

### DIFF
--- a/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
@@ -81,8 +81,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
     case class Reject(_message: String, _definiteAnswer: Boolean)(implicit
         loggingContext: ContextualizedErrorLogger
     ) extends LoggingTransactionErrorImpl(
-          cause = _message,
-          definiteAnswer = _definiteAnswer,
+          cause = _message
         )
   }
 
@@ -546,8 +545,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
           loggingContext: ContextualizedErrorLogger
       ) extends LoggingTransactionErrorImpl(
             cause =
-              s"Ledger ID '${_receivedLegerId}' not found. Actual Ledger ID is '${_expectedLedgerId}'.",
-            definiteAnswer = true,
+              s"Ledger ID '${_receivedLegerId}' not found. Actual Ledger ID is '${_expectedLedgerId}'."
           )
     }
 
@@ -823,14 +821,12 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         ) {
 
       case class Reject(
-          _definiteAnswer: Boolean = false,
           _existingCommandSubmissionId: Option[String],
           _changeId: Option[ChangeId] = None,
       )(implicit
           loggingContext: ContextualizedErrorLogger
       ) extends LoggingTransactionErrorImpl(
-            cause = "A command with the given command id has already been successfully processed",
-            definiteAnswer = _definiteAnswer,
+            cause = "A command with the given command id has already been successfully processed"
           ) {
         override def context: Map[String, String] =
           super.context ++ _existingCommandSubmissionId

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVErrors.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVErrors.scala
@@ -55,7 +55,6 @@ object KVErrors extends ErrorGroup()(ErrorGroups.rootErrorClass) {
           ErrorCategory.InvalidGivenCurrentSystemStateOther, // It may succeed at a later time
         ) {
       case class Reject(
-          override val definiteAnswer: Boolean,
           override val cause: String,
           recordTime: Instant,
           tooEarlyUntil: Option[Instant],

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVLoggingTransactionErrorImpl.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/errors/KVLoggingTransactionErrorImpl.scala
@@ -11,11 +11,10 @@ import com.google.rpc.status.Status
 class KVLoggingTransactionErrorImpl(
     cause: String,
     throwable: Option[Throwable] = None,
-    definiteAnswer: Boolean = false,
 )(implicit
     code: ErrorCode,
     loggingContext: ContextualizedErrorLogger,
-) extends LoggingTransactionErrorImpl(cause, throwable, definiteAnswer) {
+) extends LoggingTransactionErrorImpl(cause, throwable) {
   override def context: Map[String, String] = Map.empty
 
   final def asStatus: Status = GrpcStatus.toProto(asGrpcStatusFromContext)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/updates/TransactionRejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/updates/TransactionRejections.scala
@@ -41,7 +41,6 @@ private[kvutils] object TransactionRejections {
       reasonTemplate = FinalReason(
         KVErrors.Time.InvalidRecordTime
           .Reject(
-            rejectionEntry.getDefiniteAnswer,
             invalidRecordTimeReason(recordTime, tooEarlyUntil, tooLateFrom),
             recordTime.toInstant,
             tooEarlyUntil.map(_.toInstant),
@@ -57,7 +56,6 @@ private[kvutils] object TransactionRejections {
       rejectionEntry: DamlTransactionRejectionEntry,
       existingCommandSubmissionId: Option[String],
   )(implicit loggingContext: ContextualizedErrorLogger): Update.CommandRejected = {
-    val definiteAnswer = rejectionEntry.getDefiniteAnswer
     Update.CommandRejected(
       recordTime = recordTime,
       completionInfo = parseCompletionInfo(
@@ -65,7 +63,7 @@ private[kvutils] object TransactionRejections {
         rejectionEntry.getSubmitterInfo,
       ),
       reasonTemplate = FinalReason(
-        duplicateCommandsRejectionStatus(definiteAnswer, existingCommandSubmissionId)
+        duplicateCommandsRejectionStatus(existingCommandSubmissionId)
       ),
     )
   }
@@ -295,12 +293,11 @@ private[kvutils] object TransactionRejections {
   }
 
   private def duplicateCommandsRejectionStatus(
-      definiteAnswer: Boolean = false,
-      existingCommandSubmissionId: Option[String],
+      existingCommandSubmissionId: Option[String]
   )(implicit loggingContext: ContextualizedErrorLogger): Status =
     GrpcStatus.toProto(
       LedgerApiErrors.ConsistencyErrors.DuplicateCommand
-        .Reject(definiteAnswer, existingCommandSubmissionId)
+        .Reject(existingCommandSubmissionId)
         .asGrpcStatusFromContext
     )
 

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/domain/Rejection.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/domain/Rejection.scala
@@ -154,7 +154,7 @@ private[sandbox] object Rejection {
   ) extends Rejection {
     override def toStatus: Status =
       LedgerApiErrors.ConsistencyErrors.DuplicateCommand
-        .Reject(_definiteAnswer = false, None, Some(changeId))
+        .Reject(None, Some(changeId))
         .rpcStatus(completionInfo.submissionId)
   }
 


### PR DESCRIPTION
I'm not sure if this is something we can do. It would help to further simplify Daml errors - WIP PR [here](https://github.com/digital-asset/daml/pull/13185)
Putting this up to gather some feedback.