### PR TITLE
remove inherited exercise methods from Java codegen

### DIFF
--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
@@ -59,17 +59,13 @@ class Interfaces
         }
         readActiveContractsSafe(safeChildCloneFromCreatedEvent)(client, alice)
           .foreach { child =>
-            assertThrows[Exception](
-              sendCmd(
-                client,
-                alice,
-                interfaces.Child.ContractId
-                  .unsafeFromInterface(
-                    child.id.toInterface(interfaces.TIf.INTERFACE): interfaces.TIf.ContractId
-                  )
-                  .exerciseBar(),
+            val cmd = interfaces.Child.ContractId
+              .unsafeFromInterface(
+                child.id.toInterface(interfaces.TIf.INTERFACE): interfaces.TIf.ContractId
               )
-            )
+              .exerciseBar()
+            val ex = the[io.grpc.StatusRuntimeException] thrownBy sendCmd(client, alice, cmd)
+            ex.getMessage should include regex "Expected contract of type .*Child@.* but got .*ChildClone"
           }
         succeed
       }

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
@@ -38,16 +38,6 @@ class Interfaces
       } yield {
         sendCmd(client, alice, interfaces.Child.create(alice))
         sendCmd(client, alice, interfaces.ChildClone.create(alice))
-        readActiveContractsSafe[interfaces.Child.Contract](safeChildFromCreatedEvent)(
-          client,
-          alice,
-        ).foreach { child =>
-          sendCmd(
-            client,
-            alice,
-            child.id.toInterface(interfaces.TIf.INTERFACE).exerciseHam(new interfaces.Ham()),
-          )
-        }
         readActiveContractsSafe(safeChildFromCreatedEvent)(client, alice).foreach { child =>
           sendCmd(
             client,

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
@@ -20,8 +20,7 @@ class Interfaces
 
   behavior of "Generated Java code"
 
-  // TODO(#13668) Redesign the test once the issue is fixed
-  it should "contain all choices of an interface in templates implementing it" ignore withClient {
+  it should "contain all choices of an interface in templates implementing it" in withClient {
     client =>
       def checkTemplateId[T](
           shouldBeId: Identifier,
@@ -45,7 +44,11 @@ class Interfaces
           client,
           alice,
         ).foreach { child =>
-          sendCmd(client, alice, child.id.exerciseHam(new interfaces.Ham()))
+          sendCmd(
+            client,
+            alice,
+            child.id.toInterface(interfaces.TIf.INTERFACE).exerciseHam(new interfaces.Ham()),
+          )
         }
         readActiveContractsSafe(safeChildFromCreatedEvent)(client, alice).foreach { child =>
           sendCmd(
@@ -64,6 +67,7 @@ class Interfaces
                   .unsafeFromInterface(
                     child.id.toInterface(interfaces.TIf.INTERFACE): interfaces.TIf.ContractId
                   )
+                  .toInterface(interfaces.TIf.INTERFACE)
                   .exerciseHam(new interfaces.Ham()),
               )
             )

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
@@ -4,7 +4,8 @@
 package com.daml
 
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
-import com.daml.ledger.javaapi.data.{CreatedEvent, Identifier}
+import com.daml.ledger.javaapi.data.CreatedEvent
+import com.daml.ledger.javaapi.data.codegen.ContractCompanion
 import com.daml.ledger.resources.TestResourceContext
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -23,18 +24,15 @@ class Interfaces
   it should "contain all choices of an interface in templates implementing it" in withClient {
     client =>
       def checkTemplateId[T](
-          shouldBeId: Identifier,
-          fn: CreatedEvent => T,
+          companion: ContractCompanion[T, _, _]
       ): PartialFunction[CreatedEvent, T] = {
-        case event: CreatedEvent if event.getTemplateId == shouldBeId => fn(event)
+        case event if event.getTemplateId == companion.TEMPLATE_ID =>
+          companion fromCreatedEvent event
       }
       val safeChildFromCreatedEvent =
-        checkTemplateId(interfaces.Child.TEMPLATE_ID, interfaces.Child.Contract.fromCreatedEvent)
+        checkTemplateId(interfaces.Child.COMPANION)
       val safeChildCloneFromCreatedEvent =
-        checkTemplateId(
-          interfaces.ChildClone.TEMPLATE_ID,
-          interfaces.ChildClone.Contract.fromCreatedEvent,
-        )
+        checkTemplateId(interfaces.ChildClone.COMPANION)
       for {
         alice <- allocateParty
       } yield {

--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/InterfacesTest.scala
@@ -67,8 +67,7 @@ class Interfaces
                   .unsafeFromInterface(
                     child.id.toInterface(interfaces.TIf.INTERFACE): interfaces.TIf.ContractId
                   )
-                  .toInterface(interfaces.TIf.INTERFACE)
-                  .exerciseHam(new interfaces.Ham()),
+                  .exerciseBar(),
               )
             )
           }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/CodeGenRunner.scala
@@ -163,14 +163,11 @@ object CodeGenRunner extends StrictLogging {
       logger.error(error.msg)
     }
 
-    val resolvedSignatures =
-      signatures.map(resolveChoices(environmentInterface))
-
     val resolvedPrefixes =
-      resolvePackagePrefixes(packagePrefixes, modulePrefixes, resolvedSignatures)
+      resolvePackagePrefixes(packagePrefixes, modulePrefixes, signatures)
 
     new CodeGenRunner.Scope(
-      resolvedSignatures,
+      signatures,
       resolvedPrefixes,
       transitiveClosure.serializableTypes,
     )
@@ -202,11 +199,6 @@ object CodeGenRunner extends StrictLogging {
       logger.trace(s"Daml-LF Archive decoded, packageId '${interface.packageId}'")
       interface
     }
-
-  private[codegen] def resolveChoices(
-      environmentInterface: EnvironmentInterface
-  ): Interface => Interface =
-    _.resolveChoicesAndFailOnUnresolvableChoices(environmentInterface.astInterfaces)
 
   /** Given the package prefixes specified per DAR and the module-prefixes specified in
     * daml.yaml, produce the combined prefixes per package id.

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/TemplateClass.scala
@@ -30,8 +30,7 @@ private[inner] object TemplateClass extends StrictLogging {
       val fields = getFieldsWithTypes(record.fields, packagePrefixes)
       val staticCreateMethod = generateStaticCreateMethod(fields, className)
 
-      // TODO(SC #13921) replace with a call to TemplateChoices#directChoices
-      val templateChoices = template.tChoices.assumeNoOverloadedChoices(githubIssue = 13921)
+      val templateChoices = template.tChoices.directChoices
       val templateType = TypeSpec
         .classBuilder(className)
         .addModifiers(Modifier.FINAL, Modifier.PUBLIC)

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlContractTemplateGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlContractTemplateGen.scala
@@ -37,9 +37,9 @@ object DamlContractTemplateGen {
 
     logger.debug(s"generate templateDecl: ${templateName.toString}, ${templateInterface.toString}")
 
-    // TODO (#13921) replace assumeNoOverloadedChoices with directChoices
+    // TODO (#13926) replace assumeNoOverloadedChoices with directChoices
     val templateChoiceMethods =
-      templateInterface.template.tChoices.assumeNoOverloadedChoices(githubIssue = 13921).flatMap {
+      templateInterface.template.tChoices.assumeNoOverloadedChoices(githubIssue = 13926).flatMap {
         case (id, interface) =>
           util.genTemplateChoiceMethods(
             templateType = tq"${TypeName(templateName.name)}",


### PR DESCRIPTION
Fixes #13921.

```rst
CHANGELOG_BEGIN
- [Java codegen] Direct invocation of interface exercise methods on
  templates is no longer supported, and the ``exercise*`` methods, which
  could generate invalid commands in some cases anyway, are removed.
  Use ``toInterface`` to access interface exercise methods.
CHANGELOG_END
```

* [x] changelog