### PR TITLE
interfaces: Make fromInterfaceContractId pure, add fetchFromInterface

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Interface.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Interface.daml
@@ -14,6 +14,7 @@ module DA.Internal.Interface (
   toInterface,
   toInterfaceContractId,
   fromInterfaceContractId,
+  fetchFromInterface,
   _exerciseDefault,
   _exerciseInterfaceGuard
 ) where
@@ -107,7 +108,7 @@ toInterfaceContractId = coerceContractId
 -- template type.
 --
 -- In all other cases, consider using `fetchFromInterface` instead.
-fromInterfaceContractId : forall t i. (HasFromInterface t i) => ContractId i -> ContractId t
+fromInterfaceContractId : forall t i. HasFromInterface t i => ContractId i -> ContractId t
 fromInterfaceContractId = coerceContractId
 
 -- | (1.dev only) Fetch an interface and convert it to a specific

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Interface.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Interface.daml
@@ -91,21 +91,45 @@ toInterfaceContractId : forall i t. HasToInterface t i => ContractId t -> Contra
 toInterfaceContractId = coerceContractId
 
 -- | (1.dev only) Convert an interface contract id into a template
--- contract id. In order to verify that the underlying contract has
--- the expected template type, this will perform a fetch. For example:
+-- contract id. For example, `fromInterfaceContractId @MyTemplate cid`.
 --
+-- This function does not verify that the interface contract id
+-- actually points to a template of the given type. This means
+-- that a subsequent `fetch`, `exercise`, or `archive` may fail, if,
+-- for example, the contract id points to a contract that implements
+-- the interface but is of a different template type than expected.
+--
+-- Therefore, you should only use `fromInterfaceContractId` in situations
+-- where you already know that the contract id points to a contract of the
+-- right template type. You can also use it in situations where you will
+-- fetch, exercise, or archive the contract right away, when a transaction
+-- failure is the appropriate response to the contract having the wrong
+-- template type.
+--
+-- In all other cases, consider using `fetchFromInterface` instead.
+fromInterfaceContractId : forall t i. (HasFromInterface t i) => ContractId i -> ContractId t
+fromInterfaceContractId = coerceContractId
+
+-- | (1.dev only) Fetch an interface and convert it to a specific
+-- template type. If conversion is succesful, this function returns
+-- the converted contract and its converted contract id. Otherwise,
+-- this function returns `None`.
+--
+-- Example:
 -- ```
 -- do
---   templateCidOpt <- fromInterfaceContractId @MyTemplate ifaceCid
---   case templateCidOpt of
---     None -> abort "failed to convert contract id"
---     Some templateCid -> ...
+--   fetchResult <- fetchFromInterface @MyTemplate ifaceCid
+--   case fetchResult of
+--     None -> abort "Failed to convert interface to appropriate template type"
+--     Some (tplCid, tpl) -> do
+--        ... do something with tpl and tplCid ...
 -- ```
-fromInterfaceContractId : forall t i. (HasFromInterface t i, HasFetch i) => ContractId i -> Update (Optional (ContractId t))
-fromInterfaceContractId cid = do
-  iface <- fetch cid
-  pure $
-    const (coerceContractId cid) <$> fromInterface @t iface
+fetchFromInterface : forall t i. (HasFromInterface t i, HasFetch i) => ContractId i -> Update (Optional (ContractId t, t))
+fetchFromInterface cid = do
+    iface <- fetch cid
+    case fromInterface @t iface of
+      None -> pure None
+      Some tpl -> pure (Some (fromInterfaceContractId @t cid, tpl))
 
 -- | HIDE Gives a valid implementation of `HasExercise.exercise`
 -- for types that implement `HasExerciseGuarded`. This is used

--- a/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
@@ -7,8 +7,13 @@
 module InterfaceConversions where
 
 import DA.Assert ((===))
+import DA.Functor (void)
 
 interface Iface where
+    getOwner : Party
+    choice MyChoice : ()
+        controller getOwner this
+        do pure ()
 
 template Template1
     with
@@ -17,6 +22,7 @@ template Template1
     where
         signatory owner1
         implements Iface where
+            getOwner = owner1
 
 template Template2
     with
@@ -25,6 +31,7 @@ template Template2
     where
         signatory owner2
         implements Iface where
+            getOwner = owner2
 
 main = scenario do
     p <- getParty "Alice"
@@ -55,5 +62,18 @@ main = scenario do
         x2 === None
         x3 === None
         x4 === Some (templateCid2, template2)
+
+    -- Test that using fromInterfaceContractId incorrectly will result
+    -- in failed fetch/exercise/archives. I.e. using a Template1 contract
+    -- id as if it were a Template2 contract id will always fail, even
+    -- for actions that make sense for the common interface Iface.
+    let useAction : (ContractId Template2 -> Update ()) -> Update ()
+        useAction action = do
+            cid <- create (toInterface @Iface (Template1 p 10))
+            action (fromInterfaceContractId @Template2 cid)
+    submit p do useAction $ \_cid -> pure ()
+    submitMustFail p do useAction $ \cid -> void (fetch cid)
+    submitMustFail p do useAction $ \cid -> exercise cid MyChoice
+    submitMustFail p do useAction $ \cid -> archive cid
 
 -- @ENABLE-SCENARIOS

--- a/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceConversions.daml
@@ -43,14 +43,17 @@ main = scenario do
         let ifaceCid1 = toInterfaceContractId @Iface templateCid1
             ifaceCid2 = toInterfaceContractId @Iface templateCid2
 
-        x1 <- fromInterfaceContractId @Template1 ifaceCid1
-        x2 <- fromInterfaceContractId @Template2 ifaceCid1
-        x3 <- fromInterfaceContractId @Template1 ifaceCid2
-        x4 <- fromInterfaceContractId @Template2 ifaceCid2
+        fromInterfaceContractId ifaceCid1 === templateCid1
+        fromInterfaceContractId ifaceCid2 === templateCid2
 
-        x1 === Some templateCid1
+        x1 <- fetchFromInterface @Template1 ifaceCid1
+        x2 <- fetchFromInterface @Template2 ifaceCid1
+        x3 <- fetchFromInterface @Template1 ifaceCid2
+        x4 <- fetchFromInterface @Template2 ifaceCid2
+
+        x1 === Some (templateCid1, template1)
         x2 === None
         x3 === None
-        x4 === Some templateCid2
+        x4 === Some (templateCid2, template2)
 
 -- @ENABLE-SCENARIOS

--- a/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
@@ -69,11 +69,12 @@ main = scenario do
 
         let cidt2a = toInterfaceContractId @A cidt2
 
-        cidt1b' <- fromInterfaceContractId @B cidt1a
-        cidt2b' <- fromInterfaceContractId @B cidt2a
+        cidt1b === fromInterfaceContractId cidt1a
 
-        cidt1b' === Some cidt1b
-        cidt2b' === None
+        fetchPair1 <- fetchFromInterface @B cidt1a
+        fetchPair2 <- fetchFromInterface @B cidt2a
+        fetchPair1 === Some (cidt1b, t1b)
+        fetchPair2 === None
 
         exercise cidt1a ChoiceA
         exercise cidt1b ChoiceA

--- a/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
@@ -7,6 +7,7 @@
 module InterfaceUpcastDowncast where
 
 import DA.Assert ((===))
+import DA.Optional (isNone)
 
 interface A where
   getOwner : Party
@@ -73,8 +74,8 @@ main = scenario do
 
         fetchPair1 <- fetchFromInterface @B cidt1a
         fetchPair2 <- fetchFromInterface @B cidt2a
-        fetchPair1 === Some (cidt1b, t1b)
-        fetchPair2 === None
+        assertMsg "fetchPair1 != Some (cidt1b, t1b)" (fetchPair1 == Some (cidt1b, t1b))
+        assertMsg "fetchPair2 != None" (isNone fetchPair2)
 
         exercise cidt1a ChoiceA
         exercise cidt1b ChoiceA

--- a/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
+++ b/compiler/damlc/tests/daml-test-files/InterfaceUpcastDowncast.daml
@@ -8,6 +8,7 @@ module InterfaceUpcastDowncast where
 
 import DA.Assert ((===))
 import DA.Optional (isNone)
+import DA.Functor (void)
 
 interface A where
   getOwner : Party
@@ -84,5 +85,18 @@ main = scenario do
         exercise cidt1 ChoiceB
 
         pure ()
+
+    -- Test that using fromInterfaceContractId incorrectly will result
+    -- in failed fetch/exercise, across interface hierarchy.
+    -- I.e. Test that using a T2 contract id as if it were a B contract id
+    -- will always fail, even for actions that make sense with A contracts.
+    let useAction : (ContractId B -> Update ()) -> Update ()
+        useAction action = do
+            cid <- create (toInterface @A (T2 p))
+            action (fromInterfaceContractId @B cid)
+    submit p do useAction $ \_bcid -> pure ()
+    submitMustFail p do useAction $ \bcid -> void (fetch bcid)
+    submitMustFail p do useAction $ \bcid -> void (exercise bcid ChoiceA)
+    submitMustFail p do useAction $ \bcid -> void (exercise bcid ChoiceB)
 
 -- @ENABLE-SCENARIOS


### PR DESCRIPTION
This PR changes `fromInterfaceContractId` to make it pure. This means
it cannot verify the contract id coercion, and should only be used
with care. To balance this, this PR also adds `fetchFromInterface` which
combines a `fetch` with a `fromInterface` and `fromInterfaceContractId`,
to serve as a safer alternative to `fromInterfaceContractId`, and is more
useful than the old `fromInterfaceContractId` since it also returns the
fetched & converted contract payload.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
