### PR TITLE
fix daml-sdk Docker image

### DIFF
--- a/ci/docker/daml-sdk/Dockerfile
+++ b/ci/docker/daml-sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11
+FROM eclipse-temurin:11-jre-focal
 ARG VERSION
 # This is needed to get the DNS requests
 # from Haskell binaries to succeed.


### PR DESCRIPTION
It looks like the default image changed from Focal to Jammy, and for
whatever reason that completely breaks `curl`.

This pins us to Focal (for better or worse), as well as switching to the
new JRE-only images (much smaller size & attack surface than the full
JDK images).

CHANGELOG_BEGIN
CHANGELOG_END