### PR TITLE
docs: fix top-level update function

### DIFF
--- a/ci/cron/src/Docs.hs
+++ b/ci/cron/src/Docs.hs
@@ -166,7 +166,7 @@ find p = Directory.doesDirectoryExist p >>= \case
     False -> pure (Set.singleton p)
     True -> do
         children <- map ((p <> "/") <>) <$> Directory.listDirectory p
-        Set.unions <$> (sequence $ map find children)
+        Set.unions <$> mapM find children
 
 update_top_level :: DocOptions -> FilePath -> Version -> Maybe Version -> IO ()
 update_top_level opts temp new mayOld = do

--- a/ci/cron/src/Docs.hs
+++ b/ci/cron/src/Docs.hs
@@ -161,12 +161,19 @@ update_s3 opts temp vs = do
             writeFile (temp </> name) text
             proc_ ["aws", "s3", "cp", temp </> name, s3Path opts name, "--acl", "public-read"]
 
+find :: FilePath -> IO (Set.Set FilePath)
+find p = Directory.doesDirectoryExist p >>= \case
+    False -> pure (Set.singleton p)
+    True -> do
+        children <- map ((p <> "/") <>) <$> Directory.listDirectory p
+        Set.unions <$> (sequence $ map find children)
+
 update_top_level :: DocOptions -> FilePath -> Version -> Maybe Version -> IO ()
 update_top_level opts temp new mayOld = do
-    new_files <- Set.fromList <$> Directory.listDirectory (temp </> show new)
+    new_files <- find (temp </> show new)
     old_files <- case mayOld of
         Nothing -> pure Set.empty
-        Just old -> Set.fromList <$> Directory.listDirectory (temp </> show old)
+        Just old -> find (temp </> show old)
     let to_delete = Set.toList $ old_files `Set.difference` new_files
     Control.when (not $ null to_delete) $ do
         putStrLn $ "Deleting top-level files: " <> show to_delete


### PR DESCRIPTION
After yet another report of a ghost file, I stared at the code even harder than before and finally figured out what was going wrong (or at least one way it was going wrong): `listDirectory` is not recursive, so the current code would only delete top-level files.

Hopefully this fixes that. I'll try to do some manual cleanup too.

CHANGELOG_BEGIN
CHANGELOG_END
