### PR TITLE
Replace scenario messages with script

### DIFF
--- a/compiler/damlc/tests/daml-test-files/RightOfUse.daml
+++ b/compiler/damlc/tests/daml-test-files/RightOfUse.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=44:1-44:8; Scenario execution failed on commit at RightOfUse:56:5:
+-- @ERROR range=44:1-44:8; Script execution failed on commit at RightOfUse:56:5:
 
 
 module RightOfUse where

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -237,7 +237,7 @@ main =
                   matchRegex r "abortCrash"
                 expectScriptFailure rs (vr "testPartialSubmit") $ \r ->
                   matchRegex r  $ T.unlines
-                    [ "Scenario execution failed on commit at Test:57:3:"
+                    [ "Script execution failed on commit at Test:57:3:"
                     , ".*"
                     , ".*failed due to a missing authorization.*"
                     , ".*"
@@ -250,7 +250,7 @@ main =
                     ]
                 expectScriptFailure rs (vr "testPartialSubmitMustFail") $ \r ->
                   matchRegex r $ T.unlines
-                    [ "Scenario execution failed on commit at Test:62:3:"
+                    [ "Script execution failed on commit at Test:62:3:"
                     , "  Aborted:  Expected submit to fail but it succeeded"
                     , ".*"
                     , ".*"

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -1016,7 +1016,7 @@ scenarioTests mbScenarioService = Tasty.testGroup "Scenario tests"
         expectNoErrors
         expectVirtualResource vr1F "Return value: &quot;f1&quot;"
         expectVirtualResource vr2F "Return value: &quot;f2&quot;"
-        expectVirtualResourceNote vr2F "This scenario no longer exists in the source file"
+        expectVirtualResourceNote vr2F "This script no longer exists in the source file"
         expectVirtualResourceNote vr2F "F.daml"
 
         setBufferModified f $ T.unlines scenario12F
@@ -1062,7 +1062,7 @@ scenarioTests mbScenarioService = Tasty.testGroup "Scenario tests"
           expectOneError (f,1,0) "Parse error"
 
           expectVirtualResource vr1F "Return value: &quot;f1&quot;"
-          expectVirtualResourceNote vr1F "The source file containing this scenario no longer compiles"
+          expectVirtualResourceNote vr1F "The source file containing this script no longer compiles"
           expectVirtualResourceNote vr1F "F.daml"
 
           expectVirtualResource vr1G "Return value: &quot;g1&quot;"

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -967,7 +967,7 @@ scenarioTests mbScenarioService = Tasty.testGroup "Scenario tests"
         setBufferModified f $ T.unlines $ goodScenario ++ badScenario
         let vr2 = VRScenario f "example2"
         setOpenVirtualResources [vr1, vr2]
-        expectOneError (f, 2, 0) "Scenario execution failed"
+        expectOneError (f, 2, 0) "Script execution failed"
         expectVirtualResource vr2 "Assertion failed"
         setBufferModified f $ T.unlines goodScenario
         expectNoErrors

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -507,7 +507,7 @@ testsForDamlcTest damlc scriptDar script1DevDar = testGroup "damlc test" $
                 , file ]
                 ""
             stdout @?= ""
-            assertInfixOf "Scenario execution failed" stderr
+            assertInfixOf "Script execution failed" stderr
             exitCode @?= ExitFailure 1
     , testCase "damlc test --files outside of project" $
         -- TODO: does this test make sense with a daml.yaml file?

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -162,7 +162,7 @@ prettyBriefScenarioError world ScenarioError{..} = runM scenarioErrorNodes world
   ppError <- prettyScenarioErrorError scenarioErrorError
   pure $
     annotateSC ErrorSC
-      (text "Scenario execution" <->
+      (text "Script execution" <->
         (if isNothing scenarioErrorCommitLoc
          then "failed:"
          else "failed on commit at"
@@ -184,7 +184,7 @@ prettyScenarioError world ScenarioError{..} = runM scenarioErrorNodes world $ do
          "-" <-> ltext (locationDefinition loc) <-> parens (prettyLocation world loc)
   pure $
     vsep $ catMaybes
-    [ Just $ error_ (text "Scenario execution" <->
+    [ Just $ error_ (text "Script execution" <->
       (if isNothing scenarioErrorCommitLoc
        then "failed:"
        else "failed on commit at"
@@ -334,9 +334,9 @@ prettyScenarioErrorError (Just err) =  do
         ]
 
     ScenarioErrorErrorUnknownContext ctxId ->
-      pure $ "Unknown scenario interpretation context:" <-> string (show ctxId)
+      pure $ "Unknown script interpretation context:" <-> string (show ctxId)
     ScenarioErrorErrorUnknownScenario name ->
-      pure $ "Unknown scenario:" <-> prettyDefName world name
+      pure $ "Unknown script:" <-> prettyDefName world name
     ScenarioErrorErrorScenarioContractNotEffective ScenarioError_ContractNotEffective{..} ->
       pure $ vcat
         [ "Attempt to fetch or exercise a contract not yet effective."
@@ -500,7 +500,7 @@ prettyFailedAuthorization world (FailedAuthorization mbNodeId mbFa) =
 
 prettyScenarioStep :: ScenarioStep -> M (Doc SyntaxClass)
 prettyScenarioStep (ScenarioStep _stepId Nothing) =
-  pure $ text "<missing scenario step>"
+  pure $ text "<missing script step>"
 prettyScenarioStep (ScenarioStep stepId (Just step)) = do
   world <- askWorld
   case step of
@@ -1032,7 +1032,7 @@ renderScenarioError world err = TL.toStrict $ Blaze.renderHtml $ do
         let tableView = do
                 table <- renderTableView world (scenarioErrorNodes err)
                 pure $ H.div H.! A.class_ "table" $ do
-                  Pretty.renderHtml 128 $ annotateSC ErrorSC "Scenario execution failed, displaying state before failing transaction"
+                  Pretty.renderHtml 128 $ annotateSC ErrorSC "Script execution failed, displaying state before failing transaction"
                   table
         let transView =
                 let doc = prettyScenarioError world err
@@ -1070,11 +1070,11 @@ renderViews viewType tableView transView =
 
 scenarioNotInFileNote :: T.Text -> T.Text
 scenarioNotInFileNote file = htmlNote $ T.pack $
-    "This scenario no longer exists in the source file: " ++ T.unpack file
+    "This script no longer exists in the source file: " ++ T.unpack file
 
 fileWScenarioNoLongerCompilesNote :: T.Text -> T.Text
 fileWScenarioNoLongerCompilesNote file = htmlNote $ T.pack $
-    "The source file containing this scenario no longer compiles: " ++ T.unpack file
+    "The source file containing this script no longer compiles: " ++ T.unpack file
 
 htmlNote :: T.Text -> T.Text
 htmlNote t = TL.toStrict $ Blaze.renderHtml $ H.docTypeHtml $ H.span H.! A.class_ "da-hl-warning" $ H.toHtml t

--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -238,7 +238,7 @@ The ``abort``, ``assert`` and ``debug`` inbuilt functions can be used in updates
 
 .. code-block:: none
 
-    Scenario execution failed:
+    Script execution failed:
       Unhandled exception:  DA.Exception.GeneralError:GeneralError with
                               message = "stop"
 
@@ -264,7 +264,7 @@ in the contract, but not authorizing the create:
 
 .. code-block:: none
 
-    Scenario execution failed:
+    Script execution failed:
       #0: create of CreateAuthFailure:Example at unknown source
           failed due to a missing authorization from 'Bob'
 
@@ -299,7 +299,7 @@ choice 'Consume' of which he is not a controller
 
 .. code-block:: none
 
-    Scenario execution failed:
+    Script execution failed:
       #1: exercise of Consume in ExerciseAuthFailure:Example at unknown source
           failed due to a missing authorization from 'Alice'
 
@@ -343,7 +343,7 @@ to exercise the contract the following error would occur:
 
 .. code-block:: none
 
-    Scenario execution failed:
+    Script execution failed:
       Attempt to fetch or exercise a contract not visible to the reading parties.
       Contract:  #0:0 (NotVisibleFailure:Example)
       actAs: 'Bob'


### PR DESCRIPTION
In theory we could try to be clever and print the "right" thing. In
practice, scenarios are almost dead so the complexity for that doesn’t
seem worth it.

fixes #13178

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
