### PR TITLE
Add generation of FromInterfaceContractId methods for supporting templates in the java codegen

### DIFF
--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -546,6 +546,8 @@ Moreover to allow converting the ContractId of a template to an interface Contra
 
       public TIf.ContractId toTIf() { /* ... */ }
 
+      public static Child.ContractId unsafeFromTIf(interfaces.TIf.ContractId interfaceContractId)  { /* ... */ }
+
     }
 
     /* ... */

--- a/language-support/java/codegen/src/ledger-tests/daml/Interfaces.daml
+++ b/language-support/java/codegen/src/ledger-tests/daml/Interfaces.daml
@@ -29,3 +29,13 @@ template Child
     implements TIf where
       getOwner = party
       dup = toInterfaceContractId <$> create this
+
+template ChildClone
+    with
+    party: Party
+  where
+    signatory party
+
+    implements TIf where
+      getOwner = party
+      dup = toInterfaceContractId <$> create this

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
@@ -4,6 +4,7 @@
 package com.daml
 
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.ledger.javaapi.data.{CreatedEvent, Identifier}
 import com.daml.ledger.resources.TestResourceContext
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -21,18 +22,45 @@ class Interfaces
 
   it should "contain all choices of an interface in templates implementing it" in withClient {
     client =>
+      def checkTemplateId[T](
+          shouldBeId: Identifier,
+          fn: CreatedEvent => T,
+      ): PartialFunction[CreatedEvent, T] = {
+        case event: CreatedEvent if event.getTemplateId == shouldBeId => fn(event)
+      }
+      val safeChildFromCreatedEvent =
+        checkTemplateId(interfaces.Child.TEMPLATE_ID, interfaces.Child.Contract.fromCreatedEvent)
+      val safeChildCloneFromCreatedEvent =
+        checkTemplateId(
+          interfaces.ChildClone.TEMPLATE_ID,
+          interfaces.ChildClone.Contract.fromCreatedEvent,
+        )
       for {
         alice <- allocateParty
       } yield {
         sendCmd(client, alice, interfaces.Child.create(alice))
-        readActiveContracts(interfaces.Child.Contract.fromCreatedEvent)(client, alice).foreach {
-          child =>
-            sendCmd(client, alice, child.id.exerciseHam(new interfaces.Ham()))
+        sendCmd(client, alice, interfaces.ChildClone.create(alice))
+        readActiveContractsSafe[interfaces.Child.Contract](safeChildFromCreatedEvent)(
+          client,
+          alice,
+        ).foreach { child =>
+          sendCmd(client, alice, child.id.exerciseHam(new interfaces.Ham()))
         }
-        readActiveContracts(interfaces.Child.Contract.fromCreatedEvent)(client, alice).foreach {
-          child =>
-            sendCmd(client, alice, child.id.toTIf.exerciseHam(new interfaces.Ham()))
+        readActiveContractsSafe(safeChildFromCreatedEvent)(client, alice).foreach { child =>
+          sendCmd(client, alice, child.id.toTIf.exerciseHam(new interfaces.Ham()))
         }
+        readActiveContractsSafe(safeChildCloneFromCreatedEvent)(client, alice)
+          .foreach { child =>
+            assertThrows[Exception](
+              sendCmd(
+                client,
+                alice,
+                interfaces.Child.ContractId
+                  .unsafeFromTIf(child.id.toTIf)
+                  .exerciseHam(new interfaces.Ham()),
+              )
+            )
+          }
         succeed
       }
   }

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
@@ -56,7 +56,7 @@ class Interfaces
                 client,
                 alice,
                 interfaces.Child.ContractId
-                  .unsafeFromTIf(child.id.toTIf)
+                  .unsafeFromTIf(child.id.toTIf: TIf.ContractId)
                   .exerciseHam(new interfaces.Ham()),
               )
             )

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
@@ -56,7 +56,7 @@ class Interfaces
                 client,
                 alice,
                 interfaces.Child.ContractId
-                  .unsafeFromTIf(child.id.toTIf: TIf.ContractId)
+                  .unsafeFromTIf(child.id.toTIf: interfaces.TIf.ContractId)
                   .exerciseHam(new interfaces.Ham()),
               )
             )

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -34,6 +34,7 @@ object ContractIdClass {
   )
 
   case class Builder private (
+      templateClassName: ClassName,
       idClassBuilder: TypeSpec.Builder,
       choices: Map[ChoiceName, TemplateChoice[com.daml.lf.iface.Type]],
       packagePrefixes: Map[PackageId, String],
@@ -50,6 +51,18 @@ object ContractIdClass {
             .addModifiers(Modifier.PUBLIC)
             .addStatement(s"return new $name.ContractId(this.contractId)")
             .returns(ClassName.bestGuess(s"$name.ContractId"))
+            .build()
+        )
+        val tplContractIdClassName = templateClassName.nestedClass("ContractId")
+        idClassBuilder.addMethod(
+          MethodSpec
+            .methodBuilder(s"unsafeFrom$simpleName")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter(ClassName.bestGuess(s"$name.ContractId"), "interfaceContractId")
+            .addStatement(
+              s"return new ContractId(interfaceContractId.contractId)"
+            )
+            .returns(tplContractIdClassName)
             .build()
         )
       }
@@ -168,7 +181,7 @@ object ContractIdClass {
           generateExerciseMethod(choiceName, choice, templateClassName, packagePrefixes)
         idClassBuilder.addMethod(exerciseChoiceMethod)
       }
-      Builder(idClassBuilder, choices, packagePrefixes)
+      Builder(templateClassName, idClassBuilder, choices, packagePrefixes)
     }
   }
 }


### PR DESCRIPTION
Fixes #13461

changelog_begin

- Add generation of unsafeFrom{InterfaceName} methods to the ContractId class for templates implementing interfaces in the java codegen. That allows unsafe conversions between interface contract ids and template contract ids. If a conversion was wrong it will earliest blow up at runtime during cmd execution.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
