### PR TITLE
ci: pin Linux image to yesterday's because today's is broken

### DIFF
--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -64,7 +64,7 @@ resource "google_compute_instance_template" "vsts-agent-ubuntu_20_04" {
     disk_type    = "pd-ssd"
     #TODO: when the image gets fixed, go back to auto-upgrading
     #source_image = "ubuntu-os-cloud/ubuntu-2004-lts"
-    source_image = "ubuntu-os-cloud/ubuntu-2004-lts/ubuntu-2004-focal-v20220606"
+    source_image = "ubuntu-os-cloud/ubuntu-2004-focal-v20220606"
   }
 
   lifecycle {

--- a/infra/vsts_agent_ubuntu_20_04.tf
+++ b/infra/vsts_agent_ubuntu_20_04.tf
@@ -62,7 +62,9 @@ resource "google_compute_instance_template" "vsts-agent-ubuntu_20_04" {
   disk {
     disk_size_gb = local.ubuntu[count.index].disk_size
     disk_type    = "pd-ssd"
-    source_image = "ubuntu-os-cloud/ubuntu-2004-lts"
+    #TODO: when the image gets fixed, go back to auto-upgrading
+    #source_image = "ubuntu-os-cloud/ubuntu-2004-lts"
+    source_image = "ubuntu-os-cloud/ubuntu-2004-lts/ubuntu-2004-focal-v20220606"
   }
 
   lifecycle {


### PR DESCRIPTION
Running the `docker` command on today's Ubuntu images crashes the kernel. (Which is super reassuring from a security pov.)

CHANGELOG_BEGIN
CHANGELOG_END