### PR TITLE
Add /log and navigator.log to default gitignore

### DIFF
--- a/templates/default-gitignore
+++ b/templates/default-gitignore
@@ -1,1 +1,3 @@
 /.daml
+/log
+navigator.log


### PR DESCRIPTION
ensures that by default, log files are visible to git when creating a daml project with the daml cli.
Based on conversation from: https://discuss.daml.com/t/daml-cli-logs-folder-navigator-log-should-be-gitgnored/4587
