### PR TITLE
minimal Scala codegen interface support

### DIFF
--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -17,16 +17,19 @@ load(
     "lf_version_configuration",
 )
 
+# TODO(#13296) change to "latest" when interfaces released
+tested_lf_config = "dev"
+
 daml_compile(
     name = "MyMain",
     srcs = ["src/main/daml/MyMain.daml"],
-    target = lf_version_configuration.get("latest"),
+    target = lf_version_configuration.get(tested_lf_config),
 )
 
 daml_compile(
     name = "MySecondMain",
     srcs = ["src/main/daml/MySecondMain.daml"],
-    target = lf_version_configuration.get("latest"),
+    target = lf_version_configuration.get(tested_lf_config),
 )
 
 dar_to_scala(
@@ -34,7 +37,7 @@ dar_to_scala(
     srcs = [
         ":MyMain.dar",
         ":MySecondMain.dar",
-        "//daml-lf/encoder:testing-dar-latest",
+        "//daml-lf/encoder:testing-dar-%s" % tested_lf_config,
     ],
     package_prefix = "com.daml.sample",
     srcjar_out = "MyMain.srcjar",

--- a/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
+++ b/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
@@ -596,18 +596,18 @@ interface InterfaceToMix where
   choice InheritedOnly: () with
     controller getOwner this
     do return ()
+{- TODO(#13349) uncomment when overloaded choices compile
   choice OverloadedInTemplate: () with
     controller getOwner this
     do return ()
+-}
 
 template InterfaceMixer with
     party: Party
   where
     signatory party
-{- TODO(#13349) uncomment when overloaded choices compile
     choice OverloadedInTemplate: () with
-      controller getOwner this
+      controller party
       do return ()
--}
     implements InterfaceToMix where
       getOwner = party

--- a/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
+++ b/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
@@ -590,3 +590,24 @@ template JustMapUser
        aMap: JustMap Int Int
     where
       signatory party
+
+interface InterfaceToMix where
+  getOwner: Party
+  choice InheritedOnly: () with
+    controller getOwner this
+    do return ()
+  choice OverloadedInTemplate: () with
+    controller getOwner this
+    do return ()
+
+template InterfaceMixer with
+    party: Party
+  where
+    signatory party
+{- TODO(#13349) uncomment when overloaded choices compile
+    choice OverloadedInTemplate: () with
+      controller getOwner this
+      do return ()
+-}
+    implements InterfaceToMix where
+      getOwner = party

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/CodeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/CodeGen.scala
@@ -74,7 +74,7 @@ object CodeGen {
       roots: Seq[String],
   ): ValidationNel[String, Unit] =
     decodeInterfaces(files).map { interfaces: NonEmptyList[EnvironmentInterface] =>
-      val combined = interfaces.suml1
+      val combined = interfaces.suml1.resolveChoices
       val interface = combined.copy(
         typeDecls = Util.filterTemplatesBy(roots.map(_.r))(combined.typeDecls)
       )
@@ -134,7 +134,7 @@ object CodeGen {
     val typeDeclarationsToGenerate =
       DependencyGraph.transitiveClosure(
         serializableTypes = util.iface.typeDecls,
-        interfaces = Map.empty, // TODO(#13349)
+        interfaces = util.iface.astInterfaces,
       )
 
     // Each record/variant has Scala code generated for it individually, unless their names are related
@@ -164,6 +164,7 @@ object CodeGen {
     // 1. collect records, search variants and splat/filter
     val (unassociatedRecords, splattedVariants, enums) = splatVariants(definitions)
 
+    // TODO(#13349) include interfaces as well
     // 2. put templates/types into single Namespace.fromHierarchy
     val treeified: Namespace[String, Option[lf.HierarchicalOutput.TemplateOrDatatype]] =
       Namespace.fromHierarchy {


### PR DESCRIPTION
This will support a small subset of #13349:

* [x] inherited choices added directly to templates
* [x] returned `Command` uses template ID; interface IDs are not present

_Ignores #13653; you must hand-patch returned commands to account for interface IDs._

The goal is to unblock #13655 without everything in #13349 and #13668.

```rst
CHANGELOG_BEGIN
- [scala codegen] Choices inherited from interfaces may be exercised
  directly from those templates via ``createAnd``, contract ID, or
  exercise-by-key.  Exercise by interface-contract-ID and
  interface-contract-ID types in signatures are not supported.
  See `issue #13858 <https://github.com/digital-asset/daml/pull/13858>`__.
CHANGELOG_END
```

* [x] note in #13296
* [x] changelog