### PR TITLE
LF: Slightly reduce stack consumption of the type cheker.

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -51,20 +51,23 @@ object Ast {
       (typs foldLeft ETyApp(this, typ))(ETyApp)
   }
 
+  // We use this type to reduce depth of pattern matching
+  sealed abstract class ExprAtomic extends Expr
+
   /** Reference to a variable in current lexical scope. */
-  final case class EVar(value: ExprVarName) extends Expr
+  final case class EVar(value: ExprVarName) extends ExprAtomic
 
   /** Reference to a value definition. */
-  final case class EVal(value: ValueRef) extends Expr
+  final case class EVal(value: ValueRef) extends ExprAtomic
 
   /** Reference to a builtin function. */
-  final case class EBuiltin(value: BuiltinFunction) extends Expr
+  final case class EBuiltin(value: BuiltinFunction) extends ExprAtomic
 
   /** Primitive constructor, e.g. True, False or Unit. */
-  final case class EPrimCon(value: PrimCon) extends Expr
+  final case class EPrimCon(value: PrimCon) extends ExprAtomic
 
   /** Primitive literal. */
-  final case class EPrimLit(value: PrimLit) extends Expr
+  final case class EPrimLit(value: PrimLit) extends ExprAtomic
 
   /** Record construction. */
   final case class ERecCon(tycon: TypeConApp, fields: ImmArray[(FieldName, Expr)]) extends Expr
@@ -80,7 +83,7 @@ object Ast {
   final case class EVariantCon(tycon: TypeConApp, variant: VariantConName, arg: Expr) extends Expr
 
   /** Variant construction. */
-  final case class EEnumCon(tyConName: TypeConName, con: EnumConName) extends Expr
+  final case class EEnumCon(tyConName: TypeConName, con: EnumConName) extends ExprAtomic
 
   /** Struct construction. */
   final case class EStructCon(fields: ImmArray[(FieldName, Expr)]) extends Expr
@@ -114,7 +117,7 @@ object Ast {
   final case class ELet(binding: Binding, body: Expr) extends Expr
 
   /** Empty list constructor. */
-  final case class ENil(typ: Type) extends Expr
+  final case class ENil(typ: Type) extends ExprAtomic
 
   /** List construction. */
   final case class ECons(typ: Type, front: ImmArray[Expr], tail: Expr) extends Expr
@@ -128,7 +131,7 @@ object Ast {
   /** Location annotations */
   final case class ELocation(loc: Location, expr: Expr) extends Expr
 
-  final case class ENone(typ: Type) extends Expr
+  final case class ENone(typ: Type) extends ExprAtomic
 
   final case class ESome(typ: Type, body: Expr) extends Expr
 


### PR DESCRIPTION
Workaround to solve flakiness of
//daml-lf/tests:test-scenario-stable-many-field until #13410 is fixed.

Without the fix (b08fcfada33fc4a8ff5d360abeab65bd17468cd0)

```
$ bazel test --runs_per_test=100 //daml-lf/tests:test-scenario-stable-many-fields
INFO: Invocation ID: eba6a901-ba39-4f2f-ac11-2a9028437815
Loading: 
Loading: 0 packages loaded
DEBUG: /home/remy/.cache/bazel/_bazel_remy/1016251e5268d0bb8d83075fbfaf2315/external/rules_haskell/haskell/private/versions.bzl:60:10: WARNING: bazel version is too recent. Supported versions range from 4.0.0 to 4.2.1, but found: 4.2.2- (@non-git)
Analyzing: target //daml-lf/tests:test-scenario-stable-many-fields (0 packages loaded, 0 targets configured)
INFO: Analyzed target //daml-lf/tests:test-scenario-stable-many-fields (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
[...]
//daml-lf/tests:test-scenario-stable-many-fields                         FAILED in 16 out of 100 in 17.4s
[...]

Executed 1 out of 1 test: 1 fails locally.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```

With the fix (db094144c2da3c8f265f1e04805d4c31b51fd076)
```
$ bazel test --runs_per_test=100 //daml-lf/tests:test-scenario-stable-many-fields 
Starting local Bazel server and connecting to it...
INFO: Invocation ID: 3a21f0e1-4135-4d88-9c2c-ee0b607ee32e
DEBUG: /home/remy/.cache/bazel/_bazel_remy/1016251e5268d0bb8d83075fbfaf2315/external/rules_haskell/haskell/private/versions.bzl:60:10: WARNING: bazel version is too recent. Supported versions range from 4.0.0 to 4.2.1, but found: 4.2.2- (@non-git)
INFO: Analyzed target //daml-lf/tests:test-scenario-stable-many-fields (300 packages loaded, 20921 targets configured).
INFO: Found 1 test target...
INFO: Deleting stale sandbox base /home/remy/.cache/bazel/_bazel_remy/1016251e5268d0bb8d83075fbfaf2315/sandbox
Target //daml-lf/tests:test-scenario-stable-many-fields up-to-date:
  bazel-bin/daml-lf/tests/test-scenario-stable-many-fields
INFO: Elapsed time: 615.180s, Critical Path: 80.52s
INFO: 106 processes: 5 remote cache hit, 200 linux-sandbox.
INFO: Build completed successfully, 106 total actions
//daml-lf/tests:test-scenario-stable-many-fields                         PASSED in 27.0s
  Stats over 100 runs: max = 27.0s, min = 12.8s, avg = 16.2s, dev = 2.2s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 106 total actions
```

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
