### PR TITLE
docs: fix canton ref

### DIFF
--- a/docs/canton-refs.rst
+++ b/docs/canton-refs.rst
@@ -11,5 +11,5 @@ Dummy Canton Refs
 
 .. _canton-metrics:
 
-.. _high-availability:
+.. _ha_arch:
 

--- a/docs/source/json-api/production-setup.rst
+++ b/docs/source/json-api/production-setup.rst
@@ -221,7 +221,7 @@ active one drops. Just as for the *HTTP JSON API* itself, you can use orchestrat
 monitor the status of the participant nodes and have those point your (possibly highly available) *HTTP JSON API*
 nodes to the active participant node.
 
-To learn how Canton can be run with high availability and how to monitor it refer to the :ref:`Canton documentation <high-availability>`.
+To learn how Canton can be run with high availability and how to monitor it refer to the :ref:`Canton documentation <ha_arch>`.
 
 Logging
 *******


### PR DESCRIPTION
The referenced section is here:
https://github.com/DACH-NY/canton/blob/main/docs-open/src/sphinx/architecture/ha.rst

It already contains a label definition, but it doesn't directly match
the title. I've tested this fix locally by building the combined docs.

CHANGELOG_BEGIN
CHANGELOG_END