### PR TITLE
disclosures: fix buildDiscTable

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -20,7 +20,7 @@ import com.daml.lf.transaction.{
   Transaction => Tx,
 }
 import java.nio.file.Files
-import com.daml.lf.value.Value.{ValueRecord, ValueContractId, VersionedContractInstance, ContractId}
+import com.daml.lf.value.Value.{ValueContractId, VersionedContractInstance, ContractId}
 
 import com.daml.lf.language.{PackageInterface, LanguageVersion, LookupError, StablePackage}
 import com.daml.lf.validation.Validation
@@ -579,7 +579,7 @@ object Engine {
         List.empty[Versioned[DisclosedContract]],
       )
     ) { case ((m1, m2, ds), d) =>
-      // TODO (drsk) drop this conversion from SValue -> Value. 
+      // TODO (drsk) drop this conversion from SValue -> Value.
       // https://github.com/digital-asset/daml/issues/14069
       val arg = machine.normValue(d.templateId, d.argument)
       val coid = machine.normValue(d.templateId, d.contractId)
@@ -587,7 +587,7 @@ object Engine {
 
       // check for well typed contract argument
       (coid, arg) match {
-        case (ValueContractId(coid), r @ ValueRecord(None, _)) =>
+        case (ValueContractId(coid), r) =>
           // check for duplicate contract ids
           m1.get(coid) match {
             case Some(_) =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -579,13 +579,15 @@ object Engine {
         List.empty[Versioned[DisclosedContract]],
       )
     ) { case ((m1, m2, ds), d) =>
+      // TODO (drsk) drop this conversion from SValue -> Value. 
+      // https://github.com/digital-asset/daml/issues/14069
       val arg = machine.normValue(d.templateId, d.argument)
       val coid = machine.normValue(d.templateId, d.contractId)
       val version = machine.tmplId2TxVersion(d.templateId)
 
       // check for well typed contract argument
       (coid, arg) match {
-        case (ValueContractId(coid), r @ ValueRecord(Some(d.templateId), _)) =>
+        case (ValueContractId(coid), r @ ValueRecord(None, _)) =>
           // check for duplicate contract ids
           m1.get(coid) match {
             case Some(_) =>


### PR DESCRIPTION
This removes the pattern match on the template id for the argument
record in buildDiscTable. The arguments don't contain the template id
any longer.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
