### PR TITLE
[engine] Track local active contract set

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -28,6 +28,7 @@ import com.daml.lf.speedy.{ArrayList, InitialSeeding, SValue, svalue}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.command._
 import com.daml.lf.engine.Error.Interpretation
+import com.daml.lf.engine.Error.Interpretation.DamlException
 import com.daml.lf.transaction.test.TransactionBuilder.assertAsVersionedContract
 import com.daml.logging.LoggingContext
 import org.scalactic.Equality
@@ -1996,6 +1997,18 @@ class EngineTest
         ValueRecord(None, ImmArray((None, ValueInt64(0)))),
       )
       run(command) shouldBe a[Right[_, _]]
+    }
+    // TEST_EVIDENCE: Semantics: Rollback creates cannot be exercise
+    "creates in rollback are rolled back" in {
+      val command = ApiCommand.CreateAndExercise(
+        tId,
+        ValueRecord(None, ImmArray((None, ValueParty(party)))),
+        "ExerciseAfterRollbackCreate",
+        ValueRecord(None, ImmArray.empty),
+      )
+      inside(run(command)) {
+        case Left(Interpretation(DamlException(interpretation.Error.ContractNotFound(_)), _)) =>
+      }
     }
   }
 

--- a/daml-lf/tests/Exceptions.daml
+++ b/daml-lf/tests/Exceptions.daml
@@ -10,6 +10,10 @@ exception E
   where
     message "E"
 
+exception Ecid with cid: ContractId K
+  where
+    message "Ecid"
+
 template K
   with
     p : Party
@@ -90,6 +94,14 @@ template T
            E -> pure ()
          (_, k) <- fetchByKey @K (p, i)
          k === K p i "rollback"
+
+    nonconsuming choice ExerciseAfterRollbackCreate: ()
+      controller p
+      do
+        try do
+          cid <- create (K p 1 "")
+          throw (Ecid cid)
+        catch (Ecid cid) -> archive cid
 
 -- This template is used to test that the
 -- engine only ever looks up a global key once.

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
@@ -69,6 +69,9 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
     *   keyset are in [[activeState]].[[ActiveLedgerState.keys]],
     *   and similarly for all [[ActiveLedgerState]]s in [[rollbackStack]].
     *
+    * @param locallyCreated
+    *   Tracks all contracts created by this transaction including those under a rollback.
+    *
     * @param globalKeyInputs
     *   In mode [[com.daml.lf.transaction.ContractKeyUniquenessMode.byKeyOnly]],
     *   a store of key lookups (including fetch-by-key and exercise-by-key,
@@ -89,10 +92,28 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
     *                      try blocks (interpretation) or Rollback nodes (iteration).
     */
   case class State private (
+      locallyCreated: Set[ContractId],
       globalKeyInputs: Map[GlobalKey, KeyInput],
       activeState: ActiveLedgerState[Nid],
       rollbackStack: List[ActiveLedgerState[Nid]],
   ) {
+
+    /** The return value indicates if the given contract is either consumed, inactive, or otherwise
+      * - Some(Left(nid)) -- consumed by a specified node-id
+      * - Some(Right(())) -- inactive, because the (local) contract creation has been rolled-back
+      * - None -- neither consumed or inactive
+      */
+    def consumedByOrInactive(cid: Value.ContractId): Option[Either[Nid, Unit]] = {
+      activeState.consumedBy.get(cid) match {
+        case Some(nid) => Some(Left(nid)) // consumed
+        case None =>
+          if (locallyCreated(cid) && !activeState.locallyCreatedThisTimeline.contains(cid)) {
+            Some(Right(())) // inactive
+          } else {
+            None // neither
+          }
+      }
+    }
 
     def mode: ContractKeyUniquenessMode = ContractStateMachine.this.mode
 
@@ -112,10 +133,18 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
         contractId: ContractId,
         key: Option[KeyWithMaintainers],
     ): Either[DuplicateContractKey, State] = {
+      val me =
+        this.copy(
+          locallyCreated = locallyCreated + contractId,
+          activeState = this.activeState
+            .copy(locallyCreatedThisTimeline =
+              this.activeState.locallyCreatedThisTimeline + contractId
+            ),
+        )
       // if we have a contract key being added, include it in the list of
       // active keys
       key match {
-        case None => Right(this)
+        case None => Right(me)
         case Some(kWithM) =>
           val ck = GlobalKey(templateId, kWithM.key)
 
@@ -147,7 +176,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
           //         2.2.2: Not modify `globalKeyInputs` if there already was an entry.
           //         For both of those cases `globalKeyInputs` already had an entry which means
           //         we would use that as a cached result and not query the ledger.
-          val keys = activeState.keys
+          val keys = me.activeState.keys
           val conflict = keys.get(ck) match {
             case Some(keyMapping) => keyMapping.isDefined
             case None => lookupActiveGlobalKeyInput(ck).exists(_ != KeyInactive)
@@ -158,8 +187,8 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
             else globalKeyInputs.updated(ck, KeyCreate)
           Either.cond(
             !conflict || mode == ContractKeyUniquenessMode.Off,
-            this.copy(
-              activeState = activeState.copy(keys = keys.updated(ck, KeyActive(contractId))),
+            me.copy(
+              activeState = me.activeState.copy(keys = keys.updated(ck, KeyActive(contractId))),
               globalKeyInputs = newKeyInputs,
             ),
             DuplicateContractKey(ck),
@@ -392,6 +421,8 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
         _ <- consistentGlobalKeyInputs
       } yield {
         val next = ActiveLedgerState(
+          locallyCreatedThisTimeline = this.activeState.locallyCreatedThisTimeline
+            .union(substate.activeState.locallyCreatedThisTimeline),
           consumedBy = this.activeState.consumedBy ++ substate.activeState.consumedBy,
           keys = this.activeState.keys.concat(substate.activeState.keys),
         )
@@ -422,6 +453,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
             }
 
         this.copy(
+          locallyCreated = this.locallyCreated.union(substate.locallyCreated),
           globalKeyInputs = globalKeyInputs,
           activeState = next,
         )
@@ -440,7 +472,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
   }
 
   object State {
-    val empty: State = new State(Map.empty, ActiveLedgerState.empty, List.empty)
+    val empty: State = new State(Set.empty, Map.empty, ActiveLedgerState.empty, List.empty)
   }
 }
 
@@ -460,6 +492,9 @@ object ContractStateMachine {
   val KeyActive = Some
 
   /** Summarizes the updates to the current ledger state by nodes up to now.
+    *
+    * @param locallyCreatedThisTimeline
+    *   Tracks contracts created by this transaction that have not been rolled back. This is a subset of `locallyCreated`.
     *
     * @param consumedBy [[com.daml.lf.value.Value.ContractId]]s of all contracts
     *                   that have been consumed by nodes up to now.
@@ -487,6 +522,7 @@ object ContractStateMachine {
     *    all operations involving a contract with a key update this map.
     */
   final case class ActiveLedgerState[+Nid](
+      locallyCreatedThisTimeline: Set[ContractId],
       consumedBy: Map[ContractId, Nid],
       keys: Map[GlobalKey, KeyMapping],
   ) {
@@ -495,7 +531,8 @@ object ContractStateMachine {
   }
 
   object ActiveLedgerState {
-    private val EMPTY: ActiveLedgerState[Nothing] = ActiveLedgerState(Map.empty, Map.empty)
+    private val EMPTY: ActiveLedgerState[Nothing] =
+      ActiveLedgerState(Set.empty, Map.empty, Map.empty)
     def empty[Nid]: ActiveLedgerState[Nid] = EMPTY
   }
 }

--- a/security-evidence.md
+++ b/security-evidence.md
@@ -170,6 +170,7 @@
 - Evaluation order: Template precondition before interface preconditions.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L489)
 - Evaluation order: Template precondition before interface preconditions.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L712)
 - Exceptions, throw/catch.: [ExceptionTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala#L25)
+- Rollback creates cannot be exercise: [EngineTest.scala](daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala#L2001)
 - This checks that type checking in exercise_interface is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L1829)
 - This checks that type checking is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L1723)
 - This checks that type checking is done after checking activeness.: [EvaluationOrderTest.scala](daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala#L2598)


### PR DESCRIPTION

Track locally created contracts through rollback, using new fields:
- `State.locallyCreated` and
- `ActiveLedgerState.locallyCreatedThisTimeline`

Address issues: https://github.com/digital-asset/daml/issues/14148 https://github.com/digital-asset/daml/issues/13835

TODO:
- ~~Adapt existing testcases in `ContractStateMachineSpec.scala`~~
- ~~New testcase (`rbCreate`) in `ContractStateMachineSpec.scala`~~
- ~~New testcase ("creates in try are rolled back") in `Engintest.scala`~~
- ~~Fix evaluation order tests~~
- ~~Improve new test in `EngineTest.scala` to specify the expected error (in `Left`)~~
- Add test running over ledger-API (in `ExceptionsIT.scala`)
