### PR TITLE
Fix data-dependencies leaking dependency internals

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
@@ -226,10 +226,12 @@ installDar depsPath isDataDep ExtractedDar {..} = do
         fp <- dalfFileNameFromEntry dalf
         let targetFp = depsPath </> fp
         let targetDir = takeDirectory targetFp
-        if isDataDep
-          then markDirWith dataDepMarker targetDir
-          else markDirWith depMarker targetDir
-        write targetFp (ZipArchive.fromEntry dalf)
+        targetExists <- doesFileExist targetFp
+        unless targetExists $ do
+          if isDataDep
+            then markDirWith dataDepMarker targetDir
+            else markDirWith depMarker targetDir
+          write targetFp (ZipArchive.fromEntry dalf)
     writeFileUTF8 (depPath </> sdkVersionFile) edSdkVersions
 
 dalfFileNameFromEntry :: ZipArchive.Entry -> IO FilePath

--- a/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
@@ -226,8 +226,7 @@ installDar depsPath isDataDep ExtractedDar {..} = do
         fp <- dalfFileNameFromEntry dalf
         let targetFp = depsPath </> fp
         let targetDir = takeDirectory targetFp
-        targetExists <- doesFileExist targetFp
-        unless targetExists $ do
+        unlessM (doesFileExist targetFp) $ do
           if isDataDep
             then markDirWith dataDepMarker targetDir
             else markDirWith depMarker targetDir


### PR DESCRIPTION
When a dependency `dep` appears in the dependency subgraph of a data-dependency `data-dep`, it is treated as a data-dependency, which has the side effect of exposing the internal functions and types of `dep`. In turn, if a module from `dep` is imported unqualified, unrestricted, and some of its _internal_ functions/types clash with functions/types from other imported modules, the user will get 'ambiguous occurrence' errors that they wouldn't get with regular dependencies.