### PR TITLE
Disable compat tests for forks

### DIFF
--- a/ci/compatibility.yml
+++ b/ci/compatibility.yml
@@ -34,6 +34,7 @@ steps:
       set -eou pipefail
       ./compatibility/test.sh ${{ parameters.test_flags }}
     displayName: 'Run tests'
+    condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'False'))
     env:
       DOCKER_LOGIN: $(DOCKER_LOGIN)
       DOCKER_PASSWORD: $(DOCKER_PASSWORD)


### PR DESCRIPTION
They don’t get access to Oracle which just results in them failing
which is clearly no good.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
