### PR TITLE
daml test: print test summary at end of test suite.

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -154,6 +154,7 @@ da_haskell_library(
         "aeson",
         "aeson-pretty",
         "ansi-wl-pprint",
+        "ansi-terminal",
         "base",
         "base64",
         "base64-bytestring",

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -4,7 +4,7 @@ module DamlcTest
    ( main
    ) where
 
-import Data.List.Extra (isInfixOf, isSuffixOf)
+import Data.List.Extra (isInfixOf, isSuffixOf, isPrefixOf)
 import System.Directory
 import System.Environment.Blank
 import System.Exit
@@ -181,7 +181,7 @@ testsForDamlcTest damlc scriptDar script1DevDar = testGroup "damlc test" $
             stdout @?= ""
             assertInfixOf "Parse error" stderr
             exitCode @?= ExitFailure 1
-    , testCase "Test coverage report" $ do
+    , testCase "Test coverage report and summary" $ do
         withTempDir $ \dir -> do
             writeFileUTF8 (dir </> "daml.yaml") $ unlines
               [ "sdk-version: " <> sdkVersion
@@ -213,8 +213,13 @@ testsForDamlcTest damlc scriptDar script1DevDar = testGroup "damlc test" $
                 , dir ]
                 ""
             exitCode @?= ExitSuccess
-            assertBool ("test coverage is reported correctly: " <> stdout)
-                       ("test coverage: templates 50%, choices 33%\n" `isSuffixOf` stdout)
+            let out = lines stdout
+            assertBool ("test coverage is reported correctly: " <> out!!4)
+                       ("test coverage: templates 50%, choices 33%" == (out!!4))
+            assertBool ("test summary is reported correctly: " <> out!!1)
+                       ("Test Summary" `isPrefixOf` (out!!1))
+            assertBool ("test summary is reported correctly: " <> out!!3)
+                       ("./Foo.daml:x: ok, 0 active contracts, 2 transactions." == (out!!3))
     , testCase "Full test coverage report" $ do
         withTempDir $ \dir -> do
             writeFileUTF8 (dir </> "daml.yaml") $ unlines
@@ -553,6 +558,7 @@ testsForDamlcTest damlc scriptDar script1DevDar = testGroup "damlc test" $
               [ "module Foo where"
               , "import Daml.Script"
               , "x = script $ assert False"
+              , "y = script $ assert True"
               ]
             (exitCode, stdout, stderr) <-
               readProcessWithExitCode
@@ -563,9 +569,13 @@ testsForDamlcTest damlc scriptDar script1DevDar = testGroup "damlc test" $
                 , "--files"
                 , file ]
                 ""
-            stdout @?= ""
             assertInfixOf "Script execution failed" stderr
             exitCode @?= ExitFailure 1
+
+            let out = lines stdout
+            assertInfixOf "Test Summary" (out!!1)
+            assertInfixOf "Foo.daml:y: ok" (out!!3)
+            assertInfixOf "Foo.daml:x: failed" (out!!4)
     , testCase "damlc test --files outside of project" $
         -- TODO: does this test make sense with a daml.yaml file?
         withTempDir $ \projDir -> do


### PR DESCRIPTION
This changes the output of `daml test`, such that at the end of the test
suite a summary is printed, indicating which tests failed and which
passed.

Fixes #13535.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
