### PR TITLE
Remove references to missing appender

### DIFF
--- a/ledger-service/http-json-oracle/src/it/resources/logback.xml
+++ b/ledger-service/http-json-oracle/src/it/resources/logback.xml
@@ -8,10 +8,10 @@
     </appender>
 
     <logger name="io.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <logger name="io.grpc.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/ledger-service/http-json/src/failure/resources/logback.xml
+++ b/ledger-service/http-json/src/failure/resources/logback.xml
@@ -8,10 +8,10 @@
     </appender>
 
     <logger name="io.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <logger name="io.grpc.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/ledger-service/http-json/src/it/resources/logback.xml
+++ b/ledger-service/http-json/src/it/resources/logback.xml
@@ -8,10 +8,10 @@
     </appender>
 
     <logger name="io.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <logger name="io.grpc.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/triggers/service/auth/release/oauth2-middleware-logback.xml
+++ b/triggers/service/auth/release/oauth2-middleware-logback.xml
@@ -6,10 +6,10 @@
     </appender>
 
     <logger name="io.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <logger name="io.grpc.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/triggers/service/release/trigger-service-logback.xml
+++ b/triggers/service/release/trigger-service-logback.xml
@@ -6,10 +6,10 @@
     </appender>
 
     <logger name="io.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <logger name="io.grpc.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/triggers/service/src/test/resources/logback.xml
+++ b/triggers/service/src/test/resources/logback.xml
@@ -6,13 +6,13 @@
     </appender>
 
     <logger name="io.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <logger name="io.grpc.netty" level="WARN">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <logger name="com.daml.lf.engine.trigger" level="INFO">
-        <appender-ref ref="stderr-appender"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
     <root level="INFO">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
changelog_begin
[Trigger Service] Spurious logging warnings will not be printed when running `daml trigger-service`
[Oauth2 Middleware] Spurious logging warnings will not be printed when running `daml oauth2-middleware`
changelog_end

Removed references to a missing `stderr-appender` in several configuration file.

This removes warnings when running `daml trigger-service` and `daml oauth2-middleware`.

This will also remove those same warnings from several tests (HTTP JSON API and Trigger Service).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
