### PR TITLE
toInterface and unsafeToTemplate in Scala codegen

### DIFF
--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Interface.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Interface.scala
@@ -3,6 +3,10 @@
 
 package com.daml.ledger.client.binding
 
+import com.daml.ledger.api.refinements.ApiTypes
+
+import scala.annotation.nowarn
+
 /** Common superclass of interface marker types.  There are no instances of
   * subclasses of this class; it is strictly a marker type to aid in implicit
   * resolution, and only occurs within contract IDs.
@@ -10,5 +14,15 @@ package com.daml.ledger.client.binding
 abstract class Interface extends VoidValueRef
 
 object Interface {
-  // TODO #13924 unsafeToTemplate extension method for cids
+  import Primitive.ContractId, ContractId.subst
+
+  implicit final class `interface ContractId syntax`[I](private val self: ContractId[I])
+      extends AnyVal {
+    @nowarn("cat=unused&msg=parameter value ev in method")
+    def unsafeToTemplate[T](implicit ev: Template.Implements[T, I]): ContractId[T] = {
+      type K[C] = C => ApiTypes.ContractId
+      type K2[C] = ContractId[I] => C
+      subst[K2, T](subst[K, I](identity))(self)
+    }
+  }
 }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Interface.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Interface.scala
@@ -18,6 +18,17 @@ object Interface {
 
   implicit final class `interface ContractId syntax`[I](private val self: ContractId[I])
       extends AnyVal {
+
+    /** Convert an interface contract ID to a template contract ID.  Sometimes
+      * this is needed if you got an interface contract ID from a choice, but
+      * you need to assert that the contract ID is of a particular template
+      * so that you can exercise contracts on it.
+      *
+      * This checks at compile-time that `T` is in fact a template that
+      * implements interface `I`, but it does not check that the specific
+      * contract ID is actually associated with `T` on the ledger, hence the
+      * `unsafe` in the name.
+      */
     @nowarn("cat=unused&msg=parameter value ev in method")
     def unsafeToTemplate[T](implicit ev: Template.Implements[T, I]): ContractId[T] = {
       type K[C] = C => ApiTypes.ContractId

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
@@ -269,7 +269,7 @@ private[client] object OnlyPrimitive extends Primitive {
             rpccmd.Command.Command.CreateAndExercise(
               // TODO #13925 pass exerciseTarget.id.unwrap as interface ID
               rpccmd.CreateAndExerciseCommand(
-                templateId = Some(cfe.origin.id.unwrap),
+                templateId = Some(cfe.value.templateId.unwrap),
                 createArguments = Some(cfe.value.arguments),
                 choice = choiceId,
                 choiceArgument = Some(argument),

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
@@ -247,7 +247,7 @@ private[client] object OnlyPrimitive extends Primitive {
     )
 
   private[binding] override def exercise[ExOn, Tpl, Out](
-      templateCompanion: ContractTypeCompanion[Tpl],
+      exerciseTarget: ContractTypeCompanion[Tpl],
       receiver: ExOn,
       choiceId: String,
       argument: rpcvalue.Value,
@@ -258,7 +258,7 @@ private[client] object OnlyPrimitive extends Primitive {
           case _: ExerciseOn.OnId[Tpl] =>
             rpccmd.Command.Command.Exercise(
               rpccmd.ExerciseCommand(
-                templateId = Some(templateCompanion.id.unwrap),
+                templateId = Some(exerciseTarget.id.unwrap),
                 contractId = (receiver: ContractId[Tpl]).unwrap,
                 choice = choiceId,
                 choiceArgument = Some(argument),
@@ -267,7 +267,8 @@ private[client] object OnlyPrimitive extends Primitive {
           case _: ExerciseOn.CreateAndOnTemplate[Tpl] =>
             rpccmd.Command.Command.CreateAndExercise(
               rpccmd.CreateAndExerciseCommand(
-                templateId = Some(templateCompanion.id.unwrap),
+                // TODO #13925 wrong ID in interface case
+                templateId = Some(exerciseTarget.id.unwrap),
                 createArguments = Some((receiver: Template.CreateForExercise[Tpl]).value.arguments),
                 choice = choiceId,
                 choiceArgument = Some(argument),
@@ -276,7 +277,8 @@ private[client] object OnlyPrimitive extends Primitive {
           case _: ExerciseOn.OnKey[Tpl] =>
             rpccmd.Command.Command.ExerciseByKey(
               rpccmd.ExerciseByKeyCommand(
-                templateId = Some(templateCompanion.id.unwrap),
+                // TODO #13925 wrong ID in interface case
+                templateId = Some(exerciseTarget.id.unwrap),
                 contractKey = Some((receiver: Template.Key[Tpl]).encodedKey),
                 choice = choiceId,
                 choiceArgument = Some(argument),
@@ -284,7 +286,7 @@ private[client] object OnlyPrimitive extends Primitive {
             )
         }
       },
-      templateCompanion,
+      exerciseTarget,
     )
 
   private[binding] override def arguments(

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
@@ -265,21 +265,23 @@ private[client] object OnlyPrimitive extends Primitive {
               )
             )
           case _: ExerciseOn.CreateAndOnTemplate[Tpl] =>
+            val cfe: Template.CreateForExercise[Tpl] = receiver
             rpccmd.Command.Command.CreateAndExercise(
+              // TODO #13925 pass exerciseTarget.id.unwrap as interface ID
               rpccmd.CreateAndExerciseCommand(
-                // TODO #13925 wrong ID in interface case
-                templateId = Some(exerciseTarget.id.unwrap),
-                createArguments = Some((receiver: Template.CreateForExercise[Tpl]).value.arguments),
+                templateId = Some(cfe.origin.id.unwrap),
+                createArguments = Some(cfe.value.arguments),
                 choice = choiceId,
                 choiceArgument = Some(argument),
               )
             )
           case _: ExerciseOn.OnKey[Tpl] =>
+            val k: Template.Key[Tpl] = receiver
+            // TODO #13925 pass exerciseTarget.id.unwrap as interface ID
             rpccmd.Command.Command.ExerciseByKey(
               rpccmd.ExerciseByKeyCommand(
-                // TODO #13925 wrong ID in interface case
-                templateId = Some(exerciseTarget.id.unwrap),
-                contractKey = Some((receiver: Template.Key[Tpl]).encodedKey),
+                templateId = Some(k.origin.id.unwrap),
+                contractKey = Some(k.encodedKey),
                 choice = choiceId,
                 choiceArgument = Some(argument),
               )

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
@@ -267,7 +267,7 @@ private[client] object OnlyPrimitive extends Primitive {
           case _: ExerciseOn.CreateAndOnTemplate[Tpl] =>
             val cfe: Template.CreateForExercise[Tpl] = receiver
             rpccmd.Command.Command.CreateAndExercise(
-              // TODO #13925 pass exerciseTarget.id.unwrap as interface ID
+              // TODO #13993 pass exerciseTarget.id.unwrap as interface ID
               rpccmd.CreateAndExerciseCommand(
                 templateId = Some(cfe.value.templateId.unwrap),
                 createArguments = Some(cfe.value.arguments),
@@ -277,7 +277,7 @@ private[client] object OnlyPrimitive extends Primitive {
             )
           case _: ExerciseOn.OnKey[Tpl] =>
             val k: Template.Key[Tpl] = receiver
-            // TODO #13925 pass exerciseTarget.id.unwrap as interface ID
+            // TODO #13993 pass exerciseTarget.id.unwrap as interface ID
             rpccmd.Command.Command.ExerciseByKey(
               rpccmd.ExerciseByKeyCommand(
                 templateId = Some(k.origin.id.unwrap),

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
@@ -20,7 +20,7 @@ abstract class Template[+T] extends ValueRef { self: T =>
     * }}}
     */
   final def createAnd(implicit d: DummyImplicit): Template.CreateForExercise[T] =
-    Template.CreateForExercise(self)
+    Template.CreateForExercise(self, templateCompanion)
 
   final def arguments(implicit d: DummyImplicit): rpcvalue.Record =
     templateCompanion.toNamedArguments(self)
@@ -46,10 +46,13 @@ object Template {
     *   Iou(foo, bar).createAnd.exerciseTransfer(controller, ...)
     * }}}
     */
-  final case class CreateForExercise[+T](value: T with Template[_]) {
+  final case class CreateForExercise[+T](
+      private[binding] val value: Template[_],
+      private[binding] val origin: TemplateCompanion[_],
+  ) {
     @nowarn("cat=unused&msg=parameter value ev in method")
     def toInterface[T0 >: T, I](implicit ev: Implements[T0, I]): CreateForExercise[I] =
-      sys.error("TODO #13925 different value evidence")
+      CreateForExercise(value, origin)
   }
 
   /** Part of an `ExerciseByKey` command.
@@ -58,10 +61,13 @@ object Template {
     *   Iou.key(foo).exerciseTransfer(controller, ...)
     * }}}
     */
-  final case class Key[+T](encodedKey: rpcvalue.Value) {
+  final case class Key[+T](
+      private[binding] val encodedKey: rpcvalue.Value,
+      private[binding] val origin: TemplateCompanion[_],
+  ) {
     @nowarn("cat=unused&msg=parameter value ev in method")
     def toInterface[T0 >: T, I](implicit ev: Implements[T0, I]): Key[I] =
-      Key(encodedKey)
+      Key(encodedKey, origin)
   }
 
   @implicitNotFound("${T} is not a template that implements interface ${I}")

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
@@ -49,6 +49,15 @@ object Template {
   final case class CreateForExercise[+T](
       private[binding] val value: Template[_]
   ) {
+
+    /** Get access to interface choices.
+      *
+      * {{{
+      *  MyTemplate(foo, bar).createAnd
+      *    .toInterface[MyInterface]
+      *    .exerciseInterfaceChoice(controller, ...)
+      * }}}
+      */
     @nowarn("cat=unused&msg=parameter value ev in method")
     def toInterface[I](implicit ev: ToInterface[T, I]): CreateForExercise[I] =
       CreateForExercise(value)
@@ -64,6 +73,15 @@ object Template {
       private[binding] val encodedKey: rpcvalue.Value,
       private[binding] val origin: TemplateCompanion[_],
   ) {
+
+    /** Get access to interface choices.
+      *
+      * {{{
+      *  MyTemplate.key(foo)
+      *    .toInterface[MyInterface]
+      *    .exerciseInterfaceChoices(controller, ...)
+      * }}}
+      */
     @nowarn("cat=unused&msg=parameter value ev in method")
     def toInterface[I](implicit ev: ToInterface[T, I]): Key[I] =
       Key(encodedKey, origin)
@@ -89,6 +107,10 @@ object Template {
   import Primitive.ContractId, ContractId.subst
   implicit final class `template ContractId syntax`[T](private val self: ContractId[T])
       extends AnyVal {
+
+    /** Widen a contract ID to the same contract ID for one of `T`'s implemented
+      * interfaces.  Do this to get access to the interface choices.
+      */
     @nowarn("cat=unused&msg=parameter value ev in method")
     def toInterface[I](implicit ev: ToInterface[T, I]): ContractId[I] = {
       type K[C] = C => ApiTypes.ContractId

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
@@ -55,7 +55,7 @@ object Template {
   /** Part of an `ExerciseByKey` command.
     *
     * {{{
-    *   Iou key foo exerciseTransfer (controller, ...)
+    *   Iou.key(foo).exerciseTransfer(controller, ...)
     * }}}
     */
   final case class Key[+T](encodedKey: rpcvalue.Value) {

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
@@ -20,7 +20,7 @@ abstract class Template[+T] extends ValueRef { self: T =>
     * }}}
     */
   final def createAnd(implicit d: DummyImplicit): Template.CreateForExercise[T] =
-    Template.CreateForExercise(self, templateCompanion)
+    Template.CreateForExercise(self)
 
   final def arguments(implicit d: DummyImplicit): rpcvalue.Record =
     templateCompanion.toNamedArguments(self)
@@ -47,12 +47,11 @@ object Template {
     * }}}
     */
   final case class CreateForExercise[+T](
-      private[binding] val value: Template[_],
-      private[binding] val origin: TemplateCompanion[_],
+      private[binding] val value: Template[_]
   ) {
     @nowarn("cat=unused&msg=parameter value ev in method")
     def toInterface[I](implicit ev: ToInterface[T, I]): CreateForExercise[I] =
-      CreateForExercise(value, origin)
+      CreateForExercise(value)
   }
 
   /** Part of an `ExerciseByKey` command.

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
@@ -46,7 +46,11 @@ object Template {
     *   Iou(foo, bar).createAnd.exerciseTransfer(controller, ...)
     * }}}
     */
-  final case class CreateForExercise[+T](value: T with Template[T])
+  final case class CreateForExercise[+T](value: T with Template[_]) {
+    @nowarn("cat=unused&msg=parameter value ev in method")
+    def toInterface[T0 >: T, I](implicit ev: Implements[T0, I]): CreateForExercise[I] =
+      sys.error("TODO #13925 different value evidence")
+  }
 
   /** Part of an `ExerciseByKey` command.
     *
@@ -54,7 +58,11 @@ object Template {
     *   Iou key foo exerciseTransfer (controller, ...)
     * }}}
     */
-  final case class Key[+T](encodedKey: rpcvalue.Value)
+  final case class Key[+T](encodedKey: rpcvalue.Value) {
+    @nowarn("cat=unused&msg=parameter value ev in method")
+    def toInterface[T0 >: T, I](implicit ev: Implements[T0, I]): Key[I] =
+      Key(encodedKey)
+  }
 
   final class Implements[T, I]
 
@@ -62,7 +70,7 @@ object Template {
   implicit final class `template ContractId syntax`[T](private val self: ContractId[T])
       extends AnyVal {
     @nowarn("cat=unused&msg=parameter value ev in method")
-    def toInterface[I](implicit ev: Template.Implements[T, I]): ContractId[I] = {
+    def toInterface[I](implicit ev: Implements[T, I]): ContractId[I] = {
       type K[C] = C => ApiTypes.ContractId
       type K2[C] = ContractId[T] => C
       subst[K2, I](subst[K, T](identity))(self)

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.api.refinements.ApiTypes
 import ApiTypes.Choice
 import com.daml.ledger.api.v1.{value => rpcvalue}
 
-import scala.annotation.nowarn
+import scala.annotation.{nowarn, implicitNotFound}
 
 abstract class Template[+T] extends ValueRef { self: T =>
   final def create(implicit d: DummyImplicit): Primitive.Update[Primitive.ContractId[T]] =
@@ -64,6 +64,7 @@ object Template {
       Key(encodedKey)
   }
 
+  @implicitNotFound("${T} is not a template that implements interface ${I}")
   final class Implements[T, I]
 
   import Primitive.ContractId, ContractId.subst

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
@@ -30,7 +30,7 @@ abstract class TemplateCompanion[T](implicit isTemplate: T <:< Template[T])
 
   /** Prepare an exercise-by-key Update. */
   final def key(k: key)(implicit enc: ValueEncoder[key]): Template.Key[T] =
-    Template.Key(Value encode k)
+    Template.Key(Value encode k, this)
 
   /** Proof that T <: Template[T].  Expressed here instead of as a type parameter
     * bound because the latter is much more inconvenient in practice.

--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -106,6 +106,7 @@ da_scala_test(
         ],
     ),
     scala_deps = [
+        "@maven//:com_chuusai_shapeless",
         "@maven//:org_scalacheck_scalacheck",
         "@maven//:org_scalatestplus_scalacheck_1_15",
         "@maven//:org_scalaz_scalaz_core",

--- a/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
+++ b/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
@@ -607,6 +607,8 @@ template InterfaceMixer with
     party: Party
   where
     signatory party
+    key party: Party
+    maintainer key
     choice OverloadedInTemplate: () with
       controller party
       do return ()

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/DataTypeIT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/DataTypeIT.scala
@@ -86,4 +86,15 @@ class DataTypeIT extends AnyWordSpec with Matchers {
     }
   }
 
+  /*
+  "contract IDs" should {
+    val imId: P.ContractId[MyMain.SimpleListExample] = P.ContractId("fakesle")
+    val imId: P.ContractId[MyMain.InterfaceMixer] = P.ContractId("fakeimid")
+    val itmId: P.ContractId[MyMainIface.IfaceFromAnotherMod] = P.ContractId("fakeitmid")
+
+    "coerce from template to interface" in {
+      imId.toInterface[MyMainIface.IfaceFromAnotherMod]
+    }
+  }
+   */
 }

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/DataTypeIT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/DataTypeIT.scala
@@ -7,6 +7,7 @@ import com.daml.ledger.client.binding.{Value, Primitive => P}
 import com.daml.sample._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import shapeless.test.illTyped
 
 class DataTypeIT extends AnyWordSpec with Matchers {
 
@@ -86,15 +87,40 @@ class DataTypeIT extends AnyWordSpec with Matchers {
     }
   }
 
-  /*
   "contract IDs" should {
-    val imId: P.ContractId[MyMain.SimpleListExample] = P.ContractId("fakesle")
+    @annotation.nowarn("cat=unused&msg=local val sleId in")
+    val sleId: P.ContractId[MyMain.SimpleListExample] = P.ContractId("fakesle")
     val imId: P.ContractId[MyMain.InterfaceMixer] = P.ContractId("fakeimid")
     val itmId: P.ContractId[MyMainIface.IfaceFromAnotherMod] = P.ContractId("fakeitmid")
 
     "coerce from template to interface" in {
-      imId.toInterface[MyMainIface.IfaceFromAnotherMod]
+      val ifId = imId.toInterface[MyMainIface.IfaceFromAnotherMod]
+      (ifId: MyMainIface.IfaceFromAnotherMod.ContractId) should ===(imId)
+      illTyped(
+        "sleId.toInterface[MyMainIface.IfaceFromAnotherMod]",
+        "com.daml.sample.MyMain.SimpleListExample is not a template that implements interface com.daml.sample.MyMainIface.IfaceFromAnotherMod",
+      )
+      illTyped(
+        "itmId.toInterface[MyMainIface.IfaceFromAnotherMod]",
+        "value toInterface is not a member of .*ContractId.*IfaceFromAnotherMod.*",
+      )
+    }
+
+    "coerce from interface to template" in {
+      val tpId = itmId.unsafeToTemplate[MyMain.InterfaceMixer]
+      (tpId: MyMain.InterfaceMixer.ContractId) should ===(itmId)
+      illTyped(
+        "itmId.unsafeToTemplate[MyMain.SimpleListExample]",
+        ".*SimpleListExample is not a template that implements interface .*IfaceFromAnotherMod",
+      )
+      illTyped(
+        "itmId.unsafeToTemplate[MyMainIface.IfaceFromAnotherMod]",
+        ".*IfaceFromAnotherMod is not a template that implements interface .*IfaceFromAnotherMod",
+      )
+      illTyped(
+        "imId.unsafeToTemplate[MyMain.InterfaceMixer]",
+        "value unsafeToTemplate is not a member of .*ContractId.*InterfaceMixer.*",
+      )
     }
   }
-   */
 }

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
@@ -133,10 +133,27 @@ class GeneratedCommandsUT extends AnyWordSpec with Matchers with Inside {
         case rpccmd.Command.Command.ExerciseByKey(
               rpccmd.ExerciseByKeyCommand(Some(tid), Some(k), "Increment", Some(choiceArg))
             ) =>
-          import com.daml.ledger.client.binding.Value.encode
           tid should ===(KeyedNumber.id)
           k should ===(encode(alice))
           choiceArg should ===(encode(Increment(42)))
+      }
+    }
+
+    "pass template ID when exercising interface choice" in {
+      inside(
+        MyMain.InterfaceMixer
+          .key(alice)
+          .toInterface[MyMainIface.IfaceFromAnotherMod]
+          .exerciseFromAnotherMod(alice, 42)
+          .command
+          .command
+      ) {
+        case rpccmd.Command.Command.ExerciseByKey(
+              rpccmd.ExerciseByKeyCommand(Some(tid), Some(k), "FromAnotherMod", Some(choiceArg))
+            ) =>
+          tid should ===(MyMain.InterfaceMixer.id)
+          k should ===(encode(alice))
+          choiceArg should ===(encode(MyMainIface.FromAnotherMod(42)))
       }
     }
   }

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
@@ -40,7 +40,7 @@ class GeneratedCommandsUT extends AnyWordSpec with Matchers with Inside {
         MyMain
           .InterfaceMixer(alice)
           .createAnd
-          .toInterface[MyMain.InterfaceMixer, MyMainIface.IfaceFromAnotherMod]
+          .toInterface[MyMainIface.IfaceFromAnotherMod]
           .exerciseFromAnotherMod(alice, 42)
           .command
           .command

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
@@ -8,6 +8,7 @@ import MyMain.{KeyedNumber, Increment, SimpleListExample}
 import com.daml.ledger.api.refinements.ApiTypes
 import com.daml.ledger.api.v1.{commands => rpccmd}
 import com.daml.ledger.client.binding.{Primitive => P}
+import com.daml.ledger.client.binding.Value.encode
 
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
@@ -33,10 +34,34 @@ class GeneratedCommandsUT extends AnyWordSpec with Matchers with Inside {
           ()
       }
     }
+
+    "include template ID and interface ID" in {
+      inside(
+        MyMain
+          .InterfaceMixer(alice)
+          .createAnd
+          .toInterface[MyMain.InterfaceMixer, MyMainIface.IfaceFromAnotherMod]
+          .exerciseFromAnotherMod(alice, 42)
+          .command
+          .command
+      ) {
+        case rpccmd.Command.Command
+              .CreateAndExercise(
+                rpccmd.CreateAndExerciseCommand(
+                  Some(tpId),
+                  Some(payload),
+                  "FromAnotherMod",
+                  Some(choiceArg),
+                )
+              ) =>
+          tpId should ===(MyMain.InterfaceMixer.id)
+          payload should ===(MyMain.InterfaceMixer(alice).arguments)
+          choiceArg should ===(encode(MyMainIface.FromAnotherMod(42)))
+      }
+    }
   }
 
   "exercise" should {
-    import com.daml.ledger.client.binding.Value.encode
     val imId: P.ContractId[MyMain.InterfaceMixer] = P.ContractId("fakeimid")
     val itmId: P.ContractId[MyMainIface.IfaceFromAnotherMod] = P.ContractId("fakeitmid")
     val DirectTemplateId = ApiTypes.TemplateId unwrap MyMain.InterfaceMixer.id

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlContractTemplateGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlContractTemplateGen.scala
@@ -62,6 +62,14 @@ object DamlContractTemplateGen {
 
     def consumingChoicesMethod = LFUtil.genConsumingChoicesMethod(templateInterface.template)
 
+    def implementedInterfaceProof = templateInterface.template.implementedInterfaces map { ifn =>
+      val ifSn = util.mkDamlScalaName(ifn.qualifiedName)
+      q"""implicit val ${TermName(s"implements ${ifSn.qualifiedTermName}")}
+         : $domainApiAlias.Template.Implements[${TypeName(templateName.name)},
+                                               ${ifSn.qualifiedTypeName}] =
+         new $domainApiAlias.Template.Implements"""
+    }
+
     def templateObjectMembers = Seq(
       generateTemplateIdDef(templateId),
       genChoiceImplicitClass(util)(
@@ -73,7 +81,7 @@ object DamlContractTemplateGen {
       consumingChoicesMethod,
       toNamedArgumentsMethod,
       fromNamedArgumentsMethod,
-    )
+    ) ++ implementedInterfaceProof
 
     def templateClassMembers = Seq(
       q"protected[this] override def templateCompanion(implicit ` d`: $domainApiAlias.Compat.DummyImplicit) = ${TermName(templateName.name)}"


### PR DESCRIPTION
Fixes #13925.

```rst
CHANGELOG_BEGIN
- [Scala codegen] Template contract IDs and interface contract IDs have
  new coercion methods, ``toInterface`` and ``unsafeToTemplate``,
  respectively.

  ``toInterface`` can also be used with ``createAnd`` as well as ``key``
  for create-and-exercise and exercise-by-key respectively; however, see
  #13993 for a caveat regarding ledger API support.
CHANGELOG_END
```

* [x] #13975 
* [x] rebase and change PR target to main
* [x] changelog