### PR TITLE
Make methods for deserializing GRPC-commands public

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -110,7 +110,7 @@ final class CommandsValidator(ledgerId: LedgerId) {
     }
   }
 
-  private def validateInnerCommands(
+  def validateInnerCommands(
       commands: Seq[ProtoCommand]
   )(implicit
       contextualizedErrorLogger: ContextualizedErrorLogger
@@ -124,7 +124,7 @@ final class CommandsValidator(ledgerId: LedgerId) {
       } yield validatedInnerCommands :+ validatedInnerCommand
     })
 
-  private def validateInnerCommand(
+  def validateInnerCommand(
       command: ProtoCommand.Command
   )(implicit
       contextualizedErrorLogger: ContextualizedErrorLogger


### PR DESCRIPTION
Its helpful in Canton tests, if we can reuse the existing code that converts GRPC-commands to API commands.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
