### PR TITLE
[LLP] Indexer latency optimizations [DPP-1014]

### DIFF
--- a/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/Config.scala
+++ b/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/Config.scala
@@ -72,16 +72,6 @@ object Config {
         .action((value, config) =>
           config.copy(indexerConfig = config.indexerConfig.copy(submissionBatchSize = value))
         )
-      opt[Int]("indexer-tailing-rate-limit-per-second")
-        .text("Sets the value of IndexerConfig.tailingRateLimitPerSecond.")
-        .action((value, config) =>
-          config.copy(indexerConfig = config.indexerConfig.copy(tailingRateLimitPerSecond = value))
-        )
-      opt[Long]("indexer-batch-within-millis")
-        .text("Sets the value of IndexerConfig.batchWithinMillis.")
-        .action((value, config) =>
-          config.copy(indexerConfig = config.indexerConfig.copy(batchWithinMillis = value))
-        )
       opt[Boolean]("indexer-enable-compression")
         .text("Sets the value of IndexerConfig.enableCompression.")
         .action((value, config) =>

--- a/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/IndexerBenchmarkResult.scala
+++ b/ledger/indexer-benchmark/src/main/scala/ledger/indexerbenchmark/IndexerBenchmarkResult.scala
@@ -44,8 +44,6 @@ class IndexerBenchmarkResult(config: Config, metrics: Metrics, startTime: Long, 
        |  inputMappingParallelism:   ${config.indexerConfig.inputMappingParallelism}
        |  ingestionParallelism:      ${config.indexerConfig.ingestionParallelism}
        |  submissionBatchSize:       ${config.indexerConfig.submissionBatchSize}
-       |  batchWithinMillis:         ${config.indexerConfig.batchWithinMillis}
-       |  tailingRateLimitPerSecond: ${config.indexerConfig.tailingRateLimitPerSecond}
        |  full indexer config:       ${config.indexerConfig}
        |
        |Result:

--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/Config.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/Config.scala
@@ -240,14 +240,6 @@ object Config {
               .get("indexer-submission-batch-size")
               .map(_.toLong)
               .getOrElse(IndexerConfig.DefaultSubmissionBatchSize)
-            val indexerTailingRateLimitPerSecond = kv
-              .get("indexer-tailing-rate-limit-per-second")
-              .map(_.toInt)
-              .getOrElse(IndexerConfig.DefaultTailingRateLimitPerSecond)
-            val indexerBatchWithinMillis = kv
-              .get("indexer-batch-within-millis")
-              .map(_.toLong)
-              .getOrElse(IndexerConfig.DefaultBatchWithinMillis)
             val indexerEnableCompression = kv
               .get("indexer-enable-compression")
               .map(_.toBoolean)
@@ -287,8 +279,6 @@ object Config {
                 batchingParallelism = indexerBatchingParallelism,
                 ingestionParallelism = indexerIngestionParallelism,
                 submissionBatchSize = indexerSubmissionBatchSize,
-                tailingRateLimitPerSecond = indexerTailingRateLimitPerSecond,
-                batchWithinMillis = indexerBatchWithinMillis,
                 enableCompression = indexerEnableCompression,
               ),
               apiServerDatabaseConnectionPoolSize = apiServerConnectionPoolSize,

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -21,8 +21,6 @@ case class IndexerConfig(
     batchingParallelism: Int = DefaultBatchingParallelism,
     ingestionParallelism: Int = DefaultIngestionParallelism,
     submissionBatchSize: Long = DefaultSubmissionBatchSize,
-    tailingRateLimitPerSecond: Int = DefaultTailingRateLimitPerSecond,
-    batchWithinMillis: Long = DefaultBatchWithinMillis,
     enableCompression: Boolean = DefaultEnableCompression,
     haConfig: HaConfig = HaConfig(),
     // PostgresSQL specific configurations
@@ -44,8 +42,6 @@ object IndexerConfig {
   val DefaultBatchingParallelism: Int = 4
   val DefaultIngestionParallelism: Int = 16
   val DefaultSubmissionBatchSize: Long = 50L
-  val DefaultTailingRateLimitPerSecond: Int = 20
-  val DefaultBatchWithinMillis: Long = 50L
   val DefaultEnableCompression: Boolean = false
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -89,8 +89,6 @@ object JdbcIndexer {
           batchingParallelism = config.batchingParallelism,
           ingestionParallelism = config.ingestionParallelism,
           submissionBatchSize = config.submissionBatchSize,
-          tailingRateLimitPerSecond = config.tailingRateLimitPerSecond,
-          batchWithinMillis = config.batchWithinMillis,
           metrics = metrics,
         ),
         stringInterningStorageBackend = stringInterningStorageBackend,

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/BatchN.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/BatchN.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.indexer.parallel
+
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
+
+import scala.collection.mutable.ArrayBuffer
+
+/** Forms dynamically-sized batches based on downstream backpressure.
+  *   - Under light load, this flow emits batches of size 1.
+  *   - Under heavy load, this flow emits batches of `maxBatchSize`.
+  */
+object BatchN {
+  def apply[IN](
+      maxBatchSize: Int,
+      maxBatchCount: Int,
+  ): Flow[IN, ArrayBuffer[IN], NotUsed] =
+    Flow[IN]
+      .batch[Vector[ArrayBuffer[IN]]](
+        (maxBatchSize * maxBatchCount).toLong,
+        in => Vector(newBatch(maxBatchSize, in)),
+      ) { case (batches, in) =>
+        val lastBatch = batches.last
+        if (lastBatch.size < maxBatchSize) {
+          lastBatch.addOne(in)
+          batches
+        } else
+          batches :+ newBatch(maxBatchSize, in)
+      }
+      .mapConcat(identity)
+
+  private def newBatch[IN](maxBatchSize: Int, newElement: IN) = {
+    val newBatch = ArrayBuffer.empty[IN]
+    newBatch.sizeHint(maxBatchSize)
+    newBatch.addOne(newElement)
+    newBatch
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/BatchingParallelIngestionPipe.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/BatchingParallelIngestionPipe.scala
@@ -4,9 +4,8 @@
 package com.daml.platform.indexer.parallel
 
 import akka.NotUsed
-import akka.stream.scaladsl.{Flow, Source}
+import akka.stream.scaladsl.Source
 
-import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
 
 object BatchingParallelIngestionPipe {
@@ -27,7 +26,7 @@ object BatchingParallelIngestionPipe {
     // Stage 1: the stream coming from ReadService, involves deserialization and translation to Update-s
     source
       // Stage 2: Batching plus mapping to Database DTOs encapsulates all the CPU intensive computation of the ingestion. Executed in parallel.
-      .via(batchN(submissionBatchSize.toInt, inputMappingParallelism))
+      .via(BatchN(submissionBatchSize.toInt, inputMappingParallelism))
       .mapAsync(inputMappingParallelism)(inputMapper)
       // Stage 3: Encapsulates sequential/stateful computation (generation of sequential IDs for events)
       .scan(seqMapperZero)(seqMapper)
@@ -43,33 +42,4 @@ object BatchingParallelIngestionPipe {
       // Stage 7: Updating ledger-end and related data in database (this stage completion demarcates the consistent point-in-time)
       .mapAsync(1)(ingestTail)
       .map(_ => ())
-
-  /** Forms dynamically-sized batches based on downstream backpressure.
-    *   - Under light load, this flow emits batches of size 1.
-    *   - Under heavy load, this flow emits batches of `maxBatchSize`.
-    */
-  private def batchN[IN](
-      maxBatchSize: Int,
-      maxBatchCount: Int,
-  ): Flow[IN, ArrayBuffer[IN], NotUsed] =
-    Flow[IN]
-      .batch[Vector[ArrayBuffer[IN]]](
-        (maxBatchSize * maxBatchCount).toLong,
-        in => Vector(newBatch(maxBatchSize, in)),
-      ) { case (batches, in) =>
-        val lastBatch = batches.last
-        if (lastBatch.size < maxBatchSize) {
-          lastBatch.addOne(in)
-          batches
-        } else
-          batches :+ newBatch(maxBatchSize, in)
-      }
-      .flatMapConcat(v => Source.fromIterator(() => v.iterator))
-
-  private def newBatch[IN](maxBatchSize: Int, newElement: IN) = {
-    val newBatch = ArrayBuffer.empty[IN]
-    newBatch.sizeHint(maxBatchSize)
-    newBatch.addOne(newElement)
-    newBatch
-  }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/BatchingParallelIngestionPipe.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/BatchingParallelIngestionPipe.scala
@@ -4,16 +4,15 @@
 package com.daml.platform.indexer.parallel
 
 import akka.NotUsed
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Flow, Source}
 
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
 
 object BatchingParallelIngestionPipe {
 
   def apply[IN, IN_BATCH, DB_BATCH](
       submissionBatchSize: Long,
-      batchWithinMillis: Long,
       inputMappingParallelism: Int,
       inputMapper: Iterable[IN] => Future[IN_BATCH],
       seqMapperZero: IN_BATCH,
@@ -23,13 +22,12 @@ object BatchingParallelIngestionPipe {
       ingestingParallelism: Int,
       ingester: DB_BATCH => Future[DB_BATCH],
       tailer: (DB_BATCH, DB_BATCH) => DB_BATCH,
-      tailingRateLimitPerSecond: Int,
       ingestTail: DB_BATCH => Future[DB_BATCH],
   )(source: Source[IN, NotUsed]): Source[Unit, NotUsed] =
     // Stage 1: the stream coming from ReadService, involves deserialization and translation to Update-s
     source
       // Stage 2: Batching plus mapping to Database DTOs encapsulates all the CPU intensive computation of the ingestion. Executed in parallel.
-      .groupedWithin(submissionBatchSize.toInt, FiniteDuration(batchWithinMillis, "millis"))
+      .via(batchN(submissionBatchSize.toInt, inputMappingParallelism))
       .mapAsync(inputMappingParallelism)(inputMapper)
       // Stage 3: Encapsulates sequential/stateful computation (generation of sequential IDs for events)
       .scan(seqMapperZero)(seqMapper)
@@ -42,9 +40,36 @@ object BatchingParallelIngestionPipe {
       .mapAsync(ingestingParallelism)(ingester)
       // Stage 6: Preparing data sequentially for throttled mutations in database (tracking the ledger-end, corresponding sequential event ids and latest-at-the-time configurations)
       .conflate(tailer)
-      .throttle(tailingRateLimitPerSecond, FiniteDuration(1, "seconds"))
       // Stage 7: Updating ledger-end and related data in database (this stage completion demarcates the consistent point-in-time)
       .mapAsync(1)(ingestTail)
       .map(_ => ())
 
+  /** Forms dynamically-sized batches based on downstream backpressure.
+    *   - Under light load, this flow emits batches of size 1.
+    *   - Under heavy load, this flow emits batches of `maxBatchSize`.
+    */
+  private def batchN[IN](
+      maxBatchSize: Int,
+      maxBatchCount: Int,
+  ): Flow[IN, ArrayBuffer[IN], NotUsed] =
+    Flow[IN]
+      .batch[Vector[ArrayBuffer[IN]]](
+        (maxBatchSize * maxBatchCount).toLong,
+        in => Vector(newBatch(maxBatchSize, in)),
+      ) { case (batches, in) =>
+        val lastBatch = batches.last
+        if (lastBatch.size < maxBatchSize) {
+          lastBatch.addOne(in)
+          batches
+        } else
+          batches :+ newBatch(maxBatchSize, in)
+      }
+      .flatMapConcat(v => Source.fromIterator(() => v.iterator))
+
+  private def newBatch[IN](maxBatchSize: Int, newElement: IN) = {
+    val newBatch = ArrayBuffer.empty[IN]
+    newBatch.sizeHint(maxBatchSize)
+    newBatch.addOne(newElement)
+    newBatch
+  }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerSubscription.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerSubscription.scala
@@ -34,8 +34,6 @@ private[platform] case class ParallelIndexerSubscription[DB_BATCH](
     batchingParallelism: Int,
     ingestionParallelism: Int,
     submissionBatchSize: Long,
-    tailingRateLimitPerSecond: Int,
-    batchWithinMillis: Long,
     metrics: Metrics,
 ) {
   import ParallelIndexerSubscription._
@@ -50,7 +48,6 @@ private[platform] case class ParallelIndexerSubscription[DB_BATCH](
     initialized =>
       val (killSwitch, completionFuture) = BatchingParallelIngestionPipe(
         submissionBatchSize = submissionBatchSize,
-        batchWithinMillis = batchWithinMillis,
         inputMappingParallelism = inputMappingParallelism,
         inputMapper = inputMapperExecutor.execute(
           inputMapper(
@@ -76,7 +73,6 @@ private[platform] case class ParallelIndexerSubscription[DB_BATCH](
         ingestingParallelism = ingestionParallelism,
         ingester = ingester(ingestionStorageBackend.insertBatch, dbDispatcher, metrics),
         tailer = tailer(ingestionStorageBackend.batch(Vector.empty, stringInterningView)),
-        tailingRateLimitPerSecond = tailingRateLimitPerSecond,
         ingestTail =
           ingestTail[DB_BATCH](parameterStorageBackend.updateLedgerEnd, dbDispatcher, metrics),
       )(

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/parallel/BatchNSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/parallel/BatchNSpec.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.indexer.parallel
+
+import akka.stream.Attributes.InputBuffer
+import akka.stream.{Attributes, DelayOverflowStrategy}
+import akka.stream.scaladsl.{Sink, Source}
+import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
+
+class BatchNSpec extends AsyncFlatSpec with Matchers with AkkaBeforeAndAfterAll {
+  behavior of BatchN.getClass.getSimpleName
+
+  private val MaxBatchSize = 10
+  private val MaxBatchCount = 5
+
+  it should "form batches of size 1 under no load" in {
+    val inputSize = 10
+    val input = 1 to inputSize
+    val batchesF =
+      Source(input).async
+        // slow upstream
+        .delay(10.millis, DelayOverflowStrategy.backpressure)
+        .via(BatchN(MaxBatchSize, MaxBatchCount))
+        .runWith(Sink.seq[ArrayBuffer[Int]])
+
+    batchesF.map { batches =>
+      batches.flatten should contain theSameElementsInOrderAs input
+      batches.map(_.size) should contain theSameElementsAs Array.fill(inputSize)(1)
+    }
+  }
+
+  it should "form maximally-sized batches under downstream back-pressure" in {
+    val inputSize = 100
+    val input = 1 to inputSize
+
+    val batchesF =
+      Source(input)
+        .via(BatchN(MaxBatchSize, MaxBatchCount))
+        // slow downstream
+        .initialDelay(10.millis)
+        .async
+        .delay(10.millis, DelayOverflowStrategy.backpressure)
+        .addAttributes(Attributes(InputBuffer(1, 1)))
+        .runWith(Sink.seq)
+
+    batchesF.map { batches =>
+      batches.flatten should contain theSameElementsInOrderAs input
+      batches.map(_.size) should contain theSameElementsAs Array.fill(inputSize / MaxBatchSize)(
+        MaxBatchSize
+      )
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces changes to the Indexer pipeline meant to reduce the latency of the pipeline to a minimum when the system is under low load, while maintaining the bounded latency & maximum throughput capability under heavy load.

Under low load:
* Pipeline latency before: ~70ms
* Pipeline latency after this implementation: ~3ms

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
