### PR TITLE
docs: fix two code snippets

### DIFF
--- a/docs/source/daml/patterns/authorization.rst
+++ b/docs/source/daml/patterns/authorization.rst
@@ -25,8 +25,8 @@ Here is an implementation of a *Coin transfer* without any authorization:
 
 .. literalinclude:: daml/CoinIssuance.daml
   :language: daml
-  :start-after: -- BEGIN_COIN_TEMPLATE_ARCHIVE
-  :end-before: -- END_COIN_TEMPLATE_ARCHIVE
+  :start-after: -- BEGIN_COIN_TEMPLATE_TRANSFER
+  :end-before: -- END_COIN_TEMPLATE_TRANSFER
 
 This is may be insufficient since the issuer has no means to ensure the newOwner is an accredited company. The following changes fix this deficiency.
 

--- a/docs/source/daml/patterns/delegation.rst
+++ b/docs/source/daml/patterns/delegation.rst
@@ -25,8 +25,8 @@ Implementation
 
 .. literalinclude:: daml/CoinIssuance.daml
   :language: daml
-  :start-after: -- BEGIN_COIN_TEMPLATE_ARCHIVE
-  :end-before: -- END_COIN_TEMPLATE_ARCHIVE
+  :start-after: -- BEGIN_COIN_TEMPLATE_TRANSFER
+  :end-before: -- END_COIN_TEMPLATE_TRANSFER
 
 Delegation Contract
   - *Principal*, the original coin owner, is the signatory of delegation contract *CoinPoA*. This signatory is required to authorize the *Transfer* choice on *coin*.


### PR DESCRIPTION
There seems to have been some mixup in which snippets to show for these
two cases.

CHANGELOG_BEGIN
CHANGELOG_END