### PR TITLE
different representation of Leibniz and Liskov in Scala codegen base library

### DIFF
--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
@@ -9,8 +9,6 @@ import java.util.TimeZone
 import com.daml.ledger.api.refinements.ApiTypes
 import com.daml.ledger.api.v1.{commands => rpccmd, value => rpcvalue}
 import com.daml.ledger.client.binding.encoding.ExerciseOn
-import scalaz.Id.Id
-import scalaz.Leibniz.===
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.tag._
 
@@ -77,10 +75,12 @@ sealed abstract class Primitive extends PrimitiveInstances {
     def apply[V](elems: (String, V)*): TextMap[V]
     def newBuilder[V]: mutable.Builder[(String, V), TextMap[V]]
     implicit def factory[V]: Factory[(String, V), TextMap[V]]
-    final def fromMap[V](map: imm.Map[String, V]): TextMap[V] = leibniz[V].subst[Id](map)
+    final def fromMap[V](map: imm.Map[String, V]): TextMap[V] = leibniz[V](map)
     def subst[F[_[_]]](fa: F[imm.Map[String, *]]): F[TextMap]
-    final def leibniz[V]: imm.Map[String, V] === TextMap[V] =
-      subst[Lambda[g[_] => imm.Map[String, V] === g[V]]](scalaz.Leibniz.refl)
+    final def leibniz[V]: imm.Map[String, V] =:= TextMap[V] =
+      subst[Lambda[g[_] => imm.Map[String, V] =:= g[V]]](
+        implicitly[imm.Map[String, V] =:= imm.Map[String, V]]
+      )
   }
 
   sealed abstract class DateApi {

--- a/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/GenEncoding.scala
+++ b/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/GenEncoding.scala
@@ -101,7 +101,7 @@ object GenEncoding extends GenEncoding {
 
     override def valueTextMap[A](implicit ev: Out[A]): Out[P.TextMap[A]] = {
       implicit val elt: Arbitrary[A] = Arbitrary(ev)
-      P.TextMap.leibniz[A].subst(arbitrary[collection.immutable.Map[String, A]])
+      P.TextMap.leibniz[A].substituteCo(arbitrary[collection.immutable.Map[String, A]])
     }
 
     override def valueGenMap[K, V](implicit evK: Out[K], evV: Out[V]): Out[P.GenMap[K, V]] = {

--- a/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/ShowEncoding.scala
+++ b/language-support/scala/codegen-testing/src/main/scala/com/digitalasset/ledger/client/binding/encoding/ShowEncoding.scala
@@ -121,7 +121,8 @@ object ShowEncoding extends ShowEncoding {
 
     override def valueOptional[A: Show]: Show[P.Optional[A]] = optionShow
 
-    override def valueTextMap[A: Show]: Show[P.TextMap[A]] = P.TextMap.leibniz[A].subst(mapShow)
+    override def valueTextMap[A: Show]: Show[P.TextMap[A]] =
+      P.TextMap.leibniz[A].substituteCo(mapShow)
 
     override def valueGenMap[K: Show, V: Show]: Show[P.GenMap[K, V]] = {
       type SM[M[_, _]] = Show[M[K, V]]


### PR DESCRIPTION
We change a couple minor method signatures in the Scala codegen support library, against which Scala codegen output is compiled, to take advantage of Scala 2.13-only features in scala-library.

```rst
CHANGELOG_BEGIN
- [Scala codegen] The signatures of Scala codegen's base classes have
  changed; existing Scala codegen output must be recompiled.  The
  functions ``describesTemplate`` and ``TextMap.leibniz`` have different
  types; it is extremely unlikely that users have used these functions
  directly, but will need to adjust any callers if they have.
  See `issue #13687 <https://github.com/digital-asset/daml/pull/13687>`__.
CHANGELOG_END
```

Loosely related to #11755. Inspired by some discussion about improving access to the Scala bindings from Java.

Since `=:=` now contains `subst` in 2.13, you can use the [Leibniz conversion technique](https://typelevel.org/blog/2014/07/02/type_equality_to_leibniz.html#leib-power) to make a `===` if you need one, and likewise for `<:<` and `<~<`.