### PR TITLE
Upload dars sequentially for every participant defined [kvl-1369]

### DIFF
--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/future/FutureUtil.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/future/FutureUtil.scala
@@ -1,0 +1,14 @@
+package com.daml.ledger.api.testtool.infrastructure.future
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object FutureUtil {
+
+  def sequential[T, R](elements: Seq[T])(f: T => Future[R])(implicit
+      ec: ExecutionContext
+  ): Future[Seq[R]] =
+    elements.foldLeft(Future.successful(Seq.empty[R])) { case (results, newElement) =>
+      results.flatMap(resultsSoFar => f(newElement).map(resultsSoFar :+ _))
+    }
+
+}

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/future/FutureUtil.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/future/FutureUtil.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.ledger.api.testtool.infrastructure.future
 
 import scala.concurrent.{ExecutionContext, Future}


### PR DESCRIPTION
This allows us to have conflict free dar uploads for multi participant setups.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
