### PR TITLE
Use small buffers for tests

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -113,9 +113,9 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll {
     resource = newLoggingContext { implicit loggingContext =>
       for {
         dao <- daoOwner(
-          eventsPageSize = 100,
+          eventsPageSize = 4,
           eventsProcessingParallelism = 4,
-          acsIdPageSize = 2000,
+          acsIdPageSize = 4,
           acsIdFetchingParallelism = 2,
           acsContractFetchingParallelism = 2,
           acsGlobalParallelism = 10,

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -467,6 +467,27 @@ server_conformance_test(
     ],
 )
 
+# By default, participants are tuned for performance. The buffers and caches used by the participant
+# are by default so large that they are not filled by the small amount of data produced by the conformance test.
+# We run one conformance test with small buffer/cache sizes to make sure we cover cases where data doesn't fit
+# into a cache or where multiple buffers have to be combined.
+server_conformance_test(
+    name = "conformance-test-tiny-buffers",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant participant-id=example,port=6865",
+        "--enable-user-management=true",
+        "--events-page-size=2",
+        "--acs-id-page-size=2",
+        "--user-management-max-cache-size=2",
+        # "--user-management-max-users-page-size=2" -- minimum size is 100 which is not tiny anymore
+    ],
+    servers = {"postgresql": SERVERS["postgresql"]},
+    test_tool_args = [
+        "--verbose",
+    ],
+)
+
 conformance_test(
     name = "conformance-test-static-time",
     ports = [6865],

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -475,7 +475,7 @@ server_conformance_test(
     name = "conformance-test-tiny-buffers",
     server_args = [
         "--contract-id-seeding=testing-weak",
-        "--participant participant-id=example,port=6865",
+        "--participant participant-id=example,port=6865,contract-state-cache-max-size=2,contract-key-state-cache-max-size=2",
         "--enable-user-management=true",
         "--events-page-size=2",
         "--acs-id-page-size=2",


### PR DESCRIPTION
By default the buffers used in the participant are so large that they are not filled during tests. We had a few cases in the past where our tests did not catch a bug in code that deals with handling full buffers. This PR:

1. Further reduces the page sizes used in JdbcLedgerDao suite.
2. Adds a new conformance test that runs a participant with small page sizes. This increases our CI time by ~2min.

The second (and only the second) change would have caught the bug introduced in the last commit of https://github.com/digital-asset/daml/pull/13240. 