### PR TITLE
fix quadratic complexity for closure conversion of a multi-let

### DIFF
--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ClosureConversionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ClosureConversionTest.scala
@@ -153,8 +153,7 @@ class ClosureConversionTest extends AnyFreeSpec with Matchers with TableDrivenPr
 
   "stack-safety; wide" - {
 
-    // TODO https://github.com/digital-asset/daml/issues/13351
-    val width = 3000 // increase if fix quadratic behavior of let-expressions
+    val width = 10000
 
     val appGeneral = (xs: List[SExpr]) => {
       SEApp(leaf, xs)
@@ -175,7 +174,7 @@ class ClosureConversionTest extends AnyFreeSpec with Matchers with TableDrivenPr
         ("appGeneral", appGeneral),
         ("appWideBuiltin", appWideBuiltin),
         ("caseWide", caseWide),
-        ("letWide", letWide), //quadratic behavior
+        ("letWide", letWide),
       )
     }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PhaseOneTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PhaseOneTest.scala
@@ -118,7 +118,7 @@ class PhaseOneTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
         ("caseAlt1", caseAlt1),
         ("caseAlt2", caseAlt2),
         ("let1", let1),
-        ("let2", let2), //slow (2.6s for 5k; 11s for 10k -- quadratic?)
+        ("let2", let2),
         ("eabs_esome", eabs_esome),
         ("etyabs_esome", etyabs_esome),
         ("app1_esome", app1_esome),
@@ -142,10 +142,8 @@ class PhaseOneTest extends AnyFreeSpec with Matchers with TableDrivenPropertyChe
 
     {
       // TODO https://github.com/digital-asset/daml/issues/13351
-      // we reduce the depth when sequencing multiple compilation phases
-      // 2k is still plenty to check stack-safety
-      // But above this, some testcases start to become slower than 1second.
-      // And in particulat "let2' appears to quadratic behaviour
+      // The following testcases still appear quadratic during closure-conversion:
+      //    scenBlock2, ublock2, ublock3
       val depth = 2000
       s"transform(phase1, closureConversion), depth = $depth" - {
         forEvery(testCases) { (name: String, recursionPoint: Expr => Expr) =>


### PR DESCRIPTION
There were two problems in the handling of `Cont.Let1`
- use of `.length` on the growing  bounds list. now we track the size explicitly
- repeated extension of a base `env` by 1,2,3... instead of incrementally by +1, +1, +1 etc

This fix relates to these two issues: #11830  #13351
