### PR TITLE
ledger-api-tests: Add hints to `eventually` [KVL-1407]

### DIFF
--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Eventually.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Eventually.scala
@@ -4,20 +4,31 @@
 package com.daml.ledger.api.testtool.infrastructure
 
 import com.daml.timer.RetryStrategy
+import com.daml.timer.RetryStrategy.{TooManyAttemptsException, UnhandledFailureException}
 
 import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, Future}
 
 object Eventually {
+
   /*
   Runs provided closure with the exponential back-off retry strategy for a number of `attempts`.
    */
-  def eventually[A](
-      runAssertion: => Future[A],
-      attempts: Int = 10,
-      firstWaitTime: Duration = 10.millis,
+  def eventually[A](assertionName: String, attempts: Int = 10, firstWaitTime: Duration = 10.millis)(
+      runAssertion: => Future[A]
   )(implicit ec: ExecutionContext): Future[A] =
-    RetryStrategy.exponentialBackoff(attempts, firstWaitTime) { (_, _) =>
-      runAssertion
-    }
+    RetryStrategy
+      .exponentialBackoff(attempts, firstWaitTime) { (_, _) =>
+        runAssertion
+      }
+      .recoverWith {
+        case tooManyAttempts: TooManyAttemptsException =>
+          Future.failed(
+            tooManyAttempts.copy(message = s"$assertionName: ${tooManyAttempts.message}")
+          )
+        case unhandledFailure: UnhandledFailureException =>
+          Future.failed(
+            unhandledFailure.copy(message = s"$assertionName: ${unhandledFailure.message}")
+          )
+      }
 }

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Synchronize.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Synchronize.scala
@@ -41,7 +41,7 @@ object Synchronize {
       party: Party,
       contractId: Primitive.ContractId[T],
   )(implicit ec: ExecutionContext): Future[Unit] = {
-    Eventually.eventually {
+    Eventually.eventually("Wait for contract") {
       participant.activeContracts(party).map { events =>
         assert(
           events.exists(_.contractId == contractId.toString),

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Synchronize.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Synchronize.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.api.testtool.infrastructure
 
 import com.daml.ledger.api.refinements.ApiTypes.Party
+import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 import com.daml.ledger.client.binding.Primitive
 
@@ -23,7 +24,7 @@ object Synchronize {
     */
   final def synchronize(alpha: ParticipantTestContext, beta: ParticipantTestContext)(implicit
       ec: ExecutionContext
-  ): Future[Unit] = {
+  ): Future[Unit] =
     for {
       alice <- alpha.allocateParty()
       bob <- beta.allocateParty()
@@ -34,14 +35,13 @@ object Synchronize {
       // the two participants are synchronized up to the
       // point before invoking this method
     }
-  }
 
   final def waitForContract[T](
       participant: ParticipantTestContext,
       party: Party,
       contractId: Primitive.ContractId[T],
-  )(implicit ec: ExecutionContext): Future[Unit] = {
-    Eventually.eventually("Wait for contract") {
+  )(implicit ec: ExecutionContext): Future[Unit] =
+    eventually("Wait for contract to become active") {
       participant.activeContracts(party).map { events =>
         assert(
           events.exists(_.contractId == contractId.toString),
@@ -49,6 +49,5 @@ object Synchronize {
         )
       }
     }
-  }
 
 }

--- a/ledger/ledger-api-tests/suites/BUILD.bazel
+++ b/ledger/ledger-api-tests/suites/BUILD.bazel
@@ -67,6 +67,7 @@ da_scala_test_suite(
         "//daml-lf/data",
         "//ledger/ledger-api-tests/infrastructure",
         "//libs-scala/test-evidence/tag:test-evidence-tag",
+        "//libs-scala/timer-utils",
         "@maven//:org_scalatest_scalatest_compatible",
     ],
 )

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ContractKeysIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ContractKeysIT.scala
@@ -55,7 +55,7 @@ final class ContractKeysIT extends LedgerTestSuite {
       _ <- alpha.exercise(owner, showDelegated.exerciseShowIt(_, delegated))
 
       // fetch delegated
-      _ <- eventually {
+      _ <- eventually("exerciseFetchDelegated") {
         beta.exercise(delegate, delegation.exerciseFetchDelegated(_, delegated))
       }
 

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/SemanticTests.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/SemanticTests.scala
@@ -175,7 +175,9 @@ final class SemanticTests extends LedgerTestSuite {
       for {
         iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
         offer <- beta.create(painter, PaintOffer(painter, houseOwner, bank, onePound))
-        tree <- eventually { alpha.exercise(houseOwner, offer.exercisePaintOffer_Accept(_, iou)) }
+        tree <- eventually("Exercise paint offer") {
+          alpha.exercise(houseOwner, offer.exercisePaintOffer_Accept(_, iou))
+        }
       } yield {
         val agreement = assertSingleton(
           "SemanticPaintOffer",
@@ -204,13 +206,15 @@ final class SemanticTests extends LedgerTestSuite {
       for {
         iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
         offer <- beta.create(painter, PaintOffer(painter, houseOwner, bank, twoPounds))
-        counter <- eventually {
+        counter <- eventually("exerciseAndGetContract") {
           alpha.exerciseAndGetContract[PaintCounterOffer](
             houseOwner,
             offer.exercisePaintOffer_Counter(_, iou),
           )
         }
-        tree <- eventually { beta.exercise(painter, counter.exercisePaintCounterOffer_Accept) }
+        tree <- eventually("exercisePaintCounterOffer") {
+          beta.exercise(painter, counter.exercisePaintCounterOffer_Accept)
+        }
       } yield {
         val agreement = assertSingleton(
           "SemanticPaintCounterOffer",
@@ -408,7 +412,7 @@ final class SemanticTests extends LedgerTestSuite {
           // Successful divulgence and delegation
           divulgeToken <- alpha.create(owner, Delegation(owner, delegate))
           _ <- alpha.exercise(owner, divulgeToken.exerciseDelegation_Divulge_Token(_, token))
-          _ <- eventually {
+          _ <- eventually("exerciseDelegation_Token_Consume") {
             beta.exercise(delegate, delegation.exerciseDelegation_Token_Consume(_, token))
           }
         } yield {

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceAuthorizationIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceAuthorizationIT.scala
@@ -37,12 +37,12 @@ class TransactionServiceAuthorizationIT extends LedgerTestSuite {
     case Participants(Participant(alpha, operator, receiver), Participant(beta, giver)) =>
       for {
         agreementFactory <- beta.create(giver, AgreementFactory(receiver, giver))
-        agreement <- eventually {
+        agreement <- eventually("exerciseAgreementFactoryAccept") {
           alpha.exerciseAndGetContract(receiver, agreementFactory.exerciseAgreementFactoryAccept)
         }
         triProposalTemplate = TriProposal(operator, receiver, giver)
         triProposal <- alpha.create(operator, triProposalTemplate)
-        tree <- eventually {
+        tree <- eventually("exerciseAcceptTriProposal") {
           beta.exercise(giver, agreement.exerciseAcceptTriProposal(_, triProposal))
         }
       } yield {
@@ -66,7 +66,7 @@ class TransactionServiceAuthorizationIT extends LedgerTestSuite {
         beta.exerciseAndGetContract(giver, agreementFactory.exerciseAgreementFactoryAccept)
       triProposalTemplate = TriProposal(operator, giver, giver)
       triProposal <- alpha.create(operator, triProposalTemplate)
-      tree <- eventually {
+      tree <- eventually("exerciseAcceptTriProposal") {
         beta.exercise(giver, agreement.exerciseAcceptTriProposal(_, triProposal))
       }
     } yield {
@@ -87,7 +87,7 @@ class TransactionServiceAuthorizationIT extends LedgerTestSuite {
     case Participants(Participant(alpha, operator, receiver), Participant(beta, giver)) =>
       for {
         triProposal <- alpha.create(operator, TriProposal(operator, receiver, giver))
-        _ <- eventually {
+        _ <- eventually("exerciseTriProposalAccept") {
           for {
             failure <- beta
               .exercise(giver, triProposal.exerciseTriProposalAccept)
@@ -120,12 +120,12 @@ class TransactionServiceAuthorizationIT extends LedgerTestSuite {
         // TODO eventually is a temporary workaround. It should take into account
         // TODO that the contract needs to hit the target node before a choice
         // TODO is executed on it.
-        agreement <- eventually {
+        agreement <- eventually("exerciseAgreementFactoryAccept") {
           alpha.exerciseAndGetContract(receiver, agreementFactory.exerciseAgreementFactoryAccept)
         }
         triProposalTemplate = TriProposal(operator, giver, giver)
         triProposal <- alpha.create(operator, triProposalTemplate)
-        _ <- eventually {
+        _ <- eventually("exerciseAcceptTriProposal") {
           for {
             failure <- beta
               .exercise(giver, agreement.exerciseAcceptTriProposal(_, triProposal))

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceCorrectnessIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceCorrectnessIT.scala
@@ -316,7 +316,7 @@ class TransactionServiceCorrectnessIT extends LedgerTestSuite {
 }
 
 object TransactionServiceCorrectnessIT {
-  // Strip command id, offset, event id and transaction id to yield a transaction comparable across participant
+  // Strip command id, offset, event id and transaction id to yield a transaction comparable across participants
   // Furthermore, makes sure that the order is not relevant for witness parties
   // Sort by transactionId as on distributed ledgers updates can occur in different orders
   // Even if transactionIds are not the same across distributes ledgers, we still can use them for sorting

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceExerciseIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceExerciseIT.scala
@@ -77,7 +77,7 @@ class TransactionServiceExerciseIT extends LedgerTestSuite {
   )(implicit ec => { case Participants(Participant(alpha, receiver), Participant(beta, giver)) =>
     for {
       agreementFactory <- beta.create(giver, AgreementFactory(receiver, giver))
-      _ <- eventually {
+      _ <- eventually("exerciseCreateAgreement") {
         alpha.exercise(receiver, agreementFactory.exerciseCreateAgreement)
       }
       _ <- synchronize(alpha, beta)

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceVisibilityIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/TransactionServiceVisibilityIT.scala
@@ -59,34 +59,34 @@ class TransactionServiceVisibilityIT extends LedgerTestSuite {
         dkkTransfer <-
           delta.exerciseAndGetContract(dkk_bank, dkkIouIssue.exerciseIou_Transfer(_, bob))
 
-        aliceIou1 <- eventually {
+        aliceIou1 <- eventually("exerciseIouTransfer_Accept") {
           alpha.exerciseAndGetContract(alice, gbpTransfer.exerciseIouTransfer_Accept(_))
         }
-        aliceIou <- eventually {
+        aliceIou <- eventually("exerciseIou_AddObserver") {
           alpha.exerciseAndGetContract(alice, aliceIou1.exerciseIou_AddObserver(_, bob))
         }
-        bobIou <- eventually {
+        bobIou <- eventually("exerciseIouTransfer_Accept") {
           beta.exerciseAndGetContract(bob, dkkTransfer.exerciseIouTransfer_Accept(_))
         }
 
-        trade <- eventually {
+        trade <- eventually("create") {
           alpha.create(
             alice,
             IouTrade(alice, bob, aliceIou, gbp_bank, "GBP", 100, dkk_bank, "DKK", 110),
           )
         }
-        tree <- eventually {
+        tree <- eventually("exerciseIouTrade_Accept") {
           beta.exercise(bob, trade.exerciseIouTrade_Accept(_, bobIou))
         }
 
-        aliceTree <- eventually {
+        aliceTree <- eventually("transactionTreeById1") {
           alpha.transactionTreeById(tree.transactionId, alice)
         }
         bobTree <- beta.transactionTreeById(tree.transactionId, bob)
-        gbpTree <- eventually {
+        gbpTree <- eventually("transactionTreeById2") {
           alpha.transactionTreeById(tree.transactionId, gbp_bank)
         }
-        dkkTree <- eventually {
+        dkkTree <- eventually("transactionTreeById3") {
           delta.transactionTreeById(tree.transactionId, dkk_bank)
         }
 
@@ -282,7 +282,7 @@ class TransactionServiceVisibilityIT extends LedgerTestSuite {
       BranchingControllers(giver = alice, whichCtrl = true, ctrlTrue = bob, ctrlFalse = eve)
     for {
       _ <- alpha.create(alice, template)
-      _ <- eventually {
+      _ <- eventually("flatTransactions") {
         for {
           aliceView <- alpha.flatTransactions(alice)
           bobView <- beta.flatTransactions(bob)
@@ -351,7 +351,7 @@ class TransactionServiceVisibilityIT extends LedgerTestSuite {
       val create = alpha.submitAndWaitRequest(alice, template.create.command)
       for {
         transactionId <- alpha.submitAndWaitForTransactionId(create).map(_.transactionId)
-        _ <- eventually {
+        _ <- eventually("flatTransactions") {
           for {
             transactions <- beta.flatTransactions(observers: _*)
           } yield {

--- a/ledger/ledger-api-tests/suites/src/test/suite/scala/com/daml/ledger/api/testtool/suites/EventuallySpec.scala
+++ b/ledger/ledger-api-tests/suites/src/test/suite/scala/com/daml/ledger/api/testtool/suites/EventuallySpec.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.suites
+
+import com.daml.ledger.api.testtool.infrastructure.Eventually
+import com.daml.timer.RetryStrategy.TooManyAttemptsException
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+class EventuallySpec extends AsyncWordSpec with Matchers {
+
+  "eventually" should {
+    "enhance the exception message with the assertion name" in {
+      recoverToExceptionIf[TooManyAttemptsException] {
+        Eventually.eventually("test", 1, 0.millis) {
+          Future.failed(new RuntimeException())
+        }
+      }.map(_.message should startWith("test: "))
+    }
+  }
+}

--- a/ledger/ledger-api-tests/suites/src/test/suite/scala/com/daml/ledger/api/testtool/suites/EventuallySpec.scala
+++ b/ledger/ledger-api-tests/suites/src/test/suite/scala/com/daml/ledger/api/testtool/suites/EventuallySpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api.testtool.suites
 
-import com.daml.ledger.api.testtool.infrastructure.Eventually
+import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
 import com.daml.timer.RetryStrategy.TooManyAttemptsException
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
@@ -16,7 +16,7 @@ class EventuallySpec extends AsyncWordSpec with Matchers {
   "eventually" should {
     "enhance the exception message with the assertion name" in {
       recoverToExceptionIf[TooManyAttemptsException] {
-        Eventually.eventually("test", 1, 0.millis) {
+        eventually(assertionName = "test", attempts = 1, firstWaitTime = 0.millis) {
           Future.failed(new RuntimeException())
         }
       }.map(_.message should startWith("test: "))

--- a/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
+++ b/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
@@ -48,7 +48,7 @@ final class RetryStrategySpec extends AsyncWordSpec with Matchers with CustomMat
         (retryCount, result, duration) <- succeedAfter(tries = 11, retry)
       } yield {
         result should matchPattern {
-          case Failure(RetryStrategy.TooManyAttemptsException(10, _, _: FailureDuringRetry)) =>
+          case Failure(RetryStrategy.TooManyAttemptsException(10, _, _, _: FailureDuringRetry)) =>
         }
         retryCount should be(10)
         duration should beAround(100.milliseconds)
@@ -94,7 +94,7 @@ final class RetryStrategySpec extends AsyncWordSpec with Matchers with CustomMat
         (retryCount, result, duration) <- succeedAfter(tries = 6, retry)
       } yield {
         result should matchPattern {
-          case Failure(RetryStrategy.TooManyAttemptsException(5, _, _: FailureDuringRetry)) =>
+          case Failure(RetryStrategy.TooManyAttemptsException(5, _, _, _: FailureDuringRetry)) =>
         }
         retryCount should be(5)
         duration should beAround(150.milliseconds)


### PR DESCRIPTION
To improve errors that otherwise look like this:
```
Unexpected failure (TooManyAttemptsException)
  Gave up trying after 10 attempts and 5.134740667 seconds.
```

I limited this change to `Eventually` as `RetryStrategy` has a lot of usages (including production).