### PR TITLE
fix typo in error message

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NumericModule.scala
@@ -153,7 +153,7 @@ abstract class NumericModule {
     */
   final def fromBigDecimal(scale: Scale, x: BigDecimal): Either[String, Numeric] =
     if (!(x.stripTrailingZeros.scale <= scale))
-      Left(s"Cannot represent ${toString(x)} as (Numeric $scale) without lost of precision")
+      Left(s"Cannot represent ${toString(x)} as (Numeric $scale) without loss of precision")
     else
       checkForOverflow(x.setScale(scale, RoundingMode.UNNECESSARY))
 


### PR DESCRIPTION
CHANGELOG_BEGIN

- The error message for invalid numerical conversion has been corrected:
  "loss of precision" instead of "lost of precision".

CHANGELOG_END