### PR TITLE
Fix slow lookupMaximumLedgerTime

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/MutableCacheBackedContractStore.scala
@@ -115,9 +115,9 @@ private[platform] class MutableCacheBackedContractStore(
   )(implicit
       loggingContext: LoggingContext
   ): Either[Set[ContractId], (Set[Timestamp], Set[ContractId])] = {
-    val cacheQueried = ids.map(id => id -> contractsCache.get(id))
+    val cacheQueried = ids.view.map(id => id -> contractsCache.get(id)).toVector
 
-    val cached = cacheQueried.view
+    val cached = cacheQueried
       .foldLeft[Either[Set[ContractId], Set[Timestamp]]](Right(Set.empty[Timestamp])) {
         // successful lookups
         case (Right(timestamps), (_, Some(active: Active))) =>
@@ -133,7 +133,7 @@ private[platform] class MutableCacheBackedContractStore(
 
     cached
       .map { cached =>
-        val missing = cacheQueried.collect { case (id, None) => id }
+        val missing = cacheQueried.view.collect { case (id, None) => id }.toSet
         (cached, missing)
       }
   }


### PR DESCRIPTION
Fix `lookupMaximumLedgerTimeAfterInterpretation` to not uselessly compute the hash of processed Contract values.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
