### PR TITLE
Bump Canton startup timeout to 2min

### DIFF
--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
@@ -139,8 +139,8 @@ trait MultiParticipantFixture
           }
         }
       } yield (p1, p2),
-      acquisitionTimeout = 1.minute,
-      releaseTimeout = 1.minute,
+      acquisitionTimeout = 2.minute,
+      releaseTimeout = 2.minute,
     )
   }
 


### PR DESCRIPTION
It looks like 1min is too small under load.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
