### PR TITLE
[ETQ-TESTING] Fix slow flat transactions stream [DPP-1090]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/EventStorageBackendTemplate.scala
@@ -472,7 +472,6 @@ abstract class EventStorageBackendTemplate(
       partitions = List(
         "participant_events_create" -> selectColumnsForFlatTransactionsCreate,
         "participant_events_consuming_exercise" -> selectColumnsForFlatTransactionsExercise,
-        "participant_events_non_consuming_exercise" -> selectColumnsForFlatTransactionsExercise,
         // Note: previously we used divulgence events, however they don't have flat event witnesses and were thus never included anyway
         // "participant_events_divulgence" -> selectColumnsForFlatTransactionsDivulgence,
       ),


### PR DESCRIPTION
Flat transactions never contain any non-consuming events so it's safe not to query it.

We also see significant increase in performance in LR benchmarks:
```
Flat transactions benchmark             Rate before [events/s]    Rate after [events/s]
----------------------------------------------------------------------------------------
90pct-visibility-single-filter          3270.89                   6761.39
10pct-visibility-single-filter          time-out                  2086.92
10pct-visibility-composed-filter        time-out                  2232.14
0-1pct-visibility-single-filter         2.40                      24.66
0-1pct-visibility-composed-filter       2.57                      26.80
```


changelog_begin
changelog_end

