### PR TITLE
Use `rst_prolog` to define typescript link targets

### DIFF
--- a/docs/configs/html/conf.py
+++ b/docs/configs/html/conf.py
@@ -178,6 +178,9 @@ rst_prolog = """
 .. _Artifactory: https://digitalasset.jfrog.io/ui/repos/tree/General/sdk-ee
 .. _protobufs: https://github.com/digital-asset/daml/releases/download/v{release}/protobufs-{release}.zip
 .. _api-test-tool: https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/{release}/ledger-api-test-tool-{release}.jar
+.. _ts-daml-react: daml-react
+.. _ts-daml-ledger: daml-ledger
+.. _ts-daml-types: daml-types
 """.format(release = release)
 
 # Import the Daml lexer

--- a/docs/configs/pdf/conf.py
+++ b/docs/configs/pdf/conf.py
@@ -333,6 +333,9 @@ rst_prolog = """
 .. _Artifactory: https://digitalasset.jfrog.io/ui/repos/tree/General/sdk-ee
 .. _protobufs: https://github.com/digital-asset/daml/releases/download/v{release}/protobufs-{release}.zip
 .. _api-test-tool: https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/{release}/ledger-api-test-tool-{release}.jar
+.. _ts-daml-react: https://docs.daml.com/{release}/app-dev/bindings-ts/daml-react
+.. _ts-daml-ledger: https://docs.daml.com/{release}/app-dev/bindings-ts/daml-ledger
+.. _ts-daml-types: https://docs.daml.com/{release}/app-dev/bindings-ts/daml-types
 """.format(release = release)
 
 # Import the Daml lexer

--- a/docs/source/app-dev/bindings-ts/daml-ledger.rst
+++ b/docs/source/app-dev/bindings-ts/daml-ledger.rst
@@ -4,5 +4,5 @@
 @daml/ledger
 ############
 
-`@daml/ledger documentation <daml-ledger/index.html>`_
+`@daml/ledger documentation <ts-daml-ledger_>`_
 

--- a/docs/source/app-dev/bindings-ts/daml-react.rst
+++ b/docs/source/app-dev/bindings-ts/daml-react.rst
@@ -4,5 +4,5 @@
 @daml/react
 ###########
 
-`@daml/react documentation <daml-react/index.html>`_
+`@daml/react documentation <ts-daml-react_>`_
 

--- a/docs/source/app-dev/bindings-ts/daml-types.rst
+++ b/docs/source/app-dev/bindings-ts/daml-types.rst
@@ -4,5 +4,5 @@
 @daml/types
 ###########
 
-`@daml/types documentation <daml-types/index.html>`_
+`@daml/types documentation <ts-daml-types_>`_
 

--- a/docs/source/app-dev/bindings-ts/index.rst
+++ b/docs/source/app-dev/bindings-ts/index.rst
@@ -9,13 +9,13 @@ Using JavaScript Client Libraries with Daml
 The JavaScript Client Libraries are the recommended way to build a frontend for a Daml application.
 The :doc:`JavaScript Code Generator <daml2js>` can automatically generate JavaScript containing metadata about Daml packages that is required to use these libraries.
 We provide an integration for the `React <https://reactjs.org>`_ framework with the
-`@daml/react <daml-react/index.html>`_ library.  However, you can choose any JavaScript/TypeScript based framework
-and use the `@daml/ledger <daml-ledger/index.html>`_ library directly to connect and interact with a
+`@daml/react <ts-daml-react_>`_ library.  However, you can choose any JavaScript/TypeScript based framework
+and use the `@daml/ledger <ts-daml-ledger_>`_ library directly to connect and interact with a
 Daml ledger via its :ref:`HTTP JSON API <json-api>`.
 
-The `@daml/types <daml-types/index.html>`_ library contains TypeScript data types corresponding to
-primitive Daml data types, such as ``Party`` or ``Text``. It is used by the `@daml/react <daml-react/index.html>`_
-and `@daml/ledger <daml-ledger/index.html>`_ libraries.
+The `@daml/types <ts-daml-types_>`_ library contains TypeScript data types corresponding to
+primitive Daml data types, such as ``Party`` or ``Text``. It is used by the `@daml/react <ts-daml-react_>`_
+and `@daml/ledger <ts-daml-ledger_>`_ libraries.
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
This allows us to define the typescript link targets as relative
or absolute depending on html/pdf output. This fixes the broken
links in the PDF output by making them absolute; the links
in the html output stay relative.

Reported by Ben on Slack: in the current PDF, the links are dead
(because they are relative links).

changelog_begin
changelog_end

An alternative approach to https://github.com/digital-asset/docs.daml.com/pull/14

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
