### PR TITLE
add missing imports in some interface-implementation cases

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -846,6 +846,7 @@ genDefDataType curPkgId conName mod tpls def =
                     ([DeclTypeDef typeDesc, DeclTemplateDef dict, DeclTemplateNamespace associatedTypes, DeclTemplateRegistration registrations], refs)
         DataInterface -> ([], Set.empty)
 
+-- exactly like typeModuleRef; see https://github.com/digital-asset/daml/issues/13845
 qualifiedModuleRef :: Traversal' (Qualified a) ModuleRef
 qualifiedModuleRef = monoTraverse
 

--- a/language-support/ts/codegen/tests/daml/Lib/ModIfaceOnly.daml
+++ b/language-support/ts/codegen/tests/daml/Lib/ModIfaceOnly.daml
@@ -1,0 +1,15 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Lib.ModIfaceOnly where
+
+-- this module must contain _nothing_ but this interface
+-- to ensure integrity of the test for #13754
+
+interface YetAnother where
+  getOtherOwner : Party
+  somethingImpl : Update ()
+  choice SomethingElse : ()
+    controller getOtherOwner this
+    do
+      somethingImpl this

--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -6,6 +6,7 @@ module Main where
 import DA.TextMap
 import qualified DA.Map
 import Lib.Mod
+import Lib.ModIfaceOnly
 
 import T
 
@@ -193,6 +194,10 @@ template Asset with
         cid <- create Asset with issuer = issuer, owner = newOwner
         pure (toInterfaceContractId @Token cid)
     implements Other where
+      getOtherOwner = owner
+      somethingImpl = do
+        pure ()
+    implements YetAnother where
       getOtherOwner = owner
       somethingImpl = do
         pure ()


### PR DESCRIPTION
Fixes #13754.

```rst
CHANGELOG_BEGIN
- [daml codegen js] Some imports were missing in TypeScript declarations
  and JavaScript module definitions when those imports were only used to
  implement interfaces; these imports are now properly generated.
  See `issue #13844 <https://github.com/digital-asset/daml/pull/13844>`__.
CHANGELOG_END
```

* [x] build SDK and check js
* [x] changelog