### PR TITLE
Changed log level of PARTICIPANT_BACKPRESSURE to INFO.

### DIFF
--- a/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/LedgerApiErrors.scala
@@ -57,7 +57,7 @@ object LedgerApiErrors extends LedgerApiErrorGroup {
         id = "PARTICIPANT_BACKPRESSURE",
         ErrorCategory.ContentionOnSharedResources,
       ) {
-    override def logLevel: Level = Level.WARN
+    override def logLevel: Level = Level.INFO
 
     case class Rejection(reason: String)(implicit errorLogger: ContextualizedErrorLogger)
         extends DamlErrorWithDefiniteAnswer(


### PR DESCRIPTION
(Otherwise, an excessive rate of incoming commands will flood the log file with backpressure warnings.)

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
