### PR TITLE
ifaces: tests: name collisions between defs

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -992,10 +992,14 @@ object Ast {
       interfaces: Map[DottedName, GenDefInterface[E]],
       featureFlags: FeatureFlags,
   ) {
-    templates.keysIterator.foreach(name =>
-      if (exceptions.keySet.contains(name))
-        throw PackageError(s"Collision between exception and template name ${name.toString}")
+    if (
+      !(templates.keySet.intersect(exceptions.keySet).isEmpty
+        && templates.keySet.intersect(interfaces.keySet).isEmpty
+        && exceptions.keySet.intersect(interfaces.keySet).isEmpty)
     )
+      throw PackageError(
+        s"Collision between exception and template/interface name ${name.toString}"
+      )
   }
 
   private[this] def toMapWithoutDuplicate[Key, Value](

--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
@@ -212,12 +212,13 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
       )
     }
 
-    "catch collisions between exception and template" in {
+    "catch collisions between exceptions, templates and interfaces" in {
       Module.build(
         name = modName1,
         definitions = List(
           defName("defName1") -> recordDef,
           defName("defName2") -> recordDef,
+          defName("defName3") -> recordDef,
         ),
         templates = List(
           defName("defName1") -> template
@@ -225,7 +226,9 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
         exceptions = List(
           defName("defName2") -> exception
         ),
-        interfaces = List.empty,
+        interfaces = List(
+          defName("defName3") -> interface
+        ),
         featureFlags = FeatureFlags.default,
       )
 
@@ -242,7 +245,51 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
           exceptions = List(
             defName("defName1") -> exception
           ),
-          interfaces = List.empty,
+          interfaces = List(
+            defName("defName3") -> interface
+          ),
+          featureFlags = FeatureFlags.default,
+        )
+      )
+
+      a[PackageError] shouldBe thrownBy(
+        Module.build(
+          name = modName1,
+          definitions = List(
+            defName("defName1") -> recordDef,
+            defName("defName2") -> recordDef,
+            defName("defName3") -> recordDef,
+          ),
+          templates = List(
+            defName("defName1") -> template
+          ),
+          interfaces = List(
+            defName("defName1") -> interface
+          ),
+          exceptions = List(
+            defName("defName2") -> exception
+          ),
+          featureFlags = FeatureFlags.default,
+        )
+      )
+
+      a[PackageError] shouldBe thrownBy(
+        Module.build(
+          name = modName1,
+          definitions = List(
+            defName("defName1") -> recordDef,
+            defName("defName2") -> recordDef,
+            defName("defName3") -> recordDef,
+          ),
+          templates = List(
+            defName("defName1") -> template
+          ),
+          interfaces = List(
+            defName("defName2") -> interface
+          ),
+          exceptions = List(
+            defName("defName2") -> exception
+          ),
           featureFlags = FeatureFlags.default,
         )
       )


### PR DESCRIPTION
We add a check and a fix to make sure interface/exception/template names
don't collide.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
