### PR TITLE
speedy: change ResultNeedKey callback

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -363,7 +363,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
           return Result.needContract(
             contractId,
             { coinst =>
-              callback(coinst)
+              callback(coinst.unversioned)
               interpretLoop(machine, time)
             },
           )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -20,13 +20,7 @@ import com.daml.lf.speedy.{SExpr0 => compileTime}
 import com.daml.lf.speedy.{SExpr => runTime}
 import com.daml.lf.speedy.SValue.{SValue => _, _}
 import com.daml.lf.speedy.SValue.{SValue => SV}
-import com.daml.lf.transaction.{
-  GlobalKey,
-  GlobalKeyWithMaintainers,
-  Node,
-  Versioned,
-  Transaction => Tx,
-}
+import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers, Node, Transaction => Tx}
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.Value.ValueArithmeticError
 import com.daml.nameof.NameOf
@@ -1080,7 +1074,7 @@ private[lf] object SBuiltin {
             SResultNeedContract(
               coid,
               onLedger.committers,
-              { case Versioned(_, V.ContractInstance(actualTmplId, arg, _)) =>
+              { case V.ContractInstance(actualTmplId, arg, _) =>
                 machine.pushKont(KCacheContract(machine, coid))
                 machine.ctrl = SEApp(
                   // The call to ToCachedContractDefRef(actualTmplId) will query package

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -35,7 +35,7 @@ object SResult {
       // Callback
       // returns the next expression to evaluate.
       // In case of failure the call back does not throw but returns a SErrorDamlException
-      callback: Value.VersionedContractInstance => Unit,
+      callback: Value.ContractInstance => Unit,
   ) extends SResult
 
   /** Machine needs a definition that was not present when the machine was

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -57,7 +57,7 @@ private[speedy] object SpeedyTestLib {
         case SResultNeedContract(contractId, _, callback) =>
           getContract.lift(contractId) match {
             case Some(value) =>
-              callback(value)
+              callback(value.unversioned)
               loop
             case None =>
               throw UnknownContract(contractId)

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -10,7 +10,7 @@ import com.daml.lf.engine.{Engine, ValueEnricher, Result, ResultDone, ResultErro
 import com.daml.lf.engine.preprocessing.ValueTranslator
 import com.daml.lf.language.{Ast, LookupError}
 import com.daml.lf.transaction.{GlobalKey, NodeId, SubmittedTransaction}
-import com.daml.lf.value.Value.{ContractId, VersionedContractInstance}
+import com.daml.lf.value.Value.{ContractId, ContractInstance}
 import com.daml.lf.speedy._
 import com.daml.lf.speedy.SExpr.{SExpr, SEValue, SEApp}
 import com.daml.lf.speedy.SResult._
@@ -177,7 +177,7 @@ object ScenarioRunner {
         coid: ContractId,
         actAs: Set[Party],
         readAs: Set[Party],
-        cbPresent: VersionedContractInstance => Unit,
+        cbPresent: ContractInstance => Unit,
     ): Either[Error, Unit]
     def lookupKey(
         machine: Speedy.Machine,
@@ -203,7 +203,7 @@ object ScenarioRunner {
         acoid: ContractId,
         actAs: Set[Party],
         readAs: Set[Party],
-        callback: VersionedContractInstance => Unit,
+        callback: ContractInstance => Unit,
     ): Either[Error, Unit] =
       handleUnsafe(lookupContractUnsafe(acoid, actAs, readAs, callback))
 
@@ -211,7 +211,7 @@ object ScenarioRunner {
         acoid: ContractId,
         actAs: Set[Party],
         readAs: Set[Party],
-        callback: VersionedContractInstance => Unit,
+        callback: ContractInstance => Unit,
     ) = {
 
       val effectiveAt = ledger.currentTime
@@ -222,7 +222,7 @@ object ScenarioRunner {
         acoid,
       ) match {
         case ScenarioLedger.LookupOk(_, coinst, _) =>
-          callback(coinst)
+          callback(coinst.unversioned)
 
         case ScenarioLedger.LookupContractNotFound(coid) =>
           // This should never happen, hence we don't have a specific


### PR DESCRIPTION
This changes the callback of ResultNeedKey in in speedy to use
ContractInstance instead of VersionedContractInstance.

This caused problems for explicit disclosure.

Fixes #13848.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
