### PR TITLE
Override annotation for create; add toValue to Template

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Template.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Template.java
@@ -6,4 +6,6 @@ package com.daml.ledger.javaapi.data;
 public abstract class Template {
 
   public abstract CreateCommand create();
+
+  public abstract DamlRecord toValue();
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -88,6 +88,7 @@ private[inner] object TemplateClass extends StrictLogging {
     MethodSpec
       .methodBuilder("create")
       .addModifiers(Modifier.PUBLIC)
+      .addAnnotation(classOf[Override])
       .returns(classOf[javaapi.data.CreateCommand])
       .addStatement(
         "return new $T($T.$N, this.toValue())",


### PR DESCRIPTION
Fixes #13765.

```rst
CHANGELOG_BEGIN
- [daml codegen java] Templates now have a generic ``toValue`` method.
  See `issue #13859 <https://github.com/digital-asset/daml/pull/13859>`__.
CHANGELOG_END
```