### PR TITLE
two-phase create-and-exercise with unified exercise methods in Java

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Template.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Template.java
@@ -3,9 +3,19 @@
 
 package com.daml.ledger.javaapi.data;
 
+import com.daml.ledger.javaapi.data.codegen.CreateAnd;
+
 public abstract class Template {
 
   public abstract CreateCommand create();
 
   public abstract DamlRecord toValue();
+
+  /**
+   * Set up a {@link CreateAndExerciseCommand}; invoke an {@code exercise} method
+   * on the result of this to finish creating the command, or convert to an
+   * interface first with {@code toInterface} to invoke an interface {@code exercise}
+   * method.
+   */
+  public abstract CreateAnd createAnd();
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Template.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Template.java
@@ -12,10 +12,9 @@ public abstract class Template {
   public abstract DamlRecord toValue();
 
   /**
-   * Set up a {@link CreateAndExerciseCommand}; invoke an {@code exercise} method
-   * on the result of this to finish creating the command, or convert to an
-   * interface first with {@code toInterface} to invoke an interface {@code exercise}
-   * method.
+   * Set up a {@link CreateAndExerciseCommand}; invoke an {@code exercise} method on the result of
+   * this to finish creating the command, or convert to an interface first with {@code toInterface}
+   * to invoke an interface {@code exercise} method.
    */
   public abstract CreateAnd createAnd();
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
@@ -6,10 +6,7 @@ package com.daml.ledger.javaapi.data.codegen;
 import com.daml.ledger.javaapi.data.ExerciseByKeyCommand;
 import com.daml.ledger.javaapi.data.Value;
 
-/**
- * Parent of all generated {@code ByKey} classes within templates and
- * interfaces.
- */
+/** Parent of all generated {@code ByKey} classes within templates and interfaces. */
 public abstract class ByKey implements Exercises<ExerciseByKeyCommand> {
   protected final Value contractKey;
 
@@ -27,8 +24,8 @@ public abstract class ByKey implements Exercises<ExerciseByKeyCommand> {
   protected abstract ContractTypeCompanion getCompanion();
 
   /**
-   * Parent of all generated {@code ByKey} classes within interfaces.
-   * These need to pass both the template and interface ID.
+   * Parent of all generated {@code ByKey} classes within interfaces. These need to pass both the
+   * template and interface ID.
    */
   public abstract static class ToInterface extends ByKey {
     private final ContractCompanion<?, ?, ?> keySource;

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
@@ -14,11 +14,26 @@ public abstract class ByKey implements Exercises<ExerciseByKeyCommand> {
   }
 
   @Override
-  public final ExerciseByKeyCommand makeExerciseCmd(String choice, Value choiceArgument) {
+  public ExerciseByKeyCommand makeExerciseCmd(String choice, Value choiceArgument) {
     return new ExerciseByKeyCommand(
         getCompanion().TEMPLATE_ID, contractKey, choice, choiceArgument);
   }
 
   /** The origin of the choice, not the template relevant to contractKey. */
   protected abstract ContractTypeCompanion getCompanion();
+
+  public abstract static class ToInterface extends ByKey {
+    private final ContractCompanion<?, ?, ?> keySource;
+
+    protected ToInterface(ContractCompanion<?, ?, ?> keySource, Value contractKey) {
+      super(contractKey);
+      this.keySource = keySource;
+    }
+
+    @Override
+    public ExerciseByKeyCommand makeExerciseCmd(String choice, Value choiceArgument) {
+      // TODO #14056 use getCompanion().TEMPLATE_ID as the interface ID
+      return new ExerciseByKeyCommand(keySource.TEMPLATE_ID, contractKey, choice, choiceArgument);
+    }
+  }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen;
+
+import com.daml.ledger.javaapi.data.ExerciseByKeyCommand;
+import com.daml.ledger.javaapi.data.Value;
+
+public abstract class ByKey implements Exercises<ExerciseByKeyCommand> {
+  protected final Value contractKey;
+
+  protected ByKey(Value contractKey) {
+    this.contractKey = contractKey;
+  }
+
+  @Override
+  public final ExerciseByKeyCommand makeExerciseCmd(String choice, Value choiceArgument) {
+    return new ExerciseByKeyCommand(
+        getCompanion().TEMPLATE_ID, contractKey, choice, choiceArgument);
+  }
+
+  /** The origin of the choice, not the template relevant to contractKey. */
+  protected abstract ContractTypeCompanion getCompanion();
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ByKey.java
@@ -6,6 +6,10 @@ package com.daml.ledger.javaapi.data.codegen;
 import com.daml.ledger.javaapi.data.ExerciseByKeyCommand;
 import com.daml.ledger.javaapi.data.Value;
 
+/**
+ * Parent of all generated {@code ByKey} classes within templates and
+ * interfaces.
+ */
 public abstract class ByKey implements Exercises<ExerciseByKeyCommand> {
   protected final Value contractKey;
 
@@ -22,6 +26,10 @@ public abstract class ByKey implements Exercises<ExerciseByKeyCommand> {
   /** The origin of the choice, not the template relevant to contractKey. */
   protected abstract ContractTypeCompanion getCompanion();
 
+  /**
+   * Parent of all generated {@code ByKey} classes within interfaces.
+   * These need to pass both the template and interface ID.
+   */
   public abstract static class ToInterface extends ByKey {
     private final ContractCompanion<?, ?, ?> keySource;
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
@@ -21,10 +21,7 @@ import java.util.function.Function;
  * @param <Data> The generated {@link com.daml.ledger.javaapi.data.Template} subclass named after
  *     the template, whose instances contain only the payload.
  */
-public abstract class ContractCompanion<Ct, Id, Data> {
-  /** The full template ID of the template that defined this companion. */
-  public final Identifier TEMPLATE_ID;
-
+public abstract class ContractCompanion<Ct, Id, Data> extends ContractTypeCompanion {
   final String templateClassName; // not something we want outside this package
 
   protected final Function<String, Id> newContractId;
@@ -45,7 +42,7 @@ public abstract class ContractCompanion<Ct, Id, Data> {
       Identifier templateId,
       Function<String, Id> newContractId,
       Function<DamlRecord, Data> fromValue) {
-    this.TEMPLATE_ID = templateId;
+    super(templateId);
     this.templateClassName = templateClassName;
     this.newContractId = newContractId;
     this.fromValue = fromValue;

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractId.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractId.java
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.javaapi.data.codegen;
 
+import com.daml.ledger.javaapi.data.ExerciseCommand;
 import com.daml.ledger.javaapi.data.Value;
 import java.util.Objects;
 
@@ -35,7 +36,7 @@ import java.util.Objects;
  *
  * @param <T> A template type
  */
-public class ContractId<T> {
+public class ContractId<T> implements Exercises<ExerciseCommand> {
   public final String contractId;
 
   public ContractId(String contractId) {
@@ -44,6 +45,18 @@ public class ContractId<T> {
 
   public final Value toValue() {
     return new com.daml.ledger.javaapi.data.ContractId(contractId);
+  }
+
+  @Override
+  public final ExerciseCommand makeExerciseCmd(String choice, Value choiceArgument) {
+    return new ExerciseCommand(getCompanion().TEMPLATE_ID, contractId, choice, choiceArgument);
+  }
+
+  // overridden by every code generator, but decoding abstractly can e.g.
+  // produce a ContractId<Foo> that is not a Foo.ContractId
+  protected ContractTypeCompanion getCompanion() {
+    throw new UnsupportedOperationException(
+        "Cannot exercise on a contract ID type without code-generated exercise methods");
   }
 
   @Override

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
@@ -6,11 +6,11 @@ package com.daml.ledger.javaapi.data.codegen;
 import com.daml.ledger.javaapi.data.Identifier;
 
 /** The commonality between {@link ContractCompanion} and {@link InterfaceCompanion}. */
-public class ContractTypeCompanion {
+public abstract class ContractTypeCompanion {
   /** The full template ID of the template or interface that defined this companion. */
   public final Identifier TEMPLATE_ID;
 
-  public ContractTypeCompanion(Identifier templateId) {
+  protected ContractTypeCompanion(Identifier templateId) {
     TEMPLATE_ID = templateId;
   }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractTypeCompanion.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen;
+
+import com.daml.ledger.javaapi.data.Identifier;
+
+/** The commonality between {@link ContractCompanion} and {@link InterfaceCompanion}. */
+public class ContractTypeCompanion {
+  /** The full template ID of the template or interface that defined this companion. */
+  public final Identifier TEMPLATE_ID;
+
+  public ContractTypeCompanion(Identifier templateId) {
+    TEMPLATE_ID = templateId;
+  }
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
@@ -15,11 +15,27 @@ public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
   }
 
   @Override
-  public final CreateAndExerciseCommand makeExerciseCmd(String choice, Value choiceArgument) {
+  public CreateAndExerciseCommand makeExerciseCmd(String choice, Value choiceArgument) {
     return new CreateAndExerciseCommand(
         getCompanion().TEMPLATE_ID, createArguments.toValue(), choice, choiceArgument);
   }
 
   /** The origin of the choice, not the createArguments. */
   protected abstract ContractTypeCompanion getCompanion();
+
+  public abstract static class ToInterface extends CreateAnd {
+    private final ContractCompanion<?, ?, ?> createSource;
+
+    protected ToInterface(ContractCompanion<?, ?, ?> createSource, Template createArguments) {
+      super(createArguments);
+      this.createSource = createSource;
+    }
+
+    @Override
+    public final CreateAndExerciseCommand makeExerciseCmd(String choice, Value choiceArgument) {
+      // TODO #14056 use getCompanion().TEMPLATE_ID as the interface ID
+      return new CreateAndExerciseCommand(
+          createSource.TEMPLATE_ID, createArguments.toValue(), choice, choiceArgument);
+    }
+  }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
@@ -8,7 +8,7 @@ import com.daml.ledger.javaapi.data.Template;
 import com.daml.ledger.javaapi.data.Value;
 
 public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
-  private final Template createArguments;
+  protected final Template createArguments;
 
   protected CreateAnd(Template createArguments) {
     this.createArguments = createArguments;
@@ -20,5 +20,5 @@ public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
         getCompanion().TEMPLATE_ID, createArguments.toValue(), choice, choiceArgument);
   }
 
-  public abstract ContractTypeCompanion getCompanion();
+  protected abstract ContractTypeCompanion getCompanion();
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
@@ -7,6 +7,10 @@ import com.daml.ledger.javaapi.data.CreateAndExerciseCommand;
 import com.daml.ledger.javaapi.data.Template;
 import com.daml.ledger.javaapi.data.Value;
 
+/**
+ * Parent of all generated {@code CreateAnd} classes within templates and
+ * interfaces.
+ */
 public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
   protected final Template createArguments;
 
@@ -23,6 +27,10 @@ public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
   /** The origin of the choice, not the createArguments. */
   protected abstract ContractTypeCompanion getCompanion();
 
+  /**
+   * Parent of all generated {@code CreateAnd} classes within interfaces.
+   * These need to pass both the template and interface ID.
+   */
   public abstract static class ToInterface extends CreateAnd {
     private final ContractCompanion<?, ?, ?> createSource;
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen;
+
+import com.daml.ledger.javaapi.data.CreateAndExerciseCommand;
+import com.daml.ledger.javaapi.data.Template;
+import com.daml.ledger.javaapi.data.Value;
+
+public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
+  private final Template createArguments;
+
+  protected CreateAnd(Template createArguments) {
+    this.createArguments = createArguments;
+  }
+
+  @Override
+  public final CreateAndExerciseCommand makeExerciseCmd(String choice, Value choiceArgument) {
+    return new CreateAndExerciseCommand(
+        getCompanion().TEMPLATE_ID, createArguments.toValue(), choice, choiceArgument);
+  }
+
+  public abstract ContractTypeCompanion getCompanion();
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
@@ -7,10 +7,7 @@ import com.daml.ledger.javaapi.data.CreateAndExerciseCommand;
 import com.daml.ledger.javaapi.data.Template;
 import com.daml.ledger.javaapi.data.Value;
 
-/**
- * Parent of all generated {@code CreateAnd} classes within templates and
- * interfaces.
- */
+/** Parent of all generated {@code CreateAnd} classes within templates and interfaces. */
 public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
   protected final Template createArguments;
 
@@ -28,8 +25,8 @@ public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
   protected abstract ContractTypeCompanion getCompanion();
 
   /**
-   * Parent of all generated {@code CreateAnd} classes within interfaces.
-   * These need to pass both the template and interface ID.
+   * Parent of all generated {@code CreateAnd} classes within interfaces. These need to pass both
+   * the template and interface ID.
    */
   public abstract static class ToInterface extends CreateAnd {
     private final ContractCompanion<?, ?, ?> createSource;

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/CreateAnd.java
@@ -20,5 +20,6 @@ public abstract class CreateAnd implements Exercises<CreateAndExerciseCommand> {
         getCompanion().TEMPLATE_ID, createArguments.toValue(), choice, choiceArgument);
   }
 
+  /** The origin of the choice, not the createArguments. */
   protected abstract ContractTypeCompanion getCompanion();
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Exercises.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/Exercises.java
@@ -1,0 +1,15 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.javaapi.data.codegen;
+
+import com.daml.ledger.javaapi.data.Value;
+
+/**
+ * Root of all generated {@code Exercises} interfaces for templates and Daml interfaces.
+ *
+ * @param <Cmd> The returned type of ledger command.
+ */
+public interface Exercises<Cmd> {
+  Cmd makeExerciseCmd(String choice, Value choiceArgument);
+}

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/InterfaceCompanion.java
@@ -3,12 +3,16 @@
 
 package com.daml.ledger.javaapi.data.codegen;
 
+import com.daml.ledger.javaapi.data.Identifier;
+
 /**
  * Metadata and utilities associated with an interface as a whole. Its subclasses serve to
  * disambiguate various generated {@code toInterface} overloads.
  *
  * @param <I> The generated interface marker class.
  */
-public abstract class InterfaceCompanion<I> {
-  protected InterfaceCompanion() {}
+public abstract class InterfaceCompanion<I> extends ContractTypeCompanion {
+  protected InterfaceCompanion(Identifier templateId) {
+    super(templateId);
+  }
 }

--- a/language-support/java/codegen/src/ledger-tests/daml/Interfaces.daml
+++ b/language-support/java/codegen/src/ledger-tests/daml/Interfaces.daml
@@ -21,6 +21,9 @@ template Child
     party: Party
   where
     signatory party
+    key party: Party
+    maintainer key
+
     choice Bar: () with
       controller party
       do

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/CodegenLedgerTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/CodegenLedgerTest.scala
@@ -154,7 +154,7 @@ class CodegenLedgerTest
 
       val tob = Instant.now().`with`(ChronoField.NANO_OF_SECOND, 0)
       val reproduceByKeyCmd =
-        Wolpertinger.exerciseByKeyReproduce(glookoflyContract.key.get, sruquitoContract.id, tob)
+        Wolpertinger.byKey(glookoflyContract.key.get).exerciseReproduce(sruquitoContract.id, tob)
       sendCmd(client, alice, reproduceByKeyCmd)
 
       val wolpertingers = readActiveContractPayloads(Wolpertinger.COMPANION)(client, alice)
@@ -217,7 +217,7 @@ class CodegenLedgerTest
           client,
           asList(alice),
           asList(charlie),
-          MultiParty.exerciseByKeyMPFetchOtherByKey(new da.types.Tuple2(alice, bob), charlie, bob),
+          MultiParty.byKey(new da.types.Tuple2(alice, bob)).exerciseMPFetchOtherByKey(charlie, bob),
         )
       }
     } yield succeed

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/CodegenLedgerTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/CodegenLedgerTest.scala
@@ -109,7 +109,7 @@ class CodegenLedgerTest
       glookoflyContract.data shouldEqual glookofly
 
       val tob = Instant.now().`with`(ChronoField.NANO_OF_SECOND, 0)
-      val reproduceCmd = sruquito.createAndExerciseReproduce(glookoflyContract.id, tob)
+      val reproduceCmd = sruquito.createAnd.exerciseReproduce(glookoflyContract.id, tob)
       sendCmd(client, alice, reproduceCmd)
 
       val wolpertingers = readActiveContracts(Wolpertinger.Contract.fromCreatedEvent)(client, alice)

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
@@ -52,6 +52,7 @@ object ClassForType extends StrictLogging {
             className,
             interface,
             packagePrefixes,
+            typeWithContext.interface.typeDecls,
             typeWithContext.interface.packageId,
             interfaceName,
           )

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
@@ -12,7 +12,6 @@ import com.squareup.javapoet._
 import com.daml.ledger.javaapi
 
 import javax.lang.model.element.Modifier
-import scala.jdk.CollectionConverters._
 
 private[inner] object ClassGenUtils {
 
@@ -79,13 +78,12 @@ private[inner] object ClassGenUtils {
       choiceName: ChoiceName,
       choice: TemplateChoice[Type],
       fields: Fields,
-      modifiers: Seq[Modifier],
       packagePrefixes: Map[PackageId, String],
-  ): MethodSpec = {
+  )(alter: MethodSpec.Builder => MethodSpec.Builder): MethodSpec = {
     val methodName = s"$name${choiceName.capitalize}"
     val choiceBuilder = MethodSpec
       .methodBuilder(methodName)
-      .addModifiers((modifiers :+ Modifier.PUBLIC).asJava)
+      .addModifiers(Modifier.PUBLIC)
       .returns(returns)
     val javaType = toJavaTypeName(choice.param, packagePrefixes)
     for (FieldInfo(_, _, javaName, javaType) <- fields) {
@@ -97,7 +95,7 @@ private[inner] object ClassGenUtils {
       javaType,
       generateArgumentList(fields.map(_.javaName)),
     )
-    choiceBuilder.build()
+    alter(choiceBuilder).build()
   }
 
   def generateGetCompanion(companionType: TypeName, companionName: String): MethodSpec = {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
@@ -12,7 +12,7 @@ import com.squareup.javapoet._
 import com.daml.ledger.javaapi
 
 import javax.lang.model.element.Modifier
-import scala.reflect.ClassTag
+import scala.jdk.CollectionConverters._
 
 private[inner] object ClassGenUtils {
 
@@ -73,18 +73,20 @@ private[inner] object ClassGenUtils {
       )
       .build()
 
-  def generateFlattenedCreateOrExerciseMethod[T](
+  def generateFlattenedCreateOrExerciseMethod(
       name: String,
+      returns: TypeName,
       choiceName: ChoiceName,
       choice: TemplateChoice[Type],
       fields: Fields,
+      modifiers: Seq[Modifier],
       packagePrefixes: Map[PackageId, String],
-  )(implicit ct: ClassTag[T]): MethodSpec = {
+  ): MethodSpec = {
     val methodName = s"$name${choiceName.capitalize}"
     val choiceBuilder = MethodSpec
       .methodBuilder(methodName)
-      .addModifiers(Modifier.PUBLIC)
-      .returns(ct.runtimeClass)
+      .addModifiers((modifiers :+ Modifier.PUBLIC).asJava)
+      .returns(returns)
     val javaType = toJavaTypeName(choice.param, packagePrefixes)
     for (FieldInfo(_, _, javaName, javaType) <- fields) {
       choiceBuilder.addParameter(javaType, javaName)

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
@@ -98,4 +98,13 @@ private[inner] object ClassGenUtils {
     choiceBuilder.build()
   }
 
+  def generateGetCompanion(companionType: TypeName, companionName: String): MethodSpec = {
+    MethodSpec
+      .methodBuilder("getCompanion")
+      .addModifiers(Modifier.PROTECTED)
+      .addAnnotation(classOf[Override])
+      .returns(companionType)
+      .addStatement("return $N", companionName)
+      .build()
+  }
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
@@ -124,20 +124,15 @@ object ContractClass {
 
     private[this] def generateGetCompanion(templateClassName: ClassName): MethodSpec = {
       val contractClassName = ClassName bestGuess "Contract"
-      MethodSpec
-        .methodBuilder("getCompanion")
-        .addModifiers(Modifier.PROTECTED)
-        .addAnnotation(classOf[Override])
-        .returns(
-          ParameterizedTypeName.get(
-            ClassName get classOf[javaapi.data.codegen.ContractCompanion[_, _, _]],
-            contractClassName,
-            contractIdClassName,
-            templateClassName,
-          )
-        )
-        .addStatement("return $N", companionFieldName)
-        .build()
+      ClassGenUtils.generateGetCompanion(
+        ParameterizedTypeName.get(
+          ClassName get classOf[javaapi.data.codegen.ContractCompanion[_, _, _]],
+          contractClassName,
+          contractIdClassName,
+          templateClassName,
+        ),
+        companionFieldName,
+      )
     }
 
     def create(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -98,6 +98,7 @@ object ContractIdClass {
         ParameterizedTypeName
           .get(ClassName get classOf[javaapi.data.codegen.Exercises[_]], exercisesTypeParam)
       )
+      .addModifiers(Modifier.PUBLIC)
     choices foreach { case (choiceName, choice) =>
       exercisesClass addMethod Builder.generateExerciseMethod(
         choiceName,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -53,19 +53,13 @@ object ContractIdClass {
     def addConversionForImplementedInterfaces(
         implementedInterfaces: Seq[Ref.TypeConName]
     ): Builder = {
+      idClassBuilder.addMethods(
+        generateToInterfaceMethods("ContractId", "this.contractId", implementedInterfaces).asJava
+      )
       implementedInterfaces.foreach { interfaceName =>
         // XXX why doesn't this use packagePrefixes? -SC
         val name = ClassName.bestGuess(fullyQualifiedName(interfaceName.qualifiedName))
         val interfaceContractIdName = name nestedClass "ContractId"
-        idClassBuilder.addMethod(
-          MethodSpec
-            .methodBuilder("toInterface")
-            .addModifiers(Modifier.PUBLIC)
-            .addParameter(name nestedClass InterfaceClass.companionName, "interfaceCompanion")
-            .addStatement("return new $T(this.contractId)", interfaceContractIdName)
-            .returns(interfaceContractIdName)
-            .build()
-        )
         val tplContractIdClassName = templateClassName.nestedClass("ContractId")
         idClassBuilder.addMethod(
           MethodSpec

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -152,9 +152,8 @@ object ContractIdClass {
         choiceName,
         choice,
         fields,
-        Seq(Modifier.DEFAULT),
         packagePrefixes,
-      )
+      )(_.addModifiers(Modifier.DEFAULT))
 
     private[ContractIdClass] def generateExerciseMethod(
         choiceName: ChoiceName,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -50,6 +50,7 @@ object InterfaceClass extends StrictLogging {
         .addType(
           TemplateClass.generateCreateAndClass(-\/(ContractIdClass.For.Interface))
         )
+        .addType(TemplateClass.generateByKeyClass(-\/(ContractIdClass.For.Interface)))
         .addType(generateInterfaceCompanionClass(interfaceName = interfaceName))
         .addMethod {
           // interface classes are not inhabited

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -5,7 +5,7 @@ package com.daml.lf.codegen.backend.java.inner
 
 import com.daml.ledger.javaapi.data.codegen.InterfaceCompanion
 import com.daml.lf.data.Ref.{PackageId, QualifiedName}
-import com.daml.lf.iface.DefInterface
+import com.daml.lf.iface, iface.DefInterface
 import com.squareup.javapoet._
 import com.typesafe.scalalogging.StrictLogging
 
@@ -17,6 +17,7 @@ object InterfaceClass extends StrictLogging {
       interfaceName: ClassName,
       interface: DefInterface.FWT,
       packagePrefixes: Map[PackageId, String],
+      typeDeclarations: Map[QualifiedName, iface.InterfaceType],
       packageId: PackageId,
       interfaceId: QualifiedName,
   ): TypeSpec =
@@ -36,6 +37,14 @@ object InterfaceClass extends StrictLogging {
               packagePrefixes,
             )
             .build()
+        )
+        .addType(
+          ContractIdClass.generateExercisesInterface(
+            interface.choices,
+            typeDeclarations,
+            packageId,
+            packagePrefixes,
+          )
         )
         .addType(generateInterfaceCompanionClass(interfaceName = interfaceName))
         .addMethod {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -32,6 +32,7 @@ object InterfaceClass extends StrictLogging {
             .builder(
               interfaceName,
               interface.choices,
+              ContractIdClass.For.Interface,
               packagePrefixes,
             )
             .build()

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -8,6 +8,7 @@ import com.daml.lf.data.Ref.{PackageId, QualifiedName}
 import com.daml.lf.iface, iface.DefInterface
 import com.squareup.javapoet._
 import com.typesafe.scalalogging.StrictLogging
+import scalaz.-\/
 
 import javax.lang.model.element.Modifier
 
@@ -45,6 +46,9 @@ object InterfaceClass extends StrictLogging {
             packageId,
             packagePrefixes,
           )
+        )
+        .addType(
+          TemplateClass.generateCreateAndClass(-\/(ContractIdClass.For.Interface))
         )
         .addType(generateInterfaceCompanionClass(interfaceName = interfaceName))
         .addMethod {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/InterfaceClass.scala
@@ -69,8 +69,11 @@ object InterfaceClass extends StrictLogging {
     )
     .addModifiers(Modifier.FINAL, Modifier.PUBLIC, Modifier.STATIC)
     .addMethod {
-      // we define this explicitly to make it package-private
-      MethodSpec.constructorBuilder().build()
+      MethodSpec
+        .constructorBuilder()
+        // intentionally package-private
+        .addStatement("super($T.$N)", interfaceName, ClassGenUtils.templateIdFieldName)
+        .build()
     }
     .build()
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -294,7 +294,12 @@ private[inner] object TemplateClass extends StrictLogging {
   ) = {
     val methods = for ((choiceName, choice) <- choices) yield {
       val createAndExerciseChoiceMethod =
-        generateCreateAndExerciseMethod(choiceName, choice, templateClassName, packagePrefixes)
+        generateDeprecatedCreateAndExerciseMethod(
+          choiceName,
+          choice,
+          templateClassName,
+          packagePrefixes,
+        )
       val splatted =
         for (
           record <- choice.param
@@ -317,7 +322,7 @@ private[inner] object TemplateClass extends StrictLogging {
     methods.flatten.asJava
   }
 
-  private def generateCreateAndExerciseMethod(
+  private def generateDeprecatedCreateAndExerciseMethod(
       choiceName: ChoiceName,
       choice: TemplateChoice[Type],
       templateClassName: ClassName,
@@ -327,6 +332,10 @@ private[inner] object TemplateClass extends StrictLogging {
     val createAndExerciseChoiceBuilder = MethodSpec
       .methodBuilder(methodName)
       .addModifiers(Modifier.PUBLIC)
+      .addAnnotation(classOf[Deprecated])
+      .addJavadoc(
+        s"@deprecated since Daml 2.3.0; use {@code createAnd().exercise${choiceName.capitalize}} instead"
+      )
       .returns(classOf[javaapi.data.CreateAndExerciseCommand])
     val javaType = toJavaTypeName(choice.param, packagePrefixes)
     createAndExerciseChoiceBuilder.addParameter(javaType, "arg")

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -283,6 +283,7 @@ private[inner] object TemplateClass extends StrictLogging {
       )
       .build()
 
+  // TODO #14039 delete
   private def generateDeprecatedCreateAndExerciseMethods(
       choices: Map[ChoiceName, TemplateChoice[com.daml.lf.iface.Type]],
       typeDeclarations: Map[QualifiedName, InterfaceType],
@@ -318,6 +319,7 @@ private[inner] object TemplateClass extends StrictLogging {
     methods.flatten.asJava
   }
 
+  // TODO #14039 delete
   private def generateDeprecatedCreateAndExerciseMethod(
       choiceName: ChoiceName,
       choice: TemplateChoice[Type],
@@ -341,6 +343,7 @@ private[inner] object TemplateClass extends StrictLogging {
       .build()
   }
 
+  // TODO #14039 delete
   private def generateDeprecatedFlattenedCreateAndExerciseMethod(
       choiceName: ChoiceName,
       choice: TemplateChoice[Type],

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -241,7 +241,7 @@ private[inner] object TemplateClass extends StrictLogging {
       .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
       .returns(classOf[javaapi.data.ExerciseByKeyCommand])
       .makeDeprecated(
-        howToFix = s"use byKey(key).exercise${choiceName.capitalize} instead",
+        howToFix = s"use {@code byKey(key).exercise${choiceName.capitalize}} instead",
         sinceDaml = "2.3.0",
       )
       .addParameter(toJavaTypeName(key, packagePrefixes), "key")
@@ -273,7 +273,7 @@ private[inner] object TemplateClass extends StrictLogging {
       generateArgumentList(fields.map(_.javaName)),
     )
     exerciseByKeyBuilder
-      .makeDeprecated(CodeBlock.of("use $L instead", expansion), sinceDaml = "2.3.0")
+      .makeDeprecated(CodeBlock.of("use {@code $L} instead", expansion), sinceDaml = "2.3.0")
       .addStatement("return $L", expansion)
       .build()
   }
@@ -477,14 +477,16 @@ private[inner] object TemplateClass extends StrictLogging {
         isInterface.fold(_ => Some(Modifier.PUBLIC), _ => None).toList.asJava
       )
 
-    private[TemplateClass] def makeDeprecated(howToFix: String, sinceDaml: String) =
-      self
-        .addAnnotation(classOf[Deprecated])
-        .addJavadoc(
-          s"@deprecated since Daml $sinceDaml; $howToFix"
-        )
+    private[TemplateClass] def makeDeprecated(
+        howToFix: String,
+        sinceDaml: String,
+    ): MethodSpec.Builder =
+      self.makeDeprecated(howToFix = CodeBlock.of("$L", howToFix), sinceDaml = sinceDaml)
 
-    private[TemplateClass] def makeDeprecated(howToFix: CodeBlock, sinceDaml: String) =
+    private[TemplateClass] def makeDeprecated(
+        howToFix: CodeBlock,
+        sinceDaml: String,
+    ): MethodSpec.Builder =
       self
         .addAnnotation(classOf[Deprecated])
         .addJavadoc(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -306,7 +306,7 @@ private[inner] object TemplateClass extends StrictLogging {
               _ => None,
             )
         ) yield {
-          generateFlattenedCreateAndExerciseMethod(
+          generateDeprecatedFlattenedCreateAndExerciseMethod(
             choiceName,
             choice,
             getFieldsWithTypes(record.fields, packagePrefixes),
@@ -341,7 +341,7 @@ private[inner] object TemplateClass extends StrictLogging {
       .build()
   }
 
-  private def generateFlattenedCreateAndExerciseMethod(
+  private def generateDeprecatedFlattenedCreateAndExerciseMethod(
       choiceName: ChoiceName,
       choice: TemplateChoice[Type],
       fields: Fields,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -66,10 +66,6 @@ private[inner] object TemplateClass extends StrictLogging {
               ContractIdClass.For.Template,
               packagePrefixes,
             )
-            .addFlattenedExerciseMethods(
-              typeWithContext.interface.typeDecls,
-              typeWithContext.packageId,
-            )
             .addConversionForImplementedInterfaces(template.implementedInterfaces)
             .build()
         )
@@ -78,6 +74,14 @@ private[inner] object TemplateClass extends StrictLogging {
             .builder(className, template.key, packagePrefixes)
             .addGenerateFromMethods()
             .build()
+        )
+        .addType(
+          ContractIdClass.generateExercisesInterface(
+            templateChoices,
+            typeWithContext.interface.typeDecls,
+            typeWithContext.packageId,
+            packagePrefixes,
+          )
         )
         .addField(generateCompanion(className, template.key, packagePrefixes))
         .addFields(RecordFields(fields).asJava)
@@ -303,11 +307,13 @@ private[inner] object TemplateClass extends StrictLogging {
       fields: Fields,
       packagePrefixes: Map[PackageId, String],
   ): MethodSpec =
-    ClassGenUtils.generateFlattenedCreateOrExerciseMethod[javaapi.data.CreateAndExerciseCommand](
+    ClassGenUtils.generateFlattenedCreateOrExerciseMethod(
       "createAndExercise",
+      ClassName get classOf[javaapi.data.CreateAndExerciseCommand],
       choiceName,
       choice,
       fields,
+      Seq.empty[Modifier],
       packagePrefixes,
     )
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -384,9 +384,9 @@ private[inner] object TemplateClass extends StrictLogging {
     MethodSpec
       .methodBuilder(methodName)
       .addModifiers(Modifier.PUBLIC)
-      .addAnnotation(classOf[Deprecated])
-      .addJavadoc(
-        s"@deprecated since Daml 2.3.0; use {@code createAnd().exercise${choiceName.capitalize}} instead"
+      .makeDeprecated(
+        howToFix = s"use {@code createAnd().exercise${choiceName.capitalize}} instead",
+        sinceDaml = "2.3.0",
       )
       .returns(classOf[javaapi.data.CreateAndExerciseCommand])
       .addParameter(javaType, "arg")
@@ -412,11 +412,10 @@ private[inner] object TemplateClass extends StrictLogging {
       fields,
       packagePrefixes,
     )(
-      _.addAnnotation(classOf[Deprecated])
-        .addJavadoc(
-          "@deprecated since Daml 2.3.0; use {@code createAnd().exercise$L} instead",
-          choiceName.capitalize,
-        )
+      _.makeDeprecated(
+        howToFix = s"use {@code createAnd().exercise${choiceName.capitalize}} instead",
+        sinceDaml = "2.3.0",
+      )
     )
 
   private def generateTemplateIdField(typeWithContext: TypeWithContext): FieldSpec =
@@ -487,6 +486,13 @@ private[inner] object TemplateClass extends StrictLogging {
       self.addModifiers(
         isInterface.fold(_ => Some(Modifier.PUBLIC), _ => None).toList.asJava
       )
+
+    private[TemplateClass] def makeDeprecated(howToFix: String, sinceDaml: String) =
+      self
+        .addAnnotation(classOf[Deprecated])
+        .addJavadoc(
+          s"@deprecated since Daml $sinceDaml; $howToFix"
+        )
   }
 
   private implicit final class `TypeSpec extensions`(private val self: TypeSpec.Builder)

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -145,10 +145,11 @@ private[inner] object TemplateClass extends StrictLogging {
             .generateToValueConverter(key, CodeBlock.of("key"), newNameGenerator, packagePrefixes),
         )
         .addJavadoc(
-          "Set up an {@link $T};$Winvoke an {@code exercise} method on the result of$W" +
-            "this to finish creating the command, or convert to an interface first$W" +
-            "with {@code toInterface}$W" +
-            "to invoke an interface {@code exercise} method.",
+          """Set up an {@link $T};$Winvoke an {@code exercise} method on the result of
+            |this to finish creating the command, or convert to an interface first
+            |with {@code toInterface}
+            |to invoke an interface {@code exercise} method.""".stripMargin
+            .replaceAll("\n", "\\$W"),
           classOf[javaapi.data.ExerciseByKeyCommand],
         )
         .build()

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -49,7 +49,7 @@ private[inner] object TemplateClass extends StrictLogging {
           )
         )
         .addMethods(
-          generateCreateAndExerciseMethods(
+          generateDeprecatedCreateAndExerciseMethods(
             templateChoices,
             typeWithContext.interface.typeDecls,
             typeWithContext.packageId,
@@ -283,7 +283,7 @@ private[inner] object TemplateClass extends StrictLogging {
       )
       .build()
 
-  private def generateCreateAndExerciseMethods(
+  private def generateDeprecatedCreateAndExerciseMethods(
       choices: Map[ChoiceName, TemplateChoice[com.daml.lf.iface.Type]],
       typeDeclarations: Map[QualifiedName, InterfaceType],
       packageId: PackageId,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -277,7 +277,7 @@ private[inner] object TemplateClass extends StrictLogging {
   ) =
     TypeSpec
       .classBuilder(createAndClassName)
-      .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+      .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
       .superclass(classOf[javaapi.data.codegen.CreateAnd])
       .addSuperinterface(
         ParameterizedTypeName.get(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -63,6 +63,7 @@ private[inner] object TemplateClass extends StrictLogging {
             .builder(
               className,
               templateChoices,
+              ContractIdClass.For.Template,
               packagePrefixes,
             )
             .addFlattenedExerciseMethods(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -39,7 +39,7 @@ private[inner] object TemplateClass extends StrictLogging {
         .addField(generateTemplateIdField(typeWithContext))
         .addMethod(generateCreateMethod(className))
         .addMethods(
-          generateStaticExerciseByKeyMethods(
+          generateDeprecatedStaticExerciseByKeyMethods(
             templateChoices,
             template.key,
             typeWithContext.interface.typeDecls,
@@ -192,7 +192,7 @@ private[inner] object TemplateClass extends StrictLogging {
       )
       .build()
 
-  private def generateStaticExerciseByKeyMethods(
+  private def generateDeprecatedStaticExerciseByKeyMethods(
       choices: Map[ChoiceName, TemplateChoice[Type]],
       maybeKey: Option[Type],
       typeDeclarations: Map[QualifiedName, InterfaceType],
@@ -201,7 +201,7 @@ private[inner] object TemplateClass extends StrictLogging {
   ) =
     maybeKey.fold(java.util.Collections.emptyList[MethodSpec]()) { key =>
       val methods = for ((choiceName, choice) <- choices.toList) yield {
-        val raw = generateStaticExerciseByKeyMethod(
+        val raw = generateDeprecatedStaticExerciseByKeyMethod(
           choiceName,
           choice,
           key,
@@ -218,7 +218,7 @@ private[inner] object TemplateClass extends StrictLogging {
               )
           )
             yield {
-              generateFlattenedStaticExerciseByKeyMethod(
+              generateDeprecatedFlattenedStaticExerciseByKeyMethod(
                 choiceName,
                 key,
                 getFieldsWithTypes(record.fields, packagePrefixes),
@@ -230,7 +230,7 @@ private[inner] object TemplateClass extends StrictLogging {
       methods.flatten.asJava
     }
 
-  private def generateStaticExerciseByKeyMethod(
+  private def generateDeprecatedStaticExerciseByKeyMethod(
       choiceName: ChoiceName,
       choice: TemplateChoice[Type],
       key: Type,
@@ -252,7 +252,7 @@ private[inner] object TemplateClass extends StrictLogging {
       )
       .build()
 
-  private def generateFlattenedStaticExerciseByKeyMethod(
+  private def generateDeprecatedFlattenedStaticExerciseByKeyMethod(
       choiceName: ChoiceName,
       key: Type,
       fields: Fields,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -353,8 +353,13 @@ private[inner] object TemplateClass extends StrictLogging {
       choiceName,
       choice,
       fields,
-      Seq.empty[Modifier],
       packagePrefixes,
+    )(
+      _.addAnnotation(classOf[Deprecated])
+        .addJavadoc(
+          "@deprecated since Daml 2.3.0; use {@code createAnd().exercise$L} instead",
+          choiceName.capitalize,
+        )
     )
 
   private def generateTemplateIdField(typeWithContext: TypeWithContext): FieldSpec =

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -192,6 +192,7 @@ private[inner] object TemplateClass extends StrictLogging {
       )
       .build()
 
+  // TODO #14039 delete
   private def generateDeprecatedStaticExerciseByKeyMethods(
       choices: Map[ChoiceName, TemplateChoice[Type]],
       maybeKey: Option[Type],
@@ -230,6 +231,7 @@ private[inner] object TemplateClass extends StrictLogging {
       methods.flatten.asJava
     }
 
+  // TODO #14039 delete
   private def generateDeprecatedStaticExerciseByKeyMethod(
       choiceName: ChoiceName,
       choice: TemplateChoice[Type],
@@ -252,6 +254,7 @@ private[inner] object TemplateClass extends StrictLogging {
       )
       .build()
 
+  // TODO #14039 delete
   private def generateDeprecatedFlattenedStaticExerciseByKeyMethod(
       choiceName: ChoiceName,
       key: Type,

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -84,6 +84,7 @@ private[inner] object TemplateClass extends StrictLogging {
             packagePrefixes,
           )
         )
+        .addMethod(generateCreateAndMethod())
         .addType(generateCreateAndClass(\/-(template.implementedInterfaces)))
         .addField(generateCompanion(className, template.key, packagePrefixes))
         .addFields(RecordFields(fields).asJava)
@@ -228,6 +229,15 @@ private[inner] object TemplateClass extends StrictLogging {
   }
 
   private val createAndClassName = "CreateAnd"
+
+  private[this] def generateCreateAndMethod() =
+    MethodSpec
+      .methodBuilder("createAnd")
+      .returns(ClassName bestGuess createAndClassName)
+      .addModifiers(Modifier.PUBLIC)
+      .addAnnotation(classOf[Override])
+      .addStatement("return new CreateAnd(this)")
+      .build()
 
   private[inner] def generateCreateAndClass(
       implementedInterfaces: ContractIdClass.For.Interface.type \/ Seq[Ref.TypeConName]

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -144,6 +144,13 @@ private[inner] object TemplateClass extends StrictLogging {
           ToValueGenerator
             .generateToValueConverter(key, CodeBlock.of("key"), newNameGenerator, packagePrefixes),
         )
+        .addJavadoc(
+          "Set up an {@link $T};$Winvoke an {@code exercise} method on the result of$W" +
+            "this to finish creating the command, or convert to an interface first$W" +
+            "with {@code toInterface}$W" +
+            "to invoke an interface {@code exercise} method.",
+          classOf[javaapi.data.ExerciseByKeyCommand],
+        )
         .build()
     }
 


### PR DESCRIPTION
Fixes #13920.

```rst
CHANGELOG_BEGIN
- [Java codegen] ``createAndExercise*`` and ``exerciseByKey*`` methods
  are deprecated; instead, use the new ``createAnd().exercise*`` and
  ``byKey(key).exercise*`` methods.

  When the ledger API supports it, interface choices will be reachable
  via ``createAnd().toInterface(Ifc.INTERFACE).exercise*`` and
  ``byKey(key).toInterface(Ifc.INTERFACE).exercise*``, exactly the
  syntax supported by contract-ID exercise; see #14056.
CHANGELOG_END
```

* [x] #14004
* [x] rebase and change PR target to main
* [x] changelog