### PR TITLE
javadocs for codegen support in javaapi bindings

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Contract.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Contract.java
@@ -14,14 +14,19 @@ import java.util.Set;
  * @param <Data> The containing template's associated record type.
  */
 public abstract class Contract<Id, Data> implements com.daml.ledger.javaapi.data.Contract {
+  /** The contract ID retrieved from the event. */
   public final Id id;
 
+  /** The contract payload, as declared after {@code template X with}. */
   public final Data data;
 
+  /** If defined, the contract's agreement text. */
   public final Optional<String> agreementText;
 
+  /** The party IDs of this contract's signatories. */
   public final Set<String> signatories;
 
+  /** The party IDs of this contract's observers. */
   public final Set<String> observers;
 
   protected Contract(

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
@@ -12,13 +12,32 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+/**
+ * Metadata and utilities associated with a template as a whole, rather than one single contract
+ * made from that template.
+ *
+ * @param <Ct> The {@link Contract} subclass generated within the template class.
+ * @param <Id> The {@link ContractId} subclass generated within the template class.
+ * @param <Data> The generated {@link com.daml.ledger.javaapi.data.Template} subclass named after
+ *     the template, whose instances contain only the payload.
+ */
 public abstract class ContractCompanion<Ct, Id, Data> {
+  /** The full template ID of the template that defined this companion. */
   public final Identifier TEMPLATE_ID;
+
   final String templateClassName; // not something we want outside this package
 
   protected final Function<String, Id> newContractId;
   protected final Function<DamlRecord, Data> fromValue;
 
+  /**
+   * Try to parse a contract from an event expected to create a {@code Ct} contract.
+   *
+   * @param event the event to try to parse a contract from
+   * @throws IllegalArgumentException when the {@link CreatedEvent#arguments} cannot be parsed as
+   *     {@code Data}, or the {@link CreatedEvent#contractKey} cannot be parsed as {@code Key}.
+   * @return The parsed contract, with payload and metadata, if present.
+   */
   public abstract Ct fromCreatedEvent(CreatedEvent event);
 
   protected ContractCompanion(
@@ -87,6 +106,7 @@ public abstract class ContractCompanion<Ct, Id, Data> {
     }
   }
 
+  /** @param <Key> {@code Data}'s key type as represented in Java codegen. */
   public static final class WithKey<Ct, Id, Data, Key> extends ContractCompanion<Ct, Id, Data> {
     private final NewContract<Ct, Id, Data, Key> newContract;
     private final Function<Value, Key> keyFromValue;

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
@@ -31,7 +31,7 @@ public abstract class ContractCompanion<Ct, Id, Data> {
   protected final Function<DamlRecord, Data> fromValue;
 
   /**
-   * Try to parse a contract from an event expected to create a {@code Ct} contract.
+   * Tries to parse a contract from an event expected to create a {@code Ct} contract.
    *
    * @param event the event to try to parse a contract from
    * @throws IllegalArgumentException when the {@link CreatedEvent#arguments} cannot be parsed as

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractWithKey.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractWithKey.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 
 public abstract class ContractWithKey<Id, Data, Key> extends Contract<Id, Data> {
+  /** The contract's key, if it was present in the event. */
   public final Optional<Key> key;
 
   protected ContractWithKey(


### PR DESCRIPTION
One of the benefits of moving code from generated output to hand-written (#13724) is that we can make nice inherited docs. Here we do a bit of that.