### PR TITLE
Daml-script: Use curly braces notation for records in ledger export

### DIFF
--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
@@ -43,12 +43,14 @@ class EncodeValueSpec extends AnyFreeSpec with Matchers {
           ),
         )
       )
-      encodeValue(Map.empty, Map.empty, r).render(80) shouldBe
-        """M.R1 with
-        |  a = 1
-        |  b = M.R2 with
-        |    c = 42
-        |  c = M.R3""".stripMargin.replace("\r\n", "\n")
+      encodeValue(Map.empty, Map.empty, r).render(
+        80
+      ) shouldBe "(M.R1 {a = 1, b = (M.R2 {c = 42}), c = M.R3})"
+      encodeValue(Map.empty, Map.empty, r).render(30) shouldBe
+        """(M.R1 {a = 1,
+          |    b = (M.R2 {c = 42}),
+          |    c = M.R3})""".stripMargin.replace("\r\n", "\n")
+
     }
     "tuple" in {
       def tupleId(n: Int): v.Identifier = v

--- a/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
+++ b/daml-script/export/src/test/scala/com/daml/script/export/EncodeValueSpec.scala
@@ -18,35 +18,41 @@ class EncodeValueSpec extends AnyFreeSpec with Matchers {
 
   import Encode._
   "encodeValue" - {
-    "record" in {
-      val id1 = v.Identifier("pkg-id", "M", "R1")
-      val id2 = v.Identifier("pkg-id", "M", "R2")
-      val id3 = v.Identifier("pkg-id", "M", "R3")
-      val r = v.Value.Sum.Record(
-        v.Record(
-          Some(id1),
-          Seq(
-            v.RecordField("a", Some(v.Value().withInt64(1))),
-            v.RecordField(
-              "b",
-              Some(
-                v.Value()
-                  .withRecord(
-                    v.Record(Some(id2), Seq(v.RecordField("c", Some(v.Value().withInt64(42)))))
-                  )
-              ),
-            ),
-            v.RecordField(
-              "c",
-              Some(v.Value().withRecord(v.Record(Some(id3)))),
-            ),
+    val record = v.Record(
+      Some(v.Identifier("pkg-id", "M", "R1")),
+      Seq(
+        v.RecordField("a", Some(v.Value().withInt64(1))),
+        v.RecordField(
+          "b",
+          Some(
+            v.Value()
+              .withRecord(
+                v.Record(
+                  Some(v.Identifier("pkg-id", "M", "R2")),
+                  Seq(v.RecordField("c", Some(v.Value().withInt64(42)))),
+                )
+              )
           ),
-        )
-      )
-      encodeValue(Map.empty, Map.empty, r).render(
+        ),
+        v.RecordField(
+          "c",
+          Some(v.Value().withRecord(v.Record(Some(v.Identifier("pkg-id", "M", "R3"))))),
+        ),
+      ),
+    )
+    "record" in {
+      encodeValue(
+        Map.empty,
+        Map.empty,
+        v.Value.Sum.Record(record),
+      ).render(
         80
       ) shouldBe "(M.R1 {a = 1, b = (M.R2 {c = 42}), c = M.R3})"
-      encodeValue(Map.empty, Map.empty, r).render(30) shouldBe
+      encodeValue(
+        Map.empty,
+        Map.empty,
+        v.Value.Sum.Record(record),
+      ).render(30) shouldBe
         """(M.R1 {a = 1,
           |    b = (M.R2 {c = 42}),
           |    c = M.R3})""".stripMargin.replace("\r\n", "\n")
@@ -88,9 +94,25 @@ class EncodeValueSpec extends AnyFreeSpec with Matchers {
       encodeValue(Map.empty, Map(ContractId("my-contract-id") -> "mapped_cid"), cid.sum)
         .render(80) shouldBe "mapped_cid"
     }
-    "list" in {
-      val l = v.Value().withList(v.List(Seq(v.Value().withInt64(0), v.Value().withInt64(1))))
-      encodeValue(Map.empty, Map.empty, l.sum).render(80) shouldBe "[0, 1]"
+    "simple list" in {
+      val l = List(0L, 1L).map(v.Value().withInt64(_))
+      val value = v.Value().withList(v.List(l))
+      encodeValue(Map.empty, Map.empty, value.sum).render(80) shouldBe "[0, 1]"
+    }
+    "list of record" in {
+      val l = List(record, record).map(v.Value().withRecord(_))
+      val value = v.Value().withList(v.List(l))
+      encodeValue(Map.empty, Map.empty, value.sum).render(
+        100
+      ) shouldBe "[(M.R1 {a = 1, b = (M.R2 {c = 42}), c = M.R3}), (M.R1 {a = 1, b = (M.R2 {c = 42}), c = M.R3})]"
+      encodeValue(Map.empty, Map.empty, value.sum).render(
+        30
+      ) shouldBe """[(M.R1 {a = 1,
+                   |      b = (M.R2 {c = 42}),
+                   |      c = M.R3}),
+                   |  (M.R1 {a = 1,
+                   |      b = (M.R2 {c = 42}),
+                   |      c = M.R3})]""".stripMargin.replace("\r\n", "\n")
     }
     "int64" in {
       encodeValue(Map.empty, Map.empty, v.Value().withInt64(42).sum).render(80) shouldBe "42"

--- a/docs/source/tools/export/output-root/Export.daml
+++ b/docs/source/tools/export/output-root/Export.daml
@@ -70,14 +70,10 @@ export Args{parties, contracts} = do
 -- EXPORT_PARTIES_END
 -- EXPORT_PROPOSALS_BEGIN
   (coinProposal_1_0, coinProposal_1_1) <- submit bank_0 do
-    coinProposal_1_0 <- createCmd ScriptExample.CoinProposal with
-      coin = ScriptExample.Coin with
-        issuer = bank_0
-        owner = alice_0
-    coinProposal_1_1 <- createCmd ScriptExample.CoinProposal with
-      coin = ScriptExample.Coin with
-        issuer = bank_0
-        owner = bob_0
+    coinProposal_1_0 <- createCmd (ScriptExample.CoinProposal {coin = (ScriptExample.Coin {issuer = bank_0,
+            owner = alice_0})})
+    coinProposal_1_1 <- createCmd (ScriptExample.CoinProposal {coin = (ScriptExample.Coin {issuer = bank_0,
+            owner = bob_0})})
     pure (coinProposal_1_0, coinProposal_1_1)
 -- EXPORT_PROPOSALS_END
 -- EXPORT_ACCEPT_BEGIN


### PR DESCRIPTION
instead of `with` notation

fixes #13620

CHANGELOG_BEGIN
- [Daml-script] fix a bug in daml-script export formatting
  See https://github.com/digital-asset/daml/issues/13620
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
