### PR TITLE
Remove unneccesary generality from Scala codegen

### DIFF
--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraph.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraph.scala
@@ -15,7 +15,7 @@ import scalaz.syntax.foldable._
 private[codegen] object DependencyGraph {
   def orderedDependencies(
       library: EnvironmentInterface
-  ): OrderedDependencies[Identifier, TypeDeclOrTemplateWrapper[DefTemplateWithRecord.FWT]] = {
+  ): OrderedDependencies[Identifier, TypeDeclOrTemplateWrapper[DefTemplateWithRecord]] = {
     val decls = library.typeDecls
     // invariant: no type decl name equals any template alias
     val typeDeclNodes =

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/lf/DefTemplateWithRecord.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/lf/DefTemplateWithRecord.scala
@@ -3,12 +3,9 @@
 
 package com.daml.lf.codegen.lf
 
-import com.daml.lf.iface
+import com.daml.lf.iface.{DefTemplate, Record, Type}
 
-case class DefTemplateWithRecord[+Type](
-    `type`: iface.Record[Type],
-    template: iface.DefTemplate[Type],
+final case class DefTemplateWithRecord(
+    `type`: Record[Type],
+    template: DefTemplate[Type],
 )
-object DefTemplateWithRecord {
-  type FWT = DefTemplateWithRecord[iface.Type]
-}

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlContractTemplateGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlContractTemplateGen.scala
@@ -27,7 +27,7 @@ object DamlContractTemplateGen {
   def generate(
       util: LFUtil,
       templateId: Identifier,
-      templateInterface: DefTemplateWithRecord.FWT,
+      templateInterface: DefTemplateWithRecord,
       companionMembers: Iterable[Tree],
   ): (File, Set[Tree], Iterable[Tree]) = {
 

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/HierarchicalOutput.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/HierarchicalOutput.scala
@@ -34,7 +34,7 @@ private[codegen] object HierarchicalOutput {
   type ErrorsAndFiles[E, F] = (Vector[E], Vector[(F, Iterable[Tree])])
 
   type TemplateOrDatatype =
-    (Identifier, DefTemplateWithRecord.FWT \/ DamlDataTypeGen.DataType)
+    (Identifier, DefTemplateWithRecord \/ DamlDataTypeGen.DataType)
 
   /** Pull up each `Rec` into the companion implied, or not, by the keys. */
   private[this] def liftSubtrees[S, F](

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/LFUtil.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/LFUtil.scala
@@ -33,11 +33,7 @@ final case class LFUtil(
   import scala.reflect.runtime.universe._
   import LFUtil._
 
-  type Interface = EnvironmentInterface
-
-  type TemplateInterface = DefTemplateWithRecord.FWT
-
-  def templateAndTypeFiles(wp: WriteParams[TemplateInterface]) =
+  def templateAndTypeFiles(wp: WriteParams[DefTemplateWithRecord]) =
     parent.CodeGen.produceTemplateAndTypeFilesLF(wp, this)
 
   def mkDamlScalaName(
@@ -298,14 +294,14 @@ final case class LFUtil(
       }.toList
   }
 
-  def templateCount(interface: Interface): Int = {
+  def templateCount(interface: EnvironmentInterface): Int = {
     interface.typeDecls.count {
       case (_, InterfaceType.Template(_, _)) => true
       case _ => false
     }
   }
 
-  private[this] def foldTemplateReferencedTypeDeclRoots[Z](interface: Interface, z: Z)(
+  private[this] def foldTemplateReferencedTypeDeclRoots[Z](interface: EnvironmentInterface, z: Z)(
       f: (Z, ScopedDataType.Name) => Z
   ): Z =
     interface.typeDecls.foldLeft(z) {
@@ -315,7 +311,7 @@ final case class LFUtil(
     }
 
   protected[this] def precacheVariance(
-      interface: Interface
+      interface: EnvironmentInterface
   ): ScopedDataType.Name => ImmArraySeq[Variance] = {
     import UsedTypeParams.ResolvedVariance
     val resolved = foldTemplateReferencedTypeDeclRoots(interface, ResolvedVariance.Empty) {


### PR DESCRIPTION
changelog_begin
changelog_end

Addresses https://github.com/digital-asset/daml/pull/13367#discussion_r832251452

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
