### PR TITLE
remove inherited choices from Scala codegen, test interface/template IDs

### DIFF
--- a/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
+++ b/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
@@ -597,11 +597,6 @@ interface InterfaceToMix where
   choice InheritedOnly: ContractId InterfaceToMix with
     controller getOwner this
     do return self
-{- TODO(#13926) uncomment when overloaded choices compile
-  choice OverloadedInTemplate: () with
-    controller getOwner this
-    do return ()
--}
 
 template InterfaceMixer with
     party: Party

--- a/language-support/scala/codegen-sample-app/src/main/daml/MyMainIface.daml
+++ b/language-support/scala/codegen-sample-app/src/main/daml/MyMainIface.daml
@@ -9,3 +9,7 @@ interface IfaceFromAnotherMod where
       sth: Int
     controller getOwner this
     do return $ sth + 1
+  choice OverloadedInTemplate: () with
+    controller getOwner this
+    do return ()
+

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
@@ -82,6 +82,27 @@ class GeneratedCommandsUT extends AnyWordSpec with Matchers with Inside {
       }
     }
 
+    "invoke interface-defined choices, even when overloaded in template" in {
+      inside(
+        imId
+          .toInterface[MyMainIface.IfaceFromAnotherMod]
+          .exerciseOverloadedInTemplate(alice)
+          .command
+          .command
+      ) {
+        case rpccmd.Command.Command.Exercise(
+              rpccmd.ExerciseCommand(
+                Some(FAMTemplateId),
+                cid,
+                "OverloadedInTemplate",
+                Some(choiceArg),
+              )
+            ) =>
+          cid should ===(imId)
+          choiceArg should ===(encode(MyMainIface.OverloadedInTemplate()))
+      }
+    }
+
     "invoke interface-inherited choices, directly from template" in {
       inside(imId.exerciseInheritedOnly(alice).command.command) {
         case rpccmd.Command.Command.Exercise(

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
@@ -65,6 +65,7 @@ class GeneratedCommandsUT extends AnyWordSpec with Matchers with Inside {
     val imId: P.ContractId[MyMain.InterfaceMixer] = P.ContractId("fakeimid")
     val itmId: P.ContractId[MyMainIface.IfaceFromAnotherMod] = P.ContractId("fakeitmid")
     val DirectTemplateId = ApiTypes.TemplateId unwrap MyMain.InterfaceMixer.id
+    val ITMTemplateId = ApiTypes.TemplateId unwrap MyMain.InterfaceToMix.id
     val FAMTemplateId = ApiTypes.TemplateId unwrap MyMainIface.IfaceFromAnotherMod.id
 
     "invoke directly-defined choices" in {
@@ -103,11 +104,11 @@ class GeneratedCommandsUT extends AnyWordSpec with Matchers with Inside {
       }
     }
 
-    "invoke interface-inherited choices, directly from template" in {
-      inside(imId.exerciseInheritedOnly(alice).command.command) {
+    "invoke interface-inherited choices by converting to interface" in {
+      inside(imId.toInterface[MyMain.InterfaceToMix].exerciseInheritedOnly(alice).command.command) {
         case rpccmd.Command.Command.Exercise(
               rpccmd.ExerciseCommand(
-                Some(DirectTemplateId), // TODO(#13349, #13668) must be interface ID
+                Some(ITMTemplateId),
                 cid,
                 "InheritedOnly",
                 Some(choiceArg),

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/CodeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/CodeGen.scala
@@ -74,7 +74,7 @@ object CodeGen {
       roots: Seq[String],
   ): ValidationNel[String, Unit] =
     decodeInterfaces(files).map { interfaces: NonEmptyList[EnvironmentInterface] =>
-      val combined = interfaces.suml1.resolveChoices
+      val combined = interfaces.suml1
       val interface = combined.copy(
         typeDecls = Util.filterTemplatesBy(roots.map(_.r))(combined.typeDecls)
       )


### PR DESCRIPTION
Fixes #13926.

```rst
CHANGELOG_BEGIN
- [Scala codegen] Interface choices can no longer be invoked directly on
  template IDs, or via ``createAnd`` or ``key`` directly.  Instead, use
  ``toInterface[Ifn]`` before calling the relevant ``exercise*`` method.

  The resulting ledger commands now contain the correct interface ID
  rather than template ID for looking up the choice, but see #13993 for
  a caveat regarding create-and-exercise and exercise-by-key.
CHANGELOG_END
```

* [x] #13991
* [x] rebase and change PR target to main
* [x] changelog