### PR TITLE
Add test:postgres config in .bazelrc to make it easier to run test  against a non-ephemeral Postgres server

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,7 @@ fetch:darwin --repository_cache=.bazel-cache/repo
 sync:darwin --repository_cache=.bazel-cache/repo
 
 test:oracle --repo_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
+test:postgres  --test_env POSTGRESQL_HOST --test_env POSTGRESQL_PORT --test_env POSTGRESQL_USERNAME --test_env POSTGRESQL_PASSWORD
 
 # Improve remote cache hit rate by exluding environment variables from the
 # sandbox that are not whitelisted using --action_env.

--- a/compatibility/.bazelrc
+++ b/compatibility/.bazelrc
@@ -20,6 +20,7 @@ fetch:darwin --repository_cache=.bazel-cache/repo
 sync:darwin --repository_cache=.bazel-cache/repo
 
 test:oracle --repo_env DAML_ORACLE_TESTING=true --test_env ORACLE_USERNAME --test_env ORACLE_PORT --test_env ORACLE_PWD
+test:postgres  --test_env POSTGRESQL_HOST --test_env POSTGRESQL_PORT --test_env POSTGRESQL_USERNAME --test_env POSTGRESQL_PASSWORD
 
 # Improve remote cache hit rate by exluding environment variables from the
 # sandbox that are not whitelisted using --action_env.


### PR DESCRIPTION
Sample usage:

1. Set up environment variables with Postgres instance details in e.g. `.envrc.private` like so:
```
export POSTGRESQL_HOST=localhost
export POSTGRESQL_PORT=5432
export POSTGRESQL_USERNAME=username
export POSTGRESQL_PASSWORD=
```

2. You can now use that instance (instead of an ephemeral one) for running tests:
```
bazel test --config=postgres //ledger/ledger-api-bench-tool:ledger-api-bench-tool-tests_test_suite_src_test_suite_scala_com_daml_ledger_api_benchtool_submission_CommandSubmitterITSpec.scala
```

changelog_begin
changelog_end