### PR TITLE
Make building ghc in-project and with Bazel work again

### DIFF
--- a/bazel_tools/ghc-lib/defs.bzl
+++ b/bazel_tools/ghc-lib/defs.bzl
@@ -62,6 +62,7 @@ def ghc():
     )
     haskell_cabal_binary(
         name = "hadrian",
+        flags = ["with_bazel"],
         srcs = [":hadrian-srcs"],
         deps = [
             "@stackage//:base",

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "371d05ccf1086d7e9363275ce493de1770ca972e"
+GHC_REV = "0ec72694dc563bba1830d98a03e52042777ee844"
 GHC_PATCHES = [
 ]
 

--- a/ghc-lib/new-working-on-ghc-lib.md
+++ b/ghc-lib/new-working-on-ghc-lib.md
@@ -36,6 +36,15 @@ Working locally in a branch from `da-master-8.8.1`, there are two files which ge
 - [`compiler/parser/RdrHsSyn.hs`](https://github.com/digital-asset/ghc/blob/da-master-8.8.1/compiler/parser/RdrHsSyn.hs)
 
 
+The quickest way to build and test is:
+
+1. `hadrian/build.sh --configure --flavour=quickest -j`
+
+2. `./_build/stage1/bin/ghc ./Example.hs -ddump-parsed | tee desugar.out`
+
+Step 1 gives immediate feedback on build failures, but takes about 2-3 minutes when successful. For Step 2 you need a Daml example file. The input file must end in `.hs` suffix. It must begin with the pragma: `{-# LANGUAGE DamlSyntax #-}`
+
+
 ### Interactive development workflow
 
 While working on GHC, you can integrate your changes directly into the `daml` project as follows.


### PR DESCRIPTION
ghc PR: https://github.com/digital-asset/ghc/pull/121

# Purpose

Currently, the CI job in ghc-lib does not work anymore integrating da-ghc-8.8.1 due to the changes of #12508.

Also, building ghc itself using hadrian, and then running `./_build/stage1/bin/ghc` on some example `.daml` file is no longer possible.

This change is part two of the fix.

# TODO

- [x] update `GHC_REV` after merging https://github.com/digital-asset/ghc/pull/121