### PR TITLE
Fix Sandbox-on-X error messages for inconsistent/duplicate key conflicts

### DIFF
--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/domain/Rejection.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/domain/Rejection.scala
@@ -78,8 +78,8 @@ private[sandbox] object Rejection {
     override def toStatus: Status =
       LedgerApiErrors.WriteServiceRejections.Internal.InternallyInconsistentKeys
         .Reject(
-          "The transaction attempts to create two contracts with the same contract key",
-          Some(key),
+          cause = "The transaction references a contract key inconsistently",
+          keyO = Some(key),
         )
         .rpcStatus()
   }
@@ -92,7 +92,10 @@ private[sandbox] object Rejection {
   ) extends Rejection {
     override def toStatus: Status =
       LedgerApiErrors.WriteServiceRejections.Internal.InternallyDuplicateKeys
-        .Reject("The transaction references a contract key inconsistently", Some(key))
+        .Reject(
+          cause = "The transaction attempts to create two contracts with the same contract key",
+          keyO = Some(key),
+        )
         .rpcStatus()
   }
 


### PR DESCRIPTION
changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
