### PR TITLE
replace hand-disassembly of json in tests with domain model values

### DIFF
--- a/ledger-service/http-json/src/it/scala/http/TlsTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/TlsTest.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model.{StatusCodes, Uri}
 import org.scalatest.{Assertion, Inside}
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
-import spray.json.{JsArray, JsObject}
+import spray.json.JsValue
 
 import scala.concurrent.Future
 
@@ -18,6 +18,7 @@ abstract class TlsTest
     with Matchers
     with Inside
     with AbstractHttpServiceIntegrationTestFuns {
+  import json.JsonProtocol._
 
   override def jdbcConfig = None
 
@@ -30,16 +31,10 @@ abstract class TlsTest
   // TEST_EVIDENCE: Authentication: connect normally with tls on
   "connect normally with tls on" in withHttpService { fixture =>
     fixture
-      .getRequestWithMinimumAuth(Uri.Path("/v1/query"))
-      .flatMap { case (status, output) =>
-        status shouldBe StatusCodes.OK
-        assertStatus(output, StatusCodes.OK)
-        inside(output) { case JsObject(fields) =>
-          inside(fields.get("result")) { case Some(JsArray(vector)) =>
-            vector should have size 0L
-          }
-        }
-      }: Future[Assertion]
+      .getRequestWithMinimumAuth[Vector[JsValue]](Uri.Path("/v1/query"))
+      .map(inside(_) { case (StatusCodes.OK, domain.OkResponse(vector, None, StatusCodes.OK)) =>
+        vector should have size 0L
+      }): Future[Assertion]
   }
 }
 

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -881,14 +881,14 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
     val badPath = Uri.Path("/contracts/does-not-exist")
     val badUri = fixture.uri withPath badPath
     fixture
-      .getRequestWithMinimumAuth(badPath)
-      .flatMap { case (status, output) =>
-        status shouldBe StatusCodes.NotFound
-        assertStatus(output, StatusCodes.NotFound)
-        expectedOneErrorMessage(
-          output
-        ) shouldBe s"${HttpMethods.GET: HttpMethod}, uri: ${badUri: Uri}"
-      }: Future[Assertion]
+      .getRequestWithMinimumAuth[JsValue](badPath)
+      .map(inside(_) {
+        case (
+              StatusCodes.NotFound,
+              domain.ErrorResponse(Seq(errorMsg), _, StatusCodes.NotFound, _),
+            ) =>
+          errorMsg shouldBe s"${HttpMethods.GET: HttpMethod}, uri: ${badUri: Uri}"
+      }): Future[Assertion]
   }
 
   "parties endpoint should return all known parties" in withHttpService { fixture =>

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -139,14 +139,14 @@ trait AbstractHttpServiceIntegrationTestFunsCustomToken
       application = None,
     )
     fixture
-      .postJsonRequestWithMinimumAuth(
+      .postJsonRequestWithMinimumAuth[MeteringReport](
         Uri.Path("/v1/metering-report"),
         request.toJson,
       )
-      .map { case (status, value) =>
-        status shouldBe StatusCodes.OK
-        result(value).convertTo[MeteringReport].request shouldBe expected
-      }
+      .map(inside(_) {
+        case (StatusCodes.OK, domain.OkResponse(meteringReport, _, StatusCodes.OK)) =>
+          meteringReport.request shouldBe expected
+      })
   }
 
 }
@@ -708,36 +708,37 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
       val contractId = lar.ContractId(contractIdString)
       val exerciseJson: JsValue = encodeExercise(encoder)(iouExerciseTransferCommand(contractId))
       fixture
-        .postJsonRequestWithMinimumAuth(Uri.Path("/v1/exercise"), exerciseJson)
-        .flatMap { case (status, output) =>
-          status shouldBe StatusCodes.NotFound
-          assertStatus(output, StatusCodes.NotFound)
-          expectedOneErrorMessage(output) should include(
-            s"Contract could not be found with id $contractIdString"
-          )
-          val ledgerApiError =
-            output.asJsObject.fields("ledgerApiError").convertTo[domain.LedgerApiError]
-          ledgerApiError.message should include("CONTRACT_NOT_FOUND")
-          ledgerApiError.message should include(
-            "Contract could not be found with id 000000000000000000000000000000000000000000000000000000000000000000"
-          )
-          import org.scalatest.Inspectors._
-          forExactly(1, ledgerApiError.details) {
-            case domain.ErrorInfoDetail(errorCodeId, _) =>
-              errorCodeId shouldBe "CONTRACT_NOT_FOUND"
-            case _ => fail()
-          }
-          forExactly(1, ledgerApiError.details) {
-            case domain.RequestInfoDetail(_) => succeed
-            case _ => fail()
-          }
-          forExactly(1, ledgerApiError.details) {
-            case domain.ResourceInfoDetail(name, typ) =>
-              name shouldBe "000000000000000000000000000000000000000000000000000000000000000000"
-              typ shouldBe "CONTRACT_ID"
-            case _ => fail()
-          }
-        }: Future[Assertion]
+        .postJsonRequestWithMinimumAuth[JsValue](Uri.Path("/v1/exercise"), exerciseJson)
+        .map(inside(_) {
+          case (
+                StatusCodes.NotFound,
+                domain
+                  .ErrorResponse(Seq(errorMsg), None, StatusCodes.NotFound, Some(ledgerApiError)),
+              ) =>
+            errorMsg should include(
+              s"Contract could not be found with id $contractIdString"
+            )
+            ledgerApiError.message should include("CONTRACT_NOT_FOUND")
+            ledgerApiError.message should include(
+              "Contract could not be found with id 000000000000000000000000000000000000000000000000000000000000000000"
+            )
+            import org.scalatest.Inspectors._
+            forExactly(1, ledgerApiError.details) {
+              case domain.ErrorInfoDetail(errorCodeId, _) =>
+                errorCodeId shouldBe "CONTRACT_NOT_FOUND"
+              case _ => fail()
+            }
+            forExactly(1, ledgerApiError.details) {
+              case domain.RequestInfoDetail(_) => succeed
+              case _ => fail()
+            }
+            forExactly(1, ledgerApiError.details) {
+              case domain.ResourceInfoDetail(name, typ) =>
+                name shouldBe "000000000000000000000000000000000000000000000000000000000000000000"
+                typ shouldBe "CONTRACT_ID"
+              case _ => fail()
+            }
+        }): Future[Assertion]
   }
 
   "exercise Archive" in withHttpService { fixture =>
@@ -962,34 +963,35 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
 
   "parties endpoint should error if empty array passed as input" in withHttpService { fixture =>
     fixture
-      .postJsonRequestWithMinimumAuth(
+      .postJsonRequestWithMinimumAuth[JsValue](
         Uri.Path("/v1/parties"),
         JsArray(Vector.empty),
       )
-      .flatMap { case (status, output) =>
-        status shouldBe StatusCodes.BadRequest
-        assertStatus(output, StatusCodes.BadRequest)
-        val errorMsg = expectedOneErrorMessage(output)
-        errorMsg should include("Cannot read JSON: <[]>")
-        errorMsg should include("must be a JSON array with at least 1 element")
-      }: Future[Assertion]
+      .map(inside(_) {
+        case (
+              StatusCodes.BadRequest,
+              domain.ErrorResponse(Seq(errorMsg), None, StatusCodes.BadRequest, _),
+            ) =>
+          errorMsg should include("Cannot read JSON: <[]>")
+          errorMsg should include("must be a JSON array with at least 1 element")
+      }): Future[Assertion]
   }
 
   "parties endpoint returns error if empty party string passed" in withHttpService { fixture =>
     val requestedPartyIds: Vector[domain.Party] = domain.Party.subst(Vector(""))
 
     fixture
-      .postJsonRequestWithMinimumAuth(
+      .postJsonRequestWithMinimumAuth[List[domain.PartyDetails]](
         Uri.Path("/v1/parties"),
         JsArray(requestedPartyIds.map(x => JsString(x.unwrap))),
       )
-      .flatMap { case (status, output) =>
-        status shouldBe StatusCodes.BadRequest
-        inside(decode1[domain.SyncResponse, List[domain.PartyDetails]](output)) {
-          case \/-(domain.ErrorResponse(List(error), None, StatusCodes.BadRequest, _)) =>
-            error should include("Daml-LF Party is empty")
-        }
-      }: Future[Assertion]
+      .map(inside(_) {
+        case (
+              StatusCodes.BadRequest,
+              domain.ErrorResponse(List(error), None, StatusCodes.BadRequest, _),
+            ) =>
+          error should include("Daml-LF Party is empty")
+      }): Future[Assertion]
   }
 
   "parties endpoint returns empty result with warnings and OK status if nothing found" in withHttpService {

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -252,6 +252,10 @@ trait AbstractHttpServiceIntegrationTestFuns
     ): Future[(StatusCode, JsValue)] =
       HttpServiceTestFixture.postJsonRequest(uri withPath path, json, headers)
 
+    // XXX SC check that the status matches the one in the SyncResponse, and
+    // remove StatusCode from these responses everywhere, if all tests are
+    // similarly duplicative
+
     def postJsonRequestWithMinimumAuth[Result: JsonReader](
         path: Uri.Path,
         json: JsValue,

--- a/security-evidence.md
+++ b/security-evidence.md
@@ -5,7 +5,7 @@
 - Updating the package service succeeds with sufficient authorization: [AuthorizationTest.scala](ledger-service/http-json/src/it/scala/http/AuthorizationTest.scala#L89)
 - accept user tokens: [TestMiddleware.scala](triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala#L152)
 - badly-authorized create is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L60)
-- badly-authorized create is rejected: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1084)
+- badly-authorized create is rejected: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1086)
 - badly-authorized exercise is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L158)
 - badly-authorized exercise/create (create is unauthorized) is rejected: [AuthPropagationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthPropagationSpec.scala#L275)
 - badly-authorized exercise/create (exercise is unauthorized) is rejected: [AuthPropagationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthPropagationSpec.scala#L243)
@@ -18,7 +18,7 @@
 - create with no signatories is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L50)
 - create with non-signatory maintainers is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L72)
 - exercise with no controllers is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L148)
-- fetch fails when readAs not authed, even if prior fetch succeeded: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1144)
+- fetch fails when readAs not authed, even if prior fetch succeeded: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1146)
 - forbid a non-authorized party to check the status of a trigger: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L669)
 - forbid a non-authorized party to list triggers: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L659)
 - forbid a non-authorized party to start a trigger: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L648)
@@ -202,7 +202,7 @@
 
 ## Performance:
 - Tail call optimization: Tail recursion does not blow the scala JVM stack.: [TailCallTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala#L16)
-- archiving a large number of contracts should succeed: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1430)
+- archiving a large number of contracts should succeed: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1432)
 - creating and listing 20K users should be possible: [HttpServiceIntegrationTestUserManagement.scala](ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala#L565)
 
 ## Input Validation:
@@ -248,6 +248,6 @@
 - well formed lookup replay command is accepted: [ReplayCommandPreprocessorSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ReplayCommandPreprocessorSpec.scala#L155)
 
 ## Authentication:
-- connect normally with tls on: [TlsTest.scala](ledger-service/http-json/src/it/scala/http/TlsTest.scala#L30)
+- connect normally with tls on: [TlsTest.scala](ledger-service/http-json/src/it/scala/http/TlsTest.scala#L31)
 
 


### PR DESCRIPTION
Functions like `result`, `assertStatus`, and `expectedOneErrorMessage` reproduce the `JsonReader` for `domain.SyncResponse`. It's also extremely common that we want `result` to be parsed as well.

Instead of testing the JSON structure piecemeal in this way, we can parse the whole `domain.SyncResponse` and in so doing use `inside` to make our expectation of the result much more declarative.

This applies to related utilities with many more callers as well; this PR only contains some lesser-used functions' test porting.