### PR TITLE
docs: fix intro project names

### DIFF
--- a/docs/source/app-dev/app-arch.rst
+++ b/docs/source/app-dev/app-arch.rst
@@ -10,7 +10,7 @@ This section describes our recommended design of a full-stack Daml application.
 
 .. image:: ./recommended_architecture.svg
 
-The above image shows the recommended architecture. Of course there are many ways that the architecture and technology 
+The above image shows the recommended architecture. Of course there are many ways that the architecture and technology
 stack can be changed to fit your needs which we'll mention in the corresponding sections.
 
 To get started quickly with the recommended application architecture, generate a new project using the ``create-daml-app`` template:

--- a/docs/source/building-applications.rst
+++ b/docs/source/building-applications.rst
@@ -4,9 +4,9 @@
 Building Applications
 =====================
 
-The Building Applications section covers the elements that are used to create, extend, and test your Daml full-stack application (including APIs and JavaScript client libraries) and the architectural best practices for bringing those elements together.  
+The Building Applications section covers the elements that are used to create, extend, and test your Daml full-stack application (including APIs and JavaScript client libraries) and the architectural best practices for bringing those elements together.
 
-As with the Writing Daml section, you can find the Daml code for the example application and features `here <https://github.com/digital-asset/daml/tree/main/docs/source/daml/intro/daml>`_ or download it using the Daml assistant. For example, to load the sources for section 1 into a folder called 1_Token, run daml new 1_Token --template daml-intro-1. 
+As with the Writing Daml section, you can find the Daml code for the example application and features `here <https://github.com/digital-asset/daml/tree/main/docs/source/daml/intro/daml>`_ or download it using the Daml assistant. For example, to load the sources for section 1 into a folder called ``intro1``, run daml new intro1 --template daml-intro-1.
 
 To run the examples, you will first need to `install the Daml SDK <https://docs.daml.com/getting-started/installation.html>`_.
 

--- a/docs/source/daml/intro/0_Intro.rst
+++ b/docs/source/daml/intro/0_Intro.rst
@@ -10,7 +10,7 @@ Daml is a smart contract language designed to build composable applications on a
 
 In this introduction, you will learn about the structure of a Daml Ledger, and how to write Daml applications that run on any Daml Ledger implementation, by building an asset-holding and -trading application. You will gain an overview over most important language features, how they relate to the :ref:`da-ledgers` and how to use Daml's developer tools to write, test, compile, package and ship your application.
 
-This introduction is structured such that each section presents a new self-contained application with more functionality than that from the previous section. You can find the Daml code for each section `here <https://github.com/digital-asset/daml/tree/main/docs/source/daml/intro/daml>`_ or download them using the Daml assistant. For example, to load the sources for section 1 into a folder called ``1_Token``, run ``daml new 1_Token --template daml-intro-1``.
+This introduction is structured such that each section presents a new self-contained application with more functionality than that from the previous section. You can find the Daml code for each section `here <https://github.com/digital-asset/daml/tree/main/docs/source/daml/intro/daml>`_ or download them using the Daml assistant. For example, to load the sources for section 1 into a folder called ``intro1``, run ``daml new intro1 --template daml-intro-1``.
 
 Prerequisites:
 

--- a/docs/source/daml/intro/1_Token.rst
+++ b/docs/source/daml/intro/1_Token.rst
@@ -14,7 +14,7 @@ To begin with, you're going to write a very small Daml template, which represent
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder ``1_Token`` by running ``daml new 1_Token --template daml-intro-1``
+  Remember that you can load all the code for this section into a folder ``1_Token`` by running ``daml new intro1 --template daml-intro-1``
 
 Daml ledger basics
 ------------------

--- a/docs/source/daml/intro/2_DamlScript.rst
+++ b/docs/source/daml/intro/2_DamlScript.rst
@@ -17,7 +17,7 @@ In this section you will test the ``Token`` model from :doc:`1_Token` using the 
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``daml-intro-2`` by running ``daml new daml-intro-2 --template daml-intro-2``
+  Remember that you can load all the code for this section into a folder called ``daml-intro-2`` by running ``daml new intro2 --template daml-intro-2``
 
 .. script_basics:
 

--- a/docs/source/daml/intro/3_Data.rst
+++ b/docs/source/daml/intro/3_Data.rst
@@ -27,7 +27,7 @@ After this section, you should be able to use a Daml ledger as a simple database
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``3_Data`` by running ``daml new 3_Data --template daml-intro-3``
+  Remember that you can load all the code for this section into a folder called ``intro3`` by running ``daml new intro3 --template daml-intro-3``
 
 .. _native-types:
 

--- a/docs/source/daml/intro/4_Transformations.rst
+++ b/docs/source/daml/intro/4_Transformations.rst
@@ -12,7 +12,7 @@ In this section you will learn about how to define simple data transformations u
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``4_Transformations`` by running ``daml new 4_Transformations --template daml-intro-4``
+  Remember that you can load all the code for this section into a folder called ``intro4`` by running ``daml new intro4 --template daml-intro-4``
 
 Choices as methods
 ------------------

--- a/docs/source/daml/intro/5_Restrictions.rst
+++ b/docs/source/daml/intro/5_Restrictions.rst
@@ -15,7 +15,7 @@ Lastly, you will learn about time on the ledger and in Daml Script.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``5_Restrictions`` by running ``daml new 5_Restrictions --template daml-intro-5``
+  Remember that you can load all the code for this section into a folder called ``intro5`` by running ``daml new intro5 --template daml-intro-5``
 
 Template preconditions
 ----------------------

--- a/docs/source/daml/intro/6_Parties.rst
+++ b/docs/source/daml/intro/6_Parties.rst
@@ -14,7 +14,7 @@ In this section you will learn about Daml's authorization rules and how to devel
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``6_Parties`` by running ``daml new 6_Parties --template daml-intro-6``
+  Remember that you can load all the code for this section into a folder called ``intro6`` by running ``daml new intro6 --template daml-intro-6``
 
 Preventing IOU revocation
 -------------------------

--- a/docs/source/daml/intro/7_Composing.rst
+++ b/docs/source/daml/intro/7_Composing.rst
@@ -16,14 +16,14 @@ The model in this section is not a single Daml file, but a Daml project consisti
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``7_Composing`` by running ``daml new 7Composing --template daml-intro-7``
+  Remember that you can load all the code for this section into a folder called ``intro7`` by running ``daml new intro7 --template daml-intro-7``
 
 Daml projects
 -------------
 
 Daml is organized in projects, packages and modules. A Daml project is specified using a single ``daml.yaml`` file, and compiles into a package in Daml's intermediate language, or bytecode equivalent, Daml-LF. Each Daml file within a project becomes a Daml module, which is a bit like a namespace. Each Daml project has a source root specified in the ``source`` parameter in the project's ``daml.yaml`` file. The package will include all modules specified in ``*.daml`` files beneath that source directory.
 
-You can start a new project with a skeleton structure using ``daml new project_name`` in the terminal. A minimal project would contain just a ``daml.yaml`` file and an empty directory of source files.
+You can start a new project with a skeleton structure using ``daml new project-name`` in the terminal. A minimal project would contain just a ``daml.yaml`` file and an empty directory of source files.
 
  Take a look at the ``daml.yaml`` for the chapter 7 project:
 
@@ -32,7 +32,7 @@ You can start a new project with a skeleton structure using ``daml new project_n
 
 You can generally set ``name`` and ``version`` freely to describe your project. ``dependencies`` does what the name suggests: It includes dependencies. You should always include ``daml-prim`` and ``daml-stdlib``. The former contains internals of compiler and Daml Runtime, the latter gives access to the Daml Standard Library. ``daml-script`` contains the types and standard library for Daml Script.
 
-You compile a Daml project by running ``daml build`` from the project root directory. This creates a ``dar`` file in ``.daml/dist/dist/project_name-project_version.dar``. A ``dar`` file is Daml's equivalent of a ``JAR`` file in Java: it's the artifact that gets deployed to a ledger to load the package and its dependencies. ``dar`` files are fully self-contained in that they contain all dependencies of the main package. More on all of this in :doc:`9_Dependencies`.
+You compile a Daml project by running ``daml build`` from the project root directory. This creates a ``dar`` file in ``.daml/dist/dist/${project_name}-${project_version}.dar``. A ``dar`` file is Daml's equivalent of a ``JAR`` file in Java: it's the artifact that gets deployed to a ledger to load the package and its dependencies. ``dar`` files are fully self-contained in that they contain all dependencies of the main package. More on all of this in :doc:`9_Dependencies`.
 
 Project structure
 -----------------

--- a/docs/source/daml/intro/8_Exceptions.rst
+++ b/docs/source/daml/intro/8_Exceptions.rst
@@ -36,7 +36,7 @@ outside of Daml.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``8_Exceptions`` by running ``daml new 8_Exceptions --template daml-intro-8``
+  Remember that you can load all the code for this section into a folder called ``intro8`` by running ``daml new intro8 --template daml-intro-8``
 
 Our example for the use of exceptions will be a simple shop
 template. Users can order items by calling a choice and transfer money

--- a/docs/source/daml/intro/9_Dependencies.rst
+++ b/docs/source/daml/intro/9_Dependencies.rst
@@ -40,14 +40,14 @@ You'll get a whole lot of output. Under the header "DAR archive contains the fol
 #. ``*.hi`` and ``*.hie`` files for each ``*.daml`` file
 #. Some meta-inf and config files
 
-The first file is something like ``intro7-1.0.0-887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625.dalf`` which is the actual compiled package for the project. ``*.dalf`` files contain Daml-LF, which is Daml's intermediate language. The file contents are a binary encoded protobuf message from the `daml-lf schema <https://github.com/digital-asset/daml/tree/main/daml-lf/archive>`_.  Daml-LF is evaluated on the Ledger by the Daml Engine, which is a JVM component that is part of tools like the IDE's Script runner, the Sandbox, or proper production ledgers. If Daml-LF is to Daml what Java Bytecode is to Java, the Daml Engine is to Daml what the JVM is to Java.
+The first file is something like ``intro7-1.0.0-887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625.dalf`` which is the actual compiled package for the project. ``*.dalf`` files contain Daml-LF, which is Daml's intermediate language. The file contents are a binary encoded protobuf message from the `daml-lf schema <https://github.com/digital-asset/daml/tree/main/daml-lf/archive>`_. Daml-LF is evaluated on the Ledger by the Daml Engine, which is a JVM component that is part of tools like the IDE's Script runner, the Sandbox, or proper production ledgers. If Daml-LF is to Daml what Java Bytecode is to Java, the Daml Engine is to Daml what the JVM is to Java.
 
 Hashes and Identifiers
 ----------------------
 
 Under the heading "DAR archive contains the following packages:" you get a similar looking list of package names, paired with only the long random string repeated. That hexadecimal string, ``887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625`` in this case, is the package hash and the primary and only identifier for a package that's guaranteed to be available and preserved. Meta information like name ("intro7") and version ("1.0.0") help make it human readable but should not be relied upon. You may not always get DAR files from your compiler, but be loading them from a running Ledger, or get them from an artifact repository.
 
-We can see this in action. When a DAR file gets deployed to a ledger, not all meta information is preserved. 
+We can see this in action. When a DAR file gets deployed to a ledger, not all meta information is preserved.
 
 #. Note down your main package hash from running ``inspect-dar`` above
 #. Start the project using ``daml start``

--- a/docs/source/daml/intro/9_Dependencies.rst
+++ b/docs/source/daml/intro/9_Dependencies.rst
@@ -17,8 +17,8 @@ Upgrades are covered in their own section outside this introduction to Daml: :do
 
 Since we are extending chapter 7, the setup for this chapter is slightly more complex:
 
-#. In a base directory, load the chapter 7 project using ``daml new 7Composing --template daml-intro-7``. The directory ``7Composing`` here is important as it'll be referenced by the other project we are creating.
-#. In the same directory, load the chapter 8 project using ``daml new 9Dependencies --template daml-intro-9``.
+#. In a base directory, load the chapter 7 project using ``daml new intro7 --template daml-intro-7``. The directory ``intro7`` here is important as it'll be referenced by the other project we are creating.
+#. In the same directory, load the chapter 8 project using ``daml new intro9 --template daml-intro-9``.
 
 ``8Dependencies`` contains a new module ``Intro.Asset.MultiTrade`` and a corresponding test module ``Test.Intro.Asset.MultiTrade``.
 
@@ -29,7 +29,7 @@ In :doc:`7_Composing` you already learnt a little about projects, Daml-LF, DAR f
 
 Let's have a look inside the DAR file of chapter 7. DAR files, like Java JAR files are just ZIP archives, but the SDK also has a utility to inspect DARs out of the box:
 
-#. Navigate into the ``7Composing`` directory.
+#. Navigate into the ``intro7`` directory.
 #. Build using ``daml build -o assets.dar``
 #. Run ``daml damlc inspect-dar assets.dar``
 
@@ -40,12 +40,12 @@ You'll get a whole lot of output. Under the header "DAR archive contains the fol
 #. ``*.hi`` and ``*.hie`` files for each ``*.daml`` file
 #. Some meta-inf and config files
 
-The first file is something like ``7Composing-1.0.0-887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625.dalf`` which is the actual compiled package for the project. ``*.dalf`` files contain Daml-LF, which is Daml's intermediate language. The file contents are a binary encoded protobuf message from the `daml-lf schema <https://github.com/digital-asset/daml/tree/main/daml-lf/archive>`_.  Daml-LF is evaluated on the Ledger by the Daml Engine, which is a JVM component that is part of tools like the IDE's Script runner, the Sandbox, or proper production ledgers. If Daml-LF is to Daml what Java Bytecode is to Java, the Daml Engine is to Daml what the JVM is to Java.
+The first file is something like ``intro7-1.0.0-887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625.dalf`` which is the actual compiled package for the project. ``*.dalf`` files contain Daml-LF, which is Daml's intermediate language. The file contents are a binary encoded protobuf message from the `daml-lf schema <https://github.com/digital-asset/daml/tree/main/daml-lf/archive>`_.  Daml-LF is evaluated on the Ledger by the Daml Engine, which is a JVM component that is part of tools like the IDE's Script runner, the Sandbox, or proper production ledgers. If Daml-LF is to Daml what Java Bytecode is to Java, the Daml Engine is to Daml what the JVM is to Java.
 
 Hashes and Identifiers
 ----------------------
 
-Under the heading "DAR archive contains the following packages:" you get a similar looking list of package names, paired with only the long random string repeated. That hexadecimal string, ``887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625`` in this case, is the package hash and the primary and only identifier for a package that's guaranteed to be available and preserved. Meta information like name ("7Composing") and version ("1.0.0") help make it human readable but should not be relied upon. You may not always get DAR files from your compiler, but be loading them from a running Ledger, or get them from an artifact repository.
+Under the heading "DAR archive contains the following packages:" you get a similar looking list of package names, paired with only the long random string repeated. That hexadecimal string, ``887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625`` in this case, is the package hash and the primary and only identifier for a package that's guaranteed to be available and preserved. Meta information like name ("intro7") and version ("1.0.0") help make it human readable but should not be relied upon. You may not always get DAR files from your compiler, but be loading them from a running Ledger, or get them from an artifact repository.
 
 We can see this in action. When a DAR file gets deployed to a ledger, not all meta information is preserved. 
 
@@ -54,7 +54,7 @@ We can see this in action. When a DAR file gets deployed to a ledger, not all me
 #. Open a second terminal and run ``daml ledger fetch-dar --host localhost --port 6865 --main-package-id "887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625" -o assets_ledger.dar``, making sure to replace the hash with the appropriate one.
 #. Run ``daml damlc inspect-dar assets_ledger.dar``
 
-You'll notice two things. Firstly, a lot of the dependencies have lost their names, they are now only identifiable by hash. We could of course also create a second project ``7Composing-1.0.0`` with completely different contents so even when name and version are available, package hash is the only safe identifier.
+You'll notice two things. Firstly, a lot of the dependencies have lost their names, they are now only identifiable by hash. We could of course also create a second project ``intro7-1.0.0`` with completely different contents so even when name and version are available, package hash is the only safe identifier.
 
 That's why over the Ledger API, all types, like templates and records are identified by the triple ``(entity name, module name, package hash)``. Your client application should know the package hashes it wants to interact with. To aid that, ``inspect-dar`` also provides a machine-readable format for the information it emits: ``daml damlc inspect-dar --json assets_ledger.dar``. The ``main_package_id`` field in the resulting JSON payload is the package hash of our project.
 
@@ -65,7 +65,7 @@ Dependencies and Data Dependencies
 
 Dependencies under the ``daml.yaml`` ``dependencies`` group rely on the ``*.hi`` files. The information in these files is crucial for dependencies like the Standard Library, which provide functions, types and typeclasses.
 
-However, as you can see above, this information isn't preserved. Furthermore, preserving this information may not even be desirable. Imagine we had built ``7Composing`` with SDK 1.100.0, and are building ``8Dependencies`` with SDK 1.101.0. All the typeclasses and instances on the inbuilt types may have changed and are now present twice -- once from the current SDK and once from the dependency. This gets messy fast, which is why the SDK does not support ``dependencies`` across SDK versions. For dependencies on contract models that were fetched from a ledger, or come from an older SDK version, there is a simpler kind of dependency called ``data-dependencies``. The syntax for ``data-dependencies`` is the same, but they only rely on the "binary" ``*.dalf`` files. The name tries to confer that the main purpose of such dependencies is to handle data: Records, Choices, Templates. The stuff one needs to use contract composability across projects.
+However, as you can see above, this information isn't preserved. Furthermore, preserving this information may not even be desirable. Imagine we had built ``intro7`` with SDK 1.100.0, and are building ``intro8`` with SDK 1.101.0. All the typeclasses and instances on the inbuilt types may have changed and are now present twice -- once from the current SDK and once from the dependency. This gets messy fast, which is why the SDK does not support ``dependencies`` across SDK versions. For dependencies on contract models that were fetched from a ledger, or come from an older SDK version, there is a simpler kind of dependency called ``data-dependencies``. The syntax for ``data-dependencies`` is the same, but they only rely on the "binary" ``*.dalf`` files. The name tries to confer that the main purpose of such dependencies is to handle data: Records, Choices, Templates. The stuff one needs to use contract composability across projects.
 
 For an extension model like this one, ``data-dependencies`` are appropriate so the chapter 8 project includes the chapter 7 that way.
 

--- a/docs/source/daml/intro/daml/daml-intro-9/daml.yaml.template
+++ b/docs/source/daml/intro/daml/daml-intro-9/daml.yaml.template
@@ -7,6 +7,6 @@ dependencies:
   - daml-stdlib
   - daml-script
 data-dependencies:
-  - ../7Composing/assets.dar
+  - ../intro7/assets.dar
 sandbox-options:
   - --wall-clock-time

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -46,8 +46,8 @@ You can run the JSON API alongside any ledger exposing the gRPC Ledger API you w
 
 .. code-block:: shell
 
-    daml new my_project --template quickstart-java
-    cd my_project
+    daml new my-project --template quickstart-java
+    cd my-project
     daml build
     daml sandbox --wall-clock-time --ledgerid MyLedger --dar ./.daml/dist/quickstart-0.0.1.dar
 

--- a/docs/source/writing-daml.rst
+++ b/docs/source/writing-daml.rst
@@ -8,7 +8,7 @@ Daml is a smart contract language designed to build composable applications on t
 
 The Writing Daml section will teach you how to write Daml applications that run on any Daml Ledger implementation, including key language features, how they relate to the Daml Ledger Model and how to use Daml’s developer tools. It also covers the structure of a Daml Ledger as it pertains to designing your application.
 
-You can find the Daml code for the example application and features in each section `here <https://github.com/digital-asset/daml/tree/main/docs/source/daml/intro/daml>`_ or download it using the Daml assistant. For example, to load the sources for section 1 into a folder called 1_Token, run daml new 1_Token --template daml-intro-1. 
+You can find the Daml code for the example application and features in each section `here <https://github.com/digital-asset/daml/tree/main/docs/source/daml/intro/daml>`_ or download it using the Daml assistant. For example, to load the sources for section 1 into a folder called ``intro1``, run ``daml new intro1 --template daml-intro-1``.
 
 To run the examples, you will first need to `install the Daml SDK <https://docs.daml.com/getting-started/installation.html>`_.
 


### PR DESCRIPTION
It looks like we have changed the package naming rules such that a lot
of examples in our documentation are now producing warnings. This PR
fixes the `daml new` commands, though I believe we should rather change
the package name constraints back, as it looks like a gratuitous
backwards-compatibility break.

CHANGELOG_BEGIN
CHANGELOG_END