### PR TITLE
Add interface support to `transitiveClosure`

### DIFF
--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/DefDataType.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/DefDataType.scala
@@ -248,7 +248,15 @@ object TemplateChoice {
 final case class DefInterface[+Ty](choices: Map[Ref.ChoiceName, TemplateChoice[Ty]])
     extends DefTemplate.GetChoices[Ty]
 
-object DefInterface extends FWTLike[DefInterface]
+object DefInterface extends FWTLike[DefInterface] {
+
+  implicit val `InterfaceDecl fold`: Foldable[DefInterface] =
+    new Foldable.FromFoldMap[DefInterface] {
+      override def foldMap[A, B: Monoid](fa: DefInterface[A])(f: A => B): B =
+        fa.choices.foldMap(_ foldMap f)
+    }
+
+}
 
 /** Add aliases to companions. */
 sealed abstract class FWTLike[F[+_]] {

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraph.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraph.scala
@@ -58,17 +58,7 @@ private[codegen] object DependencyGraph {
   def transitiveClosure(
       serializableTypes: Map[Identifier, InterfaceType],
       interfaces: Map[Identifier, DefInterface.FWT],
-  ): TransitiveClosure = {
-    val dependencies = orderedDependencies(serializableTypes, interfaces)
-    val (s, i) = dependencies.deps.partitionMap {
-      case (id, Node(NodeType.Internal(defDataType), _)) =>
-        Left(id -> InterfaceType.Normal(defDataType))
-      case (id, Node(NodeType.Root.Template(record, template), _)) =>
-        Left(id -> InterfaceType.Template(record, template))
-      case (id, Node(NodeType.Root.Interface(defInterface), _)) =>
-        Right(id -> defInterface)
-    }
-    TransitiveClosure(s, i, dependencies.errors)
-  }
+  ): TransitiveClosure =
+    TransitiveClosure.from(orderedDependencies(serializableTypes, interfaces))
 
 }

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraph.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraph.scala
@@ -61,7 +61,7 @@ private[codegen] object DependencyGraph {
   ): TransitiveClosure = {
     val dependencies = orderedDependencies(serializableTypes, interfaces)
     TransitiveClosure(
-      orderedDependencies = orderedDependencies(serializableTypes, interfaces).deps.map {
+      orderedDependencies = dependencies.deps.map {
         case (id, Node(NodeType.Internal(defDataType), _)) =>
           id -> Right(InterfaceType.Normal(defDataType))
         case (id, Node(NodeType.Root.Template(record, template), _)) =>

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/Node.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/Node.scala
@@ -3,4 +3,4 @@
 
 package com.daml.lf.codegen.dependencygraph
 
-final case class Node[+K, +A](content: A, dependencies: List[K], collectDepError: Boolean)
+final case class Node[+K, +A](content: A, dependencies: List[K])

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/NodeType.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/NodeType.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.codegen.dependencygraph
+
+import com.daml.lf.iface.{DefTemplate, DefInterface, DefDataType, Record}
+
+sealed abstract class NodeType extends Product with Serializable
+
+private[dependencygraph] object NodeType {
+
+  sealed abstract class Root extends NodeType
+
+  object Root {
+
+    final case class Template(record: Record.FWT, defTemplate: DefTemplate.FWT) extends Root
+
+    final case class Interface(defInterface: DefInterface.FWT) extends Root
+
+  }
+
+  final case class Internal(defDataType: DefDataType.FWT) extends NodeType
+
+}

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/TransitiveClosure.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/TransitiveClosure.scala
@@ -5,7 +5,7 @@ package com.daml.lf.codegen.dependencygraph
 
 import com.daml.lf.codegen.exception.UnsupportedTypeError
 import com.daml.lf.data.Ref.Identifier
-import com.daml.lf.iface.InterfaceType
+import com.daml.lf.iface.{InterfaceType, DefInterface}
 
 /** Represents a collection of templates and all the type
   * declarations for which code must be generated so that
@@ -14,6 +14,13 @@ import com.daml.lf.iface.InterfaceType
   * Ledger API.
   */
 final case class TransitiveClosure(
-    interfaceTypes: Vector[(Identifier, InterfaceType)],
+    orderedDependencies: Vector[(Identifier, Either[DefInterface.FWT, InterfaceType])],
     errors: List[UnsupportedTypeError],
-)
+) {
+
+  lazy val (interfaces, serializableTypes) = orderedDependencies.partitionMap {
+    case (id, Left(interface)) => Left(id -> interface)
+    case (id, Right(serializable)) => Right(id -> serializable)
+  }
+
+}

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/TransitiveClosure.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/TransitiveClosure.scala
@@ -14,13 +14,7 @@ import com.daml.lf.iface.{InterfaceType, DefInterface}
   * Ledger API.
   */
 final case class TransitiveClosure(
-    orderedDependencies: Vector[(Identifier, Either[DefInterface.FWT, InterfaceType])],
+    serializableTypes: Vector[(Identifier, InterfaceType)],
+    interfaces: Vector[(Identifier, DefInterface.FWT)],
     errors: List[UnsupportedTypeError],
-) {
-
-  lazy val (interfaces, serializableTypes) = orderedDependencies.partitionMap {
-    case (id, Left(interface)) => Left(id -> interface)
-    case (id, Right(serializable)) => Right(id -> serializable)
-  }
-
-}
+)

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/TransitiveClosure.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/TransitiveClosure.scala
@@ -18,3 +18,19 @@ final case class TransitiveClosure(
     interfaces: Vector[(Identifier, DefInterface.FWT)],
     errors: List[UnsupportedTypeError],
 )
+
+object TransitiveClosure {
+
+  def from(orderedDependencies: OrderedDependencies[Identifier, NodeType]): TransitiveClosure = {
+    val (serializableTypes, interfaces) = orderedDependencies.deps.partitionMap {
+      case (id, Node(NodeType.Internal(defDataType), _)) =>
+        Left(id -> InterfaceType.Normal(defDataType))
+      case (id, Node(NodeType.Root.Template(record, template), _)) =>
+        Left(id -> InterfaceType.Template(record, template))
+      case (id, Node(NodeType.Root.Interface(defInterface), _)) =>
+        Right(id -> defInterface)
+    }
+    TransitiveClosure(serializableTypes, interfaces, orderedDependencies.errors)
+  }
+
+}

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraphSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraphSpec.scala
@@ -4,7 +4,9 @@
 package com.daml.lf.codegen.dependencygraph
 
 import com.daml.lf.codegen.Util
-import com.daml.lf.data.Ref
+import com.daml.lf.data.ImmArray.ImmArraySeq
+import com.daml.lf.data.{Ref, ImmArray}
+import com.daml.lf.iface._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scalaz.syntax.std.map._
@@ -14,8 +16,47 @@ final class DependencyGraphSpec extends AnyWordSpec with Matchers {
   "orderedDependencies" should {
     "include contract keys" in {
       val declarations = Util.filterTemplatesBy(Seq("HasKey".r))(DependencyGraphSpec.typeDecls)
-      DependencyGraph.orderedDependencies(declarations).deps map (_._1) should ===(
+      DependencyGraph.orderedDependencies(declarations, Map.empty).deps map (_._1) should ===(
         Vector("a:b:It", "a:b:HasKey") map Ref.Identifier.assertFromString
+      )
+    }
+    "include dependencies of interfaces" in {
+      val interface = Ref.Identifier.assertFromString("a:b:Interface")
+      val foo = Ref.Identifier.assertFromString("a:b:Foo")
+      val bar = Ref.Identifier.assertFromString("a:b:Bar")
+      val baz = Ref.Identifier.assertFromString("a:b:Baz")
+      val quux = Ref.Identifier.assertFromString("a:b:Quux")
+      DependencyGraph
+        .orderedDependencies(
+          serializableTypes = Map(
+            foo -> InterfaceType.Normal(
+              DefDataType(
+                ImmArray(bar.qualifiedName.name.segments.last).toSeq,
+                Record(ImmArraySeq.empty),
+              )
+            ),
+            bar -> InterfaceType.Normal(DefDataType(ImmArraySeq.empty, Record(ImmArraySeq.empty))),
+            baz -> InterfaceType.Normal(DefDataType(ImmArraySeq.empty, Record(ImmArraySeq.empty))),
+            quux -> InterfaceType.Normal(DefDataType(ImmArraySeq.empty, Record(ImmArraySeq.empty))),
+          ),
+          interfaces = Map(
+            interface -> DefInterface(
+              choices = Map(
+                Ref.ChoiceName.assertFromString("SomeChoice") -> TemplateChoice[Type](
+                  param = TypeCon(
+                    TypeConName(foo),
+                    ImmArray(TypeCon(TypeConName(bar), ImmArraySeq.empty)).toSeq,
+                  ),
+                  consuming = false,
+                  returnType = TypeCon(TypeConName(baz), ImmArraySeq.empty),
+                )
+              )
+            )
+          ),
+        )
+        .deps
+        .map(_._1) should ===(
+        Vector(foo, bar, baz, interface)
       )
     }
   }
@@ -23,9 +64,6 @@ final class DependencyGraphSpec extends AnyWordSpec with Matchers {
 }
 
 object DependencyGraphSpec {
-
-  import com.daml.lf.iface._
-  import com.daml.lf.data.ImmArray.ImmArraySeq
 
   private[this] val fooRec = Record(ImmArraySeq.empty)
   private val typeDecls =

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/dependencygraph/GraphSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/dependencygraph/GraphSpec.scala
@@ -12,7 +12,7 @@ class GraphSpec extends AnyFlatSpec with Matchers {
       contentAndId: Int,
       deps: List[Int] = List.empty[Int],
   ): (Int, Node[Int, Int]) =
-    contentAndId -> Node(contentAndId, deps, collectDepError = true)
+    contentAndId -> Node(contentAndId, deps)
 
   private[this] def orderedDependencies[K, A](
       nodes: Iterable[(K, Node[K, A])]

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/CodeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/CodeGen.scala
@@ -131,13 +131,17 @@ object CodeGen {
     }
 
   private def packageInterfaceToScalaCode(util: LFUtil): Unit = {
-    val typeDeclarationsToGenerate = DependencyGraph.transitiveClosure(util.iface.typeDecls)
+    val typeDeclarationsToGenerate =
+      DependencyGraph.transitiveClosure(
+        serializableTypes = util.iface.typeDecls,
+        interfaces = Map.empty, // TODO(#13349)
+      )
 
     // Each record/variant has Scala code generated for it individually, unless their names are related
     writeTemplatesAndTypes(util)(WriteParams(typeDeclarationsToGenerate))
 
     val totalTemplates = templateCount(util.iface.typeDecls)
-    val generated = templateCount(typeDeclarationsToGenerate.interfaceTypes)
+    val generated = templateCount(typeDeclarationsToGenerate.serializableTypes) // TODO(#13349)
     val notGenerated = totalTemplates - generated
 
     val errorMessages = typeDeclarationsToGenerate.errors.map(_.msg).mkString("\n")

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/LFUtil.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/LFUtil.scala
@@ -432,7 +432,7 @@ object LFUtil {
 
   object WriteParams {
     def apply(tc: TransitiveClosure): WriteParams = {
-      val (templateIds, typeDeclarations) = tc.interfaceTypes.partitionMap {
+      val (templateIds, typeDeclarations) = tc.serializableTypes.partitionMap { // TODO(#13349)
         case (id, InterfaceType.Template(record, template)) =>
           Left(id -> DefTemplateWithRecord(record, template))
         case (id, InterfaceType.Normal(t)) =>


### PR DESCRIPTION
Contributes to https://github.com/digital-asset/daml/issues/13324

changelog_begin
changelog_end

This work can be reused to address https://github.com/digital-asset/daml/issues/13349 and I left `TODO`s where appropriate.

While I was there, I removed a field in `Node` that was not used.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
