### PR TITLE
Add `logback.xml` file in the distributable JAR for the Trigger Service

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -328,3 +328,5 @@ EOF
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],
 )
+
+exports_files(["release/trigger-service-logback.xml"])

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -106,30 +106,30 @@ binary_deps = [
     "@maven//:org_slf4j_slf4j_api",
 ]
 
-da_scala_binary(
-    name = "trigger-service-binary-ce",
-    srcs = [triggerMain],
-    main_class = "com.daml.lf.engine.trigger.ServiceMain",
-    scala_deps = scala_binary_deps,
-    visibility = ["//visibility:public"],
-    deps = binary_deps + [
-        "//runtime-components/jdbc-drivers:jdbc-drivers-ce",
-    ],
-)
+trigger_service_runtime_deps = {
+    "ce": [],
+    "ee": ["@maven//:com_oracle_database_jdbc_ojdbc8"],
+}
 
-da_scala_binary(
-    name = "trigger-service-binary-ee",
-    srcs = [triggerMain],
-    main_class = "com.daml.lf.engine.trigger.ServiceMain",
-    scala_deps = scala_binary_deps,
-    visibility = ["//visibility:public"],
-    runtime_deps = [
-        "@maven//:com_oracle_database_jdbc_ojdbc8",
-    ],
-    deps = binary_deps + [
-        "//runtime-components/jdbc-drivers:jdbc-drivers-ee",
-    ],
-)
+[
+    da_scala_binary(
+        name = "trigger-service-binary-{}".format(edition),
+        srcs = [triggerMain],
+        main_class = "com.daml.lf.engine.trigger.ServiceMain",
+        resource_strip_prefix = "triggers/service/release/trigger-service-",
+        resources = ["release/trigger-service-logback.xml"],
+        scala_deps = scala_binary_deps,
+        visibility = ["//visibility:public"],
+        runtime_deps = trigger_service_runtime_deps.get(edition),
+        deps = binary_deps + [
+            "//runtime-components/jdbc-drivers:jdbc-drivers-{}".format(edition),
+        ],
+    )
+    for edition in [
+        "ce",
+        "ee",
+    ]
+]
 
 da_scala_library(
     name = "trigger-service-tests",
@@ -328,5 +328,3 @@ EOF
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],
 )
-
-exports_files(["release/trigger-service-logback.xml"])


### PR DESCRIPTION
Fixes #13042

changelog_begin
[Trigger Service] Debug logging is now hidden by default. See #13042
changelog_end

Summary of changes:
- remove unused `exports_files`
- refactor trigger-service-binary rules in a single comprehension
- add the `logback.xml` file in the JAR root

Tested manually: listed the contents of the output of `bazel build //triggers/service:trigger-service-binary-ce_deploy.jar` and `bazel build //triggers/service:trigger-service-binary-ee_deploy.jar` before and after the fix, observed that the only difference is the `logback.xml` file in the JAR root; added a debug logger call and ran both JARs before and after the fix, observed that after the fix the debug logging line is no longer printed.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
