### PR TITLE
fix build-and-lint

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/package.json
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
+    "@types/prettier": "2.6.0",
     "@types/lodash": "4.14.161",
     "@types/node": "^12.12.14",
     "@types/wait-on": "^3.2.0",


### PR DESCRIPTION
To be clear, this is a hotfix. Whoever is responsible for this test should provide a more comprehensive fix with a fairly high degree of urgency.

Current main is broken because we have a transitive dependency on `@types/prettier` with a version constraint of `"*"`, and the latest version (`2.6.1`) is not compatible with our pinned-down version of the TypeScript compiler (`3.8.3`). A short-term solution would seem to be to generally bump most of our npm dependencies in this test.

Currently, main tests are _not_ failing because they're still using the cache, which has a success for this test (and its inputs, as far as Bazel can determine, have not changed). This is in my opinion a more important failure (that it doesn't fail), and so a proper fix of this issue should include pinning down all of our transitive dependencies (not just `@types/prettier` as I've done here). Arguably _in addition to_ bumping most of them to recent-ish versions.

The daily releases break because the version string invalidates the cache, which is how the problem surfaced.

CHANGELOG_BEGIN
CHANGELOG_END