### PR TITLE
Fix: Add activity check for disclosed contracts

### DIFF
--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -332,6 +332,11 @@ prettyScenarioErrorError (Just err) =  do
         , "for template"
         , nest 2 (prettyMay "<missing template id>" (prettyDefName world) (globalKeyTemplateId gk))
         ]
+    ScenarioErrorErrorScenarioCommitError (CommitError (Just (CommitErrorSumContractNotActive ref))) -> do
+      pure $ vcat
+        [ "Attempt to exercise an inactive contract."
+        , "Contract:" <-> (prettyContractRef world ref)
+        ]
 
     ScenarioErrorErrorUnknownContext ctxId ->
       pure $ "Unknown script interpretation context:" <-> string (show ctxId)

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -540,6 +540,7 @@ message CommitError {
   oneof sum {
     FailedAuthorizations failed_authorizations = 1;
     GlobalKey unique_key_violation = 2;
+    ContractRef contract_not_active = 3;
   }
 }
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -284,7 +284,9 @@ final class Conversions(
     val builder = proto.CommitError.newBuilder
     commitError match {
       case ScenarioLedger.CommitError.UniqueKeyViolation(gk) =>
-        builder.setUniqueKeyViolation(convertGlobalKey(gk.gk))
+        builder.setUniqueKeyViolation(convertGlobalKey(gk))
+      case ScenarioLedger.CommitError.ContractNotActive(coid, tid) =>
+        builder.setContractNotActive(mkContractRef(coid, tid))
     }
     builder.build
   }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
@@ -51,13 +51,16 @@ private[lf] object Pretty {
             stakeholders.map(prettyParty),
           ) + char('.')
 
-      case Error.CommitError(ScenarioLedger.CommitError.UniqueKeyViolation(gk)) =>
+      case Error.CommitError(ScenarioLedger.CommitError.UniqueKeyViolation(key)) =>
         (text("Scenario failed due to unique key violation for key:") & prettyValue(false)(
-          gk.gk.key
+          key.key
         ) & text(
           "for template"
-        ) & prettyIdentifier(gk.gk.templateId))
+        ) & prettyIdentifier(key.templateId))
 
+      case Error.CommitError(ScenarioLedger.CommitError.ContractNotActive(coid, tid)) =>
+        text("Scenario failed due to a fetch of a consumed contract") & prettyContractId(coid) &
+        char('(') + (prettyIdentifier(tid)) + text(").")
       case Error.MustFailSucceeded(tx @ _) =>
         // TODO(JM): Further info needed. Location annotations?
         text("Scenario failed due to a mustfailAt that succeeded.")


### PR DESCRIPTION
This adds an activeness check for disclosed contracts. I think this can only be done for the `ScenarioLedger`, as there is no way to check an unknown contract for activeness on a real ledger, or did I get this wrong @cocreature .

TODO: Tests

Fixes #14186.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
