### PR TITLE
Change misleading messages

### DIFF
--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -195,7 +195,7 @@ final class LedgerTestCasesRunner(
   ): Future[Vector[LedgerTestSummary]] = {
     val testCaseRepetitions = testCases.flatMap(_.repetitions)
     val testCount = testCaseRepetitions.size
-    logger.info(s"Running $testCount tests, ${math.min(testCount, concurrency)} at a time.")
+    logger.info(s"Running $testCount tests with concurrency of $concurrency.")
     Source(testCaseRepetitions.zipWithIndex)
       .mapAsyncUnordered(concurrency) { case (test, index) =>
         run(test, ledgerSession).map(summarize(test.suite, test.testCase, _) -> index)

--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/Config.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/Config.scala
@@ -178,7 +178,6 @@ object Config {
               "management-service-timeout, " +
               "run-mode, " +
               "shard-name, " +
-              "indexer-connection-pool-size, " +
               "indexer-connection-timeout, " +
               "indexer-max-input-buffer-size, " +
               "indexer-input-mapping-parallelism, " +

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigurationSubscriptionFromIndex.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/configuration/LedgerConfigurationSubscriptionFromIndex.scala
@@ -4,11 +4,11 @@
 package com.daml.platform.apiserver.configuration
 
 import java.util.concurrent.atomic.AtomicReference
-
 import akka.actor.{Cancellable, Scheduler}
 import akka.stream.scaladsl.{Keep, RestartSource, Sink}
 import akka.stream.{KillSwitches, Materializer, RestartSettings, UniqueKillSwitch}
 import akka.{Done, NotUsed}
+import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.domain.LedgerOffset
 import com.daml.ledger.configuration.Configuration
@@ -87,7 +87,9 @@ private[apiserver] final class LedgerConfigurationSubscriptionFromIndex(
             override def run(): Unit = {
               if (readyPromise.trySuccess(())) {
                 logger.warn(
-                  s"No ledger configuration found after $configurationLoadTimeout. The ledger API server will now start but all services that depend on the ledger configuration will return UNAVAILABLE until at least one ledger configuration is found."
+                  s"No ledger configuration found after $configurationLoadTimeout. The ledger API server will now start " +
+                    s"but all services that depend on the ledger configuration will return " +
+                    s"${LedgerApiErrors.RequestValidation.NotFound.LedgerConfiguration.id} until at least one ledger configuration is found."
                 )
               }
               ()


### PR DESCRIPTION
1. `indexer-connection-pool-size` no longer exists.
2. The logging was resulting in misleading log messages, especially when running with `--include`:
```
23-03-2022 14:53:37.338 UTC|INFO ||c.d.l.a.t.i.LedgerTestCasesRunner|scala-execution-context-global-22|||||Running 0 tests, 0 at a time.||
23-03-2022 14:53:37.426 UTC|INFO ||c.d.l.a.t.i.LedgerTestCasesRunner|scala-execution-context-global-22|||||Running 2 tests, 1 at a time.||
```
3. If config doesn't exist, services return "LEDGER_CONFIGURATION_NOT_FOUND" and not "UNAVAILABLE".

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
