### PR TITLE
docs: fix ts docs pages

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -436,11 +436,6 @@ genrule(
     tar -xzf $(location //language-support/ts/daml-react:docs) --strip-components 1 -C $$DIR/html/app-dev/bindings-ts/daml-react/
     tar -xzf $(location //language-support/ts/daml-ledger:docs) --strip-components 1 -C $$DIR/html/app-dev/bindings-ts/daml-ledger/
     tar -xzf $(location //language-support/ts/daml-types:docs) --strip-components 1 -C $$DIR/html/app-dev/bindings-ts/daml-types/
-    # The generated docs of the typescript libraries are published at two places: The npm
-    # registry and on docs.daml.com. The docs at the npm registry contain a link pointing
-    # to docs.daml.com. We remove it for the version published at docs.daml.com as it would be
-    # pointing to itself.
-    sed -i -e 's,^.*\\(Comprehensive documentation\\|<h2>Documentation</h2>\\|0.0.0-SDKVERSION\\).*$$,,' $$DIR/html/app-dev/bindings-ts/*/index.html
 
     # Get the daml cheat sheet
     mkdir -p $$DIR/html/cheat-sheet

--- a/language-support/ts/daml-ledger/README.md
+++ b/language-support/ts/daml-ledger/README.md
@@ -3,10 +3,14 @@
 > Client side API implementation for a Daml based ledgers. This library implements the [JSON
 > API](https://docs.daml.com/json-api/index.html) for a Daml ledger.
 
+<!-- START_BACKLINK -->
+
 ## Documentation
 
 Comprehensive documentation for `@daml/ledger` can be found
 [here](https://docs.daml.com/0.0.0-SDKVERSION/app-dev/bindings-ts/daml-ledger/index.html).
+
+<!-- END_BACKLINK -->
 
 ## Usage
 

--- a/language-support/ts/daml-react/README.md
+++ b/language-support/ts/daml-react/README.md
@@ -2,9 +2,13 @@
 
 > React framework for Daml applications
 
+<!-- START_BACKLINK -->
+
 ## Documentation
 
 Comprehensive documentation for `@daml/react` can be found [here](https://docs.daml.com/0.0.0-SDKVERSION/app-dev/bindings-ts/daml-react/index.html).
+
+<!-- END_BACKLINK -->
 
 ## Usage
 

--- a/language-support/ts/daml-types/README.md
+++ b/language-support/ts/daml-types/README.md
@@ -2,10 +2,14 @@
 
 > Primitive types of the Daml language and their serialization.
 
+<!-- START_BACKLINK -->
+
 ## Documentation
 
 Comprehensive documentation for `@daml/types` can be found
 [here](https://docs.daml.com/0.0.0-SDKVERSION/app-dev/bindings-ts/daml-types/index.html).
+
+<!-- END_BACKLINK -->
 
 ## Description 
 

--- a/language-support/ts/typedoc.bzl
+++ b/language-support/ts/typedoc.bzl
@@ -30,11 +30,19 @@ def ts_docs(pkg_name, srcs, deps):
           trap "rm -rf $$WORKDIR" EXIT
           mkdir -p $$WORKDIR/docs
           cp -r $$DIR/* $$WORKDIR/docs
+
+          # Replace version number in all files
           sed -i -e 's/0.0.0-SDKVERSION/{sdk_version}/' $$WORKDIR/**/*.html
+
+          # We want the NPM version of the docs (i.e. the README.md) to point
+          # back to our own documentation, but here we're creating our local
+          # copy and that one shouldn't link to itself.
+          sed -i -e '/START_BACKLINK/,/END_BACKLINK/d' $$WORKDIR/docs/index.html
+
           OUT=$$PWD/$@
           MKTGZ=$$PWD/$(execpath //bazel_tools/sh:mktgz)
           cd $$WORKDIR
           $$MKTGZ $$OUT -h docs
-        """,
+        """.format(sdk_version = sdk_version),
         visibility = ["//visibility:public"],
     ) if not is_windows else None


### PR DESCRIPTION
- The "version replacement" step was broken: it replaced
  `0.0.0-SDKVERSION` with `{sdk_version}` instead of the current SDK
  version. This is fixed by adding a `format` call in the `ts_docs`
  Bazel rule.
- The section removal was broken as it assumed the version number was
  not replaced at all (so tried to detect `0.0.0-SDKVERSION` still).
  This is fixed by using a more robust "section removal" method.

CHANGELOG_BEGIN
CHANGELOG_END