### PR TITLE
Expose default value for PostgresDataSourceConfig

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -32,18 +32,20 @@ object IndexerConfig {
   def dataSourceProperties(config: IndexerConfig): DataSourceProperties =
     config.dataSourceProperties.getOrElse(createDataSourceProperties(config.ingestionParallelism))
 
-  private def createDataSourceProperties(
-      ingestionParallelism: Int
-  ): DataSourceProperties = DataSourceProperties(
-    // PostgresSQL specific configurations
-    postgres = PostgresDataSourceConfig(
+  val DefaultPostgresDataSourceConfig: PostgresDataSourceConfig = PostgresDataSourceConfig(
       synchronousCommit = Some(PostgresDataSourceConfig.SynchronousCommitValue.Off),
       // Setting aggressive keep-alive defaults to aid prompt release of the locks on the server side.
       // For reference https://www.postgresql.org/docs/13/runtime-config-connection.html#RUNTIME-CONFIG-CONNECTION-SETTINGS
       tcpKeepalivesIdle = Some(10),
       tcpKeepalivesInterval = Some(1),
       tcpKeepalivesCount = Some(5),
-    ),
+    )
+
+  private def createDataSourceProperties(
+      ingestionParallelism: Int
+  ): DataSourceProperties = DataSourceProperties(
+    // PostgresSQL specific configurations
+    postgres = DefaultPostgresDataSourceConfig,
     connectionPool = ConnectionPoolConfig(
       connectionPoolSize = ingestionParallelism + 1, // + 1 for the tailing ledger_end updates
       // 250 millis is the lowest possible value for this Hikari configuration (see HikariConfig JavaDoc)


### PR DESCRIPTION
The goal is to be able to use these defaults in Canton (so that we are aligned on default values)

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
