### PR TITLE
Replace 'fetchByKey' with 'lookupByKey' in 'LookupKeyed' choice in `KeyNotVisibleStakeholders`

### DIFF
--- a/compiler/damlc/tests/daml-test-files/KeyNotVisibleStakeholders.daml
+++ b/compiler/damlc/tests/daml-test-files/KeyNotVisibleStakeholders.daml
@@ -49,10 +49,10 @@ template Delegation
         fetchByKey @Keyed sig
 
     choice LookupKeyed
-      : (ContractId Keyed, Keyed)
+      : Optional (ContractId Keyed)
       controller divulgee
       do
-        fetchByKey @Keyed sig
+        lookupByKey sig
 
 divulgeeFetch = scenario do
   sig <- getParty "s" -- Signatory


### PR DESCRIPTION
replaces https://github.com/digital-asset/daml/pull/14001
(removed trailing whitespace)