### PR TITLE
[LLP] Move `ledger-api-transactions-buffer-max-size` to Config from ParticipantConfig

### DIFF
--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfig.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfig.scala
@@ -449,6 +449,7 @@ object CliConfig {
 
         opt[Int]("ledger-api-transactions-buffer-max-size")
           .optional()
+          .hidden()
           .text(
             s"Maximum size of the in-memory fan-out buffer used for serving Ledger API transaction streams. Default is ${IndexServiceConfig.DefaultMaxTransactionsInMemoryFanOutBufferSize}."
           )

--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfigConverter.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfigConverter.scala
@@ -36,7 +36,7 @@ object CliConfigConverter {
       eventsProcessingParallelism = cliConfig.eventsProcessingParallelism,
       maxContractStateCacheSize = config.maxContractStateCacheSize,
       maxContractKeyStateCacheSize = config.maxContractKeyStateCacheSize,
-      maxTransactionsInMemoryFanOutBufferSize = config.maxTransactionsInMemoryFanOutBufferSize,
+      maxTransactionsInMemoryFanOutBufferSize = cliConfig.maxTransactionsInMemoryFanOutBufferSize,
     ),
     lfValueTranslationCache = LfValueTranslationCache.Config(
       contractsMaximumSize = cliConfig.lfValueTranslationContractCache.maximumSize,

--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliParticipantConfig.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliParticipantConfig.scala
@@ -26,8 +26,6 @@ final case class CliParticipantConfig(
       CliParticipantConfig.DefaultApiServerDatabaseConnectionTimeout,
     maxContractStateCacheSize: Long = IndexServiceConfig.DefaultMaxContractStateCacheSize,
     maxContractKeyStateCacheSize: Long = IndexServiceConfig.DefaultMaxContractKeyStateCacheSize,
-    maxTransactionsInMemoryFanOutBufferSize: Long =
-      IndexServiceConfig.DefaultMaxTransactionsInMemoryFanOutBufferSize,
 )
 
 object CliParticipantConfig {

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
@@ -16,7 +16,7 @@ final case class IndexServiceConfig(
     acsGlobalParallelism: Int = IndexServiceConfig.DefaultAcsGlobalParallelism,
     maxContractStateCacheSize: Long = IndexServiceConfig.DefaultMaxContractStateCacheSize,
     maxContractKeyStateCacheSize: Long = IndexServiceConfig.DefaultMaxContractKeyStateCacheSize,
-    maxTransactionsInMemoryFanOutBufferSize: Long =
+    maxTransactionsInMemoryFanOutBufferSize: Int =
       IndexServiceConfig.DefaultMaxTransactionsInMemoryFanOutBufferSize,
     enableInMemoryFanOutForLedgerApi: Boolean =
       IndexServiceConfig.DefaultEnableInMemoryFanOutForLedgerApi,
@@ -34,7 +34,7 @@ object IndexServiceConfig {
   val DefaultAcsGlobalParallelism: Int = 10
   val DefaultMaxContractStateCacheSize: Long = 100000L
   val DefaultMaxContractKeyStateCacheSize: Long = 100000L
-  val DefaultMaxTransactionsInMemoryFanOutBufferSize: Long = 10000L
+  val DefaultMaxTransactionsInMemoryFanOutBufferSize: Int = 10000
   val DefaultEnableInMemoryFanOutForLedgerApi = false
   val DefaultApiStreamShutdownTimeout: Duration = FiniteDuration(5, "seconds")
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/EventsBuffer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/EventsBuffer.scala
@@ -34,7 +34,7 @@ import scala.math.Ordering
   * @tparam ENTRY The entry buffer type.
   */
 final class EventsBuffer[ENTRY](
-    maxBufferSize: Long,
+    maxBufferSize: Int,
     metrics: Metrics,
     bufferQualifier: String,
     isRangeEndMarker: ENTRY => Boolean,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/BufferedTransactionsReaderSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/appendonlydao/events/BufferedTransactionsReaderSpec.scala
@@ -73,7 +73,7 @@ class BufferedTransactionsReaderSpec
       .toMap
 
     val transactionsBuffer = new EventsBuffer[TransactionLogUpdate](
-      maxBufferSize = 3L,
+      maxBufferSize = 3,
       metrics = metrics,
       bufferQualifier = "test",
       isRangeEndMarker = _.isInstanceOf[TransactionLogUpdate.LedgerEndMarker],
@@ -159,7 +159,7 @@ class BufferedTransactionsReaderSpec
 
       "fetch from buffer and storage chunked" in {
         val transactionsBufferWithSmallChunkSize = new EventsBuffer[TransactionLogUpdate](
-          maxBufferSize = 3L,
+          maxBufferSize = 3,
           metrics = metrics,
           bufferQualifier = "test",
           isRangeEndMarker = _.isInstanceOf[TransactionLogUpdate.LedgerEndMarker],
@@ -194,7 +194,7 @@ class BufferedTransactionsReaderSpec
     "request before buffer bounds" should {
       "fetch only from storage" in {
         val transactionsBuffer = new EventsBuffer[TransactionLogUpdate](
-          maxBufferSize = 1L,
+          maxBufferSize = 1,
           metrics = metrics,
           bufferQualifier = "test",
           isRangeEndMarker = _.isInstanceOf[TransactionLogUpdate.LedgerEndMarker],

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/EventsBufferSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/cache/EventsBufferSpec.scala
@@ -33,7 +33,7 @@ class EventsBufferSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPr
 
   "push" when {
     "max buffer size reached" should {
-      "drop oldest" in withBuffer(3L) { buffer =>
+      "drop oldest" in withBuffer(3) { buffer =>
         buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
           bufferedStartExclusive = offset2,
           slice = Vector(entry3, entry4),
@@ -47,7 +47,7 @@ class EventsBufferSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPr
     }
 
     "element with smaller offset added" should {
-      "throw" in withBuffer(3L) { buffer =>
+      "throw" in withBuffer(3) { buffer =>
         intercept[UnorderedException[Int]] {
           buffer.push(offset1, 2)
         }.getMessage shouldBe s"Elements appended to the buffer should have strictly increasing offsets: $offset4 vs $offset1"
@@ -55,7 +55,7 @@ class EventsBufferSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPr
     }
 
     "element with equal offset added" should {
-      "throw" in withBuffer(3L) { buffer =>
+      "throw" in withBuffer(3) { buffer =>
         intercept[UnorderedException[Int]] {
           buffer.push(offset4, 2)
         }.getMessage shouldBe s"Elements appended to the buffer should have strictly increasing offsets: $offset4 vs $offset4"
@@ -63,7 +63,7 @@ class EventsBufferSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPr
     }
 
     "range end with equal offset added" should {
-      "accept it" in withBuffer(3L) { buffer =>
+      "accept it" in withBuffer(3) { buffer =>
         buffer.push(LastOffset, Int.MaxValue)
         buffer.slice(BeginOffset, LastOffset, IdentityFilter) shouldBe LastBufferChunkSuffix(
           bufferedStartExclusive = offset2,
@@ -118,7 +118,7 @@ class EventsBufferSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPr
           buffer.slice(offset2, offset1, IdentityFilter) shouldBe Inclusive(Vector.empty)
       }
       "return an empty LastBufferChunkSuffix slice if startExclusive is before buffer start" in withBuffer(
-        maxBufferSize = 2L
+        maxBufferSize = 2
       ) { buffer =>
         buffer.slice(offset1, offset1, IdentityFilter) shouldBe LastBufferChunkSuffix(
           offset1,
@@ -345,7 +345,7 @@ class EventsBufferSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPr
   }
 
   private def withBuffer(
-      maxBufferSize: Long = 5L,
+      maxBufferSize: Int = 5,
       elems: immutable.Vector[(Offset, Int)] = bufferElements,
       maxFetchSize: Int = 10,
   )(test: EventsBuffer[Int] => Assertion): Assertion = {

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -509,7 +509,7 @@ conformance_test(
     server = ":app",
     server_args = [
         "--contract-id-seeding=testing-weak",
-        "--participant participant-id=example,port=6865,ledger-api-transactions-buffer-max-size=100000",
+        "--participant participant-id=example,port=6865",
         "--buffered-ledger-api-streams",
     ],
     test_tool_args = [
@@ -523,7 +523,8 @@ conformance_test(
     server = ":app",
     server_args = [
         "--contract-id-seeding=testing-weak",
-        "--participant participant-id=example,port=6865,ledger-api-transactions-buffer-max-size=3",
+        "--participant participant-id=example,port=6865",
+        "--ledger-api-transactions-buffer-max-size=3",
         "--buffered-streams-page-size=1",
         "--buffered-ledger-api-streams",
     ],

--- a/ledger/sandbox-on-x/src/classic/scala/com/daml/platform/ledger/ConfigConverter.scala
+++ b/ledger/sandbox-on-x/src/classic/scala/com/daml/platform/ledger/ConfigConverter.scala
@@ -8,6 +8,7 @@ import com.daml.lf.engine.EngineConfig
 import com.daml.lf.language.LanguageVersion
 import com.daml.platform.apiserver.AuthServiceConfig
 import com.daml.platform.common.LedgerIdMode
+import com.daml.platform.configuration.IndexServiceConfig
 import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode}
 import com.daml.platform.sandbox.config.SandboxConfig.{DefaultTimeProviderType, EngineMode}
 import com.daml.platform.sandbox.config.{LedgerName, SandboxConfig}
@@ -87,6 +88,8 @@ object ConfigConverter {
       lfValueTranslationEventCache = sandboxConfig.lfValueTranslationEventCacheConfiguration,
       maxDeduplicationDuration = sandboxConfig.maxDeduplicationDuration,
       maxInboundMessageSize = sandboxConfig.maxInboundMessageSize,
+      maxTransactionsInMemoryFanOutBufferSize =
+        IndexServiceConfig.DefaultMaxTransactionsInMemoryFanOutBufferSize,
       metricsReporter = sandboxConfig.metricsReporter,
       metricsReportingInterval = sandboxConfig.metricsReportingInterval.toJava,
       mode = Mode.Run,


### PR DESCRIPTION
**NOTE**: This change is only for ease of testability purposes on a feature that is not currently deemed production ready. This change will be reverted.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
