### PR TITLE
cron: faster check_releases (hopefully)

### DIFF
--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -71,31 +71,24 @@ steps:
         jq -n --arg message "$message" '{"text": $message}' \
          | curl -XPOST -i -H 'Content-Type: application/json' -d @- $channel
     }
-    gcs() {
-        local args cleanup cmd cred key restore_trap ret
-        ret=1
-
+    wrap_gcloud() (
         cred="$1"
         cmd="$2"
-        args=(${@:3})
-
         key=$(mktemp)
-        # There may already be a trap; this will save it
-        restore_trap=$(trap -p EXIT)
         config_dir=$(mktemp -d)
-        cleanup="rm -rf $key $config_dir"
-        trap "$cleanup; $restore_trap" EXIT
+        trap "rm -rf $key $config_dir" EXIT
         echo "$cred" > $key
         export CLOUDSDK_CONFIG="$config_dir"
+        export BOTO_CONFIG=/dev/null
         gcloud auth activate-service-account --key-file=$key
+        eval "$cmd"
+    )
+    gcs() (
+        cred="$1"
+        cmd="${@:2}"
 
-        BOTO_CONFIG=/dev/null gsutil $cmd "${args[@]}"
-        ret=$?
-        eval "$cleanup"
-        trap - EXIT
-        eval "$restore_trap"
-        return $ret
-    }
+        wrap_gcloud "$cred" "gsutil $cmd"
+    )
     gpg_verify() {
         local key gpg_dir signature_file res
         signature_file=$1

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -334,9 +334,10 @@ jobs:
       - bash: |
           set -euo pipefail
           eval "$(dev-env/bin/dade assist)"
+          source $(bash_lib)
 
           bazel build //ci/cron:cron
-          bazel-bin/ci/cron/cron check --bash-lib $(bash_lib) --gcp-creds "$GCRED"
+          wrap_gcloud "$GCRED" "bazel-bin/ci/cron/cron check --bash-lib $(bash_lib)"
         displayName: check releases
         env:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)

--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -13,7 +13,6 @@ import qualified System.IO.Extra as IO
 
 data CliArgs = Docs
              | Check { bash_lib :: String,
-                       gcp_credentials :: Maybe String,
                        max_releases :: Maybe Int }
              | BazelCache BazelCache.Opts
 
@@ -29,10 +28,6 @@ parser = info "This program is meant to be run by CI cron. You probably don't ha
                      (Check <$> Opt.strOption (Opt.long "bash-lib"
                                          <> Opt.metavar "PATH"
                                          <> Opt.help "Path to Bash library file.")
-                            <*> (Opt.optional $
-                                  Opt.strOption (Opt.long "gcp-creds"
-                                         <> Opt.metavar "CRED_STRING"
-                                         <> Opt.help "GCP credentials as a string."))
                             <*> (Opt.optional $
                                   Opt.option Opt.auto (Opt.long "max-releases"
                                          <> Opt.metavar "INT"
@@ -71,6 +66,6 @@ main = do
       Docs -> do
           Docs.docs Docs.sdkDocOpts
           Docs.docs Docs.damlOnSqlDocOpts
-      Check { bash_lib, gcp_credentials, max_releases } ->
-          CheckReleases.check_releases gcp_credentials bash_lib max_releases
+      Check { bash_lib, max_releases } ->
+          CheckReleases.check_releases bash_lib max_releases
       BazelCache opts -> BazelCache.run opts


### PR DESCRIPTION
The check_releases job has been a major player in the flakiness of the daily test lately, simply by _timing out_ despite its 6h limit.

There are smarter, more "permanent" fixes we could implement here, but as a quick stopgap measure I wanted to try out how much faster we would go if we didn't need to reestablish a GCloud identity for each file.

CHANGELOG_BEGIN
CHANGELOG_END

run-full-compat: true