### PR TITLE
Reduce noise when building `//daml-lf/encoder:testing-dar-*`

### DIFF
--- a/daml-lf/encoder/BUILD.bazel
+++ b/daml-lf/encoder/BUILD.bazel
@@ -71,6 +71,9 @@ da_scala_binary(
     main_class = "com.daml.lf.archive.testing.DamlLfEncoder",
     scalacopts = lf_scalacopts,
     visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@maven//:ch_qos_logback_logback_classic",
+    ],
     deps = [
         ":encoder",
         "//:sdk-version-scala-lib",


### PR DESCRIPTION
changelog_begin
changelog_end

Adding Logback to the runtime dependencies allows to avoid having
logging noise when building this due to the missing logger implementation.

Came across this while working on the Java codegen (which depends on this)
as part of my work on https://github.com/digital-asset/daml/issues/13308.

Before:

```
> bazel build //daml-lf/encoder:testing-dar-1.12
INFO: Invocation ID: fd46d196-8780-4b3a-9c23-41501a4668d2
INFO: Analyzed target //daml-lf/encoder:testing-dar-1.12 (1 packages loaded, 27 targets configured).
INFO: Found 1 target...
INFO: From Executing genrule //daml-lf/encoder:testing-dar-1.12:
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Target //daml-lf/encoder:testing-dar-1.12 up-to-date:
  bazel-bin/daml-lf/encoder/test-1.12.dar
INFO: Elapsed time: 0.365s, Critical Path: 0.01s
INFO: 5 processes: 1 remote cache hit, 4 internal.
INFO: Build completed successfully, 5 total actions
```

After:

```
> bazel build //daml-lf/encoder:testing-dar-1.12
INFO: Invocation ID: d79a9df8-8243-49db-bd67-56a4f53ca746
INFO: Analyzed target //daml-lf/encoder:testing-dar-1.12 (1 packages loaded, 27 targets configured).
INFO: Found 1 target...
Target //daml-lf/encoder:testing-dar-1.12 up-to-date:
  bazel-bin/daml-lf/encoder/test-1.12.dar
INFO: Elapsed time: 0.332s, Critical Path: 0.01s
INFO: 5 processes: 1 remote cache hit, 4 internal.
INFO: Build completed successfully, 5 total actions
```

Notice the lack of SLF4J warnings.

See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
