### PR TITLE
Add globalKeyMapping to WriteService [DPP-1067]

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -762,19 +762,19 @@ object Transaction {
 
   /** Transaction meta data
     *
-    * @param submissionSeed : the submission seed used to derive the contract IDs.
-    *                       If undefined no seed has been used (the legacy contract ID scheme
-    *                       have been used) or it is unknown (output of partial reinterpretation).
-    * @param submissionTime : the submission time
-    * @param usedPackages   The set of packages used during command processing.
-    *                       This is a hint for what packages are required to validate
-    *                       the transaction using the current interpreter.
-    *                       If set to `empty` the package dependency have not be computed.
-    * @param dependsOnTime  : indicate the transaction computation depends on ledger
-    *                       time.
-    * @param nodeSeeds      : An association list that maps to each ID of create and exercise
-    *                       nodes its seeds.
-    * @param keyMapping    : input key mapping inferred by interpretation
+    * @param submissionSeed   : the submission seed used to derive the contract IDs.
+    *                         If undefined no seed has been used (the legacy contract ID scheme
+    *                         have been used) or it is unknown (output of partial reinterpretation).
+    * @param submissionTime   : the submission time
+    * @param usedPackages     The set of packages used during command processing.
+    *                         This is a hint for what packages are required to validate
+    *                         the transaction using the current interpreter.
+    *                         If set to `empty` the package dependency have not be computed.
+    * @param dependsOnTime    : indicate the transaction computation depends on ledger
+    *                         time.
+    * @param nodeSeeds        : An association list that maps to each ID of create and exercise
+    *                         nodes its seeds.
+    * @param globalKeyMapping : input key mapping inferred by interpretation
     */
   final case class Metadata(
       submissionSeed: Option[crypto.Hash],

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutionResult.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutionResult.scala
@@ -4,7 +4,8 @@
 package com.daml.platform.apiserver.execution
 
 import com.daml.ledger.participant.state.{v2 => state}
-import com.daml.lf.transaction.SubmittedTransaction
+import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction}
+import com.daml.lf.value.Value
 
 /** The result of command execution.
   *
@@ -25,4 +26,5 @@ private[apiserver] final case class CommandExecutionResult(
     transaction: SubmittedTransaction,
     dependsOnLedgerTime: Boolean,
     interpretationTimeNanos: Long,
+    globalKeyMapping: Map[GlobalKey, Option[Value.ContractId]],
 )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -115,6 +115,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
       transaction = updateTx,
       dependsOnLedgerTime = meta.dependsOnTime,
       interpretationTimeNanos = interpretationTimeNanos,
+      globalKeyMapping = meta.globalKeyMapping,
     )
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -259,6 +259,7 @@ private[apiserver] final class ApiSubmissionService private[services] (
         result.transactionMeta,
         result.transaction,
         result.interpretationTimeNanos,
+        result.globalKeyMapping,
       )
       .toScalaUnwrapped
   }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
@@ -81,6 +81,7 @@ class LedgerTimeAwareCommandExecutorSpec
       transaction,
       dependsOnLedgerTime,
       5L,
+      Map.empty,
     )
 
     val mockExecutor = mock[CommandExecutor]
@@ -145,6 +146,7 @@ class LedgerTimeAwareCommandExecutorSpec
             transaction,
             dependsOnLedgerTime,
             5L,
+            Map.empty,
           )
         )
 

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v2/metrics/TimedWriteService.scala
@@ -17,7 +17,8 @@ import com.daml.ledger.participant.state.v2.{
   WriteService,
 }
 import com.daml.lf.data.{Ref, Time}
-import com.daml.lf.transaction.SubmittedTransaction
+import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction}
+import com.daml.lf.value.Value
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.telemetry.TelemetryContext
@@ -29,6 +30,7 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
+      globalKeyMapping: Map[GlobalKey, Option[Value.ContractId]],
   )(implicit
       loggingContext: LoggingContext,
       telemetryContext: TelemetryContext,
@@ -41,6 +43,7 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
         transactionMeta,
         transaction,
         estimatedInterpretationCost,
+        globalKeyMapping,
       ),
     )
 

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v2/WriteService.scala
@@ -6,7 +6,8 @@ package com.daml.ledger.participant.state.v2
 import java.util.concurrent.CompletionStage
 
 import com.daml.ledger.api.health.ReportsHealth
-import com.daml.lf.transaction.SubmittedTransaction
+import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction}
+import com.daml.lf.value.Value
 import com.daml.logging.LoggingContext
 import com.daml.telemetry.TelemetryContext
 
@@ -95,12 +96,16 @@ trait WriteService
     *                                    daml-lf/spec/contract-id.rst.
     * @param estimatedInterpretationCost Estimated cost of interpretation that may be used for
     *                                    handling submitted transactions differently.
+    * @param globalKeyMapping            Input key mapping inferred by interpretation.
+    *                                    The map should contain all contract keys that were used during interpretation.
+    *                                    A value of None means no contract was found with this contract key.
     */
   def submitTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
+      globalKeyMapping: Map[GlobalKey, Option[Value.ContractId]],
   )(implicit
       loggingContext: LoggingContext,
       telemetryContext: TelemetryContext,

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeWriteService.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeWriteService.scala
@@ -17,13 +17,14 @@ import com.daml.ledger.participant.state.v2._
 import com.daml.ledger.sandbox.bridge.{BridgeMetrics, LedgerBridge}
 import com.daml.ledger.sandbox.domain.{Rejection, Submission}
 import com.daml.lf.data.{Ref, Time}
-import com.daml.lf.transaction.SubmittedTransaction
+import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.InstrumentedGraph
 import com.daml.telemetry.TelemetryContext
-
 import java.time.Duration
 import java.util.concurrent.{CompletableFuture, CompletionStage}
+
+import com.daml.lf.value.Value
 
 class BridgeWriteService(
     feedSink: Sink[(Offset, Update), NotUsed],
@@ -47,6 +48,7 @@ class BridgeWriteService(
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long,
+      globalKeyMapping: Map[GlobalKey, Option[Value.ContractId]],
   )(implicit
       loggingContext: LoggingContext,
       telemetryContext: TelemetryContext,


### PR DESCRIPTION
The field globalKeyMapping is recently added to
lf.transaction.Transaction.Metadata, and which is
computed by the Engine.
This field might be needed for processing by WriteService
implementors.
This PR adds this to the WriteService.

changelog_begin
Global contract key mapping is added to WriteService.
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
