### PR TITLE
Daml-script: marking MultiParticipantIT as falky in windows

### DIFF
--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -4,10 +4,12 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
+    "da_scala_test",
     "da_scala_test_suite",
 )
 load("//bazel_tools:haskell.bzl", "da_haskell_test")
 load("@build_environment//:configuration.bzl", "sdk_version")
+load("@os_info//:os_info.bzl", "is_windows")
 
 genrule(
     name = "script-test",
@@ -166,9 +168,14 @@ da_scala_library(
     ],
 )
 
+MultiParticipantIT = "src/com/digitalasset/daml/lf/engine/script/test/MultiParticipantIT.scala"
+
 da_scala_test_suite(
     name = "test",
-    srcs = glob(["src/com/**/*.scala"]),
+    srcs = glob(
+        ["src/com/**/*.scala"],
+        exclude = [MultiParticipantIT],
+    ),
     data = [
         ":script-test.dar",
         ":script-test-1.dev.dar",
@@ -228,6 +235,41 @@ da_scala_test_suite(
         "//libs-scala/resources-grpc",
         "@maven//:com_auth0_java_jwt",
         "@maven//:io_dropwizard_metrics_metrics_core",
+    ],
+)
+
+# TODO: https://github.com/digital-asset/daml/issues/13737
+#  the test is flaky on windows.
+#  merge it back in scala suite `test` once fixed.
+da_scala_test(
+    name = "multi-participant-integration-test",
+    srcs = [MultiParticipantIT],
+    data = [
+        ":script-test.dar",
+        ":script-test-1.dev.dar",
+        ":script-test-no-ledger.dar",
+        "//ledger/test-common/test-certificates",
+        "@canton//:lib",
+    ],
+    flaky = is_windows,
+    resources = glob(["src/main/resources/**/*"]),
+    scala_deps = ["@maven//:io_spray_spray_json"],
+    deps = [
+        ":test-utils",
+        "//bazel_tools/runfiles:scala_runfiles",
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/data",
+        "//daml-lf/interface",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
+        "//daml-script/runner:script-runner-lib",
+        "//language-support/scala/bindings",
+        "//language-support/scala/bindings-akka",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger/ledger-resources",
+        "//libs-scala/ports",
+        "//libs-scala/resources",
     ],
 )
 


### PR DESCRIPTION
The problem is tracked by #13737.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
