### PR TITLE
Test that we return a 404 when requesting information about non-existing packages

### DIFF
--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -2006,6 +2006,21 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
       }: Future[Assertion]
   }
 
+  "packages/packageId should return NotFound if a non-existing package is requested" in withHttpServiceAndClient {
+    (uri, _, _, _, _) =>
+      Http()
+        .singleRequest(
+          HttpRequest(
+            method = HttpMethods.GET,
+            uri = uri.withPath(Uri.Path(s"/v1/packages/12345678")),
+            headers = headersWithAdminAuth,
+          )
+        )
+        .map { resp =>
+          resp.status shouldBe StatusCodes.NotFound
+        }
+  }
+
   "packages upload endpoint" in withHttpServiceAndClient { (uri, _, _, _, _) =>
     val newDar = AbstractHttpServiceIntegrationTestFuns.dar3
 


### PR DESCRIPTION
As part of gardening I wanted to fix https://github.com/digital-asset/daml/issues/6593 and noticed that it was already fixed without us noticing it. Therefor this only contains a test that makes sure that we don't regress.

changelog_begin

- [HTTP-JSON] If information about a package is requested that doesn't exist on the ledger you will now get a 404 instead of a 500 as response.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
