### PR TITLE
Add information and separator to `unreleased.sh` output

### DIFF
--- a/unreleased.sh
+++ b/unreleased.sh
@@ -39,5 +39,11 @@ extract_changelog () {
 
 for SHA in $COMMITS_IN_GIVEN_RANGE; do
     COMMIT_MESSAGE_BODY=$(git show --quiet --format=%b "$SHA")
-    echo "$COMMIT_MESSAGE_BODY" | extract_changelog
+    COMMIT_CHANGELOG=$(echo "$COMMIT_MESSAGE_BODY" | extract_changelog)
+    if [[ ! -z "$COMMIT_CHANGELOG" ]]; then
+        COMMIT_AUTHOR_AND_SUBJECT=$(git show --quiet --format="* %s (committer: %an | hash: %h)" "$SHA")
+        echo "$COMMIT_AUTHOR_AND_SUBJECT"
+        echo "$COMMIT_CHANGELOG"
+        echo "----------------"
+    fi
 done


### PR DESCRIPTION
changelog_begin
changelog_end

Adds a small separator between changelog entries for separate commits to improve readability.

Adds a "title" to each changelog entry to provide context to the reader to ensure that
the changelog entry can be traced back to a commit. The title line is composed of the
commit subject (which usually includes the PR number), author and hash. This set of
information should help the reader trace back a changelog entry to a commit/PR to
improve the understanding of the contribution in case the changelog entry is difficult
to understand without proper context.

As an example, given the following command:

```
./unreleased.sh v2.2.0-snapshot.20220425.9780.0.f4d60375..v2.2.0-snapshot.20220504.9851.0.4c8e027d
```

here is the difference for the first few lines of output.

Before:

```
Fixing Ledger API Bug: Exercise nodes in transaction trees
have child_event_ids out of order.

- [HTTP-JSON] The field "@type" was renamed to "type" for encoding the ErrorDetails case

- [Daml Triggers] Add `queryFilter` matching Daml Script’s
  `queryFilter` which queries contracts of a given template and filters
  them down to those where the predicate holds.
```

After:

```
* Fix random exercise node's childEventId order [DPP-1018] (#13740) (committer: Marton Nagy | hash: 0ea140f51e)
Fixing Ledger API Bug: Exercise nodes in transaction trees
have child_event_ids out of order.
----------------
* Use deriveFormat for ErrorDetailsFormat instead of hand written JsonFormat (#13770) (committer: Victor Peter Rouven Müller | hash: 3decea2a95)

- [HTTP-JSON] The field "@type" was renamed to "type" for encoding the ErrorDetails case

----------------
* Updating Titles and Headings (#13592) (committer: carrielaben-da | hash: 58c615a251)

----------------
* Add queryFilter to triggers (#13769) (committer: Moritz Kiefer | hash: d3280ac87d)

- [Daml Triggers] Add `queryFilter` matching Daml Script’s
  `queryFilter` which queries contracts of a given template and filters
  them down to those where the predicate holds.
```

Another further advantage is that it's now clearer to identify sources
of dangling newlines. I tried fix those myself but to no avail. I'm open
to suggestions as to how to get rid of empty changelog entries that
still happen to contain just newlines (I think that's the source of the
issue).

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->


[DPP-1018]: https://digitalasset.atlassian.net/browse/DPP-1018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ