### PR TITLE
clarify entry points to type checking code

### DIFF
--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -43,11 +43,12 @@ private[validation] object Typing {
     case PLRoundingMode(_) => TRoundingMode
   }
 
+  private def tBinop(typ: Type): Type = typ ->: typ ->: typ
+
   protected[validation] lazy val typeOfBuiltinFunction = {
     val alpha = TVar(Name.assertFromString("$alpha$"))
     val beta = TVar(Name.assertFromString("$beta$"))
     val gamma = TVar(Name.assertFromString("$gamma$"))
-    def tBinop(typ: Type): Type = typ ->: typ ->: typ
     val tNumBinop = TForall(alpha.name -> KNat, tBinop(TNumeric(alpha)))
     val tMultiNumBinop =
       TForall(
@@ -256,7 +257,7 @@ private[validation] object Typing {
     case PCUnit => TUnit
   }
 
-  def checkModule(interface: PackageInterface, pkgId: PackageId, mod: Module): Unit = {
+  def checkModule(interface: PackageInterface, pkgId: PackageId, mod: Module): Unit = { // entry point
     val langVersion = handleLookup(Context.None, interface.lookupPackage(pkgId)).languageVersion
     mod.definitions.foreach {
       case (dfnName, DDataType(_, params, cons)) =>
@@ -264,15 +265,16 @@ private[validation] object Typing {
           Env(langVersion, interface, Context.DefDataType(pkgId, mod.name, dfnName), params.toMap)
         params.values.foreach(env.checkKind)
         checkUniq[TypeVarName](params.keys, EDuplicateTypeParam(env.ctx, _))
-        def tyConName = TypeConName(pkgId, QualifiedName(mod.name, dfnName))
         cons match {
           case DataRecord(fields) =>
             env.checkRecordType(fields)
           case DataVariant(fields) =>
             env.checkVariantType(fields)
           case DataEnum(values) =>
+            val tyConName = TypeConName(pkgId, QualifiedName(mod.name, dfnName))
             env.checkEnumType(tyConName, params, values)
           case DataInterface =>
+            val tyConName = TypeConName(pkgId, QualifiedName(mod.name, dfnName))
             env.checkInterfaceType(tyConName, params)
         }
       case (dfnName, dfn: DValue) =>
@@ -340,7 +342,7 @@ private[validation] object Typing {
     private def lookupTypeVar(name: TypeVarName): Kind =
       tVars.getOrElse(name, throw EUnknownTypeVar(ctx, name))
 
-    def checkKind(kind: Kind): Unit = {
+    def checkKind(kind: Kind): Unit = { // testing entry point
       @tailrec
       def loop(k: Kind, stack: List[Kind] = List.empty): Unit =
         k match {
@@ -361,12 +363,12 @@ private[validation] object Typing {
 
     /* Typing Ops*/
 
-    def checkVariantType(variants: ImmArray[(VariantConName, Type)]): Unit = {
+    private[Typing] def checkVariantType(variants: ImmArray[(VariantConName, Type)]): Unit = {
       checkUniq[VariantConName](variants.keys, EDuplicateVariantCon(ctx, _))
       variants.values.foreach(checkType(_, KStar))
     }
 
-    def checkEnumType[X](
+    private[Typing] def checkEnumType[X](
         tyConName: => TypeConName,
         params: ImmArray[X],
         values: ImmArray[EnumConName],
@@ -375,7 +377,7 @@ private[validation] object Typing {
       checkUniq[Name](values.iterator, EDuplicateEnumCon(ctx, _))
     }
 
-    def checkInterfaceType[X](
+    private[Typing] def checkInterfaceType[X](
         tyConName: => TypeConName,
         params: ImmArray[X],
     ): Unit = {
@@ -383,7 +385,7 @@ private[validation] object Typing {
       val _ = handleLookup(ctx, interface.lookupInterface(tyConName))
     }
 
-    def checkDValue(dfn: DValue): Unit = dfn match {
+    private[Typing] def checkDValue(dfn: DValue): Unit = dfn match {
       case DValue(typ, body, isTest) =>
         checkType(typ, KStar)
         checkExpr(body, typ)
@@ -398,7 +400,7 @@ private[validation] object Typing {
       case _ => typ0
     }
 
-    def checkRecordType(fields: ImmArray[(FieldName, Type)]): Unit = {
+    private[Typing] def checkRecordType(fields: ImmArray[(FieldName, Type)]): Unit = {
       checkUniq[FieldName](fields.keys, EDuplicateField(ctx, _))
       fields.values.foreach(checkType(_, KStar))
     }
@@ -427,7 +429,7 @@ private[validation] object Typing {
           ()
       }
 
-    def checkTemplate(tplName: TypeConName, template: Template): Unit = {
+    private[Typing] def checkTemplate(tplName: TypeConName, template: Template): Unit = {
       val Template(
         param,
         precond,
@@ -454,7 +456,7 @@ private[validation] object Typing {
       }
     }
 
-    def checkDefIface(ifaceName: TypeConName, iface: DefInterface): Unit =
+    private[Typing] def checkDefIface(ifaceName: TypeConName, iface: DefInterface): Unit =
       iface match {
         case DefInterface(requires, param, fixedChoices, methods, precond) =>
           val env = introExprVar(param, TTyCon(ifaceName))
@@ -470,15 +472,15 @@ private[validation] object Typing {
           fixedChoices.values.foreach(env.checkChoice(ifaceName, _))
       }
 
-    def checkIfaceMethod(method: InterfaceMethod): Unit = {
+    private def checkIfaceMethod(method: InterfaceMethod): Unit = {
       checkType(method.returnType, KStar)
     }
 
-    def alphaEquiv(t1: Type, t2: Type) =
+    private def alphaEquiv(t1: Type, t2: Type) =
       AlphaEquiv.alphaEquiv(t1, t2) ||
         AlphaEquiv.alphaEquiv(expandTypeSynonyms(t1), expandTypeSynonyms(t2))
 
-    def checkIfaceImplementations(
+    private def checkIfaceImplementations(
         tplTcon: TypeConName,
         impls: Map[TypeConName, TemplateImplements],
     ): Unit = {
@@ -517,7 +519,10 @@ private[validation] object Typing {
       }
     }
 
-    def checkDefException(excepName: TypeConName, defException: DefException): Unit = {
+    private[Typing] def checkDefException(
+        excepName: TypeConName,
+        defException: DefException,
+    ): Unit = {
       checkExpr(defException.message, TTyCon(excepName) ->: TText)
       ()
     }
@@ -530,7 +535,7 @@ private[validation] object Typing {
         TypeSubst.substitute((tparams.keys zip tArgs.iterator).toMap, dataCons)
     }
 
-    def checkType(typ: Type, kind: Kind): Unit = {
+    private[Typing] def checkType(typ: Type, kind: Kind): Unit = {
       val typKind = kindOf(typ)
       if (kind != typKind)
         throw EKindMismatch(ctx, foundKind = typKind, expectedKind = kind)
@@ -539,7 +544,8 @@ private[validation] object Typing {
     private def kindOfDataType(defDataType: DDataType): Kind =
       defDataType.params.reverse.foldLeft[Kind](KStar) { case (acc, (_, k)) => KArrow(k, acc) }
 
-    def kindOf(typ0: Type): Kind = typ0 match {
+    def kindOf(typ0: Type): Kind = typ0 match { // testing entry point
+
       case TSynApp(syn, args) =>
         val ty = expandSynApp(syn, args)
         checkType(ty, KStar)
@@ -674,13 +680,13 @@ private[validation] object Typing {
 
     private def typeOfTyApp(expr: Expr, typs: List[Type]): Type = {
       @tailrec
-      def unwrapForall(body0: Type, typs: List[Type], acc: Map[TypeVarName, Type]): Type =
+      def loopForall(body0: Type, typs: List[Type], acc: Map[TypeVarName, Type]): Type =
         typs match {
           case head :: tail =>
             toForall(body0) match {
               case TForall((v, k), body) =>
                 checkType(head, k)
-                unwrapForall(body, tail, acc.updated(v, head))
+                loopForall(body, tail, acc.updated(v, head))
               case otherwise =>
                 throw EExpectedUniversalType(ctx, otherwise)
             }
@@ -688,7 +694,7 @@ private[validation] object Typing {
             TypeSubst.substitute(acc, body0)
         }
 
-      unwrapForall(typeOf(expr), typs, Map.empty)
+      loopForall(typeOf(expr), typs, Map.empty)
     }
 
     private def typeOfTmLam(x: ExprVarName, typ: Type, body: Expr): Type = {
@@ -1069,7 +1075,7 @@ private[validation] object Typing {
       case _ => throw EExpectedExceptionType(ctx, typ)
     }
 
-    def typeOf(expr: ExprAtomic): Type = expr match {
+    private def typeOf(expr: ExprAtomic): Type = expr match {
       case EVar(name) =>
         lookupExpVar(name)
       case EVal(ref) =>
@@ -1091,7 +1097,7 @@ private[validation] object Typing {
         TOptional(typ)
     }
 
-    def typeOf(expr0: Expr): Type = expr0 match {
+    def typeOf(expr0: Expr): Type = expr0 match { // testing entry point
       case expr: ExprAtomic =>
         typeOf(expr)
       case ERecCon(tycon, fields) =>
@@ -1214,14 +1220,14 @@ private[validation] object Typing {
         typ
     }
 
-    def resolveExprType(expr: Expr, typ: Type): Type = {
+    private def resolveExprType(expr: Expr, typ: Type): Type = {
       val exprType = typeOf(expr)
       if (!alphaEquiv(exprType, typ))
         throw ETypeMismatch(ctx, foundType = exprType, expectedType = typ, expr = Some(expr))
       exprType
     }
 
-    def checkExpr(expr: Expr, typ0: Type): Unit = {
+    private def checkExpr(expr: Expr, typ0: Type): Unit = {
       discard[Type](resolveExprType(expr, typ0))
     }
 
@@ -1279,7 +1285,7 @@ private[validation] object Typing {
   /* Utils */
 
   private implicit final class TypeOp(val rightType: Type) extends AnyVal {
-    def ->:(leftType: Type) = TFun(leftType, rightType)
+    private[Typing] def ->:(leftType: Type) = TFun(leftType, rightType)
   }
 
   private def typeConAppToType(app: TypeConApp): Type = app match {
@@ -1287,11 +1293,12 @@ private[validation] object Typing {
   }
 
   private[this] class ExpectedPatterns(val number: Int, patterns: => Iterator[CasePat]) {
-    def missingPatterns(ranks: Set[Int]): List[CasePat] =
+    private[Typing] def missingPatterns(ranks: Set[Int]): List[CasePat] =
       patterns.zipWithIndex.collect { case (p, i) if !ranks(i) => p }.toList
   }
   private[this] object ExpectedPatterns {
-    def apply(patterns: CasePat*) = new ExpectedPatterns(patterns.length, patterns.iterator)
+    private[Typing] def apply(patterns: CasePat*) =
+      new ExpectedPatterns(patterns.length, patterns.iterator)
   }
 
   private[this] val wildcard: ExprVarName = Name.assertFromString("_")


### PR DESCRIPTION
Clarify entry points to type checking code:
- by annotating entry points with a comment 
- by marking non entry-point `def`s as `private` or `private [Typing]` where possible
- couple of renames to make local `loop` defs (which cannot be marked as `private`) more apparent

prep for #13410