### PR TITLE
damlc: add option to filter which scenarios to run

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -823,8 +823,9 @@ runScenariosRule =
     define $ \RunScenarios file -> do
       m <- moduleForScenario file
       world <- worldForFile file
-      let scenarios = map fst $ scenariosInModule m
       Just scenarioService <- envScenarioService <$> getDamlServiceEnv
+      testFilter <- envTestFilter <$> getDamlServiceEnv
+      let scenarios =  [sc | (sc, _scLoc) <- scenariosInModule m, testFilter $ LF.unExprValName $ LF.qualObject sc]
       ctxRoot <- use_ GetScenarioRoot file
       ctxId <- use_ CreateScenarioContext ctxRoot
       scenarioResults <-
@@ -842,8 +843,9 @@ runScriptsRule =
     define $ \RunScripts file -> do
       m <- moduleForScenario file
       world <- worldForFile file
-      let scenarios = map fst $ scriptsInModule m
       Just scenarioService <- envScenarioService <$> getDamlServiceEnv
+      testFilter <- envTestFilter <$> getDamlServiceEnv
+      let scenarios =  [sc | (sc, _scLoc) <- scriptsInModule m, testFilter $ LF.unExprValName $ LF.qualObject sc]
       ctxRoot <- use_ GetScenarioRoot file
       ctxId <- use_ CreateScenarioContext ctxRoot
       scenarioResults <-

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -56,6 +56,7 @@ data DamlEnv = DamlEnv
   , envSkipScenarioValidation :: SkipScenarioValidation
   , envIsGenerated :: Bool
   , envEnableScenarios :: EnableScenarios
+  , envTestFilter :: T.Text -> Bool
   }
 
 instance IsIdeGlobal DamlEnv
@@ -74,6 +75,7 @@ mkDamlEnv opts scenarioService = do
         , envSkipScenarioValidation = optSkipScenarioValidation opts
         , envIsGenerated = optIsGenerated opts
         , envEnableScenarios = optEnableScenarios opts
+        , envTestFilter = optTestFilter opts
         }
 
 getDamlServiceEnv :: Action DamlEnv

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -83,6 +83,8 @@ data Options = Options
   , optEnableScenarios :: EnableScenarios
     -- ^ Whether old-style scenarios should be run by the scenario service.
     -- This will be switched to False by default once scenarios are no longer supported in 2.0.
+  , optTestFilter :: T.Text -> Bool
+    -- ^ Only execute tests with a name for which the given predicate holds.
   , optSkipScenarioValidation :: SkipScenarioValidation
     -- ^ Controls whether the scenario service server run package validations.
     -- This is mostly used to run additional checks on CI while keeping the IDE fast.
@@ -113,7 +115,7 @@ data Options = Options
   , optAccessTokenPath :: Maybe FilePath
   -- ^ Path to a file containing an access JWT token. This is used for building to query/fetch
   -- packages from remote ledgers.
-  } deriving Show
+  }
 
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
   deriving Show
@@ -193,6 +195,7 @@ defaultOptions mbVersion =
         , optGhcCustomOpts = []
         , optScenarioService = EnableScenarioService True
         , optEnableScenarios = EnableScenarios False
+        , optTestFilter = const True
         , optSkipScenarioValidation = SkipScenarioValidation False
         , optDlintUsage = DlintDisabled
         , optIsGenerated = False

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -253,7 +253,7 @@ data CmdArgs = Damldoc
     , cAnchorPath :: Maybe FilePath
     , cExternalAnchorPath :: Maybe FilePath
     , cMainFiles :: [FilePath]
-    } deriving (Show)
+    }
 
 exec :: CmdArgs -> IO ()
 exec Damldoc{..} = do

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -19,6 +19,7 @@ import DA.Daml.Project.Types
 import qualified DA.Service.Logger as Logger
 import qualified Module as GHC
 import qualified Text.ParserCombinators.ReadP as R
+import qualified Data.Text as T
 
 
 -- | Pretty-printing documents with syntax-highlighting annotations.
@@ -302,6 +303,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = do
     let optEnableOfInterestRule = False
     optCppPath <- optCppPath
     optEnableScenarios <- enableScenariosOpt
+    optTestFilter <- compilePatternExpr <$> optTestPattern
 
     return Options{..}
   where
@@ -378,6 +380,18 @@ optionsParser numProcessors enableScenarioService parsePkgName = do
         help "Tell the compiler that the source was generated." <>
         long "generated-src" <>
         internal
+
+    optTestPattern :: Parser (Maybe String)
+    optTestPattern = optional . option str
+        $ metavar "PATTERN"
+        <> long "test-pattern"
+        <> short 'p'
+        <> help "Only scripts with names containing the given pattern will be executed."
+
+    compilePatternExpr :: Maybe String -> (T.Text -> Bool)
+    compilePatternExpr = \case
+      Nothing -> const True
+      Just needle ->  T.isInfixOf (T.pack needle)
 
     -- optparse-applicative does not provide a nice way
     -- to make the argument for -j optional, see


### PR DESCRIPTION
This adds an option to specify a pattern such that only tests containing
the given pattern in their name will be executed.

Fixes #13534.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
