### PR TITLE
Benchtool: Improve payload size handling [DPP-1028]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooCommandGenerator.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooCommandGenerator.scala
@@ -9,7 +9,6 @@ import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value}
 import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.test.model.Foo._
 
-import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicLong
 import scala.util.control.NonFatal
 import scala.util.{Failure, Try}
@@ -201,6 +200,8 @@ object FooCommandGenerator {
   private[submission] def randomPayload(
       randomnessProvider: RandomnessProvider,
       sizeBytes: Int,
-  ): String =
-    new String(randomnessProvider.randomBytes(sizeBytes), StandardCharsets.UTF_8)
+  ): String = {
+    randomnessProvider.randomAsciiString(sizeBytes)
+  }
+
 }

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/RandomnessProvider.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/RandomnessProvider.scala
@@ -5,7 +5,9 @@ package com.daml.ledger.api.benchtool.submission
 
 trait RandomnessProvider {
   def randomDouble(): Double // 0.0 <= randomDouble() < 1.0
-  def randomBytes(n: Int): Array[Byte]
+  /** Guarantees that each character will take exactly one byte in UTF-8.
+    */
+  def randomAsciiString(n: Int): String
   def randomNatural(n: Int): Int // 0 <= randomNatural(n) < n
 }
 
@@ -13,11 +15,13 @@ object RandomnessProvider {
   object Default extends RandomnessProvider {
     private val r = new scala.util.Random(System.currentTimeMillis())
     override def randomDouble(): Double = r.nextDouble()
-    override def randomBytes(n: Int): Array[Byte] = {
-      val arr = Array.ofDim[Byte](n)
-      r.nextBytes(arr)
-      arr
-    }
     override def randomNatural(n: Int): Int = r.nextInt(n)
+    override def randomAsciiString(n: Int): String = {
+      val buffer = new StringBuilder(n)
+      0.until(n).foreach { _ =>
+        buffer.append(r.nextInt(127).toChar)
+      }
+      buffer.toString()
+    }
   }
 }

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandGeneratorSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandGeneratorSpec.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.submission
+
+import java.nio.charset.StandardCharsets
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FooCommandGeneratorSpec extends AnyFlatSpec with Matchers {
+
+  it should "generate random payload of a given size" in {
+    FooCommandGenerator
+      .randomPayload(RandomnessProvider.Default, sizeBytes = 100)
+      .getBytes(StandardCharsets.UTF_8)
+      .length shouldBe 100
+  }
+
+}

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
@@ -15,7 +15,6 @@ import com.daml.ledger.api.benchtool.submission.EventsObserver.ObservedEvents
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.platform.sandbox.fixture.SandboxFixture
-import org.scalactic.TripleEqualsSupport
 import org.scalatest.AppendedClues
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -100,34 +99,19 @@ class FooCommandSubmitterITSpec
     } yield {
       observerResult.createEvents.size shouldBe config.numberOfInstances withClue ("number of create events")
 
-      observerResult.avgSizeOfCreateEventPerTemplateName("Foo1") shouldBe roughly(
-        foo1Config.payloadSizeBytes * 2,
-        toleranceMul = 0.5,
-      ) withClue ("payload size of create Foo1")
-      observerResult.avgSizeOfCreateEventPerTemplateName("Foo2") shouldBe roughly(
-        foo2Config.payloadSizeBytes * 2,
-        toleranceMul = 0.5,
-      ) withClue ("payload size of create Foo2")
-      observerResult.avgSizeOfConsumingExercise shouldBe roughly(
-        consumingExercisesConfig.payloadSizeBytes * 2,
-        toleranceMul = 0.5,
-      )
-      observerResult.avgSizeOfNonconsumingExercise shouldBe roughly(
-        nonConsumingExercisesConfig.payloadSizeBytes * 2,
-        toleranceMul = 0.5,
-      )
-
+      observerResult.avgSizeOfCreateEventPerTemplateName(
+        "Foo1"
+      ) shouldBe (foo1Config.payloadSizeBytes + 56) withClue ("payload size of create Foo1")
+      observerResult.avgSizeOfCreateEventPerTemplateName(
+        "Foo2"
+      ) shouldBe (foo2Config.payloadSizeBytes + 56) withClue ("payload size of create Foo2")
+      observerResult.avgSizeOfConsumingExercise shouldBe (consumingExercisesConfig.payloadSizeBytes + 8)
+      observerResult.avgSizeOfNonconsumingExercise shouldBe (nonConsumingExercisesConfig.payloadSizeBytes + 8)
       observerResult.consumingExercises.size.toDouble shouldBe (config.numberOfInstances * consumingExercisesConfig.probability) withClue ("number of consuming exercises")
       observerResult.nonConsumingExercises.size.toDouble shouldBe (config.numberOfInstances * nonConsumingExercisesConfig.probability) withClue ("number of non consuming exercises")
 
       succeed
     }
-  }
-
-  private def roughly(n: Int, toleranceMul: Double): TripleEqualsSupport.Spread[Int] = {
-    require(toleranceMul > 0.0)
-    val skew = Math.round(toleranceMul * n).toInt
-    n +- skew
   }
 
 }


### PR DESCRIPTION
Previous approach was generating random bytes
and encoding them into UTF-8 strings.
This turned out to be problematic as not every
random byte sequence is valid in the UTF-8 charset, and
`java.lang.String#String(byte[], java.lang.String)` constructor's
documentation states that in such cases its behavior
is unspecified.

In practice the size of the byte array obtained from decoding the
generated string was almost twice the size of the orginal byte array.

Current approach limits the generated bytes to valid ASCII characters,
each of which takes exactly one byte in UTF-8 encoding.

changelog_begin
changelog_end

