### PR TITLE
ifaces: tests for by_interface in transactions

### DIFF
--- a/compiler/scenario-service/client/test/DA/Daml/LF/PrettyScenarioSpec.hs
+++ b/compiler/scenario-service/client/test/DA/Daml/LF/PrettyScenarioSpec.hs
@@ -65,12 +65,14 @@ toPtx nodes = case runState (mapM go nodes) (0, []) of
                 , node_CreateSignatories = V.empty
                 , node_CreateStakeholders = V.empty
                 , node_CreateKeyWithMaintainers = Nothing
+                , node_CreateByInterface = Nothing
                 }
               Fetch -> pure $ S.NodeNodeFetch S.Node_Fetch
                 { node_FetchContractId = "#0"
                 , node_FetchTemplateId = Nothing
                 , node_FetchSignatories = V.empty
                 , node_FetchStakeholders = V.empty
+                , node_FetchByInterface = Nothing
                 }
               Lookup -> pure $ S.NodeNodeLookupByKey S.Node_LookupByKey
                 { node_LookupByKeyTemplateId = Nothing
@@ -94,6 +96,7 @@ toPtx nodes = case runState (mapM go nodes) (0, []) of
                     , node_ExerciseChildren = V.fromList children'
                     , node_ExerciseExerciseResult = if complete then Just (S.Value (Just (S.ValueSumUnit S.Empty))) else Nothing
                     , node_ExerciseConsuming = False
+                    , node_ExerciseByInterface = Nothing
                     }
           let node = S.Node
                 { nodeNodeId = Just nid

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -551,6 +551,7 @@ message Node {
     repeated Party signatories = 2;
     repeated Party stakeholders = 3;
     KeyWithMaintainers key_with_maintainers = 4; // optional
+    Identifier byInterface = 5; //optional
   }
 
   message Fetch {
@@ -558,6 +559,7 @@ message Node {
     Identifier template_id = 2;
     repeated Party signatories = 3;
     repeated Party stakeholders = 4;
+    Identifier byInterface = 5; //optional
   }
 
   message Exercise {
@@ -572,6 +574,7 @@ message Node {
     repeated Party stakeholders = 9;
     repeated NodeId children = 11;
     Value exercise_result = 12; // None for incomplete/aborted exercise nodes.
+    Identifier byInterface = 13; // optional
   }
 
   message LookupByKey {

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -523,14 +523,16 @@ final class Conversions(
         nodeInfo.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setCreate(createBuilder.build)
       case fetch: Node.Fetch =>
-        builder.setFetch(
+        val fetchBuilder =
           proto.Node.Fetch.newBuilder
             .setContractId(coidToEventId(fetch.coid).toLedgerString)
             .setTemplateId(convertIdentifier(fetch.templateId))
             .addAllSignatories(fetch.signatories.map(convertParty).asJava)
             .addAllStakeholders(fetch.stakeholders.map(convertParty).asJava)
-            .build
+        fetch.byInterface.foreach(ifaceId =>
+          fetchBuilder.setByInterface(convertIdentifier(ifaceId))
         )
+        builder.setFetch(fetchBuilder.build)
       case ex: Node.Exercise =>
         nodeInfo.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         val exerciseBuilder =
@@ -549,6 +551,9 @@ final class Conversions(
                 .toSeq
                 .asJava
             )
+        ex.byInterface.foreach(ifaceId =>
+          exerciseBuilder.setByInterface(convertIdentifier(ifaceId))
+        )
 
         ex.exerciseResult.foreach { result =>
           exerciseBuilder.setExerciseResult(convertValue(result))
@@ -609,6 +614,9 @@ final class Conversions(
             )
             .addAllSignatories(create.signatories.map(convertParty).asJava)
             .addAllStakeholders(create.stakeholders.map(convertParty).asJava)
+        create.byInterface.foreach(ifaceId =>
+          createBuilder.setByInterface(convertIdentifier(ifaceId))
+        )
         create.versionedKey.foreach(key =>
           createBuilder.setKeyWithMaintainers(convertKeyWithMaintainers(key))
         )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -257,13 +257,21 @@ private[lf] object Pretty {
       case Node.Rollback(children) =>
         text("rollback:") / stack(children.toList.map(prettyEventInfo(l, txId)))
       case create: Node.Create =>
-        val d = "create" &: prettyContractInst(create.coinst)
+        val d = ("create" &: prettyContractInst(create.coinst)) &
+          (create.byInterface match {
+            case None => text("")
+            case Some(ifaceId) => text("as interface") & prettyIdentifier(ifaceId)
+          })
         create.versionedKey match {
           case None => d
           case Some(key) => d / text("key") & prettyVersionedKeyWithMaintainers(key)
         }
       case ea: Node.Fetch =>
-        "ensure active" &: prettyContractId(ea.coid)
+        ("ensure active" &: prettyContractId(ea.coid)) &
+          (ea.byInterface match {
+            case None => text("")
+            case Some(ifaceId) => text("as interface") & prettyIdentifier(ifaceId)
+          })
       case ex: Node.Exercise =>
         val children =
           if (ex.children.nonEmpty)
@@ -272,6 +280,10 @@ private[lf] object Pretty {
             text("")
         intercalate(text(", "), ex.actingParties.map(p => text(p))) &
           text("exercises") & text(ex.choiceId) + char(':') + prettyIdentifier(ex.templateId) &
+          (ex.byInterface match {
+            case None => text("")
+            case Some(ifaceId) => text("as interface") & prettyIdentifier(ifaceId)
+          }) &
           text("on") & prettyContractId(ex.targetCoid) /
           (text("    ") + text("with") & prettyValue(false)(ex.chosenValue) / children)
             .nested(4)

--- a/daml-lf/tests/scenario/actualize.sh
+++ b/daml-lf/tests/scenario/actualize.sh
@@ -7,7 +7,7 @@
 #
 # Note: Use absolute path for the target Daml file as bazel seems to set the current directory...
 #
-# Usage: actualize.sh <path-to-daml-file>
+# Usage: actualize.sh <path-to-daml-file> <1.dev>
 #
 
 set -eux
@@ -15,13 +15,20 @@ set -eux
 export LC_ALL="en_US.UTF-8"
 
 TESTMAIN=$1
+USEDEV=$2
 TESTDIR="$(dirname $TESTMAIN)"
 TESTDAR="$TESTDIR/Main.dar"
 BAZEL_BIN="$(bazel info bazel-bin)"
 REGEX_HIDE_HASHES="s,@[a-z0-9]{8},@XXXXXXXX,g"
 
+if [ "$2" = "1.dev" ] ; then
+  TARGETFLAG="--target 1.dev"
+else
+  TARGETFLAG=""
+fi
+
 bazel build //compiler/damlc:damlc
-../../../bazel-bin/compiler/damlc/damlc package --debug $TESTMAIN main -o $TESTDAR
+../../../bazel-bin/compiler/damlc/damlc package $TARGETFLAG --enable-scenarios=yes --debug $TESTMAIN main -o $TESTDAR
 
 bazel build //daml-lf/repl:repl
 ../../../bazel-bin/daml-lf/repl/repl --dev test Test:run $TESTDAR | sed -E "$REGEX_HIDE_HASHES" | tee ${TESTDIR}/EXPECTED.ledger.new

--- a/daml-lf/tests/scenario/dev/interfaces/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/dev/interfaces/EXPECTED.ledger
@@ -7,7 +7,7 @@ TX #1 1970-01-01T00:00:00Z [Test:84] version: dev
 │   referenced by #1:1, #1:2, #1:3
 │   known to (since): alice (#1)
 └─> create Test:Asset@XXXXXXXX
-    with: { issuer = 'alice', owner = 'alice', amount = 15 } 
+    with: { issuer = 'alice', owner = 'alice', amount = 15 }
 
 #1:1 version: dev
 │   known to (since): alice (#1)

--- a/daml-lf/tests/scenario/dev/interfaces/EXPECTED.ledger.new
+++ b/daml-lf/tests/scenario/dev/interfaces/EXPECTED.ledger.new
@@ -1,0 +1,33 @@
+transactions:
+mustFailAt actAs: {'alice'} readAs: {} [Test:79]
+
+TX #1 1970-01-01T00:00:00Z [Test:84] version: dev
+#1:0 version: dev
+│   archived by #1:3
+│   referenced by #1:1, #1:2, #1:3
+│   known to (since): alice (#1)
+└─> create Test:Asset@XXXXXXXX
+    with: { issuer = 'alice', owner = 'alice', amount = 15 } 
+
+#1:1 version: dev
+│   known to (since): alice (#1)
+└─> alice exercises Noop:Test:Asset@XXXXXXXX as interface Test:Token@XXXXXXXX on 00f8a135f7c19707ef22dcfdd998a7d09626193f2776c56dad4576e9967ac4bd21
+    with { nothing = <unit> }
+    
+
+#1:2 version: dev
+│   known to (since): alice (#1)
+└─> ensure active 00f8a135f7c19707ef22dcfdd998a7d09626193f2776c56dad4576e9967ac4bd21 as interface Test:Token@XXXXXXXX
+
+#1:3 version: dev
+│   known to (since): alice (#1)
+└─> alice exercises GetRich:Test:Asset@XXXXXXXX as interface Test:Token@XXXXXXXX on 00f8a135f7c19707ef22dcfdd998a7d09626193f2776c56dad4576e9967ac4bd21
+    with { byHowMuch = 20 }
+    children:
+    #1:4 version: dev
+    │   known to (since): alice (#1)
+    └─> create Test:Asset@XXXXXXXX
+        with: { issuer = 'alice', owner = 'alice', amount = 35 } as interface Test:Token@XXXXXXXX
+
+active contracts:
+   00ad0974bff76405de024a21c5a62e6cf98a195d5c412bad51f4e5f3ca50f1a58b

--- a/daml-lf/tests/scenario/dev/interfaces/Test.daml
+++ b/daml-lf/tests/scenario/dev/interfaces/Test.daml
@@ -1,0 +1,93 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF-FEATURE DAML_INTERFACE
+
+module Test where
+
+import DA.Assert ((===))
+
+-- | An interface comment.
+interface Token where
+  getOwner : Party -- ^ A method comment.
+  getAmount : Int
+  setAmount : Int -> Token
+
+  splitImpl : Int -> Update (ContractId Token, ContractId Token)
+  transferImpl : Party -> Update (ContractId Token)
+  noopImpl : () -> Update ()
+
+  ensure (getAmount this >= 0)
+
+  choice Split : (ContractId Token, ContractId Token) -- ^ An interface choice comment.
+    with
+      splitAmount : Int -- ^ A choice field comment.
+    controller getOwner this
+    do
+      splitImpl this splitAmount
+
+  choice Transfer : ContractId Token
+    with
+      newOwner : Party
+    controller getOwner this, newOwner
+    do
+      transferImpl this newOwner
+
+  nonconsuming choice Noop : ()
+    with
+      nothing : ()
+    controller getOwner this
+    do
+      noopImpl this nothing
+
+  choice GetRich : ContractId Token
+    with
+      byHowMuch : Int
+    controller getOwner this
+    do
+        assert (byHowMuch > 0)
+        create $ setAmount this (getAmount this + byHowMuch)
+
+template Asset
+  with
+    issuer : Party
+    owner : Party
+    amount : Int
+  where
+    signatory issuer, owner
+    implements Token where
+      getOwner = owner
+      getAmount = amount
+      setAmount x = toInterface @Token (this with amount = x)
+
+      splitImpl splitAmount = do
+        assert (splitAmount < amount)
+        cid1 <- create this with amount = splitAmount
+        cid2 <- create this with amount = amount - splitAmount
+        pure (toInterfaceContractId @Token cid1, toInterfaceContractId @Token cid2)
+
+      transferImpl newOwner = do
+        cid <- create this with owner = newOwner
+        pure (toInterfaceContractId @Token cid)
+
+      noopImpl nothing = do
+        [1] === [1] -- make sure `mkMethod` calls are properly erased in the presence of polymorphism.
+        pure ()
+
+run = do
+  p <- getParty "alice"
+  p `submitMustFail` do
+    create Asset with
+      issuer = p
+      owner = p
+      amount = -1
+  p `submit` do
+    cidAsset1 <- create Asset with
+      issuer = p
+      owner = p
+      amount = 15
+    let cidToken1 = toInterfaceContractId @Token cidAsset1
+    cid <- exercise cidToken1 (Noop ())
+    _ <- fetch cidToken1
+    exercise cidToken1 $ GetRich with byHowMuch = 20
+    pure ()

--- a/daml-lf/tests/scenario/reset.sh
+++ b/daml-lf/tests/scenario/reset.sh
@@ -4,6 +4,6 @@
 
 shopt -s nullglob
 set -e
-for actual in */ACTUAL.ledger; do
-  cp -v "$actual" "${actual/ACTUAL/EXPECTED}"
+for actual in $(find . -name '*.new'); do
+  mv -v "$actual" "${actual%.new}"
 done


### PR DESCRIPTION
We add tests to check that by_interface fields are set for interface
transactions. We also extend the scenario service to show the
by_interface fields in the pretty printed transactions.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
