### PR TITLE
remove some contract-ID generality from TypedValueGenerators

### DIFF
--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -80,7 +80,6 @@ class OrderingSpec
 
   private val randomComparableValues: TableFor2[String, Gen[SValue]] = {
     import com.daml.lf.value.test.TypedValueGenerators.{ValueAddend => VA}
-    implicit val cidArb: Arbitrary[Value.ContractId] = Arbitrary(Gen.fail[Value.ContractId])
     def r(name: String, va: VA)(sv: va.Inj => SValue) =
       (name, va.injarb.arbitrary map sv)
     Table(

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/TypedValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/TypedValueGenerators.scala
@@ -120,37 +120,28 @@ object TypedValueGenerators {
         }
       }
 
-    private[this] def inductive1[F[_]](pt: PT, elt: ValueAddend)(
-        inj0: (F[elt.Inj], elt.Inj => Value) => Value,
-        prj0: (Value, Value => Option[elt.Inj]) => Option[F[elt.Inj]],
-        ord0: Order[elt.Inj] => Order[F[elt.Inj]],
-        arb0: Arbitrary[elt.Inj] => Arbitrary[F[elt.Inj]],
-        shr0: Shrink[elt.Inj] => Shrink[F[elt.Inj]],
-    ): Aux[F[elt.Inj]] = new ValueAddend {
-      type Inj = F[elt.Inj]
-      override val t = TypePrim(pt, ImmArraySeq(elt.t))
-      override def inj(elts: Inj) = inj0(elts, elt.inj)
-      override def prj = prj0(_, elt.prj)
-      override def injord = ord0(elt.injord)
-      override def injarb = arb0(elt.injarb)
-      override def injshrink = shr0(elt.injshrink)
-    }
-
-    def list(elt: ValueAddend): Aux[Vector[elt.Inj]] = inductive1(PT.List, elt)(
-      (elts, eltinj) => ValueList(elts.map(eltinj).to(FrontStack)),
-      {
-        case (ValueList(v), eltprj) =>
+    def list(elt: ValueAddend): Aux[Vector[elt.Inj]] = new ValueAddend {
+      type Inj = Vector[elt.Inj]
+      override val t = TypePrim(PT.List, ImmArraySeq(elt.t))
+      override def inj(elts: Inj) =
+        ValueList(elts.map(elt.inj(_)).to(FrontStack))
+      override def prj = {
+        case ValueList(v) =>
           import scalaz.std.vector._
-          v.toImmArray.toSeq.to(Vector) traverse eltprj
+          v.toImmArray.toSeq.to(Vector) traverse elt.prj
         case _ => None
-      },
-      { implicit e =>
+      }
+      override def injord = {
         import scalaz.std.iterable._ // compatible with SValue ordering
+        implicit val e: Order[elt.Inj] = elt.injord
         Order[Iterable[elt.Inj]] contramap identity
-      },
-      implicit e => Tag unsubst implicitly[Arbitrary[Vector[elt.Inj] @@ Div3]],
-      implicit e => implicitly[Shrink[Vector[elt.Inj]]],
-    )
+      }
+      override def injarb = {
+        implicit val e: Arbitrary[elt.Inj] = elt.injarb
+        Tag unsubst implicitly[Arbitrary[Vector[elt.Inj] @@ Div3]]
+      }
+      override def injshrink = implicitly[Shrink[Vector[elt.Inj]]]
+    }
 
     def optional(elt: ValueAddend): Aux[Option[elt.Inj]] = new ValueAddend {
       type Inj = Option[elt.Inj]

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -374,7 +374,8 @@ class HashSpec extends AnyWordSpec with Matchers {
           "0007e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5",
           "0059b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b",
         ).map { str =>
-          VA.contractId.inj(ContractId.V1 assertFromString str)
+          import org.scalacheck.{Arbitrary, Gen}
+          VA.contractId(Arbitrary(Gen.fail)).inj(ContractId.V1 assertFromString str)
         }
 
       val enumT1 = VA.enumeration("Color", List("Red", "Green"))._2

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -75,7 +75,7 @@ class ValueSpec
   private def checkOrderPreserved(
       va: VA,
       scope: Value.LookupVariantEnum,
-  )(implicit cid: Arbitrary[Value.ContractId]) = {
+  ) = {
     import va.{injord, injarb, injshrink}
     implicit val targetOrd: Order[Value] = Tag unsubst Value.orderInstance(scope)
     forAll(minSuccessful(20)) { (a: va.Inj, b: va.Inj) =>

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -1432,6 +1432,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
     maxInboundMessageSize = StartSettings.DefaultMaxInboundMessageSize * 10
   ) { fixture =>
     import fixture.encoder
+    import org.scalacheck.{Arbitrary, Gen}
     fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (alice, headers) =>
       // The numContracts size should test for https://github.com/digital-asset/daml/issues/10339
       val numContracts: Long = 2000
@@ -1459,7 +1460,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
               ShRecord(cids =
                 lfToApi(
                   VAx
-                    .seq(VA.contractId)
+                    .seq(VA.contractId(Arbitrary(Gen.fail)))
                     .inj(cids map lfv.Value.ContractId.assertFromString)
                 ).sum
               )


### PR DESCRIPTION
`injarb` took the contract ID's arbitrary instance as a parameter because `ValueAddend`s used to describe contract-ID-abstracted values. However, this abstraction was removed from `Value`, so we can move this parameter to simplify the implementation.