### PR TITLE
support cross-module interface implementation in typescript codegen

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -28,7 +28,6 @@ import Data.Either
 import Data.Tuple.Extra
 import Data.List.Extra
 import Data.Maybe
-import Debug.Trace
 import Options.Applicative
 import System.Directory
 import System.Environment
@@ -916,10 +915,7 @@ genType (TypeRef curModName t) mbSubst = go t
 -- differently.
 genTypeCon :: ModuleName -> Qualified TypeConName -> (T.Text, T.Text)
 genTypeCon curModName (Qualified pkgRef modName conParts) =
-    if ("Other" `T.isSuffixOf` ty) || ("Other" `T.isSuffixOf` ser)
-    then (curModName, (pkgRef, modName, conParts), (ty, ser)) `traceShow` result else result
-     where
-       result@(ty, ser) = case unTypeConName conParts of
+    case unTypeConName conParts of
         [] -> error "IMPOSSIBLE: empty type constructor name"
         _: _: _: _ -> error "TODO(MH): multi-part type constructor names"
         [c1 ,c2]
@@ -930,6 +926,7 @@ genTypeCon curModName (Qualified pkgRef modName conParts) =
           | modRef == (PRSelf, curModName) ->
             (conName, "exports" <.> conName)
           | otherwise -> dupe $ genModuleRef modRef <.> conName
+     where
        modRef = (pkgRef, modName)
 
 pkgVar :: PackageId -> T.Text

--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -28,6 +28,7 @@ import Data.Either
 import Data.Tuple.Extra
 import Data.List.Extra
 import Data.Maybe
+import Debug.Trace
 import Options.Applicative
 import System.Directory
 import System.Environment
@@ -915,7 +916,10 @@ genType (TypeRef curModName t) mbSubst = go t
 -- differently.
 genTypeCon :: ModuleName -> Qualified TypeConName -> (T.Text, T.Text)
 genTypeCon curModName (Qualified pkgRef modName conParts) =
-    case unTypeConName conParts of
+    if ("Other" `T.isSuffixOf` ty) || ("Other" `T.isSuffixOf` ser)
+    then (curModName, (pkgRef, modName, conParts), (ty, ser)) `traceShow` result else result
+     where
+       result@(ty, ser) = case unTypeConName conParts of
         [] -> error "IMPOSSIBLE: empty type constructor name"
         _: _: _: _ -> error "TODO(MH): multi-part type constructor names"
         [c1 ,c2]
@@ -926,7 +930,6 @@ genTypeCon curModName (Qualified pkgRef modName conParts) =
           | modRef == (PRSelf, curModName) ->
             (conName, "exports" <.> conName)
           | otherwise -> dupe $ genModuleRef modRef <.> conName
-     where
        modRef = (pkgRef, modName)
 
 pkgVar :: PackageId -> T.Text

--- a/language-support/ts/codegen/tests/daml/Lib/Mod.daml
+++ b/language-support/ts/codegen/tests/daml/Lib/Mod.daml
@@ -15,3 +15,11 @@ template NonTopLevel with
     party: Party
   where
     signatory party
+
+interface Other where
+  getOtherOwner : Party
+  somethingImpl : Update ()
+  choice Something : ()
+    controller getOtherOwner this
+    do
+      somethingImpl this

--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -181,14 +181,6 @@ interface Token where
     do
       transferImpl this newOwner
 
-interface Other where
-  getOtherOwner : Party
-  somethingImpl : Update ()
-  choice Something : ()
-    controller getOtherOwner this
-    do
-      somethingImpl this
-
 template Asset with
     issuer: Party
     owner: Party


### PR DESCRIPTION
Fixes #13501. `genTypeCon` was producing the right result, but this was being discarded in favor of unconditionally prefixing `exports.`, which is not right for cross-module interfaces.

```rst
CHANGELOG_BEGIN
- [daml codegen js] Support templates implementing interfaces that are defined in
  separate modules.
  See `issue #13636 <https://github.com/digital-asset/daml/pull/13636>`__.
CHANGELOG_END
```

* [x] changelog