### PR TITLE
Small cleanup to daml-lf testing setup for interpreter & validation

### DIFF
--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -44,8 +44,6 @@ da_scala_library(
     ],
 )
 
-bigNumericTests = "src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinBigNumericTest.scala"
-
 da_scala_library(
     name = "interpreter-test-lib",
     srcs = glob(["src/test/**/*Lib.scala"]),
@@ -68,7 +66,6 @@ da_scala_test_suite(
     srcs = glob(
         ["src/test/**/*.scala"],
         exclude = [
-            bigNumericTests,
             "src/test/**/*Lib.scala",
         ],
     ),
@@ -98,29 +95,6 @@ da_scala_test_suite(
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_scalatest_scalatest_compatible",
         "@maven//:org_slf4j_slf4j_api",
-    ],
-)
-
-da_scala_test(
-    name = "test_bignumeric",
-    srcs = [bigNumericTests],
-    scala_deps = [
-        "@maven//:org_scalatest_scalatest_core",
-        "@maven//:org_scalatest_scalatest_freespec",
-        "@maven//:org_scalatest_scalatest_matchers_core",
-        "@maven//:org_scalatest_scalatest_shouldmatchers",
-        "@maven//:org_scalaz_scalaz_core",
-    ],
-    scalacopts = lf_scalacopts,
-    deps = [
-        ":interpreter",
-        ":interpreter-test-lib",
-        "//daml-lf/data",
-        "//daml-lf/language",
-        "//daml-lf/parser",
-        "//daml-lf/transaction",
-        "//libs-scala/contextualized-logging",
-        "@maven//:org_scalatest_scalatest_compatible",
     ],
 )
 

--- a/daml-lf/validation/BUILD.bazel
+++ b/daml-lf/validation/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "da_scala_benchmark_jmh",
     "da_scala_library",
     "da_scala_test",
+    "da_scala_test_suite",
     "lf_scalacopts",
     "lf_scalacopts_stricter",
 )
@@ -30,13 +31,31 @@ da_scala_library(
     ],
 )
 
-da_scala_test(
-    name = "validation-test",
+da_scala_library(
+    name = "validation-test-lib",
+    srcs = glob(["src/test/**/SpecUtil.scala"]),
+    scala_deps = [
+        "@maven//:org_scalactic_scalactic",
+    ],
+    scalacopts = lf_scalacopts_stricter,
+    deps = [
+        ":validation",
+        "//daml-lf/language",
+        "//daml-lf/parser",
+    ],
+)
+
+da_scala_test_suite(
+    name = "tests",
     size = "small",
-    srcs = glob(["src/test/**/*.scala"]),
+    srcs = glob(
+        ["src/test/**/*.scala"],
+        exclude = ["src/test/**/*SpecUtil.scala"],
+    ),
     scalacopts = lf_scalacopts,
     deps = [
         ":validation",
+        ":validation-test-lib",
         "//daml-lf/data",
         "//daml-lf/language",
         "//daml-lf/parser",


### PR DESCRIPTION
Small cleanup to the bazel testing setup for  `daml-lf/interpreter` and `daml-lf/validation`

For `daml-lf/interpreter`:
- merge the _bignumeric_ tests (was target `"test_bignumeric"` defined using `da_scala_test`) into the general `"tests"` target (defined using the `da_scala_test_suite`)
- confirm that running the _bignumeric_ using `size = small` doesn't lead to any flakiness:

```
bazel test -t- --runs_per_test=100 //daml-lf/interpreter:tests_test_suite_src_test_scala_com_digitalasset_daml_lf_speedy_SBuiltinBigNumericTest.scala
```

For `daml-lf/validation`:
- setup tests using `da_scala_test_suite` instead of `da_scala_test` for consistently with `daml-lf/interpreter'
