### PR TITLE
Remove committer support for non pre-execution [kvl-734]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
@@ -9,7 +9,6 @@ import com.daml.lf.data.Ref
 /** Errors thrown by kvutils.
   *
   * Validation and consistency errors are turned into command rejections.
-  * Note that [[KeyValueCommitting.processSubmission]] can also fail with a protobuf exception,
   * e.g. https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/InvalidProtocolBufferException.
   */
 sealed abstract class Err extends RuntimeException with Product with Serializable {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Err.scala
@@ -9,6 +9,7 @@ import com.daml.lf.data.Ref
 /** Errors thrown by kvutils.
   *
   * Validation and consistency errors are turned into command rejections.
+  * Note that [[KeyValueCommitting.preExecuteSubmission]] can also fail with a protobuf exception,
   * e.g. https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/InvalidProtocolBufferException.
   */
 sealed abstract class Err extends RuntimeException with Product with Serializable {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -40,29 +40,29 @@ class KeyValueCommitting private[daml] (
 ) {
 
   /** Processes a Daml submission, given the allocated log entry id, the submission and its resolved inputs.
-   * Produces the log entry to be committed, and Daml state updates.
-   *
-   * The caller is expected to resolve the inputs declared in [[DamlSubmission]] prior
-   * to calling this method, e.g. by reading [[DamlSubmission!.getInputEntriesList]] and
-   * [[DamlSubmission!.getInputStateList]]
-   *
-   * The caller is expected to store the produced [[DamlLogEntry]] in key-value store at a location
-   * that can be accessed through `entryId`. The Daml state updates may create new entries or update
-   * existing entries in the key-value store.
-   *
-   * @param defaultConfig: The default configuration that is to be used if no configuration has been committed to state.
-   * @param submission: Submission to commit to the ledger.
-   * @param participantId: The participant from which the submission originates. Expected to be authenticated.
-   * @param inputState:
-   *   Resolved input state specified in submission. Optional to mark that input state was resolved
-   *   but not present. Specifically we require the command de-duplication input to be resolved, but don't
-   *   expect to be present.
-   *   We also do not trust the submitter to provide the correct list of input keys and we need
-   *   to verify that an input actually does not exist and was not just included in inputs.
-   *   For example when committing a configuration we need the current configuration to authorize
-   *   the submission.
-   * @return Log entry to be committed and the Daml state updates to be applied.
-   */
+    * Produces the log entry to be committed, and Daml state updates.
+    *
+    * The caller is expected to resolve the inputs declared in [[DamlSubmission]] prior
+    * to calling this method, e.g. by reading [[DamlSubmission!.getInputEntriesList]] and
+    * [[DamlSubmission!.getInputStateList]]
+    *
+    * The caller is expected to store the produced [[DamlLogEntry]] in key-value store at a location
+    * that can be accessed through `entryId`. The Daml state updates may create new entries or update
+    * existing entries in the key-value store.
+    *
+    * @param defaultConfig: The default configuration that is to be used if no configuration has been committed to state.
+    * @param submission: Submission to commit to the ledger.
+    * @param participantId: The participant from which the submission originates. Expected to be authenticated.
+    * @param inputState:
+    *   Resolved input state specified in submission. Optional to mark that input state was resolved
+    *   but not present. Specifically we require the command de-duplication input to be resolved, but don't
+    *   expect to be present.
+    *   We also do not trust the submitter to provide the correct list of input keys and we need
+    *   to verify that an input actually does not exist and was not just included in inputs.
+    *   For example when committing a configuration we need the current configuration to authorize
+    *   the submission.
+    * @return Log entry to be committed and the Daml state updates to be applied.
+    */
   @throws(classOf[Err])
   def preExecuteSubmission(
       defaultConfig: Configuration,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -39,6 +39,30 @@ class KeyValueCommitting private[daml] (
     metrics: Metrics,
 ) {
 
+  /** Processes a Daml submission, given the allocated log entry id, the submission and its resolved inputs.
+   * Produces the log entry to be committed, and Daml state updates.
+   *
+   * The caller is expected to resolve the inputs declared in [[DamlSubmission]] prior
+   * to calling this method, e.g. by reading [[DamlSubmission!.getInputEntriesList]] and
+   * [[DamlSubmission!.getInputStateList]]
+   *
+   * The caller is expected to store the produced [[DamlLogEntry]] in key-value store at a location
+   * that can be accessed through `entryId`. The Daml state updates may create new entries or update
+   * existing entries in the key-value store.
+   *
+   * @param defaultConfig: The default configuration that is to be used if no configuration has been committed to state.
+   * @param submission: Submission to commit to the ledger.
+   * @param participantId: The participant from which the submission originates. Expected to be authenticated.
+   * @param inputState:
+   *   Resolved input state specified in submission. Optional to mark that input state was resolved
+   *   but not present. Specifically we require the command de-duplication input to be resolved, but don't
+   *   expect to be present.
+   *   We also do not trust the submitter to provide the correct list of input keys and we need
+   *   to verify that an input actually does not exist and was not just included in inputs.
+   *   For example when committing a configuration we need the current configuration to authorize
+   *   the submission.
+   * @return Log entry to be committed and the Daml state updates to be applied.
+   */
   @throws(classOf[Err])
   def preExecuteSubmission(
       defaultConfig: Configuration,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
@@ -25,8 +25,6 @@ import scala.jdk.CollectionConverters._
 
 /** Methods to produce the [[DamlSubmission]] message.
   *
-  * [[DamlSubmission]] is processed for committing with [[KeyValueCommitting.processSubmission]].
-  *
   * These methods are the only acceptable way of producing the submission messages.
   * The protocol buffer messages must not be embedded in other protocol buffer messages,
   * and embedding should happen through conversion into a byte string (via

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
@@ -25,6 +25,8 @@ import scala.jdk.CollectionConverters._
 
 /** Methods to produce the [[DamlSubmission]] message.
   *
+  * [[DamlSubmission]] is processed for committing with [[KeyValueCommitting.preExecuteSubmission]].
+  *
   * These methods are the only acceptable way of producing the submission messages.
   * The protocol buffer messages must not be embedded in other protocol buffer messages,
   * and embedding should happen through conversion into a byte string (via

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -50,9 +50,6 @@ package com.daml.ledger.participant.state.kvutils
   *   contract instance is now stored within DamlContractStatus.
   * - Configuration extended with "Open World" flag that defines whether
   *   submissions from unallocated parties are accepted.
-  * - Support for authenticating submissions based on participant id. The
-  *   [[KeyValueCommitting.processSubmission]] method now takes the participant id as
-  *   argument.
   * - Support for submitting authenticated configuration changes.
   * - Bug in command deduplication fixed: rejected commands are now deduplicated correctly.
   */

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -50,6 +50,9 @@ package com.daml.ledger.participant.state.kvutils
   *   contract instance is now stored within DamlContractStatus.
   * - Configuration extended with "Open World" flag that defines whether
   *   submissions from unallocated parties are accepted.
+  * - Support for authenticating submissions based on participant id. The
+  *   [[KeyValueCommitting.preExecuteSubmission]] method now takes the participant id as
+  *   argument.
   * - Support for submitting authenticated configuration changes.
   * - Bug in command deduplication fixed: rejected commands are now deduplicated correctly.
   */

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -11,12 +11,11 @@ import com.daml.logging.{ContextualizedLogger, LoggingContext}
 
 import scala.collection.{Factory, mutable}
 
-/** Commit context provides access to state inputs, commit parameters (e.g. record time) and
+/** Commit context provides access to state inputs, commit parameters and
   * allows committer to set state outputs.
   */
 private[kvutils] case class CommitContext(
     private val inputs: DamlStateMap,
-    recordTime: Option[Timestamp],
     participantId: Ref.ParticipantId,
 ) {
   private[this] val logger = ContextualizedLogger.get(getClass)
@@ -35,8 +34,6 @@ private[kvutils] case class CommitContext(
   // Rejection log entry used for generating an out-of-time-bounds log entry in case of
   // pre-execution.
   var outOfTimeBoundsLogEntry: Option[DamlLogEntry] = None
-
-  def preExecute: Boolean = recordTime.isEmpty
 
   /** Retrieve value from output state, or if not found, from input state.
     * Throws an exception if the key is not found in either.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -167,12 +167,4 @@ object Committer {
       }
       .getOrElse(None -> defaultConfig)
 
-  def buildLogEntryWithOptionalRecordTime(
-      addSubmissionSpecificEntry: DamlLogEntry.Builder => DamlLogEntry.Builder
-  ): DamlLogEntry = {
-    val logEntryBuilder = DamlLogEntry.newBuilder
-    addSubmissionSpecificEntry(logEntryBuilder)
-    logEntryBuilder.build
-  }
-
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -8,16 +8,10 @@ import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.kvutils._
-import com.daml.ledger.participant.state.kvutils.store.{
-  DamlLogEntry,
-  DamlOutOfTimeBoundsEntry,
-  DamlStateKey,
-  DamlStateValue,
-}
 import com.daml.ledger.participant.state.kvutils.store.events.DamlConfigurationEntry
+import com.daml.ledger.participant.state.kvutils.store.{DamlLogEntry, DamlOutOfTimeBoundsEntry}
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
-import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.data.{Ref, Time}
+import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext.withEnrichedLoggingContextFrom
 import com.daml.logging.entries.LoggingEntries
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -56,7 +50,6 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
 
   // These are lazy because they rely on `committerName`, which is defined in the subclass and
   // therefore not set at object initialization.
-  private lazy val runTimer: Timer = metrics.daml.kvutils.committer.runTimer(committerName)
   private lazy val preExecutionRunTimer: Timer =
     metrics.daml.kvutils.committer.preExecutionRunTimer(committerName)
   private lazy val stepTimers: Map[StepInfo, Timer] =
@@ -79,26 +72,13 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
 
   protected val metrics: Metrics
 
-  /** A committer can `run` a submission and produce a log entry and output states. */
-  def run(
-      recordTime: Option[Time.Timestamp],
-      submission: DamlSubmission,
-      participantId: Ref.ParticipantId,
-      inputState: DamlStateMap,
-  )(implicit loggingContext: LoggingContext): (DamlLogEntry, Map[DamlStateKey, DamlStateValue]) =
-    runTimer.time { () =>
-      val commitContext = CommitContext(inputState, recordTime, participantId)
-      val logEntry = runSteps(commitContext, submission)
-      logEntry -> commitContext.getOutputs.toMap
-    }
-
   def runWithPreExecution(
       submission: DamlSubmission,
       participantId: Ref.ParticipantId,
       inputState: DamlStateMap,
   )(implicit loggingContext: LoggingContext): PreExecutionResult =
     preExecutionRunTimer.time { () =>
-      val commitContext = CommitContext(inputState, recordTime = None, participantId)
+      val commitContext = CommitContext(inputState, participantId)
       preExecute(submission, commitContext)
     }
 
@@ -188,20 +168,11 @@ object Committer {
       .getOrElse(None -> defaultConfig)
 
   def buildLogEntryWithOptionalRecordTime(
-      recordTime: Option[Timestamp],
-      addSubmissionSpecificEntry: DamlLogEntry.Builder => DamlLogEntry.Builder,
+      addSubmissionSpecificEntry: DamlLogEntry.Builder => DamlLogEntry.Builder
   ): DamlLogEntry = {
     val logEntryBuilder = DamlLogEntry.newBuilder
     addSubmissionSpecificEntry(logEntryBuilder)
-    setRecordTimeIfAvailable(recordTime, logEntryBuilder)
     logEntryBuilder.build
   }
 
-  private def setRecordTimeIfAvailable(
-      recordTime: Option[Timestamp],
-      logEntryBuilder: DamlLogEntry.Builder,
-  ): DamlLogEntry.Builder =
-    recordTime.fold(logEntryBuilder)(timestamp =>
-      logEntryBuilder.setRecordTime(buildTimestamp(timestamp))
-    )
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -184,9 +184,10 @@ private[kvutils] class ConfigCommitter(
           .build,
       )
 
-      val successLogEntry = buildLogEntryWithOptionalRecordTime(
-        _.setConfigurationEntry(configurationEntry)
-      )
+      val successLogEntry = DamlLogEntry
+        .newBuilder()
+        .setConfigurationEntry(configurationEntry)
+        .build()
       StepStop(successLogEntry)
     }
   }
@@ -212,8 +213,9 @@ private[kvutils] class ConfigCommitter(
       submission: DamlConfigurationSubmission,
       addErrorDetails: DamlConfigurationRejectionEntry.Builder => DamlConfigurationRejectionEntry.Builder,
   ): DamlLogEntry = {
-    buildLogEntryWithOptionalRecordTime(
-      _.setConfigurationRejectionEntry(
+    DamlLogEntry
+      .newBuilder()
+      .setConfigurationRejectionEntry(
         addErrorDetails(
           DamlConfigurationRejectionEntry.newBuilder
             .setSubmissionId(submission.getSubmissionId)
@@ -221,7 +223,7 @@ private[kvutils] class ConfigCommitter(
             .setConfiguration(submission.getConfiguration)
         )
       )
-    )
+      .build()
   }
 
   override protected val steps: Steps[Result] = Iterable(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -4,11 +4,7 @@
 package com.daml.ledger.participant.state.kvutils.committer
 
 import com.daml.ledger.configuration.Configuration
-import com.daml.ledger.participant.state.kvutils.Conversions.{
-  buildTimestamp,
-  configDedupKey,
-  configurationStateKey,
-}
+import com.daml.ledger.participant.state.kvutils.Conversions.{configDedupKey, configurationStateKey}
 import com.daml.ledger.participant.state.kvutils.committer.Committer._
 import com.daml.ledger.participant.state.kvutils.store.events.{
   DamlConfigurationEntry,
@@ -17,7 +13,6 @@ import com.daml.ledger.participant.state.kvutils.store.events.{
   GenerationMismatch,
   Invalid,
   ParticipantNotAuthorized,
-  TimedOut,
 }
 import com.daml.ledger.participant.state.kvutils.store.{
   DamlLogEntry,
@@ -71,25 +66,12 @@ private[kvutils] class ConfigCommitter(
     def apply(
         ctx: CommitContext,
         result: Result,
-    )(implicit loggingContext: LoggingContext): StepResult[Result] =
-      // Check the maximum record time against the record time of the commit.
-      // This mechanism allows the submitter to detect lost submissions and retry
-      // with a submitter controlled rate.
-      if (ctx.recordTime.exists(_ > maximumRecordTime)) {
-        rejectionTraceLog(s"submission timed out (${ctx.recordTime} > $maximumRecordTime)")
-        reject(
-          ctx.recordTime,
-          result.submission,
-          _.setTimedOut(TimedOut.newBuilder.setMaximumRecordTime(buildTimestamp(maximumRecordTime))),
-        )
-      } else {
-        if (ctx.preExecute) {
-          // Propagate the time bounds and defer the checks to post-execution.
-          ctx.maximumRecordTime = Some(maximumRecordTime)
-          setOutOfTimeBoundsLogEntry(result.submission, ctx)
-        }
-        StepContinue(result)
-      }
+    )(implicit loggingContext: LoggingContext): StepResult[Result] = {
+      // Propagate the time bounds and defer the checks to post-execution.
+      ctx.maximumRecordTime = Some(maximumRecordTime)
+      setOutOfTimeBoundsLogEntry(result.submission, ctx)
+      StepContinue(result)
+    }
   }
 
   private val authorizeSubmission: Step = new Step {
@@ -113,7 +95,6 @@ private[kvutils] class ConfigCommitter(
           s"participant id ${result.submission.getParticipantId} did not match authenticated participant id ${ctx.participantId}"
         rejectionTraceLog(message)
         reject(
-          ctx.recordTime,
           result.submission,
           _.setParticipantNotAuthorized(ParticipantNotAuthorized.newBuilder.setDetails(message)),
         )
@@ -121,7 +102,6 @@ private[kvutils] class ConfigCommitter(
         val message = s"${ctx.participantId} is not authorized to change configuration."
         rejectionTraceLog(message)
         reject(
-          ctx.recordTime,
           result.submission,
           _.setParticipantNotAuthorized(ParticipantNotAuthorized.newBuilder.setDetails(message)),
         )
@@ -141,14 +121,12 @@ private[kvutils] class ConfigCommitter(
         .fold(
           err =>
             reject(
-              ctx.recordTime,
               result.submission,
               _.setInvalidConfiguration(Invalid.newBuilder.setDetails(err)),
             ),
           config =>
             if (config.generation != (1 + result.currentConfig._2.generation))
               reject(
-                ctx.recordTime,
                 result.submission,
                 _.setGenerationMismatch(
                   GenerationMismatch.newBuilder
@@ -172,7 +150,6 @@ private[kvutils] class ConfigCommitter(
         val message = s"duplicate submission='${result.submission.getSubmissionId}'"
         rejectionTraceLog(message)
         reject(
-          ctx.recordTime,
           result.submission,
           _.setDuplicateSubmission(Duplicate.newBuilder.setDetails(message)),
         )
@@ -208,20 +185,18 @@ private[kvutils] class ConfigCommitter(
       )
 
       val successLogEntry = buildLogEntryWithOptionalRecordTime(
-        ctx.recordTime,
-        _.setConfigurationEntry(configurationEntry),
+        _.setConfigurationEntry(configurationEntry)
       )
       StepStop(successLogEntry)
     }
   }
 
   private def reject[PartialResult](
-      recordTime: Option[Timestamp],
       submission: DamlConfigurationSubmission,
       addErrorDetails: DamlConfigurationRejectionEntry.Builder => DamlConfigurationRejectionEntry.Builder,
   ): StepResult[PartialResult] = {
     metrics.daml.kvutils.committer.config.rejections.inc()
-    StepStop(buildRejectionLogEntry(recordTime, submission, addErrorDetails))
+    StepStop(buildRejectionLogEntry(submission, addErrorDetails))
   }
 
   private def setOutOfTimeBoundsLogEntry(
@@ -229,17 +204,15 @@ private[kvutils] class ConfigCommitter(
       commitContext: CommitContext,
   ): Unit = {
     commitContext.outOfTimeBoundsLogEntry = Some(
-      buildRejectionLogEntry(recordTime = None, submission, identity)
+      buildRejectionLogEntry(submission, identity)
     )
   }
 
   private def buildRejectionLogEntry(
-      recordTime: Option[Timestamp],
       submission: DamlConfigurationSubmission,
       addErrorDetails: DamlConfigurationRejectionEntry.Builder => DamlConfigurationRejectionEntry.Builder,
   ): DamlLogEntry = {
     buildLogEntryWithOptionalRecordTime(
-      recordTime,
       _.setConfigurationRejectionEntry(
         addErrorDetails(
           DamlConfigurationRejectionEntry.newBuilder
@@ -247,7 +220,7 @@ private[kvutils] class ConfigCommitter(
             .setParticipantId(submission.getParticipantId)
             .setConfiguration(submission.getConfiguration)
         )
-      ),
+      )
     )
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -6,7 +6,6 @@ package com.daml.ledger.participant.state.kvutils.committer
 import java.util.concurrent.Executors
 
 import com.daml.ledger.participant.state.kvutils.Conversions.packageUploadDedupKey
-import com.daml.ledger.participant.state.kvutils.committer.Committer.buildLogEntryWithOptionalRecordTime
 import com.daml.ledger.participant.state.kvutils.store.events.PackageUpload.{
   DamlPackageUploadEntry,
   DamlPackageUploadRejectionEntry,
@@ -88,15 +87,16 @@ final private[kvutils] class PackageCommitter(
       participantId: String,
       addErrorDetails: DamlPackageUploadRejectionEntry.Builder => DamlPackageUploadRejectionEntry.Builder,
   ): DamlLogEntry =
-    buildLogEntryWithOptionalRecordTime(
-      _.setPackageUploadRejectionEntry(
+    DamlLogEntry
+      .newBuilder()
+      .setPackageUploadRejectionEntry(
         addErrorDetails(
           DamlPackageUploadRejectionEntry.newBuilder
             .setSubmissionId(submissionId)
             .setParticipantId(participantId)
         )
       )
-    )
+      .build()
 
   private def setOutOfTimeBoundsLogEntry(
       uploadEntry: DamlPackageUploadEntry.Builder,
@@ -435,7 +435,7 @@ final private[kvutils] class PackageCommitter(
           .build,
       )
       val successLogEntry =
-        buildLogEntryWithOptionalRecordTime(_.setPackageUploadEntry(uploadEntry))
+        DamlLogEntry.newBuilder().setPackageUploadEntry(uploadEntry).build()
       setOutOfTimeBoundsLogEntry(uploadEntry, ctx)
       StepStop(successLogEntry)
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.participant.state.kvutils.committer
 
 import com.daml.ledger.participant.state.kvutils.Conversions.partyAllocationDedupKey
-import com.daml.ledger.participant.state.kvutils.committer.Committer.buildLogEntryWithOptionalRecordTime
 import com.daml.ledger.participant.state.kvutils.store.events.{
   AlreadyExists,
   DamlPartyAllocationEntry,
@@ -158,9 +157,10 @@ private[kvutils] class PartyAllocationCommitter(
           .build,
       )
 
-      val successLogEntry = buildLogEntryWithOptionalRecordTime(
-        _.setPartyAllocationEntry(result)
-      )
+      val successLogEntry = DamlLogEntry
+        .newBuilder()
+        .setPartyAllocationEntry(result)
+        .build()
       setOutOfTimeBoundsLogEntry(result, ctx)
       StepStop(successLogEntry)
     }
@@ -178,15 +178,16 @@ private[kvutils] class PartyAllocationCommitter(
       result: Result,
       addErrorDetails: DamlPartyAllocationRejectionEntry.Builder => DamlPartyAllocationRejectionEntry.Builder,
   ): DamlLogEntry = {
-    buildLogEntryWithOptionalRecordTime(
-      _.setPartyAllocationRejectionEntry(
+    DamlLogEntry
+      .newBuilder()
+      .setPartyAllocationRejectionEntry(
         addErrorDetails(
           DamlPartyAllocationRejectionEntry.newBuilder
             .setSubmissionId(result.getSubmissionId)
             .setParticipantId(result.getParticipantId)
         )
       )
-    )
+      .build()
   }
 
   private def setOutOfTimeBoundsLogEntry(result: Result, commitContext: CommitContext): Unit = {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/SubmissionExecutor.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/SubmissionExecutor.scala
@@ -5,18 +5,11 @@ package com.daml.ledger.participant.state.kvutils.committer
 
 import com.daml.ledger.participant.state.kvutils.DamlStateMap
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
-import com.daml.ledger.participant.state.kvutils.store.{DamlLogEntry, DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
-import com.daml.lf.data.{Ref, Time}
+import com.daml.lf.data.Ref
 import com.daml.logging.LoggingContext
 
 trait SubmissionExecutor {
-  def run(
-      recordTime: Option[Time.Timestamp],
-      submission: DamlSubmission,
-      participantId: Ref.ParticipantId,
-      inputState: DamlStateMap,
-  )(implicit loggingContext: LoggingContext): (DamlLogEntry, Map[DamlStateKey, DamlStateValue])
 
   def runWithPreExecution(
       submission: DamlSubmission,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
@@ -5,8 +5,8 @@ package com.daml.ledger.participant.state.kvutils.committer.transaction
 
 import com.codahale.metrics.Counter
 import com.daml.ledger.participant.state.kvutils.Conversions
-import com.daml.ledger.participant.state.kvutils.committer.Committer.buildLogEntryWithOptionalRecordTime
 import com.daml.ledger.participant.state.kvutils.committer.{StepResult, StepStop}
+import com.daml.ledger.participant.state.kvutils.store.DamlLogEntry
 import com.daml.ledger.participant.state.kvutils.store.events.{
   DamlSubmitterInfo,
   DamlTransactionRejectionEntry,
@@ -35,9 +35,7 @@ private[transaction] class Rejections(metrics: Metrics) {
     Metrics.rejections(rejectionEntry.getReasonCase.getNumber).inc()
     logger.trace(s"Transaction rejected, $rejectionDescription.")
     StepStop(
-      buildLogEntryWithOptionalRecordTime(
-        _.setTransactionRejectionEntry(rejectionEntry)
-      )
+      DamlLogEntry.newBuilder().setTransactionRejectionEntry(rejectionEntry).build()
     )
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/Rejections.scala
@@ -22,25 +22,21 @@ private[transaction] class Rejections(metrics: Metrics) {
   def reject[A](
       transactionEntry: DamlTransactionEntrySummary,
       rejection: Rejection,
-      recordTime: Option[Timestamp],
   )(implicit loggingContext: LoggingContext): StepResult[A] =
     reject(
       Conversions.encodeTransactionRejectionEntry(transactionEntry.submitterInfo, rejection),
       rejection.description,
-      recordTime,
     )
 
   def reject[A](
       rejectionEntry: DamlTransactionRejectionEntry.Builder,
       rejectionDescription: String,
-      recordTime: Option[Timestamp],
   )(implicit loggingContext: LoggingContext): StepResult[A] = {
     Metrics.rejections(rejectionEntry.getReasonCase.getNumber).inc()
     logger.trace(s"Transaction rejected, $rejectionDescription.")
     StepStop(
       buildLogEntryWithOptionalRecordTime(
-        recordTime,
-        _.setTransactionRejectionEntry(rejectionEntry),
+        _.setTransactionRejectionEntry(rejectionEntry)
       )
     )
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TimeBoundBindingStep.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TimeBoundBindingStep.scala
@@ -18,20 +18,18 @@ object TimeBoundBindingStep {
       val (_, config) = getCurrentConfiguration(defaultConfig, commitContext)
       val timeModel = config.timeModel
 
-      if (commitContext.preExecute) {
-        val minimumRecordTime = transactionMinRecordTime(
-          transactionEntry.submissionTime,
-          transactionEntry.ledgerEffectiveTime,
-          timeModel,
-        )
-        val maximumRecordTime = transactionMaxRecordTime(
-          transactionEntry.submissionTime,
-          transactionEntry.ledgerEffectiveTime,
-          timeModel,
-        )
-        commitContext.minimumRecordTime = Some(minimumRecordTime)
-        commitContext.maximumRecordTime = Some(maximumRecordTime)
-      }
+      val minimumRecordTime = transactionMinRecordTime(
+        transactionEntry.submissionTime,
+        transactionEntry.ledgerEffectiveTime,
+        timeModel,
+      )
+      val maximumRecordTime = transactionMaxRecordTime(
+        transactionEntry.submissionTime,
+        transactionEntry.ledgerEffectiveTime,
+        timeModel,
+      )
+      commitContext.minimumRecordTime = Some(minimumRecordTime)
+      commitContext.maximumRecordTime = Some(maximumRecordTime)
       StepContinue(transactionEntry)
     }
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -65,7 +65,7 @@ private[kvutils] class TransactionCommitter(
     DamlTransactionEntrySummary(submission.getTransactionEntry)
 
   private val rejections = new Rejections(metrics)
-  private val ledgerTimeValidator = new LedgerTimeValidator(defaultConfig)
+  private val ledgerTimeValidator = new LedgerTimeValidator
   private val committerModelConformanceValidator =
     new CommitterModelConformanceValidator(engine, metrics)
 
@@ -129,7 +129,6 @@ private[kvutils] class TransactionCommitter(
         rejections.reject(
           transactionEntry,
           reason,
-          commitContext.recordTime,
         )
 
       authorizeAll(transactionEntry.submitters)
@@ -213,7 +212,6 @@ private[kvutils] class TransactionCommitter(
         rejections.reject(
           transactionEntry,
           Rejection.PartiesNotKnownOnLedger(missingParties),
-          commitContext.recordTime,
         )
     }
   }
@@ -326,19 +324,16 @@ private[kvutils] object TransactionCommitter {
       transactionEntry: DamlTransactionEntrySummary,
       commitContext: CommitContext,
   ): DamlLogEntry = {
-    if (commitContext.preExecute) {
-      val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
-        .setTransactionRejectionEntry(
-          DamlTransactionRejectionEntry.newBuilder
-            .setDefiniteAnswer(false)
-            .setSubmitterInfo(transactionEntry.submitterInfo)
-        )
-        .build
-      commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
-    }
+    val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
+      .setTransactionRejectionEntry(
+        DamlTransactionRejectionEntry.newBuilder
+          .setDefiniteAnswer(false)
+          .setSubmitterInfo(transactionEntry.submitterInfo)
+      )
+      .build
+    commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
     buildLogEntryWithOptionalRecordTime(
-      commitContext.recordTime,
-      _.setTransactionEntry(transactionEntry.submission),
+      _.setTransactionEntry(transactionEntry.submission)
     )
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitter.scala
@@ -8,7 +8,6 @@ package com.daml.ledger.participant.state.kvutils.committer.transaction
 
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Conversions._
-import com.daml.ledger.participant.state.kvutils.committer.Committer._
 import com.daml.ledger.participant.state.kvutils.committer._
 import com.daml.ledger.participant.state.kvutils.committer.transaction.validation.{
   CommitterModelConformanceValidator,
@@ -332,9 +331,10 @@ private[kvutils] object TransactionCommitter {
       )
       .build
     commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
-    buildLogEntryWithOptionalRecordTime(
-      _.setTransactionEntry(transactionEntry.submission)
-    )
+    DamlLogEntry
+      .newBuilder()
+      .setTransactionEntry(transactionEntry.submission)
+      .build()
   }
 
   // Helper to read the _current_ contract state.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidator.scala
@@ -3,12 +3,9 @@
 
 package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
 
-import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.participant.state.kvutils.Err
-import com.daml.ledger.participant.state.kvutils.committer.Committer.getCurrentConfiguration
 import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,
-  Rejection,
   Rejections,
   Step,
 }
@@ -16,8 +13,7 @@ import com.daml.ledger.participant.state.kvutils.committer.{CommitContext, StepC
 import com.daml.ledger.participant.state.kvutils.store.DamlLogEntry
 import com.daml.logging.LoggingContext
 
-private[transaction] class LedgerTimeValidator(defaultConfig: Configuration)
-    extends TransactionValidator {
+private[transaction] class LedgerTimeValidator extends TransactionValidator {
 
   /** Creates a committer step that validates ledger effective time and the command's time-to-live. */
   override def createValidationStep(rejections: Rejections): Step =
@@ -27,42 +23,23 @@ private[transaction] class LedgerTimeValidator(defaultConfig: Configuration)
           transactionEntry: DamlTransactionEntrySummary,
       )(implicit loggingContext: LoggingContext): StepResult[DamlTransactionEntrySummary] = {
 
-        commitContext.recordTime match {
-          case Some(recordTime) =>
-            val givenLedgerTime = transactionEntry.ledgerEffectiveTime
-            val (_, config) = getCurrentConfiguration(defaultConfig, commitContext)
-            val timeModel = config.timeModel
-
-            timeModel
-              .checkTime(ledgerTime = givenLedgerTime, recordTime = recordTime)
-              .fold(
-                outOfRange =>
-                  rejections.reject(
-                    transactionEntry,
-                    Rejection.LedgerTimeOutOfRange(outOfRange),
-                    commitContext.recordTime,
-                  ),
-                _ => StepContinue(transactionEntry),
-              )
-          case None => // Pre-execution: propagate the time bounds and defer the checks to post-execution.
-            (commitContext.minimumRecordTime, commitContext.maximumRecordTime) match {
-              case (Some(minimumRecordTime), Some(maximumRecordTime)) =>
-                val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
-                  .setTransactionRejectionEntry(
-                    rejections.preExecutionOutOfTimeBoundsRejectionEntry(
-                      transactionEntry.submitterInfo,
-                      minimumRecordTime,
-                      maximumRecordTime,
-                    )
-                  )
-                  .build
-                commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
-                StepContinue(transactionEntry)
-              case _ =>
-                throw Err.InternalError(
-                  "Minimum and maximum record times were not set in the committer context"
+        (commitContext.minimumRecordTime, commitContext.maximumRecordTime) match {
+          case (Some(minimumRecordTime), Some(maximumRecordTime)) =>
+            val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
+              .setTransactionRejectionEntry(
+                rejections.preExecutionOutOfTimeBoundsRejectionEntry(
+                  transactionEntry.submitterInfo,
+                  minimumRecordTime,
+                  maximumRecordTime,
                 )
-            }
+              )
+              .build
+            commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
+            StepContinue(transactionEntry)
+          case _ =>
+            throw Err.InternalError(
+              "Minimum and maximum record times were not set in the committer context"
+            )
         }
       }
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidator.scala
@@ -109,7 +109,6 @@ private[transaction] object TransactionConsistencyValidator extends TransactionV
         rejections.reject(
           transactionEntry,
           rejection,
-          commitContext.recordTime,
         )
     }
   }
@@ -135,7 +134,6 @@ private[transaction] object TransactionConsistencyValidator extends TransactionV
       rejections.reject(
         transactionEntry,
         Rejection.ExternallyInconsistentTransaction.InconsistentContracts,
-        commitContext.recordTime,
       )
   }
 

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -54,11 +54,10 @@ object TestHelpers {
     Ref.LedgerString.assertFromString(UUID.randomUUID().toString)
 
   def createCommitContext(
-      recordTime: Option[Timestamp],
       inputs: DamlStateMap = Map.empty,
       participantId: Int = 0,
   ): CommitContext =
-    CommitContext(inputs, recordTime, mkParticipantId(participantId))
+    CommitContext(inputs, mkParticipantId(participantId))
 
   def createEmptyTransactionEntry(submitters: List[String]): DamlTransactionEntry =
     createTransactionEntry(submitters, TransactionBuilder.EmptySubmitted)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -90,9 +90,9 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
           submissionId = Ref.LedgerString.assertFromString("some-submission-id"),
         )
       } yield {
-        val logEntry = result.outOfTimeBoundsLogEntry
+        val logEntry = result.outOfTimeBoundsLogEntry.getOutOfTimeBoundsEntry.getEntry
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_REJECTION_ENTRY
-        logEntry.getConfigurationRejectionEntry.getReasonCase shouldEqual DamlConfigurationRejectionEntry.ReasonCase.TIMED_OUT
+        logEntry.getConfigurationRejectionEntry.getReasonCase shouldEqual DamlConfigurationRejectionEntry.ReasonCase.REASON_NOT_SET
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -54,7 +54,7 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
 
     "check generation" in KVTest.runTest {
       for {
-        result <- preExecuteConfig(
+        result1 <- preExecuteConfig(
           configModify = c => c.copy(generation = c.generation + 1),
           submissionId = Ref.LedgerString.assertFromString("submission0"),
         )
@@ -68,10 +68,10 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
         newConfig2 <- getConfiguration
 
       } yield {
-        val logEntry = result.successfulLogEntry
+        val logEntry1 = result1.successfulLogEntry
         val logEntry2 = result2.successfulLogEntry
-        logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
-        logEntry.getConfigurationEntry.getSubmissionId shouldEqual "submission0"
+        logEntry1.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
+        logEntry1.getConfigurationEntry.getSubmissionId shouldEqual "submission0"
         newConfig.generation shouldEqual 1
 
         logEntry2.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_REJECTION_ENTRY

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -54,20 +54,22 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
 
     "check generation" in KVTest.runTest {
       for {
-        logEntry <- submitConfig(
+        result <- preExecuteConfig(
           configModify = c => c.copy(generation = c.generation + 1),
           submissionId = Ref.LedgerString.assertFromString("submission0"),
         )
         newConfig <- getConfiguration
 
         // Change again, but without bumping generation.
-        logEntry2 <- submitConfig(
+        result2 <- preExecuteConfig(
           configModify = c => c.copy(generation = c.generation),
           submissionId = Ref.LedgerString.assertFromString("submission1"),
         )
         newConfig2 <- getConfiguration
 
       } yield {
+        val logEntry = result.successfulLogEntry
+        val logEntry2 = result2.successfulLogEntry
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
         logEntry.getConfigurationEntry.getSubmissionId shouldEqual "submission0"
         newConfig.generation shouldEqual 1
@@ -80,7 +82,7 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
 
     "reject expired submissions" in KVTest.runTest {
       for {
-        logEntry <- submitConfig(
+        result <- preExecuteConfig(
           minMaxRecordTimeDelta = Duration.ofMinutes(-1),
           configModify = { c =>
             c.copy(generation = c.generation + 1)
@@ -88,6 +90,7 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
           submissionId = Ref.LedgerString.assertFromString("some-submission-id"),
         )
       } yield {
+        val logEntry = result.outOfTimeBoundsLogEntry
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_REJECTION_ENTRY
         logEntry.getConfigurationRejectionEntry.getReasonCase shouldEqual DamlConfigurationRejectionEntry.ReasonCase.TIMED_OUT
       }
@@ -99,7 +102,7 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
 
       for {
         // Set a configuration with an authorized participant id
-        logEntry0 <- submitConfig(
+        result0 <- preExecuteConfig(
           { c =>
             c.copy(
               generation = c.generation + 1
@@ -112,8 +115,8 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
         // A well authorized submission
         //
 
-        logEntry1 <- withParticipantId(p0) {
-          submitConfig(
+        result1 <- withParticipantId(p0) {
+          preExecuteConfig(
             { c =>
               c.copy(
                 generation = c.generation + 1
@@ -127,8 +130,8 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
         // A badly authorized submission
         //
 
-        logEntry2 <- withParticipantId(p1) {
-          submitConfig(
+        result2 <- withParticipantId(p1) {
+          preExecuteConfig(
             { c =>
               c.copy(
                 generation = c.generation + 1
@@ -139,6 +142,9 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
         }
 
       } yield {
+        val logEntry0 = result0.successfulLogEntry
+        val logEntry1 = result1.successfulLogEntry
+        val logEntry2 = result2.successfulLogEntry
         logEntry0.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
         logEntry1.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
 
@@ -152,7 +158,7 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
 
     "reject duplicate" in KVTest.runTest {
       for {
-        logEntry0 <- submitConfig(
+        result0 <- preExecuteConfig(
           { c =>
             c.copy(
               generation = c.generation + 1
@@ -161,7 +167,7 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
           submissionId = Ref.LedgerString.assertFromString("submission-id-1"),
         )
 
-        logEntry1 <- submitConfig(
+        result1 <- preExecuteConfig(
           { c =>
             c.copy(
               generation = c.generation + 1
@@ -171,6 +177,8 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
         )
 
       } yield {
+        val logEntry0 = result0.successfulLogEntry
+        val logEntry1 = result1.successfulLogEntry
         logEntry0.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY
         logEntry1.getPayloadCase shouldEqual
           DamlLogEntry.PayloadCase.CONFIGURATION_REJECTION_ENTRY
@@ -183,7 +191,7 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
     "update metrics" in KVTest.runTest {
       for {
         //Submit config twice to force one acceptance and one rejection on duplicate
-        _ <- submitConfig(
+        _ <- preExecuteConfig(
           { c =>
             c.copy(
               generation = c.generation + 1
@@ -192,7 +200,7 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
           submissionId = Ref.LedgerString.assertFromString("submission-id-1"),
         )
 
-        _ <- submitConfig(
+        _ <- preExecuteConfig(
           { c =>
             c.copy(
               generation = c.generation + 1
@@ -204,7 +212,7 @@ class KVUtilsConfigSpec extends AnyWordSpec with Matchers {
         // Check that we're updating the metrics (assuming this test at least has been run)
         metrics.daml.kvutils.committer.config.accepts.getCount should be >= 1L
         metrics.daml.kvutils.committer.config.rejections.getCount should be >= 1L
-        metrics.daml.kvutils.committer.runTimer("config").getCount should be >= 1L
+        metrics.daml.kvutils.committer.preExecutionRunTimer("config").getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
@@ -96,7 +96,9 @@ class KVUtilsPackageSpec extends AnyWordSpec with Matchers with BazelRunfiles {
         // Check that we're updating the metrics (assuming this test at least has been run)
         metrics.daml.kvutils.committer.packageUpload.accepts.getCount should be >= 1L
         metrics.daml.kvutils.committer.packageUpload.rejections.getCount should be >= 1L
-        metrics.daml.kvutils.committer.runTimer("package_upload").getCount should be >= 1L
+        metrics.daml.kvutils.committer
+          .preExecutionRunTimer("package_upload")
+          .getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
@@ -29,16 +29,18 @@ class KVUtilsPackageSpec extends AnyWordSpec with Matchers with BazelRunfiles {
     "be able to submit simple package" in KVTest.runTest {
       for {
         // NOTE(JM): 'runTest' always uploads 'simpleArchive' by default.
-        logEntry <- submitArchives("simple-archive-submission-1", simpleArchive).map(_._2)
+        result <- preExecuteArchives("simple-archive-submission-1", simpleArchive).map(_._2)
         archiveState <- getDamlState(
           Conversions.packageStateKey(simplePackage.mainPackageId)
         )
 
         // Submit again and verify that the uploaded archive didn't appear again.
-        logEntry2 <- submitArchives("simple-archive-submission-2", simpleArchive)
+        result2 <- preExecuteArchives("simple-archive-submission-2", simpleArchive)
           .map(_._2)
 
       } yield {
+        val logEntry = result.successfulLogEntry
+        val logEntry2 = result2.successfulLogEntry
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_ENTRY
         logEntry.getPackageUploadEntry.getArchivesCount shouldEqual 1
 
@@ -53,40 +55,30 @@ class KVUtilsPackageSpec extends AnyWordSpec with Matchers with BazelRunfiles {
 
     "be able to submit model-test.dar" in KVTest.runTest {
       for {
-        logEntry <- submitArchives("model-test-submission", testStablePackages.all: _*).map(_._2)
+        result <- preExecuteArchives("model-test-submission", testStablePackages.all: _*).map(_._2)
       } yield {
+        val logEntry = result.successfulLogEntry
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_ENTRY
         logEntry.getPackageUploadEntry.getArchivesCount shouldEqual testStablePackages.all.length
       }
     }
 
-    "be able to pre-execute model-test.dar" in KVTest.runTest {
-      for {
-        preExecutionResult <- preExecuteArchives(
-          "model-test-submission",
-          testStablePackages.all: _*
-        )
-          .map(_._2)
-        actualLogEntry = preExecutionResult.successfulLogEntry
-      } yield {
-        actualLogEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_ENTRY
-        actualLogEntry.getPackageUploadEntry.getArchivesCount shouldEqual testStablePackages.all.length
-      }
-    }
-
     "reject invalid packages" in KVTest.runTest {
       for {
-        logEntry <- submitArchives("bad-archive-submission", badArchive).map(_._2)
+        result <- preExecuteArchives("bad-archive-submission", badArchive).map(_._2)
       } yield {
+        val logEntry = result.successfulLogEntry
         logEntry.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_REJECTION_ENTRY
       }
     }
 
     "reject duplicate" in KVTest.runTest {
       for {
-        logEntry0 <- submitArchives("simple-archive-submission-1", simpleArchive).map(_._2)
-        logEntry1 <- submitArchives("simple-archive-submission-1", simpleArchive).map(_._2)
+        result0 <- preExecuteArchives("simple-archive-submission-1", simpleArchive).map(_._2)
+        result1 <- preExecuteArchives("simple-archive-submission-1", simpleArchive).map(_._2)
       } yield {
+        val logEntry0 = result0.successfulLogEntry
+        val logEntry1 = result1.successfulLogEntry
         logEntry0.getPayloadCase shouldEqual DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_ENTRY
         logEntry1.getPayloadCase shouldEqual
           DamlLogEntry.PayloadCase.PACKAGE_UPLOAD_REJECTION_ENTRY
@@ -98,8 +90,8 @@ class KVUtilsPackageSpec extends AnyWordSpec with Matchers with BazelRunfiles {
     "update metrics" in KVTest.runTest {
       for {
         //Submit archive twice to force one acceptance and one rejection on duplicate
-        _ <- submitArchives("simple-archive-submission-1", simpleArchive).map(_._2)
-        _ <- submitArchives("simple-archive-submission-1", simpleArchive).map(_._2)
+        _ <- preExecuteArchives("simple-archive-submission-1", simpleArchive).map(_._2)
+        _ <- preExecuteArchives("simple-archive-submission-1", simpleArchive).map(_._2)
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
         metrics.daml.kvutils.committer.packageUpload.accepts.getCount should be >= 1L

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
@@ -10,10 +10,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class KVUtilsPartySpec extends AnyWordSpec with Matchers {
-  // TESTS:
-  // - party allocation rejected if participant id does not match
-  // - party allocation rejected with bad party string
-  // - party allocation succeeds
 
   import KVTest._
   import TestHelpers._
@@ -92,7 +88,9 @@ class KVUtilsPartySpec extends AnyWordSpec with Matchers {
         // Check that we're updating the metrics (assuming this test at least has been run)
         metrics.daml.kvutils.committer.partyAllocation.accepts.getCount should be >= 1L
         metrics.daml.kvutils.committer.partyAllocation.rejections.getCount should be >= 1L
-        metrics.daml.kvutils.committer.runTimer("party_allocation").getCount should be >= 1L
+        metrics.daml.kvutils.committer
+          .preExecutionRunTimer("party_allocation")
+          .getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -575,11 +575,11 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
   private def logEntryWithRecordTime(
       entry: DamlLogEntry
-  ) = {
+  ): DamlLogEntry =
     entry.toBuilder
       .setRecordTime(Timestamp.getDefaultInstance)
       .build()
-  }
+
   private def preExecuteCreateSimpleContract(
       submitter: Ref.Party,
       seed: Hash,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -10,7 +10,6 @@ import com.daml.ledger.participant.state.kvutils.store.{
   DamlStateValue,
 }
 import com.daml.ledger.participant.state.kvutils.{DamlStateMap, Err, TestHelpers}
-import com.daml.lf.data.Time
 import com.daml.logging.LoggingContext
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -146,18 +145,6 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
       context.getOutputs should have size 0
     }
   }
-
-  "preExecute" should {
-    "return false in case record time is set" in {
-      val context = newInstance(recordTime = Some(Time.Timestamp.now()))
-      context.preExecute shouldBe false
-    }
-
-    "return true in case record time is not set" in {
-      val context = newInstance(recordTime = None)
-      context.preExecute shouldBe true
-    }
-  }
 }
 
 object CommitContextSpec {
@@ -174,10 +161,9 @@ object CommitContextSpec {
     .build
 
   private def newInstance(
-      recordTime: Option[Time.Timestamp] = Some(Time.Timestamp.now()),
-      inputs: DamlStateMap = Map.empty,
+      inputs: DamlStateMap = Map.empty
   ) =
-    CommitContext(inputs, recordTime, TestHelpers.mkParticipantId(1))
+    CommitContext(inputs, TestHelpers.mkParticipantId(1))
 
   private def newDamlStateMap(keyAndValues: (DamlStateKey, DamlStateValue)*): DamlStateMap =
     (for ((key, value) <- keyAndValues)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -163,16 +163,6 @@ class CommitterSpec
     }
   }
 
-  "buildLogEntryWithOptionalRecordTime" should {
-
-    "skip setting record time in log entry when it is not available" in {
-      val actualLogEntry =
-        Committer.buildLogEntryWithOptionalRecordTime(identity)
-
-      actualLogEntry.hasRecordTime shouldBe false
-    }
-  }
-
   "run" should {
     "run init" in {
       val initialized = new AtomicBoolean(false)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitterSpec.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.participant.state.kvutils.committer
 
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.participant.state.kvutils.TestHelpers.{createCommitContext, theRecordTime}
+import com.daml.ledger.participant.state.kvutils.TestHelpers.createCommitContext
 import com.daml.ledger.participant.state.kvutils.store.events.DamlPartyAllocationEntry
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
@@ -20,13 +20,12 @@ class PartyAllocationCommitterSpec extends AnyWordSpec with Matchers {
     .setParticipantId("a participant")
 
   "buildLogEntry" should {
-    "produce an out-of-time-bounds rejection log entry in case pre-execution is enabled" in {
+    "produce an out-of-time-bounds rejection log entry" in {
       val instance = new PartyAllocationCommitter(metrics)
-      val context = createCommitContext(recordTime = None)
+      val context = createCommitContext()
 
       instance.buildLogEntry(context, aPartyAllocationEntry)
 
-      context.preExecute shouldBe true
       context.outOfTimeBoundsLogEntry should not be empty
       context.outOfTimeBoundsLogEntry.foreach { actual =>
         actual.hasRecordTime shouldBe false
@@ -36,14 +35,5 @@ class PartyAllocationCommitterSpec extends AnyWordSpec with Matchers {
       }
     }
 
-    "not set an out-of-time-bounds rejection log entry in case pre-execution is disabled" in {
-      val instance = new PartyAllocationCommitter(metrics)
-      val context = createCommitContext(recordTime = Some(theRecordTime))
-
-      instance.buildLogEntry(context, aPartyAllocationEntry)
-
-      context.preExecute shouldBe false
-      context.outOfTimeBoundsLogEntry shouldBe empty
-    }
   }
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -57,6 +57,7 @@ class CommandDeduplicationSpec
   private val timestamp: Timestamp = Timestamp.now()
 
   "deduplicating command" when {
+
     "having no deduplication entry" should {
       "continue if no deduplication entry could be found" in {
         val (_, context) = contextBuilder(_ => None)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -56,14 +56,6 @@ class CommandDeduplicationSpec
     CommandDeduplication.setDeduplicationEntryStep(theDefaultConfig)
   private val timestamp: Timestamp = Timestamp.now()
 
-  val contextBuilder: (Timestamp => Option[DamlStateValue]) => (Timestamp, CommitContext) =
-    dedupValueBuilder => {
-      val dedupValue = dedupValueBuilder(timestamp)
-      val commitContext = createCommitContext(Map(aDedupKey -> dedupValue))
-      commitContext.minimumRecordTime = Some(timestamp)
-      commitContext.maximumRecordTime = Some(Timestamp.Epoch)
-      timestamp -> commitContext
-    }
   "deduplicating command" when {
     "having no deduplication entry" should {
       "continue if no deduplication entry could be found" in {
@@ -226,6 +218,16 @@ class CommandDeduplicationSpec
       rejectionEntry.getSubmitterInfo.getDeduplicationDuration shouldBe buildDuration(
         deltaBetweenRecords
       )
+    }
+
+    def contextBuilder(
+        dedupValueBuilder: Timestamp => Option[DamlStateValue]
+    ): (Timestamp, CommitContext) = {
+      val dedupValue = dedupValueBuilder(timestamp)
+      val commitContext = createCommitContext(Map(aDedupKey -> dedupValue))
+      commitContext.minimumRecordTime = Some(timestamp)
+      commitContext.maximumRecordTime = Some(Timestamp.Epoch)
+      timestamp -> commitContext
     }
   }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -308,6 +308,8 @@ class CommandDeduplicationSpec
           _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration))
             .setSubmissionId(submissionId),
         )
+      context.minimumRecordTime = Some(timestamp)
+      context.maximumRecordTime = Some(timestamp)
       setDeduplicationEntryStep(context, transactionEntrySummary)
       deduplicateValueStoredInContext(context, transactionEntrySummary)
         .map(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -56,40 +56,88 @@ class CommandDeduplicationSpec
     CommandDeduplication.setDeduplicationEntryStep(theDefaultConfig)
   private val timestamp: Timestamp = Timestamp.now()
 
-  "deduplicateCommand" when {
-    Map[String, (Timestamp => Option[DamlStateValue]) => (Timestamp, CommitContext)](
-      "pre-execution" -> (dedupValueBuilder => {
-        val dedupValue = dedupValueBuilder(timestamp)
-        val commitContext = createCommitContext(None, Map(aDedupKey -> dedupValue))
-        commitContext.minimumRecordTime = Some(timestamp)
-        commitContext.maximumRecordTime = Some(Timestamp.Epoch)
-        timestamp -> commitContext
-      }),
-      "normal-execution" -> (dedupValueBuilder => {
-        val dedupValue = dedupValueBuilder(timestamp)
-        val commitContext = createCommitContext(Some(timestamp), Map(aDedupKey -> dedupValue))
-        timestamp -> commitContext
-      }),
-    ).foreach { case (key, contextBuilder) =>
-      key should {
-        "continue if no deduplication entry could be found" in {
-          val (_, context) = contextBuilder(_ => None)
+  val contextBuilder: (Timestamp => Option[DamlStateValue]) => (Timestamp, CommitContext) =
+    dedupValueBuilder => {
+      val dedupValue = dedupValueBuilder(timestamp)
+      val commitContext = createCommitContext(Map(aDedupKey -> dedupValue))
+      commitContext.minimumRecordTime = Some(timestamp)
+      commitContext.maximumRecordTime = Some(Timestamp.Epoch)
+      timestamp -> commitContext
+    }
+  "deduplicating command" when {
+    "having no deduplication entry" should {
+      "continue if no deduplication entry could be found" in {
+        val (_, context) = contextBuilder(_ => None)
 
-          deduplicationStepContinues(context)
+        deduplicationStepContinues(context)
+      }
+
+      "continue if deduplication entry has no value set" in {
+        val (_, context) = contextBuilder(_ => Some(newDedupValue(identity)))
+
+        deduplicationStepContinues(context)
+      }
+    }
+
+    "using deduplicate until" should {
+      "continue if record time is after deduplication time in case a deduplication entry is found" in {
+        val (_, context) = contextBuilder(timestamp =>
+          Some(
+            newDedupValue(
+              _.setDeduplicatedUntil(buildTimestamp(timestamp.subtract(Duration.ofSeconds(1))))
+            )
+          )
+        )
+
+        deduplicationStepContinues(context)
+      }
+
+      "produce rejection log entry in case record time is on or before deduplication time" in {
+        for (
+          durationToAdd <- Iterable(
+            Duration.ZERO,
+            Duration.ofSeconds(1),
+          )
+        ) {
+          val (_, context) = contextBuilder(timestamp =>
+            Some(
+              newDedupValue(
+                _.setDeduplicatedUntil(buildTimestamp(timestamp.add(durationToAdd)))
+              )
+            )
+          )
+          deduplicateStepHasTransactionRejectionEntry(context)
         }
+      }
+    }
 
-        "continue if deduplication entry has no value set" in {
-          val (_, context) = contextBuilder(_ => Some(newDedupValue(identity)))
-
-          deduplicationStepContinues(context)
-        }
-
-        "using deduplicate until" should {
+    "using record time" should {
+      forAll(
+        Table[
+          String,
+          Timestamp => DamlCommandDedupValue.Builder => DamlCommandDedupValue.Builder,
+        ](
+          "identifier" -> "time setter",
+          "record time" -> (timestamp =>
+            builder => builder.setRecordTime(buildTimestamp(timestamp))
+          ),
+          "record time bounds" -> (timestamp =>
+            builder =>
+              builder.setRecordTimeBounds(
+                buildPreExecutionDeduplicationBounds(
+                  timestamp.subtract(deduplicationDuration),
+                  timestamp,
+                )
+              )
+          ),
+        )
+      ) { case (identifier, timeSetter) =>
+        identifier should {
           "continue if record time is after deduplication time in case a deduplication entry is found" in {
             val (_, context) = contextBuilder(timestamp =>
               Some(
                 newDedupValue(
-                  _.setDeduplicatedUntil(buildTimestamp(timestamp.subtract(Duration.ofSeconds(1))))
+                  timeSetter(timestamp.subtract(deduplicationDuration.plusMillis(1)))
                 )
               )
             )
@@ -97,9 +145,9 @@ class CommandDeduplicationSpec
             deduplicationStepContinues(context)
           }
 
-          "produce rejection log entry in case record time is on or before deduplication time" in {
+          "produce rejection log entry in case transaction timestamp is on or before deduplication time" in {
             for (
-              durationToAdd <- Iterable(
+              durationToSubstractFromDeduplicationDuration <- Iterable(
                 Duration.ZERO,
                 Duration.ofSeconds(1),
               )
@@ -107,136 +155,77 @@ class CommandDeduplicationSpec
               val (_, context) = contextBuilder(timestamp =>
                 Some(
                   newDedupValue(
-                    _.setDeduplicatedUntil(buildTimestamp(timestamp.add(durationToAdd)))
+                    timeSetter(
+                      timestamp.subtract(
+                        deduplicationDuration.minus(
+                          durationToSubstractFromDeduplicationDuration
+                        )
+                      )
+                    )
                   )
                 )
               )
               deduplicateStepHasTransactionRejectionEntry(context)
             }
           }
-        }
 
-        "using record time" should {
-          forAll(
-            Table[
-              String,
-              Timestamp => DamlCommandDedupValue.Builder => DamlCommandDedupValue.Builder,
-            ](
-              "identifier" -> "time setter",
-              "record time" -> (timestamp =>
-                builder => builder.setRecordTime(buildTimestamp(timestamp))
-              ),
-              "record time bounds" -> (timestamp =>
-                builder =>
-                  builder.setRecordTimeBounds(
-                    buildPreExecutionDeduplicationBounds(
-                      timestamp.subtract(deduplicationDuration),
-                      timestamp,
-                    )
-                  )
-              ),
+          "include the submission id in the rejection" in {
+            val submissionId = "submissionId"
+            val (_, context) = contextBuilder(timestamp =>
+              Some(
+                newDedupValue(builder =>
+                  timeSetter(timestamp)(builder.setSubmissionId(submissionId))
+                )
+              )
             )
-          ) { case (identifier, timeSetter) =>
-            identifier should {
-              "continue if record time is after deduplication time in case a deduplication entry is found" in {
-                val (_, context) = contextBuilder(timestamp =>
-                  Some(
-                    newDedupValue(
-                      timeSetter(timestamp.subtract(deduplicationDuration.plusMillis(1)))
-                    )
-                  )
-                )
-
-                deduplicationStepContinues(context)
-              }
-
-              "produce rejection log entry in case transaction timestamp is on or before deduplication time" in {
-                for (
-                  durationToSubstractFromDeduplicationDuration <- Iterable(
-                    Duration.ZERO,
-                    Duration.ofSeconds(1),
-                  )
-                ) {
-                  val (_, context) = contextBuilder(timestamp =>
-                    Some(
-                      newDedupValue(
-                        timeSetter(
-                          timestamp.subtract(
-                            deduplicationDuration.minus(
-                              durationToSubstractFromDeduplicationDuration
-                            )
-                          )
-                        )
-                      )
-                    )
-                  )
-                  deduplicateStepHasTransactionRejectionEntry(context)
-                }
-              }
-
-              "include the submission id in the rejection" in {
-                val submissionId = "submissionId"
-                val (_, context) = contextBuilder(timestamp =>
-                  Some(
-                    newDedupValue(builder =>
-                      timeSetter(timestamp)(builder.setSubmissionId(submissionId))
-                    )
-                  )
-                )
-                val rejection = deduplicateStepHasTransactionRejectionEntry(context)
-                rejection.getDuplicateCommand.getSubmissionId shouldBe submissionId
-              }
-
-            }
+            val rejection = deduplicateStepHasTransactionRejectionEntry(context)
+            rejection.getDuplicateCommand.getSubmissionId shouldBe submissionId
           }
+
         }
       }
     }
 
-    "using pre-execution" should {
+    "produce rejection log entry when there's an overlap between previous transaction max-record-time and current transaction min-record-time" in {
+      val dedupValue = newDedupValue(
+        _.setRecordTimeBounds(buildPreExecutionDeduplicationBounds(timestamp, timestamp))
+      )
+      val commitContext = createCommitContext(Map(aDedupKey -> Some(dedupValue)))
+      commitContext.minimumRecordTime = Some(timestamp.subtract(Duration.ofMillis(1)))
+      commitContext.maximumRecordTime = Some(Timestamp.Epoch)
 
-      "produce rejection log entry when there's an overlap between previous transaction max-record-time and current transaction min-record-time" in {
-        val dedupValue = newDedupValue(
-          _.setRecordTimeBounds(buildPreExecutionDeduplicationBounds(timestamp, timestamp))
+      deduplicateStepHasTransactionRejectionEntry(commitContext)
+    }
+
+    "return the command deduplication duration as deduplication duration when this exceeds the max delta between record times" in {
+      val dedupValue = newDedupValue(
+        _.setRecordTimeBounds(buildPreExecutionDeduplicationBounds(timestamp, timestamp))
+      )
+      val commitContext = createCommitContext(Map(aDedupKey -> Some(dedupValue)))
+      commitContext.minimumRecordTime = Some(timestamp)
+      commitContext.maximumRecordTime = Some(timestamp.add(Duration.ofSeconds(1)))
+
+      val rejectionEntry = deduplicateStepHasTransactionRejectionEntry(commitContext)
+      rejectionEntry.getSubmitterInfo.getDeduplicationDuration shouldBe buildDuration(
+        deduplicationDuration
+      )
+    }
+
+    "the deduplication duration is the delta between records when this exceeds the deduplication duration sent in the command" in {
+      val dedupValue = newDedupValue(
+        _.setRecordTimeBounds(
+          buildPreExecutionDeduplicationBounds(timestamp, timestamp.add(Duration.ofSeconds(1)))
         )
-        val commitContext = createCommitContext(None, Map(aDedupKey -> Some(dedupValue)))
-        commitContext.minimumRecordTime = Some(timestamp.subtract(Duration.ofMillis(1)))
-        commitContext.maximumRecordTime = Some(Timestamp.Epoch)
+      )
+      val commitContext = createCommitContext(Map(aDedupKey -> Some(dedupValue)))
+      val deltaBetweenRecords = deduplicationDuration.plusMillis(1)
+      commitContext.minimumRecordTime = Some(timestamp)
+      commitContext.maximumRecordTime = Some(timestamp.add(deltaBetweenRecords))
 
-        deduplicateStepHasTransactionRejectionEntry(commitContext)
-      }
-
-      "return the command deduplication duration as deduplication duration when this exceeds the max delta between record times" in {
-        val dedupValue = newDedupValue(
-          _.setRecordTimeBounds(buildPreExecutionDeduplicationBounds(timestamp, timestamp))
-        )
-        val commitContext = createCommitContext(None, Map(aDedupKey -> Some(dedupValue)))
-        commitContext.minimumRecordTime = Some(timestamp)
-        commitContext.maximumRecordTime = Some(timestamp.add(Duration.ofSeconds(1)))
-
-        val rejectionEntry = deduplicateStepHasTransactionRejectionEntry(commitContext)
-        rejectionEntry.getSubmitterInfo.getDeduplicationDuration shouldBe buildDuration(
-          deduplicationDuration
-        )
-      }
-
-      "the deduplication duration is the delta between records when this exceeds the deduplication duration sent in the command" in {
-        val dedupValue = newDedupValue(
-          _.setRecordTimeBounds(
-            buildPreExecutionDeduplicationBounds(timestamp, timestamp.add(Duration.ofSeconds(1)))
-          )
-        )
-        val commitContext = createCommitContext(None, Map(aDedupKey -> Some(dedupValue)))
-        val deltaBetweenRecords = deduplicationDuration.plusMillis(1)
-        commitContext.minimumRecordTime = Some(timestamp)
-        commitContext.maximumRecordTime = Some(timestamp.add(deltaBetweenRecords))
-
-        val rejectionEntry = deduplicateStepHasTransactionRejectionEntry(commitContext)
-        rejectionEntry.getSubmitterInfo.getDeduplicationDuration shouldBe buildDuration(
-          deltaBetweenRecords
-        )
-      }
-
+      val rejectionEntry = deduplicateStepHasTransactionRejectionEntry(commitContext)
+      rejectionEntry.getSubmitterInfo.getDeduplicationDuration shouldBe buildDuration(
+        deltaBetweenRecords
+      )
     }
   }
 
@@ -311,49 +300,6 @@ class CommandDeduplicationSpec
       }
     }
 
-    "using normal execution" should {
-
-      "set the record time in the committer context values" in {
-        val recordTime = timestamp
-        val (context, transactionEntrySummary) =
-          buildContextAndTransaction(
-            submissionTime,
-            _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration)),
-            Some(recordTime),
-          )
-        setDeduplicationEntryStep(context, transactionEntrySummary)
-        parseTimestamp(
-          deduplicateValueStoredInContext(context, transactionEntrySummary)
-            .map(
-              _.getRecordTime
-            )
-            .value
-        ) shouldBe recordTime
-      }
-
-      "set pruning time based on record time" in {
-        val recordTime = timestamp
-        val (context, transactionEntrySummary) =
-          buildContextAndTransaction(
-            submissionTime,
-            identity,
-            Some(recordTime),
-          )
-        setDeduplicationEntryStep(context, transactionEntrySummary)
-        parseTimestamp(
-          deduplicateValueStoredInContext(context, transactionEntrySummary)
-            .map(
-              _.getPrunableFrom
-            )
-            .value
-        ) shouldBe recordTime
-          .add(theDefaultConfig.maxDeduplicationDuration)
-          .add(theDefaultConfig.timeModel.minSkew)
-          .add(theDefaultConfig.timeModel.maxSkew)
-      }
-
-    }
-
     "set the submission id in the dedup value" in {
       val submissionId = "submissionId"
       val (context, transactionEntrySummary) =
@@ -361,7 +307,6 @@ class CommandDeduplicationSpec
           submissionTime,
           _.setDeduplicationDuration(Conversions.buildDuration(deduplicationDuration))
             .setSubmissionId(submissionId),
-          Some(timestamp),
         )
       setDeduplicationEntryStep(context, transactionEntrySummary)
       deduplicateValueStoredInContext(context, transactionEntrySummary)
@@ -446,9 +391,8 @@ object CommandDeduplicationSpec {
   private def buildContextAndTransaction(
       submissionTime: protobuf.Timestamp,
       submitterInfoAugmenter: DamlSubmitterInfo.Builder => DamlSubmitterInfo.Builder,
-      recordTime: Option[Timestamp] = None,
   ) = {
-    val context = createCommitContext(recordTime)
+    val context = createCommitContext()
     context.set(Conversions.configurationStateKey, aDamlConfigurationStateValue)
     val transactionEntrySummary = DamlTransactionEntrySummary(
       aDamlTransactionEntry.toBuilder

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TimeBoundsBindingStepSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TimeBoundsBindingStepSpec.scala
@@ -85,7 +85,7 @@ class TimeBoundsBindingStepSpec extends AnyWordSpec with Matchers {
 
     "mark config as accessed in context" in {
       val commitContext =
-        createCommitContext(recordTime = None, inputWithConfiguration)
+        createCommitContext(inputWithConfiguration)
 
       step.apply(commitContext, aTransactionEntrySummary)
 
@@ -94,7 +94,7 @@ class TimeBoundsBindingStepSpec extends AnyWordSpec with Matchers {
   }
 
   private def contextWithTimeModelAndEmptyCommandDeduplication() =
-    createCommitContext(recordTime = None, inputs = inputWithTimeModelAndEmptyCommandDeduplication)
+    createCommitContext(inputs = inputWithTimeModelAndEmptyCommandDeduplication)
 
   private def createProtobufTimestamp(seconds: Long): timestamp.Timestamp = {
     timestamp.Timestamp(seconds)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -263,7 +263,6 @@ class TransactionCommitterSpec
 
       "a submitting party is not known" in {
         val context = createCommitContext(
-          recordTime = None,
           inputs = createInputs(
             Alice -> Some(hostedParty(Alice)),
             Bob -> None,
@@ -300,7 +299,6 @@ class TransactionCommitterSpec
             .build
         )
         val context = createCommitContext(
-          recordTime = None,
           inputs = createInputs(
             Alice -> Some(hostedParty(Alice))
           ) + configurationInput + commandDeduplicationInput,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state.kvutils.committer.transaction
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.configuration.Configuration
-import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
 import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
 import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepStop}
@@ -23,14 +22,13 @@ import com.daml.ledger.participant.state.kvutils.store.{
 }
 import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
 import com.daml.ledger.participant.state.kvutils.{Conversions, Err, KeyValueCommitting, committer}
-import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.Engine
 import com.daml.lf.kv.contracts.ContractConversions
 import com.daml.lf.transaction._
 import com.daml.lf.transaction.test.TransactionBuilder
-import com.daml.lf.value.Value.{ContractId, ValueRecord, ValueText}
 import com.daml.lf.value.Value
+import com.daml.lf.value.Value.{ContractId, ValueRecord, ValueText}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.google.protobuf.{ByteString, Duration}
@@ -59,7 +57,6 @@ class TransactionCommitterSpec
   "authorizeSubmitters" should {
     "reject a submission when any of the submitters keys is not present in the input state" in {
       val context = createCommitContext(
-        recordTime = None,
         inputs = createInputs(
           Alice -> Some(hostedParty(Alice)),
           Bob -> Some(hostedParty(Bob)),
@@ -76,7 +73,6 @@ class TransactionCommitterSpec
 
     "reject a submission when any of the submitters is not known" in {
       val context = createCommitContext(
-        recordTime = None,
         inputs = createInputs(
           Alice -> Some(hostedParty(Alice)),
           Bob -> None,
@@ -95,7 +91,6 @@ class TransactionCommitterSpec
 
     "reject a submission when any of the submitters' participant id is incorrect" in {
       val context = createCommitContext(
-        recordTime = None,
         inputs = createInputs(
           Alice -> Some(hostedParty(Alice)),
           Bob -> Some(notHostedParty(Bob)),
@@ -116,7 +111,6 @@ class TransactionCommitterSpec
 
     "allow a submission when all of the submitters are hosted on the participant" in {
       val context = createCommitContext(
-        recordTime = None,
         inputs = createInputs(
           Alice -> Some(hostedParty(Alice)),
           Bob -> Some(hostedParty(Bob)),
@@ -133,7 +127,7 @@ class TransactionCommitterSpec
 
   "trimUnnecessaryNodes" should {
     "remove `Fetch`, `LookupByKey`, and `Rollback` nodes from the transaction tree" in {
-      val context = createCommitContext(recordTime = None)
+      val context = createCommitContext()
 
       val actual = transactionCommitter.trimUnnecessaryNodes(
         context,
@@ -168,7 +162,7 @@ class TransactionCommitterSpec
     }
 
     "fail on a non-parsable transaction" in {
-      val context = createCommitContext(recordTime = None)
+      val context = createCommitContext()
       val brokenEntry =
         aDamlTransactionEntry.toBuilder.setRawTransaction(ByteString.copyFromUtf8("wrong")).build()
 
@@ -179,7 +173,7 @@ class TransactionCommitterSpec
     }
 
     "fail on a transaction with invalid roots" in {
-      val context = createCommitContext(recordTime = None)
+      val context = createCommitContext()
       val brokenEntry = aDamlTransactionEntry.toBuilder
         .setRawTransaction(
           aRichNodeTreeTransaction.toBuilder.addRoots("non-existent").build().toByteString
@@ -193,34 +187,12 @@ class TransactionCommitterSpec
   }
 
   "buildLogEntry" should {
-    "set record time in log entry when it is available" in {
-      val context = createCommitContext(recordTime = Some(theRecordTime))
 
-      val actual = TransactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
-
-      actual.hasRecordTime shouldBe true
-      actual.getRecordTime shouldBe buildTimestamp(theRecordTime)
-      actual.hasTransactionEntry shouldBe true
-      actual.getTransactionEntry shouldBe aTransactionEntrySummary.submission
-    }
-
-    "skip setting record time in log entry when it is not available" in {
-      val context = createCommitContext(recordTime = None)
-
-      val actual =
-        TransactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
-
-      actual.hasRecordTime shouldBe false
-      actual.hasTransactionEntry shouldBe true
-      actual.getTransactionEntry shouldBe aTransactionEntrySummary.submission
-    }
-
-    "produce an out-of-time-bounds rejection log entry in case pre-execution is enabled" in {
-      val context = createCommitContext(recordTime = None)
+    "produce an out-of-time-bounds rejection log entry" in {
+      val context = createCommitContext()
 
       TransactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
 
-      context.preExecute shouldBe true
       context.outOfTimeBoundsLogEntry should not be empty
       context.outOfTimeBoundsLogEntry.foreach { actual =>
         actual.hasRecordTime shouldBe false
@@ -231,19 +203,11 @@ class TransactionCommitterSpec
       }
     }
 
-    "not set an out-of-time-bounds rejection log entry in case pre-execution is disabled" in {
-      val context = createCommitContext(recordTime = Some(aRecordTime))
-
-      TransactionCommitter.buildLogEntry(aTransactionEntrySummary, context)
-
-      context.preExecute shouldBe false
-      context.outOfTimeBoundsLogEntry shouldBe empty
-    }
   }
 
   "blind" should {
     "always set blindingInfo" in {
-      val context = createCommitContext(recordTime = None)
+      val context = createCommitContext()
       context.set(Conversions.configurationStateKey, aDamlConfigurationStateValue)
 
       val builder = TransactionBuilder()
@@ -414,7 +378,6 @@ object TransactionCommitterSpec {
   private val OtherParticipantId = 1
   private val aDamlTransactionEntry = createEmptyTransactionEntry(List("aSubmitter"))
   private val aTransactionEntrySummary = DamlTransactionEntrySummary(aDamlTransactionEntry)
-  private val aRecordTime = Timestamp(100)
   private val aDummyValue = TransactionBuilder.record("field" -> "value")
   private val aKey = "key"
   private val aKeyMaintainer = "maintainer"

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/CommitterModelConformanceValidatorSpec.scala
@@ -129,11 +129,10 @@ class CommitterModelConformanceValidatorSpec
 
       validator.createValidationStep(rejections)(
         createCommitContext(
-          None,
           Map(
             inputContractIdStateKey -> Some(makeContractIdStateValue()),
             contractIdStateKey1 -> Some(makeContractIdStateValue()),
-          ),
+          )
         ),
         aTransactionEntry,
       ) shouldBe StepContinue(aTransactionEntry)
@@ -163,11 +162,10 @@ class CommitterModelConformanceValidatorSpec
       val step = validator
         .createValidationStep(rejections)(
           createCommitContext(
-            None,
             Map(
               inputContractIdStateKey -> Some(makeContractIdStateValue()),
               contractIdStateKey1 -> Some(makeContractIdStateValue()),
-            ),
+            )
           ),
           aTransactionEntry,
         )
@@ -181,7 +179,7 @@ class CommitterModelConformanceValidatorSpec
 
       val step = validator
         .createValidationStep(rejections)(
-          createCommitContext(None),
+          createCommitContext(),
           aTransactionEntry,
         )
       inside(step) { case StepStop(logEntry) =>
@@ -195,7 +193,7 @@ class CommitterModelConformanceValidatorSpec
 
       val step = validator
         .createValidationStep(rejections)(
-          createCommitContext(None),
+          createCommitContext(),
           aTransactionEntry,
         )
       inside(step) { case StepStop(logEntry) =>
@@ -238,12 +236,11 @@ class CommitterModelConformanceValidatorSpec
   "lookupContract" should {
     "return Some when a contract is present in the current state" in {
       val commitContext = createCommitContext(
-        None,
         Map(
           inputContractIdStateKey -> Some(
             aContractIdStateValue
           )
-        ),
+        )
       )
 
       val contractInstance = defaultValidator.lookupContract(commitContext)(
@@ -256,8 +253,7 @@ class CommitterModelConformanceValidatorSpec
     "throw if a contract does not exist in the current state" in {
       an[Err.MissingInputState] should be thrownBy defaultValidator.lookupContract(
         createCommitContext(
-          None,
-          Map.empty,
+          Map.empty
         )
       )(Conversions.decodeContractId(inputContractId.coid))
     }
@@ -290,8 +286,7 @@ class CommitterModelConformanceValidatorSpec
         .setArchive(anArchive.byteString)
         .build()
       val commitContext = createCommitContext(
-        None,
-        Map(stateKey -> Some(stateValue)),
+        Map(stateKey -> Some(stateValue))
       )
 
       val maybePackage = defaultValidator.lookupPackage(commitContext)(aPackageId)
@@ -302,8 +297,7 @@ class CommitterModelConformanceValidatorSpec
     "fail when the package is missing" in {
       an[Err.MissingInputState] should be thrownBy defaultValidator.lookupPackage(
         createCommitContext(
-          None,
-          Map.empty,
+          Map.empty
         )
       )(Ref.PackageId.assertFromString("nonexistentPackageId"))
     }
@@ -320,8 +314,7 @@ class CommitterModelConformanceValidatorSpec
       forAll(stateValues) { stateValue =>
         an[Err.ArchiveDecodingFailed] should be thrownBy defaultValidator.lookupPackage(
           createCommitContext(
-            None,
-            Map(stateKey -> Some(stateValue)),
+            Map(stateKey -> Some(stateValue))
           )
         )(Ref.PackageId.assertFromString("invalidPackage"))
       }
@@ -334,11 +327,10 @@ class CommitterModelConformanceValidatorSpec
         .validateCausalMonotonicity(
           aTransactionEntry,
           createCommitContext(
-            None,
             Map(
               inputContractIdStateKey -> Some(makeContractIdStateValue()),
               contractIdStateKey1 -> Some(aStateValueActiveAt(ledgerEffectiveTime.minusSeconds(1))),
-            ),
+            )
           ),
           rejections,
         ) shouldBe StepContinue(aTransactionEntry)
@@ -349,11 +341,10 @@ class CommitterModelConformanceValidatorSpec
         .validateCausalMonotonicity(
           aTransactionEntry,
           createCommitContext(
-            None,
             Map(
               inputContractIdStateKey -> Some(makeContractIdStateValue()),
               contractIdStateKey1 -> Some(aStateValueActiveAt(ledgerEffectiveTime.plusSeconds(1))),
-            ),
+            )
           ),
           rejections,
         )
@@ -373,7 +364,7 @@ class CommitterModelConformanceValidatorSpec
     "accept a transaction in case an input contract is non-existent (possibly because it has been pruned)" in {
       val step = defaultValidator.validateCausalMonotonicity(
         aTransactionEntry,
-        createCommitContext(None, Map.empty), // No contract is present in the commit context.
+        createCommitContext(Map.empty), // No contract is present in the commit context.
         rejections,
       )
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/LedgerTimeValidatorSpec.scala
@@ -4,23 +4,16 @@
 package com.daml.ledger.participant.state.kvutils.committer.transaction.validation
 
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.configuration.Configuration
+import com.daml.ledger.participant.state.kvutils.Err
 import com.daml.ledger.participant.state.kvutils.TestHelpers.{
   createCommitContext,
   createEmptyTransactionEntry,
-  theDefaultConfig,
 }
 import com.daml.ledger.participant.state.kvutils.committer.transaction.{
   DamlTransactionEntrySummary,
   Rejections,
 }
-import com.daml.ledger.participant.state.kvutils.committer.{StepContinue, StepStop}
-import com.daml.ledger.participant.state.kvutils.store.DamlStateValue
-import com.daml.ledger.participant.state.kvutils.store.events.{
-  DamlConfigurationEntry,
-  DamlTransactionEntry,
-}
-import com.daml.ledger.participant.state.kvutils.{Conversions, Err}
+import com.daml.ledger.participant.state.kvutils.store.events.DamlTransactionEntry
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
@@ -34,18 +27,16 @@ class LedgerTimeValidatorSpec extends AnyWordSpec with Matchers {
   private val metrics = new Metrics(new MetricRegistry)
   private val rejections = new Rejections(metrics)
   private val ledgerTimeValidationStep =
-    new LedgerTimeValidator(theDefaultConfig).createValidationStep(rejections)
+    new LedgerTimeValidator().createValidationStep(rejections)
   private val aDamlTransactionEntry: DamlTransactionEntry = createEmptyTransactionEntry(
     List("aSubmitter")
   )
   private val aTransactionEntrySummary = DamlTransactionEntrySummary(aDamlTransactionEntry)
-  private val emptyConfigurationStateValue: DamlStateValue =
-    defaultConfigurationStateValueBuilder().build
 
   "LedgerTimeValidator" can {
     "when the record time is not available" should {
       "compute and correctly set out-of-time-bounds log entry with min/max record time available in the committer context" in {
-        val context = createCommitContext(recordTime = None)
+        val context = createCommitContext()
         context.minimumRecordTime = Some(Timestamp.now())
         context.maximumRecordTime = Some(Timestamp.now())
         ledgerTimeValidationStep.apply(
@@ -61,7 +52,7 @@ class LedgerTimeValidatorSpec extends AnyWordSpec with Matchers {
       }
 
       "fail if minimum record time is not set" in {
-        val context = createCommitContext(recordTime = None)
+        val context = createCommitContext()
         context.maximumRecordTime = Some(Timestamp.now())
         an[Err.InternalError] shouldBe thrownBy(
           ledgerTimeValidationStep.apply(
@@ -72,7 +63,7 @@ class LedgerTimeValidatorSpec extends AnyWordSpec with Matchers {
       }
 
       "fail if maximum record time is not set" in {
-        val context = createCommitContext(recordTime = None)
+        val context = createCommitContext()
         context.minimumRecordTime = Some(Timestamp.now())
         an[Err.InternalError] shouldBe thrownBy(
           ledgerTimeValidationStep.apply(
@@ -82,47 +73,5 @@ class LedgerTimeValidatorSpec extends AnyWordSpec with Matchers {
         )
       }
     }
-
-    "produce rejection log entry if record time is outside of ledger effective time bounds" in {
-      val recordTime = Timestamp.now()
-      val recordTimeInstant = recordTime.toInstant
-      val lowerBound =
-        recordTimeInstant
-          .minus(theDefaultConfig.timeModel.minSkew)
-          .minusMillis(1)
-      val upperBound =
-        recordTimeInstant.plus(theDefaultConfig.timeModel.maxSkew).plusMillis(1)
-      val inputWithDeclaredConfig =
-        Map(Conversions.configurationStateKey -> Some(emptyConfigurationStateValue))
-
-      for (ledgerEffectiveTime <- Iterable(lowerBound, upperBound)) {
-        val context =
-          createCommitContext(recordTime = Some(recordTime), inputs = inputWithDeclaredConfig)
-        val transactionEntrySummary = DamlTransactionEntrySummary(
-          aDamlTransactionEntry.toBuilder
-            .setLedgerEffectiveTime(
-              com.google.protobuf.Timestamp.newBuilder
-                .setSeconds(ledgerEffectiveTime.getEpochSecond)
-                .setNanos(ledgerEffectiveTime.getNano)
-            )
-            .build
-        )
-        val actual = ledgerTimeValidationStep.apply(context, transactionEntrySummary)
-
-        actual match {
-          case StepContinue(_) => fail()
-          case StepStop(actualLogEntry) =>
-            actualLogEntry.hasTransactionRejectionEntry shouldBe true
-        }
-      }
-    }
-
   }
-
-  private def defaultConfigurationStateValueBuilder(): DamlStateValue.Builder =
-    DamlStateValue.newBuilder
-      .setConfigurationEntry(
-        DamlConfigurationEntry.newBuilder
-          .setConfiguration(Configuration.encode(theDefaultConfig))
-      )
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/validation/TransactionConsistencyValidatorSpec.scala
@@ -131,11 +131,10 @@ class TransactionConsistencyValidatorSpec extends AnyWordSpec with Matchers {
       val globalCid = freshContractId
       val globalCreate = newCreateNodeWithFixedKey(globalCid)
       val context = createCommitContext(
-        recordTime = None,
         inputs = Map(
           makeContractIdStateKey(globalCid.coid) -> Some(makeContractIdStateValue()),
           contractStateKey(conflictingKey) -> Some(contractKeyStateValue(globalCid.coid)),
-        ),
+        )
       )
       val builder = TransactionBuilder()
       builder.add(archive(globalCreate, Set("Alice")))
@@ -243,7 +242,6 @@ class TransactionConsistencyValidatorSpec extends AnyWordSpec with Matchers {
       val globalCid = freshContractId
       val globalCreate = newCreateNodeWithFixedKey(globalCid)
       val context = createCommitContext(
-        recordTime = None,
         inputs = Map(
           makeContractIdStateKey(globalCid.coid) -> Some(
             makeContractIdStateValue().toBuilder
@@ -252,7 +250,7 @@ class TransactionConsistencyValidatorSpec extends AnyWordSpec with Matchers {
               )
               .build()
           )
-        ),
+        )
       )
       val builder = TransactionBuilder()
       builder.add(archive(globalCreate, Set("Alice")))
@@ -334,10 +332,9 @@ object TransactionConsistencyValidatorSpec {
       contractKeyIdPairs: (DamlContractKey, Option[String])*
   ): CommitContext =
     createCommitContext(
-      recordTime = None,
       inputs = contractKeyIdPairs.map { case (key, id) =>
         contractStateKey(key) -> id.map(contractKeyStateValue)
-      }.toMap,
+      }.toMap
     )
 
   private def contractStateKey(contractKey: DamlContractKey): DamlStateKey =


### PR DESCRIPTION
CHANGELOG_BEGIN
[kvutils] - Pre-execution is the only supported execution mode
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
