### PR TITLE
Ledger API stream buffers moved in IndexServiceImpl

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -368,6 +368,10 @@ final class Metrics(val registry: MetricRegistry) {
         registry.counter(Prefix :+ "transaction_trees_buffer_size")
       val flatTransactionsBufferSize: Counter =
         registry.counter(Prefix :+ "flat_transactions_buffer_size")
+      val activeContractsBufferSize: Counter =
+        registry.counter(Prefix :+ "active_contracts_buffer_size")
+      val completionsBufferSize: Counter =
+        registry.counter(Prefix :+ "completions_buffer_size")
 
       val contractStateEventsBufferSize: Counter =
         registry.counter(Prefix :+ "contract_state_events_buffer_size")

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceBuilder.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceBuilder.scala
@@ -110,6 +110,7 @@ private[platform] case class IndexServiceBuilder(
       contractStore,
       pruneBuffers,
       generalDispatcher,
+      metrics,
     )
   }
 


### PR DESCRIPTION
This PR improves the behavior of the Ledger API streams Akka buffers.

In the current implementation, the buffers are added after each transactions window (i.e. Dispatcher-issued window). This can lead to the buffers never filling up in case when the window of events is too small. 

**Resolution**: The buffers are added after the stream construction in `IndexServiceImpl`, ensuring that they can be fully utilized regardless of the transactions window fill size. 

Additionally, the `getActiveContracts` and `getCompletions` stream buffers is instrumented.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
