### PR TITLE
Change `CODEOWNERS` entries for @stefanobaghino-da's

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # Only files explicitly mentioned are guarded by code owners (no * rule).
 
-CODEOWNERS   @gerolf-da @stefanobaghino-da
+CODEOWNERS   @gerolf-da
 LATEST       @gerolf-da @bame-da @ray-roestenburg-da @adriaanm-da
 
 # Build / CI / environment
@@ -64,19 +64,18 @@ NOTICES     @garyverhaegen-da @dasormeter
 
 # Ecosystems
 /language-support/hs/       @nickchapman-da @sofiafaro-da
-/language-support/java/     @stefanobaghino-da @ray-roestenburg-da
-/language-support/scala/    @S11001001 @stefanobaghino-da @ray-roestenburg-da
-/language-support/ts/       @robin-da @garyverhaegen-da @stefanobaghino-da @ray-roestenburg-da
+/language-support/java/     @ray-roestenburg-da
+/language-support/scala/    @S11001001 @ray-roestenburg-da
+/language-support/ts/       @robin-da @garyverhaegen-da @ray-roestenburg-da
 
 # Application Runtime
-/ledger-service/       @stefanobaghino-da @ray-roestenburg-da
-/navigator/            @stefanobaghino-da @ray-roestenburg-da
-/runtime-components/   @stefanobaghino-da @ray-roestenburg-da
-/triggers/service/     @stefanobaghino-da @ray-roestenburg-da
+/ledger-service/       @ray-roestenburg-da
+/navigator/            @ray-roestenburg-da
+/runtime-components/   @ray-roestenburg-da
+/triggers/service/     @ray-roestenburg-da
 
 # Misc
 /docs/              @stefanobaghino-da
-/libs-scala/        @stefanobaghino-da
 /libs-scala/nonempty-cats/src/    @S11001001
 /libs-scala/scala-utils/src/    @S11001001
 /libs-scala/scalatest-utils/src/    @S11001001


### PR DESCRIPTION
changelog_begin
changelog_end

In my new role, my main concern is providing context and get out of the
way of far more skilled and technically-involved engineers. As such, for
the time being I decided to reduce my subscriptions to the bare minimum.

That boils down to keeping an eye on `//docs`. This doesn't mean I don't
want to be involved in code anymore. Please do mention me in PRs if you
believe my attention is required.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
