### PR TITLE
Do not point at a milestone from the HTTP JSON API docs

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -25,7 +25,7 @@ For these and other features, use :doc:`the Ledger API </app-dev/ledger-api>`
 instead.
 
 We welcome feedback about the JSON API on
-`our issue tracker <https://github.com/digital-asset/daml/issues/new?milestone=HTTP+JSON+API+Maintenance>`_, or
+`our issue tracker <https://github.com/digital-asset/daml/issues/new/choose>`_, or
 `on our forum <https://discuss.daml.com>`_.
 
 .. toctree::


### PR DESCRIPTION
We recently started to use a project board to prioritize our work.

As such, we will soon remove our milestones and move relevant tickets
to the board after ensuring that all items that belong to us are
tracked by the appropriate team label (`team/app-runtime`).

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
