### PR TITLE
Preserve fixity information in data-dependencies

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -55,7 +55,7 @@ import Development.IDE.Core.API
 import Development.IDE.Core.Compile (compileModule, typecheckModule, RunSimplifier(..))
 import Development.IDE.Core.RuleTypes
 import Development.IDE.Core.RuleTypes.Daml
-import Development.IDE.Core.Rules.Daml (diagsToIdeResult, getExternalPackages, ideErrorPretty, modInfoDepOrphanModules)
+import Development.IDE.Core.Rules.Daml (diagsToIdeResult, getExternalPackages, ideErrorPretty)
 import Development.IDE.Core.Service
 import Development.IDE.Core.Service.Daml (DamlEnv(..), getDamlServiceEnv)
 import Development.IDE.Core.Shake
@@ -66,7 +66,7 @@ import Development.IDE.Types.Options
 import ErrUtils
 import GHC hiding (typecheckModule)
 import GHC.LanguageExtensions.Type
-import HscTypes (HscEnv(..), HscSource(HsSrcFile))
+import HscTypes (HscEnv(..), HscSource(HsSrcFile), HomeModInfo(hm_iface))
 import Language.Haskell.GhclibParserEx.Parse
 import qualified Language.LSP.Types as LSP
 import Module (mainUnitId, unitIdString)
@@ -485,8 +485,8 @@ runRepl importPkgs opts replClient logger ideState = do
             let core = cgGutsToCoreModule safeMode cgGuts details
             PackageMap pkgMap <- useE' GeneratePackageMap file
             stablePkgs <- lift $ useNoFile_ GenerateStablePackages
-            let depOrphanModules = modInfoDepOrphanModules (tmrModInfo tm)
-            case convertModule lfVersion envEnableScenarios pkgMap (Map.map LF.dalfPackageId stablePkgs) False file core depOrphanModules details of
+            let modIface = hm_iface (tmrModInfo tm)
+            case convertModule lfVersion envEnableScenarios pkgMap (Map.map LF.dalfPackageId stablePkgs) False file core modIface details of
                 Left diag -> handleIdeResult ([diag], Nothing)
                 Right v -> do
                    pkgs <- lift $ getExternalPackages file

--- a/compiler/damlc/tests/daml-test-files/Fixities.daml
+++ b/compiler/damlc/tests/daml-test-files/Fixities.daml
@@ -1,0 +1,26 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Check that fixity metadata is added when available.
+
+-- @SINCE-LF 1.8
+-- @QUERY-LF [ .modules[].values[].name_with_type | select(lf::get_value_name($pkg)[0] | startswith("$$$$fixity")) | lf::norm_fixity_info($pkg) ] | any(. == {name: {namespace: "VarName", value: "pair"}, fixity: {precedence: 5, direction: "R"}}) and any(. == {name: {namespace: "TcClsName", value: "Pair"}, fixity: {precedence: 5, direction: "R"}}) and any(. == {name: {namespace: "DataName", value: "Pair"}, fixity: {precedence: 5, direction: "R"}}) and any(. == {name: {namespace: "VarName", value: "$u003c$u003c$u003c"}, fixity: {precedence: 1, direction: "R"}}) and any(. == {name: {namespace: "VarName", value: "$u0026$u0026$u0026"}, fixity: {precedence: 3, direction: "R"}})
+module Fixities where
+
+data Pair a b = Pair with
+  fst : a
+  snd : b
+infixr 5 `Pair`
+
+pair : a -> b -> Pair a b
+pair = Pair
+infixr 5 `pair`
+
+class Category cat where
+  id : cat a a
+  (<<<) : cat b c -> cat a b -> cat a c
+  infixr 1 <<<
+
+class Category a => Arrow a where
+  (&&&) : a b c -> a b c' -> a b (c,c')
+  infixr 3 &&&

--- a/compiler/damlc/tests/src/query-lf.jq
+++ b/compiler/damlc/tests/src/query-lf.jq
@@ -36,6 +36,14 @@ def norm_qualified_module(pkg; f):
         )
     } + f;
 
+def norm_occ_name_0(pkg):
+    .struct.fields |
+    map(.type | norm_ty(pkg) | .struct.fields[0] | get_field(pkg)) |
+    { namespace: .[0], value: .[1]};
+
+def norm_occ_name(pkg):
+    .type | norm_ty(pkg) | norm_occ_name_0(pkg);
+
 # @SINCE-LF 1.7
 def norm_imports(pkg):
     .type | norm_ty(pkg) | .struct.fields |
@@ -44,9 +52,7 @@ def norm_imports(pkg):
 # @SINCE-LF 1.7
 def norm_qualified_module_name(pkg):
     norm_qualified_module(pkg;
-        .[2].struct.fields |
-        map(.type | norm_ty(pkg) | .struct.fields[0] | get_field(pkg)) |
-        { name: { namespace: .[0], value: .[1]}}
+        { name: .[2] | norm_occ_name_0(pkg) }
     );
 
 # @SINCE-LF 1.7
@@ -82,4 +88,17 @@ def norm_export_info(pkg):
             (try (.type | norm_ty(pkg) | .struct.fields |
             map(norm_field_label(pkg))) catch null)
         }
+    };
+
+def norm_fixity(pkg):
+    .type | norm_ty(pkg) | .struct.fields |
+    map(.type | norm_ty(pkg) | .struct.fields[0] | get_field(pkg)) |
+    { precedence: .[0] | ltrimstr("_") | tonumber
+    , direction: .[1]
+    };
+
+def norm_fixity_info(pkg):
+    .type | norm_ty(pkg) | .struct.fields |
+    { "name": .[0] | norm_occ_name(pkg)
+    , "fixity": .[1] | norm_fixity(pkg)
     };


### PR DESCRIPTION
Closes #13763 

Please let me know if you'd improve the changelog entry

```
changelog_begin
* data-dependencies: newly built 'dar's preserve fixity declarations
changelog_end
```