### PR TITLE
use domain.Party instead of String in json-api tests

### DIFF
--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala
@@ -82,7 +82,7 @@ class HttpServiceIntegrationTestUserManagementNoAuth
   "create IOU should work with correct user rights" in withHttpService { fixture =>
     import fixture.{encoder, client => ledgerClient}
     val alice = getUniqueParty("Alice")
-    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice.unwrap)
+    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice)
     val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
     for {
       user <- createUser(ledgerClient)(
@@ -109,7 +109,7 @@ class HttpServiceIntegrationTestUserManagementNoAuth
     import fixture.{encoder, client => ledgerClient}
     val alice = getUniqueParty("Alice")
     val bob = getUniqueParty("Bob")
-    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice.unwrap)
+    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice)
     val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
     for {
       user <- createUser(ledgerClient)(
@@ -139,7 +139,7 @@ class HttpServiceIntegrationTestUserManagementNoAuth
       val bob = getUniqueParty("Bob")
       val meta = domain.CommandMeta(None, Some(NonEmptyList(bob)), None)
       val command: domain.CreateCommand[v.Record, OptionalPkg] =
-        iouCreateCommand(alice.unwrap, meta = Some(meta))
+        iouCreateCommand(alice, meta = Some(meta))
       val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
       for {
         user <- createUser(ledgerClient)(

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -95,7 +95,7 @@ trait AbstractHttpServiceIntegrationTestFunsCustomToken
   "create should fail with custom tokens that contain no ledger id" in withHttpService { fixture =>
     import fixture.encoder
     val alice = getUniqueParty("Alice")
-    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice.unwrap)
+    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice)
     val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
 
     val headers = HttpServiceTestFixture.authorizationHeader(
@@ -172,15 +172,13 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
 
   protected def genSearchDataSet(
       party: domain.Party
-  ): List[domain.CreateCommand[v.Record, OptionalPkg]] = {
-    val partyName = party.unwrap
+  ): List[domain.CreateCommand[v.Record, OptionalPkg]] =
     List(
-      iouCreateCommand(amount = "111.11", currency = "EUR", partyName = partyName),
-      iouCreateCommand(amount = "222.22", currency = "EUR", partyName = partyName),
-      iouCreateCommand(amount = "333.33", currency = "GBP", partyName = partyName),
-      iouCreateCommand(amount = "444.44", currency = "BTC", partyName = partyName),
+      iouCreateCommand(amount = "111.11", currency = "EUR", partyName = party),
+      iouCreateCommand(amount = "222.22", currency = "EUR", partyName = party),
+      iouCreateCommand(amount = "333.33", currency = "GBP", partyName = party),
+      iouCreateCommand(amount = "444.44", currency = "BTC", partyName = party),
     )
-  }
 
   "query GET" in withHttpService { fixture =>
     fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (alice, headers) =>
@@ -400,7 +398,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
         searchExpectOk(
           genSearchDataSet(alice) :+ iouCreateCommand(
             currency = testCurrency,
-            partyName = alice.unwrap,
+            partyName = alice,
           ),
           jsObject(
             s"""{"templateIds": ["Iou:Iou"], "query": {"currency": ${testCurrency.toJson}}}"""
@@ -507,7 +505,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
   "create IOU" in withHttpService { fixture =>
     import fixture.encoder
     fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (alice, headers) =>
-      val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice.unwrap)
+      val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice)
 
       postCreateCommand(command, fixture, headers)
         .map(inside(_) {
@@ -521,7 +519,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
   "create IOU should fail if authorization header is missing" in withHttpService { fixture =>
     import fixture.encoder
     val alice = getUniqueParty("Alice")
-    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice.unwrap)
+    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice)
     val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
 
     fixture
@@ -541,7 +539,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
   "create IOU should support extra readAs parties" in withHttpService { fixture =>
     import fixture.encoder
     val alice = getUniqueParty("Alice")
-    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice.unwrap)
+    val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice)
     val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
 
     fixture
@@ -566,7 +564,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
       import fixture.encoder
       fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (alice, headers) =>
         val command: domain.CreateCommand[v.Record, OptionalPkg] =
-          iouCreateCommand(alice.unwrap).copy(templateId = domain.TemplateId(None, "Iou", "Dummy"))
+          iouCreateCommand(alice).copy(templateId = domain.TemplateId(None, "Iou", "Dummy"))
         val input: JsValue = encoder.encodeCreateCommand(command).valueOr(e => fail(e.shows))
 
         fixture
@@ -590,7 +588,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
   "exercise IOU_Transfer" in withHttpService { fixture =>
     import fixture.encoder
     fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (alice, headers) =>
-      val create: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice.unwrap)
+      val create: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice)
       postCreateCommand(create, fixture, headers)
         .flatMap(inside(_) {
           case (StatusCodes.OK, domain.OkResponse(createResult, _, StatusCodes.OK)) =>
@@ -619,7 +617,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
     import fixture.encoder
     fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (alice, headers) =>
       val cmd: domain.CreateAndExerciseCommand[v.Record, v.Value, OptionalPkg] =
-        iouCreateAndExerciseTransferCommand(alice.unwrap)
+        iouCreateAndExerciseTransferCommand(alice)
 
       val json: JsValue = encoder.encodeCreateAndExerciseCommand(cmd).valueOr(e => fail(e.shows))
 
@@ -721,7 +719,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
   "exercise Archive" in withHttpService { fixture =>
     import fixture.encoder
     fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (alice, headers) =>
-      val create: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice.unwrap)
+      val create: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice)
       postCreateCommand(create, fixture, headers)
         .flatMap(inside(_) {
           case (StatusCodes.OK, domain.OkResponse(createResult, _, StatusCodes.OK)) =>
@@ -818,7 +816,8 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
     import json.JsonProtocol._
     import util.ErrorOps._
 
-    val command0: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand("Alice")
+    val command0: domain.CreateCommand[v.Record, OptionalPkg] =
+      iouCreateCommand(domain.Party("Alice"))
 
     type F[A] = EitherT[Future, JsonError, A]
     val x: F[Assertion] = for {
@@ -1053,7 +1052,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
 
   "fetch by contractId" in withHttpService { fixture =>
     fixture.getUniquePartyAndAuthHeaders("Alice").flatMap { case (alice, headers) =>
-      val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice.unwrap)
+      val command: domain.CreateCommand[v.Record, OptionalPkg] = iouCreateCommand(alice)
 
       postCreateCommand(command, fixture, headers).flatMap(inside(_) {
         case (StatusCodes.OK, domain.OkResponse(result, _, StatusCodes.OK)) =>
@@ -1087,7 +1086,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
       for {
         res <- fixture.getUniquePartyAndAuthHeaders("Alice")
         (alice, aliceHeaders) = res
-        command = iouCreateCommand(alice.unwrap)
+        command = iouCreateCommand(alice)
         createStatusOutput <- postCreateCommand(command, fixture, aliceHeaders)
         contractId = inside(createStatusOutput) {
           case (StatusCodes.OK, domain.OkResponse(result, _, StatusCodes.OK)) =>

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -655,7 +655,7 @@ abstract class AbstractHttpServiceIntegrationTestTokenIndependent
         // checking contracts
         inside(contract1) { case domain.Contract(-\/(archivedContract)) =>
           Future {
-            (archivedContract.contractId.unwrap: String) shouldBe (exerciseCmd.reference.contractId.unwrap: String)
+            (archivedContract.contractId: domain.ContractId) shouldBe (exerciseCmd.reference.contractId: domain.ContractId)
           }
         } *>
           inside(contract2) { case domain.Contract(\/-(activeContract)) =>

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -409,12 +409,12 @@ trait AbstractHttpServiceIntegrationTestFuns
   }
 
   protected def iouCreateCommand(
-      partyName: String,
+      partyName: domain.Party,
       amount: String = "999.9900000000",
       currency: String = "USD",
       meta: Option[domain.CommandMeta] = None,
   ): domain.CreateCommand[v.Record, OptionalPkg] = {
-    val party = Ref.Party assertFromString partyName
+    val party = Ref.Party assertFromString partyName.unwrap
     val arg = argToApi(iouVA)(
       ShRecord(
         issuer = party,
@@ -440,11 +440,11 @@ trait AbstractHttpServiceIntegrationTestFuns
   }
 
   protected def iouCreateAndExerciseTransferCommand(
-      partyName: String,
+      partyName: domain.Party,
       amount: String = "999.9900000000",
       currency: String = "USD",
   ): domain.CreateAndExerciseCommand[v.Record, v.Value, OptionalPkg] = {
-    val party = Ref.Party assertFromString partyName
+    val party = Ref.Party assertFromString partyName.unwrap
     val payload = argToApi(iouVA)(
       ShRecord(
         issuer = party,

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala
@@ -1005,7 +1005,7 @@ abstract class AbstractWebsocketServiceIntegrationTest
       // make a contract
       create <- liftF(
         postCreateCommand(
-          iouCreateCommand(domain.Party unwrap party),
+          iouCreateCommand(party),
           fixture,
           headers,
         )

--- a/security-evidence.md
+++ b/security-evidence.md
@@ -5,7 +5,7 @@
 - Updating the package service succeeds with sufficient authorization: [AuthorizationTest.scala](ledger-service/http-json/src/it/scala/http/AuthorizationTest.scala#L85)
 - accept user tokens: [TestMiddleware.scala](triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala#L152)
 - badly-authorized create is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L60)
-- badly-authorized create is rejected: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1029)
+- badly-authorized create is rejected: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1028)
 - badly-authorized exercise is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L158)
 - badly-authorized exercise/create (create is unauthorized) is rejected: [AuthPropagationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthPropagationSpec.scala#L275)
 - badly-authorized exercise/create (exercise is unauthorized) is rejected: [AuthPropagationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthPropagationSpec.scala#L243)
@@ -18,7 +18,7 @@
 - create with no signatories is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L50)
 - create with non-signatory maintainers is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L72)
 - exercise with no controllers is rejected: [AuthorizationSpec.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/AuthorizationSpec.scala#L148)
-- fetch fails when readAs not authed, even if prior fetch succeeded: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1083)
+- fetch fails when readAs not authed, even if prior fetch succeeded: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1082)
 - forbid a non-authorized party to check the status of a trigger: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L680)
 - forbid a non-authorized party to list triggers: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L670)
 - forbid a non-authorized party to start a trigger: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L659)
@@ -26,7 +26,7 @@
 - forbid a non-authorized user to upload a DAR: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L712)
 - multiple websocket requests over the same WebSocket connection are NOT allowed: [AbstractWebsocketServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractWebsocketServiceIntegrationTest.scala#L115)
 - refresh a token after expiry on the server side: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L737)
-- reject requests with missing auth header: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L520)
+- reject requests with missing auth header: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L518)
 - request a fresh token after expiry on user request: [TriggerServiceTest.scala](triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala#L722)
 - return the token from a cookie: [TestMiddleware.scala](triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala#L96)
 - return unauthorized on an expired token: [TestMiddleware.scala](triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala#L139)
@@ -202,7 +202,7 @@
 
 ## Performance:
 - Tail call optimization: Tail recursion does not blow the scala JVM stack.: [TailCallTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala#L16)
-- archiving a large number of contracts should succeed: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1358)
+- archiving a large number of contracts should succeed: [AbstractHttpServiceIntegrationTest.scala](ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTest.scala#L1357)
 - creating and listing 20K users should be possible: [HttpServiceIntegrationTestUserManagement.scala](ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala#L557)
 
 ## Input Validation:


### PR DESCRIPTION
If we're always calling unwrap to make an argument to a function, we can do it in that function.

* [x] empty changelog