### PR TITLE
Added readiness endpoint to trigger service.

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -2188,6 +2188,6 @@ Readiness Check
 
 A status code of ``200`` indicates a successful readiness check.
 
-This is an unauthenticated endpoint intended to be used as a liveness
+This is an unauthenticated endpoint intended to be used as a readiness
 probe. It validates both the ledger connection as well as the database
 connection.

--- a/docs/source/tools/trigger-service/index.rst
+++ b/docs/source/tools/trigger-service/index.rst
@@ -328,9 +328,27 @@ HTTP Request
 HTTP Response
 -------------
 
+A status code of ``200`` indicates a successful liveness check.
+
 - Content-Type: ``application/json``
 - Content:
 
 .. code-block:: json
 
     { "status": "pass" }
+
+Readiness Check
+===============
+
+This can be used as a readiness probe, e.g., in Kubernetes.
+
+HTTP Request
+------------
+
+- URL: ``/readyz``
+- Method: ``GET``
+
+HTTP Response
+-------------
+
+A status code of ``200`` indicates a successful readiness check.


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/13819

CHANGELOG_BEGIN
A ‘/readyz’ endpoint has been added to the trigger service to support readiness probes.
CHANGELOG_END