### PR TITLE
Move the public methods on `NonEmpty` to companion object

### DIFF
--- a/libs-scala/nonempty-cats/src/main/scala/nonempty/catsinstances/impl/CatsInstancesLow.scala
+++ b/libs-scala/nonempty-cats/src/main/scala/nonempty/catsinstances/impl/CatsInstancesLow.scala
@@ -11,7 +11,7 @@ abstract class CatsInstancesLow extends CatsInstancesLow1 {
   implicit def `cats nonempty foldable`[F[_]](implicit
       F: Foldable[F]
   ): Foldable[NonEmptyF[F, *]] with ImplicitPreference[Nothing] =
-    ImplicitPreference[Foldable[NonEmptyF[F, *]], Nothing](NonEmpty substF F)
+    ImplicitPreference[Foldable[NonEmptyF[F, *]], Nothing](NonEmptyColl.Instance substF F)
 }
 
 abstract class CatsInstancesLow1 {

--- a/libs-scala/nonempty-cats/src/main/scala/nonempty/catsinstances/package.scala
+++ b/libs-scala/nonempty-cats/src/main/scala/nonempty/catsinstances/package.scala
@@ -7,5 +7,5 @@ import cats.Traverse
 
 package object catsinstances extends catsinstances.impl.CatsInstancesLow {
   implicit def `cats nonempty traverse`[F[_]](implicit F: Traverse[F]): Traverse[NonEmptyF[F, *]] =
-    NonEmpty substF F
+    NonEmptyColl.Instance substF F
 }

--- a/libs-scala/nonempty-cats/src/test/scala/nonempty/catsinstances/CatsInstancesSpec.scala
+++ b/libs-scala/nonempty-cats/src/test/scala/nonempty/catsinstances/CatsInstancesSpec.scala
@@ -47,6 +47,6 @@ object CatsInstancesSpec {
 
   implicit def `nonempty f eq`[F[_], A](implicit FA: Eq[F[A]]): Eq[NonEmptyF[F, A]] = {
     type T[k[_]] = Eq[k[A]]
-    NonEmpty.substF[T, F](FA)
+    NonEmptyColl.Instance.substF[T, F](FA)
   }
 }

--- a/libs-scala/nonempty/src/main/scala/nonempty/NonEmptyReturningOps.scala
+++ b/libs-scala/nonempty/src/main/scala/nonempty/NonEmptyReturningOps.scala
@@ -17,25 +17,25 @@ object NonEmptyReturningOps {
       private val self: IterableOps[A, CC, C with imm.Iterable[A]]
   ) extends AnyVal {
     def groupBy1[K](f: A => K): Map[K, NonEmpty[C]] =
-      NonEmpty.subst[Lambda[f[_] => Map[K, f[C]]]](self groupBy f)
+      NonEmptyColl.Instance.subst[Lambda[f[_] => Map[K, f[C]]]](self groupBy f)
   }
 
   implicit final class `NE Seq Ops`[A, CC[X] <: imm.Seq[X], C](
       private val self: SeqOps[A, CC, C with imm.Seq[A]]
   ) extends AnyVal {
-    import NonEmpty.{unsafeNarrow => un}
+    import NonEmptyColl.Instance.{unsafeNarrow => un}
 
     def +-:(elem: A): NonEmpty[CC[A]] = un(elem +: self)
     def :-+(elem: A): NonEmpty[CC[A]] = un(self :+ elem)
   }
 
   implicit final class `NE Set Ops`[A](private val self: Set[A]) extends AnyVal {
-    import NonEmpty.{unsafeNarrow => un}
+    import NonEmptyColl.Instance.{unsafeNarrow => un}
     def incl1(elem: A): NonEmpty[Set[A]] = un(self + elem)
   }
 
   implicit final class `NE Foldable1 Ops`[F[_], A](self: F[A])(implicit F: Foldable1[F]) {
-    import NonEmpty.{unsafeNarrow => un}
+    import NonEmptyColl.Instance.{unsafeNarrow => un}
     def toSet1: NonEmpty[Set[A]] = un(F toSet self)
     def toVector1: NonEmpty[Vector[A]] = un(F toVector self)
   }

--- a/libs-scala/nonempty/src/main/scala/nonempty/package.scala
+++ b/libs-scala/nonempty/src/main/scala/nonempty/package.scala
@@ -4,7 +4,6 @@
 package com.daml
 
 package object nonempty {
-  val NonEmpty: NonEmptyColl = NonEmptyColl.Instance
 
   /** A non-empty `A`.  Implicitly converts to `A` in relevant contexts.
     *
@@ -29,7 +28,7 @@ package object nonempty {
     * Using this library sensibly with Scala 2.12 requires `-Xsource:2.13` and
     * `-Ypartial-unification`.
     */
-  type NonEmpty[+A] = NonEmpty.NonEmpty[A]
+  type NonEmpty[+A] = NonEmptyColl.Instance.NonEmpty[A]
 
   /** A subtype of `NonEmpty[F[A]]` where `A` is in position to be inferred
     * properly.  When attempting to fit a type to the type params `C[T]`, scalac
@@ -50,7 +49,7 @@ package object nonempty {
     * V]]`, then `bar.toNEF: NonEmptyF[Map[K, *], V]`, because that's how scalac
     * destructures that type.
     */
-  type NonEmptyF[F[_], A] = NonEmpty.NonEmptyF[F, A]
+  type NonEmptyF[F[_], A] = NonEmptyColl.Instance.NonEmptyF[F, A]
 
   val ±: : +-:.type = +-:
   val :∓ : :-+.type = :-+


### PR DESCRIPTION
Now the signatures of those methods refer to the type synonyms defined in the package object rather than to the abstract type members of the class.
This makes sure that IntelliJ will find the implict classes for NonEmpty and NonEmptyF.

Before this change, there is a lot of red in IntelliJ 2021.2.4:
![image](https://user-images.githubusercontent.com/36634420/160120772-4008fef7-8f96-48be-a97d-cd12103dd91b.png)


After this change, it looks all nice:
![image](https://user-images.githubusercontent.com/36634420/160119861-521b1f92-88a7-481b-bc7f-94d68c1dc1f8.png)



### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
