### PR TITLE
Fix reproducibility issue in ghc-lib(-parser) sdist

### DIFF
--- a/bazel_tools/ghc-lib/defs.bzl
+++ b/bazel_tools/ghc-lib/defs.bzl
@@ -132,6 +132,11 @@ cp -rLt $$TMP $$GHC/.
 export HOME="$$TMP"
 
 $(execpath @ghc-lib-gen) $$TMP --ghc-lib{component} --ghc-flavor={ghc_flavor}
+# Remove absolute paths to the execroot.
+sed -i.bak \\
+  -e "s#$$EXECROOT/##" \\
+  $$TMP/ghc-lib/stage0/lib/settings
+# Patch the ghc-lib version.
 sed -i.bak \\
   -e 's#version: 0.1.0#version: {ghc_lib_version}#' \\
   $$TMP/ghc-lib{component}.cabal


### PR DESCRIPTION
The generated `settings` file that's included in the sdist can include absolute paths to the execroot in the tool paths, `PerlCmd` in particular. This PR fixes that.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
