### PR TITLE
reduce trampoline bouncing in ANF transform

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -117,6 +117,8 @@ private[lf] object Anf {
     Env(absMap = env.absMap ++ extra, oldDepth = env.oldDepth.incr(n))
   }
 
+  private[this] type Res = Trampoline[target.SExpr]
+
   /** Tx is the type for the stacked transformation functions managed by the ANF
     * transformation, mainly transformExp.
     *
@@ -134,9 +136,6 @@ private[lf] object Anf {
     * @tparam A The return type of the continuation (minus the Trampoline
     *           wrapping).
     */
-
-  private[this] type Res = Trampoline[target.SExpr]
-
   private[this] type Tx[T] = (DepthA, T) => K[target.SExpr] => Res
 
   /** K Is the type for continuations.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -305,9 +305,9 @@ private[lf] object Anf {
         // It's also safe to perform ANF for applications of a single argument.
         val singleArg = args.lengthCompare(1) == 0
         if (safeFunc || singleArg) {
-          transformMultiApp(depth, env, func, args.toArray, k)(transform)
+          transformMultiApp(depth, env, func, args, k)(transform)
         } else {
-          transformMultiAppSafely(depth, env, func, args.toArray, k)(transform)
+          transformMultiAppSafely(depth, env, func, args, k)(transform)
         }
 
       case source.SEMakeClo(fvs0, arity, body) =>
@@ -429,12 +429,12 @@ private[lf] object Anf {
       depth: DepthA,
       env: Env,
       func: source.SExpr,
-      args: Array[source.SExpr],
+      args: List[source.SExpr],
       k: K[target.SExpr],
   )(transform: Tx[target.SExpr]): Res = {
 
     atomizeExp(depth, env, func, k) { (depth, func) => k =>
-      atomizeExps(depth, env, args.toList, k) { (depth, args) => k =>
+      atomizeExps(depth, env, args, k) { (depth, args) => k =>
         val func1 = makeRelativeA(depth)(func)
         val args1 = args.map(makeRelativeA(depth))
         transform(depth, target.SEAppAtomic(func1, args1.toArray))(k)
@@ -450,14 +450,14 @@ private[lf] object Anf {
       depth: DepthA,
       env: Env,
       func: source.SExpr,
-      args: Array[source.SExpr],
+      args: List[source.SExpr],
       k: K[target.SExpr],
   )(transform: Tx[target.SExpr]): Res = {
 
     atomizeExp(depth, env, func, k) { (depth, func) => k =>
       val func1 = makeRelativeA(depth)(func)
       // we dont atomize the args here
-      flattenExpList(depth, env, args.toList) { args =>
+      flattenExpList(depth, env, args) { args =>
         // we build a non-atomic application here (only the function is atomic)
         transform(depth, target.SEAppAtomicFun(func1, args.toArray))(k)
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -376,8 +376,12 @@ private[lf] object Anf {
       case Nil => transform(depth, Nil)(k)
       case exp :: exps =>
         atomizeExp(depth, env, exp, k) { (depth, atom) => k =>
-          atomizeExps(depth, env, exps, k) { (depth, atoms) => k =>
-            transform(depth, atom :: atoms)(k)
+          Bounce { () =>
+            atomizeExps(depth, env, exps, k) { (depth, atoms) => k =>
+              Bounce { () =>
+                transform(depth, atom :: atoms)(k)
+              }
+            }
           }
         }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -133,16 +133,12 @@ private[lf] object Anf {
     * a parameterized type, so we use nested `defs` instead.
     *
     * @tparam T The type of expression this will be applied to.
-    * @tparam A The return type of the continuation (minus the Trampoline
-    *           wrapping).
     */
   private[this] type Tx[T] = (DepthA, T) => K[target.SExpr] => Res
 
   /** K Is the type for continuations.
     *
     * @tparam T Type the function would have returned had it not been in CPS.
-    * @tparam A The return type of the continuation (minus the Trampoline
-    *           wrapping).
     */
   private[this] type K[T] = T => Res
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -297,11 +297,14 @@ private[lf] object Anf {
         val safeFunc =
           func match {
             // we know that trivially in these two cases
-            case source.SEBuiltin(b) => (args.size <= b.arity)
+            case source.SEBuiltin(b) =>
+              val overApp = args.lengthCompare(b.arity) > 0
+              !overApp
             case _ => false
           }
         // It's also safe to perform ANF for applications of a single argument.
-        if (safeFunc || args.size == 1) {
+        val singleArg = args.lengthCompare(1) == 0
+        if (safeFunc || singleArg) {
           transformMultiApp(depth, env, func, args.toArray, k)(transform)
         } else {
           transformMultiAppSafely(depth, env, func, args.toArray, k)(transform)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -307,9 +307,7 @@ private[lf] object Anf {
 
       case source.SEMakeClo(fvs0, arity, body) =>
         val fvs = fvs0.map((loc) => makeRelativeL(depth)(makeAbsoluteL(env, loc)))
-        val depth0 = DepthA(0)
-        val env0 = initEnv
-        flattenExp(depth0, env0, body) { body =>
+        flattenExp(DepthA(0), initEnv, body) { body =>
           transform(depth, target.SEMakeClo(fvs.toArray, arity, body))(k)
         }
 


### PR DESCRIPTION
Cleanup and simplify `Anf.scala` code

- remove calls to `Bounce`: only needs to be placed where necessary to break recursion

Other small cleanups to improve layout and clarity:

- always use curly braces for constructing continuation functions
- use multi args lists
- use shadow variable naming to show link between pre/post transformed vars
- remove unnecessary polymorpism: fix `A` as `target.SExpr`,
- define the type for final result: `type Res = Trampoline[target.SExpr]`
