### PR TITLE
iface: Use ImplementsDefRef instead of PackageInterface in speedy builtins

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1256,7 +1256,9 @@ private[lf] object SBuiltin {
     ) = {
       val (tyCon, record) = getSAnyContract(args, 0)
       machine.returnValue =
-        if (machine.compiledPackages.getDefinition(ImplementsDefRef(tyCon, requiringIfaceId)).isEmpty)
+        if (
+          machine.compiledPackages.getDefinition(ImplementsDefRef(tyCon, requiringIfaceId)).isEmpty
+        )
           SOptional(None)
         else
           SOptional(Some(SAnyContract(tyCon, record)))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1146,7 +1146,11 @@ private[lf] object SBuiltin {
     ) = {
       val contractId = getSContractId(args, 0)
       val (actualTmplId, record @ _) = getSAnyContract(args, 1)
-      if (machine.compiledPackages.getDefinition(ImplementsDefRef(actualTmplId, requiringIface)).isEmpty)
+      if (
+        machine.compiledPackages
+          .getDefinition(ImplementsDefRef(actualTmplId, requiringIface))
+          .isEmpty
+      )
         throw SErrorDamlException(
           IE.ContractDoesNotImplementRequiringInterface(
             requiringIfaceId,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1148,7 +1148,7 @@ private[lf] object SBuiltin {
       val (actualTmplId, record @ _) = getSAnyContract(args, 1)
       if (
         machine.compiledPackages
-          .getDefinition(ImplementsDefRef(actualTmplId, requiringIface))
+          .getDefinition(ImplementsDefRef(actualTmplId, requiringIfaceId))
           .isEmpty
       )
         throw SErrorDamlException(
@@ -1244,10 +1244,10 @@ private[lf] object SBuiltin {
     }
   }
 
-  // Convert an interface `requiredIface` to another interface `requiringIface`, if
-  // the `requiringIface` implements `requiredIface`.
+  // Convert an interface value to another interface `requiringIfaceId`, if
+  // the underlying template implements `requiringIfaceId`. Else return `None`.
   final case class SBFromRequiredInterface(
-      requiringIface: TypeConName
+      requiringIfaceId: TypeConName
   ) extends SBuiltin(1) {
 
     override private[speedy] def execute(
@@ -1256,15 +1256,16 @@ private[lf] object SBuiltin {
     ) = {
       val (tyCon, record) = getSAnyContract(args, 0)
       machine.returnValue =
-        if (machine.compiledPackages.getDefinition(ImplementsDefRef(tyCon, requiringIface)).isEmpty)
+        if (machine.compiledPackages.getDefinition(ImplementsDefRef(tyCon, requiringIfaceId)).isEmpty)
           SOptional(None)
         else
           SOptional(Some(SAnyContract(tyCon, record)))
     }
   }
 
-  // Convert an interface `requiredIface` to another interface `requiringIface`, if
-  // the `requiringIface` implements `requiredIface`.
+  // Convert an interface `requiredIfaceId`  to another interface `requiringIfaceId`, if
+  // the underlying template implements `requiringIfaceId`. Else throw a fatal
+  // `ContractDoesNotImplementRequiringInterface` exception.
   final case class SBUnsafeFromRequiredInterface(
       requiredIfaceId: TypeConName,
       requiringIfaceId: TypeConName,
@@ -1276,7 +1277,7 @@ private[lf] object SBuiltin {
     ) = {
       val coid = getSContractId(args, 0)
       val (tyCon, record) = getSAnyContract(args, 1)
-      if (machine.compiledPackages.getDefinition(ImplementsDefRef(tyCon, requiringIface)).isEmpty)
+      if (machine.compiledPackages.getDefinition(ImplementsDefRef(tyCon, requiringIfaceId)).isEmpty)
         throw SErrorDamlException(
           IE.ContractDoesNotImplementRequiringInterface(
             requiringIfaceId,

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/PackageInterface.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/PackageInterface.scala
@@ -319,7 +319,7 @@ private[lf] class PackageInterface(signatures: PartialFunction[PackageId, Packag
           case Some(choice) => Right(ChoiceInfo.Interface(choice))
           case None => {
             // TODO(drsk) improve the performance of this lookup. Tracked in issue
-            // https://github.com/digital-asset/daml/issues/11345.
+            // https://github.com/digital-asset/daml/issues/13630.
             interface.requires.view
               .map((iface) =>
                 lookupInterfaceChoice(iface, chName, context).map((choice) => (choice, iface))


### PR DESCRIPTION
For looking up required interface conversions, like we already do in other cases.

Fixes #11345 (updated the ticket for the package interface TODO since it's very different)

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
