### PR TITLE
Switch to asynchronous teardown at Dispatcher

### DIFF
--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -47,6 +47,7 @@ da_scala_library(
         "//libs-scala/resources",
         "//libs-scala/resources-akka",
         "//libs-scala/resources-grpc",
+        "//libs-scala/timer-utils",
         "@maven//:commons_codec_commons_codec",
         "@maven//:commons_io_commons_io",
         "@maven//:io_dropwizard_metrics_metrics_core",

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherSpec.scala
@@ -187,7 +187,7 @@ class DispatcherSpec
       forAllSteppingModes() { subSrc =>
         val dispatcher = newDispatcher()
 
-        dispatcher.close()
+        dispatcher.shutdown()
 
         dispatcher.signalNewHead(Index(1)) // should not throw
         dispatcher
@@ -220,7 +220,7 @@ class DispatcherSpec
         val out = collect(i50, i100, dispatcher, subSrc)
         publish(i100, dispatcher)
 
-        dispatcher.close()
+        dispatcher.shutdown()
 
         out.map(_ shouldEqual pairs100)
       }
@@ -279,7 +279,7 @@ class DispatcherSpec
         val out75F = collect(i75, i100, dispatcher, subSrc)
         publish(i100, dispatcher)
 
-        dispatcher.close()
+        dispatcher.shutdown()
 
         validate4Sections(pairs25, pairs50, pairs75, pairs100, outF, out25F, out50F, out75F)
       }
@@ -308,7 +308,7 @@ class DispatcherSpec
           val out75F = collect(i75, i100, dispatcher, subSrc, delayMs = 10)
           publish(i100, dispatcher)
 
-          dispatcher.close()
+          dispatcher.shutdown()
 
           validate4Sections(pairs25, pairs50, pairs75, pairs100, outF, out25F, out50F, out75F)
       }
@@ -327,7 +327,7 @@ class DispatcherSpec
         for {
           results <- resultsF
         } yield {
-          dispatcher.close()
+          dispatcher.shutdown()
           results shouldEqual pairs25
         }
       }
@@ -344,7 +344,7 @@ class DispatcherSpec
         collect(Index(startIndex), i25, dispatcher, oneAfterAnotherSteppingMode),
         1.second,
       ).andThen { case _ =>
-        dispatcher.close()
+        dispatcher.shutdown()
       }
     }
 
@@ -357,7 +357,7 @@ class DispatcherSpec
       1.to(updateCount).foreach(_ => dispatcher.signalNewHead(Index(random.nextInt(100))))
       dispatcher.signalNewHead(Index(100))
       out.map(_ shouldEqual pairs).andThen { case _ =>
-        dispatcher.close()
+        dispatcher.shutdown()
       }
     }
   }

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherTest.scala
@@ -53,7 +53,7 @@ class DispatcherTest
             .run()
         }
 
-        d.close()
+        d.shutdown()
 
         subscriptions.zip(1 until 10) foreach { case (f, i) =>
           whenReady(f) { vals =>

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/SignalDispatcherTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/SignalDispatcherTest.scala
@@ -67,7 +67,7 @@ class SignalDispatcherTest
       s.request(1L)
       s.expectNext(SignalDispatcher.Signal)
       sut.getRunningState should have size 1L
-      sut.close()
+      sut.shutdown()
       assertThrows[IllegalStateException](sut.getRunningState)
       assertThrows[IllegalStateException](sut.signal())
       s.expectComplete()

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -89,6 +89,7 @@ private[daml] object ApiServices {
       checkOverloaded: TelemetryContext => Option[state.SubmissionResult],
       ledgerFeatures: LedgerFeatures,
       userManagementConfig: UserManagementConfig,
+      apiStreamShutdownTimeout: scala.concurrent.duration.Duration,
   )(implicit
       materializer: Materializer,
       esf: ExecutionSequencerFactory,
@@ -177,7 +178,7 @@ private[daml] object ApiServices {
       val apiTimeServiceOpt =
         optTimeServiceBackend.map(tsb =>
           new TimeServiceAuthorization(
-            ApiTimeService.create(ledgerId, tsb),
+            ApiTimeService.create(ledgerId, tsb, apiStreamShutdownTimeout),
             authorizer,
           )
         )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -30,6 +30,7 @@ import scalaz.{-\/, \/-}
 
 import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success, Try}
 
 object StandaloneApiServer {
@@ -55,6 +56,7 @@ object StandaloneApiServer {
         _ => None, // Used for Canton rate-limiting,
       ledgerFeatures: LedgerFeatures,
       userManagementConfig: UserManagementConfig,
+      apiStreamShutdownTimeout: Duration,
   )(implicit
       actorSystem: ActorSystem,
       materializer: Materializer,
@@ -112,6 +114,7 @@ object StandaloneApiServer {
         userManagementStore = userManagementStore,
         ledgerFeatures = ledgerFeatures,
         userManagementConfig = config.userManagementConfig,
+        apiStreamShutdownTimeout = apiStreamShutdownTimeout,
       )(materializer, executionSequencerFactory, loggingContext)
         .map(_.withServices(otherServices))
       apiServer <- new LedgerApiServer(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneIndexService.scala
@@ -89,6 +89,7 @@ object StandaloneIndexService {
         maxContractKeyStateCacheSize = config.maxContractKeyStateCacheSize,
         maxTransactionsInMemoryFanOutBufferSize = config.maxTransactionsInMemoryFanOutBufferSize,
         enableInMemoryFanOutForLedgerApi = config.enableInMemoryFanOutForLedgerApi,
+        apiStreamShutdownTimeout = config.apiStreamShutdownTimeout,
       )(materializer, loggingContext, servicesExecutionContext)
         .owner()
         .map(index => new TimedIndexService(index, metrics))

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexConfiguration.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexConfiguration.scala
@@ -5,6 +5,8 @@ package com.daml.platform.configuration
 
 import java.io.File
 
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
 final case class IndexConfiguration(
     archiveFiles: List[File] = IndexConfiguration.DefaultArchiveFiles,
     eventsPageSize: Int = IndexConfiguration.DefaultEventsPageSize,
@@ -19,6 +21,7 @@ final case class IndexConfiguration(
       IndexConfiguration.DefaultMaxTransactionsInMemoryFanOutBufferSize,
     enableInMemoryFanOutForLedgerApi: Boolean =
       IndexConfiguration.DefaultEnableInMemoryFanOutForLedgerApi,
+    apiStreamShutdownTimeout: Duration = IndexConfiguration.DefaultApiStreamShutdownTimeout,
 )
 
 object IndexConfiguration {
@@ -33,4 +36,5 @@ object IndexConfiguration {
   val DefaultMaxTransactionsInMemoryFanOutBufferSize: Long = 10000L
   val DefaultEnableInMemoryFanOutForLedgerApi = false
   val DefaultArchiveFiles = List.empty[File]
+  val DefaultApiStreamShutdownTimeout: Duration = FiniteDuration(5, "seconds")
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceBuilder.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceBuilder.scala
@@ -57,6 +57,7 @@ private[platform] case class IndexServiceBuilder(
     maxTransactionsInMemoryFanOutBufferSize: Long,
     enableInMemoryFanOutForLedgerApi: Boolean,
     participantId: Ref.ParticipantId,
+    apiStreamShutdownTimeout: Duration,
 )(implicit
     mat: Materializer,
     loggingContext: LoggingContext,
@@ -257,6 +258,11 @@ private[platform] case class IndexServiceBuilder(
       name = "sql-ledger",
       zeroIndex = Offset.beforeBegin,
       headAtInitialization = ledgerEnd,
+      shutdownTimeout = apiStreamShutdownTimeout,
+      onShutdownTimeout = () =>
+        logger.warn(
+          s"Shutdown of API streams did not finish in ${apiStreamShutdownTimeout.toSeconds} seconds. System shutdown continues."
+        ),
     )
 
   private def verifyLedgerId(

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
@@ -257,6 +257,7 @@ object SandboxOnXRunner {
         ),
       ),
       userManagementConfig = config.userManagementConfig,
+      apiStreamShutdownTimeout = apiServerConfig.indexConfiguration.apiStreamShutdownTimeout,
     )
 
   private def buildIndexerServer(

--- a/libs-scala/timer-utils/src/main/scala/com/digitalasset/timer/Timeout.scala
+++ b/libs-scala/timer-utils/src/main/scala/com/digitalasset/timer/Timeout.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timer
+
+import java.util.TimerTask
+
+import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration.Duration
+
+object Timeout {
+
+  /** Creates a new Future with specifying a timeout.
+    * A Future cannot be stopped once started. With this utility the resulting Future will finish with a different result if the timeout is reached, with the subsequent result of the original Future being discarded.
+    * Important note: the original future will always run until completion, even if the timeout is reached.
+    *
+    * @param duration The timeout duration: if infinite, no timeout will happen.
+    * @param onTimeout A computation resulting in a value of type T or an exception.
+    *                  The value will be computed when the timeout is reached.
+    *                  If it is computed, it will determine the value of the result Future.
+    * @param f The original future.
+    * @return either the result of the original (if it completes in time),
+    *         or the result of the computation specified for onTimeout.
+    *         If onTimeout is computed, it will be the result as well.
+    */
+  def apply[T](duration: Duration)(onTimeout: => T)(f: Future[T]): Future[T] =
+    if (duration.isFinite) {
+      val p = Promise[Option[T]]()
+      val timeoutTask = new TimerTask {
+        override def run(): Unit = {
+          p.trySuccess(None)
+          ()
+        }
+      }
+      Timer.schedule(timeoutTask, duration.toMillis)
+      f.onComplete { result =>
+        if (p.tryComplete(result.map(Some(_)))) timeoutTask.cancel()
+        ()
+      }(scala.concurrent.ExecutionContext.parasitic)
+      p.future.map {
+        case None => onTimeout
+        case Some(result) => result
+      }(scala.concurrent.ExecutionContext.parasitic)
+    } else {
+      f
+    }
+
+  implicit class FutureTimeoutOps[T](val f: Future[T]) extends AnyVal {
+    def withTimeout(duration: Duration)(onTimeout: => T): Future[T] =
+      Timeout(duration)(onTimeout)(f)
+  }
+}

--- a/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/TimeoutSpec.scala
+++ b/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/TimeoutSpec.scala
@@ -1,0 +1,92 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timer
+
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+class TimeoutSpec extends AsyncFlatSpec with Matchers {
+  import Timeout._
+  // in order to have a multi-threaded EC in scope
+  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  behavior of "Futures with Timeout"
+
+  it should "time out, and result should be taken from onTimeout" in {
+    val resultPromise = Promise[Int]()
+    Future {
+      Thread.sleep(100)
+      10
+    }
+      .withTimeout(FiniteDuration(50, "millis"))(5)
+      .onComplete(resultPromise.tryComplete)
+    Thread.sleep(25)
+    resultPromise.isCompleted shouldBe false
+    Thread.sleep(50)
+    resultPromise.isCompleted shouldBe true
+    resultPromise.future.map {
+      _ shouldBe 5
+    }
+  }
+
+  it should "time out, and exception should be taken from onTimeout" in {
+    val resultPromise = Promise[Int]()
+    Future {
+      Thread.sleep(100)
+      10
+    }
+      .withTimeout(FiniteDuration(50, "millis"))(throw new Exception("boom"))
+      .onComplete(resultPromise.tryComplete)
+    Thread.sleep(25)
+    resultPromise.isCompleted shouldBe false
+    Thread.sleep(50)
+    resultPromise.isCompleted shouldBe true
+    resultPromise.future.failed.map {
+      _.getMessage shouldBe "boom"
+    }
+  }
+
+  it should "not time out if timeout is not reached, and onTimeout should not be executed" in {
+    val resultPromise = Promise[Int]()
+    val timeoutPromise = Promise[Unit]()
+    Future {
+      Thread.sleep(25)
+      10
+    }
+      .withTimeout(FiniteDuration(50, "millis")) {
+        timeoutPromise.trySuccess(())
+        throw new Exception("boom")
+      }
+      .onComplete(resultPromise.tryComplete)
+    Thread.sleep(10)
+    resultPromise.isCompleted shouldBe false
+    Thread.sleep(50)
+    resultPromise.isCompleted shouldBe true
+    resultPromise.future.map { result =>
+      result shouldBe 10
+      timeoutPromise.isCompleted shouldBe false
+    }
+  }
+
+  it should "not time out if timeout is infinite" in {
+    val resultPromise = Promise[Int]()
+    Future {
+      Thread.sleep(25)
+      10
+    }
+      .withTimeout(Duration.Inf)(throw new Exception("boom"))
+      .onComplete(resultPromise.tryComplete)
+    Thread.sleep(10)
+    resultPromise.isCompleted shouldBe false
+    Thread.sleep(50)
+    resultPromise.isCompleted shouldBe true
+    resultPromise.future.map {
+      _ shouldBe 10
+    }
+  }
+
+}


### PR DESCRIPTION
Previously a fire and forget release process
was implemented, which in corner cases could
result in exceptions, as API stream was still running after DbDispatcher was released.

This PR changes to waiting for all the streams to finish as releasing Dispatcher.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
