### PR TITLE
redirect old trigger-service page

### DIFF
--- a/docs/redirects.map
+++ b/docs/redirects.map
@@ -796,6 +796,7 @@ daml/intro/10_StdLib.html -> /daml/intro/11_StdLib.html
 daml/intro/11_Testing.html -> /daml/intro/12_Testing.html
 daml-script/daml-script-docs.html -> /daml-script/api/index.html
 triggers/trigger-docs.html -> /triggers/api/index.html
+tools/trigger-service.html -> trigger-service/index.html
 support.html -> /support/support.html
 release-notes.html -> /support/releases.html#release-notes
 support/release-notes.html -> /support/releases.html#release-notes


### PR DESCRIPTION
It still exist (clenup is not perfect on the docs bucket) and is wrong.
Another option would be to manually delete the file on s3, but since
people seem to still find it somehow, I think a redirect to the correct
page is better than a 404.

CHANGELOG_BEGIN
CHANGELOG_END