### PR TITLE
Speed up ghc-lib(-parser) sdist generation

### DIFF
--- a/bazel_tools/ghc-lib/ghc-lib-no-stack.patch
+++ b/bazel_tools/ghc-lib/ghc-lib-no-stack.patch
@@ -1,9 +1,9 @@
 diff --git a/ghc-lib-gen/src/Ghclibgen.hs b/ghc-lib-gen/src/Ghclibgen.hs
-index 2efef5e..c340958 100644
+index 3574255..4fee612 100644
 --- a/ghc-lib-gen/src/Ghclibgen.hs
 +++ b/ghc-lib-gen/src/Ghclibgen.hs
-@@ -332,10 +332,7 @@ calcParserModules ghcFlavor = do
-       hsSrcIncludes = map ("-i" ++ ) hsSrcDirs
+@@ -336,10 +336,7 @@ calcParserModules ghcFlavor = do
+       hsSrcIncludes = map ("-i" ++ ) (placeholderModulesDir : hsSrcDirs)
        -- See [Note: GHC now depends on exceptions package].
        cmd = unwords $
 -        [ "stack exec" ] ++
@@ -14,7 +14,7 @@ index 2efef5e..c340958 100644
          , "-dep-suffix ''"
          , "-dep-makefile .parser-depends"
          , "-M"
-@@ -1246,15 +1243,13 @@ generatePrerequisites ghcFlavor = do
+@@ -1258,15 +1255,13 @@ generatePrerequisites ghcFlavor = do
    -- If building happy in the next step, the configure it does
    -- requires some versions of alex and happy pre-exist. We make sure
    -- of this in CI.hs.

--- a/bazel_tools/ghc-lib/ghc-lib-parser/ghc-lib-parser.cabal
+++ b/bazel_tools/ghc-lib/ghc-lib-parser/ghc-lib-parser.cabal
@@ -40,10 +40,10 @@ extra-source-files:
     ghc-lib/stage0/compiler/build/primop-vector-tys.hs-incl
     ghc-lib/stage0/compiler/build/primop-vector-uniques.hs-incl
     ghc-lib/stage0/compiler/build/ghc_boot_platform.h
-    ghc-lib/stage0/compiler/build/Fingerprint.hs
+    compiler/utils/Fingerprint.hsc
     ghc-lib/stage0/compiler/build/Config.hs
-    ghc-lib/stage0/compiler/build/Parser.hs
-    ghc-lib/stage0/compiler/build/Lexer.hs
+    compiler/parser/Parser.y
+    compiler/parser/Lexer.x
     includes/MachDeps.h
     includes/stg/MachRegs.h
     includes/CodeGen.Platform.hs

--- a/bazel_tools/ghc-lib/ghc-lib/ghc-lib.cabal
+++ b/bazel_tools/ghc-lib/ghc-lib/ghc-lib.cabal
@@ -40,7 +40,7 @@ extra-source-files:
     ghc-lib/stage0/compiler/build/primop-vector-tys.hs-incl
     ghc-lib/stage0/compiler/build/primop-vector-uniques.hs-incl
     ghc-lib/stage0/compiler/build/ghc_boot_platform.h
-    ghc-lib/stage0/compiler/build/Fingerprint.hs
+    compiler/utils/Fingerprint.hsc
     includes/MachDeps.h
     includes/stg/MachRegs.h
     includes/CodeGen.Platform.hs

--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 GHC_LIB_REPO_URL = "https://github.com/digital-asset/ghc-lib"
-GHC_LIB_REV = "c6c184cdbc3493100f787ba87ce9971b2fbba22a"
-GHC_LIB_SHA256 = "2da9ac94fbe8b5af465cf0a25316d392a0023ca0469fb83310c5fe1ace9499ea"
+GHC_LIB_REV = "b503248db52d6049d18a9dbfa31e0f11aef71df7"
+GHC_LIB_SHA256 = "2d677bd4bfe6c91fd989551b0821b87b48ab49473a747f548cb58766f9636c11"
 GHC_LIB_PATCHES = [
     "@//bazel_tools/ghc-lib:ghc-lib-no-stack.patch",
 ]


### PR DESCRIPTION
Update ghc-lib to incorporate digital-asset/ghc-lib#379, which is a more generic version of the changes introduced in 41ab1c2 to speed-up ghc-lib(-parser) sdist generation in Daml.

The slowest step in the ghc-lib(-parser) sdist generation is the generation of `.hs` files from `.hsc` files via `hsc2hs` and from `.x` or `.y` files via `alex` or `happy`. The reason that it's slow is that `ghc-lib-gen` performs these through GHC's build system, hadrian, and these steps require almost a full stage1 GHC build.

The `.hs` files are only needed to enable dependency discovery through `ghc -M`, as it doesn't understand `.hsc|.x|.y` files. Apart from that we can use the original `.hsc|.x|.y` files in the final sdist.

With this update `ghc-lib-gen` finds all relevant `.hsc|.x|.y` files and replaces them with dummy `.hs` files that have the same module name and the same imports. These dummy files are only used for the purposes of dependency discovery via `ghc -M` and are not included in the final sdist.

With this update the sdist generation is sped up between 4.3 to 4.5 times:
- ghc-lib-parser: 3m2s down to 42.04s (4.3x)
- ghc-lib: 3m5s down to 40.96s (4.5x)

I've applied `diffoscope` to the generated sdist tarballs with and without this update to ensure that no unexpected differences are introduced with this change.

digital-asset/ghc-lib#379 reports a less dramatic speed up of about a third reduction in build time for `stack runhaskell CI.hs`. The reason for the discrepancy is that `CI.hs` performs more steps than just the sdist generation, e.g. checking out GHC's source tree, or building hadrian. These steps are not included in the above benchmarks, because they are executed in separate Bazel actions and can be cached separately.
