### PR TITLE
Return a wrapper `GetUserResponse` type for the Java bindings

### DIFF
--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/UserManagementClient.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/UserManagementClient.java
@@ -14,9 +14,9 @@ public interface UserManagementClient {
 
   Single<CreateUserResponse> createUser(@NonNull CreateUserRequest request, String accessToken);
 
-  Single<User> getUser(@NonNull GetUserRequest request);
+  Single<GetUserResponse> getUser(@NonNull GetUserRequest request);
 
-  Single<User> getUser(@NonNull GetUserRequest request, String accessToken);
+  Single<GetUserResponse> getUser(@NonNull GetUserRequest request, String accessToken);
 
   Single<DeleteUserResponse> deleteUser(@NonNull DeleteUserRequest request);
 

--- a/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/UserManagementClientImpl.java
+++ b/language-support/java/bindings-rxjava/src/main/java/com/daml/ledger/rxjava/grpc/UserManagementClientImpl.java
@@ -50,22 +50,23 @@ public final class UserManagementClientImpl implements UserManagementClient {
     return createUser(request, Optional.of(accessToken));
   }
 
-  private Single<User> getUser(
+  private Single<GetUserResponse> getUser(
       @NonNull GetUserRequest request, @NonNull Optional<String> maybeToken) {
     return CreateSingle.fromFuture(
             StubHelper.authenticating(this.serviceFutureStub, maybeToken)
                 .getUser(request.toProto()),
             sequencerFactory)
-        .map(res -> User.fromProto(res.getUser()));
+        .map(GetUserResponse::fromProto);
   }
 
   @Override
-  public Single<User> getUser(@NonNull GetUserRequest request) {
+  public Single<GetUserResponse> getUser(@NonNull GetUserRequest request) {
     return getUser(request, Optional.empty());
   }
 
   @Override
-  public Single<User> getUser(@NonNull GetUserRequest request, @NonNull String accessToken) {
+  public Single<GetUserResponse> getUser(
+      @NonNull GetUserRequest request, @NonNull String accessToken) {
     return getUser(request, Optional.of(accessToken));
   }
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/GetUserResponse.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/GetUserResponse.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data;
+
+import com.daml.ledger.api.v1.admin.UserManagementServiceOuterClass;
+import java.util.Objects;
+
+public final class GetUserResponse {
+
+  private final User user;
+
+  public GetUserResponse(User user) {
+    this.user = user;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public static GetUserResponse fromProto(UserManagementServiceOuterClass.GetUserResponse proto) {
+    return new GetUserResponse(User.fromProto(proto.getUser()));
+  }
+
+  public UserManagementServiceOuterClass.GetUserResponse toProto() {
+    return UserManagementServiceOuterClass.GetUserResponse.newBuilder()
+        .setUser(this.user.toProto())
+        .build();
+  }
+
+  @Override
+  public String toString() {
+    return "GetUserResponse{" + "user=" + user + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GetUserResponse that = (GetUserResponse) o;
+    return user.equals(that.user);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(user);
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/13274

changelog_begin
[Java bindings] The `UserManagementClient.getUser` methods have been changed to return a
custom wrapper type `GetUserResponse` instead of a `User` directly. If you were already
using these methods, you can make your code work as before by adding a call to the
`getUser` method defined on the `GetUserResponse` type you now get back. You can read
more about this issue here: https://github.com/digital-asset/daml/issues/13274
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
