### PR TITLE
[KV] - Replace RESOURCE_EXHAUSTED KV error with RESOURCE_OVERLOADED [kvl-1290]

### DIFF
--- a/docs/resources/generated-error-pages/error-codes-inventory.rst.inc
+++ b/docs/resources/generated-error-pages/error-codes-inventory.rst.inc
@@ -124,7 +124,25 @@ Errors that relate to system resources.
 RESOURCE_EXHAUSTED
 ---------------------------------------------------------------------------------------------------------------------------------------
     
+    **Deprecation**: Replaced by RESOURCE_OVERLOADED. Since: 2.3.0
+    
     **Explanation**: A system resource has been exhausted.
+
+    **Category**: ContentionOnSharedResources
+
+    **Conveyance**: This error is logged with log-level INFO on the server side. This error is exposed on the API with grpc-status ABORTED including a detailed error message
+
+    **Resolution**: Retry the transaction submission or provide the details to the participant operator.
+
+
+
+
+.. _error_code_RESOURCE_OVERLOADED:
+
+RESOURCE_OVERLOADED
+---------------------------------------------------------------------------------------------------------------------------------------
+    
+    **Explanation**: A system resource is overloaded.
 
     **Category**: ContentionOnSharedResources
 

--- a/ledger/participant-state-kv-errors/src/main/scala/com/daml/ledger/error/definitions/kv/KvErrors.scala
+++ b/ledger/participant-state-kv-errors/src/main/scala/com/daml/ledger/error/definitions/kv/KvErrors.scala
@@ -151,6 +151,7 @@ object KvErrors extends ErrorGroup()(ErrorGroups.rootErrorClass) {
     @Resolution(
       "Retry the transaction submission or provide the details to the participant operator."
     )
+    @deprecated(since = "2.3.0", message = "Replaced by RESOURCE_OVERLOADED.")
     object ResourceExhausted
         extends ErrorCode(
           id = "RESOURCE_EXHAUSTED",
@@ -161,6 +162,23 @@ object KvErrors extends ErrorGroup()(ErrorGroups.rootErrorClass) {
       )(implicit loggingContext: ContextualizedErrorLogger)
           extends KVLoggingTransactionErrorImpl(
             cause = s"Resources exhausted: $details"
+          )
+    }
+
+    @Explanation("A system resource is overloaded.")
+    @Resolution(
+      "Retry the transaction submission or provide the details to the participant operator."
+    )
+    object ResourceOverloaded
+        extends ErrorCode(
+          id = "RESOURCE_OVERLOADED",
+          ErrorCategory.ContentionOnSharedResources,
+        ) {
+      case class Reject(
+          details: String
+      )(implicit loggingContext: ContextualizedErrorLogger)
+          extends KVLoggingTransactionErrorImpl(
+            cause = s"Resources overloaded: $details"
           )
     }
 


### PR DESCRIPTION
As RESOURCE_EXHAUSTED also represents a gRPC status code, to avoid confusion (as the error is mapped to gRPC status code ABORTED), we replace it with RESOURCE_OVERLOADED

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
