### PR TITLE
cross-reference associated WS and normal POST docs

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -926,6 +926,12 @@ Contract Found HTTP Response
 Fetch Contract by Key
 *********************
 
+Show the currently active contract that matches a given key.
+
+The websocket endpoint `/v1/stream/fetch <#fetch-by-key-contracts-stream>`__ can
+be used to search multiple keys in the same request, or in place of iteratively
+invoking this endpoint to respond to changes on the ledger.
+
 HTTP Request
 ============
 
@@ -2093,6 +2099,10 @@ Fetch by Key Contracts Stream
 - Protocol: ``WebSocket``
 
 List currently active contracts that match one of the given ``{templateId, key}`` pairs, with continuous updates.
+
+Simpler use-cases that search for only a single key and do not require
+continuous updates should use the simpler
+`/v1/fetch <#fetch-contract-by-key>`__ endpoint instead.
 
 ``application/json`` body must be sent first, formatted according to the following rule:
 

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1019,6 +1019,10 @@ Get all Active Contracts Matching a Given Query
 
 List currently active contracts that match a given query.
 
+The websocket endpoint `/v1/stream/query <#contracts-query-stream>`__ can be
+used in place of iteratively invoking this endpoint to respond to changes on the
+ledger.
+
 HTTP Request
 ============
 
@@ -1882,6 +1886,10 @@ Contracts Query Stream
 
 List currently active contracts that match a given query, with
 continuous updates.
+
+Simpler use-cases that do not require continuous updates should use the simpler
+`/v1/query <#get-all-active-contracts-matching-a-given-query>`__ endpoint
+instead.
 
 ``application/json`` body must be sent first, formatted according to the
 :doc:`search-query-language`::


### PR DESCRIPTION
Mention that for /v1/query you may want /v1/stream/query and vice versa, and likewise for the fetch-by-key endpoints.

Fixes #8034.