### PR TITLE
Fix performance regression flat and tree transaction streams on Postgres

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -419,14 +419,16 @@ abstract class EventStorageBackendTemplate(
         (wildcardPartiesClause ::: filterPartiesClauses).mkComposite("(", " or ", ")")
 
       def selectFrom(table: String, selectColumns: String) = cSQL"""
-        (SELECT
+        (SELECT #$selectColumns, event_witnesses, command_id FROM ( SELECT
           #$selectColumns, #$witnessesColumn as event_witnesses, command_id
         FROM
           #$table $joinClause
+
         WHERE
           $additionalAndClause
           $witnessesWhereClause
-        ORDER BY event_sequential_id)
+         ORDER BY event_sequential_id
+         ) x)
       """
 
       val selectClause = partitions

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -419,13 +419,14 @@ abstract class EventStorageBackendTemplate(
         (wildcardPartiesClause ::: filterPartiesClauses).mkComposite("(", " or ", ")")
 
       def selectFrom(table: String, selectColumns: String) = cSQL"""
-        SELECT
+        (SELECT
           #$selectColumns, #$witnessesColumn as event_witnesses, command_id
         FROM
           #$table $joinClause
         WHERE
           $additionalAndClause
           $witnessesWhereClause
+        ORDER BY event_sequential_id)
       """
 
       val selectClause = partitions

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -418,6 +418,10 @@ abstract class EventStorageBackendTemplate(
       val witnessesWhereClause =
         (wildcardPartiesClause ::: filterPartiesClauses).mkComposite("(", " or ", ")")
 
+      // NOTE:
+      // 1. We use `order by event_sequential_id` to hint Postgres to use an index scan rather than a sequential scan.
+      // 2. We also need to wrap this subquery in another subquery because
+      // on Oracle subqueries used with `union all` cannot contain an `order by` clause.
       def selectFrom(table: String, selectColumns: String) = cSQL"""
         (SELECT #$selectColumns, event_witnesses, command_id FROM ( SELECT
           #$selectColumns, #$witnessesColumn as event_witnesses, command_id


### PR DESCRIPTION
Before Postgres ended up using sequential scans.
With added "order by" clauses Postgres uses index scans.

```
Benchmark                               | value              | LR
run-huntsman-sandbox-nfr-800tps-1.      | 759.53 trades/s    | 6983
synthetic transaction streams:          |                    | 6958
  transactions-obs-1                    | 6343.07 items/s    |
  transaction-trees-obs-1               | 6766.99 items/s    |
```




changelog_begin
changelog_end

