### PR TITLE
remove two-argument fromIdAndRecord from Java codegen output

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/codegen/ContractCompanion.java
@@ -7,7 +7,6 @@ import com.daml.ledger.javaapi.data.CreatedEvent;
 import com.daml.ledger.javaapi.data.DamlRecord;
 import com.daml.ledger.javaapi.data.Identifier;
 import com.daml.ledger.javaapi.data.Value;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -72,16 +71,6 @@ public abstract class ContractCompanion<Ct, Id, Data> extends ContractTypeCompan
       return newContract.newContract(id, data, agreementText, signatories, observers);
     }
 
-    /**
-     * @deprecated since introduction; only exists to support generated method that has itself been
-     *     deprecated since v0.12.18
-     */
-    @Deprecated
-    public Ct fromIdAndRecord(String contractId, DamlRecord record$) {
-      return fromIdAndRecord(
-          contractId, record$, Optional.empty(), Collections.emptySet(), Collections.emptySet());
-    }
-
     @Override
     public Ct fromCreatedEvent(CreatedEvent event) {
       return fromIdAndRecord(
@@ -130,21 +119,6 @@ public abstract class ContractCompanion<Ct, Id, Data> extends ContractTypeCompan
       Id id = newContractId.apply(contractId);
       Data data = fromValue.apply(record$);
       return newContract.newContract(id, data, agreementText, key, signatories, observers);
-    }
-
-    /**
-     * @deprecated since introduction; only exists to support generated method that has itself been
-     *     deprecated since v0.12.18
-     */
-    @Deprecated
-    public Ct fromIdAndRecord(String contractId, DamlRecord record$) {
-      return fromIdAndRecord(
-          contractId,
-          record$,
-          Optional.empty(),
-          Optional.empty(),
-          Collections.emptySet(),
-          Collections.emptySet());
     }
 
     @Override

--- a/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
+++ b/language-support/java/codegen/src/it/java/com/daml/TemplateMethodTest.java
@@ -59,13 +59,6 @@ public class TemplateMethodTest {
   }
 
   @Test
-  void contractHasDeprecatedFromIdAndRecord() {
-    SimpleTemplate.Contract contract =
-        SimpleTemplate.Contract.fromIdAndRecord("SomeId", simpleTemplateRecord);
-    assertFalse(contract.agreementText.isPresent(), "Field agreementText should not be present");
-  }
-
-  @Test
   void contractHasFromIdAndRecord() {
     SimpleTemplate.Contract emptyAgreement =
         SimpleTemplate.Contract.fromIdAndRecord(

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
@@ -39,9 +39,6 @@ object ContractClass {
           )
         )
         .addMethod(
-          Builder.generateFromIdAndRecordDeprecated(contractClassName)
-        )
-        .addMethod(
           Builder.generateFromCreatedEvent(contractClassName)
         )
       this
@@ -66,18 +63,6 @@ object ContractClass {
         className,
         identity,
         (ClassName get classOf[javaapi.data.CreatedEvent], "event"),
-      )
-
-    // XXX remove; see digital-asset/daml#13773
-    private def generateFromIdAndRecordDeprecated(
-        className: ClassName
-    ): MethodSpec =
-      generateCompanionForwarder(
-        "fromIdAndRecord",
-        className,
-        _.addAnnotation(classOf[Deprecated]),
-        (ClassName get classOf[String], "contractId"),
-        (ClassName get classOf[javaapi.data.DamlRecord], "record$"),
       )
 
     private[inner] def generateFromIdAndRecord(


### PR DESCRIPTION
Fixes #13773.

```rst
CHANGELOG_BEGIN
- [Java codegen] The two-argument overload for ``fromIdAndRecord``,
  deprecated since SDK 0.12.18, has been removed.  Code that still uses
  this should use either ``fromCreatedEvent``, or the remaining overload
  of ``fromIdAndRecord`` if no ``CreatedEvent`` is available.
CHANGELOG_END
```