### PR TITLE
Fix for unclear installation instructions

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -105,8 +105,6 @@ If you have a license for Daml Enterprise, you
 can install it as follows:
 
 
-- Canton can be downloaded from this `repository <https://digitalasset.jfrog.io/artifactory/canton-enterprise/>`_
-  , or you can use our Canton Enterprise Docker images as described in our `Docker instructions <https://www.canton.io/docs/dev/user-manual/usermanual/docker.html#docker-instructions>`_.
 - On Windows, download the installer from Artifactory_ instead of Github
   releases. 
 - On Linux and MacOS, download the corresponding tarball,
@@ -114,6 +112,9 @@ can install it as follows:
   :ref:`global daml-config.yaml <global_daml_config>` and add an entry
   with your Artifactory API key. The API key can be found in your
   Artifactory user profile.
+  - The Enterprise edition includes Canton. You can download Canton from this `repository <https://digitalasset.jfrog.io/artifactory/canton-enterprise/>`_ 
+  , or use the Canton Enterprise Docker images as described in our `Docker instructions <https://www.canton.io/docs/dev/user-manual/usermanual/docker.html#docker-instructions>`_. 
+  - After downloading Canton, unpack it in the directory you want or follow the instructions found `here <https://www.canton.io/docs/dev/user-manual/usermanual/docker.html#starting-canton> to run in Docker.
 
 .. code-block:: yaml
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -114,7 +114,7 @@ can install it as follows:
   Artifactory user profile.
   - The Enterprise edition includes Canton. You can download Canton from this `repository <https://digitalasset.jfrog.io/artifactory/canton-enterprise/>`_ 
   , or use the Canton Enterprise Docker images as described in our `Docker instructions <https://www.canton.io/docs/dev/user-manual/usermanual/docker.html#docker-instructions>`_. 
-  - After downloading Canton, unpack it in the directory you want or follow the instructions found `here <https://www.canton.io/docs/dev/user-manual/usermanual/docker.html#starting-canton> to run in Docker.
+  - After downloading Canton, unpack it in the directory you want or `follow the instructions found here <https://www.canton.io/docs/dev/user-manual/usermanual/docker.html#starting-canton>`_ to run in Docker.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
An attempted fix to the unclear installation instructions. This is based on the most recent version of Canton installation instructions I could find from before the merge, dated Dec. 22, 2021

[CHANGELOG_BEGIN]

[CHANGELOG_END]

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
