### PR TITLE
DPP-1026 Validate explicit disclosure in SoX

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -27,6 +27,7 @@ import com.daml.lf.data.Ref.{ApplicationId, Party}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
+import com.daml.lf.value.Value.VersionedContractInstance
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 
@@ -136,6 +137,16 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
     Timed.future(
       metrics.daml.services.index.lookupActiveContract,
       delegate.lookupActiveContract(readers, contractId),
+    )
+
+  override def lookupContractAfterInterpretation(
+      contractId: Value.ContractId
+  )(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[(VersionedContractInstance, Timestamp)]] =
+    Timed.future(
+      metrics.daml.services.index.lookupActiveContract, // TODO DPP-1026: introduce a new metric for this
+      delegate.lookupContractAfterInterpretation(contractId),
     )
 
   override def lookupContractKey(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -191,6 +191,13 @@ private[index] class IndexServiceImpl(
   ): Future[Option[VersionedContractInstance]] =
     contractStore.lookupActiveContract(forParties, contractId)
 
+  override def lookupContractAfterInterpretation(
+      contractId: ContractId
+  )(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[(VersionedContractInstance, Timestamp)]] =
+    contractStore.lookupContractAfterInterpretation(contractId)
+
   override def getTransactionById(
       transactionId: TransactionId,
       requestingParties: Set[Ref.Party],

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
@@ -39,6 +39,17 @@ trait ContractStore {
   def lookupMaximumLedgerTimeAfterInterpretation(ids: Set[ContractId])(implicit
       loggingContext: LoggingContext
   ): Future[MaximumLedgerTime]
+
+  // TODO DPP-1026: Check whether this should move to a new trait. ContractStore is meant to be used for command interpretation, not transaction validation.
+  /** Look up an active contract, ignoring contract visibility.
+    *  This lookup will not return contracts that have only been divulged to this store.
+    *  This is useful for validating transactions after submission.
+    */
+  def lookupContractAfterInterpretation(
+      contractId: ContractId
+  )(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[(VersionedContractInstance, Timestamp)]]
 }
 
 /** The outcome of determining the maximum ledger time of a set of contracts.

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/validate/ConflictCheckWithCommittedImpl.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/bridge/validate/ConflictCheckWithCommittedImpl.scala
@@ -7,13 +7,14 @@ import com.daml.error.ContextualizedErrorLogger
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.{IndexService, MaximumLedgerTime}
 import ConflictCheckingLedgerBridge._
-import com.daml.ledger.participant.state.v2.CompletionInfo
+import com.daml.ledger.participant.state.v2.{CompletionInfo, DisclosedContract}
 import com.daml.ledger.sandbox.bridge.BridgeMetrics
 import com.daml.ledger.sandbox.domain.Rejection._
 import com.daml.ledger.sandbox.domain.Submission.Transaction
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.transaction.{Transaction => LfTransaction}
+import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Timed
@@ -53,13 +54,21 @@ private[validate] class ConflictCheckWithCommittedImpl(
         Timed
           .future(
             bridgeMetrics.Stages.ConflictCheckWithCommitted.timer,
-            validateCausalMonotonicity(
-              transaction = originalSubmission,
-              inputContracts = inputContracts,
-              transactionLedgerEffectiveTime =
-                originalSubmission.transactionMeta.ledgerEffectiveTime,
-              divulged = blindingInfo.divulgence.keySet,
+            validateExplicitDisclosure(
+              originalSubmission.submitterInfo.explicitDisclosure,
+              originalSubmission.loggingContext,
+              originalSubmission.submitterInfo.toCompletionInfo(),
             ).flatMap {
+              case Right(_) =>
+                validateCausalMonotonicity(
+                  transaction = originalSubmission,
+                  inputContracts = inputContracts,
+                  transactionLedgerEffectiveTime =
+                    originalSubmission.transactionMeta.ledgerEffectiveTime,
+                  divulged = blindingInfo.divulgence.keySet,
+                )
+              case rejection => Future.successful(rejection)
+            }.flatMap {
               case Right(_) =>
                 validateKeyUsages(
                   transactionInformees,
@@ -149,4 +158,96 @@ private[validate] class ConflictCheckWithCommittedImpl(
     }
   }
 
+  private def sameContractData(
+      actual: (Value.VersionedContractInstance, Timestamp),
+      provided: DisclosedContract,
+  )(implicit loggingContext: LoggingContext): Boolean = {
+    // TODO DPP-1026: Note: Not validating transaction version or agreement text here, because we're making those up
+
+    // TODO DPP-1026: Template id validation can probably be removed once we switch from VersionedContractInstance to Value
+    val actualTemplate = actual._1.unversioned.template
+    val providedTemplate = provided.contractInst.unversioned.template
+
+    // TODO DPP-1026: Do we need the user to provide verbose arguments?
+    // Or can we pass around explicit disclosure contract payloads without type information?
+    val actualArgument = removeTypeInfo(actual._1.unversioned.arg)
+    val providedArgument = removeTypeInfo(provided.contractInst.unversioned.arg)
+
+    if (actualTemplate != providedTemplate) {
+      // TODO DPP-1026: fix the logging context, it should include at least the submission id (to track malicious users).
+      logger.warn(s"Disclosed contract ${provided.contractId.coid} has invalid template id")
+      false
+    } else if (actualArgument != providedArgument) {
+      logger.warn(s"Disclosed contract ${provided.contractId.coid} has invalid argument")
+      false
+    } else if (actual._2 != provided.ledgerEffectiveTime) {
+      logger.warn(s"Disclosed contract ${provided.contractId.coid} has invalid ledgerEffectiveTime")
+      false
+    } else {
+      true
+    }
+  }
+
+  // TODO DPP-1026: Move to package com.daml.lf
+  def removeTypeInfo(a: Value): Value = {
+    a match {
+      case Value.ValueInt64(_) => a
+      case Value.ValueNumeric(_) => a
+      case Value.ValueText(_) => a
+      case Value.ValueTimestamp(_) => a
+      case Value.ValueParty(_) => a
+      case Value.ValueBool(_) => a
+      case Value.ValueDate(_) => a
+      case Value.ValueUnit => a
+      case Value.ValueContractId(_) => a
+      case Value.ValueRecord(_, fields) =>
+        Value.ValueRecord(None, fields.map(t => None -> t._2))
+      case Value.ValueVariant(_, variant, value) =>
+        Value.ValueVariant(None, variant, value)
+      case Value.ValueEnum(_, value) =>
+        Value.ValueEnum(None, value)
+      case Value.ValueList(values) =>
+        Value.ValueList(values.map(removeTypeInfo))
+      case Value.ValueOptional(value) =>
+        Value.ValueOptional(value.map(removeTypeInfo))
+      case Value.ValueTextMap(map) =>
+        Value.ValueTextMap(map.mapValue(removeTypeInfo))
+      case Value.ValueGenMap(entries) =>
+        Value.ValueGenMap(entries.map(t => removeTypeInfo(t._1) -> removeTypeInfo(t._2)))
+    }
+  }
+
+  private def validateExplicitDisclosure(
+      disclosedContracts: Set[DisclosedContract],
+      loggingContext: LoggingContext,
+      completionInfo: CompletionInfo,
+  )(implicit
+      contextualizedErrorLogger: ContextualizedErrorLogger
+  ): AsyncValidation[Unit] = {
+    disclosedContracts.foldLeft(Future.successful[Validation[Unit]](Right(()))) {
+      case (f, provided) =>
+        f.flatMap {
+          case Right(_) =>
+            indexService
+              .lookupContractAfterInterpretation(provided.contractId)(loggingContext)
+              .map {
+                case None =>
+                  Left(
+                    // Disclosed contract was archived or never existed
+                    // This has intentionally the same error code as the cases below,
+                    // to make sure malicious users cannot learn about the activeness of a third party contract
+                    // by faking the contract stakeholders to get around Daml authorization rules.
+                    DisclosedContractInvalid(provided.contractId, completionInfo)
+                  )
+                case Some(actual) if !sameContractData(actual, provided)(loggingContext) =>
+                  Left(
+                    // Disclosed contract has a bad payload, most likely submitted by a malicious user
+                    DisclosedContractInvalid(provided.contractId, completionInfo)
+                  )
+                case _ => Right(())
+              }
+          case left => Future.successful(left)
+        }
+    }
+  }
 }


### PR DESCRIPTION
The placeholder test now fails because the explicit disclosure validation catches the mismatch in ledger effective time. To fix this, we need to properly send contract metadata over the transaction stream (right now the metadata is still empty).