### PR TITLE
Ensure out of time bounds entries are set for all rejections [KVL-1412]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
@@ -23,7 +23,6 @@ import com.daml.ledger.participant.state.kvutils.store.events.{
 }
 import com.daml.ledger.participant.state.kvutils.store.{
   DamlCommandDedupValue,
-  DamlLogEntry,
   DamlStateValue,
   PreExecutionDeduplicationBounds,
 }
@@ -71,8 +70,6 @@ private[transaction] object CommandDeduplication {
           StepContinue(transactionEntry)
         } else {
           if (commitContext.preExecute) {
-            // The out of time bounds entry is required in the committer, so we set it to the default value as we stop the steps here with the duplicate rejection
-            commitContext.outOfTimeBoundsLogEntry = Some(DamlLogEntry.getDefaultInstance)
             preExecutionDuplicateRejection(
               commitContext,
               transactionEntry,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -72,8 +72,10 @@ private[kvutils] class TransactionCommitter(
   /** The order of the steps matters
     */
   override protected val steps: Steps[DamlTransactionEntrySummary] = Iterable(
-    "set_time_bounds" -> TimeBoundBindingStep.setTimeBoundsInContextStep(defaultConfig),
-    "validate_ledger_time" -> ledgerTimeValidator.createValidationStep(rejections),
+    "set_context_min_max_record_time" -> TimeBoundBindingStep.setTimeBoundsInContextStep(
+      defaultConfig
+    ),
+    "set_context_out_of_time_bounds_entry" -> ledgerTimeValidator.createValidationStep(rejections),
     "authorize_submitter" -> authorizeSubmitters,
     "check_informee_parties_allocation" -> checkInformeePartiesAllocation,
     "deduplicate" -> CommandDeduplication.deduplicateCommandStep(rejections),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -69,12 +69,14 @@ private[kvutils] class TransactionCommitter(
   private val committerModelConformanceValidator =
     new CommitterModelConformanceValidator(engine, metrics)
 
+  /** The order of the steps matters
+    */
   override protected val steps: Steps[DamlTransactionEntrySummary] = Iterable(
+    "set_time_bounds" -> TimeBoundBindingStep.setTimeBoundsInContextStep(defaultConfig),
+    "validate_ledger_time" -> ledgerTimeValidator.createValidationStep(rejections),
     "authorize_submitter" -> authorizeSubmitters,
     "check_informee_parties_allocation" -> checkInformeePartiesAllocation,
-    "set_time_bounds" -> TimeBoundBindingStep.setTimeBoundsInContextStep(defaultConfig),
     "deduplicate" -> CommandDeduplication.deduplicateCommandStep(rejections),
-    "validate_ledger_time" -> ledgerTimeValidator.createValidationStep(rejections),
     "validate_committer_model_conformance" -> committerModelConformanceValidator
       .createValidationStep(rejections),
     "validate_consistency" -> TransactionConsistencyValidator.createValidationStep(rejections),

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -73,6 +73,7 @@ object TestHelpers {
         DamlSubmitterInfo.newBuilder
           .setCommandId("commandId")
           .addAllSubmitters(submitters.asJava)
+          .setDeduplicationDuration(Conversions.buildDuration(Duration.ofSeconds(30)))
       )
       .setSubmissionSeed(ByteString.copyFromUtf8("a" * 32))
       .build

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -206,18 +206,6 @@ class CommandDeduplicationSpec
         deduplicateStepHasTransactionRejectionEntry(commitContext)
       }
 
-      "set the out of time bounds log entry during rejections" in {
-        val dedupValue = newDedupValue(
-          _.setRecordTimeBounds(buildPreExecutionDeduplicationBounds(timestamp, timestamp))
-        )
-        val commitContext = createCommitContext(None, Map(aDedupKey -> Some(dedupValue)))
-        commitContext.minimumRecordTime = Some(timestamp)
-        commitContext.maximumRecordTime = Some(timestamp)
-
-        deduplicateStepHasTransactionRejectionEntry(commitContext)
-        commitContext.outOfTimeBoundsLogEntry shouldBe 'defined
-      }
-
       "return the command deduplication duration as deduplication duration when this exceeds the max delta between record times" in {
         val dedupValue = newDedupValue(
           _.setRecordTimeBounds(buildPreExecutionDeduplicationBounds(timestamp, timestamp))


### PR DESCRIPTION
Change the order of transaction committing steps so that the out of time bounds entry is set before any step can reject the transaction.


This ensure that we always have a valid out of time bounds entry set.
Also remove the overriding of the out of time bounds entry from the command deduplication step.

CHANGELOG_BEGIN
[kvutils] - Fix bug where an invalid out of time bounds write set was generated when the transaction was rejected. This would lead to failures if the out of time bounds write set was actually written by the committer.
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
