### PR TITLE
narrow CodegenCommonConfig."reject empty versions" to property-satisfiable inputs

### DIFF
--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReader.scala
@@ -174,7 +174,7 @@ object CodegenConfigReader {
     }
   }
 
-  private val PackageReferenceSeparator = '-'
+  private[conf] val PackageReferenceSeparator = '-'
 
   implicit val decodePackageReference: KeyDecoder[PackageReference] =
     key =>

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
@@ -293,3 +293,24 @@ class CodegenConfigReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckP
 
   private val projectRoot = Paths.get("/project/root")
 }
+
+object CodegenConfigReaderSpec {
+  import org.scalacheck.{Arbitrary, Gen}
+
+  implicit def `package Ref Arb`: Arbitrary[PackageReference] =
+    Arbitrary(
+      Gen
+        .zip(
+          Gen.stringOf(Gen.oneOf(('0' to '9') ++ ('a' to 'z') ++ ('A' to 'Z') ++ "_-".toSeq)),
+          Gen.posNum[Int],
+          Gen.option(Gen.posNum[Int]),
+        )
+        .map { case (name, wholeVersion, decVersion) =>
+          PackageReference.NameVersion(
+            PackageName assertFromString name,
+            PackageVersion assertFromString s"$wholeVersion${decVersion.fold("")(n => s".$n")}",
+          )
+        }
+    )
+
+}

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
@@ -297,20 +297,12 @@ class CodegenConfigReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckP
 object CodegenConfigReaderSpec {
   import org.scalacheck.{Arbitrary, Gen}
 
-  implicit def `package Ref Arb`: Arbitrary[PackageReference] =
+  implicit def `package Version Arb`: Arbitrary[PackageVersion] =
     Arbitrary(
       Gen
-        .zip(
-          Gen.stringOf(Gen.oneOf(('0' to '9') ++ ('a' to 'z') ++ ('A' to 'Z') ++ "_-".toSeq)),
-          Gen.posNum[Int],
-          Gen.option(Gen.posNum[Int]),
-        )
-        .map { case (name, wholeVersion, decVersion) =>
-          PackageReference.NameVersion(
-            PackageName assertFromString name,
-            PackageVersion assertFromString s"$wholeVersion${decVersion.fold("")(n => s".$n")}",
-          )
+        .zip(Gen.posNum[Int], Gen.option(Gen.posNum[Int]))
+        .map { case (wholeVersion, decVersion) =>
+          PackageVersion assertFromString s"$wholeVersion${decVersion.fold("")(n => s".$n")}"
         }
     )
-
 }

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
@@ -29,11 +29,11 @@ class CodegenConfigReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckP
       }
   }
 
-  it should "reject empty names" in forAll { (name: String, separator: Char) =>
+  it should "reject empty versions" in forAll { (name: String, separator: Char) =>
     CodegenConfigReader.splitNameAndVersion(s"$name$separator", separator) shouldBe None
   }
 
-  it should "reject empty versions" in forAll { version: PackageVersion =>
+  it should "reject empty names" in forAll { version: PackageVersion =>
     val separator = CCR.PackageReferenceSeparator
     CCR.splitNameAndVersion(s"$separator$version", separator) shouldBe None
   }

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
@@ -35,6 +35,12 @@ class CodegenConfigReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckP
     CodegenConfigReader.splitNameAndVersion(s"$separator$version", separator) shouldBe None
   }
 
+  it should "reject empty versions: verified regression" in {
+    val separator = '-'
+    val version = "1-2"
+    CodegenConfigReader.splitNameAndVersion(s"$separator$version", separator) shouldBe None
+  }
+
   it should "reject any string where only the separator appears" in forAll { (separator: Char) =>
     CodegenConfigReader.splitNameAndVersion(separator.toString, separator) shouldBe None
   }

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/conf/CodegenConfigReaderSpec.scala
@@ -7,13 +7,15 @@ import java.nio.file.{Path, Paths}
 
 import ch.qos.logback.classic.Level
 import com.daml.assistant.config.{ProjectConfig, ConfigParseError, ConfigMissing}
-import com.daml.lf.codegen.conf.CodegenConfigReader.{Java, Result, CodegenDest}
+import com.daml.lf.codegen.conf.{CodegenConfigReader => CCR}
+import CCR.{Java, Result, CodegenDest}
 import com.daml.lf.data.Ref.{PackageName, PackageVersion}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class CodegenConfigReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
+  import CodegenConfigReaderSpec._
 
   behavior of "CodegenConfigReader.splitNameAndVersion"
 
@@ -31,14 +33,9 @@ class CodegenConfigReaderSpec extends AnyFlatSpec with Matchers with ScalaCheckP
     CodegenConfigReader.splitNameAndVersion(s"$name$separator", separator) shouldBe None
   }
 
-  it should "reject empty versions" in forAll { (separator: Char, version: String) =>
-    CodegenConfigReader.splitNameAndVersion(s"$separator$version", separator) shouldBe None
-  }
-
-  it should "reject empty versions: verified regression" in {
-    val separator = '-'
-    val version = "1-2"
-    CodegenConfigReader.splitNameAndVersion(s"$separator$version", separator) shouldBe None
+  it should "reject empty versions" in forAll { version: PackageVersion =>
+    val separator = CCR.PackageReferenceSeparator
+    CCR.splitNameAndVersion(s"$separator$version", separator) shouldBe None
   }
 
   it should "reject any string where only the separator appears" in forAll { (separator: Char) =>


### PR DESCRIPTION
Fixes #13368. Also flips the names of the tests, which were backwards.