### PR TITLE
[Backport] Ledger API mutable contract state cache update synchronization fix

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractKeyStateCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractKeyStateCache.scala
@@ -10,10 +10,11 @@ import com.daml.metrics.Metrics
 import scala.concurrent.ExecutionContext
 
 object ContractKeyStateCache {
-  def apply(cacheSize: Long, metrics: Metrics)(implicit
+  def apply(initialCacheIndex: Long, cacheSize: Long, metrics: Metrics)(implicit
       ec: ExecutionContext
   ): StateCache[GlobalKey, ContractKeyStateValue] =
-    StateCache(
+    new StateCache(
+      initialCacheIndex = initialCacheIndex,
       cache = SizedCache.from[GlobalKey, ContractKeyStateValue](
         SizedCache.Configuration(cacheSize),
         metrics.daml.execution.cache.keyState,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractsStateCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/ContractsStateCache.scala
@@ -9,10 +9,11 @@ import com.daml.metrics.Metrics
 import scala.concurrent.ExecutionContext
 
 object ContractsStateCache {
-  def apply(cacheSize: Long, metrics: Metrics)(implicit
+  def apply(initialCacheIndex: Long, cacheSize: Long, metrics: Metrics)(implicit
       ec: ExecutionContext
   ): StateCache[ContractId, ContractStateValue] =
-    StateCache(
+    new StateCache(
+      initialCacheIndex = initialCacheIndex,
       cache = SizedCache.from[ContractId, ContractStateValue](
         SizedCache.Configuration(cacheSize),
         metrics.daml.execution.cache.contractState,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -28,23 +28,19 @@ import com.daml.platform.store.interfaces.LedgerDaoContractsReader.{
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Success
-import scala.util.chaining._
+import scala.util.{Failure, Success}
 import scala.util.control.NoStackTrace
 
 private[platform] class MutableCacheBackedContractStore(
     metrics: Metrics,
     contractsReader: LedgerDaoContractsReader,
     signalNewLedgerHead: SignalNewLedgerHead,
-    startIndexExclusive: (Offset, Long),
     private[cache] val keyCache: StateCache[GlobalKey, ContractKeyStateValue],
     private[cache] val contractsCache: StateCache[ContractId, ContractStateValue],
 )(implicit executionContext: ExecutionContext, loggingContext: LoggingContext)
     extends ContractStore {
 
   private val logger = ContextualizedLogger.get(getClass)
-
-  private[cache] val cacheIndex = MutableLedgerEndCache().tap(_.set(startIndexExclusive))
 
   def push(event: ContractStateEvent): Unit = {
     debugEvents(event)
@@ -144,31 +140,28 @@ private[platform] class MutableCacheBackedContractStore(
 
   private def readThroughContractsCache(contractId: ContractId)(implicit
       loggingContext: LoggingContext
-  ) = {
-    val currentCacheSequentialId = cacheIndex()._2
-    val fetchStateRequest =
-      Timed.future(
-        metrics.daml.index.lookupContract,
-        contractsReader.lookupContractState(contractId, currentCacheSequentialId),
-      )
-    val eventualValue = fetchStateRequest.map(toContractCacheValue)
+  ): Future[ContractStateValue] = {
+    val readThroughRequest =
+      (validAt: Long) =>
+        contractsReader
+          .lookupContractState(contractId, validAt)
+          .map(toContractCacheValue)
+          .transformWith {
+            case Success(NotFound) =>
+              metrics.daml.execution.cache.readThroughNotFound.inc()
+              // We must not cache negative lookups by contract-id, as they can be invalidated by later divulgence events.
+              // This is OK from a performance perspective, as we do not expect uses-cases that require
+              // caching of contract absence or the results of looking up divulged contracts.
+              Future.failed(ContractReadThroughNotFound(contractId))
+            case result => Future.fromTry(result)
+          }
 
-    for {
-      _ <- contractsCache.putAsync(
-        key = contractId,
-        validAt = currentCacheSequentialId,
-        eventualValue = eventualValue.transformWith {
-          case Success(NotFound) =>
-            metrics.daml.execution.cache.readThroughNotFound.inc()
-            // We must not cache negative lookups by contract-id, as they can be invalidated by later divulgence events.
-            // This is OK from a performance perspective, as we do not expect uses-cases that require
-            // caching of contract absence or the results of looking up divulged contracts.
-            Future.failed(ContractReadThroughNotFound(contractId))
-          case result => Future.fromTry(result)
-        },
-      )
-      value <- eventualValue
-    } yield value
+    contractsCache
+      .putAsync(contractId, readThroughRequest)
+      .transformWith {
+        case Failure(_: ContractReadThroughNotFound) => Future.successful(NotFound)
+        case other => Future.fromTry(other)
+      }
   }
 
   private def keyStateToResponse(
@@ -241,22 +234,16 @@ private[platform] class MutableCacheBackedContractStore(
 
   private def readThroughKeyCache(
       key: GlobalKey
-  )(implicit loggingContext: LoggingContext) = {
-    val currentCacheSequentialId = cacheIndex()._2
-    val eventualResult = contractsReader.lookupKeyState(key, currentCacheSequentialId)
-    val eventualValue = eventualResult.map(toKeyCacheValue)
-
-    for {
-      _ <- keyCache.putAsync(key, currentCacheSequentialId, eventualValue)
-      value <- eventualValue
-    } yield value
+  )(implicit loggingContext: LoggingContext): Future[ContractKeyStateValue] = {
+    val readThroughRequest = (validAt: Long) =>
+      contractsReader.lookupKeyState(key, validAt).map(toKeyCacheValue)
+    keyCache.putAsync(key, readThroughRequest)
   }
 
   private def nonEmptyIntersection[T](one: Set[T], other: Set[T]): Boolean =
     one.intersect(other).nonEmpty
 
   private def updateOffsets(event: ContractStateEvent): Unit = {
-    cacheIndex.set(event.eventOffset, event.eventSequentialId)
     metrics.daml.execution.cache.indexSequentialId
       .updateValue(event.eventSequentialId)
     event match {
@@ -339,12 +326,12 @@ private[platform] object MutableCacheBackedContractStore {
   type SignalNewLedgerHead = (Offset, Long) => Unit
   // Subscribe to the contract state events stream starting at a specific event_offset and event_sequential_id
   type SubscribeToContractStateEvents =
-    ((Offset, EventSequentialId)) => Source[ContractStateEvent, NotUsed]
+    () => Source[ContractStateEvent, NotUsed]
 
   def apply(
       contractsReader: LedgerDaoContractsReader,
       signalNewLedgerHead: SignalNewLedgerHead,
-      startIndexExclusive: (Offset, Long),
+      startIndexExclusive: Long,
       metrics: Metrics,
       maxContractsCacheSize: Long,
       maxKeyCacheSize: Long,
@@ -356,9 +343,8 @@ private[platform] object MutableCacheBackedContractStore {
       metrics,
       contractsReader,
       signalNewLedgerHead,
-      startIndexExclusive,
-      ContractKeyStateCache(maxKeyCacheSize, metrics),
-      ContractsStateCache(maxContractsCacheSize, metrics),
+      ContractKeyStateCache(startIndexExclusive, maxKeyCacheSize, metrics),
+      ContractsStateCache(startIndexExclusive, maxContractsCacheSize, metrics),
     )
 
   final class CacheUpdateSubscription(
@@ -378,10 +364,8 @@ private[platform] object MutableCacheBackedContractStore {
               maxBackoff = 10.seconds,
               randomFactor = 0.2,
             )
-          )(() =>
-            subscribeToContractStateEvents(contractStore.cacheIndex())
-              .map(contractStore.push)
-          )
+          )(() => subscribeToContractStateEvents())
+          .map(contractStore.push)
           .viaMat(KillSwitches.single)(Keep.right[NotUsed, UniqueKillSwitch])
           .toMat(Sink.ignore)(Keep.both[UniqueKillSwitch, Future[Done]])
           .run()

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.transaction.GlobalKey
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
-import com.daml.metrics.{Metrics, Timed}
+import com.daml.metrics.Metrics
 import com.daml.platform.store.appendonlydao.events.ContractStateEvent
 import com.daml.platform.store.appendonlydao.events.ContractStateEvent.LedgerEndMarker
 import com.daml.platform.store.cache.ContractKeyStateValue._

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/StateCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/StateCache.scala
@@ -7,20 +7,30 @@ import com.codahale.metrics.Timer
 import com.daml.caching.Cache
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Timed
+import com.daml.platform.store.cache.MutableCacheBackedContractStore.ContractReadThroughNotFound
 import com.daml.platform.store.cache.StateCache.PendingUpdatesState
 import com.daml.scalautil.Statement.discard
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 
-/** This class is a wrapper around a Caffeine cache designed to handle
-  * correct resolution of concurrent updates for the same key.
+/** This class is a wrapper around a Caffeine cache designed to handle correct resolution of
+  * concurrent updates for the same key.
+  *
+  * The [[StateCache]] tracks its own notion of logical time with the `cacheIndex`
+  * which evolves monotonically based on the index DB's event sequential id (updated by [[put]]).
+  *
+  * The cache's logical time (i.e. the `cacheIndex`) is used for establishing precedence of cache updates
+  * stemming from read-throughs triggered from command interpretation on cache misses.
   */
-private[platform] case class StateCache[K, V](cache: Cache[K, V], registerUpdateTimer: Timer)(
-    implicit ec: ExecutionContext
-) {
+private[platform] case class StateCache[K, V](
+    initialCacheIndex: Long,
+    cache: Cache[K, V],
+    registerUpdateTimer: Timer,
+)(implicit ec: ExecutionContext) {
   private val logger: ContextualizedLogger = ContextualizedLogger.get(getClass)
   private[cache] val pendingUpdates = mutable.Map.empty[K, PendingUpdatesState]
+  @volatile private[cache] var cacheIndex = initialCacheIndex
 
   /** Fetch the corresponding value for an input key, if present.
     *
@@ -30,40 +40,40 @@ private[platform] case class StateCache[K, V](cache: Cache[K, V], registerUpdate
   def get(key: K)(implicit loggingContext: LoggingContext): Option[V] =
     cache.getIfPresent(key) match {
       case Some(value) =>
-        logger.debug(s"Cache hit for $key -> ${value.toString.take(100)}")
+        logger.debug(s"Cache hit for $key -> ${truncateValueForLogging(value)}")
         Some(value)
       case None =>
         logger.debug(s"Cache miss for $key ")
         None
     }
 
-  /** Update the cache synchronously.
-    *
-    * In face of multiple in-flight updates competing for the `key` (see [[putAsync()]]),
-    * this method updates the cache only if the to-be-inserted tuple is the most recent
-    * (i.e. it has `validAt` highest amongst the competing updates).
+  /** Synchronous cache updates evolve the cache ahead with the most recent Index DB entries.
+    * This method increases the `cacheIndex` monotonically.
     *
     * @param key the key at which to update the cache
     * @param validAt ordering discriminator for pending updates for the same key
     * @param value the value to insert
     */
-  def put(key: K, validAt: Long, value: V): Unit = Timed.value(
-    registerUpdateTimer, {
-      pendingUpdates.synchronized {
-        val competingLatestForKey =
-          pendingUpdates
-            .get(key)
-            .map { pendingUpdate =>
-              val oldLatestValidAt = pendingUpdate.latestValidAt
-              pendingUpdate.latestValidAt = Math.max(validAt, pendingUpdate.latestValidAt)
-              oldLatestValidAt
-            }
-            .getOrElse(Long.MinValue)
-
-        if (competingLatestForKey < validAt) cache.put(key, value) else ()
-      }
-    },
-  )
+  def put(key: K, validAt: Long, value: V)(implicit loggingContext: LoggingContext): Unit =
+    Timed.value(
+      registerUpdateTimer, {
+        pendingUpdates.synchronized {
+          // The mutable contract state cache update stream should generally increase the cacheIndex strictly monotonically.
+          // However, the most recent updates can be replayed in case of failure of the mutable contract state cache update stream.
+          // In this case, we must ignore the already seen updates (i.e. that have `validAt` before or at the cacheIndex).
+          if (validAt > cacheIndex) {
+            pendingUpdates
+              .get(key)
+              .foreach(_.latestValidAt = validAt)
+            cacheIndex = validAt
+            putInternal(key, value, validAt)
+          } else
+            logger.warn(
+              s"Ignoring incoming synchronous update at an index ($validAt) equal to or before the cache index ($cacheIndex)"
+            )
+        }
+      },
+    )
 
   /** Update the cache asynchronously.
     *
@@ -73,22 +83,31 @@ private[platform] case class StateCache[K, V](cache: Cache[K, V], registerUpdate
     * (i.e. it has `validAt` highest amongst the competing updates).
     *
     * @param key the key at which to update the cache
-    * @param validAt ordering discriminator for pending updates for the same key
-    * @param eventualValue the eventual result signaling successful enqueuing of the cache async update
+    * @param fetchAsync fetches asynchronously the value for key `key` at the current cache index
     */
-  final def putAsync(key: K, validAt: Long, eventualValue: Future[V])(implicit
+  def putAsync(key: K, fetchAsync: Long => Future[V])(implicit
       loggingContext: LoggingContext
-  ): Future[Unit] = Timed.value(
+  ): Future[V] = Timed.value(
     registerUpdateTimer,
     pendingUpdates.synchronized {
+      val validAt = cacheIndex
+      val eventualValue = Future.delegate(fetchAsync(validAt))
       val pendingUpdatesForKey = pendingUpdates.getOrElseUpdate(key, PendingUpdatesState.empty)
       if (pendingUpdatesForKey.latestValidAt < validAt) {
         pendingUpdatesForKey.latestValidAt = validAt
         pendingUpdatesForKey.pendingCount += 1
         registerEventualCacheUpdate(key, eventualValue, validAt)
-      } else Future.unit
+          .flatMap(_ => eventualValue)
+      } else eventualValue
     },
   )
+
+  private def putInternal(key: K, value: V, validAt: Long)(implicit
+      loggingContext: LoggingContext
+  ): Unit = {
+    cache.put(key, value)
+    logger.debug(s"Updated cache for $key with ${truncateValueForLogging(value)} at $validAt")
+  }
 
   private def registerEventualCacheUpdate(
       key: K,
@@ -101,19 +120,33 @@ private[platform] case class StateCache[K, V](cache: Cache[K, V], registerUpdate
           pendingUpdates
             .get(key)
             .map { pendingForKey =>
-              if (pendingForKey.latestValidAt == validAt)
-                cache.put(key, value)
-              else ()
+              // Only update the cache if the current update is targeting the cacheIndex
+              // sampled when initially dispatched in `putAsync`.
+              // Otherwise we can assume that a more recent `putAsync` has an update in-flight
+              // or that the entry has been updated synchronously with `put` with a recent Index DB entry.
+              if (pendingForKey.latestValidAt == validAt) {
+                putInternal(key, value, validAt)
+              }
               removeFromPending(key)
             }
             .getOrElse(logger.error(s"Pending updates tracker for $key not registered "))
         }
       }
-      .recover { case err =>
-        pendingUpdates.synchronized {
-          removeFromPending(key)
-        }
-        logger.warn(s"Failure in pending cache update for key $key", err)
+      .recover {
+        // Negative contract lookups are forwarded to `putAsync` as failed futures as they should not be cached
+        // since they can still resolve on subsequent divulgence lookups (see [[MutableCacheBackedContractStore.readThroughContractsCache]]).
+        // Hence, this scenario is not considered an error condition and should not be logged as such.
+        // TODO Remove this type-check when properly caching divulgence lookups
+        case contractNotFound: ContractReadThroughNotFound =>
+          pendingUpdates.synchronized {
+            removeFromPending(key)
+          }
+          logger.debug(s"Not caching negative lookup for contract at key $key", contractNotFound)
+        case err =>
+          pendingUpdates.synchronized {
+            removeFromPending(key)
+          }
+          logger.warn(s"Failure in pending cache update for key $key", err)
       }
 
   private def removeFromPending(key: K)(implicit loggingContext: LoggingContext): Unit =
@@ -130,6 +163,14 @@ private[platform] case class StateCache[K, V](cache: Cache[K, V], registerUpdate
           logger.error(s"Expected pending updates tracker for key $key is missing")
         }
     )
+
+  private def truncateValueForLogging(value: V) = {
+    val stringValueRepr = value.toString
+    val maxValueLength = 250
+    if (stringValueRepr.length > maxValueLength)
+      stringValueRepr.take(maxValueLength) + "..."
+    else stringValueRepr
+  }
 }
 
 object StateCache {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreRaceTests.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreRaceTests.scala
@@ -1,0 +1,471 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.cache
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.offset.Offset
+import com.daml.lf.crypto.Hash
+import com.daml.lf.data.{Ref, Time}
+import com.daml.lf.transaction.GlobalKey
+import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value.{ContractInstance, ValueInt64, VersionedValue}
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.store.EventSequentialId
+import com.daml.platform.store.appendonlydao.events.ContractStateEvent
+import com.daml.platform.store.cache.MutableCacheBackedContractStore.EventSequentialId
+import com.daml.platform.store.cache.MutableCacheBackedContractStoreRaceTests.{
+  IndexViewContractsReader,
+  assert_sync_vs_async_race_contract,
+  assert_sync_vs_async_race_key,
+  buildContractStore,
+  generateWorkload,
+  test,
+}
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader
+import com.daml.platform.store.interfaces.LedgerDaoContractsReader._
+import org.mockito.MockitoSugar
+import org.scalatest.Assertions.fail
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.Executors
+import scala.annotation.tailrec
+import scala.collection.immutable.{TreeMap, VectorMap}
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.Random
+
+class MutableCacheBackedContractStoreRaceTests
+    extends AsyncFlatSpec
+    with Matchers
+    with Eventually
+    with MockitoSugar
+    with BeforeAndAfterAll {
+  behavior of "Mutable state cache updates"
+
+  private val unboundedExecutionContext =
+    ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
+  private val actorSystem = ActorSystem()
+  private implicit val materializer: Materializer = Materializer(actorSystem)
+
+  it should "preserve causal monotonicity under contention for key state" in {
+    val workload = generateWorkload(keysCount = 10L, contractsCount = 1000L)
+    val indexViewContractsReader = IndexViewContractsReader()(unboundedExecutionContext)
+    val contractStore = buildContractStore(indexViewContractsReader, unboundedExecutionContext)
+
+    for {
+      _ <- test(indexViewContractsReader, workload, unboundedExecutionContext) { ec => event =>
+        assert_sync_vs_async_race_key(contractStore)(event)(ec)
+      }
+    } yield succeed
+  }
+
+  it should "preserve causal monotonicity under contention for contract state" in {
+    val workload = generateWorkload(keysCount = 10L, contractsCount = 1000L)
+    val indexViewContractsReader = IndexViewContractsReader()(unboundedExecutionContext)
+    val contractStore = buildContractStore(indexViewContractsReader, unboundedExecutionContext)
+
+    for {
+      _ <- test(indexViewContractsReader, workload, unboundedExecutionContext) { ec => event =>
+        assert_sync_vs_async_race_contract(contractStore)(event)(ec)
+      }
+    } yield succeed
+  }
+
+  override def afterAll(): Unit = {
+    Await.ready(actorSystem.terminate(), 10.seconds)
+    materializer.shutdown()
+  }
+}
+
+private object MutableCacheBackedContractStoreRaceTests {
+  private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
+  private val stakeholders = Set(Ref.Party.assertFromString("some-stakeholder"))
+
+  private def test(
+      indexViewContractsReader: IndexViewContractsReader,
+      workload: Seq[EventSequentialId => SimplifiedContractStateEvent],
+      unboundedExecutionContext: ExecutionContext,
+  )(
+      assert: ExecutionContext => SimplifiedContractStateEvent => Future[Unit]
+  )(implicit materializer: Materializer): Future[Done] =
+    Source
+      .fromIterator(() => workload.iterator)
+      .statefulMapConcat { () =>
+        var eventSequentialId = 0L
+
+        eventCtor => {
+          eventSequentialId += 1
+          Iterator(eventCtor(eventSequentialId))
+        }
+      }
+      .map(event => {
+        indexViewContractsReader.update(event)
+        event
+      })
+      .mapAsync(1)(
+        // Validate the view's contents (test sanity-check)
+        assertIndexState(indexViewContractsReader, _)(unboundedExecutionContext)
+      )
+      .mapAsync(1)(assert(unboundedExecutionContext))
+      .run()
+
+  private def assert_sync_vs_async_race_key(
+      contractStore: MutableCacheBackedContractStore
+  )(event: SimplifiedContractStateEvent)(implicit ec: ExecutionContext): Future[Unit] = {
+    val contractStateEvent = toContractStateEvent(event)
+
+    // Start async key lookup
+    // Use Future.delegate here to ensure immediate control handover to the next statement
+    val keyLookupF = Future.delegate(contractStore.lookupContractKey(stakeholders, event.key))
+    // Update the mutable contract state cache synchronously
+    contractStore.push(contractStateEvent)
+
+    for {
+      // Lookup after synchronous update
+      firstAsyncLookupResult <- contractStore.lookupContractKey(stakeholders, event.key)
+      _ <- keyLookupF
+      // Lookup after asynchronous update
+      secondAsyncLookupResult <- contractStore.lookupContractKey(stakeholders, event.key)
+    } yield {
+      assertKeyAssignmentAfterAppliedEvent(firstAsyncLookupResult)(event)
+      assertKeyAssignmentAfterAppliedEvent(secondAsyncLookupResult)(event)
+    }
+  }
+
+  private def assert_sync_vs_async_race_contract(
+      contractStore: MutableCacheBackedContractStore
+  )(event: SimplifiedContractStateEvent)(implicit ec: ExecutionContext): Future[Unit] = {
+    val contractStateEvent = toContractStateEvent(event)
+
+    // Start async contract lookup
+    // Use Future.delegate here to ensure immediate control handover to the next statement
+    val keyLookupF =
+      Future.delegate(contractStore.lookupActiveContract(stakeholders, event.contractId))
+    // Update the mutable contract state cache synchronously
+    contractStore.push(contractStateEvent)
+
+    for {
+      // Lookup after synchronous update
+      firstAsyncLookupResult <- contractStore.lookupActiveContract(stakeholders, event.contractId)
+      _ <- keyLookupF
+      // Lookup after asynchronous update
+      secondAsyncLookupResult <- contractStore.lookupActiveContract(stakeholders, event.contractId)
+    } yield {
+      assertContractIdAssignmentAfterAppliedEvent(firstAsyncLookupResult)(event)
+      assertContractIdAssignmentAfterAppliedEvent(secondAsyncLookupResult)(event)
+    }
+  }
+
+  private def assertKeyAssignmentAfterAppliedEvent(
+      assignment: Option[ContractId]
+  )(event: SimplifiedContractStateEvent): Unit =
+    assignment match {
+      case Some(contractId) if (event.contractId != contractId) || !event.created =>
+        fail(message =
+          s"Key state corruption for ${event.key}: " +
+            s"expected ${if (event.created) s"assignment to ${event.contractId} -> ${event.contract}"
+            else "unassigned"}, " +
+            s"but got assignment to $contractId"
+        )
+      case None if event.created =>
+        fail(message =
+          s"Key state corruption for ${event.key}: expected assignment to ${event.contractId} -> ${event.contract} " +
+            "but got unassigned instead"
+        )
+      case _ => ()
+    }
+
+  private def assertContractIdAssignmentAfterAppliedEvent(
+      assignment: Option[Contract]
+  )(event: SimplifiedContractStateEvent): Unit =
+    assignment match {
+      case Some(actualContract) if (event.contract != actualContract) || !event.created =>
+        fail(message =
+          s"Contract state corruption for ${event.contractId}: " +
+            s"expected ${if (event.created) s"active contract (${event.contract})"
+            else "non-active contract"}, but got assignment to $actualContract"
+        )
+      case None if event.created =>
+        fail(message =
+          s"Contract state corruption for ${event.contractId}: expected active contract ${event.contract} " +
+            "but got non-active contract"
+        )
+      case _ => ()
+    }
+
+  private def assertIndexState(
+      indexViewContractsReader: IndexViewContractsReader,
+      event: SimplifiedContractStateEvent,
+  )(implicit ec: ExecutionContext) =
+    for {
+      _ <- indexViewContractsReader
+        .lookupKeyState(event.key, event.eventSequentialId)
+        .map {
+          case KeyAssigned(contractId, _) if contractId == event.contractId && event.created =>
+          case KeyUnassigned if !event.created =>
+          case actual =>
+            fail(
+              s"Test bug: actual $actual after event $event: index view: ${indexViewContractsReader.keyStateStore
+                .get(event.key)}"
+            )
+        }
+      _ <- indexViewContractsReader
+        .lookupContractState(event.contractId, event.eventSequentialId)
+        .map {
+          case Some(ActiveContract(actualContract, _, _))
+              if event.created && event.contract == actualContract =>
+          case Some(ArchivedContract(_)) if !event.created =>
+          case actual =>
+            fail(
+              s"Test bug: actual $actual after event $event: index view: ${indexViewContractsReader.contractStateStore
+                .get(event.contractId)}"
+            )
+        }
+    } yield event
+
+  private def generateWorkload(
+      keysCount: Long,
+      contractsCount: Long,
+  ): Seq[EventSequentialId => SimplifiedContractStateEvent] = {
+    val keys = (0L until keysCount).map { keyIdx =>
+      keyIdx -> GlobalKey(Identifier.assertFromString("pkgId:module:entity"), ValueInt64(keyIdx))
+    }.toMap
+
+    val keysToContracts = keys.map { case (keyIdx, key) =>
+      val contractLifecyclesForKey = contractsCount / keysCount
+      key -> (0L until contractLifecyclesForKey)
+        .map { contractIdx =>
+          val globalContractIdx = keyIdx * contractLifecyclesForKey + contractIdx
+          val contractId = ContractId.V1(Hash.hashPrivateKey(globalContractIdx.toString))
+          val contractRef = contract(globalContractIdx)
+          (contractId, contractRef)
+        }
+        .foldLeft(VectorMap.empty[ContractId, Contract]) { case (r, (k, v)) =>
+          r.updated(k, v)
+        }
+    }
+
+    val updates =
+      keysToContracts.map { case (key, contracts) =>
+        contracts.flatMap { case (contractId, contractRef) =>
+          Vector(
+            (eventSeqId: EventSequentialId) =>
+              SimplifiedContractStateEvent(
+                eventSequentialId = eventSeqId,
+                contractId = contractId,
+                contract = contractRef,
+                created = true,
+                key = key,
+              ),
+            (eventSeqId: EventSequentialId) =>
+              SimplifiedContractStateEvent(
+                eventSequentialId = eventSeqId,
+                contractId = contractId,
+                contract = contractRef,
+                created = false,
+                key = key,
+              ),
+          )
+        }
+      }
+
+    interleaveRandom(updates)
+  }
+
+  private def interleaveRandom(
+      indexContractsUpdates: Iterable[Iterable[EventSequentialId => SimplifiedContractStateEvent]]
+  ): Seq[EventSequentialId => SimplifiedContractStateEvent] = {
+    @tailrec
+    def interleaveIteratorsRandom[T](acc: Vector[T], col: Set[Iterator[T]]): Vector[T] =
+      if (col.isEmpty) acc
+      else {
+        val vCol = col.toVector
+        val randomIteratorIndex = Random.nextInt(vCol.size)
+        val targetIterator = vCol(randomIteratorIndex)
+        if (targetIterator.hasNext) interleaveIteratorsRandom(acc :+ targetIterator.next(), col)
+        else interleaveIteratorsRandom(acc, col - targetIterator)
+      }
+
+    interleaveIteratorsRandom(
+      Vector.empty[EventSequentialId => SimplifiedContractStateEvent],
+      indexContractsUpdates.map(_.iterator).toSet,
+    )
+  }
+
+  final case class SimplifiedContractStateEvent(
+      eventSequentialId: EventSequentialId,
+      contractId: ContractId,
+      contract: Contract,
+      created: Boolean,
+      key: GlobalKey,
+  )
+
+  private def contract(idx: Long): Contract = {
+    val templateId = Identifier.assertFromString(s"somePackage:someModule:someEntity")
+    val contractArgument = Value.ValueInt64(idx)
+    val contractInstance = ContractInstance(templateId, contractArgument, "some agreement")
+    TransactionBuilder().versionContract(contractInstance)
+  }
+
+  private def buildContractStore(
+      indexViewContractsReader: IndexViewContractsReader,
+      ec: ExecutionContext,
+  ) = MutableCacheBackedContractStore(
+    contractsReader = indexViewContractsReader,
+    signalNewLedgerHead = (_, _) => (),
+    startIndexExclusive = EventSequentialId.beforeBegin,
+    metrics = new Metrics(new MetricRegistry),
+    maxContractsCacheSize = 1L,
+    maxKeyCacheSize = 1L,
+  )(ec, loggingContext)
+
+  private val toContractStateEvent: SimplifiedContractStateEvent => ContractStateEvent = {
+    case SimplifiedContractStateEvent(eventSequentialId, contractId, contract, created, key) =>
+      if (created)
+        ContractStateEvent.Created(
+          contractId = contractId,
+          contract = contract,
+          globalKey = Some(key),
+          ledgerEffectiveTime = Time.Timestamp.MinValue, // Not used
+          stakeholders = stakeholders, // Not used
+          eventOffset = Offset.beforeBegin, // Not used
+          eventSequentialId = eventSequentialId,
+        )
+      else
+        ContractStateEvent.Archived(
+          contractId = contractId,
+          globalKey = Some(key),
+          stakeholders = stakeholders, // Not used
+          eventOffset = Offset.beforeBegin, // Not used
+          eventSequentialId = eventSequentialId,
+        )
+  }
+
+  final case class ContractLifecycle(
+      contractId: ContractId,
+      contract: Contract,
+      createdAt: Long,
+      archivedAt: Option[Long],
+  )
+
+  // Simplified view of the index which models the evolution of the key and contracts state
+  private case class IndexViewContractsReader()(implicit ec: ExecutionContext)
+      extends LedgerDaoContractsReader {
+    private type CreatedAt = Long
+    @volatile private[cache] var contractStateStore = Map.empty[ContractId, ContractLifecycle]
+    @volatile private[cache] var keyStateStore = Map.empty[Key, TreeMap[CreatedAt, ContractId]]
+
+    // Evolves the index state
+    // Non-thread safe
+    def update(event: SimplifiedContractStateEvent): Unit =
+      if (event.created) {
+        // On create
+        contractStateStore = contractStateStore.updatedWith(event.contractId) {
+          case None =>
+            Some(
+              ContractLifecycle(
+                contractId = event.contractId,
+                contract = event.contract,
+                createdAt = event.eventSequentialId,
+                archivedAt = None,
+              )
+            )
+          case lastState @ Some(_) =>
+            fail(s"Contract state update conflict: last state $lastState vs even $event")
+        }
+
+        keyStateStore = keyStateStore.updatedWith(event.key) {
+          case None => Some(TreeMap(event.eventSequentialId -> event.contractId))
+          case Some(assignments) =>
+            val (lastContractAssignedAt, currentContractId) = assignments.last
+            val lastContract = contractStateStore(currentContractId)
+            val createdAt = event.eventSequentialId
+            if (lastContractAssignedAt < createdAt && lastContract.archivedAt.exists(_ < createdAt))
+              Some(assignments + (createdAt -> event.contractId))
+            else fail(s"Key state update conflict: last state $lastContract vs event $event")
+        }
+      } else {
+        // On archive
+        contractStateStore = contractStateStore.updatedWith(event.contractId) {
+          case Some(contractLifecycle @ ContractLifecycle(contractId, _, createdAt, None))
+              if event.eventSequentialId > createdAt && event.contractId == contractId =>
+            Some(contractLifecycle.copy(archivedAt = Some(event.eventSequentialId)))
+          case lastState =>
+            fail(s"Contract state update conflict: last state $lastState vs even $event")
+        }
+
+        keyStateStore = keyStateStore.updatedWith(event.key) {
+          case Some(assignments) =>
+            val (currentCreatedAt, currentContractId) = assignments.last
+            val lastContractAssignment = contractStateStore(currentContractId)
+            val archivedAt = event.eventSequentialId
+            if (currentCreatedAt < archivedAt && lastContractAssignment.archivedAt.nonEmpty)
+              Some(assignments + (archivedAt -> event.contractId))
+            else
+              fail(s"Key state update conflict: last state $lastContractAssignment vs event $event")
+          case faultyState =>
+            fail(s"Key state update conflict: $faultyState vs event $event")
+        }
+      }
+
+    override def lookupContractState(contractId: ContractId, validAt: Long)(implicit
+        loggingContext: LoggingContext
+    ): Future[Option[ContractState]] =
+      Future {
+        val _ = loggingContext
+        contractStateStore
+          .get(contractId)
+          .flatMap { case ContractLifecycle(_, contract, createdAt, maybeArchivedAt) =>
+            if (validAt < createdAt) None
+            else if (maybeArchivedAt.forall(_ > validAt))
+              Some(ActiveContract(contract, stakeholders, Time.Timestamp.MinValue))
+            else Some(ArchivedContract(stakeholders))
+          }
+      }(ec)
+
+    override def lookupKeyState(key: Key, validAt: Long)(implicit
+        loggingContext: LoggingContext
+    ): Future[KeyState] = Future {
+      val _ = loggingContext
+      keyStateStore
+        .get(key)
+        .map(_.maxBefore(validAt + 1) match {
+          case Some((_, contractId)) =>
+            contractStateStore(contractId).archivedAt match {
+              case Some(archivedAt) if archivedAt <= validAt => KeyUnassigned
+              case _ => KeyAssigned(contractId, stakeholders)
+            }
+          case None => KeyUnassigned
+        })
+        .getOrElse(KeyUnassigned)
+    }(ec)
+
+    override def lookupActiveContractAndLoadArgument(readers: Set[Party], contractId: ContractId)(
+        implicit loggingContext: LoggingContext
+    ): Future[Option[Contract]] = {
+      val _ = (loggingContext, readers, contractId)
+      // Needs to return None for divulgence lookups
+      Future.successful(None)
+    }
+
+    override def lookupActiveContractWithCachedArgument(
+        readers: Set[Party],
+        contractId: ContractId,
+        createArgument: VersionedValue,
+    )(implicit loggingContext: LoggingContext): Future[Option[Contract]] = {
+      val _ = (loggingContext, readers, contractId, createArgument)
+      // Needs to return None for divulgence lookups
+      Future.successful(None)
+    }
+  }
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/MutableCacheBackedContractStoreSpec.scala
@@ -69,15 +69,17 @@ class MutableCacheBackedContractStoreSpec
 
   "cache initialization" should {
     "set the cache index to the initialization index" in {
-      val cacheInitializationIndex = Offset.fromByteArray(1337.toByteArray) -> 1337L
+      val cacheInitializationIndex = 1337L
       contractStore(cachesSize = 0L, startIndexExclusive = cacheInitializationIndex).asFuture
-        .map(_.cacheIndex() shouldBe cacheInitializationIndex)
+        .map { mutableCacheBackedContractStore =>
+          mutableCacheBackedContractStore.keyCache.cacheIndex shouldBe 1337L
+          mutableCacheBackedContractStore.contractsCache.cacheIndex shouldBe 1337L
+        }
     }
   }
 
   "event stream consumption" should {
     "populate the caches from the contract state event stream" in {
-
       val lastLedgerHead =
         new AtomicReference[(Offset, Long)]((Offset.beforeBegin, EventSequentialId.beforeBegin))
       val capture_signalLedgerHead: SignalNewLedgerHead =
@@ -95,26 +97,23 @@ class MutableCacheBackedContractStoreSpec
           cachesSize = 2L,
           ContractsReaderFixture(),
           capture_signalLedgerHead,
-          _ => source,
+          () => source,
         ).asFuture
         c1 <- createdEvent(cId_1, contract1, Some(someKey), Set(charlie), 1L, t1)
         _ <- eventually {
           store.contractsCache.get(cId_1) shouldBe Some(Active(contract1, Set(charlie), t1))
           store.keyCache.get(someKey) shouldBe Some(Assigned(cId_1, Set(charlie)))
-          store.cacheIndex()._2 shouldBe 1L
         }
 
         _ <- archivedEvent(c1, eventSequentialId = 2L)
         _ <- eventually {
           store.contractsCache.get(cId_1) shouldBe Some(Archived(Set(charlie)))
           store.keyCache.get(someKey) shouldBe Some(Unassigned)
-          store.cacheIndex()._2 shouldBe 2L
         }
 
         someOffset = Offset.fromByteArray(1337.toByteArray)
         _ <- ledgerEnd(someOffset, 3L)
         _ <- eventually {
-          store.cacheIndex()._2 shouldBe 3L
           lastLedgerHead.get() shouldBe (someOffset -> 3L)
         }
       } yield succeed
@@ -158,15 +157,17 @@ class MutableCacheBackedContractStoreSpec
       )
 
       val sourceSubscriptionFixture: SubscribeToContractStateEvents = {
-        case (Offset.beforeBegin, EventSequentialId.beforeBegin) =>
-          Source
-            .fromIterator(() => Iterator(created, archived, dummy))
-            // Simulate the source failure at the last event
-            .map(x => if (x == dummy) throw new RuntimeException("some transient failure") else x)
-        case (_, 2L) =>
-          Source.fromIterator(() => Iterator(anotherCreate))
-        case subscriptionOffset =>
-          fail(s"Unexpected subscription offsets $subscriptionOffset")
+        @volatile var firstSource = true
+        () =>
+          if (firstSource) {
+            firstSource = false
+            Source
+              .fromIterator(() => Iterator(created, archived, dummy))
+              // Simulate the source failure at the last event
+              .map(x => if (x == dummy) throw new RuntimeException("some transient failure") else x)
+          } else {
+            Source.fromIterator(() => Iterator(anotherCreate))
+          }
       }
 
       for {
@@ -180,7 +181,6 @@ class MutableCacheBackedContractStoreSpec
           store.contractsCache.get(cId_1) shouldBe Some(Archived(Set(charlie)))
           store.contractsCache.get(cId_2) shouldBe Some(Active(contract2, Set(alice), t2))
           store.keyCache.get(someKey) shouldBe Some(Assigned(cId_2, Set(alice)))
-          store.cacheIndex() shouldBe offset3 -> 3L
         }
       } yield succeed
     }
@@ -191,15 +191,15 @@ class MutableCacheBackedContractStoreSpec
       val spyContractsReader = spy(ContractsReaderFixture())
       for {
         store <- contractStore(cachesSize = 1L, spyContractsReader).asFuture
-        _ = store.cacheIndex.set(unusedOffset, 1L)
+        _ = store.contractsCache.cacheIndex = 1L
         cId2_lookup <- store.lookupActiveContract(Set(alice), cId_2)
         another_cId2_lookup <- store.lookupActiveContract(Set(alice), cId_2)
 
-        _ = store.cacheIndex.set(unusedOffset, 2L)
+        _ = store.contractsCache.cacheIndex = 2L
         cId3_lookup <- store.lookupActiveContract(Set(bob), cId_3)
         another_cId3_lookup <- store.lookupActiveContract(Set(bob), cId_3)
 
-        _ = store.cacheIndex.set(unusedOffset, 3L)
+        _ = store.contractsCache.cacheIndex = 3L
         nonExistentCId = contractId(5)
         nonExistentCId_lookup <- store.lookupActiveContract(Set.empty, nonExistentCId)
         another_nonExistentCId_lookup <- store.lookupActiveContract(Set.empty, nonExistentCId)
@@ -224,7 +224,7 @@ class MutableCacheBackedContractStoreSpec
       val spyContractsReader = spy(ContractsReaderFixture())
       for {
         store <- contractStore(cachesSize = 1L, spyContractsReader).asFuture
-        _ = store.cacheIndex.set(unusedOffset, 1L)
+        _ = store.contractsCache.cacheIndex = 1L
         negativeLookup_cId6 <- store.lookupActiveContract(Set(alice), cId_6)
         positiveLookup_cId6 <- store.lookupActiveContract(Set(alice), cId_6)
       } yield {
@@ -241,7 +241,7 @@ class MutableCacheBackedContractStoreSpec
       val spyContractsReader = spy(ContractsReaderFixture())
       for {
         store <- contractStore(cachesSize = 1L, spyContractsReader).asFuture
-        _ = store.cacheIndex.set(unusedOffset, 1L)
+        _ = store.contractsCache.cacheIndex = 1L
         resolvedLookup_cId7 <- store.lookupActiveContract(Set(bob), cId_7)
       } yield {
         resolvedLookup_cId7 shouldBe Some(contract7)
@@ -257,11 +257,11 @@ class MutableCacheBackedContractStoreSpec
         cId1_lookup0 <- store.lookupActiveContract(Set(alice), cId_1)
         cId2_lookup0 <- store.lookupActiveContract(Set(bob), cId_2)
 
-        _ = store.cacheIndex.set(unusedOffset, 1L)
+        _ = store.contractsCache.cacheIndex = 1L
         cId1_lookup1 <- store.lookupActiveContract(Set(alice), cId_1)
         cid1_lookup1_archivalNotDivulged <- store.lookupActiveContract(Set(charlie), cId_1)
 
-        _ = store.cacheIndex.set(unusedOffset, 2L)
+        _ = store.contractsCache.cacheIndex = 2L
         cId2_lookup2 <- store.lookupActiveContract(Set(bob), cId_2)
         cid2_lookup2_divulged <- store.lookupActiveContract(Set(charlie), cId_2)
         cid2_lookup2_nonVisible <- store.lookupActiveContract(Set(alice), cId_2)
@@ -289,7 +289,7 @@ class MutableCacheBackedContractStoreSpec
         assigned_firstLookup <- store.lookupContractKey(Set(alice), someKey)
         assigned_secondLookup <- store.lookupContractKey(Set(alice), someKey)
 
-        _ = store.cacheIndex.set(unusedOffset, 1L)
+        _ = store.keyCache.cacheIndex = 1L
         unassigned_firstLookup <- store.lookupContractKey(Set(alice), unassignedKey)
         unassigned_secondLookup <- store.lookupContractKey(Set(alice), unassignedKey)
       } yield {
@@ -311,14 +311,14 @@ class MutableCacheBackedContractStoreSpec
         store <- contractStore(cachesSize = 0L).asFuture
         key_lookup0 <- store.lookupContractKey(Set(alice), someKey)
 
-        _ = store.cacheIndex.set(unusedOffset, 1L)
+        _ = store.keyCache.cacheIndex = 1L
         key_lookup1 <- store.lookupContractKey(Set(alice), someKey)
 
-        _ = store.cacheIndex.set(unusedOffset, 2L)
+        _ = store.keyCache.cacheIndex = 2L
         key_lookup2 <- store.lookupContractKey(Set(bob), someKey)
         key_lookup2_notVisible <- store.lookupContractKey(Set(charlie), someKey)
 
-        _ = store.cacheIndex.set(unusedOffset, 3L)
+        _ = store.keyCache.cacheIndex = 3L
         key_lookup3 <- store.lookupContractKey(Set(bob), someKey)
       } yield {
         key_lookup0 shouldBe Some(cId_1)
@@ -334,7 +334,6 @@ class MutableCacheBackedContractStoreSpec
     "return the maximum ledger time with cached values" in {
       for {
         store <- contractStore(cachesSize = 2L).asFuture
-        _ = store.cacheIndex.set(unusedOffset, 2L)
         // populate the cache
         _ <- store.lookupActiveContract(Set(bob), cId_2)
         _ <- store.lookupActiveContract(Set(bob), cId_3)
@@ -347,7 +346,6 @@ class MutableCacheBackedContractStoreSpec
     "fail if one of the cached contract ids doesn't have an associated active contract" in {
       for {
         store <- contractStore(cachesSize = 1L).asFuture
-        _ = store.cacheIndex.set(unusedOffset, 2L)
         // populate the cache
         _ <- store.lookupActiveContract(Set(bob), cId_5)
         maxLedgerTime <- store.lookupMaximumLedgerTimeAfterInterpretation(Set(cId_1, cId_5))
@@ -359,7 +357,6 @@ class MutableCacheBackedContractStoreSpec
     "fail if one of the fetched contract ids doesn't have an associated active contract" in {
       for {
         store <- contractStore(cachesSize = 0L).asFuture
-        _ = store.cacheIndex.set(unusedOffset, 2L)
         maxLedgerTime <- store.lookupMaximumLedgerTimeAfterInterpretation(Set(cId_1, cId_5))
       } yield {
         // since with cacheIndex 2L both of them are archived due to set semantics it is accidental which we check first with read-through
@@ -421,7 +418,6 @@ class MutableCacheBackedContractStoreSpec
 }
 
 object MutableCacheBackedContractStoreSpec {
-  private val unusedOffset = Offset.beforeBegin
   private val Seq(alice, bob, charlie) = Seq("alice", "bob", "charlie").map(party)
   private val (
     Seq(cId_1, cId_2, cId_3, cId_4, cId_5, cId_6, cId_7),
@@ -438,9 +434,8 @@ object MutableCacheBackedContractStoreSpec {
       cachesSize: Long,
       readerFixture: LedgerDaoContractsReader = ContractsReaderFixture(),
       signalNewLedgerHead: (Offset, Long) => Unit = (_, _) => (),
-      sourceSubscriber: SubscribeToContractStateEvents = _ => Source.empty,
-      startIndexExclusive: (Offset, EventSequentialId) =
-        Offset.beforeBegin -> EventSequentialId.beforeBegin,
+      sourceSubscriber: SubscribeToContractStateEvents = () => Source.empty,
+      startIndexExclusive: EventSequentialId = EventSequentialId.beforeBegin,
   )(implicit loggingContext: LoggingContext, materializer: Materializer) = {
     implicit val resourceContext: ResourceContext = ResourceContext(
       scala.concurrent.ExecutionContext.global

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/StateCacheSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/StateCacheSpec.scala
@@ -3,8 +3,6 @@
 
 package com.daml.platform.store.cache
 
-import java.util.concurrent.TimeUnit
-
 import com.codahale.metrics.MetricRegistry
 import com.daml.caching.{CaffeineCache, ConcurrentCache}
 import com.daml.logging.LoggingContext
@@ -13,15 +11,19 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import org.mockito.MockitoSugar
 import org.scalatest.Assertion
 import org.scalatest.concurrent.Eventually
-import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Success
 
-class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Eventually {
+class StateCacheSpec extends AsyncFlatSpec with Matchers with MockitoSugar with Eventually {
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
+  override implicit def executionContext: ExecutionContext =
+    scala.concurrent.ExecutionContext.global
+
   private val cacheUpdateTimer = new Metrics(
     new MetricRegistry
   ).daml.execution.cache.registerCacheUpdate
@@ -29,13 +31,15 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
   behavior of s"${classOf[StateCache[_, _]].getSimpleName}.putAsync"
 
   it should "asynchronously store the update" in {
-    implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
-
     val cache = mock[ConcurrentCache[String, String]]
-    val stateCache = StateCache[String, String](cache, cacheUpdateTimer)
+    val stateCache = StateCache[String, String](
+      initialCacheIndex = 0L,
+      cache = cache,
+      registerUpdateTimer = cacheUpdateTimer,
+    )
 
     val asyncUpdatePromise = Promise[String]()
-    val putAsyncResult = stateCache.putAsync("key", 1L, asyncUpdatePromise.future)
+    val putAsyncResult = stateCache.putAsync("key", { case 0L => asyncUpdatePromise.future })
     asyncUpdatePromise.completeWith(Future.successful("value"))
 
     for {
@@ -49,7 +53,6 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
   }
 
   it should "store the latest key update in face of conflicting pending updates" in {
-    implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
     val `number of competing updates` = 100L
     val `number of keys in cache` = 100L
 
@@ -61,9 +64,7 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
 
     insertionDuration should be < 1.second
 
-    insertions.foreach { case (_, (promise, value, _)) =>
-      promise.complete(Success(value))
-    }
+    insertions.foreach { case (_, (promise, value)) => promise.complete(Success(value)) }
 
     for {
       result <- Future.sequence(insertionFutures.toVector)
@@ -74,7 +75,6 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
   }
 
   it should "putAsync 100_000 values for the same key in 1 second" in {
-    implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
     val `number of competing updates` = 100000L
     val `number of keys in cache` = 1L
 
@@ -86,9 +86,7 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
 
     insertionDuration should be < 1.second
 
-    insertions.foreach { case (_, (promise, value, _)) =>
-      promise.complete(Success(value))
-    }
+    insertions.foreach { case (_, (promise, value)) => promise.complete(Success(value)) }
 
     for {
       result <- Future.sequence(insertionFutures.toVector)
@@ -101,13 +99,15 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
   behavior of s"${classOf[StateCache[_, _]].getSimpleName}.put"
 
   it should "synchronously update the cache in front of older asynchronous updates" in {
-    implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
-
     val cache = mock[ConcurrentCache[String, String]]
-    val stateCache = StateCache[String, String](cache, cacheUpdateTimer)
+    val stateCache = StateCache[String, String](
+      initialCacheIndex = 0L,
+      cache = cache,
+      registerUpdateTimer = cacheUpdateTimer,
+    )
 
     val asyncUpdatePromise = Promise[String]()
-    val putAsyncResult = stateCache.putAsync("key", 1L, asyncUpdatePromise.future)
+    val putAsyncResult = stateCache.putAsync("key", { case 0L => asyncUpdatePromise.future })
     stateCache.put("key", 2L, "value")
     asyncUpdatePromise.completeWith(Future.successful("should not update the cache"))
 
@@ -121,29 +121,23 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
     }
   }
 
-  it should "not update the cache if the update is older than other competing updates" in {
-    implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
-
+  it should "not update the cache if called with a non-increasing `validAt`" in {
     val cache = mock[ConcurrentCache[String, String]]
-    val stateCache = StateCache[String, String](cache, cacheUpdateTimer)
+    val stateCache = StateCache[String, String](0L, cache, cacheUpdateTimer)
 
-    val asyncUpdatePromise = Promise[String]()
-    val putAsyncResult = stateCache.putAsync("key", 2L, asyncUpdatePromise.future)
-    stateCache.put("key", 1L, "should not update the cache")
-    asyncUpdatePromise.completeWith(Future.successful("value"))
+    stateCache.put("key", 2L, "value")
+    // `Put` at a decreasing validAt
+    stateCache.put("key", 1L, "earlier value")
+    stateCache.put("key", 2L, "value at same validAt")
 
-    for {
-      _ <- putAsyncResult
-    } yield {
-      verify(cache).put("key", "value")
-      // Synchronous update should not insert in the cache
-      verifyNoMoreInteractions(cache)
-      succeed
-    }
+    verify(cache).put("key", "value")
+    verifyNoMoreInteractions(cache)
+    succeed
   }
 
   private def buildStateCache(cacheSize: Long): StateCache[String, String] =
     StateCache[String, String](
+      initialCacheIndex = 0L,
       cache = CaffeineCache[String, String](
         Caffeine
           .newBuilder()
@@ -156,15 +150,15 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
   private def prepare(
       `number of competing updates`: Long,
       `number of keys in cache`: Long,
-  ): Seq[(String, (Promise[String], String, Long))] = {
+  ): Seq[(String, (Promise[String], String))] = {
     for {
       i <- 1L to `number of keys in cache`
       j <- 1L to `number of competing updates`
-    } yield (s"key-$i", (Promise[String](), s"value-$j", j))
+    } yield (s"key-$i", (Promise[String](), s"value-$j"))
   }
 
   private def assertCacheElements(stateCache: StateCache[String, String])(
-      insertions: Seq[(String, (Promise[String], String, Long))],
+      insertions: Seq[(String, (Promise[String], String))],
       numberOfCompetingUpdates: Long,
   ): Assertion = {
     insertions
@@ -179,11 +173,15 @@ class StateCacheSpec extends AnyFlatSpec with Matchers with MockitoSugar with Ev
   }
 
   private def insertTimed(stateCache: StateCache[String, String])(
-      insertions: Seq[(String, (Promise[String], String, Long))]
+      insertions: Seq[(String, (Promise[String], String))]
   ): (Seq[Future[Unit]], FiniteDuration) =
     time {
-      insertions.map { case (key, (promise, _, validAt)) =>
-        stateCache.putAsync(key, validAt, promise.future)
+      insertions.map { case (key, (promise, _)) =>
+        stateCache.cacheIndex += 1
+        val validAt = stateCache.cacheIndex
+        stateCache
+          .putAsync(key, { case `validAt` => promise.future })
+          .map(_ => ())(scala.concurrent.ExecutionContext.global)
       }
     }
 


### PR DESCRIPTION
This PR is a backport of https://github.com/digital-asset/daml/pull/13325. 

changelog_begin
[Ledger API] A race condition bug is fixed in the Ledger API mutable contract state cache.
The bug allowed the cache to become corrupted with stale references when the Ledger API
was subjected to concurrent submissions racing to update/fetch the same contract key.
The stale references were causing the Ledger API to erroneously reject submissions in
certain corner-cases.
changelog_end

* Pull cache indexes to StateCache
* Passes the test

* Fixing StateCacheSpec and MutabelCacheBackedContractStoreSpec
* Added invalidate test to ConcurrentCacheCachingSpecBase

* Address Marton's review comments

* Do not log a warn on negative contract lookups

* Update cache outside the source restart

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
