### PR TITLE
Publish daml-lf/snapshot proto [KVL-1245]

### DIFF
--- a/daml-lf/snapshot/BUILD.bazel
+++ b/daml-lf/snapshot/BUILD.bazel
@@ -13,7 +13,7 @@ load(
 )
 
 proto_jars(
-    name = "snapshot-proto",
+    name = "snapshot_proto",
     srcs = ["src/main/protobuf/com/daml/lf/snapshot.proto"],
     maven_artifact_prefix = "daml-lf-snapshot",
     maven_group = "com.daml",
@@ -28,7 +28,7 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core",
     ],
     deps = [
-        "snapshot-proto_java",
+        "snapshot_proto_java",
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/data",
         "//daml-lf/engine",

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -91,7 +91,7 @@ da_scala_binary(
     scala_deps = ["@maven//:com_github_scopt_scopt"],
     deps = [
         "//daml-lf/data",
-        "//daml-lf/snapshot:snapshot-proto_java",
+        "//daml-lf/snapshot:snapshot_proto_java",
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils:daml_kvutils_proto_java",
         "@maven//:com_google_protobuf_protobuf_java",

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -29,6 +29,10 @@
   type: jar-scala
 - target: //daml-lf/scenario-interpreter:scenario-interpreter
   type: jar-scala
+- target: //daml-lf/snapshot:snapshot_proto_jar
+  type: jar-lib
+- target: //daml-lf/snapshot:snapshot_proto_java
+  type: jar-proto
 - target: //daml-lf/transaction:transaction
   type: jar-scala
 - target: //daml-lf/transaction:transaction_proto_jar


### PR DESCRIPTION
Required to move `submission-entries-extractor` to the integration kit.