### PR TITLE
Add unionWith to DA.Map

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Map.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Map.daml
@@ -48,6 +48,7 @@ module DA.Map
     , insert
     , alter
     , union
+    , unionWith
     , merge
     , keys
     , values
@@ -175,6 +176,15 @@ alter f k m =
 -- keys are encountered.
 union : Ord k => Map k v -> Map k v -> Map k v
 union m1 m2 = foldl (\acc (k, v) -> insert k v acc) m2 (toList m1)
+
+-- | The union of two maps using the combining function to merge values that
+-- exist in both maps.
+unionWith : forall k v. Ord k => (v -> v -> v) -> Map k v -> Map k v -> Map k v
+unionWith combine m1 m2 = foldl f m1 (toList m2)
+  where f : Map k v -> (k, v) -> Map k v
+        f acc (k, v) = case lookup k acc of
+          None -> insert k v acc
+          Some v' -> insert k (combine v' v) acc
 
 -- | Combine two maps, using separate functions based on whether
 -- a key appears only in the first map, only in the second map,

--- a/compiler/damlc/tests/daml-test-files/Map.daml
+++ b/compiler/damlc/tests/daml-test-files/Map.daml
@@ -75,4 +75,13 @@ testMerge = scenario do
   [(1, "a"), (3, "b")] === toList (merge (\_ v -> Some v) (\_ v -> if v <= "bb" then Some v else None) (\_ _ _ -> None) M.empty m2)
   [(1,"bb"), (2,"dd"), (3,"aa")] === toList (merge (\_ _ -> None) (\_ _ -> None) (\_ v _ -> Some v) m1 m2)
 
+testUnionWith = scenario do
+  let m1 = fromList [(1, 1), (2, 2), (3, 3)]
+      m2 = fromList [(1, 3), (2, 5), (4, 7)]
+  unionWith (+) m1 m2
+    === fromList [(1, 4), (2, 7), (3, 3), (4, 7)]
+
+  unionWith (-) m1 m2
+    === fromList [(1, -2), (2, -3), (3, 3), (4, 7)]
+
 -- @ENABLE-SCENARIOS


### PR DESCRIPTION
changelog_begin

- [Daml Stdlib] Add `unionWith` function. `unionWith` is a more
  flexible version of `union` that accepts a function to combine
  values found in both maps.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description
- [ ] If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
