### PR TITLE
ledger api: add interface subscriptions exercise streams

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -7,6 +7,8 @@ package com.daml.ledger.api.v1;
 
 import "com/daml/ledger/api/v1/value.proto";
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/any.proto";
+import "google/rpc/status.proto";
 
 
 option java_outer_classname = "EventOuterClass";
@@ -54,8 +56,21 @@ message CreatedEvent {
   Value contract_key = 7;
 
   // The arguments that have been used to create the contract.
-  // Required
+  // Set if there was a match by template_id in the given transaction filter.
+  // Optional
   Record create_arguments = 4;
+
+  // Opaque representation of contract payload intented for forwarding
+  // to an API server as a contract disclosed as part of a command
+  // submission.
+  // Optional
+  google.protobuf.Any create_arguments_blob = 10;
+
+  // Interface views specified in the transaction filter. Only contains entries
+  // for the intersection of interfaces implemented by the template
+  // and the interfaces specified in the transaction filter.
+  // Optional
+  repeated InterfaceView interface_views = 11;
 
   // The parties that are notified of this event. When a ``CreatedEvent``
   // is returned as part of a transaction tree, this will include all
@@ -84,6 +99,25 @@ message CreatedEvent {
   google.protobuf.StringValue agreement_text = 6;
 }
 
+// View of a create event matched by an interface filter.
+message InterfaceView {
+
+  // The interface implemented by the matched event.
+  // Required
+  Identifier interface_id = 1;
+
+  // Whether the view was successfully computed, and if not,
+  // the reason for the error. The error is reported using the same rules
+  // for error codes and messages as the errors returned for API requests.
+  // Required
+  google.rpc.Status view_status = 2;
+
+  // The value of the interface's canonical view method on this event.
+  // Optional
+  Record view_value = 3;
+
+}
+
 // Records that a contract has been archived, and choices may no longer be exercised on it.
 message ArchivedEvent {
 
@@ -101,7 +135,7 @@ message ArchivedEvent {
   // Required
   Identifier template_id = 3;
 
-  // The parties that are notified of this event. For ``ArchivedEvent``s,
+  // The parties that are notified of this event. For an ``ArchivedEvent``,
   // these are the intersection of the stakeholders of the contract in
   // question and the parties specified in the ``TransactionFilter``. The
   // stakeholders are the union of the signatories and the observers of
@@ -129,22 +163,22 @@ message ExercisedEvent {
   // Required
   Identifier template_id = 3;
 
-  // The interface where the choice is defined if inherited
+  // The interface where the choice is defined, if inherited.
   // Optional
   Identifier interface_id = 13;
 
   reserved 4; // removed field
 
-  // The choice that's been exercised on the target contract.
+  // The choice that was exercised on the target contract.
   // Must be a valid NameString (as described in ``value.proto``).
   // Required
   string choice = 5;
 
-  // The argument the choice was made with.
+  // The argument of the exercised choice.
   // Required
   Value choice_argument = 6;
 
-  // The parties that made the choice.
+  // The parties that exercised the choice.
   // Each element must be a valid PartyIdString (as described in ``value.proto``).
   // Required
   repeated string acting_parties = 7;
@@ -176,8 +210,8 @@ message ExercisedEvent {
   // Optional
   repeated string child_event_ids = 11;
 
-  // The result of exercising the choice
+  // The result of exercising the choice.
   // Required
   Value exercise_result = 12;
-
 }
+

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction.proto
@@ -68,7 +68,7 @@ message TreeEvent {
     }
 }
 
-// Filtered view of an on-ledger transaction.
+// Filtered view of an on-ledger transaction's create and archive events.
 message Transaction {
 
   // Assigned by the server. Useful for correlating logs.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction.proto
@@ -101,3 +101,36 @@ message Transaction {
   string offset = 6;
 
 }
+
+
+// Filtered view of an on-ledger transaction's exercise events.
+message TransactionExercises {
+
+  // Assigned by the server. Useful for correlating logs.
+  // Must be a valid LedgerString (as described in ``value.proto``).
+  // Required
+  string transaction_id = 1;
+
+  // The ID of the command which resulted in this transaction. Missing for everyone except the submitting party.
+  // Must be a valid LedgerString (as described in ``value.proto``).
+  // Optional
+  string command_id = 2;
+
+  // The workflow ID used in command submission.
+  // Must be a valid LedgerString (as described in ``value.proto``).
+  // Optional
+  string workflow_id = 3;
+
+  // Ledger effective time.
+  // Must be a valid LedgerString (as described in ``value.proto``).
+  // Required
+  google.protobuf.Timestamp effective_at = 4;
+
+  // The exercise events matching the filter in the order they were executed.
+  // Required
+  repeated ExercisedEvent events = 5;
+
+  // The absolute offset. The format of this field is described in ``ledger_offset.proto``.
+  // Required
+  string offset = 6;
+}

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -12,6 +12,10 @@ option java_outer_classname = "TransactionFilterOuterClass";
 option java_package = "com.daml.ledger.api.v1";
 option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 
+
+// Filtering Transaction, TransactionTree, and Active Contract Set streams
+//////////////////////////////////////////////////////////////////////////
+
 // A filter both for filtering create and archive events as well as for
 // filtering transaction trees.
 message TransactionFilter {
@@ -72,3 +76,39 @@ message InterfaceFilter {
   // Optional
   bool include_create_arguments_blob = 3;
 }
+
+
+// Filtering Exercise Event streams
+///////////////////////////////////
+
+// A filter for exercise events.
+message TransactionExerciseFilter {
+
+  // Include exercises of choices that are witnessed by the given party
+  // and match the per-party exercise event filter.
+  map<string, ExerciseEventFilter> per_party_filter = 1;
+}
+
+// An exercise event matches this filter if it matches one of the choice
+// filters. In contrast to a ``TransactionFilter``, no wildcard matches are
+// supported.
+message ExerciseEventFilter {
+
+  // Choices of interest.
+  // Required
+  repeated ChoiceFilter choices = 1;
+}
+
+// An exercise event matches a choice filter if the event's exercised choice
+// is equal to the one referenced in the filter.
+message ChoiceFilter {
+
+    // The template or interface defining the choice.
+    // Required
+    Identifier template_or_interface_id = 1;
+
+    // The name of the choice.
+    // Required
+    string choice = 3;
+}
+

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -12,30 +12,63 @@ option java_outer_classname = "TransactionFilterOuterClass";
 option java_package = "com.daml.ledger.api.v1";
 option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 
-// Used for filtering Transaction and Active Contract Set streams.
-// Determines which on-ledger events will be served to the client.
+// A filter both for filtering create and archive events as well as for
+// filtering transaction trees.
 message TransactionFilter {
 
-  // Keys of the map determine which parties' on-ledger transactions are being queried.
-  // Values of the map determine which events are disclosed in the stream per party.
-  // At the minimum, a party needs to set an empty Filters message to receive any events.
   // Each key must be a valid PartyIdString (as described in ``value.proto``).
+  // The interpretation of the filter depends on the stream being filtered:
+  // (1) For **transaction tree streams** only the listed parties matter, and all subtrees
+  //     whose root has one of the listed parties as an informee are returned.
+  // (2) For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
+  //    stakeholders include at least one of the listed parties and match the
+  //    per-party filter.
   // Required
   map<string, Filters> filters_by_party = 1;
 }
 
+// The union of a set of contract filters, or a wildcard.
 message Filters {
 
-  // If not set, no filters will be applied.
+  // If set, then contracts matching any of the ``InclusiveFilters`` match
+  // this filter.
+  // If not set, any contract matches this filter.
   // Optional
   InclusiveFilters inclusive = 1;
 }
 
-// If no internal fields are set, no filters will be applied.
+// A filter that matches all contracts that are either an instance of one of
+// the ``template_ids`` or that match one of the ``interface_filters``.
 message InclusiveFilters {
 
-  // A collection of templates.
+  // A collection of templates for which the payload will be included in the
+  // ``create_arguments`` of a matching ``CreatedEvent``.
   // SHOULD NOT contain duplicates.
-  // Required
+  // Optional
   repeated Identifier template_ids = 1;
+
+  // Include an ``InterfaceView`` for every ``InterfaceFilter`` matching a contract.
+  // Optional
+  repeated InterfaceFilter interface_filters = 2;
+}
+
+// This filter matches contracts that implement a specific interface.
+message InterfaceFilter {
+
+  // The interface that a matching contract must implement.
+  // Required
+  Identifier interface_id = 1;
+
+  // Whether to include the canonical interface view on the contract in the
+  // returned ``CreateEvent``.
+  // Use this to access contract data in a uniform manner in your API client.
+  // Optional
+  bool include_interface_view = 2;
+
+  // Whether to include a ``create_arguments_blob`` in the returned
+  // ``CreateEvent``.
+  // Use this to access the complete contract data in your API client
+  // for submitting it as a disclosed contract with future commands.
+  // Optional
+  bool include_create_arguments_blob = 3;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -39,6 +39,11 @@ service TransactionService {
   // - ``OUT_OF_RANGE``: if the ``begin`` parameter value is not before the end of the ledger
   rpc GetTransactionTrees (GetTransactionsRequest) returns (stream GetTransactionTreesResponse);
 
+
+  // Read the ledger's filtered transaction tree stream and emit the flat exercise events for a set of parties.
+  // Emits only exercise events.
+  rpc GetExerciseEvents (GetExerciseEventsRequest) returns (stream GetExerciseEventsResponse);
+
   // Lookup a transaction tree by the ID of an event that appears within it.
   // For looking up a transaction instead of a transaction tree, please see GetFlatTransactionByEventId
   // Errors:
@@ -176,4 +181,31 @@ message GetLedgerEndRequest {
 message GetLedgerEndResponse {
   // The absolute offset of the current ledger end.
   LedgerOffset offset = 1;
+}
+
+message GetExerciseEventsRequest {
+
+  // Beginning of the requested ledger section.
+  // This offset is exclusive: the response will only contain transactions whose offset is strictly greater than this.
+  // Required
+  LedgerOffset begin = 2;
+
+  // End of the requested ledger section.
+  // This offset is inclusive: the response will only contain transactions whose offset is less than or equal to this.
+  // Optional, if not set, the stream will not terminate.
+  LedgerOffset end = 3;
+
+  // The filter determining whether to include an ``ExercisedEvent`` in the
+  // result.
+  // Required
+  TransactionExerciseFilter filter = 4;
+
+  // If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+  // In particular, setting the verbose flag to true triggers the ledger to include labels for record fields.
+  // Optional
+  bool verbose = 5;
+}
+
+message GetExerciseEventsResponse {
+  TransactionExercises exercises = 1;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -177,4 +177,3 @@ message GetLedgerEndResponse {
   // The absolute offset of the current ledger end.
   LedgerOffset offset = 1;
 }
-


### PR DESCRIPTION
Uses #14033 as the base, as we we expect to first implement interface subscriptions for the ACS and transaction streams.

CHANGELOG_BEGIN
* ledger api: add exercise streams with interface subscriptions
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
