### PR TITLE
Interface subscription PoC

### DIFF
--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
@@ -189,15 +189,17 @@ object TransactionGenerator {
   } yield (
     Created(
       CreatedEvent(
-        eventId,
-        contractId,
-        Some(scalaTemplateId),
-        contractKey.map(_._1),
-        Some(scalaRecord),
-        signatories ++ observers,
-        signatories,
-        observers,
-        agreementText,
+        eventId = eventId,
+        contractId = contractId,
+        templateId = Some(scalaTemplateId),
+        contractKey = contractKey.map(_._1),
+        createArguments = Some(scalaRecord),
+        createArgumentsBlob = None, // TODO DPP-1068
+        interfaceViews = Seq.empty, // TODO DPP-1068
+        witnessParties = signatories ++ observers,
+        signatories = signatories,
+        observers = observers,
+        agreementText = agreementText,
       )
     ),
     new data.CreatedEvent(

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -7,6 +7,8 @@ package com.daml.ledger.api.v1;
 
 import "com/daml/ledger/api/v1/value.proto";
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/any.proto";
+import "google/rpc/status.proto";
 
 
 option java_outer_classname = "EventOuterClass";
@@ -54,8 +56,21 @@ message CreatedEvent {
   Value contract_key = 7;
 
   // The arguments that have been used to create the contract.
-  // Required
+  // Set if there was a match by template_id in the given transaction filter.
+  // Optional
   Record create_arguments = 4;
+
+  // Opaque representation of contract payload intented for forwarding
+  // to an API server as a contract disclosed as part of a command
+  // submission.
+  // Optional
+  google.protobuf.Any create_arguments_blob = 10;
+
+  // Interface views specified in the transaction filter. Only contains entries
+  // for the intersection of interfaces implemented by the template
+  // and the interfaces specified in the transaction filter.
+  // Optional
+  repeated InterfaceView interface_views = 11;
 
   // The parties that are notified of this event. When a ``CreatedEvent``
   // is returned as part of a transaction tree, this will include all
@@ -84,6 +99,25 @@ message CreatedEvent {
   google.protobuf.StringValue agreement_text = 6;
 }
 
+// View of a create event matched by an interface filter.
+message InterfaceView {
+
+  // The interface implemented by the matched event.
+  // Required
+  Identifier interface_id = 1;
+
+  // Whether the view was successfully computed, and if not,
+  // the reason for the error. The error is reported using the same rules
+  // for error codes and messages as the errors returned for API requests.
+  // Required
+  google.rpc.Status view_status = 2;
+
+  // The value of the interface's canonical view method on this event.
+  // Optional
+  Record view_value = 3;
+
+}
+
 // Records that a contract has been archived, and choices may no longer be exercised on it.
 message ArchivedEvent {
 
@@ -101,7 +135,7 @@ message ArchivedEvent {
   // Required
   Identifier template_id = 3;
 
-  // The parties that are notified of this event. For ``ArchivedEvent``s,
+  // The parties that are notified of this event. For an ``ArchivedEvent``,
   // these are the intersection of the stakeholders of the contract in
   // question and the parties specified in the ``TransactionFilter``. The
   // stakeholders are the union of the signatories and the observers of
@@ -129,22 +163,22 @@ message ExercisedEvent {
   // Required
   Identifier template_id = 3;
 
-  // The interface where the choice is defined if inherited
+  // The interface where the choice is defined, if inherited.
   // Optional
   Identifier interface_id = 13;
 
   reserved 4; // removed field
 
-  // The choice that's been exercised on the target contract.
+  // The choice that was exercised on the target contract.
   // Must be a valid NameString (as described in ``value.proto``).
   // Required
   string choice = 5;
 
-  // The argument the choice was made with.
+  // The argument of the exercised choice.
   // Required
   Value choice_argument = 6;
 
-  // The parties that made the choice.
+  // The parties that exercised the choice.
   // Each element must be a valid PartyIdString (as described in ``value.proto``).
   // Required
   repeated string acting_parties = 7;
@@ -176,8 +210,8 @@ message ExercisedEvent {
   // Optional
   repeated string child_event_ids = 11;
 
-  // The result of exercising the choice
+  // The result of exercising the choice.
   // Required
   Value exercise_result = 12;
-
 }
+

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -112,7 +112,9 @@ message InterfaceView {
   // Required
   google.rpc.Status view_status = 2;
 
-  // The value of the interface's canonical view method on this event.
+  // The value of the interface's view method on this event.
+  // Set if it was requested in the ``InterfaceFilter`` and it could be
+  // sucessfully computed.
   // Optional
   Record view_value = 3;
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction.proto
@@ -68,7 +68,7 @@ message TreeEvent {
     }
 }
 
-// Filtered view of an on-ledger transaction.
+// Filtered view of an on-ledger transaction's create and archive events.
 message Transaction {
 
   // Assigned by the server. Useful for correlating logs.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -18,7 +18,7 @@ message TransactionFilter {
 
   // Each key must be a valid PartyIdString (as described in ``value.proto``).
   // The interpretation of the filter depends on the stream being filtered:
-  // (1) For **transaction tree streams** only the listed parties matter, and all subtrees
+  // (1) For **transaction tree streams** only party filters with wildcards are allowed, and all subtrees
   //     whose root has one of the listed parties as an informee are returned.
   // (2) For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
   //    stakeholders include at least one of the listed parties and match the
@@ -59,8 +59,7 @@ message InterfaceFilter {
   // Required
   Identifier interface_id = 1;
 
-  // Whether to include the canonical interface view on the contract in the
-  // returned ``CreateEvent``.
+  // Whether to include the interface view on the contract in the returned ``CreateEvent``.
   // Use this to access contract data in a uniform manner in your API client.
   // Optional
   bool include_interface_view = 2;

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -12,30 +12,63 @@ option java_outer_classname = "TransactionFilterOuterClass";
 option java_package = "com.daml.ledger.api.v1";
 option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 
-// Used for filtering Transaction and Active Contract Set streams.
-// Determines which on-ledger events will be served to the client.
+// A filter both for filtering create and archive events as well as for
+// filtering transaction trees.
 message TransactionFilter {
 
-  // Keys of the map determine which parties' on-ledger transactions are being queried.
-  // Values of the map determine which events are disclosed in the stream per party.
-  // At the minimum, a party needs to set an empty Filters message to receive any events.
   // Each key must be a valid PartyIdString (as described in ``value.proto``).
+  // The interpretation of the filter depends on the stream being filtered:
+  // (1) For **transaction tree streams** only the listed parties matter, and all subtrees
+  //     whose root has one of the listed parties as an informee are returned.
+  // (2) For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
+  //    stakeholders include at least one of the listed parties and match the
+  //    per-party filter.
   // Required
   map<string, Filters> filters_by_party = 1;
 }
 
+// The union of a set of contract filters, or a wildcard.
 message Filters {
 
-  // If not set, no filters will be applied.
+  // If set, then contracts matching any of the ``InclusiveFilters`` match
+  // this filter.
+  // If not set, any contract matches this filter.
   // Optional
   InclusiveFilters inclusive = 1;
 }
 
-// If no internal fields are set, no filters will be applied.
+// A filter that matches all contracts that are either an instance of one of
+// the ``template_ids`` or that match one of the ``interface_filters``.
 message InclusiveFilters {
 
-  // A collection of templates.
+  // A collection of templates for which the payload will be included in the
+  // ``create_arguments`` of a matching ``CreatedEvent``.
   // SHOULD NOT contain duplicates.
-  // Required
+  // Optional
   repeated Identifier template_ids = 1;
+
+  // Include an ``InterfaceView`` for every ``InterfaceFilter`` matching a contract.
+  // Optional
+  repeated InterfaceFilter interface_filters = 2;
+}
+
+// This filter matches contracts that implement a specific interface.
+message InterfaceFilter {
+
+  // The interface that a matching contract must implement.
+  // Required
+  Identifier interface_id = 1;
+
+  // Whether to include the canonical interface view on the contract in the
+  // returned ``CreateEvent``.
+  // Use this to access contract data in a uniform manner in your API client.
+  // Optional
+  bool include_interface_view = 2;
+
+  // Whether to include a ``create_arguments_blob`` in the returned
+  // ``CreateEvent``.
+  // Use this to access the complete contract data in your API client
+  // for submitting it as a disclosed contract with future commands.
+  // Optional
+  bool include_create_arguments_blob = 3;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -177,4 +177,3 @@ message GetLedgerEndResponse {
   // The absolute offset of the current ledger end.
   LedgerOffset offset = 1;
 }
-

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -177,3 +177,4 @@ message GetLedgerEndResponse {
   // The absolute offset of the current ledger end.
   LedgerOffset offset = 1;
 }
+

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.api.validation
 import com.daml.error.ContextualizedErrorLogger
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.domain.InclusiveFilters
-import com.daml.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
+import com.daml.ledger.api.v1.transaction_filter.{Filters, InterfaceFilter, TransactionFilter}
 import com.daml.platform.server.api.validation.FieldValidations
 import io.grpc.StatusRuntimeException
 import scalaz.std.either._
@@ -43,9 +43,26 @@ object TransactionFilterValidator {
     filters.inclusive
       .fold[Either[StatusRuntimeException, domain.Filters]](Right(domain.Filters.noFilter)) {
         inclusive =>
-          val validatedIdents =
-            inclusive.templateIds.toList traverse validateIdentifier
-          validatedIdents.map(ids => domain.Filters(Some(InclusiveFilters(ids.toSet))))
+          for {
+            validatedIdents <- inclusive.templateIds.toList traverse validateIdentifier
+            validatedInterfaces <-
+              inclusive.interfaceFilters.toList traverse validateInterfaceFilter
+          } yield domain.Filters(
+            Some(InclusiveFilters(validatedIdents.toSet, validatedInterfaces.toSet))
+          )
       }
+  }
+
+  def validateInterfaceFilter(filter: InterfaceFilter)(implicit
+      contextualizedErrorLogger: ContextualizedErrorLogger
+  ): Either[StatusRuntimeException, domain.InterfaceFilter] = {
+    for {
+      interfaceId <- requirePresence(filter.interfaceId, "interfaceId")
+      validatedId <- validateIdentifier(interfaceId)
+    } yield domain.InterfaceFilter(
+      validatedId,
+      filter.includeInterfaceView,
+      filter.includeCreateArgumentsBlob,
+    )
   }
 }

--- a/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
+++ b/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
@@ -46,7 +46,8 @@ trait ValidatorTestUtils extends Matchers with Inside with OptionValues { self: 
                   Ref.DottedName.assertFromString(includedTemplate),
                 ),
               )
-            )
+            ),
+            Set.empty,
           )
         )
       )

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
@@ -231,7 +231,7 @@ class TransactionServiceRequestValidatorTest
           filtersByParty should have size 1
           inside(filtersByParty.headOption.value) { case (p, filters) =>
             p shouldEqual party
-            filters shouldEqual domain.Filters(Some(domain.InclusiveFilters(Set())))
+            filters shouldEqual domain.Filters(Some(domain.InclusiveFilters(Set(), Set())))
           }
           req.verbose shouldEqual verbose
         }

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -45,7 +45,16 @@ object domain {
     def apply(inclusive: InclusiveFilters) = new Filters(Some(inclusive))
   }
 
-  final case class InclusiveFilters(templateIds: immutable.Set[Ref.Identifier])
+  final case class InterfaceFilter(
+      interfaceId: Ref.Identifier,
+      includeView: Boolean,
+      includeBlob: Boolean,
+  )
+
+  final case class InclusiveFilters(
+      templateIds: immutable.Set[Ref.Identifier],
+      interfaceFilters: immutable.Set[InterfaceFilter],
+  )
 
   sealed abstract class LedgerOffset extends Product with Serializable
 

--- a/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-tests/infrastructure/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -58,6 +58,18 @@ object Assertions {
     }
   }
 
+  def assertNotEquals[T](context: String, actual: T, expected: T): Unit = {
+    try {
+      MUnit.assertNotEquals(actual, expected, context)
+    } catch {
+      case e: ComparisonFailException =>
+        throw AssertionErrorWithPreformattedMessage(
+          e.message,
+          s"$context: two objects are supposed to be different but they are equal",
+        )
+    }
+  }
+
   def assertSameElements[T](actual: Iterable[T], expected: Iterable[T]): Unit = {
     assert(
       actual.toSet == expected.toSet,

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev.scala
@@ -8,7 +8,10 @@ import com.daml.ledger.api.tls.TlsConfiguration
 
 package object v1_dev {
   def default(timeoutScaleFactor: Double): Vector[LedgerTestSuite] =
-    v1_14.default(timeoutScaleFactor) :+ new InterfaceIT
+    v1_14.default(timeoutScaleFactor) ++ Vector(
+      new InterfaceIT,
+      new InterfaceSubscriptionsIT,
+    )
 
   def optional(tlsConfig: Option[TlsConfiguration]): Vector[LedgerTestSuite] =
     v1_14.optional(tlsConfig)

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/InterfaceSubscriptionsIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/InterfaceSubscriptionsIT.scala
@@ -41,7 +41,7 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
       c3 <- ledger.create(party, T3(party, 3)) // Implements I with a view that crashes
       _ <- ledger.create(party, T4(party, 4)) // Does not implement I
       transactions <- ledger.flatTransactions(
-        interfaceSubscription(party, Seq.empty, Seq(InterfaceId), ledger)
+        transactionSubscription(party, Seq.empty, Seq(InterfaceId), ledger)
       )
     } yield {
       assertLength("3 transactions found", 3, transactions)
@@ -102,15 +102,15 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
       _ <- ledger.create(party, T4(party, 4))
       // 1. Subscribe by the interface
       transactions1 <- ledger.flatTransactions(
-        interfaceSubscription(party, Seq.empty, Seq(InterfaceId), ledger)
+        transactionSubscription(party, Seq.empty, Seq(InterfaceId), ledger)
       )
       // 2. Subscribe by all implementing templates
       transactions2 <- ledger.flatTransactions(
-        interfaceSubscription(party, allImplementations, Seq.empty, ledger)
+        transactionSubscription(party, allImplementations, Seq.empty, ledger)
       )
       // 3. Subscribe by both the interface and all templates (redundant filters)
       transactions3 <- ledger.flatTransactions(
-        interfaceSubscription(party, allImplementations, Seq(InterfaceId), ledger)
+        transactionSubscription(party, allImplementations, Seq(InterfaceId), ledger)
       )
     } yield {
       assertLength("3 transactions found", 3, transactions1)
@@ -135,11 +135,104 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
       _ <- ledger.create(party, T3(party, 3))
       _ <- ledger.create(party, T4(party, 4))
       _ <- ledger
-        .flatTransactions(interfaceSubscription(party, Seq.empty, Seq(unknownInterface), ledger))
+        .flatTransactions(transactionSubscription(party, Seq.empty, Seq(unknownInterface), ledger))
         .failed
     } yield {
       // TODO DPP-1068: The error is currently not a self-service error, check here the error code once that is fixed
       ()
+    }
+  })
+
+  test(
+    "ISAcsBasic",
+    "Basic functionality for interface subscriptions on ACS streams",
+    allocate(SingleParty),
+  )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    for {
+      c1 <- ledger.create(party, T1(party, 1)) // Implements I with view (1, true)
+      c2 <- ledger.create(party, T2(party, 2)) // Implements I with view (2, false)
+      c3 <- ledger.create(party, T3(party, 3)) // Implements I with a view that crashes
+      _ <- ledger.create(party, T4(party, 4)) // Does not implement I
+      (_, acs) <- ledger.activeContracts(
+        acsSubscription(party, Seq.empty, Seq(InterfaceId), ledger)
+      )
+    } yield {
+      assertLength("3 transactions found", 3, acs)
+
+      // T1
+      val createdEvent1 = acs(0)
+      assertLength("Create event 1 has a view", 1, createdEvent1.interfaceViews)
+      assertEquals(
+        "Create event 1 template ID",
+        createdEvent1.templateId.get.toString,
+        Tag.unwrap(T1.id).toString,
+      )
+      assertEquals("Create event 1 contract ID", createdEvent1.contractId, c1.toString)
+      assertViewEquals(createdEvent1.interfaceViews.head, InterfaceId) { value =>
+        assertLength("View1 has 2 fields", 2, value.fields)
+        assertEquals("View1.a", value.fields(0).getValue.getInt64, 1)
+        assertEquals("View1.b", value.fields(1).getValue.getBool, true)
+      }
+
+      // T2
+      val createdEvent2 = acs(1)
+      assertLength("Create event 2 has a view", 1, createdEvent2.interfaceViews)
+      assertEquals(
+        "Create event 2 template ID",
+        createdEvent2.templateId.get.toString,
+        Tag.unwrap(T2.id).toString,
+      )
+      assertEquals("Create event 2 contract ID", createdEvent2.contractId, c2.toString)
+      assertViewEquals(createdEvent2.interfaceViews.head, InterfaceId) { value =>
+        assertLength("View2 has 2 fields", 2, value.fields)
+        assertEquals("View2.a", value.fields(0).getValue.getInt64, 2)
+        assertEquals("View2.b", value.fields(1).getValue.getBool, false)
+      }
+
+      // T3
+      val createdEvent3 = acs(2)
+      assertLength("Create event 3 has a view", 1, createdEvent3.interfaceViews)
+      assertEquals(
+        "Create event 3 template ID",
+        createdEvent3.templateId.get.toString,
+        Tag.unwrap(T3.id).toString,
+      )
+      assertEquals("Create event 3 contract ID", createdEvent3.contractId, c3.toString)
+      assertViewFailed(createdEvent3.interfaceViews.head, InterfaceId)
+    }
+  })
+
+  test(
+    "ISAcsEquivalentFilters",
+    "Subscribing by interface or all implementing templates gives the same result",
+    allocate(SingleParty),
+  )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    val allImplementations = Seq(Tag.unwrap(T1.id), Tag.unwrap(T2.id), Tag.unwrap(T3.id))
+    for {
+      _ <- ledger.create(party, T1(party, 1))
+      _ <- ledger.create(party, T2(party, 2))
+      _ <- ledger.create(party, T3(party, 3))
+      _ <- ledger.create(party, T4(party, 4))
+      // 1. Subscribe by the interface
+      (_, acs1) <- ledger.activeContracts(
+        acsSubscription(party, Seq.empty, Seq(InterfaceId), ledger)
+      )
+      // 2. Subscribe by all implementing templates
+      (_, acs2) <- ledger.activeContracts(
+        acsSubscription(party, allImplementations, Seq.empty, ledger)
+      )
+      // 3. Subscribe by both the interface and all templates (redundant filters)
+      (_, acs3) <- ledger.activeContracts(
+        acsSubscription(party, allImplementations, Seq(InterfaceId), ledger)
+      )
+    } yield {
+      assertLength("3 active contracts found", 3, acs1)
+      assertEquals(
+        "1 and 2 find the same contracts (but not the same views)",
+        acs1.map(_.contractId),
+        acs2.map(_.contractId),
+      )
+      assertEquals("1 and 3 produce the exact same result", acs1, acs3)
     }
   })
 
@@ -165,7 +258,7 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
   }
 
   // TODO DPP-1068: Factor out methods for creating interface subscriptions, see ParticipantTestContext.getTransactionsRequest
-  private def interfaceSubscription(
+  private def transactionSubscription(
       party: Party,
       templateIds: Seq[Identifier],
       interfaceIds: Seq[Identifier],
@@ -191,6 +284,36 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
     )
     ledger
       .getTransactionsRequest(Seq(party))
+      .update(_.filter := filter)
+  }
+
+  // TODO DPP-1068: Factor out methods for creating interface subscriptions, see ParticipantTestContext.getTransactionsRequest
+  private def acsSubscription(
+      party: Party,
+      templateIds: Seq[Identifier],
+      interfaceIds: Seq[Identifier],
+      ledger: ParticipantTestContext,
+  ) = {
+    val filter = new TransactionFilter(
+      Map(
+        party.toString -> new Filters(
+          Some(
+            new InclusiveFilters(
+              templateIds = templateIds,
+              interfaceFilters = interfaceIds.map(id =>
+                new InterfaceFilter(
+                  Some(id),
+                  includeInterfaceView = true,
+                  includeCreateArgumentsBlob = true,
+                )
+              ),
+            )
+          )
+        )
+      )
+    )
+    ledger
+      .activeContractsRequest(Seq(party))
       .update(_.filter := filter)
   }
 

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/InterfaceSubscriptionsIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/InterfaceSubscriptionsIT.scala
@@ -3,13 +3,24 @@
 
 package com.daml.ledger.api.testtool.suites.v1_dev
 
-import com.daml.ledger.api.testtool.infrastructure.Allocation.{Participant, Participants, SingleParty, allocate}
+import com.daml.ledger.api.testtool.infrastructure.Allocation.{
+  Participant,
+  Participants,
+  SingleParty,
+  allocate,
+}
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
-import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, InterfaceFilter, TransactionFilter}
-import com.daml.ledger.api.v1.value.Identifier
+import com.daml.ledger.api.v1.event.InterfaceView
+import com.daml.ledger.api.v1.transaction_filter.{
+  Filters,
+  InclusiveFilters,
+  InterfaceFilter,
+  TransactionFilter,
+}
+import com.daml.ledger.api.v1.value.{Identifier, Record}
 import com.daml.ledger.client.binding.Primitive.Party
 import com.daml.ledger.test.semantic.InterfaceViews._
 import scalaz.Tag
@@ -17,42 +28,169 @@ import scalaz.Tag
 // TODO DPP-1068: Move to an appropriate place, maybe merge with InterfaceIT?
 class InterfaceSubscriptionsIT extends LedgerTestSuite {
 
-  private[this] val T1Id = Tag.unwrap(T1.id)
-  private[this] val T2Id = Tag.unwrap(T2.id)
-  private[this] val T3Id = Tag.unwrap(T3.id)
-  private[this] val T4Id = Tag.unwrap(T4.id)
-  private[this] val IId = Tag.unwrap(T1.id).copy(moduleName = "Interface1", entityName = "I")
+  private[this] val InterfaceId = Tag.unwrap(T1.id).copy(entityName = "I")
 
   test(
-    "ISPlaceholder",
-    "Placeholder test",
+    "ISTransactionsBasic",
+    "Basic functionality for interface subscriptions on transaction streams",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
     for {
-      _ <- ledger.create(party, T1(party, 1)) // Implements I with view (1, true)
-      _ <- ledger.create(party, T2(party, 2)) // Implements I with view (2, false)
-      _ <- ledger.create(party, T3(party, 3)) // Implements I with a view that crashes
+      c1 <- ledger.create(party, T1(party, 1)) // Implements I with view (1, true)
+      c2 <- ledger.create(party, T2(party, 2)) // Implements I with view (2, false)
+      c3 <- ledger.create(party, T3(party, 3)) // Implements I with a view that crashes
       _ <- ledger.create(party, T4(party, 4)) // Does not implement I
-      transactions <- ledger.flatTransactions(interfaceSubscription(party, Seq(IId), ledger))
+      transactions <- ledger.flatTransactions(
+        interfaceSubscription(party, Seq.empty, Seq(InterfaceId), ledger)
+      )
     } yield {
-      assertLength(s"3 transactions found", 2, transactions)
-      val firstCreatedEvent = createdEvents(transactions.head).head
-      assertLength(s"2 interface views in the first create event", 2, firstCreatedEvent.interfaceViews)
-      val firstInterfaceView = firstCreatedEvent.interfaceViews.head
-      assertDefined(firstInterfaceView.viewValue, "First interface view has a value")
-      assertEquals("Interface view has the right value", firstInterfaceView.viewValue.get.fields.head.value.get.getParty, party)
+      assertLength("3 transactions found", 3, transactions)
+
+      // T1
+      val createdEvent1 = createdEvents(transactions(0)).head
+      assertLength("Create event 1 has a view", 1, createdEvent1.interfaceViews)
+      assertEquals(
+        "Create event 1 template ID",
+        createdEvent1.templateId.get.toString,
+        Tag.unwrap(T1.id).toString,
+      )
+      assertEquals("Create event 1 contract ID", createdEvent1.contractId, c1.toString)
+      assertViewEquals(createdEvent1.interfaceViews.head, InterfaceId) { value =>
+        assertLength("View1 has 2 fields", 2, value.fields)
+        assertEquals("View1.a", value.fields(0).getValue.getInt64, 1)
+        assertEquals("View1.b", value.fields(1).getValue.getBool, true)
+      }
+
+      // T2
+      val createdEvent2 = createdEvents(transactions(1)).head
+      assertLength("Create event 2 has a view", 1, createdEvent2.interfaceViews)
+      assertEquals(
+        "Create event 2 template ID",
+        createdEvent2.templateId.get.toString,
+        Tag.unwrap(T2.id).toString,
+      )
+      assertEquals("Create event 2 contract ID", createdEvent2.contractId, c2.toString)
+      assertViewEquals(createdEvent2.interfaceViews.head, InterfaceId) { value =>
+        assertLength("View2 has 2 fields", 2, value.fields)
+        assertEquals("View2.a", value.fields(0).getValue.getInt64, 2)
+        assertEquals("View2.b", value.fields(1).getValue.getBool, false)
+      }
+
+      // T3
+      val createdEvent3 = createdEvents(transactions(2)).head
+      assertLength("Create event 3 has a view", 1, createdEvent3.interfaceViews)
+      assertEquals(
+        "Create event 3 template ID",
+        createdEvent3.templateId.get.toString,
+        Tag.unwrap(T3.id).toString,
+      )
+      assertEquals("Create event 3 contract ID", createdEvent3.contractId, c3.toString)
+      assertViewFailed(createdEvent3.interfaceViews.head, InterfaceId)
     }
   })
 
+  test(
+    "ISTransactionsEquivalentFilters",
+    "Subscribing by interface or all implementing templates gives the same result",
+    allocate(SingleParty),
+  )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    val allImplementations = Seq(Tag.unwrap(T1.id), Tag.unwrap(T2.id), Tag.unwrap(T3.id))
+    for {
+      _ <- ledger.create(party, T1(party, 1))
+      _ <- ledger.create(party, T2(party, 2))
+      _ <- ledger.create(party, T3(party, 3))
+      _ <- ledger.create(party, T4(party, 4))
+      // 1. Subscribe by the interface
+      transactions1 <- ledger.flatTransactions(
+        interfaceSubscription(party, Seq.empty, Seq(InterfaceId), ledger)
+      )
+      // 2. Subscribe by all implementing templates
+      transactions2 <- ledger.flatTransactions(
+        interfaceSubscription(party, allImplementations, Seq.empty, ledger)
+      )
+      // 3. Subscribe by both the interface and all templates (redundant filters)
+      transactions3 <- ledger.flatTransactions(
+        interfaceSubscription(party, allImplementations, Seq(InterfaceId), ledger)
+      )
+    } yield {
+      assertLength("3 transactions found", 3, transactions1)
+      assertEquals(
+        "1 and 2 find the same transactions",
+        transactions1.map(_.transactionId),
+        transactions2.map(_.transactionId),
+      )
+      assertEquals("1 and 3 produce the exact same result", transactions1, transactions3)
+    }
+  })
+
+  test(
+    "ISTransactionsUnknownInterface",
+    "Subscribing by an unknown interface fails",
+    allocate(SingleParty),
+  )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    val unknownInterface = InterfaceId.copy(entityName = "IDoesNotExist")
+    for {
+      _ <- ledger.create(party, T1(party, 1))
+      _ <- ledger.create(party, T2(party, 2))
+      _ <- ledger.create(party, T3(party, 3))
+      _ <- ledger.create(party, T4(party, 4))
+      _ <- ledger
+        .flatTransactions(interfaceSubscription(party, Seq.empty, Seq(unknownInterface), ledger))
+        .failed
+    } yield {
+      // TODO DPP-1068: The error is currently not a self-service error, check here the error code once that is fixed
+      ()
+    }
+  })
+
+  private def assertViewFailed(view: InterfaceView, interfaceId: Identifier): Unit = {
+    val actualInterfaceId = assertDefined(view.interfaceId, "Interface ID is not defined")
+    assertEquals("View has correct interface ID", interfaceId, actualInterfaceId)
+
+    val status = assertDefined(view.viewStatus, "Status is not defined")
+    assertNotEquals("Status must be failed", status.code, 0)
+  }
+
+  private def assertViewEquals(view: InterfaceView, interfaceId: Identifier)(
+      checkValue: Record => Unit
+  ): Unit = {
+    val actualInterfaceId = assertDefined(view.interfaceId, "Interface ID is not defined")
+    assertEquals("View has correct interface ID", interfaceId, actualInterfaceId)
+
+    val status = assertDefined(view.viewStatus, "Status is not defined")
+    assertEquals("Status must be successful", status.code, 0)
+
+    val actualValue = assertDefined(view.viewValue, "Value is not defined")
+    checkValue(actualValue)
+  }
+
   // TODO DPP-1068: Factor out methods for creating interface subscriptions, see ParticipantTestContext.getTransactionsRequest
-  private def interfaceSubscription(party: Party, interfaceIds: Seq[Identifier], ledger: ParticipantTestContext) = {
-    val filter = new TransactionFilter(Map(party.toString -> new Filters(Some(new InclusiveFilters(
-      templateIds = Seq.empty,
-      interfaceFilters = interfaceIds.map(id =>
-        new InterfaceFilter(Some(id), includeInterfaceView = true, includeCreateArgumentsBlob = true),
-      ),
-    )))))
-    ledger.getTransactionsRequest(Seq(party))
+  private def interfaceSubscription(
+      party: Party,
+      templateIds: Seq[Identifier],
+      interfaceIds: Seq[Identifier],
+      ledger: ParticipantTestContext,
+  ) = {
+    val filter = new TransactionFilter(
+      Map(
+        party.toString -> new Filters(
+          Some(
+            new InclusiveFilters(
+              templateIds = templateIds,
+              interfaceFilters = interfaceIds.map(id =>
+                new InterfaceFilter(
+                  Some(id),
+                  includeInterfaceView = true,
+                  includeCreateArgumentsBlob = true,
+                )
+              ),
+            )
+          )
+        )
+      )
+    )
+    ledger
+      .getTransactionsRequest(Seq(party))
       .update(_.filter := filter)
   }
 

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/InterfaceSubscriptionsIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/InterfaceSubscriptionsIT.scala
@@ -115,7 +115,7 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
     } yield {
       assertLength("3 transactions found", 3, transactions1)
       assertEquals(
-        "1 and 2 find the same transactions",
+        "1 and 2 find the same transactions (but not the same views)",
         transactions1.map(_.transactionId),
         transactions2.map(_.transactionId),
       )

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/InterfaceSubscriptionsIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/InterfaceSubscriptionsIT.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.suites.v1_dev
+
+import com.daml.ledger.api.testtool.infrastructure.Allocation.{Participant, Participants, SingleParty, allocate}
+import com.daml.ledger.api.testtool.infrastructure.Assertions._
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
+import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
+import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
+import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, InterfaceFilter, TransactionFilter}
+import com.daml.ledger.api.v1.value.Identifier
+import com.daml.ledger.client.binding.Primitive.Party
+import com.daml.ledger.test.semantic.InterfaceViews._
+import scalaz.Tag
+
+// TODO DPP-1068: Move to an appropriate place, maybe merge with InterfaceIT?
+class InterfaceSubscriptionsIT extends LedgerTestSuite {
+
+  private[this] val T1Id = Tag.unwrap(T1.id)
+  private[this] val T2Id = Tag.unwrap(T2.id)
+  private[this] val T3Id = Tag.unwrap(T3.id)
+  private[this] val T4Id = Tag.unwrap(T4.id)
+  private[this] val IId = Tag.unwrap(T1.id).copy(moduleName = "Interface1", entityName = "I")
+
+  test(
+    "ISPlaceholder",
+    "Placeholder test",
+    allocate(SingleParty),
+  )(implicit ec => { case Participants(Participant(ledger, party)) =>
+    for {
+      _ <- ledger.create(party, T1(party, 1)) // Implements I with view (1, true)
+      _ <- ledger.create(party, T2(party, 2)) // Implements I with view (2, false)
+      _ <- ledger.create(party, T3(party, 3)) // Implements I with a view that crashes
+      _ <- ledger.create(party, T4(party, 4)) // Does not implement I
+      transactions <- ledger.flatTransactions(interfaceSubscription(party, Seq(IId), ledger))
+    } yield {
+      assertLength(s"3 transactions found", 2, transactions)
+      val firstCreatedEvent = createdEvents(transactions.head).head
+      assertLength(s"2 interface views in the first create event", 2, firstCreatedEvent.interfaceViews)
+      val firstInterfaceView = firstCreatedEvent.interfaceViews.head
+      assertDefined(firstInterfaceView.viewValue, "First interface view has a value")
+      assertEquals("Interface view has the right value", firstInterfaceView.viewValue.get.fields.head.value.get.getParty, party)
+    }
+  })
+
+  // TODO DPP-1068: Factor out methods for creating interface subscriptions, see ParticipantTestContext.getTransactionsRequest
+  private def interfaceSubscription(party: Party, interfaceIds: Seq[Identifier], ledger: ParticipantTestContext) = {
+    val filter = new TransactionFilter(Map(party.toString -> new Filters(Some(new InclusiveFilters(
+      templateIds = Seq.empty,
+      interfaceFilters = interfaceIds.map(id =>
+        new InterfaceFilter(Some(id), includeInterfaceView = true, includeCreateArgumentsBlob = true),
+      ),
+    )))))
+    ledger.getTransactionsRequest(Seq(party))
+      .update(_.filter := filter)
+  }
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneIndexService.scala
@@ -46,6 +46,7 @@ object StandaloneIndexService {
         lfValueTranslationCache = lfValueTranslationCache,
         enricher = new ValueEnricher(engine),
         sharedStringInterningViewO = sharedStringInterningViewO,
+        engine = engine,
       )(materializer, loggingContext, servicesExecutionContext)
         .owner()
         .map(index => new TimedIndexService(index, metrics))

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -36,6 +36,7 @@ import com.daml.logging.entries.{LoggingEntries, LoggingValue}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.platform.apiserver.services.{StreamMetrics, logging}
+import com.daml.platform.participant.util.LfEngineToApi
 import com.daml.platform.server.api.services.domain.TransactionService
 import com.daml.platform.server.api.services.grpc.GrpcTransactionService
 import com.daml.platform.store.cache.SingletonPackageMetadataCache
@@ -96,14 +97,6 @@ private[apiserver] final class ApiTransactionService private (
         ),
       )
 
-    // TODO DPP-1068: Surely there is a better way
-    def damlLfIdentifierToApiIdentifier(id: Ref.Identifier): Identifier =
-      Identifier(
-        packageId = id.packageId,
-        moduleName = id.qualifiedName.module.toString,
-        entityName = id.qualifiedName.name.toString,
-      )
-
     // Template ID to list of interface IDs that need to include their view
     val viewsByTemplate: mutable.Map[Ref.Identifier, Set[Ref.Identifier]] = mutable.Map.empty
 
@@ -154,7 +147,7 @@ private[apiserver] final class ApiTransactionService private (
                       val interfaceViews = viewsToInclude
                         .map(iid =>
                           com.daml.ledger.api.v1.event.InterfaceView(
-                            interfaceId = Some(damlLfIdentifierToApiIdentifier(iid)),
+                            interfaceId = Some(LfEngineToApi.toApiIdentifier(iid)),
                             viewStatus = Some(com.google.rpc.status.Status.of(0, "", Seq.empty)),
                             viewValue = Some(???),
                           )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -11,7 +11,6 @@ import com.daml.error.{ContextualizedErrorLogger, DamlContextualizedErrorLogger}
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.ledger.api.domain.{
   Filters,
-  InclusiveFilters,
   LedgerId,
   LedgerOffset,
   TransactionFilter,
@@ -24,11 +23,9 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse,
 }
-import com.daml.ledger.api.v1.value.Identifier
 import com.daml.ledger.api.validation.PartyNameChecker
 import com.daml.ledger.api.validation.ValidationErrors.invalidArgument
 import com.daml.ledger.participant.state.index.v2.IndexTransactionsService
-import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.ledger.{EventId => LfEventId}
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
@@ -36,14 +33,11 @@ import com.daml.logging.entries.{LoggingEntries, LoggingValue}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.platform.apiserver.services.{StreamMetrics, logging}
-import com.daml.platform.participant.util.LfEngineToApi
 import com.daml.platform.server.api.services.domain.TransactionService
 import com.daml.platform.server.api.services.grpc.GrpcTransactionService
-import com.daml.platform.store.cache.SingletonPackageMetadataCache
 import io.grpc._
 import scalaz.syntax.tag._
 
-import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 
 private[apiserver] object ApiTransactionService {
@@ -75,99 +69,6 @@ private[apiserver] final class ApiTransactionService private (
   override def getLedgerEnd(ledgerId: String): Future[LedgerOffset.Absolute] =
     transactionsService.currentLedgerEnd().andThen(logger.logErrorsOnCall[LedgerOffset.Absolute])
 
-  // Approach:
-  //   1: Convert interface filters to template filters
-  //   2: Start regular flat transaction stream using the transactionsService
-  //   3: Add interface view values to the result
-  // TODO DPP-1068: Check if this is the right place to implement this logic
-  private def transactionsWithInterfaceSubscriptions(
-      begin: LedgerOffset,
-      endAt: Option[LedgerOffset],
-      filter: TransactionFilter,
-      verbose: Boolean,
-  )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed] = {
-
-    // TODO DPP-1068: Copied from LfValueSerialization
-    def apiIdentifierToDamlLfIdentifier(id: Identifier): Ref.Identifier =
-      Ref.Identifier(
-        Ref.PackageId.assertFromString(id.packageId),
-        Ref.QualifiedName(
-          Ref.ModuleName.assertFromString(id.moduleName),
-          Ref.DottedName.assertFromString(id.entityName),
-        ),
-      )
-
-    // Template ID to list of interface IDs that need to include their view
-    val viewsByTemplate: mutable.Map[Ref.Identifier, Set[Ref.Identifier]] = mutable.Map.empty
-
-    val filtersByPartyWithoutInterfaces = filter.filtersByParty.view
-      .mapValues(filters =>
-        Filters(filters.inclusive.map(inclusiveFilters => {
-          val interfaceTemplateIds = inclusiveFilters.interfaceFilters.flatMap(interfaceFilter => {
-            // Find all templates that implement this interface
-            val templateIds =
-              SingletonPackageMetadataCache.getInterfaceImplementations(interfaceFilter.interfaceId)
-            // Remember for each of these templates whether we have to compute the view
-            if (interfaceFilter.includeView) {
-              templateIds.foreach(tid =>
-                viewsByTemplate.updateWith(tid) {
-                  case None => Some(Set(interfaceFilter.interfaceId))
-                  case Some(other) => Some(other + interfaceFilter.interfaceId)
-                }
-              )
-            }
-            templateIds
-          })
-          val allTemplateIds = inclusiveFilters.templateIds ++ interfaceTemplateIds
-          InclusiveFilters(
-            templateIds = allTemplateIds,
-            interfaceFilters = Set.empty,
-          )
-        }))
-      )
-      .toMap
-    val filterWithoutInterfaces = TransactionFilter(
-      filtersByPartyWithoutInterfaces
-    )
-
-    transactionsService
-      .transactions(begin, endAt, filterWithoutInterfaces, verbose)
-      .map(res => {
-        val transactionsWithViews: scala.Seq[com.daml.ledger.api.v1.transaction.Transaction] =
-          res.transactions.map(tx =>
-            tx.update(
-              _.events := tx.events.map(outerEvent =>
-                outerEvent.event match {
-                  case com.daml.ledger.api.v1.event.Event.Event.Created(created) =>
-                    val templateId = apiIdentifierToDamlLfIdentifier(created.templateId.get)
-                    val viewsToInclude = viewsByTemplate.getOrElse(templateId, Set.empty)
-                    if (viewsToInclude.isEmpty) {
-                      outerEvent
-                    } else {
-                      val interfaceViews = viewsToInclude
-                        .map(iid =>
-                          com.daml.ledger.api.v1.event.InterfaceView(
-                            interfaceId = Some(LfEngineToApi.toApiIdentifier(iid)),
-                            viewStatus = Some(com.google.rpc.status.Status.of(0, "", Seq.empty)),
-                            viewValue = Some(???),
-                          )
-                        )
-                        .toSeq
-                      com.daml.ledger.api.v1.event.Event.of(
-                        com.daml.ledger.api.v1.event.Event.Event
-                          .Created(created.update(_.interfaceViews := interfaceViews))
-                      )
-                    }
-
-                  case _ => outerEvent
-                }
-              )
-            )
-          )
-        res.update(_.transactions := transactionsWithViews)
-      })
-  }
-
   override def getTransactions(
       request: GetTransactionsRequest
   ): Source[GetTransactionsResponse, NotUsed] = {
@@ -182,12 +83,13 @@ private[apiserver] final class ApiTransactionService private (
     }
     logger.trace(s"Transaction request: $request")
 
-    transactionsWithInterfaceSubscriptions(
-      request.startExclusive,
-      request.endInclusive,
-      request.filter,
-      request.verbose,
-    )
+    transactionsService
+      .transactions(
+        request.startExclusive,
+        request.endInclusive,
+        request.filter,
+        request.verbose,
+      )
       .via(logger.enrichedDebugStream("Responding with transactions.", transactionsLoggable))
       .via(logger.logErrorsOnStream)
       .via(StreamMetrics.countElements(metrics.daml.lapi.streams.transactions))

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceBuilder.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceBuilder.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.IndexService
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.lf.data.Ref
-import com.daml.lf.engine.ValueEnricher
+import com.daml.lf.engine.{Engine, ValueEnricher}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.platform.{PruneBuffers, PruneBuffersNoOp}
@@ -52,6 +52,7 @@ private[platform] case class IndexServiceBuilder(
     enricher: ValueEnricher,
     participantId: Ref.ParticipantId,
     sharedStringInterningViewO: Option[StringInterningView],
+    engine: Engine,
 )(implicit
     mat: Materializer,
     loggingContext: LoggingContext,
@@ -112,6 +113,7 @@ private[platform] case class IndexServiceBuilder(
       pruneBuffers,
       generalDispatcher,
       metrics,
+      engine,
     )
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -197,7 +197,6 @@ private[index] class IndexServiceImpl(
             val interfaceOffset = SingletonPackageMetadataCache.interfaceAddedAt(interfaceId)
             if (interfaceOffset.isEmpty) {
               // TODO DPP-1068: Proper error handling
-              SingletonPackageMetadataCache.dumpDebugInfo()
               throw new RuntimeException(
                 s"Interface $interfaceId is not known"
               )

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -105,7 +105,6 @@ private[index] class IndexServiceImpl(
               packageMetadataCache = SingletonPackageMetadataCache,
               filter = filter,
             )
-            Console.println(s"filter=$filter, converted=$convertedFilter")
             transactionsReader
               .getFlatTransactions(
                 startExclusive,

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -10,16 +10,7 @@ import com.daml.error.DamlContextualizedErrorLogger
 import com.daml.error.definitions.LedgerApiErrors
 import com.daml.ledger.api.{TraceIdentifiers, domain}
 import com.daml.ledger.api.domain.ConfigurationEntry.Accepted
-import com.daml.ledger.api.domain.{
-  Filters,
-  InclusiveFilters,
-  LedgerId,
-  LedgerOffset,
-  PackageEntry,
-  PartyEntry,
-  TransactionFilter,
-  TransactionId,
-}
+import com.daml.ledger.api.domain.{LedgerId, LedgerOffset, PackageEntry, PartyEntry, TransactionId}
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
@@ -29,8 +20,6 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse,
 }
-import com.daml.ledger.api.v1.value.{Identifier => apiIdentifier}
-import com.daml.ledger.api.validation.ValueValidator
 import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2
@@ -44,17 +33,8 @@ import com.daml.ledger.participant.state.index.v2.{
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{ApplicationId, Identifier, Party}
 import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.engine.{
-  Engine,
-  Result,
-  ResultDone,
-  ResultError,
-  ResultNeedContract,
-  ResultNeedKey,
-  ResultNeedPackage,
-}
-import com.daml.lf.transaction.{GlobalKey, Versioned}
-import com.daml.lf.value.Value
+import com.daml.lf.engine.Engine
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value.{ContractId, VersionedContractInstance}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
@@ -63,16 +43,13 @@ import com.daml.platform.ApiOffset.ApiOffsetConverter
 import com.daml.platform.{ApiOffset, PruneBuffers}
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.akkastreams.dispatcher.SubSource.RangeSource
-import com.daml.platform.participant.util.LfEngineToApi
 import com.daml.platform.store.cache.SingletonPackageMetadataCache
+import com.daml.platform.store.dao.events.TransactionFilter
 import com.daml.platform.store.dao.{LedgerDaoTransactionsReader, LedgerReadDao}
 import com.daml.platform.store.entries.PartyLedgerEntry
 import com.daml.telemetry.{Event, SpanAttribute, Spans}
-import io.grpc.Status.Code
 import scalaz.syntax.tag.ToTagOps
 
-import scala.annotation.tailrec
-import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 
 private[index] class IndexServiceImpl(
@@ -104,170 +81,7 @@ private[index] class IndexServiceImpl(
   ): Future[Option[ContractId]] =
     contractStore.lookupContractKey(readers, key)
 
-  // TODO DPP-1068: Copied from LfValueSerialization
-  private def apiIdentifierToDamlLfIdentifier(id: apiIdentifier): Ref.Identifier =
-    Ref.Identifier(
-      Ref.PackageId.assertFromString(id.packageId),
-      Ref.QualifiedName(
-        Ref.ModuleName.assertFromString(id.moduleName),
-        Ref.DottedName.assertFromString(id.entityName),
-      ),
-    )
-
-  private def computeInterfaceView(
-      templateId: Ref.Identifier,
-      record: com.daml.ledger.api.v1.value.Record,
-      interfaceId: Ref.Identifier,
-  )(implicit loggingContext: LoggingContext): com.daml.ledger.api.v1.event.InterfaceView = {
-    // TODO DPP-1068: The transaction stream contains protobuf-serialized transactions (Source[GetTransactionsResponse, NotUsed]),
-    //   we don't have access to the original Daml-LF value.
-    //   Here we deserialize the contract argument, use it in the engine, and then serialize it back. This needs to be improved.
-    val value = ValueValidator
-      .validateRecord(record)(
-        DamlContextualizedErrorLogger.forTesting(getClass)
-      )
-      .getOrElse(throw new RuntimeException("This should never fail"))
-
-    @tailrec
-    def go(res: Result[Versioned[Value]]): Either[String, Versioned[Value]] =
-      res match {
-        case ResultDone(x) => Right(x)
-        case ResultError(err) => Left(err.message)
-        // Note: the compiler should enforce that the computation is a pure function,
-        // ResultNeedContract and ResultNeedKey should never appear in the result.
-        case ResultNeedContract(_, _) => Left("View computation must be a pure function")
-        case ResultNeedKey(_, _) => Left("View computation must be a pure function")
-        case ResultNeedPackage(pkgId, resume) =>
-          // TODO DPP-1068: Package loading makes the view computation asynchronous, which is annoying to deal with (see LfValueTranslation).
-          //   Here we rely on the package metadata cache to always contain all decoded packages that exist on this participant,
-          //   so that we can fetch the decoded package synchronously.
-          go(resume(SingletonPackageMetadataCache.getPackage(pkgId)))
-      }
-    val result = go(engine.computeInterfaceView(templateId, value, interfaceId))
-
-    result
-      .flatMap(versionedValue =>
-        LfEngineToApi.lfValueToApiRecord(
-          verbose = false,
-          recordValue = versionedValue.unversioned,
-        )
-      )
-      .fold(
-        error =>
-          // Note: the view computation is an arbitrary Daml function and can thus fail (e.g., with a Daml exception)
-          com.daml.ledger.api.v1.event.InterfaceView(
-            interfaceId = Some(LfEngineToApi.toApiIdentifier(interfaceId)),
-            // TODO DPP-1068: Use a proper error status
-            viewStatus =
-              Some(com.google.rpc.status.Status.of(Code.INTERNAL.value(), error, Seq.empty)),
-            viewValue = None,
-          ),
-        value =>
-          com.daml.ledger.api.v1.event.InterfaceView(
-            interfaceId = Some(LfEngineToApi.toApiIdentifier(interfaceId)),
-            viewStatus = Some(com.google.rpc.status.Status.of(0, "", Seq.empty)),
-            viewValue = Some(value),
-          ),
-      )
-  }
-
-  // Approach:
-  //   1: Convert interface filters to template filters
-  //   2: Start regular flat transaction stream using the transactionsService
-  //   3: Add interface view values to the result
-  // TODO DPP-1068: Move this to below the dispatcher call. The translation from interfaces to templates MUST be
-  //   done separately for each offset page, otherwise we won't properly include newly introduced interface implementations.
-  override def transactions(
-      startExclusive: domain.LedgerOffset,
-      endInclusive: Option[domain.LedgerOffset],
-      filter: domain.TransactionFilter,
-      verbose: Boolean,
-  )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed] = {
-
-    // Template ID to list of interface IDs that need to include their view
-    val viewsByTemplate: mutable.Map[Ref.Identifier, Set[Ref.Identifier]] = mutable.Map.empty
-
-    val filtersByPartyWithoutInterfaces = filter.filtersByParty.view
-      .mapValues(filters =>
-        Filters(filters.inclusive.map(inclusiveFilters => {
-          val interfaceTemplateIds = inclusiveFilters.interfaceFilters.flatMap(interfaceFilter => {
-            val interfaceId = interfaceFilter.interfaceId
-
-            // Check whether the interface is known
-            val interfaceOffset = SingletonPackageMetadataCache.interfaceAddedAt(interfaceId)
-            if (interfaceOffset.isEmpty) {
-              // TODO DPP-1068: Proper error handling
-              throw new RuntimeException(
-                s"Interface $interfaceId is not known"
-              )
-            }
-
-            // Find all templates that implement this interface
-            val templateIds =
-              SingletonPackageMetadataCache.getInterfaceImplementations(interfaceId)
-
-            // Remember for each of these templates whether we have to compute the view
-            if (interfaceFilter.includeView) {
-              templateIds.foreach(tid =>
-                viewsByTemplate.updateWith(tid) {
-                  case None => Some(Set(interfaceId))
-                  case Some(other) => Some(other + interfaceId)
-                }
-              )
-            }
-            templateIds
-          })
-          val allTemplateIds = inclusiveFilters.templateIds ++ interfaceTemplateIds
-          InclusiveFilters(
-            templateIds = allTemplateIds,
-            interfaceFilters = Set.empty,
-          )
-        }))
-      )
-      .toMap
-
-    // TODO DPP-1068: Here we could filter out all templates that did not exist for the given offset range.
-    //   The package metadata cache can provide this information.
-    //   This would also benefit historical transaction streams that subscribe to a set of templates.
-    val filterWithoutInterfaces = TransactionFilter(
-      filtersByPartyWithoutInterfaces
-    )
-
-    transactionsWithoutInterfaces(startExclusive, endInclusive, filterWithoutInterfaces, verbose)
-      .map(res => {
-        val transactionsWithViews: scala.Seq[com.daml.ledger.api.v1.transaction.Transaction] =
-          res.transactions.map(tx =>
-            tx.update(
-              _.events := tx.events.map(outerEvent =>
-                outerEvent.event match {
-                  case com.daml.ledger.api.v1.event.Event.Event.Created(created) =>
-                    val templateId = apiIdentifierToDamlLfIdentifier(created.templateId.get)
-                    val viewsToInclude = viewsByTemplate.getOrElse(templateId, Set.empty)
-                    if (viewsToInclude.isEmpty) {
-                      outerEvent
-                    } else {
-                      val interfaceViews = viewsToInclude
-                        .map(iid =>
-                          computeInterfaceView(templateId, created.createArguments.get, iid)
-                        )
-                        .toSeq
-                      com.daml.ledger.api.v1.event.Event.of(
-                        com.daml.ledger.api.v1.event.Event.Event
-                          .Created(created.update(_.interfaceViews := interfaceViews))
-                      )
-                    }
-
-                  case _ => outerEvent
-                }
-              )
-            )
-          )
-        res.update(_.transactions := transactionsWithViews)
-      })
-  }
-
-  // TODO DPP-1068: For a better separation of the new code, the previous transactions() method was only renamed and left otherwise untouched
-  def transactionsWithoutInterfaces(
+  def transactions(
       startExclusive: domain.LedgerOffset,
       endInclusive: Option[domain.LedgerOffset],
       filter: domain.TransactionFilter,
@@ -283,7 +97,26 @@ private[index] class IndexServiceImpl(
       dispatcher
         .startingAt(
           from.getOrElse(Offset.beforeBegin),
-          RangeSource(transactionsReader.getFlatTransactions(_, _, convertFilter(filter), verbose)),
+          RangeSource { case (startExclusive, endInclusive) =>
+            // Note: it is important that the filter is converted separately for each offset range,
+            // so that the stream can properly pick up newly added templates.
+            val convertedFilter = TransactionFilter(
+              endInclusive = endInclusive,
+              packageMetadataCache = SingletonPackageMetadataCache,
+              filter = filter,
+            )
+            Console.println(s"filter=$filter, converted=$convertedFilter")
+            transactionsReader
+              .getFlatTransactions(
+                startExclusive,
+                endInclusive,
+                convertedFilter.templatesToInclude,
+                verbose,
+              )
+              .map { case (offset, response) =>
+                offset -> TransactionFilter.computeInterfaceViews(response, convertedFilter, engine)
+              }
+          },
           to,
         )
         .map(_._2)
@@ -362,7 +195,7 @@ private[index] class IndexServiceImpl(
       .buffered(metrics.daml.index.completionsBufferSize, LedgerApiStreamsBufferSize)
 
   override def getActiveContracts(
-      filter: TransactionFilter,
+      filter: domain.TransactionFilter,
       verbose: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetActiveContractsResponse, NotUsed] = {
     val currentLedgerEnd = ledgerEnd()
@@ -559,7 +392,7 @@ private[index] class IndexServiceImpl(
     }
   }
 
-  private def convertFilter(filter: TransactionFilter): Map[Party, Set[Identifier]] =
+  private def convertFilter(filter: domain.TransactionFilter): Map[Party, Set[Identifier]] =
     filter.filtersByParty.map { case (party, filters) =>
       party -> filters.inclusive.fold(Set.empty[Identifier])(_.templateIds)
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
@@ -16,6 +16,7 @@ import com.daml.lf.transaction.Transaction.ChildrenRecursion
 import com.daml.platform.{Create, Exercise, Key, Node, NodeId}
 import com.daml.platform.index.index.StatusDetails
 import com.daml.platform.store.ChoiceCoder
+import com.daml.platform.store.cache.SingletonPackageMetadataCache
 import com.daml.platform.store.dao.JdbcLedgerDao
 import com.daml.platform.store.dao.events._
 
@@ -93,6 +94,10 @@ object UpdateToDbDto {
         )
 
       case u: PublicPackageUpload =>
+        // TODO DPP-1068: Move to the right place
+        //  It doesn't matter where in the indexing pipeline the cache is updated,
+        //  as long as it's before updating the ledger end
+        SingletonPackageMetadataCache.add(u.archives, offset)
         val uploadId = u.submissionId.getOrElse(UUID.randomUUID().toString)
         val packages = u.archives.iterator.map { archive =>
           DbDto.Package(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/UpdateToDbDto.scala
@@ -97,6 +97,12 @@ object UpdateToDbDto {
         // TODO DPP-1068: Move to the right place
         //  It doesn't matter where in the indexing pipeline the cache is updated,
         //  as long as it's before updating the ledger end
+        // TODO DPP-1068: The following tests have been flaky on the PoC branch, which seems to be related
+        //  (removing the line makes the tests pass):
+        //  - //ledger/participant-integration-api:participant-integration-api-tests_test_suite_src_test_suite_scala_platform_indexer_parallel_BatchingParallelIngestionPipeSpec.scala
+        //  - //daml-assistant/daml-helper:test-daml-packages
+        //  - //compiler/damlc/tests:package-manager
+        //  - //language-support/hs/bindings:test
         SingletonPackageMetadataCache.add(u.archives, offset)
         val uploadId = u.submissionId.getOrElse(UUID.randomUUID().toString)
         val packages = u.archives.iterator.map { archive =>

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/PackageMetadataCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/PackageMetadataCache.scala
@@ -60,7 +60,7 @@ object SingletonPackageMetadataCache extends PackageMetadataCache {
         }
       }
 
-      // Templates/interfaces/packages are immutable, there will be no collisions
+      // Templates/interfaces/packages are immutable, there will be no conflicting map values
       val resultDefinedAt = definedAt ++ other.definedAt
       val resultDecodedPackages = decodedPackages ++ other.decodedPackages
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/cache/PackageMetadataCache.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/cache/PackageMetadataCache.scala
@@ -1,0 +1,111 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.cache
+
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.offset.Offset
+import com.daml.lf.archive.Decode
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.DottedName
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.collection.mutable
+
+/** For each operation, the following holds:
+  * - The result MUST include all packages uploaded at or before
+  *   the current ledger end
+  * - The result MAY include packages uploaded after the current
+  *   ledger end
+  */
+trait PackageMetadataCache {
+
+  /** List of templates implementing an interface */
+  def getInterfaceImplementations(id: Ref.Identifier): Set[Ref.Identifier]
+
+  /** Return the offset at which the given interface was defined,
+    * i.e., at which the corresponding package was uploaded.
+    * Returns None if the interface is unknown.
+    */
+  def interfaceAddedAt(id: Ref.Identifier): Option[Offset]
+
+  /** Same as interfaceAddedAt, but for templates */
+  def templateAddedAt(id: Ref.Identifier): Option[Offset]
+}
+
+// TODO DPP-1068: use a proper cache instead of a global variable
+object SingletonPackageMetadataCache extends PackageMetadataCache {
+
+  case class State(
+      definedAt: Map[Ref.Identifier, Offset],
+      implementations: Map[Ref.Identifier, Set[Ref.Identifier]],
+  ) {
+    def mergeWith(other: State): State = {
+      val resultImplementations = mutable.Map.empty[Ref.Identifier, Set[Ref.Identifier]]
+      resultImplementations.addAll(implementations.toSeq)
+      other.implementations.foreach { case (id, otherTemplateIds) =>
+        resultImplementations.updateWith(id) {
+          case None => Some(otherTemplateIds)
+          case Some(thisTemplateIds) => Some(thisTemplateIds ++ otherTemplateIds)
+        }
+      }
+
+      // Template/interface IDs can not be defined in two different packages, there will be no collisions
+      val resultDefinedAt = definedAt ++ other.definedAt
+
+      State(
+        definedAt = resultDefinedAt,
+        implementations = resultImplementations.toMap,
+      )
+    }
+  }
+  object State {
+    def empty: State = State(Map.empty, Map.empty)
+  }
+  private val state = new AtomicReference[State](State.empty)
+
+  def add(archives: List[DamlLf.Archive], offset: Offset): Unit = {
+    val newState = archivesToState(archives, offset)
+    state.updateAndGet(_.mergeWith(newState))
+    ()
+  }
+
+  private def archivesToState(archives: List[DamlLf.Archive], offset: Offset): State = {
+    val newDefinitions = mutable.Map.empty[Ref.Identifier, Offset]
+    val newImplementations = mutable.Map.empty[Ref.Identifier, Set[Ref.Identifier]]
+
+    archives.foreach(archive => {
+      val (packageId, ast) = Decode
+        .decodeArchive(archive, true)
+        .getOrElse(throw new RuntimeException("error handling not implemented"))
+      ast.modules.foreach { case (moduleName, module) =>
+        def identifier(name: DottedName) =
+          Ref.Identifier(packageId, Ref.QualifiedName(moduleName, name))
+
+        module.templates.keys.foreach(tid => newDefinitions.addOne(identifier(tid) -> offset))
+        module.interfaces.keys.foreach(iid => newDefinitions.addOne(identifier(iid) -> offset))
+        module.templates.foreach { case (tid, t) =>
+          t.implements.values.foreach(i =>
+            newImplementations.updateWith(i.interfaceId) {
+              case None => Some(Set(identifier(tid)))
+              case Some(previous) => Some(previous + identifier(tid))
+            }
+          )
+        }
+      }
+    })
+
+    State(
+      definedAt = newDefinitions.toMap,
+      implementations = newImplementations.toMap,
+    )
+  }
+
+  def getInterfaceImplementations(id: Ref.Identifier): Set[Ref.Identifier] =
+    state.get.implementations(id)
+
+  def interfaceAddedAt(id: Ref.Identifier): Option[Offset] = state.get.definedAt.get(id)
+
+  def templateAddedAt(id: Ref.Identifier): Option[Offset] = state.get.definedAt.get(id)
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionFilter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionFilter.scala
@@ -1,0 +1,209 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+import com.daml.error.DamlContextualizedErrorLogger
+import com.daml.ledger.api.v1.transaction_service.GetTransactionsResponse
+import com.daml.lf.data.Ref
+import com.daml.ledger.api.domain
+import com.daml.ledger.api.v1.transaction.Transaction
+import com.daml.ledger.api.validation.ValueValidator
+import com.daml.ledger.offset.Offset
+import com.daml.lf.engine.{Engine, Result, ResultDone, ResultError, ResultNeedContract, ResultNeedKey, ResultNeedPackage}
+import com.daml.lf.transaction.Versioned
+import com.daml.lf.value.Value
+import com.daml.logging.LoggingContext
+import com.daml.platform.participant.util.LfEngineToApi
+import com.daml.platform.store.cache.{PackageMetadataCache, SingletonPackageMetadataCache}
+import io.grpc.Status.Code
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+
+private[platform] case class TransactionFilter(
+  // For each party, the set of templates that should be included in the result
+  // If the set is empty, all templates should be included
+  // TODO DPP-1068: better representation of wildcard filters? Some ADT instead of Set.empty?
+  templatesToInclude: Map[Ref.Party, Set[Ref.Identifier]],
+
+  // For each template, the set of interfaces for which the view needs to be computed
+  // If the set is empty, no views should be computed
+  viewsToCompute: Map[Ref.Identifier, Set[Ref.Identifier]],
+)
+
+// TODO DPP-1068: Add unit tests for this
+private[platform] object TransactionFilter {
+
+  def apply(
+      endInclusive: Offset,
+      packageMetadataCache: PackageMetadataCache,
+      filter: domain.TransactionFilter,
+  ): TransactionFilter = {
+
+    val listOfViewsToCompute: ListBuffer[(Ref.Identifier, Ref.Identifier)] = ListBuffer.empty
+
+    val templatesToInclude = filter.filtersByParty.view
+      .mapValues(filters => filters.inclusive.fold(
+        Set.empty[Ref.Identifier]
+      )(inclusiveFilters => {
+        val interfaceTemplateIds = inclusiveFilters.interfaceFilters.flatMap(interfaceFilter => {
+          val interfaceId = interfaceFilter.interfaceId
+
+          // Check whether the interface is known
+          // TODO DPP-1068: compare interfaceOffset with the ledger end queried before this call.
+          //  If the offset is higher than current ledger end, it means the package defining the interface
+          //  was uploaded right now, and the cache might only contain partial data for this interface.
+          //  SingletonPackageMetadataCached doesn't have this problem as it updates its state atomically,
+          //  but other implementations might not.
+          val interfaceOffset = packageMetadataCache.interfaceAddedAt(interfaceId)
+          if (interfaceOffset.isEmpty) {
+            // TODO DPP-1068: Proper error handling, maybe return Either[Error, TransactionFilter]
+            throw new RuntimeException(
+              s"Interface $interfaceId is not known"
+            )
+          }
+
+          // Find all templates that implement this interface
+          val templateIds = packageMetadataCache.getInterfaceImplementations(interfaceId)
+
+          // Remember for each of these templates whether we have to compute the view
+          if (interfaceFilter.includeView) {
+            templateIds.foreach(tid => listOfViewsToCompute.addOne(tid -> interfaceId))
+          }
+
+          templateIds
+        })
+
+        val allTemplateIds = inclusiveFilters.templateIds ++ interfaceTemplateIds
+
+        // Optimization: filter out templates that were introduced after endInclusive,
+        // as there will be no contracts for those templates in the given offset range.
+        val relevantTemplateIds = allTemplateIds.filter(id => packageMetadataCache.templateAddedAt(id).exists(o => o <= endInclusive))
+
+        relevantTemplateIds
+      }))
+      .toMap // Note: force the computation, otherwise listOfViewsToCompute will be empty in the next step
+
+    val viewsToCompute = listOfViewsToCompute
+      .groupBy(_._1)
+      .view
+      .mapValues(x => x.map(_._2).toSet)
+      .toMap
+
+    TransactionFilter(
+      templatesToInclude = templatesToInclude,
+      viewsToCompute = viewsToCompute,
+    )
+  }
+
+  def computeInterfaceViews(
+    respose: GetTransactionsResponse,
+    filter: TransactionFilter,
+    engine: Engine,
+  )(implicit loggingContext: LoggingContext): GetTransactionsResponse = {
+    val transactionsWithViews = respose.transactions.map(tx => computeInterfaceViews(tx, filter, engine))
+    respose.update(_.transactions := transactionsWithViews)
+  }
+
+  /** Returns a copy of the given transaction that contains all required interface views */
+  private def computeInterfaceViews(
+    transaction: Transaction,
+    filter: TransactionFilter,
+    engine: Engine,
+  )(implicit loggingContext: LoggingContext): Transaction = {
+    transaction.update(
+      _.events := transaction.events.map(outerEvent =>
+        outerEvent.event match {
+          case com.daml.ledger.api.v1.event.Event.Event.Created(created) =>
+            val templateId = apiIdentifierToDamlLfIdentifier(created.templateId.get)
+            val viewsToInclude = filter.viewsToCompute.getOrElse(templateId, Set.empty)
+            if (viewsToInclude.isEmpty) {
+              outerEvent
+            } else {
+              val interfaceViews = viewsToInclude
+                .map(iid =>
+                  computeInterfaceView(templateId, created.createArguments.get, iid, engine)
+                )
+                .toSeq
+              com.daml.ledger.api.v1.event.Event.of(
+                com.daml.ledger.api.v1.event.Event.Event
+                  .Created(created.update(_.interfaceViews := interfaceViews))
+              )
+            }
+
+          case _ => outerEvent
+        }
+      )
+    )
+  }
+
+  /** Computes all required interface views for the given template */
+  private def computeInterfaceView(
+    templateId: Ref.Identifier,
+    record: com.daml.ledger.api.v1.value.Record,
+    interfaceId: Ref.Identifier,
+    engine: Engine,
+  )(implicit loggingContext: LoggingContext): com.daml.ledger.api.v1.event.InterfaceView = {
+    // TODO DPP-1068: The transaction stream contains protobuf-serialized transactions (Source[GetTransactionsResponse, NotUsed]),
+    //   we don't have access to the original Daml-LF value.
+    //   Here we deserialize the contract argument, use it in the engine, and then serialize it back. This needs to be improved.
+    val value = ValueValidator
+      .validateRecord(record)(
+        DamlContextualizedErrorLogger.forTesting(getClass)
+      )
+      .getOrElse(throw new RuntimeException("This should never fail"))
+
+    @tailrec
+    def go(res: Result[Versioned[Value]]): Either[String, Versioned[Value]] =
+      res match {
+        case ResultDone(x) => Right(x)
+        case ResultError(err) => Left(err.message)
+        // Note: the compiler should enforce that the computation is a pure function,
+        // ResultNeedContract and ResultNeedKey should never appear in the result.
+        case ResultNeedContract(_, _) => Left("View computation must be a pure function")
+        case ResultNeedKey(_, _) => Left("View computation must be a pure function")
+        case ResultNeedPackage(pkgId, resume) =>
+          // TODO DPP-1068: Package loading makes the view computation asynchronous, which is annoying to deal with (see LfValueTranslation).
+          //   Here we rely on the package metadata cache to always contain all decoded packages that exist on this participant,
+          //   so that we can fetch the decoded package synchronously.
+          go(resume(SingletonPackageMetadataCache.getPackage(pkgId)))
+      }
+    val result = go(engine.computeInterfaceView(templateId, value, interfaceId))
+
+    result
+      .flatMap(versionedValue =>
+        LfEngineToApi.lfValueToApiRecord(
+          verbose = false,
+          recordValue = versionedValue.unversioned,
+        )
+      )
+      .fold(
+        error =>
+          // Note: the view computation is an arbitrary Daml function and can thus fail (e.g., with a Daml exception)
+          com.daml.ledger.api.v1.event.InterfaceView(
+            interfaceId = Some(LfEngineToApi.toApiIdentifier(interfaceId)),
+            // TODO DPP-1068: Use a proper error status
+            viewStatus =
+              Some(com.google.rpc.status.Status.of(Code.INTERNAL.value(), error, Seq.empty)),
+            viewValue = None,
+          ),
+        value =>
+          com.daml.ledger.api.v1.event.InterfaceView(
+            interfaceId = Some(LfEngineToApi.toApiIdentifier(interfaceId)),
+            viewStatus = Some(com.google.rpc.status.Status.of(0, "", Seq.empty)),
+            viewValue = Some(value),
+          ),
+      )
+  }
+
+  // TODO DPP-1068: Copied from LfValueSerialization
+  private def apiIdentifierToDamlLfIdentifier(id: com.daml.ledger.api.v1.value.Identifier): Ref.Identifier =
+    Ref.Identifier(
+      Ref.PackageId.assertFromString(id.packageId),
+      Ref.QualifiedName(
+        Ref.ModuleName.assertFromString(id.moduleName),
+        Ref.DottedName.assertFromString(id.entityName),
+      ),
+    )
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/EventFilterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/EventFilterSpec.scala
@@ -56,9 +56,14 @@ final class EventFilterSpec extends AnyWordSpec with Matchers with ScalaFutures 
   private val filter = (event: ApiEvent) => EventFilter(event)(TransactionFilter(mapping))
 
   def getFilter(templateIds: Seq[(String, String)]) =
-    Filters(InclusiveFilters(templateIds.map { case (mod, ent) =>
-      mkIdent(mod, ent)
-    }.toSet))
+    Filters(
+      InclusiveFilters(
+        templateIds.map { case (mod, ent) =>
+          mkIdent(mod, ent)
+        }.toSet,
+        Set.empty,
+      )
+    )
 
   "EventFilter" when {
 
@@ -119,6 +124,8 @@ final class EventFilterSpec extends AnyWordSpec with Matchers with ScalaFutures 
           Some(templateId),
           None,
           Some(Record(None, Seq.empty)),
+          createArgumentsBlob = None, // TODO DPP-1068
+          interfaceViews = Seq.empty, // TODO DPP-1068
           Seq(party, otherPartyWhoSeesEvents),
           Seq.empty,
           Seq.empty,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionConversionSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionConversionSpec.scala
@@ -29,7 +29,19 @@ final class TransactionConversionSpec extends AnyWordSpec with Matchers {
   private def create(contractId: Value.ContractId): Event =
     Event.of(
       Event.Event.Created(
-        CreatedEvent("", contractId.coid, None, None, None, Seq.empty, Seq.empty, Seq.empty, None)
+        CreatedEvent(
+          "",
+          contractId.coid,
+          None,
+          None,
+          None,
+          None,
+          Seq.empty,
+          Seq.empty,
+          Seq.empty,
+          Seq.empty,
+          None,
+        )
       )
     )
 

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -538,3 +538,21 @@ conformance_test(
         "--verbose",
     ],
 )
+
+# TODO DPP-1068: Make sure InterfaceSubscriptionsIT is run on all servers
+server_conformance_test(
+    name = "conformance-test-interface-subscriptions",
+    lf_versions = [
+        "1.dev",
+    ],
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant participant-id=example,port=6865",
+        "--enable-user-management=true",
+    ],
+    servers = SERVERS,
+    test_tool_args = [
+        "--verbose",
+        "--include=InterfaceSubscriptionsIT",
+    ],
+)

--- a/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/AcsBench.scala
+++ b/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/AcsBench.scala
@@ -58,7 +58,8 @@ class AcsBench extends TestCommands with InfAwait {
   ): Option[String] = {
     val events = response.activeContracts.toSet
     events.collectFirst {
-      case CreatedEvent(contractId, _, Some(id), _, _, _, _, _, _) if id == template => contractId
+      case CreatedEvent(contractId, _, Some(id), _, _, _, _, _, _, _, _) if id == template =>
+        contractId
     }
   }
 

--- a/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/TestHelper.scala
+++ b/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/TestHelper.scala
@@ -130,7 +130,7 @@ trait TestHelper {
       templateId: Identifier
   )(response: GetActiveContractsResponse): List[String] =
     response.activeContracts.toList.collect {
-      case CreatedEvent(_, contractId, Some(actualTemplateId), _, _, _, _, _, _)
+      case CreatedEvent(_, contractId, Some(actualTemplateId), _, _, _, _, _, _, _, _)
           if IdentifierEqual.equal(actualTemplateId, templateId) =>
         contractId
     }

--- a/ledger/test-common/src/main/daml/semantic/InterfaceViews.daml
+++ b/ledger/test-common/src/main/daml/semantic/InterfaceViews.daml
@@ -1,0 +1,53 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- TODO DPP-1068: The exact same file exists in the //daml-lf/tests package
+module InterfaceViews where
+
+data View = View with
+  a : Int
+  b : Bool
+
+interface I where
+    _view : View
+
+interface INoView where
+
+template T1
+  with
+    p : Party
+    a : Int
+  where
+    signatory p
+    implements I where
+      _view = View with
+        a
+        b = True
+    implements INoView where
+
+template T2
+  with
+    p : Party
+    a : Int
+  where
+    signatory p
+    implements I where
+      _view = View with
+        a
+        b = False
+
+template T3
+  with
+    p : Party
+    a : Int
+  where
+    signatory p
+    implements I where
+      _view = error "view crashed"
+
+template T4
+  with
+    p : Party
+    a : Int
+  where
+    signatory p


### PR DESCRIPTION
# What works

- Ledger API definition is extended
- Transaction streams support interface subscriptions

# What doesn't work

- ACS streams don't support interface subscriptions yet
- Initializing the package metadata cache on startup is not implemented yet. Restarting the participant will lead to errors. 