### PR TITLE
start: work with console

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -440,10 +440,10 @@ commandParser = subparser $ fold
 
     cantonSandboxCmd = do
         cantonOptions <- do
-            cantonLedgerApi <- option auto (long "port" <> value 6865)
-            cantonAdminApi <- option auto (long "admin-api-port" <> value 6866)
-            cantonDomainPublicApi <- option auto (long "domain-public-port" <> value 6867)
-            cantonDomainAdminApi <- option auto (long "domain-admin-port" <> value 6868)
+            cantonLedgerApi <- option auto (long "port" <> value (ledger defaultSandboxPorts))
+            cantonAdminApi <- option auto (long "admin-api-port" <> value (admin defaultSandboxPorts))
+            cantonDomainPublicApi <- option auto (long "domain-public-port" <> value (domainPublic defaultSandboxPorts))
+            cantonDomainAdminApi <- option auto (long "domain-admin-port" <> value (domainAdmin defaultSandboxPorts))
             cantonPortFileM <- optional $ option str (long "canton-port-file" <> metavar "PATH"
                 <> help "File to write canton participant ports when ready")
             cantonStaticTime <- StaticTime <$>

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -68,10 +68,10 @@ getPortForSandbox defaultPortSpec portSpecM =
 
 determineCantonOptions :: Maybe SandboxPortSpec -> SandboxCantonPortSpec -> FilePath -> IO CantonOptions
 determineCantonOptions ledgerApiSpec SandboxCantonPortSpec{..} portFile = do
-    cantonLedgerApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6865)) ledgerApiSpec
-    cantonAdminApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6866)) adminApiSpec
-    cantonDomainPublicApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6867)) domainPublicApiSpec
-    cantonDomainAdminApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6868)) domainAdminApiSpec
+    cantonLedgerApi <- getPortForSandbox (SpecifiedPort (SandboxPort (ledger defaultSandboxPorts))) ledgerApiSpec
+    cantonAdminApi <- getPortForSandbox (SpecifiedPort (SandboxPort (admin defaultSandboxPorts))) adminApiSpec
+    cantonDomainPublicApi <- getPortForSandbox (SpecifiedPort (SandboxPort (domainPublic defaultSandboxPorts))) domainPublicApiSpec
+    cantonDomainAdminApi <- getPortForSandbox (SpecifiedPort (SandboxPort (domainAdmin defaultSandboxPorts))) domainAdminApiSpec
     let cantonPortFileM = Just portFile -- TODO allow canton port file to be passed in from command line?
     let cantonStaticTime = StaticTime False
     let cantonHelp = False

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -69,9 +69,9 @@ getPortForSandbox defaultPortSpec portSpecM =
 determineCantonOptions :: Maybe SandboxPortSpec -> SandboxCantonPortSpec -> FilePath -> IO CantonOptions
 determineCantonOptions ledgerApiSpec SandboxCantonPortSpec{..} portFile = do
     cantonLedgerApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6865)) ledgerApiSpec
-    cantonAdminApi <- getPortForSandbox FreePort adminApiSpec
-    cantonDomainPublicApi <- getPortForSandbox FreePort domainPublicApiSpec
-    cantonDomainAdminApi <- getPortForSandbox FreePort domainAdminApiSpec
+    cantonAdminApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6866)) adminApiSpec
+    cantonDomainPublicApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6867)) domainPublicApiSpec
+    cantonDomainAdminApi <- getPortForSandbox (SpecifiedPort (SandboxPort 6868)) domainAdminApiSpec
     let cantonPortFileM = Just portFile -- TODO allow canton port file to be passed in from command line?
     let cantonStaticTime = StaticTime False
     let cantonHelp = False

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -25,6 +25,8 @@ module DA.Daml.Helper.Util
   , waitForHttpServer
   , tokenFor
   , StaticTime(..)
+  , SandboxPorts(..)
+  , defaultSandboxPorts
   , CantonOptions(..)
   , decodeCantonSandboxPort
   , CantonReplApi(..)
@@ -249,6 +251,16 @@ tokenFor parties ledgerId applicationId =
                   ])
             ]
       }
+
+data SandboxPorts = SandboxPorts
+  { ledger :: Int
+  , admin :: Int
+  , domainPublic :: Int
+  , domainAdmin :: Int
+  }
+
+defaultSandboxPorts :: SandboxPorts
+defaultSandboxPorts = SandboxPorts 6865 6866 6867 6868
 
 runCantonSandbox :: CantonOptions -> [String] -> IO ()
 runCantonSandbox options args = withCantonSandbox options args (const $ pure ())


### PR DESCRIPTION
This fixes the bug reported by `kctam` on [the forum]: that

[the forum]: https://discuss.daml.com/t/daml-start-then-using-daml-canton-console-to-access/4723

```
daml start
```

followed by

```
daml canton-console
```

doesn't work (because the console can't know which ports to connect to).

I'm very much not familiar at all with this area of the repo, so it's possible this is not the right approach to solving that at all. Please feel free to close and solve it in a better way if you know better.

```
CHANGELOG_BEGIN
- When using `daml start` (with no sandbox port configured in
  `daml.yaml`), the sandbox ports will no longer be random, and
  instead be the same ports as a plain `daml sandbox`.
CHANGELOG_END
```