### PR TITLE
[Benchtool] Allow for setting a timeout for every stream [DPP-1088]

### DIFF
--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/Cli.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/Cli.scala
@@ -181,9 +181,6 @@ object Cli {
             case None => Left(s"Missing field: '$fieldName'")
           }
 
-        def longField(fieldName: String): Either[String, Long] =
-          stringField(fieldName).map(_.toLong)
-
         def optionalStringField(fieldName: String): Either[String, Option[String]] =
           Right(m.get(fieldName))
 
@@ -240,6 +237,7 @@ object Cli {
           minItemRate <- optionalDoubleField("min-item-rate")
           maxItemRate <- optionalDoubleField("max-item-rate")
           maxItemCount <- optionalLongField("max-item-count")
+          timeoutInSecondsO <- optionalLongField("timeout")
         } yield WorkflowConfig.StreamConfig.TransactionsStreamConfig(
           name = name,
           filters = filters,
@@ -247,6 +245,7 @@ object Cli {
           endOffset = endOffset,
           objectives =
             transactionObjectives(maxDelaySeconds, minConsumptionSpeed, minItemRate, maxItemRate),
+          timeoutInSecondsO = timeoutInSecondsO,
           maxItemCount = maxItemCount,
         )
 
@@ -262,6 +261,7 @@ object Cli {
             minItemRate <- optionalDoubleField("min-item-rate")
             maxItemRate <- optionalDoubleField("max-item-rate")
             maxItemCount <- optionalLongField("max-item-count")
+            timeoutInSecondsO <- optionalLongField("timeout")
           } yield WorkflowConfig.StreamConfig.TransactionTreesStreamConfig(
             name = name,
             filters = filters,
@@ -269,6 +269,7 @@ object Cli {
             endOffset = endOffset,
             objectives =
               transactionObjectives(maxDelaySeconds, minConsumptionSpeed, minItemRate, maxItemRate),
+            timeoutInSecondsO = timeoutInSecondsO,
             maxItemCount = maxItemCount,
           )
 
@@ -294,10 +295,12 @@ object Cli {
           minItemRate <- optionalDoubleField("min-item-rate")
           maxItemRate <- optionalDoubleField("max-item-rate")
           maxItemCount <- optionalLongField("max-item-count")
+          timeoutInSecondsO <- optionalLongField("timeout")
         } yield WorkflowConfig.StreamConfig.ActiveContractsStreamConfig(
           name = name,
           filters = filters,
           objectives = rateObjectives(minItemRate, maxItemRate),
+          timeoutInSecondsO = timeoutInSecondsO,
           maxItemCount = maxItemCount,
         )
 
@@ -309,7 +312,7 @@ object Cli {
             beginOffset <- optionalStringField("begin-offset").map(_.map(offset))
             minItemRate <- optionalDoubleField("min-item-rate")
             maxItemRate <- optionalDoubleField("max-item-rate")
-            timeoutInSeconds <- longField("timeout")
+            timeoutInSecondsO <- optionalLongField("timeout")
             maxItemCount <- optionalLongField("max-item-count")
           } yield WorkflowConfig.StreamConfig.CompletionsStreamConfig(
             name = name,
@@ -317,7 +320,7 @@ object Cli {
             applicationId = applicationId,
             beginOffset = beginOffset,
             objectives = rateObjectives(minItemRate, maxItemRate),
-            timeoutInSeconds = timeoutInSeconds,
+            timeoutInSecondsO = timeoutInSecondsO,
             maxItemCount = maxItemCount,
           )
 

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfig.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfig.scala
@@ -81,6 +81,10 @@ object WorkflowConfig {
     /** If specified, used to cancel the stream when enough items has been seen.
       */
     def maxItemCount: Option[Long] = None
+
+    /** If specified, used to cancel the stream after the specified time out
+      */
+    def timeoutInSecondsO: Option[Long] = None
   }
 
   object StreamConfig {
@@ -91,6 +95,7 @@ object WorkflowConfig {
         endOffset: Option[LedgerOffset],
         objectives: Option[StreamConfig.TransactionObjectives],
         override val maxItemCount: Option[Long],
+        override val timeoutInSecondsO: Option[Long],
     ) extends StreamConfig
 
     final case class TransactionTreesStreamConfig(
@@ -100,6 +105,7 @@ object WorkflowConfig {
         endOffset: Option[LedgerOffset],
         objectives: Option[StreamConfig.TransactionObjectives],
         override val maxItemCount: Option[Long],
+        override val timeoutInSecondsO: Option[Long],
     ) extends StreamConfig
 
     final case class ActiveContractsStreamConfig(
@@ -107,6 +113,7 @@ object WorkflowConfig {
         filters: List[PartyFilter],
         objectives: Option[StreamConfig.RateObjectives],
         override val maxItemCount: Option[Long],
+        override val timeoutInSecondsO: Option[Long],
     ) extends StreamConfig
 
     final case class CompletionsStreamConfig(
@@ -114,9 +121,9 @@ object WorkflowConfig {
         parties: List[String],
         applicationId: String,
         beginOffset: Option[LedgerOffset],
-        timeoutInSeconds: Long,
         objectives: Option[StreamConfig.RateObjectives],
         override val maxItemCount: Option[Long],
+        override val timeoutInSecondsO: Option[Long],
     ) extends StreamConfig
 
     final case class PartyFilter(party: String, templates: List[String])

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParser.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParser.scala
@@ -53,31 +53,34 @@ object WorkflowConfigParser {
       )(StreamConfig.PartyFilter.apply)
 
     implicit val transactionStreamDecoder: Decoder[StreamConfig.TransactionsStreamConfig] =
-      Decoder.forProduct6(
+      Decoder.forProduct7(
         "name",
         "filters",
         "begin_offset",
         "end_offset",
         "objectives",
         "max_item_count",
+        "timeout_in_seconds",
       )(StreamConfig.TransactionsStreamConfig.apply)
 
     implicit val transactionTreesStreamDecoder: Decoder[StreamConfig.TransactionTreesStreamConfig] =
-      Decoder.forProduct6(
+      Decoder.forProduct7(
         "name",
         "filters",
         "begin_offset",
         "end_offset",
         "objectives",
         "max_item_count",
+        "timeout_in_seconds",
       )(StreamConfig.TransactionTreesStreamConfig.apply)
 
     implicit val activeContractsStreamDecoder: Decoder[StreamConfig.ActiveContractsStreamConfig] =
-      Decoder.forProduct4(
+      Decoder.forProduct5(
         "name",
         "filters",
         "objectives",
         "max_item_count",
+        "timeout_in_seconds",
       )(StreamConfig.ActiveContractsStreamConfig.apply)
 
     implicit val completionsStreamDecoder: Decoder[StreamConfig.CompletionsStreamConfig] =
@@ -86,9 +89,9 @@ object WorkflowConfigParser {
         "parties",
         "application_id",
         "begin_offset",
-        "timeout_in_seconds",
         "objectives",
         "max_item_count",
+        "timeout_in_seconds",
       )(StreamConfig.CompletionsStreamConfig.apply)
 
     implicit val streamConfigDecoder: Decoder[StreamConfig] =

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/util/ObserverWithResult.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/util/ObserverWithResult.scala
@@ -11,6 +11,7 @@ import org.slf4j.Logger
 import scala.concurrent.{Future, Promise}
 
 object ClientCancelled extends Exception
+
 abstract class ObserverWithResult[RespT, Result](logger: Logger)
     extends ClientResponseObserver[Any, RespT] {
 

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/CliSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/CliSpec.scala
@@ -93,6 +93,7 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           endOffset = None,
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         ),
         s"stream-type=transaction-trees,name=$name,filters=$party1" -> TransactionTreesStreamConfig(
           name = name,
@@ -101,12 +102,14 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           endOffset = None,
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         ),
         s"stream-type=active-contracts,name=$name,filters=$party1" -> ActiveContractsStreamConfig(
           name = name,
           filters = List(PartyFilter(party1, Nil)),
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         ),
         s"stream-type=completions,name=$name,parties=$party1+$party2,application-id=$appId,timeout=123,max-item-count=5" -> CompletionsStreamConfig(
           name = name,
@@ -114,7 +117,7 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           applicationId = appId,
           beginOffset = None,
           objectives = None,
-          timeoutInSeconds = 123,
+          timeoutInSecondsO = Some(123),
           maxItemCount = Some(5),
         ),
       )
@@ -150,6 +153,7 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           endOffset = None,
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         ),
         s"stream-type=transaction-trees,name=$name,filters=$filters" -> TransactionTreesStreamConfig(
           name = name,
@@ -158,12 +162,14 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           endOffset = None,
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         ),
         s"stream-type=active-contracts,name=$name,filters=$filters" -> ActiveContractsStreamConfig(
           name = name,
           filters = filtersList,
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         ),
       )
       forAll(cases) { (argument, config) =>
@@ -196,6 +202,7 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           endOffset = None,
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         )
         val expectedConfig =
           Config.Default.copy(workflow = Config.Default.workflow.copy(streams = List(streamConfig)))
@@ -229,6 +236,7 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           endOffset = Some(offset),
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         )
         val expectedConfig =
           Config.Default.copy(workflow = Config.Default.workflow.copy(streams = List(streamConfig)))
@@ -274,6 +282,7 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           endOffset = None,
           objectives = Some(objectives),
           maxItemCount = None,
+          timeoutInSecondsO = None,
         )
         val expectedConfig =
           Config.Default.copy(workflow = Config.Default.workflow.copy(streams = List(streamConfig)))
@@ -300,6 +309,7 @@ class CliSpec extends AnyWordSpec with Matchers with OptionValues with TableDriv
           filters = List(PartyFilter(party, Nil)),
           objectives = Some(objectives),
           maxItemCount = None,
+          timeoutInSecondsO = None,
         )
         val expectedConfig =
           Config.Default.copy(workflow = Config.Default.workflow.copy(streams = List(streamConfig)))

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParserSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/config/WorkflowConfigParserSpec.scala
@@ -111,6 +111,7 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
                 )
               ),
               maxItemCount = Some(700),
+              timeoutInSecondsO = None,
             )
           ),
         )
@@ -242,6 +243,7 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
                 )
               ),
               maxItemCount = None,
+              timeoutInSecondsO = None,
             )
           ),
         )
@@ -286,6 +288,7 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
                 )
               ),
               maxItemCount = None,
+              timeoutInSecondsO = None,
             )
           ),
         )
@@ -320,6 +323,7 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
               endOffset = Some(offset("bar")),
               objectives = None,
               maxItemCount = None,
+              timeoutInSecondsO = None,
             )
           ),
         )
@@ -366,6 +370,7 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
                 )
               ),
               maxItemCount = None,
+              timeoutInSecondsO = None,
             )
           ),
         )
@@ -404,6 +409,7 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
                 )
               ),
               maxItemCount = None,
+              timeoutInSecondsO = None,
             )
           ),
         )
@@ -438,7 +444,7 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
                   maxItemRate = Some(345),
                 )
               ),
-              timeoutInSeconds = 100,
+              timeoutInSecondsO = Some(100),
               maxItemCount = Some(101L),
             )
           ),
@@ -474,6 +480,7 @@ class WorkflowConfigParserSpec extends AnyWordSpec with Matchers {
               endOffset = Some(ledgerEndOffset),
               objectives = None,
               maxItemCount = None,
+              timeoutInSecondsO = None,
             )
           ),
         )

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FibonacciCommandSubmitterITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FibonacciCommandSubmitterITSpec.scala
@@ -78,6 +78,7 @@ class FibonacciCommandSubmitterITSpec
           endOffset = Some(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         ),
         observer = eventsObserver,
       )

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
@@ -142,6 +142,7 @@ class FooCommandSubmitterITSpec
       endOffset = Some(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
       objectives = None,
       maxItemCount = None,
+      timeoutInSecondsO = None,
     )
     apiServices.transactionService.transactionTrees(
       config = config,

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonStakeholderInformeesITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonStakeholderInformeesITSpec.scala
@@ -168,6 +168,7 @@ class NonStakeholderInformeesITSpec
           endOffset = Some(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         ),
         observer = treeTxObserver,
       )
@@ -184,6 +185,7 @@ class NonStakeholderInformeesITSpec
           endOffset = Some(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
           objectives = None,
           maxItemCount = None,
+          timeoutInSecondsO = None,
         ),
         observer = flatTxObserver,
       )

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/WeightedApplicationIdsAndSubmittersITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/WeightedApplicationIdsAndSubmittersITSpec.scala
@@ -128,7 +128,7 @@ class WeightedApplicationIdsAndSubmittersITSpec
         applicationId = applicationId,
         beginOffset = Some(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)),
         objectives = None,
-        timeoutInSeconds = 0,
+        timeoutInSecondsO = None,
         maxItemCount = None,
       ),
       observer = observer,


### PR DESCRIPTION
Some of the new flat transaction benchmarks exhibit very low rate and eventually cause LR time-out after 90minutes.
This PR allows to set a shorter time-out on the Benchtool level per each benchmark

changelog_begin
changelog_end
