### PR TITLE
add missing type parameter evidence to Java codegen output when Numeric used

### DIFF
--- a/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
@@ -61,36 +61,11 @@ data FixedContractId = FixedContractId
   deriving (Eq, Show)
 
 data ClaimF t a x
-  = ZeroF
-  | OneF a
-  | GiveF x
-  | AndF with claims: [x]
-  | OrF with lhs: x, rhs: x
-  | CondF with predicate: (Observation t Bool), success: x, failure: x
-  | ScaleF with k: (Observation t Decimal), claim: x
-  | WhenF with predicate: (Observation t Bool), claim: x
-  | AnytimeF with predicate: (Observation t Bool), zlabel: Text, claim: x
-  | UntilF with predicate: (Observation t Bool), zlabel: Text, repeatable: Bool, claim: x
-  | LabelF with label: Text, claim: x
+  = ClaimF with k: (Observation t Decimal), claim: x
   deriving (Eq, Show)
 
 data Observation t a
-  = DecimalConst Decimal
-  | DecimalObs Text
-  | DecimalLte (Observation t Decimal, Observation t Decimal)
-  | DecimalEqu (Observation t Decimal, Observation t Decimal)
-  | DecimalAdd (Observation t Decimal, Observation t Decimal)
-  | DecimalNeg (Observation t Decimal)
-  | DecimalMul (Observation t Decimal, Observation t Decimal)
-  | DecimalDiv (Observation t Decimal, Observation t Decimal)
-  | BoolConst Bool
-  | BoolNot (Observation t Bool)
-  | BoolAnd (Observation t Bool, Observation t Bool)
-  | BoolOr (Observation t Bool, Observation t Bool)
-  | DateIdentity
-  | DateConst t
-  | DateLte (Observation t t, Observation t t)
-  | DateEqu (Observation t t, Observation t t)
+  = Observation with obs: t
   deriving (Eq, Show)
 
 -- Not part of the test but the codegen filters out

--- a/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
@@ -61,36 +61,13 @@ data FixedContractId = FixedContractId
   deriving (Eq, Show)
 
 data ClaimF t a x
-  = ZeroF
-  | OneF a
-  | GiveF x
-  | AndF with claims: [x]
-  | OrF with lhs: x, rhs: x
-  | CondF with predicate: (Observation t Bool), success: x, failure: x
+  = OneF a
   | ScaleF with k: (Observation t Decimal), claim: x
-  | WhenF with predicate: (Observation t Bool), claim: x
-  | AnytimeF with predicate: (Observation t Bool), zlabel: Text, claim: x
-  | UntilF with predicate: (Observation t Bool), zlabel: Text, repeatable: Bool, claim: x
-  | LabelF with label: Text, claim: x
   deriving (Eq, Show)
 
 data Observation t a
-  = DecimalConst Decimal
-  | DecimalObs Text
-  | DecimalLte (Observation t Decimal, Observation t Decimal)
-  | DecimalEqu (Observation t Decimal, Observation t Decimal)
-  | DecimalAdd (Observation t Decimal, Observation t Decimal)
-  | DecimalNeg (Observation t Decimal)
-  | DecimalMul (Observation t Decimal, Observation t Decimal)
-  | DecimalDiv (Observation t Decimal, Observation t Decimal)
-  | BoolConst Bool
-  | BoolNot (Observation t Bool)
-  | BoolAnd (Observation t Bool, Observation t Bool)
-  | BoolOr (Observation t Bool, Observation t Bool)
-  | DateIdentity
-  | DateConst t
+  = DecimalLte (Observation t Decimal, Observation t Decimal)
   | DateLte (Observation t t, Observation t t)
-  | DateEqu (Observation t t, Observation t t)
   deriving (Eq, Show)
 
 -- Not part of the test but the codegen filters out

--- a/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
@@ -60,12 +60,12 @@ data FixedContractId = FixedContractId
         fixedContractId: ParametrizedContractId Foo
   deriving (Eq, Show)
 
-data ClaimF t a x
-  = ClaimF with k: (Observation t Decimal), claim: x
+data UsesNumType t x
+  = UsesNumType with k: (Const t Decimal), x: x
   deriving (Eq, Show)
 
-data Observation t a
-  = Observation with obs: t
+data Const t a
+  = Const with runConst: t
   deriving (Eq, Show)
 
 -- Not part of the test but the codegen filters out
@@ -79,6 +79,6 @@ template RecordTestTemplate
         nestedRecord : NestedRecord
         parametrizedContractId : ParametrizedContractId Int
         fixedContractId : FixedContractId
-        claimF : ClaimF Int Int Int
+        usesNumType : UsesNumType Int Int
     where
         signatory owner

--- a/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
@@ -60,6 +60,39 @@ data FixedContractId = FixedContractId
         fixedContractId: ParametrizedContractId Foo
   deriving (Eq, Show)
 
+data ClaimF t a x
+  = ZeroF
+  | OneF a
+  | GiveF x
+  | AndF with claims: [x]
+  | OrF with lhs: x, rhs: x
+  | CondF with predicate: (Observation t Bool), success: x, failure: x
+  | ScaleF with k: (Observation t Decimal), claim: x
+  | WhenF with predicate: (Observation t Bool), claim: x
+  | AnytimeF with predicate: (Observation t Bool), zlabel: Text, claim: x
+  | UntilF with predicate: (Observation t Bool), zlabel: Text, repeatable: Bool, claim: x
+  | LabelF with label: Text, claim: x
+  deriving (Eq, Show)
+
+data Observation t a
+  = DecimalConst Decimal
+  | DecimalObs Text
+  | DecimalLte (Observation t Decimal, Observation t Decimal)
+  | DecimalEqu (Observation t Decimal, Observation t Decimal)
+  | DecimalAdd (Observation t Decimal, Observation t Decimal)
+  | DecimalNeg (Observation t Decimal)
+  | DecimalMul (Observation t Decimal, Observation t Decimal)
+  | DecimalDiv (Observation t Decimal, Observation t Decimal)
+  | BoolConst Bool
+  | BoolNot (Observation t Bool)
+  | BoolAnd (Observation t Bool, Observation t Bool)
+  | BoolOr (Observation t Bool, Observation t Bool)
+  | DateIdentity
+  | DateConst t
+  | DateLte (Observation t t, Observation t t)
+  | DateEqu (Observation t t, Observation t t)
+  deriving (Eq, Show)
+
 -- Not part of the test but the codegen filters out
 -- data definitions which are not used in a template
 template RecordTestTemplate
@@ -71,5 +104,6 @@ template RecordTestTemplate
         nestedRecord : NestedRecord
         parametrizedContractId : ParametrizedContractId Int
         fixedContractId : FixedContractId
+        claimF : ClaimF Int Int Int
     where
         signatory owner

--- a/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
@@ -61,11 +61,36 @@ data FixedContractId = FixedContractId
   deriving (Eq, Show)
 
 data ClaimF t a x
-  = ClaimF with k: (Observation t Decimal), claim: x
+  = ZeroF
+  | OneF a
+  | GiveF x
+  | AndF with claims: [x]
+  | OrF with lhs: x, rhs: x
+  | CondF with predicate: (Observation t Bool), success: x, failure: x
+  | ScaleF with k: (Observation t Decimal), claim: x
+  | WhenF with predicate: (Observation t Bool), claim: x
+  | AnytimeF with predicate: (Observation t Bool), zlabel: Text, claim: x
+  | UntilF with predicate: (Observation t Bool), zlabel: Text, repeatable: Bool, claim: x
+  | LabelF with label: Text, claim: x
   deriving (Eq, Show)
 
 data Observation t a
-  = Observation with obs: t
+  = DecimalConst Decimal
+  | DecimalObs Text
+  | DecimalLte (Observation t Decimal, Observation t Decimal)
+  | DecimalEqu (Observation t Decimal, Observation t Decimal)
+  | DecimalAdd (Observation t Decimal, Observation t Decimal)
+  | DecimalNeg (Observation t Decimal)
+  | DecimalMul (Observation t Decimal, Observation t Decimal)
+  | DecimalDiv (Observation t Decimal, Observation t Decimal)
+  | BoolConst Bool
+  | BoolNot (Observation t Bool)
+  | BoolAnd (Observation t Bool, Observation t Bool)
+  | BoolOr (Observation t Bool, Observation t Bool)
+  | DateIdentity
+  | DateConst t
+  | DateLte (Observation t t, Observation t t)
+  | DateEqu (Observation t t, Observation t t)
   deriving (Eq, Show)
 
 -- Not part of the test but the codegen filters out

--- a/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
@@ -61,13 +61,11 @@ data FixedContractId = FixedContractId
   deriving (Eq, Show)
 
 data ClaimF t a x
-  = OneF a
-  | ScaleF with k: (Observation t Decimal), claim: x
+  = ClaimF with k: (Observation t Decimal), claim: x
   deriving (Eq, Show)
 
 data Observation t a
-  = DecimalLte (Observation t Decimal, Observation t Decimal)
-  | DateLte (Observation t t, Observation t t)
+  = Observation with obs: (Observation t t, Observation t t)
   deriving (Eq, Show)
 
 -- Not part of the test but the codegen filters out

--- a/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
+++ b/language-support/java/codegen/src/it/daml/Tests/RecordTest.daml
@@ -65,7 +65,7 @@ data ClaimF t a x
   deriving (Eq, Show)
 
 data Observation t a
-  = Observation with obs: (Observation t t, Observation t t)
+  = Observation with obs: t
   deriving (Eq, Show)
 
 -- Not part of the test but the codegen filters out

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
@@ -19,7 +19,9 @@ private[inner] object RecordMethods {
 
     val constructor = ConstructorGenerator.generateConstructor(fields)
 
-    val conversionMethods = distinctTypeVars(fields, typeParameters).flatMap { params =>
+    val dtv = distinctTypeVars(fields, typeParameters)
+    println(s"s11 params $dtv for class $className")
+    val conversionMethods = dtv.flatMap { params =>
       val fromValue = FromValueGenerator.generateFromValueForRecordLike(
         fields,
         className.parameterized(typeParameters),

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordMethods.scala
@@ -19,9 +19,7 @@ private[inner] object RecordMethods {
 
     val constructor = ConstructorGenerator.generateConstructor(fields)
 
-    val dtv = distinctTypeVars(fields, typeParameters)
-    println(s"s11 params $dtv for class $className")
-    val conversionMethods = dtv.flatMap { params =>
+    val conversionMethods = distinctTypeVars(fields, typeParameters).flatMap { params =>
       val fromValue = FromValueGenerator.generateFromValueForRecordLike(
         fields,
         className.parameterized(typeParameters),

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
@@ -192,7 +192,7 @@ package object inner {
         case TypeVar(x) => typeParams + JavaEscaper.escapeString(x)
         case TypePrim(_, args) => args.foldLeft(typeParams)(go)
         case TypeCon(_, args) => args.foldLeft(typeParams)(go)
-        case TypeNumeric(_) => Set.empty
+        case TypeNumeric(_) => typeParams
       }
     }
     val res = go(Set.empty, tpe).toVector

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
@@ -195,7 +195,12 @@ package object inner {
         case TypeNumeric(_) => Set.empty
       }
     }
-    go(Set.empty, tpe).toVector
+    val res = go(Set.empty, tpe).toVector
+    // TODO s11 tparams Vector() of tpe
+    //  TypeCon(TypeConName(9f33dc55c00991bc2612fc9f1ae3f2581b5e1da3de90b2e8a7353c1d36b3f27e:Tests.RecordTest:Observation),
+    //          IndexedSeq(TypeVar(t), TypeNumeric(10)))
+    println(s"s11 tparams $res of tpe $tpe")
+    res
   }
 
   def createPackageIdField(packageId: PackageId): FieldSpec = {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
@@ -195,12 +195,7 @@ package object inner {
         case TypeNumeric(_) => typeParams
       }
     }
-    val res = go(Set.empty, tpe).toVector
-    // TODO s11 tparams Vector() of tpe
-    //  TypeCon(TypeConName(9f33dc55c00991bc2612fc9f1ae3f2581b5e1da3de90b2e8a7353c1d36b3f27e:Tests.RecordTest:Observation),
-    //          IndexedSeq(TypeVar(t), TypeNumeric(10)))
-    println(s"s11 tparams $res of tpe $tpe")
-    res
+    go(Set.empty, tpe).toVector
   }
 
   def createPackageIdField(packageId: PackageId): FieldSpec = {


### PR DESCRIPTION
Fixes #13308.

```rst
CHANGELOG_BEGIN
- [daml codegen java] The Java codegen could produce invalid Java code
  for Daml data types with type parameters that also used Numeric or
  Decimal in their definitions; this has been fixed.
  See `issue #13658 <https://github.com/digital-asset/daml/pull/13658>`__.
CHANGELOG_END
```

* [x] minimize repro
* [x] describe
* [x] changelog