### PR TITLE
Document how to use x64 binaries on M1 MacOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ fi
 ```
 See https://github.com/NixOS/nix/issues/3616 for more information about this issue.
 
+##### MacOS M1
+
+The above procedure will use and build native arm64 M1 binaries for this
+project. However, note that at the time of writing the CI system of the Daml
+project does not yet include MacOS M1 nodes. Therefore, the M1 configuration is
+untested on CI, and the remote cache is not populated with native M1 artifacts.
+
+If you encounter issues with a native M1 build, then you can configure project
+to build x86-64 binaries instead and run them through Rosetta. To do that
+replace the contents of the file `nix/system.nix` with the following content:
+
+```nix
+"x86_64-darwin"
+```
+
 #### Windows
 
 On Windows you need to enable long file paths by running the following command in an admin powershell:


### PR DESCRIPTION
As discussed with @garyverhaegen-da . Since CI does not currently offer M1 nodes to test the native M1 configuration and populate the remote cache with M1 artifacts, it may be easier for some engineers to use x64 artifacts and rely on Rosetta for their execution on M1 machines. This adds a section to the readme explaining how to set this up.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
