### PR TITLE
[backport][kvutils] Ensure out of time bounds entries are set for all rejections [KVL-1412]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplication.scala
@@ -23,7 +23,6 @@ import com.daml.ledger.participant.state.kvutils.store.events.{
 }
 import com.daml.ledger.participant.state.kvutils.store.{
   DamlCommandDedupValue,
-  DamlLogEntry,
   DamlStateValue,
   PreExecutionDeduplicationBounds,
 }
@@ -71,8 +70,6 @@ private[transaction] object CommandDeduplication {
           StepContinue(transactionEntry)
         } else {
           if (commitContext.preExecute) {
-            // The out of time bounds entry is required in the committer, so we set it to the default value as we stop the steps here with the duplicate rejection
-            commitContext.outOfTimeBoundsLogEntry = Some(DamlLogEntry.getDefaultInstance)
             preExecutionDuplicateRejection(
               commitContext,
               transactionEntry,

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -73,6 +73,7 @@ object TestHelpers {
         DamlSubmitterInfo.newBuilder
           .setCommandId("commandId")
           .addAllSubmitters(submitters.asJava)
+          .setDeduplicationDuration(Conversions.buildDuration(Duration.ofSeconds(30)))
       )
       .setSubmissionSeed(ByteString.copyFromUtf8("a" * 32))
       .build

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/CommandDeduplicationSpec.scala
@@ -206,18 +206,6 @@ class CommandDeduplicationSpec
         deduplicateStepHasTransactionRejectionEntry(commitContext)
       }
 
-      "set the out of time bounds log entry during rejections" in {
-        val dedupValue = newDedupValue(
-          _.setRecordTimeBounds(buildPreExecutionDeduplicationBounds(timestamp, timestamp))
-        )
-        val commitContext = createCommitContext(None, Map(aDedupKey -> Some(dedupValue)))
-        commitContext.minimumRecordTime = Some(timestamp)
-        commitContext.maximumRecordTime = Some(timestamp)
-
-        deduplicateStepHasTransactionRejectionEntry(commitContext)
-        commitContext.outOfTimeBoundsLogEntry shouldBe 'defined
-      }
-
       "return the command deduplication duration as deduplication duration when this exceeds the max delta between record times" in {
         val dedupValue = newDedupValue(
           _.setRecordTimeBounds(buildPreExecutionDeduplicationBounds(timestamp, timestamp))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -14,11 +14,15 @@ import com.daml.ledger.participant.state.kvutils.store.events.{
   DamlTransactionRejectionEntry,
 }
 import com.daml.ledger.participant.state.kvutils.store.{
+  DamlCommandDedupValue,
+  DamlLogEntry,
   DamlPartyAllocation,
   DamlStateKey,
   DamlStateValue,
+  PreExecutionDeduplicationBounds,
 }
-import com.daml.ledger.participant.state.kvutils.{Conversions, Err, committer}
+import com.daml.ledger.participant.state.kvutils.wire.DamlSubmission
+import com.daml.ledger.participant.state.kvutils.{Conversions, Err, KeyValueCommitting, committer}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.Engine
@@ -286,6 +290,78 @@ class TransactionCommitterSpec
 
         case StepStop(_) => fail()
       }
+    }
+  }
+
+  "out of time bounds entry" should {
+
+    "be set" when {
+
+      "a submitting party is not known" in {
+        val context = createCommitContext(
+          recordTime = None,
+          inputs = createInputs(
+            Alice -> Some(hostedParty(Alice)),
+            Bob -> None,
+          ) + (Conversions.configurationStateKey -> None),
+          participantId = ParticipantId,
+        )
+        val transactionEntry = createEmptyTransactionEntry(List(Alice, Bob))
+        val result = transactionCommitter.preExecute(
+          DamlSubmission.newBuilder().setTransactionEntry(transactionEntry).build(),
+          context,
+        )
+        resultIsRejectedWithPayload(
+          result,
+          DamlTransactionRejectionEntry.ReasonCase.SUBMITTING_PARTY_NOT_KNOWN_ON_LEDGER,
+        )
+      }
+
+      "the command is a duplicate" in {
+        val transactionEntry = createEmptyTransactionEntry(List(Alice))
+        val configurationInput = Conversions.configurationStateKey -> None
+        val commandDeduplicationInput = Conversions.commandDedupKey(
+          transactionEntry.getSubmitterInfo
+        ) -> Some(
+          DamlStateValue.newBuilder
+            .setCommandDedup(
+              DamlCommandDedupValue.newBuilder
+                .setRecordTimeBounds(
+                  PreExecutionDeduplicationBounds
+                    .newBuilder()
+                    .setMaxRecordTime(transactionEntry.getSubmissionTime)
+                    .setMinRecordTime(transactionEntry.getSubmissionTime)
+                )
+            )
+            .build
+        )
+        val context = createCommitContext(
+          recordTime = None,
+          inputs = createInputs(
+            Alice -> Some(hostedParty(Alice))
+          ) + configurationInput + commandDeduplicationInput,
+          participantId = ParticipantId,
+        )
+        val result = transactionCommitter.preExecute(
+          DamlSubmission.newBuilder().setTransactionEntry(transactionEntry).build(),
+          context,
+        )
+        resultIsRejectedWithPayload(
+          result,
+          DamlTransactionRejectionEntry.ReasonCase.DUPLICATE_COMMAND,
+        )
+      }
+    }
+
+    def resultIsRejectedWithPayload(
+        result: KeyValueCommitting.PreExecutionResult,
+        transactionRejectionReason: DamlTransactionRejectionEntry.ReasonCase,
+    ) = {
+      result.outOfTimeBoundsLogEntry.getPayloadCase shouldBe DamlLogEntry.PayloadCase.OUT_OF_TIME_BOUNDS_ENTRY
+      result.outOfTimeBoundsLogEntry.getOutOfTimeBoundsEntry.getEntry.getPayloadCase shouldBe DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY
+      result.outOfTimeBoundsLogEntry.getOutOfTimeBoundsEntry.getEntry.getTransactionRejectionEntry.getReasonCase shouldBe DamlTransactionRejectionEntry.ReasonCase.RECORD_TIME_OUT_OF_RANGE
+      result.successfulLogEntry.getPayloadCase shouldBe DamlLogEntry.PayloadCase.TRANSACTION_REJECTION_ENTRY
+      result.successfulLogEntry.getTransactionRejectionEntry.getReasonCase shouldBe transactionRejectionReason
     }
   }
 


### PR DESCRIPTION
backports (#13595) 
This is done for consistency only, the 2.1.x version is not actually used

changelog_begin
[kvutils] - Fix bug where an invalid out of time bounds write set was generated when the transaction was rejected. This would lead to failures if the out of time bounds write set was actually written by the committer.
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
