### PR TITLE
ifaces:tests: extend encoder tests, fix bugs

### DIFF
--- a/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
+++ b/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
@@ -40,6 +40,20 @@ class EncodeV1Spec extends AnyWordSpec with Matchers with TableDrivenPropertyChe
 
             record @serializable Person = { person: Party, name: Text } ;
 
+            interface (this: Human) = {
+              precondition False;
+              method asParty: Party;
+              method getName: Text;
+              choice HumanSleep (self) (u:Unit) : ContractId Mod:Human
+                , controllers Cons @Party [call_method @Mod:Human asParty this] (Nil @Party)
+                , observers Nil @Party
+                to upure @(ContractId Mod:Human) self;
+              choice @nonConsuming HumanNap (self) (i : Int64): Int64
+                , controllers Cons @Party [call_method @Mod:Human asParty this] (Nil @Party)
+                , observers Nil @Party
+                to upure @Int64 i;
+            } ;
+
             template (this : Person) =  {
               precondition True;
               signatories Cons @Party [Mod:Person {person} this] (Nil @Party);
@@ -53,6 +67,12 @@ class EncodeV1Spec extends AnyWordSpec with Matchers with TableDrivenPropertyChe
                   controllers Cons @Party [Mod:Person {person} this] (Nil @Party),
                   observers Cons @Party [Mod:Person {person} this] (Nil @Party)
               to upure @Int64 i;
+              implements Mod:Human {
+                method asParty = Mod:Person {person} this;
+                method getName = Mod:Person {name} this;
+                choice HumanNap;
+                choice HumanSleep;
+              };
               key @Party (Mod:Person {person} this) (\ (p: Party) -> Cons @Party [p] (Nil @Party));
             };
 

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -266,7 +266,7 @@ private[daml] class AstRewriter(
           },
           apply(observers),
           key.map(apply),
-          implements.transform((_, x) => apply(x)),
+          implements.map({ case (t, x) => (apply(t), apply(x)) }),
         )
     }
 
@@ -302,7 +302,7 @@ private[daml] class AstRewriter(
             inheritedChoices,
           ) =>
         TemplateImplements(
-          interface,
+          apply(interface),
           methods.transform((_, x) => apply(x)),
           inheritedChoices,
         )


### PR DESCRIPTION
This extends the Scala encoder tests to include interface definitions
and interface implementatioins. Some bugs in the encoder and ast
rewriter are fixed.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
