### PR TITLE
Benchtool: Make non-consuming events visible to observer parties [DPP-1056]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
@@ -13,10 +13,13 @@ import com.daml.ledger.api.benchtool.metrics.MetricsManager.NoOpMetricsManager
 import com.daml.ledger.api.benchtool.services.LedgerApiServices
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import com.daml.ledger.client.binding
 import com.daml.platform.sandbox.fixture.SandboxFixture
 import org.scalatest.AppendedClues
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.Future
 
 class FooCommandSubmitterITSpec
     extends AsyncFlatSpec
@@ -47,7 +50,7 @@ class FooCommandSubmitterITSpec
     )
     val config = WorkflowConfig.FooSubmissionConfig(
       numberOfInstances = 10,
-      numberOfObservers = 1,
+      numberOfObservers = 2,
       numberOfDivulgees = 0,
       numberOfExtraSubmitters = 0,
       uniqueParties = false,
@@ -85,39 +88,63 @@ class FooCommandSubmitterITSpec
         names = names,
       )
       _ <- tested.performSubmission()
-      eventsObserver = TreeEventsObserver(expectedTemplateNames = Set("Foo1", "Foo2"))
-      _ <- apiServices.transactionService.transactionTrees(
-        config = WorkflowConfig.StreamConfig.TransactionTreesStreamConfig(
-          name = "dummy-name",
-          filters = List(
-            WorkflowConfig.StreamConfig.PartyFilter(
-              party = allocatedParties.signatory.toString,
-              templates = List.empty,
-            )
-          ),
-          beginOffset = None,
-          endOffset = Some(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
-          objectives = None,
-        ),
-        observer = eventsObserver,
+      observerResult_signatory: ObservedEvents <- treeEventsObserver(
+        apiServices = apiServices,
+        party = allocatedParties.signatory,
       )
-      observerResult: ObservedEvents <- eventsObserver.result
+      observerResult_observer0: ObservedEvents <- treeEventsObserver(
+        apiServices = apiServices,
+        party = allocatedParties.observers(0),
+      )
+      observerResult_observer1: ObservedEvents <- treeEventsObserver(
+        apiServices = apiServices,
+        party = allocatedParties.observers(1),
+      )
     } yield {
-      observerResult.createEvents.size shouldBe config.numberOfInstances withClue ("number of create events")
+      observerResult_signatory.createEvents.size shouldBe config.numberOfInstances withClue ("number of create events")
 
-      observerResult.avgSizeOfCreateEventPerTemplateName(
+      observerResult_signatory.avgSizeOfCreateEventPerTemplateName(
         "Foo1"
       ) shouldBe (foo1Config.payloadSizeBytes + 60) +- 20 withClue ("payload size of create Foo1")
-      observerResult.avgSizeOfCreateEventPerTemplateName(
+      observerResult_signatory.avgSizeOfCreateEventPerTemplateName(
         "Foo2"
       ) shouldBe (foo2Config.payloadSizeBytes + 60) +- 20 withClue ("payload size of create Foo2")
-      observerResult.avgSizeOfConsumingExercise shouldBe (consumingExercisesConfig.payloadSizeBytes + 10) +- 5
-      observerResult.avgSizeOfNonconsumingExercise shouldBe (nonConsumingExercisesConfig.payloadSizeBytes + 10) +- 5
-      observerResult.consumingExercises.size.toDouble shouldBe (config.numberOfInstances * consumingExercisesConfig.probability) withClue ("number of consuming exercises")
-      observerResult.nonConsumingExercises.size.toDouble shouldBe (config.numberOfInstances * nonConsumingExercisesConfig.probability) withClue ("number of non consuming exercises")
+      observerResult_signatory.avgSizeOfConsumingExercise shouldBe (consumingExercisesConfig.payloadSizeBytes + 10) +- 5
+      observerResult_signatory.avgSizeOfNonconsumingExercise shouldBe (nonConsumingExercisesConfig.payloadSizeBytes + 10) +- 5
+      observerResult_signatory.consumingExercises.size.toDouble shouldBe (config.numberOfInstances * consumingExercisesConfig.probability) withClue ("number of consuming exercises")
+      val expectedNumberOfNonConsumingExercises =
+        config.numberOfInstances * nonConsumingExercisesConfig.probability.toInt
+      observerResult_signatory.nonConsumingExercises.size shouldBe expectedNumberOfNonConsumingExercises withClue ("number of non consuming exercises visible to signatory")
+      // First observer can see all non-consuming events
+      observerResult_observer0.nonConsumingExercises.size shouldBe expectedNumberOfNonConsumingExercises withClue ("number of non consuming exercises visible to Obs-0")
+      // Second observer can see ~10% of all non-consuming events
+      observerResult_observer1.nonConsumingExercises.size should be > 0 withClue ("number of non consuming exercises visible to Obs-1")
 
       succeed
     }
+  }
+
+  private def treeEventsObserver(
+      apiServices: LedgerApiServices,
+      party: binding.Primitive.Party,
+  ): Future[ObservedEvents] = {
+    val eventsObserver = TreeEventsObserver(expectedTemplateNames = Set("Foo1", "Foo2"))
+    val config = WorkflowConfig.StreamConfig.TransactionTreesStreamConfig(
+      name = "dummy-name",
+      filters = List(
+        WorkflowConfig.StreamConfig.PartyFilter(
+          party = party.toString,
+          templates = List.empty,
+        )
+      ),
+      beginOffset = None,
+      endOffset = Some(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
+      objectives = None,
+    )
+    apiServices.transactionService.transactionTrees(
+      config = config,
+      observer = eventsObserver,
+    )
   }
 
 }

--- a/ledger/test-common/BUILD.bazel
+++ b/ledger/test-common/BUILD.bazel
@@ -103,6 +103,7 @@ da_scala_dar_resources_library(
             "**/*Exception*.daml",
             "**/*Interface*daml",
             "**/Limits.daml",
+            "**/Foo.daml",
         ],
         "1.14": [
             "**/*Interface*daml",

--- a/ledger/test-common/src/main/daml/model/Foo.daml
+++ b/ledger/test-common/src/main/daml/model/Foo.daml
@@ -62,6 +62,7 @@ template Foo1
     nonconsuming choice Foo1_NonconsumingChoice: ()
       with
         exercisePayload: Text
+      observer observers
       controller signatory
       do
         return ()
@@ -88,6 +89,7 @@ template Foo2
     nonconsuming choice Foo2_NonconsumingChoice: ()
       with
         exercisePayload: Text
+      observer observers
       controller signatory
       do
         return ()
@@ -114,6 +116,7 @@ template Foo3
     nonconsuming choice Foo3_NonconsumingChoice: ()
       with
         exercisePayload: Text
+      observer observers
       controller signatory
       do
         return ()


### PR DESCRIPTION
By making contract observers choice observer on the non-consuming choice (on Foo1, Foo2 and Foo3 contracts)

changelog_begin
changelog_end
