### PR TITLE
Remove mentions of Daml connect

### DIFF
--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -12,7 +12,7 @@ overwrite the one on Docker Hub should they differ.
 > This image is not supported for production use-cases. Please contact Digital
 > Asset to obtain supported production-ready artifacts.
 
-Digital Asset's [Daml Connect SDK](https://docs.daml.com/) in a can.
+Digital Asset's [Daml SDK](https://docs.daml.com/) in a can.
 
 ## Tags
 
@@ -48,7 +48,7 @@ repository key of
 
 > Note: This image is primarily intended for CI workflows, where the benefits
 > of caching Docker images can outweigh the awkwardness of the above command.
-> For local development, we strongly recommend installing the Daml Connect SDK on the
+> For local development, we strongly recommend installing the Daml SDK on the
 > host development machine instead, by running `curl https://get.daml.com |
 > bash`. For production use-cases, we strongly recommend using a supported
 > production binary, which can be obtained by contacting Digital Asset.

--- a/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
+++ b/daml-script/export/src/main/scala/com/daml/script/export/Config.scala
@@ -134,7 +134,7 @@ object Config {
         opt[String]("sdk-version")
           .required()
           .action(actionExportScript((x, c) => c.copy(sdkVersion = x)))
-          .text("Specify this Daml Connect version in the generated project."),
+          .text("Specify this Daml version in the generated project."),
       )
     checkConfig(c =>
       c.exportType match {

--- a/language-support/scala/examples/quickstart-scala/README.md
+++ b/language-support/scala/examples/quickstart-scala/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to:
 - how to exercise a choice and send a corresponding exercise command
 - subscribe to receive ledger events and decode them into generated Scala ADTs
 
-All instructions below assume that you have the Daml Connect SDK installed. If you have not installed it yet, please follow these instructions: https://docs.daml.com/getting-started/installation.html
+All instructions below assume that you have the Daml SDK installed. If you have not installed it yet, please follow these instructions: https://docs.daml.com/getting-started/installation.html
 
 ## Create a quickstart-scala project
 ```

--- a/release/windows-installer/src/WindowsInstaller.hs
+++ b/release/windows-installer/src/WindowsInstaller.hs
@@ -17,7 +17,7 @@ main = do
 
 installer :: FilePath -> FilePath -> Action SectionId
 installer sdkDir logo = do
-    name "Daml Connect SDK"
+    name "Daml SDK"
     outFile "daml-sdk-installer.exe"
     installIcon (fromString logo)
     requestExecutionLevel User
@@ -32,7 +32,7 @@ installer sdkDir logo = do
         -- that nsis will cleanup automatically.
         unsafeInject "InitPluginsDir"
         iff_ (fileExists "$APPDATA/daml") $ do
-            answer <- messageBox [MB_YESNO] "Daml Connect SDK is already installed. Do you want to remove the installed SDKs before installing this one?"
+            answer <- messageBox [MB_YESNO] "Daml SDK is already installed. Do you want to remove the installed SDKs before installing this one?"
             iff (answer %== "YES")
                 (rmdir [Recursive] "$APPDATA/daml")
                 (abort "Existing installation detected.")


### PR DESCRIPTION
Daml Connect is no longer a thing. I replaced usages with either Daml or Daml SDK. This is not meant to really be final or exhaustive, I just fixed what I could find with a very short search. Most of the relevant mentions have already been removed from the docs with https://github.com/digital-asset/daml/pull/12668.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
