### PR TITLE
add stack-safety tests for wide expressions

### DIFF
--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ClosureConversionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ClosureConversionTest.scala
@@ -153,6 +153,7 @@ class ClosureConversionTest extends AnyFreeSpec with Matchers with TableDrivenPr
 
   "stack-safety; wide" - {
 
+    // TODO https://github.com/digital-asset/daml/issues/13351
     val width = 3000 // increase if fix quadratic behavior of let-expressions
 
     val appGeneral = (xs: List[SExpr]) => {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PhaseOneTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PhaseOneTest.scala
@@ -141,6 +141,7 @@ class PhaseOneTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
     }
 
     {
+      // TODO https://github.com/digital-asset/daml/issues/13351
       // we reduce the depth when sequencing multiple compilation phases
       // 2k is still plenty to check stack-safety
       // But above this, some testcases start to become slower than 1second.
@@ -156,6 +157,7 @@ class PhaseOneTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
     }
 
     {
+      // TODO https://github.com/digital-asset/daml/issues/13351
       val depth = 3000
       s"transform(phase1, closureConversion, flattenToAnf), depth = $depth" - {
         forEvery(testCases) { (name: String, recursionPoint: Expr => Expr) =>


### PR DESCRIPTION
- Fill in some holes in the stack-safety testing, for wide expressions
