### PR TITLE
Improve description of the HTTP JSON API in the Ledger API docs

### DIFF
--- a/docs/source/app-dev/ledger-api.rst
+++ b/docs/source/app-dev/ledger-api.rst
@@ -66,7 +66,7 @@ You can also use the :doc:`HTTP JSON API Service </json-api/index>` to tap into 
 At its core, this service provides a simplified view of the active contract set and additional primitives to query it and
 exposing it using a well-defined JSON-based encoding over a conventional HTTP connection.
 
-A subset of the services mentioned above is also available as part of it.
+A subset of the services mentioned above is also available as part of the HTTP JSON API.
 
 .. _daml-lf-intro:
 

--- a/docs/source/app-dev/ledger-api.rst
+++ b/docs/source/app-dev/ledger-api.rst
@@ -17,7 +17,7 @@ The Ledger API
    bindings-x-lang/index
 
 
-To write an application around a Daml ledger, you'll need to interact with the **Ledger API**.
+To write an application around a Daml ledger, you will need to interact with the **Ledger API**.
 
 Every ledger that Daml can run on exposes this same API.
 
@@ -57,7 +57,7 @@ How to Access the Ledger API
 
 You can access the Ledger API via the :doc:`Java Bindings <bindings-java/index>`.
 
-If you don't use a language that targets the JVM you can use gRPC to generate the code to access the Ledger API in
+If you don't use a language that targets the JVM, you can use gRPC to generate the code to access the Ledger API in
 several supported programming languages. :doc:`Further documentation <bindings-x-lang/index>` provides a few
 pointers on how you may want to approach this.
 

--- a/docs/source/app-dev/ledger-api.rst
+++ b/docs/source/app-dev/ledger-api.rst
@@ -61,12 +61,12 @@ If you don't use a language that targets the JVM you can use gRPC to generate th
 several supported programming languages. :doc:`Further documentation <bindings-x-lang/index>` provides a few
 pointers on how you may want to approach this.
 
-As an alternative way to tap into the Ledger API you can also use the :doc:`HTTP JSON API Service</json-api/index>`.
+You can also use the :doc:`HTTP JSON API Service </json-api/index>` to tap into the Ledger API.
 
 At its core, it provides a simplified view of the active contract set and additional primities to query it and
 exposing it using a well-defined JSON-based encoding over a conventional HTTP connection.
 
-On top of that, a subset of the services mentioned above is also available as part of it.
+A subset of the services mentioned above is also available as part of it.
 
 .. _daml-lf-intro:
 

--- a/docs/source/app-dev/ledger-api.rst
+++ b/docs/source/app-dev/ledger-api.rst
@@ -63,7 +63,7 @@ pointers on how you may want to approach this.
 
 You can also use the :doc:`HTTP JSON API Service </json-api/index>` to tap into the Ledger API.
 
-At its core, it provides a simplified view of the active contract set and additional primities to query it and
+At its core, this service provides a simplified view of the active contract set and additional primitives to query it and
 exposing it using a well-defined JSON-based encoding over a conventional HTTP connection.
 
 A subset of the services mentioned above is also available as part of it.

--- a/docs/source/app-dev/ledger-api.rst
+++ b/docs/source/app-dev/ledger-api.rst
@@ -17,14 +17,14 @@ The Ledger API
    bindings-x-lang/index
 
 
-To write an application around a Daml ledger, you'll need to interact with the **Ledger API** from
-another language. Every ledger that Daml can run on exposes this same API.
+To write an application around a Daml ledger, you'll need to interact with the **Ledger API**.
+
+Every ledger that Daml can run on exposes this same API.
 
 What's in the Ledger API
 ************************
 
-You can access the Ledger API via the HTTP JSON API, Java bindings or gRPC. In
-all cases, the Ledger API exposes the same services:
+The Ledger API exposes the following services:
 
 - Submitting commands to the ledger
 
@@ -51,6 +51,22 @@ all cases, the Ledger API exposes the same services:
 For full information on the services see :doc:`/app-dev/services`.
 
 You may also want to read the :doc:`protobuf documentation </app-dev/grpc/proto-docs>`, which explains how each service is defined as protobuf messages.
+
+How to Access the Ledger API
+****************************
+
+You can access the Ledger API via the :doc:`Java Bindings <bindings-java/index>`.
+
+If you don't use a language that targets the JVM you can use gRPC to generate the code to access the Ledger API in
+several supported programming languages. :doc:`Further documentation <bindings-x-lang/index>` provides a few
+pointers on how you may want to approach this.
+
+As an alternative way to tap into the Ledger API you can also use the :doc:`HTTP JSON API Service</json-api/index>`.
+
+At its core, it provides a simplified view of the active contract set and additional primities to query it and
+exposing it using a well-defined JSON-based encoding over a conventional HTTP connection.
+
+On top of that, a subset of the services mentioned above is also available as part of it.
 
 .. _daml-lf-intro:
 


### PR DESCRIPTION
changelog_begin
changelog_end

Fixes https://github.com/digital-asset/daml/issues/13029

Summary of changes:
- removed the reference to the fact that one needs to use _another_ language to access the Ledger API (Daml Script is still Daml)
- moved ways to access the Ledger API into its own paragraph:
  - suggest first to use the Java bindings
  - be more explicit about how gRPC enters the picture
  - be more specific about how the HTTP JSON API enters the picture

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
