### PR TITLE
fix Docker image

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -83,7 +83,10 @@ jobs:
               echo "Building version ${version#v}..."
               git checkout "$version"
               cd ci/docker/daml-sdk
+              # The internet changed from under us: 11 now means 11-jammy, and curl breaks
+              sed -i '1s/^FROM eclipse-temurin:11$/FROM eclipse-temurin:11-focal/' Dockerfile
               docker build -t digitalasset/daml-sdk:${version#v} --build-arg VERSION=${version#v} .
+              git checkout Dockerfile
               # Despite the name not suggesting it at all, this actually signs
               # _and pushes_ the image; see
               # https://docs.docker.com/engine/security/trust/#signing-images-with-docker-content-trust


### PR DESCRIPTION
Same goal as #14055, but this should fix this week's image (we build from the release commit, so #14055 only fixes future images), as well as allow us to rebuild past images should we ever need to.

CHANGELOG_BEGIN
CHANGELOG_END