### PR TITLE
Update puppeteer for M1 support

### DIFF
--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "^13.11.1",
     "@types/puppeteer": "^3.0.1",
     "@types/wait-on": "^4.0.0",
-    "puppeteer": "^4.0.1",
+    "puppeteer": "^10.0.0",
     "wait-on": "^4.0.2"
   }
 }

--- a/templates/create-daml-app-test-resources/testDeps.json
+++ b/templates/create-daml-app-test-resources/testDeps.json
@@ -4,7 +4,7 @@
     "@types/node": "^13.11.1",
     "@types/puppeteer": "^3.0.1",
     "@types/wait-on": "^4.0.0",
-    "puppeteer": "^4.0.1",
+    "puppeteer": "^10.0.0",
     "wait-on": "^4.0.2"
   }
 }

--- a/templates/create-daml-app/config-overrides.js
+++ b/templates/create-daml-app/config-overrides.js
@@ -1,0 +1,22 @@
+/* config-overrides.js */
+const webpack = require('webpack');
+module.exports = function override(config, env) {
+    config.resolve.fallback = {
+        //url: require.resolve('url'),
+        //assert: require.resolve('assert'),
+        crypto: require.resolve('crypto-browserify'),
+        //http: require.resolve('stream-http'),
+        //https: require.resolve('https-browserify'),
+        //os: require.resolve('os-browserify/browser'),
+        //buffer: require.resolve('buffer'),
+        //stream: require.resolve('stream-browserify'),
+    };
+    config.plugins.push(
+        new webpack.ProvidePlugin({
+            process: 'process/browser',
+            Buffer: ['buffer', 'Buffer'],
+        }),
+    );
+
+    return config;
+}

--- a/templates/create-daml-app/ui/config-overrides.js
+++ b/templates/create-daml-app/ui/config-overrides.js
@@ -9,7 +9,7 @@ module.exports = function override(config, env) {
         //https: require.resolve('https-browserify'),
         //os: require.resolve('os-browserify/browser'),
         //buffer: require.resolve('buffer'),
-        //stream: require.resolve('stream-browserify'),
+        stream: require.resolve('stream-browserify'),
     };
     config.plugins.push(
         new webpack.ProvidePlugin({

--- a/templates/create-daml-app/ui/package.json.template
+++ b/templates/create-daml-app/ui/package.json.template
@@ -43,7 +43,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/dotenv": "^8.2.0",
     "http-proxy-middleware": "^1.0.4",
-    "react-scripts": "^4.0.3",
+    "react-scripts": "^5.0.0",
     "typescript": "~3.8.3"
   }
 }

--- a/templates/create-daml-app/ui/package.json.template
+++ b/templates/create-daml-app/ui/package.json.template
@@ -8,7 +8,6 @@
     "@daml/react": "__VERSION__",
     "@daml/types": "__VERSION__",
     "@daml/hub-react": "^1.0.0",
-    "crypto": "npm:crypto-browserify",
     "crypto-browserify": "^3.12.0",
     "dotenv": "^8.2.0",
     "jwt-simple": "^0.5.6",
@@ -16,12 +15,13 @@
     "react-app-rewired": "^2.1.9",
     "react-dom": "^17.0.0",
     "semantic-ui-css": "^2.4.1",
-    "semantic-ui-react": "^2.0.0"
+    "semantic-ui-react": "^2.0.0",
+    "stream-browserify": "^3.0.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --testURL='http://localhost:7575'",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test --testURL='http://localhost:7575'",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src/"
   },
@@ -45,6 +45,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/dotenv": "^8.2.0",
+    "process": "0.11.10",
     "http-proxy-middleware": "^1.0.4",
     "react-scripts": "^5.0.0",
     "typescript": "~3.8.3"

--- a/templates/create-daml-app/ui/package.json.template
+++ b/templates/create-daml-app/ui/package.json.template
@@ -8,9 +8,12 @@
     "@daml/react": "__VERSION__",
     "@daml/types": "__VERSION__",
     "@daml/hub-react": "^1.0.0",
+    "crypto": "npm:crypto-browserify",
+    "crypto-browserify": "^3.12.0",
     "dotenv": "^8.2.0",
     "jwt-simple": "^0.5.6",
     "react": "^17.0.0",
+    "react-app-rewired": "^2.1.9",
     "react-dom": "^17.0.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.0"


### PR DESCRIPTION
The puppeteer version that we pinned in the create-daml-app template was incompatible with M1. It wants to download a Chromium installation but assumes that none is available on M1 and fails. Later versions (^10.0.0) download an x86_64 release and rely on Rosetta. See https://github.com/puppeteer/puppeteer/issues/6622#issuecomment-906476717

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
