### PR TITLE
ledger-api-test-tool - Adapt for concurrent conflicts [kvl-1369]

### DIFF
--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -17,6 +17,7 @@ import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
+import scala.util.{Success, Try}
 
 object Assertions {
   def fail(message: String): Nothing =
@@ -66,6 +67,15 @@ object Assertions {
 
   def assertIsEmpty(actual: Iterable[_]): Unit = {
     assertSameElements(actual, Seq.empty)
+  }
+
+  def assertGrpcErrorOneOf(t: Throwable, errors: ErrorCode*): Unit = {
+    val hasErrorCode = errors.map(errorCode => Try(assertGrpcError(t, errorCode, None))).exists {
+      case Success(_) => true
+      case _ => false
+    }
+    if (hasErrorCode) ()
+    else fail(s"gRPC failure did not contain one of the expected error codes $errors.", t)
   }
 
   def assertGrpcError(

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -170,7 +170,10 @@ final class LedgerTestCasesRunner(
               identifierSuffix = identifierSuffix,
               features = session.features,
             )
-            _ <- Future.sequence(Dars.resources.map(uploadDar(context, _)))
+            // upload the dars sequentially to avoid conflicts
+            _ <- Dars.resources.foldLeft(Future.unit) { case (result, newResource) =>
+              result.flatMap(_ => uploadDar(context, newResource))
+            }
           } yield ()
         })
         .map(_ => ())

--- a/ledger/ledger-api-tests/suites/deps.bzl
+++ b/ledger/ledger-api-tests/suites/deps.bzl
@@ -9,6 +9,7 @@ def deps(lf_version):
         "//ledger/ledger-api-common",
         "//ledger/ledger-api-tests/infrastructure:infrastructure-%s" % lf_version,
         "//ledger/ledger-resources",
+        "//ledger/participant-state-kv-errors",
         "//libs-scala/test-evidence/tag:test-evidence-tag",
         "//ledger/test-common:dar-files-%s-lib" % lf_version,
         "//ledger/test-common:model-tests-%s.scala" % lf_version,

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_8/ConfigManagementServiceIT.scala
@@ -19,7 +19,7 @@ import com.google.protobuf.duration.Duration
 import io.grpc.Status
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 final class ConfigManagementServiceIT extends LedgerTestSuite {
   test(
@@ -135,60 +135,36 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
   )(implicit ec => { case Participants(Participant(ledger)) =>
     for {
       // Get the current time model
-      response1 <- ledger.getTimeModel()
+      preUpdateTimeModelResponse <- ledger.getTimeModel()
       oldTimeModel = {
-        assert(response1.timeModel.isDefined, "Expected time model to be defined")
-        response1.timeModel.get
+        assert(preUpdateTimeModelResponse.timeModel.isDefined, "Expected time model to be defined")
+        preUpdateTimeModelResponse.timeModel.get
       }
 
       // Set a new time model with the next generation in parallel
       t1 <- ledger.time()
       f1 = ledger.setTimeModel(
         mrt = t1.plusSeconds(30),
-        generation = response1.configurationGeneration,
+        generation = preUpdateTimeModelResponse.configurationGeneration,
         newTimeModel = oldTimeModel,
       )
       f2 = ledger.setTimeModel(
         mrt = t1.plusSeconds(30),
-        generation = response1.configurationGeneration,
+        generation = preUpdateTimeModelResponse.configurationGeneration,
         newTimeModel = oldTimeModel,
       )
 
-      failure <- f1
+      _ <- f1
         .flatMap(_ => f2)
         .mustFail("setting Time Model with an outdated generation")
 
       // Check if generation got updated (meaning, one of the above succeeded)
-      response2 <- ledger.getTimeModel()
+      postUpdateTimeModelResponse <- ledger.getTimeModel()
     } yield {
       assert(
-        response1.configurationGeneration + 1 == response2.configurationGeneration,
-        s"New configuration's generation (${response2.configurationGeneration} should be original configurations's generation (${response1.configurationGeneration} + 1) )",
+        preUpdateTimeModelResponse.configurationGeneration + 1 == postUpdateTimeModelResponse.configurationGeneration,
+        s"New configuration's generation (${postUpdateTimeModelResponse.configurationGeneration} should be original configurations's generation (${preUpdateTimeModelResponse.configurationGeneration} + 1) )",
       )
-      Try {
-        // if the "looser" command fails already on command submission (the winner completed before looser submission is over)
-        assertGrpcError(
-          failure,
-          LedgerApiErrors.RequestValidation.InvalidArgument,
-          Some("Mismatching configuration generation"),
-        )
-      }.recover { case _ =>
-        // if the "looser" command fails after command submission (the winner completed after looser did submit the configuration change)
-        assertGrpcError(
-          failure,
-          LedgerApiErrors.Admin.ConfigurationEntryRejected,
-          Some("Generation mismatch"),
-        )
-      } match {
-        case Failure(GrpcException(GrpcStatus(notExpectedCode, _), _)) =>
-          fail(s"One of the submissions failed with an unexpected status code: $notExpectedCode")
-
-        case Failure(notExpectedException) =>
-          fail(
-            s"Unexpected exception: type:${notExpectedException.getClass.getName}, message:${notExpectedException.getMessage}"
-          )
-        case Success(_) => ()
-      }
     }
   })
 


### PR DESCRIPTION
- Upload dars sequentially to avoid conflicts with dependencies included multiple times in separate dars
- Leaner assertions for concurrent config submission, this allows the implementation to have more flexibility in the errors it returns

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
