### PR TITLE
Explore interpreter performance

### DIFF
--- a/daml-lf/interpreter/perf/daml/Examples.daml
+++ b/daml-lf/interpreter/perf/daml/Examples.daml
@@ -3,9 +3,10 @@
 
 module Examples where
 
-nfib 0 = 1
-nfib 1 = 1
-nfib n = nfib (n-1) + nfib (n-2) + 1
+--nfib 0 = 1
+--nfib 1 = 1
+--nfib n = nfib (n-1) + nfib (n-2) + 1
+nfib n = if n < 2 then 1 else nfib (n-1) + nfib (n-2) + 1
 
 triangle 0 = 0
 triangle n = n + triangle (n-1)

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/SpeedTestNfib.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/SpeedTestNfib.scala
@@ -22,7 +22,7 @@ object SpeedTestNfib extends App {
 
   println(s"Running...");
 
-  val n = 28L
+  val n = 29L
 
   while (true) {
     val start = System.currentTimeMillis()

--- a/xbc/BUILD.bazel
+++ b/xbc/BUILD.bazel
@@ -1,0 +1,28 @@
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+)
+
+da_scala_binary(
+    name = "xbc",
+    srcs = glob([
+        "src/**/*.scala",
+    ]),
+    main_class = "xbc.Speed",
+    deps = [
+        "@maven//:org_ow2_asm_asm",
+        "byhandjava",
+    ],
+)
+
+java_library(
+    name = "byhandjava",
+    srcs = glob([
+        "src/**/*.java",
+    ]),
+    deps = [
+    ],
+)

--- a/xbc/bytecode.text
+++ b/xbc/bytecode.text
@@ -1,0 +1,199 @@
+Classfile /home/nic/daml/tmp/xbc/ByHandScala$.class
+  Last modified Jan 1, 2010; size 942 bytes
+  MD5 checksum 18778ac8ccc8ba32c12291cd2531f452
+  Compiled from "ByHandScala.scala"
+public final class xbc.ByHandScala$
+  minor version: 0
+  major version: 52
+  flags: (0x0031) ACC_PUBLIC, ACC_FINAL, ACC_SUPER
+  this_class: #2                          // xbc/ByHandScala$
+  super_class: #4                         // java/lang/Object
+  interfaces: 0, fields: 1, methods: 5, attributes: 3
+Constant pool:
+   #1 = Utf8               xbc/ByHandScala$
+   #2 = Class              #1             // xbc/ByHandScala$
+   #3 = Utf8               java/lang/Object
+   #4 = Class              #3             // java/lang/Object
+   #5 = Utf8               ByHandScala.scala
+   #6 = Utf8               MODULE$
+   #7 = Utf8               Lxbc/ByHandScala$;
+   #8 = Utf8               <clinit>
+   #9 = Utf8               ()V
+  #10 = Utf8               <init>
+  #11 = NameAndType        #10:#9         // "<init>":()V
+  #12 = Methodref          #2.#11         // xbc/ByHandScala$."<init>":()V
+  #13 = NameAndType        #6:#7          // MODULE$:Lxbc/ByHandScala$;
+  #14 = Fieldref           #2.#13         // xbc/ByHandScala$.MODULE$:Lxbc/ByHandScala$;
+  #15 = Utf8               nfib
+  #16 = Utf8               (J)J
+  #17 = Utf8               n
+  #18 = Long               2l
+  #20 = NameAndType        #15:#16        // nfib:(J)J
+  #21 = Methodref          #2.#20         // xbc/ByHandScala$.nfib:(J)J
+  #22 = Utf8               this
+  #23 = Utf8               J
+  #24 = Utf8               tripLoop
+  #25 = Utf8               (JJJ)J
+  #26 = Utf8               step
+  #27 = Utf8               acc
+  #28 = Utf8               i
+  #29 = Utf8               trip
+  #30 = Long               3l
+  #32 = NameAndType        #24:#25        // tripLoop:(JJJ)J
+  #33 = Methodref          #2.#32         // xbc/ByHandScala$.tripLoop:(JJJ)J
+  #34 = Methodref          #4.#11         // java/lang/Object."<init>":()V
+  #35 = Utf8               Code
+  #36 = Utf8               LineNumberTable
+  #37 = Utf8               StackMapTable
+  #38 = Utf8               LocalVariableTable
+  #39 = Utf8               MethodParameters
+  #40 = Utf8               SourceFile
+  #41 = Utf8               ScalaInlineInfo
+  #42 = Utf8               Scala
+{
+  public static final xbc.ByHandScala$ MODULE$;
+    descriptor: Lxbc/ByHandScala$;
+    flags: (0x0019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL
+
+  public static {};
+    descriptor: ()V
+    flags: (0x0009) ACC_PUBLIC, ACC_STATIC
+    Code:
+      stack=2, locals=0, args_size=0
+         0: new           #2                  // class xbc/ByHandScala$
+         3: dup
+         4: invokespecial #12                 // Method "<init>":()V
+         7: putstatic     #14                 // Field MODULE$:Lxbc/ByHandScala$;
+        10: return
+      LineNumberTable:
+        line 9: 0
+
+  public long nfib(long);
+    descriptor: (J)J
+    flags: (0x0001) ACC_PUBLIC
+    Code:
+      stack=7, locals=3, args_size=2
+         0: lload_1
+         1: ldc2_w        #18                 // long 2l
+         4: lcmp
+         5: ifge          12
+         8: lconst_1
+         9: goto          31
+        12: aload_0
+        13: lload_1
+        14: lconst_1
+        15: lsub
+        16: invokevirtual #21                 // Method nfib:(J)J
+        19: aload_0
+        20: lload_1
+        21: ldc2_w        #18                 // long 2l
+        24: lsub
+        25: invokevirtual #21                 // Method nfib:(J)J
+        28: ladd
+        29: lconst_1
+        30: ladd
+        31: lreturn
+      StackMapTable: number_of_entries = 2
+        frame_type = 12 /* same */
+        frame_type = 82 /* same_locals_1_stack_item */
+          stack = [ long ]
+      LineNumberTable:
+        line 14: 0
+        line 15: 8
+        line 17: 12
+      LocalVariableTable:
+        Start  Length  Slot  Name   Signature
+            0      32     0  this   Lxbc/ByHandScala$;
+            0      32     1     n   J
+    MethodParameters:
+      Name                           Flags
+      n                              final
+
+  public long tripLoop(long, long, long);
+    descriptor: (JJJ)J
+    flags: (0x0001) ACC_PUBLIC
+    Code:
+      stack=8, locals=7, args_size=4
+         0: lload         5
+         2: lconst_1
+         3: lcmp
+         4: ifge          11
+         7: lload_3
+         8: goto          26
+        11: lload_1
+        12: lload_3
+        13: lload_1
+        14: ladd
+        15: lload         5
+        17: lconst_1
+        18: lsub
+        19: lstore        5
+        21: lstore_3
+        22: lstore_1
+        23: goto          0
+        26: lreturn
+      StackMapTable: number_of_entries = 3
+        frame_type = 0 /* same */
+        frame_type = 10 /* same */
+        frame_type = 78 /* same_locals_1_stack_item */
+          stack = [ long ]
+      LineNumberTable:
+        line 23: 0
+        line 25: 11
+      LocalVariableTable:
+        Start  Length  Slot  Name   Signature
+            0      27     0  this   Lxbc/ByHandScala$;
+            0      27     1  step   J
+            0      27     3   acc   J
+            0      27     5     i   J
+    MethodParameters:
+      Name                           Flags
+      step                           final
+      acc                            final
+      i                              final
+
+  public long trip(long);
+    descriptor: (J)J
+    flags: (0x0001) ACC_PUBLIC
+    Code:
+      stack=7, locals=5, args_size=2
+         0: ldc2_w        #30                 // long 3l
+         3: lstore_3
+         4: aload_0
+         5: lload_3
+         6: lconst_0
+         7: lload_1
+         8: invokevirtual #33                 // Method tripLoop:(JJJ)J
+        11: lreturn
+      LineNumberTable:
+        line 31: 0
+        line 32: 4
+      LocalVariableTable:
+        Start  Length  Slot  Name   Signature
+            4       7     3  step   J
+            0      12     0  this   Lxbc/ByHandScala$;
+            0      12     1     i   J
+    MethodParameters:
+      Name                           Flags
+      i                              final
+
+  private xbc.ByHandScala$();
+    descriptor: ()V
+    flags: (0x0002) ACC_PRIVATE
+    Code:
+      stack=1, locals=1, args_size=1
+         0: aload_0
+         1: invokespecial #34                 // Method java/lang/Object."<init>":()V
+         4: return
+      LineNumberTable:
+        line 9: 0
+      LocalVariableTable:
+        Start  Length  Slot  Name   Signature
+            0       5     0  this   Lxbc/ByHandScala$;
+}
+SourceFile: "ByHandScala.scala"
+  ScalaInlineInfo: length = 0x18 (unknown attribute)
+   01 01 00 04 00 0A 00 09 01 00 0F 00 10 01 00 1D
+   00 10 01 00 18 00 19 01
+  Scala: length = 0x0 (unknown attribute)
+

--- a/xbc/inspect-bytecode.sh
+++ b/xbc/inspect-bytecode.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# expect to be run from root of repo
+
+t=tmp # fixed temp dir local to invoking dir, it'll do!
+rm -rf $t
+
+repo=/home/nic/daml #discover automtically from here
+jar=$repo/bazel-bin/xbc/xbc.jar
+class=xbc/ByHandScala$.class
+
+mkdir $t
+(cd $t; cat $jar | jar -x $class)
+find $t -name *.class | xargs javap -p -v > xbc/bytecode.text
+rm -rf $t
+

--- a/xbc/src/BoxedValue.scala
+++ b/xbc/src/BoxedValue.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+sealed abstract class BoxedValue
+
+object BoxedValue {
+
+  final case class Number(x: Long) extends BoxedValue
+  final case class String(s: String) extends BoxedValue
+
+  def mul(v1: BoxedValue, v2: BoxedValue): BoxedValue = {
+    (v1, v2) match {
+      case (Number(x1), Number(x2)) => Number(x1 * x2)
+      case _ => sys.error("BoxedValue.mul")
+    }
+  }
+
+  def add(v1: BoxedValue, v2: BoxedValue): BoxedValue = {
+    (v1, v2) match {
+      case (Number(x1), Number(x2)) => Number(x1 + x2)
+      case _ => sys.error("BoxedValue.add")
+    }
+  }
+
+  def sub(v1: BoxedValue, v2: BoxedValue): BoxedValue = {
+    (v1, v2) match {
+      case (Number(x1), Number(x2)) => Number(x1 - x2)
+      case _ => sys.error("BoxedValue.sub")
+    }
+  }
+
+  def cmp(v1: BoxedValue, v2: BoxedValue): BoxedValue = {
+    (v1, v2) match {
+      case (Number(x1), Number(x2)) => Number(if (x1 > x2) 1 else if (x1 == x2) 0 else -1)
+      case _ => sys.error("BoxedValue.cmp")
+    }
+  }
+
+  def isNeg(v: BoxedValue): Boolean = {
+    v match {
+      case Number(x) => x < 0
+      case _ => sys.error("BoxedValue.isNeg")
+    }
+  }
+
+  def getNumber(v: BoxedValue): Option[Long] = {
+    v match {
+      case Number(x) => Some(x)
+      case _ => None
+    }
+  }
+
+}

--- a/xbc/src/ByHandJava.java
+++ b/xbc/src/ByHandJava.java
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc;
+
+// Examples writen natively in JAVA -- using static methods
+class ByHandJava {
+
+    // v1: uppercase "Long" -- slow!
+    static Long nfib_v1(Long n) {
+        if (n < 2) {
+            return 1L;
+        } else {
+            return nfib_v1(n - 1) + nfib_v1(n - 2) + 1L;
+        }
+    }
+
+    // v2: lowercase "long" -- quick!
+    static long nfib_v2(long n) {
+        if (n < 2) {
+            return 1L;
+        } else {
+            return nfib_v2(n - 1) + nfib_v2(n - 2) + 1L;
+        }
+    }
+
+
+}

--- a/xbc/src/ByHandJava.java
+++ b/xbc/src/ByHandJava.java
@@ -6,23 +6,21 @@ package xbc;
 // Examples writen natively in JAVA -- using static methods
 class ByHandJava {
 
-    // v1: uppercase "Long" -- slow!
-    static Long nfib_v1(Long n) {
-        if (n < 2) {
-            return 1L;
-        } else {
-            return nfib_v1(n - 1) + nfib_v1(n - 2) + 1L;
-        }
+  // v1: uppercase "Long" -- slow!
+  static Long nfib_v1(Long n) {
+    if (n < 2) {
+      return 1L;
+    } else {
+      return nfib_v1(n - 1) + nfib_v1(n - 2) + 1L;
     }
+  }
 
-    // v2: lowercase "long" -- quick!
-    static long nfib_v2(long n) {
-        if (n < 2) {
-            return 1L;
-        } else {
-            return nfib_v2(n - 1) + nfib_v2(n - 2) + 1L;
-        }
+  // v2: lowercase "long" -- quick!
+  static long nfib_v2(long n) {
+    if (n < 2) {
+      return 1L;
+    } else {
+      return nfib_v2(n - 1) + nfib_v2(n - 2) + 1L;
     }
-
-
+  }
 }

--- a/xbc/src/ByHandScala.scala
+++ b/xbc/src/ByHandScala.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+import scala.annotation.tailrec
+
+// Examples writen natively in scala
+object ByHandScala {
+
+  def nfib(n: Long): Long = {
+    // Not quite the fib function, as here we +1 in the recursive case.
+    // So the function result is equal to the number of function calls.
+    if (n < 2) {
+      1
+    } else {
+      nfib(n - 1) + nfib(n - 2) + 1
+    }
+  }
+
+  @tailrec
+  def tripLoop(step: Long, acc: Long, i: Long): Long = {
+    if (i < 1) acc
+    else {
+      tripLoop(step, acc + step, i - 1)
+    }
+  }
+
+  def trip(i: Long): Long = {
+    // compute 3*n using iteration
+    val step = 3L
+    tripLoop(step, 0L, i)
+  }
+
+}

--- a/xbc/src/ByteCode.scala
+++ b/xbc/src/ByteCode.scala
@@ -11,7 +11,7 @@ final class ByteCode(className: String, methodName: String, bytes: Array[Byte]) 
     val base = "/tmp/"
     val path = base + className + ".class"
     val f = new FileOutputStream(path)
-    //println(s"generating $path, #${bytes.length} bytes")
+    // println(s"generating $path, #${bytes.length} bytes")
     f.write(bytes)
   }
 

--- a/xbc/src/ByteCode.scala
+++ b/xbc/src/ByteCode.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+import java.io.FileOutputStream
+
+final class ByteCode(className: String, methodName: String, bytes: Array[Byte]) {
+
+  def dump() = {
+    val base = "/tmp/"
+    val path = base + className + ".class"
+    val f = new FileOutputStream(path)
+    //println(s"generating $path, #${bytes.length} bytes")
+    f.write(bytes)
+  }
+
+  // load and invoke some (perhaps dynamically generated) bytecode
+  case object MyClassLoader extends ClassLoader {
+    override def findClass(name: String): Class[_] = {
+      defineClass(name, bytes, 0, bytes.length)
+    }
+  }
+
+  def run0(): Long = { // run with 0 args; return long
+    val aClass = MyClassLoader.loadClass(className)
+    val method = aClass.getMethod(methodName)
+    method.invoke(null).asInstanceOf[Long]
+  }
+
+  def run2(arg1: Long, arg2: Long): Long = { // run with 2 long args; return long
+    val aClass = MyClassLoader.loadClass(className)
+    val longType: Class[_] = classOf[Long]
+    val method = aClass.getMethod(methodName, longType, longType)
+    val res: Object = method.invoke(null, arg1, arg2)
+    res.asInstanceOf[Long]
+  }
+
+}

--- a/xbc/src/Compiler.scala
+++ b/xbc/src/Compiler.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+import org.objectweb.asm._
+import org.objectweb.asm.Opcodes._
+
+object Compiler { // compiler from Lang to ByteCode
+
+  import Lang._
+
+  type Value = Long
+
+  val className = "ClassForCompiledLangExpression"
+
+  def compile(program: Program): ByteCode = {
+
+    val cw: ClassWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES)
+    cw.visit(V1_8, ACC_PUBLIC, className, null, "java/lang/Object", null)
+
+    def compileMethod(mv: MethodVisitor, body: Exp): Unit = {
+
+      def compileBinOp(binOp: BinOp): Unit = {
+        binOp match {
+          case MulOp => mv.visitInsn(LMUL)
+          case AddOp => mv.visitInsn(LADD)
+          case SubOp => mv.visitInsn(LSUB)
+          case CmpOp => mv.visitInsn(LCMP)
+        }
+      }
+
+      def compileExp(exp: Exp): Unit = {
+        exp match {
+
+          case Num(long) =>
+            mv.visitLdcInsn(long)
+
+          case Builtin(binOp, e1, e2) =>
+            compileExp(e1)
+            compileExp(e2)
+            compileBinOp(binOp)
+
+          case IfNeg(e1, e2, e3) =>
+            val labElse = new Label()
+            val labJoin = new Label()
+            compileExp(e1)
+            mv.visitJumpInsn(IFGE, labElse)
+            compileExp(e2)
+            mv.visitJumpInsn(GOTO, labJoin)
+            mv.visitLabel(labElse)
+            compileExp(e3)
+            mv.visitLabel(labJoin)
+
+          case Arg(i) =>
+            // compute assuming we are a static method, and all args are long
+            val pos = 2 * i
+            mv.visitIntInsn(LLOAD, pos)
+
+          case FnCall(fnName, args) =>
+            val subMethodName = "my_" + fnName
+            args.foreach { arg =>
+              compileExp(arg)
+            }
+            val arity = args.length
+            val argTypes = List.fill(arity)('J').mkString
+            mv.visitMethodInsn(
+              INVOKESTATIC,
+              className,
+              subMethodName,
+              s"($argTypes)J",
+              false,
+            )
+        }
+      }
+      compileExp(body)
+      mv.visitInsn(LRETURN)
+      mv.visitMaxs(-1, -1)
+    }
+
+    def compileDef(fnName: FnName, arity: Int, body: Exp): Unit = {
+      val subMethodName = "my_" + fnName
+      val argTypes = List.fill(arity)('J').mkString
+      val mv: MethodVisitor =
+        cw.visitMethod(
+          ACC_PUBLIC | ACC_STATIC,
+          subMethodName,
+          s"($argTypes)J",
+          null,
+          null,
+        )
+      compileMethod(mv, body)
+    }
+
+    val entryMethodName = "startHere"
+
+    def compileMain(main: Exp): Unit = {
+      val mv: MethodVisitor =
+        cw.visitMethod(ACC_PUBLIC | ACC_STATIC, entryMethodName, "()J", null, null)
+      compileMethod(mv, main)
+    }
+
+    program match {
+      case Program(defs, main) =>
+        defs.foreach { case ((name, arity), body) =>
+          compileDef(name, arity, body)
+        }
+        compileMain(main)
+    }
+
+    val bytes = cw.toByteArray()
+    new ByteCode(className, entryMethodName, bytes)
+
+  }
+
+}

--- a/xbc/src/Interpret.scala
+++ b/xbc/src/Interpret.scala
@@ -44,7 +44,7 @@ object Interpret { // basic interpreter for Lang
                 case None => sys.error(s"FnCall: $fnName/$arity")
                 case Some(body) =>
                   val vs = args.map(eval(_)).toVector
-                  evalFrame(vs, body) //tailcall
+                  evalFrame(vs, body) // tailcall
               }
             case _ =>
               eval(body)

--- a/xbc/src/Interpret.scala
+++ b/xbc/src/Interpret.scala
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+import scala.annotation.tailrec
+
+object Interpret { // basic interpreter for Lang
+
+  import Lang._
+
+  type Value = Long
+
+  def standard(program: Program): Value = {
+    program match {
+      case Program(defs, main) =>
+        def nested_evalFrame = evalFrame _
+
+        @tailrec
+        def evalFrame(actuals: Vector[Value], body: Exp): Value = {
+
+          def eval(exp: Exp): Value =
+            exp match {
+              case Num(x) => x
+              case Builtin(binOp, e1, e2) => applyBinOp(binOp, eval(e1), eval(e2))
+              case IfNeg(e1, e2, e3) => if (eval(e1) < 0) eval(e2) else eval(e3)
+              case Arg(i) => actuals(i)
+              case FnCall(fnName, args) =>
+                val arity = args.length
+                defs.get(fnName, arity) match {
+                  case None => sys.error(s"FnCall: $fnName/$arity")
+                  case Some(body) =>
+                    val vs = args.map(eval(_)).toVector
+                    nested_evalFrame(vs, body)
+                }
+            }
+
+          body match {
+            case IfNeg(e1, e2, e3) =>
+              if (eval(e1) < 0) evalFrame(actuals, e2) else evalFrame(actuals, e3)
+            case FnCall(fnName, args) =>
+              val arity = args.length
+              defs.get(fnName, arity) match {
+                case None => sys.error(s"FnCall: $fnName/$arity")
+                case Some(body) =>
+                  val vs = args.map(eval(_)).toVector
+                  evalFrame(vs, body) //tailcall
+              }
+            case _ =>
+              eval(body)
+          }
+        }
+
+        evalFrame(Vector(), main)
+    }
+  }
+
+  def applyBinOp(binOp: BinOp, v1: Value, v2: Value): Value = {
+    binOp match {
+      case MulOp => v1 * v2
+      case AddOp => v1 + v2
+      case SubOp => v1 - v2
+      case CmpOp => if (v1 > v2) 1 else if (v1 == v2) 0 else -1
+    }
+  }
+
+}

--- a/xbc/src/InterpretB.scala
+++ b/xbc/src/InterpretB.scala
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+import scala.annotation.tailrec
+
+object InterpretB { // interpreter for Lang, producing boxed values
+  import Lang._
+
+  type Value = BoxedValue
+
+  def run(program: Program): Value = {
+    program match {
+      case Program(defs, main) =>
+        def nested_evalFrame = evalFrame _
+
+        @tailrec
+        def evalFrame(actuals: Vector[Value], body: Exp): Value = {
+
+          def eval(exp: Exp): Value =
+            exp match {
+              case Num(x) => BoxedValue.Number(x)
+              case Builtin(binOp, e1, e2) => applyBinOp(binOp, eval(e1), eval(e2))
+              case IfNeg(e1, e2, e3) =>
+                if (BoxedValue.isNeg(eval(e1))) eval(e2) else eval(e3)
+              case Arg(i) => actuals(i)
+              case FnCall(fnName, args) =>
+                val arity = args.length
+                defs.get(fnName, arity) match {
+                  case None => sys.error(s"FnCall: $fnName/$arity")
+                  case Some(body) =>
+                    val vs = args.map(eval(_)).toVector
+                    nested_evalFrame(vs, body)
+                }
+            }
+
+          body match {
+            case IfNeg(e1, e2, e3) =>
+              if (BoxedValue.isNeg(eval(e1))) evalFrame(actuals, e2) else evalFrame(actuals, e3)
+            case FnCall(fnName, args) =>
+              val arity = args.length
+              defs.get(fnName, arity) match {
+                case None => sys.error(s"FnCall: $fnName/$arity")
+                case Some(body) =>
+                  val vs = args.map(eval(_)).toVector
+                  evalFrame(vs, body) //tailcall
+              }
+            case _ =>
+              eval(body)
+          }
+        }
+
+        evalFrame(Vector(), main)
+    }
+  }
+
+  def applyBinOp(binOp: BinOp, v1: Value, v2: Value): Value = {
+    binOp match {
+      case MulOp => BoxedValue.mul(v1, v2)
+      case AddOp => BoxedValue.add(v1, v2)
+      case SubOp => BoxedValue.sub(v1, v2)
+      case CmpOp => BoxedValue.cmp(v1, v2)
+    }
+  }
+
+}

--- a/xbc/src/InterpretB.scala
+++ b/xbc/src/InterpretB.scala
@@ -44,7 +44,7 @@ object InterpretB { // interpreter for Lang, producing boxed values
                 case None => sys.error(s"FnCall: $fnName/$arity")
                 case Some(body) =>
                   val vs = args.map(eval(_)).toVector
-                  evalFrame(vs, body) //tailcall
+                  evalFrame(vs, body) // tailcall
               }
             case _ =>
               eval(body)

--- a/xbc/src/InterpretK.scala
+++ b/xbc/src/InterpretK.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+import scala.annotation.tailrec
+
+object InterpretK { // cps-style interpreter for Lang (for stack-safety)
+
+  import Lang._
+
+  type Value = Long
+
+  sealed abstract trait Trav
+  final case class Down(actuals: Vector[Value], exp: Exp) extends Trav
+  final case class Up(res: Value) extends Trav
+
+  sealed abstract trait K
+  final case object KRet extends K
+  final case class KBin1(b: BinOp, actuals: Vector[Value], e2: Exp, k: K) extends K
+  final case class KBin2(b: BinOp, res1: Value, k: K) extends K
+  final case class KIf(actuals: Vector[Value], e2: Exp, e3: Exp, k: K) extends K
+  final case class KMoreArgs(
+      actuals: Vector[Value],
+      results: List[Value],
+      exps: List[Exp],
+      body: Exp,
+      k: K,
+  ) extends K
+
+  def cps(program: Program): Value = {
+    program match {
+      case Program(defs, main) =>
+        val _ = defs
+
+        @tailrec
+        def loop(trav: Trav, k: K): Value = {
+          trav match {
+            case Down(actuals, exp) =>
+              exp match {
+                case Num(x) => loop(Up(x), k)
+                case Builtin(b, e1, e2) => loop(Down(actuals, e1), KBin1(b, actuals, e2, k))
+                case Arg(i) => loop(Up(actuals(i)), k)
+                case IfNeg(e1, e2, e3) => loop(Down(actuals, e1), KIf(actuals, e2, e3, k))
+                case FnCall(fnName, args) =>
+                  val arity = args.length
+                  defs.get(fnName, arity) match {
+                    case None => sys.error(s"FnCall: $fnName/$arity")
+                    case Some(body) =>
+                      args match {
+                        case Nil =>
+                          loop(Down(Vector(), body), k)
+                        case arg :: args =>
+                          loop(Down(actuals, arg), KMoreArgs(actuals, Nil, args, body, k))
+                      }
+                  }
+              }
+            case Up(res) =>
+              k match {
+                case KRet => res
+                case KBin1(b, actuals, e2, k) => loop(Down(actuals, e2), KBin2(b, res, k))
+                case KBin2(b, res1, k) => loop(Up(applyBinOp(b, res1, res)), k)
+                case KIf(actuals, e2, e3, k) =>
+                  if (res < 0) loop(Down(actuals, e2), k) else loop(Down(actuals, e3), k)
+                case KMoreArgs(actuals, results0, args, body, k) =>
+                  val results = res :: results0
+                  args match {
+                    case Nil =>
+                      val vs = results.reverse.toVector
+                      loop(Down(vs, body), k)
+                    case arg :: args =>
+                      loop(Down(actuals, arg), KMoreArgs(actuals, results, args, body, k))
+                  }
+              }
+          }
+        }
+
+        loop(Down(Vector(), main), KRet)
+    }
+  }
+
+  def applyBinOp(binOp: BinOp, v1: Value, v2: Value): Value = {
+    binOp match {
+      case MulOp => v1 * v2
+      case AddOp => v1 + v2
+      case SubOp => v1 - v2
+      case CmpOp => if (v1 > v2) 1 else if (v1 == v2) 0 else -1
+    }
+  }
+
+}

--- a/xbc/src/Lang.scala
+++ b/xbc/src/Lang.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+object Lang {
+
+  type FnName = String
+
+  sealed abstract class BinOp
+  final case object MulOp extends BinOp
+  final case object AddOp extends BinOp
+  final case object SubOp extends BinOp
+  final case object CmpOp extends BinOp
+
+  sealed abstract class Exp
+  final case class Num(x: Long) extends Exp
+  final case class Builtin(b: BinOp, e1: Exp, e2: Exp) extends Exp
+  final case class IfNeg(e1: Exp, e2: Exp, e3: Exp) extends Exp
+  final case class Arg(i: Int) extends Exp
+  final case class FnCall(f: FnName, arg: List[Exp]) extends Exp
+
+  case class Program(defs: Map[(FnName, Int), Exp], main: Exp)
+
+  def Mul(e1: Exp, e2: Exp): Exp = Builtin(MulOp, e1, e2)
+  def Add(e1: Exp, e2: Exp): Exp = Builtin(AddOp, e1, e2)
+  def Sub(e1: Exp, e2: Exp): Exp = Builtin(SubOp, e1, e2)
+  def Cmp(e1: Exp, e2: Exp): Exp = Builtin(CmpOp, e1, e2)
+
+  object Examples {
+
+    def nfibProgram(size: Long): Program = {
+      def nfib(e: Exp) = FnCall("nfib", List(e))
+      val body: Exp = {
+        val n = Arg(0)
+        IfNeg(
+          Cmp(n, Num(2)),
+          Num(1),
+          Add(Add(nfib(Sub(n, Num(1))), nfib(Sub(n, Num(2)))), Num(1)),
+        )
+      }
+      Program(
+        defs = Map(("nfib", 1) -> body),
+        main = nfib(Num(size)),
+      )
+    }
+
+    def tripProgram(i: Long): Program = {
+      def loop(step: Exp, acc: Exp, i: Exp) = FnCall("loop", List(step, acc, i))
+      val body: Exp = {
+        val (step, acc, i) = (Arg(0), Arg(1), Arg(2))
+        IfNeg(
+          Cmp(i, Num(1)),
+          acc,
+          loop(step, Add(acc, step), Sub(i, Num(1))),
+        )
+      }
+      Program(
+        defs = Map(("loop", 3) -> body),
+        main = loop(Num(3L), Num(0L), Num(i)),
+      )
+    }
+
+  }
+}

--- a/xbc/src/Play.scala
+++ b/xbc/src/Play.scala
@@ -1,0 +1,113 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+import org.objectweb.asm._
+import org.objectweb.asm.Opcodes._
+
+object Bucket {
+  def myLong2String(x: Long): String = {
+    s"myLong2String[$x]"
+  }
+  def mySubtract(x: Long, y: Long): Long = {
+    x - y
+  }
+}
+
+object Play { // Play with bytecode generation using Asm
+
+  def makeCodeToPrintMessage(message: String): ByteCode = {
+
+    val className = "PlayGen"
+    val methodName = "doit"
+
+    val cw: ClassWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES)
+    cw.visit(V1_8, ACC_PUBLIC, className, null, "java/lang/Object", null)
+
+    {
+      val sub: MethodVisitor =
+        cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "mySquare", "(J)J", null, null)
+
+      sub.visitIntInsn(LLOAD, 0)
+      sub.visitIntInsn(LLOAD, 0)
+      sub.visitInsn(LMUL)
+      sub.visitInsn(LRETURN)
+      sub.visitMaxs(-1, -1)
+    }
+
+    val mv: MethodVisitor =
+      cw.visitMethod(ACC_PUBLIC | ACC_STATIC, methodName, "(JJ)J", null, null)
+
+    // print(message)
+    mv.visitFieldInsn(GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
+    mv.visitLdcInsn(message)
+    mv.visitMethodInsn(
+      INVOKEVIRTUAL,
+      "java/io/PrintStream",
+      "println",
+      "(Ljava/lang/String;)V",
+      false,
+    )
+
+    /*
+       print(myLong2String(mySquare(100) + mySubtract( ...?:... ,  1)))
+     */
+    mv.visitFieldInsn(GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
+    mv.visitFieldInsn(GETSTATIC, "xbc/Bucket$", "MODULE$", "Lxbc/Bucket$;")
+
+    mv.visitLdcInsn(100L)
+    mv.visitMethodInsn(INVOKESTATIC, className, "mySquare", "(J)J", false)
+
+    mv.visitFieldInsn(GETSTATIC, "xbc/Bucket$", "MODULE$", "Lxbc/Bucket$;")
+
+    /*
+         (firstLongArg < secondLongArg)
+         ? (secondLongArg - firstLongArg)
+         : (firstLongArg - secondLongArg)
+     */
+    val labElse = new Label()
+    val labJoin = new Label()
+    mv.visitIntInsn(LLOAD, 0)
+    mv.visitIntInsn(LLOAD, 2)
+    mv.visitInsn(LCMP)
+    mv.visitJumpInsn(IFGE, labElse)
+    mv.visitIntInsn(LLOAD, 2)
+    mv.visitIntInsn(LLOAD, 0)
+    mv.visitInsn(LSUB)
+    mv.visitJumpInsn(GOTO, labJoin)
+    mv.visitLabel(labElse)
+    mv.visitIntInsn(LLOAD, 0)
+    mv.visitIntInsn(LLOAD, 2)
+    mv.visitInsn(LSUB)
+    mv.visitLabel(labJoin)
+
+    mv.visitLdcInsn(1L)
+    mv.visitMethodInsn(INVOKEVIRTUAL, "xbc/Bucket$", "mySubtract", "(JJ)J", false)
+    mv.visitInsn(LADD)
+    mv.visitMethodInsn(
+      INVOKEVIRTUAL,
+      "xbc/Bucket$",
+      "myLong2String",
+      "(J)Ljava/lang/String;",
+      false,
+    )
+    mv.visitMethodInsn(
+      INVOKEVIRTUAL,
+      "java/io/PrintStream",
+      "println",
+      "(Ljava/lang/String;)V",
+      false,
+    )
+
+    // return(42)
+    mv.visitLdcInsn(42L)
+    mv.visitInsn(LRETURN)
+
+    mv.visitMaxs(-1, -1)
+
+    val bytes = cw.toByteArray()
+    new ByteCode(className, methodName, bytes)
+  }
+
+}

--- a/xbc/src/Speed.scala
+++ b/xbc/src/Speed.scala
@@ -24,7 +24,7 @@ object Speed extends App {
       case "c" => "compiled-via-bytecode"
       case s => s
     }
-    //val defaultConf = Conf.WholeGroup("nfib")
+    // val defaultConf = Conf.WholeGroup("nfib")
     val defaultConf = Conf.TryCompileToBytecode()
     args.toList match {
       case Nil =>
@@ -77,17 +77,17 @@ object Speed extends App {
 
     val compiled1: FUT = (x: Long) => {
       def prog = Lang.Examples.nfibProgram(x)
-      //println("compile...")
+      // println("compile...")
       val bc: ByteCode = Compiler.compile(prog)
-      //println("dump...")
-      bc.dump() //find in /tmp
-      //println("run...")
+      // println("dump...")
+      bc.dump() // find in /tmp
+      // println("run...")
       bc.run0()
     }
     val _ = compiled1
 
     List(
-      //NICK: add baseline for speedy on same example
+      // NICK: add baseline for speedy on same example
       "interpreter-cps" -> interpreter_cps,
       "interpreter-boxed-value" -> interpreter_boxed_value,
       "interpreter" -> interpreter,
@@ -172,7 +172,7 @@ object Speed extends App {
       println(s"eval via Interpreter --> $res1")
 
       val bc: ByteCode = Compiler.compile(prog)
-      bc.dump() //find in /tmp
+      bc.dump() // find in /tmp
       val res2 = bc.run0()
 
       println(s"eval via Compiled bytecode --> $res2")

--- a/xbc/src/Speed.scala
+++ b/xbc/src/Speed.scala
@@ -1,0 +1,295 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package xbc
+
+object Speed extends App {
+
+  sealed trait Conf
+  object Conf {
+    final case class FixedN(group: String, version: String, n: Long) extends Conf
+    final case class IncreasingN(group: String, version: String) extends Conf
+    final case class WholeGroup(group: String) extends Conf
+    final case class PlayGenBytecode() extends Conf
+    final case class TryCompileToBytecode() extends Conf
+  }
+
+  def conf: Conf = {
+    def xv(v: String) = v match {
+      case "hs" => "byhand-scala"
+      case "hj" => "byhand-java-v2"
+      case "i" => "interpreter"
+      case "iv" => "interpreter-boxed-value"
+      case "ik" => "interpreter-cps"
+      case "c" => "compiled-via-bytecode"
+      case s => s
+    }
+    //val defaultConf = Conf.WholeGroup("nfib")
+    val defaultConf = Conf.TryCompileToBytecode()
+    args.toList match {
+      case Nil =>
+        defaultConf
+      case "play" :: Nil =>
+        Conf.PlayGenBytecode()
+      case "compile" :: Nil =>
+        Conf.TryCompileToBytecode()
+      case group :: Nil =>
+        Conf.WholeGroup(group)
+      case group :: version :: Nil =>
+        Conf.IncreasingN(group, xv(version))
+      case group :: version :: n :: Nil =>
+        Conf.FixedN(group, xv(version), n.toLong)
+      case _ =>
+        sys.error(s"\n**unexpected command line: $args")
+    }
+  }
+
+  println(s"Running: $conf...");
+
+  type FUT = (Long => Long) // function under test
+
+  // Examples should be scalable:
+  // - the computational effort should scale exponentially with the input N
+  // - the result should be indicative of the computation effort
+
+  val nfibVersions: List[(String, FUT)] = {
+
+    val interpreter: FUT = (x: Long) => {
+      def prog = Lang.Examples.nfibProgram(x)
+      Interpret.standard(prog)
+    }
+    val interpreter_boxed_value: FUT = (x: Long) => {
+      def prog = Lang.Examples.nfibProgram(x)
+      val box = InterpretB.run(prog)
+      BoxedValue.getNumber(box) match {
+        case None => sys.error(s"\n**nfib_ib, expected number, got: box")
+        case Some(x) => x
+      }
+    }
+    val interpreter_cps: FUT = (x: Long) => {
+      def prog = Lang.Examples.nfibProgram(x)
+      InterpretK.cps(prog)
+    }
+
+    val scala: FUT = ByHandScala.nfib(_)
+    val java1: FUT = ByHandJava.nfib_v1(_)
+    val java2: FUT = ByHandJava.nfib_v2(_)
+
+    val compiled1: FUT = (x: Long) => {
+      def prog = Lang.Examples.nfibProgram(x)
+      //println("compile...")
+      val bc: ByteCode = Compiler.compile(prog)
+      //println("dump...")
+      bc.dump() //find in /tmp
+      //println("run...")
+      bc.run0()
+    }
+    val _ = compiled1
+
+    List(
+      //NICK: add baseline for speedy on same example
+      "interpreter-cps" -> interpreter_cps,
+      "interpreter-boxed-value" -> interpreter_boxed_value,
+      "interpreter" -> interpreter,
+      "byhand-scala" -> scala,
+      "byhand-java-v1" -> java1,
+      "byhand-java-v2" -> java2,
+      "compiled-via-bytecode" -> compiled1,
+    )
+  }
+
+  val tripVersions: List[(String, FUT)] = {
+    val interpreter: FUT = (x: Long) => {
+      val y = lpower(2, x)
+      def prog = Lang.Examples.tripProgram(y)
+      Interpret.standard(prog) / 3L
+    }
+    val interpreter_cps: FUT = (x: Long) => {
+      val y = lpower(2, x)
+      def prog = Lang.Examples.tripProgram(y)
+      InterpretK.cps(prog) / 3L
+    }
+    val scala: FUT = (x: Long) => {
+      val y = lpower(2, x) // make it scalable
+      ByHandScala.trip(y) / 3L
+    }
+    List(
+      "interpreter-cps" -> interpreter_cps,
+      "interpreter" -> interpreter,
+      "byhand-scala" -> scala,
+    )
+  }
+
+  // map of groups of FUTs
+  def m: Map[String, (Option[Double], List[(String, FUT)])] = Map(
+    "nfib" -> (None, nfibVersions),
+    "trip" -> (None, tripVersions),
+  )
+
+  def getVersions(group: String): (Option[Double], List[String]) = {
+    m.get(group) match {
+      case None => sys.error(s"\n**unknown group: $group")
+      case Some((optBaseline, g)) => (optBaseline, (g.map(_._1)))
+    }
+  }
+
+  def getFUT(group: String, version: String): FUT = {
+    m.get(group) match {
+      case None => sys.error(s"\n**unknown group: $group")
+      case Some((_, g)) =>
+        g.toMap.get(version) match {
+          case None => sys.error(s"\n**unknown version: $version")
+          case Some(f) => f
+        }
+    }
+  }
+
+  conf match {
+
+    case Conf.PlayGenBytecode() =>
+      val code1 = Play.makeCodeToPrintMessage("Hello, world!")
+      code1.dump()
+      List((55L, 13L), (13L, 55L)).foreach { case (a, b) =>
+        val res: Long = code1.run2(a, b)
+        println(s"PlayGenBytecode($a,$b) -> $res")
+      }
+
+    case Conf.TryCompileToBytecode() =>
+      import Lang._
+      val prog =
+        Program(
+          defs = Map(
+            ("square", 1) -> Mul(Arg(0), Arg(0)),
+            ("foo", 2) -> Sub(
+              FnCall("square", List(Arg(0))),
+              FnCall("square", List(Arg(1))),
+            ),
+          ),
+          main = FnCall("foo", List(Num(10L), Num(7L))),
+        )
+      println(s"TryCompileToBytecode: $prog")
+      val res1 = Interpret.standard(prog)
+      println(s"eval via Interpreter --> $res1")
+
+      val bc: ByteCode = Compiler.compile(prog)
+      bc.dump() //find in /tmp
+      val res2 = bc.run0()
+
+      println(s"eval via Compiled bytecode --> $res2")
+      if (res1 != res2) {
+        sys.error("\n**interpret VS bytecode: result differ")
+      }
+
+    case Conf.FixedN(group, version, n) =>
+      printHeader()
+      val setup = Setup(group, version, n)
+      while (true) {
+        val outcome = runTest(setup)
+        printOutcomeLine(outcome, 1.0)
+      }
+
+    case Conf.IncreasingN(group, version) =>
+      printHeader()
+      var n: Long = 15L
+      while (true) {
+        val setup = Setup(group, version, n)
+        val outcome = runTest(setup)
+        printOutcomeLine(outcome, 1.0)
+        n += 1
+      }
+
+    case Conf.WholeGroup(group) =>
+      printHeader()
+
+      def runVersion(version: String): Outcome = {
+        def loop(n: Long): Outcome = {
+          val setup = Setup(group, version, n)
+          val outcome = runTest(setup)
+          if (outcome.dur_s > 0.3) {
+            outcome
+          } else {
+            loop(n + 1)
+          }
+        }
+        loop(20L)
+      }
+
+      val (optBaseline, versions) = getVersions(group)
+      versions match {
+        case Nil =>
+          sys.error(s"\n**no versions for group: $group")
+        case leadVersion :: versions =>
+          val leadOutcome = runVersion(leadVersion)
+          val baselineSpeed = optBaseline match {
+            case None => leadOutcome.speed
+            case Some(baseline) => baseline
+          }
+          val leadRelative = leadOutcome.speed / baselineSpeed
+          printOutcomeLine(leadOutcome, leadRelative)
+
+          versions.foreach { version =>
+            val outcome = runVersion(version)
+            val relative = outcome.speed / baselineSpeed
+            printOutcomeLine(outcome, relative)
+          }
+      }
+  }
+
+  case class Setup(group: String, version: String, n: Long)
+
+  case class Outcome(setup: Setup, res: Long, dur_s: Double, speed: Double)
+
+  def runTest(setup: Setup): Outcome = {
+    setup match {
+      case Setup(group, version, n) =>
+        val functionUnderTest = getFUT(group, version)
+        val start = System.currentTimeMillis()
+        val res = functionUnderTest(n)
+        val end = System.currentTimeMillis()
+        val dur_ms = end - start
+        val dur_s = dur_ms.toFloat / 1000.0
+        val speed = res / (1000 * dur_ms).toDouble
+        Outcome(setup, res, dur_s, speed)
+    }
+  }
+
+  def printHeader() = {
+    println(s"size result   duration  speed     relative  name")
+    println(s"N   #ops         secs   ops/us    speedup   group:version")
+    println(s"----------------------------------------------------------")
+  }
+
+  def printOutcomeLine(outcome: Outcome, relative0: Double) = {
+
+    def pad(s: String, max: Int): String = {
+      val ss = s.size
+      val n = if (ss < max) max - ss else 0
+      val padding: String = List.fill(n)(' ').mkString
+      s + padding
+    }
+
+    outcome match {
+      case Outcome(setup, res0, dur0, speed0) =>
+        setup match {
+          case Setup(group, version, n0) =>
+            val n = pad(s"$n0", 3)
+            val res = pad(s"$res0", 12)
+            val dur = pad(f"$dur0%.2f", 6)
+            val speed = pad(f"$speed0%.2f", 9)
+            val relative = pad(f"$relative0%.2f", 9)
+            val gv = s"$group:$version"
+            println(s"$n $res $dur $speed $relative $gv")
+        }
+    }
+  }
+
+  def lpower(base: Long, exponent: Long): Long = {
+    if (exponent < 0) {
+      sys.error(s"\n**lpower, negative exponent: $exponent")
+    } else {
+      def powerLoop(i: Long): Long = if (i == 0) 1 else base * powerLoop(i - 1)
+      powerLoop(exponent)
+    }
+  }
+
+}


### PR DESCRIPTION
Exploration...
- Just how much does interpreter based evaluation cost?
- How hard would it be to do JVM bytecode generation?

Results from my _favourite_ example `nfib`...
```
Running: WholeGroup(nfib)...
size result   duration  speed     relative  name
N   #ops         secs   ops/us    speedup   group:version
----------------------------------------------------------
30  2692537      0.48   5.63      1.00      nfib:interpreter-cps
30  2692537      0.30   8.92      1.58      nfib:interpreter-boxed-value
31  4356617      0.45   9.79      1.74      nfib:interpreter
39  204668309    0.32   643.61    114.26    nfib:byhand-scala
38  126491971    0.44   288.14    51.15     nfib:byhand-java-v1
40  331160281    0.45   735.91    130.64    nfib:byhand-java-v2
40  331160281    0.45   729.43    129.49    nfib:compiled-via-bytecode
```

The `nfib` function is defined like this: (this is the hand written scala definition).
```
  def nfib(n: Long): Long = {
    // Not quite the fib function, as here we +1 in the recursive case.
    // So the function result is equal to the number of function calls.
    if (n < 2) {
      1
    } else {
      nfib(n - 1) + nfib(n - 2) + 1
    }
  }
```

The example is nice because:
-  It makes use of language features: basic arithmetic,  function call/return, conditionals
-  The value of the result is directly proportional to the effort required to compute it, providing a natural definition of _speed_. Reported above in _ops/micro-second_. Bigger is better.
- The example is naturally _scalable_, meaning that by adjusting the input _N_ we can find a setting which allows the example to run for any duration we wish. (The above table reports the first value which makes the duration exceed 0.3s), thus providing an easy way to compare versions with widely differing speeds.


