### PR TITLE
split releases: add parameter

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -60,7 +60,6 @@ jobs:
 - job: Linux
   dependsOn:
     - check_for_release
-    - git_sha
   variables:
     - name: release_sha
       value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
@@ -108,7 +107,6 @@ jobs:
 - job: macOS
   dependsOn:
     - check_for_release
-    - git_sha
   timeoutInMinutes: 360
   pool:
     name: macOS-pool
@@ -147,7 +145,6 @@ jobs:
 - job: Windows
   dependsOn:
     - check_for_release
-    - git_sha
   variables:
     - name: release_sha
       value: $[ dependencies.check_for_release.outputs['out.release_sha'] ]

--- a/ci/daily-snapshot.yml
+++ b/ci/daily-snapshot.yml
@@ -10,13 +10,16 @@ schedules:
     include:
     - main
 
+parameters:
+- name: version
+  type: string
+  default: snapshot
+- name: commit
+  type: string
+  default: HEAD
+
 jobs:
 - job: check_for_release
-  dependsOn:
-    - git_sha
-  variables:
-    branch_sha: $[ dependencies.git_sha.outputs['out.branch'] ]
-    fork_sha: $[ dependencies.git_sha.outputs['out.fork_point'] ]
   pool:
     name: "ubuntu_20_04"
     demands: assignment -equals default
@@ -30,7 +33,11 @@ jobs:
         source $(bash-lib)
 
         prefix=$(cat NIGHTLY_PREFIX)
-        release=$(./release.sh snapshot HEAD $prefix | awk '{print $2}')
+        if [ "${{ parameters.version }}" = "snapshot" ]; then
+            release=$(./release.sh snapshot HEAD $prefix | awk '{print $2}')
+        else
+            release=${{ parameters.version }}
+        fi
 
         ERR=$(mktemp)
         OUT=$(curl https://digitalasset.jfrog.io/artifactory/api/storage/assembly/daml/$release \
@@ -45,9 +52,9 @@ jobs:
             ;;
           404)
             setvar is_release true
-            setvar trigger_sha "$(branch_sha)"
-            setvar release_sha "$(branch_sha)"
-            setvar release_tag "$release"
+            setvar trigger_sha $(git rev-parse HEAD)
+            setvar release_sha $(git rev-parse ${{ parameters.commit }})
+            setvar release_tag $release
             setvar split_release_process true
             ;;
           *)


### PR DESCRIPTION
This adds parameters to the "split release" job. At the moment, when run, the job just builds the current commit with a snapshot version. With this change, we'll be able to build a split release for any commit with any version tag.

The reason for this change is we want to trigger this job from the assembly repo, to reduce the number of manual interventions needed in the release process.

CHANGELOG_BEGIN
CHANGELOG_END