### PR TITLE
[Engine] clean key uniqueness mode

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -135,7 +135,7 @@ final class Conversions(
                     .setConsumedBy(proto.NodeId.newBuilder.setId(consumedBy.toString).build)
                     .build
                 )
-              case LocalContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
+              case ContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
                 builder.setScenarioContractKeyNotVisible(
                   proto.ScenarioError.ContractKeyNotVisible.newBuilder
                     .setContractRef(mkContractRef(coid, gk.templateId))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -57,7 +57,7 @@ private[lf] object Pretty {
           "Update failed due to fetch-by-key or exercise-by-key which did not find a contract with key"
         ) &
           prettyValue(false)(gk.key) & char('(') + prettyIdentifier(gk.templateId) + char(')')
-      case LocalContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
+      case ContractKeyNotVisible(coid, gk, actAs, readAs, stakeholders) =>
         text(
           "Update failed due to a fetch, lookup or exercise by key of contract not visible to the reading parties"
         ) & prettyContractId(coid) &

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1461,17 +1461,7 @@ private[lf] object SBuiltin {
           keyMapping match {
             case ContractStateMachine.KeyActive(coid)
                 if onLedger.ptx.contractState.locallyCreated.contains(coid) =>
-              val cachedContract = onLedger.cachedContracts
-                .getOrElse(coid, crash(s"Local contract ${coid.coid} not in cachedContracts"))
-              val stakeholders = cachedContract.signatories union cachedContract.observers
-              onLedger.visibleToStakeholders(stakeholders) match {
-                case SVisibleToStakeholders.Visible =>
-                  operation.handleKeyFound(machine, coid)
-                case SVisibleToStakeholders.NotVisible(actAs, readAs) =>
-                  machine.ctrl = SEDamlException(
-                    IE.LocalContractKeyNotVisible(coid, gkey, actAs, readAs, stakeholders)
-                  )
-              }
+              machine.checkKeyVisibility(onLedger, gkey, coid, operation.handleKeyFound)
             case _ =>
               operation.handleKnownInputKey(machine, gkey, keyMapping)
           }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -822,7 +822,7 @@ private[lf] object Speedy {
             case SVisibleToStakeholders.NotVisible(actAs, readAs) =>
               throw SErrorDamlException(
                 interpretation.Error
-                  .LocalContractKeyNotVisible(coid, gkey, actAs, readAs, stakeholders)
+                  .ContractKeyNotVisible(coid, gkey, actAs, readAs, stakeholders)
               )
             case _ =>
               handleKeyFound(this, coid)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
@@ -1478,7 +1478,7 @@ class EvaluationOrderTest extends AnyFreeSpec with Matchers with Inside {
           )
           inside(res) {
             case Success(
-                  Left(SErrorDamlException(IE.LocalContractKeyNotVisible(_, key, _, _, _)))
+                  Left(SErrorDamlException(IE.ContractKeyNotVisible(_, key, _, _, _)))
                 ) =>
               key.templateId shouldBe T
               msgs shouldBe Seq("starts test", "maintainers")
@@ -2319,7 +2319,7 @@ class EvaluationOrderTest extends AnyFreeSpec with Matchers with Inside {
           )
           inside(res) {
             case Success(
-                  Left(SErrorDamlException(IE.LocalContractKeyNotVisible(_, key, _, _, _)))
+                  Left(SErrorDamlException(IE.ContractKeyNotVisible(_, key, _, _, _)))
                 ) =>
               key.templateId shouldBe T
               msgs shouldBe Seq("starts test", "maintainers")
@@ -2826,7 +2826,7 @@ class EvaluationOrderTest extends AnyFreeSpec with Matchers with Inside {
           )
           inside(res) {
             case Success(
-                  Left(SErrorDamlException(IE.LocalContractKeyNotVisible(_, key, _, _, _)))
+                  Left(SErrorDamlException(IE.ContractKeyNotVisible(_, key, _, _, _)))
                 ) =>
               key.templateId shouldBe T
               msgs shouldBe Seq("starts test", "maintainers")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -24,7 +24,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   private[this] val committers: Set[data.Ref.Party] = Set.empty
 
   private[this] val initialState = PartialTransaction.initial(
-    ContractKeyUniquenessMode.On,
+    ContractKeyUniquenessMode.Strict,
     data.Time.Timestamp.Epoch,
     InitialSeeding.TransactionSeed(transactionSeed),
     committers,

--- a/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
+++ b/daml-lf/transaction/src/main/scala/com/daml/lf/Error.scala
@@ -45,7 +45,7 @@ object Error {
       consumedBy: NodeId,
   ) extends Error
 
-  final case class LocalContractKeyNotVisible(
+  final case class ContractKeyNotVisible(
       coid: ContractId,
       key: GlobalKey,
       actAs: Set[Party],

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
@@ -230,7 +230,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
       }
     }
 
-    /**  Must be used to handle lookups iff in [[com.daml.lf.transaction.ContractKeyUniquenessMode.Off]] mode
+    /**  Must be used to handle lookups iff in [[com.daml.lf.transaction.ContractKeyUniquenessMode.Strict]] mode
       */
     def handleLookup(lookup: Node.LookupByKey): Either[KeyInputError, State] = {
       // If the key has not yet been resolved, we use the resolution from the lookup node,
@@ -259,7 +259,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
     ): Either[KeyInputError, State] = {
       if (mode != ContractKeyUniquenessMode.Off)
         throw new UnsupportedOperationException(
-          "handleLookup can only be used if only by-key nodes are considered"
+          "handleLookupWith can only be used if only by-key nodes are considered"
         )
       visitLookup(lookup.templateId, lookup.key.key, keyInput, lookup.result).left.map(Left(_))
     }
@@ -391,13 +391,13 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
     private def withinRollbackScope: Boolean = rollbackStack.nonEmpty
 
     /** Let `resolver` be a [[KeyResolver]] that can be used during interpretation to obtain a transaction `tx`
-      * in modes [[com.daml.lf.transaction.ContractKeyUniquenessMode.Off]],
+      * in mode [[com.daml.lf.transaction.ContractKeyUniquenessMode.Off]],
       * or `Map.empty` in mode [[com.daml.lf.transaction.ContractKeyUniquenessMode.Strict]].
       *
       * Let `this` state be the result of iterating over `tx` up to a node `n` exclusive using `resolver`.
       * Let `substate` be the state obtained after fully iterating over the subtree rooted at `n` starting from [[State.empty]],
       * using the resolver [[projectKeyResolver]](`resolver`)
-      * in modes [[com.daml.lf.transaction.ContractKeyUniquenessMode.Off]]
+      * in mode [[com.daml.lf.transaction.ContractKeyUniquenessMode.Off]]
       * or `Map.empty` in mode [[com.daml.lf.transaction.ContractKeyUniquenessMode.Strict]].
       * Then, the returned state is the same as if
       * the iteration over tx continued from `this` state through the whole subtree rooted at `n` using `resolver`.
@@ -533,7 +533,7 @@ object ContractStateMachine {
     *     on contracts with a key (regardless of whether they were byKey or not) excluding
     *     nodes under a rollback.
     *
-    *   - In modes [[com.daml.lf.transaction.ContractKeyUniquenessMode.Off]]
+    *   - In mode [[com.daml.lf.transaction.ContractKeyUniquenessMode.Off]]
     *     the following operations mutate this map:
     *     1. fetch-by-key/lookup-by-key/exercise-by-key/create-contract-with-key will insert an
     *        an entry in the map if there wasn’t already one (i.e., if they queried the ledger).

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
@@ -256,8 +256,13 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
     def handleLookupWith(
         lookup: Node.LookupByKey,
         keyInput: Option[ContractId],
-    ): Either[KeyInputError, State] =
+    ): Either[KeyInputError, State] = {
+      if (mode != ContractKeyUniquenessMode.Off)
+        throw new UnsupportedOperationException(
+          "handleLookup can only be used if only by-key nodes are considered"
+        )
       visitLookup(lookup.templateId, lookup.key.key, keyInput, lookup.result).left.map(Left(_))
+    }
 
     private[lf] def visitLookup(
         templateId: TypeConName,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -54,7 +54,8 @@ sealed abstract class ContractKeyUniquenessMode extends Product with Serializabl
 object ContractKeyUniquenessMode {
 
   /** Disable key uniqueness checks and only consider byKey operations.
-      Note that no stable semantics are provided for off mode. */
+    *      Note that no stable semantics are provided for off mode.
+    */
   case object Off extends ContractKeyUniquenessMode
 
   /** Considers all nodes mentioning keys as byKey operations and checks for contract key uniqueness. */

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -53,9 +53,10 @@ sealed abstract class ContractKeyUniquenessMode extends Product with Serializabl
 
 object ContractKeyUniquenessMode {
 
-  /** Note that no stable semantics are provided for off mode. */
+  /** Disable key uniqueness checks and only consider byKey operations.
+      Note that no stable semantics are provided for off mode. */
   case object Off extends ContractKeyUniquenessMode
 
-  /** Considers all nodes mentioning keys for contract key uniqueness */
+  /** Considers all nodes mentioning keys as byKey operations and checks for contract key uniqueness. */
   case object Strict extends ContractKeyUniquenessMode
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -49,24 +49,13 @@ final case class GlobalKeyWithMaintainers(
   * This is always turned on with the exception of Canton which allows turning this on or off
   * and forces it to be turned off in multi-domain mode.
   */
-sealed trait ContractKeyUniquenessMode extends Product with Serializable {
+sealed abstract class ContractKeyUniquenessMode extends Product with Serializable
 
-  /** Whether only by-key nodes (including creates) are considered for contract key uniqueness */
-  def byKeyOnly: Boolean
-}
 object ContractKeyUniquenessMode {
 
-  /** Considers only by-key and create nodes for the contract key uniqueness checks */
-  sealed trait ContractByKeyUniquenessMode extends ContractKeyUniquenessMode {
-    override def byKeyOnly: Boolean = true
-  }
-  case object On extends ContractByKeyUniquenessMode
-
   /** Note that no stable semantics are provided for off mode. */
-  case object Off extends ContractByKeyUniquenessMode
+  case object Off extends ContractKeyUniquenessMode
 
   /** Considers all nodes mentioning keys for contract key uniqueness */
-  case object Strict extends ContractKeyUniquenessMode {
-    override def byKeyOnly: Boolean = false
-  }
+  case object Strict extends ContractKeyUniquenessMode
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
@@ -517,7 +517,6 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
       tx,
       Map(
         ContractKeyUniquenessMode.Strict -> expected,
-        ContractKeyUniquenessMode.On -> expected,
         ContractKeyUniquenessMode.Off -> expected,
       ),
     )

--- a/ledger/error/src/main/scala/com/daml/error/definitions/RejectionGenerators.scala
+++ b/ledger/error/src/main/scala/com/daml/error/definitions/RejectionGenerators.scala
@@ -70,7 +70,7 @@ object RejectionGenerators {
         case e: LfInterpretationError.ContractNotActive =>
           LedgerApiErrors.CommandExecution.Interpreter.ContractNotActive
             .Reject(renderedMessage, e)
-        case _: LfInterpretationError.LocalContractKeyNotVisible =>
+        case _: LfInterpretationError.ContractKeyNotVisible =>
           LedgerApiErrors.CommandExecution.Interpreter.GenericInterpretationError
             .Error(renderedMessage)
         case LfInterpretationError.DuplicateContractKey(key) =>


### PR DESCRIPTION
This is a follow up of #14175 and #14176.  

Basically
-  we kill the `On` mode which is not used anymore.
- we factorize the visibility check.
- we rename `LocalContractNotVisible` into `ContractNotVisible`

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
