### PR TITLE
DPP-687 fix removing partially written data

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/IngestionStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/IngestionStorageBackendTemplate.scala
@@ -9,30 +9,35 @@ import com.daml.platform.store.backend.common.ComposableQuery.SqlStringInterpola
 import com.daml.platform.store.backend.{DbDto, IngestionStorageBackend, ParameterStorageBackend}
 import com.daml.platform.store.interning.StringInterning
 
-private[backend] class IngestionStorageBackendTemplate(schema: Schema[DbDto])
-    extends IngestionStorageBackend[AppendOnlySchema.Batch] {
+private[backend] class IngestionStorageBackendTemplate(
+    queryStrategy: QueryStrategy,
+    schema: Schema[DbDto],
+) extends IngestionStorageBackend[AppendOnlySchema.Batch] {
 
   override def deletePartiallyIngestedData(
       ledgerEnd: ParameterStorageBackend.LedgerEnd
   )(connection: Connection): Unit = {
-    import com.daml.platform.store.Conversions.OffsetToStatement
     val ledgerOffset = ledgerEnd.lastOffset
     val lastStringInterningId = ledgerEnd.lastStringInterningId
     val lastEventSequentialId = ledgerEnd.lastEventSeqId
 
     List(
-      SQL"DELETE FROM configuration_entries WHERE ledger_offset > $ledgerOffset",
-      SQL"DELETE FROM package_entries WHERE ledger_offset > $ledgerOffset",
-      SQL"DELETE FROM packages WHERE ledger_offset > $ledgerOffset",
-      SQL"DELETE FROM participant_command_completions WHERE completion_offset > $ledgerOffset",
-      SQL"DELETE FROM participant_events_divulgence WHERE event_offset > $ledgerOffset",
-      SQL"DELETE FROM participant_events_create WHERE event_offset > $ledgerOffset",
-      SQL"DELETE FROM participant_events_consuming_exercise WHERE event_offset > $ledgerOffset",
-      SQL"DELETE FROM participant_events_non_consuming_exercise WHERE event_offset > $ledgerOffset",
-      SQL"DELETE FROM party_entries WHERE ledger_offset > $ledgerOffset",
+      SQL"DELETE FROM configuration_entries WHERE ${queryStrategy.offsetIsGreater("ledger_offset", ledgerOffset)}",
+      SQL"DELETE FROM package_entries WHERE ${queryStrategy.offsetIsGreater("ledger_offset", ledgerOffset)}",
+      SQL"DELETE FROM packages WHERE ${queryStrategy.offsetIsGreater("ledger_offset", ledgerOffset)}",
+      SQL"DELETE FROM participant_command_completions WHERE ${queryStrategy
+        .offsetIsGreater("completion_offset", ledgerOffset)}",
+      SQL"DELETE FROM participant_events_divulgence WHERE ${queryStrategy
+        .offsetIsGreater("event_offset", ledgerOffset)}",
+      SQL"DELETE FROM participant_events_create WHERE ${queryStrategy.offsetIsGreater("event_offset", ledgerOffset)}",
+      SQL"DELETE FROM participant_events_consuming_exercise WHERE ${queryStrategy
+        .offsetIsGreater("event_offset", ledgerOffset)}",
+      SQL"DELETE FROM participant_events_non_consuming_exercise WHERE ${queryStrategy
+        .offsetIsGreater("event_offset", ledgerOffset)}",
+      SQL"DELETE FROM party_entries WHERE ${queryStrategy.offsetIsGreater("ledger_offset", ledgerOffset)}",
       SQL"DELETE FROM string_interning WHERE internal_id > $lastStringInterningId",
       SQL"DELETE FROM participant_events_create_filter WHERE event_sequential_id > $lastEventSequentialId",
-      SQL"DELETE FROM transaction_metering WHERE ledger_offset > $ledgerOffset",
+      SQL"DELETE FROM transaction_metering WHERE ${queryStrategy.offsetIsGreater("ledger_offset", ledgerOffset)}",
     ).map(_.execute()(connection))
 
     ()

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/QueryStrategy.scala
@@ -87,6 +87,22 @@ trait QueryStrategy {
     }
   }
 
+  /** Expression for `(offset > startExclusive)`
+    *
+    *  The offset column must only contain valid offsets (no NULL, no Offset.beforeBegin)
+    */
+  def offsetIsGreater(nonNullableColumn: String, startExclusive: Offset): CompositeSql = {
+    import com.daml.platform.store.Conversions.OffsetToStatement
+    // Note: there are two reasons for special casing Offset.beforeBegin:
+    // 1. simpler query
+    // 2. on Oracle, Offset.beforeBegin is equivalent to NULL and cannot be compared with
+    if (startExclusive == Offset.beforeBegin) {
+      cSQL"#${constBoolean(true)}"
+    } else {
+      cSQL"#$nonNullableColumn > $startExclusive"
+    }
+  }
+
   /** Expression for `(startExclusive < offset <= endExclusive)`
     *
     *  The offset column must only contain valid offsets (no NULL, no Offset.beforeBegin)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackendFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/h2/H2StorageBackendFactory.scala
@@ -30,7 +30,7 @@ import com.daml.platform.store.interning.StringInterning
 object H2StorageBackendFactory extends StorageBackendFactory with CommonStorageBackendFactory {
 
   override val createIngestionStorageBackend: IngestionStorageBackend[_] =
-    new IngestionStorageBackendTemplate(H2Schema.schema)
+    new IngestionStorageBackendTemplate(H2QueryStrategy, H2Schema.schema)
 
   override def createPackageStorageBackend(ledgerEndCache: LedgerEndCache): PackageStorageBackend =
     new PackageStorageBackendTemplate(H2QueryStrategy, ledgerEndCache)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackendFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/oracle/OracleStorageBackendFactory.scala
@@ -31,7 +31,7 @@ import com.daml.platform.store.interning.StringInterning
 object OracleStorageBackendFactory extends StorageBackendFactory with CommonStorageBackendFactory {
 
   override val createIngestionStorageBackend: IngestionStorageBackend[_] =
-    new IngestionStorageBackendTemplate(OracleSchema.schema)
+    new IngestionStorageBackendTemplate(OracleQueryStrategy, OracleSchema.schema)
 
   override def createPackageStorageBackend(ledgerEndCache: LedgerEndCache): PackageStorageBackend =
     new PackageStorageBackendTemplate(OracleQueryStrategy, ledgerEndCache)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackendFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/postgresql/PostgresStorageBackendFactory.scala
@@ -13,7 +13,7 @@ object PostgresStorageBackendFactory
     with CommonStorageBackendFactory {
 
   override val createIngestionStorageBackend: IngestionStorageBackend[_] =
-    new IngestionStorageBackendTemplate(PGSchema.schema)
+    new IngestionStorageBackendTemplate(PostgresQueryStrategy, PGSchema.schema)
 
   override def createPackageStorageBackend(ledgerEndCache: LedgerEndCache): PackageStorageBackend =
     new PackageStorageBackendTemplate(PostgresQueryStrategy, ledgerEndCache)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsInitializeIngestion.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsInitializeIngestion.scala
@@ -173,4 +173,87 @@ private[backend] trait StorageBackendTestsInitializeIngestion
     metering2.applicationData should have size 2 // Partially ingested data removed
 
   }
+
+  it should "delete overspill entries written before first ledger end update" in {
+    val signatory = Ref.Party.assertFromString("signatory")
+
+    val dtos1: Vector[DbDto] = Vector(
+      // 1: config change
+      dtoConfiguration(offset(1), someConfiguration),
+      // 2: party allocation
+      dtoPartyEntry(offset(2), "party1"),
+      // 3: package upload
+      dtoPackage(offset(3)),
+      dtoPackageEntry(offset(3)),
+      // 4: transaction with create node
+      dtoCreate(offset(4), 1L, hashCid("#4"), signatory = signatory),
+      DbDto.CreateFilter(1L, someTemplateId.toString, someParty.toString),
+      dtoCompletion(offset(4)),
+      // 5: transaction with exercise node and retroactive divulgence
+      dtoExercise(offset(5), 2L, false, hashCid("#4")),
+      dtoDivulgence(Some(offset(5)), 3L, hashCid("#4")),
+      dtoCompletion(offset(5)),
+      // Transaction Metering
+      dtoMetering("AppA", offset(1)),
+      dtoMetering("AppB", offset(4)),
+    )
+
+    val readers = Set(signatory)
+
+    // Initialize
+    executeSql(backend.parameter.initializeParameters(someIdentityParams))
+    executeSql(backend.meteringParameter.initializeLedgerMeteringEnd(someLedgerMeteringEnd))
+
+    // Start the indexer (a no-op in this case)
+    val end1 = executeSql(backend.parameter.ledgerEnd)
+    executeSql(backend.ingestion.deletePartiallyIngestedData(end1))
+
+    // Insert first batch of updates, but crash before writing the first ledger end
+    executeSql(ingest(dtos1, _))
+
+    // Restart the indexer - should delete data from the partial insert above
+    val end2 = executeSql(backend.parameter.ledgerEnd)
+    executeSql(backend.ingestion.deletePartiallyIngestedData(end2))
+
+    // Move the ledger end so that any non-deleted data would become visible
+    executeSql(updateLedgerEnd(ledgerEnd(10, 6L)))
+
+    // Check the contents
+    val parties2 = executeSql(backend.party.knownParties)
+    val config2 = executeSql(backend.configuration.ledgerConfiguration)
+    val packages2 = executeSql(backend.packageBackend.lfPackages)
+    val contract42 = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        readers,
+        hashCid("#4"),
+      )
+    )
+    val contract92 = executeSql(
+      backend.contract.activeContractWithoutArgument(
+        readers,
+        hashCid("#9"),
+      )
+    )
+    val filterIds2 = executeSql(
+      backend.event.activeContractEventIds(
+        partyFilter = someParty,
+        templateIdFilter = None,
+        startExclusive = 0,
+        endInclusive = 1000,
+        limit = 1000,
+      )
+    )
+
+    val metering2 =
+      executeSql(backend.metering.read.reportData(Timestamp.Epoch, None, None))
+
+    parties2 shouldBe empty
+    packages2 shouldBe empty
+    config2 shouldBe empty
+    contract42 shouldBe None
+    contract92 shouldBe None
+    filterIds2 shouldBe empty
+    metering2.applicationData shouldBe empty
+
+  }
 }


### PR DESCRIPTION
.. if the indexer crashes before writing the first ledger end

I have verified that the new test fails on Oracle without the fix included in this PR:

```
- should delete overspill entries written before first ledger end update *** FAILED *** (120 milliseconds)
  List(PartyDetails(party1,Some(party1),true)) was not empty (StorageBackendTestsInitializeIngestion.scala:250)
```
