### PR TITLE
[stdlib] fix DA.Foldable

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Foldable.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Foldable.daml
@@ -10,11 +10,10 @@
 module DA.Foldable where
 
 import Prelude hiding (foldr, foldl, any, all)
-import Prelude qualified as P
 
 import DA.Monoid
 
-import DA.Either qualified as E
+import DA.List qualified as L
 import DA.Optional qualified as O
 
 -- | Class of data structures that can be folded to a summary value.
@@ -32,13 +31,11 @@ class Foldable t where
 
   -- | Right-associative fold of a structure.
   foldr : (a -> b -> b) -> b -> t a -> b
-  foldr f z t = let endo{-: Endo b-} = \a -> Endo (f a)
-                in appEndo (foldMap endo t) z
+  foldr f z t = appEndo (foldMap (Endo . f) t) z
 
   -- | Left-associative fold of a structure.
   foldl : (b -> a -> b) -> b -> t a -> b
-  foldl f z t = let endo{-: Endo b-} = \a -> Endo (flip f a)
-                in appEndo (foldMap endo t) z
+  foldl f z = L.foldl f z . toList
 
   -- | A variant of foldr that has no base case, and thus should only be applied to non-empty structures.
   foldr1 : (a -> a -> a) -> t a -> a
@@ -54,15 +51,15 @@ class Foldable t where
 
   -- | List of elements of a structure, from left to right.
   toList : t a -> [a]
-  toList t = foldl (\b a -> a::b) [] t
+  toList t = foldr (::) [] t
 
   -- | Test whether the structure is empty. The default implementation is optimized for structures that are similar to cons-lists, because there is no general way to do better.
   null : t a -> Bool
-  null = foldl (\_ _ -> False) True
+  null = foldr (\_ _ -> False) True
 
   -- | Returns the size/length of a finite structure as an `Int`. The default implementation is optimized for structures that are similar to cons-lists, because there is no general way to do better.
   length : t a -> Int
-  length = foldl (\c _ -> c + 1) 0
+  length = foldr (\_ -> (+1)) 0
 
   -- | Does the element occur in the structure?
   elem : Eq a => a -> t a -> Bool
@@ -70,23 +67,19 @@ class Foldable t where
 
   -- | The sum function computes the sum of the numbers of a structure.
   sum : Additive a => t a -> a
-  sum = foldl (+) aunit
+  sum = foldr (+) aunit
 
   -- | The product function computes the product of the numbers of a structure.
   product : Multiplicative a => t a -> a
-  product = foldl (*) munit
+  product = foldr (*) munit
 
   -- | The least element of a non-empty structure.
   minimum : Ord a => t a -> a
-  minimum = foldl1 m
-    where
-      m x y = if x > y then y else x
+  minimum = foldr1 min
 
   -- | The largest element of a non-empty structure.
   maximum : Ord a => t a -> a
-  maximum = foldl1 m
-    where
-      m x y = if x < y then y else x
+  maximum = foldr1 max
 
 -- | Map each element of a structure to an action, evaluate these
 -- actions from left to right, and ignore the results. For a version
@@ -111,7 +104,7 @@ sequence_ = foldr (>>) (return ())
 
 -- | The concatenation of all the elements of a container of lists.
 concat : Foldable t => t [a] -> [a]
-concat xs = foldr (\x y -> foldr (::) y x) [] xs
+concat = fold
 
 -- | `and` returns the conjunction of a container of Bools. For the result to be `True`, the container must be finite; `False`, however, results from a `False` value finitely far from the left end.
 and : Foldable t => t Bool -> Bool
@@ -134,15 +127,15 @@ all p = getAll . foldMap (All . p)
 --
 
 instance Foldable [] where
-  foldr = P.foldr
-  foldl = P.foldl
+  foldr = L.foldr
+  foldl = L.foldl
   toList = identity
-  null xs = case xs of [] -> True; _ -> False
-  length = P.length
-  elem = P.elem
+  null = L.null
+  length = L.length
+  elem = L.elem
 
-instance Foldable (E.Either a) where
-  foldMap _ (E.Left _) = mempty
+instance Foldable (Either a) where
+  foldMap _ (Left _) = mempty
   foldMap f (Right y) = f y
 
 instance Foldable O.Optional where

--- a/compiler/damlc/tests/daml-test-files/Foldable.daml
+++ b/compiler/damlc/tests/daml-test-files/Foldable.daml
@@ -1,0 +1,57 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @ENABLE-SCENARIOS
+
+module Foldable where
+
+import Prelude hiding (concat, foldl1, foldl, foldr, foldr1)
+
+--import qualified DA.List as L
+import DA.Assert
+import DA.Foldable
+
+data RList a = RN | RC { rh: a, rb: RList a } deriving (Eq, Show)
+data LList a = LN | LC { lt: LList a, lh: a } deriving (Eq, Show)
+
+instance Foldable RList where
+  -- foldr : (a -> b -> b) -> b -> t a -> b
+  foldr _ z RN = z
+  foldr f z (RC h t) = f h (foldr f z t)
+
+instance Foldable LList where
+  -- foldl : (b -> a -> b) -> b -> t a -> b
+  foldl _ z LN = z
+  foldl f z (LC t h) = f (foldl f z t) h
+  foldMap f = foldl (\z x -> z <> f x)  mempty
+
+testFoldl = scenario do
+   27 === foldl1 (\a b -> (a + (2 * b))) ll
+   23 === foldl1 (\a b -> (a + (2 * b))) rll
+   41 === foldr1 (\a b -> (a + (2 * b))) ll
+   29 === foldr1 (\a b -> (a + (2 * b))) rll
+   27 === foldl1 (\a b -> (a + (2 * b))) rl
+   23 === foldl1 (\a b -> (a + (2 * b))) rrl
+   41 === foldr1 (\a b -> (a + (2 * b))) rl
+   29 === foldr1 (\a b -> (a + (2 * b))) rrl
+ where
+   ll = RC 3 (RC 5 (RC 7 RN))
+   rll = RC 7 (RC 5 (RC 3 RN))
+   rl = LC (LC (LC LN 3) 5) 7
+   rrl = LC (LC (LC LN 7) 5) 3
+
+testToList = scenario do
+  []  === toList (RN @())
+  [0] === toList (RC 0 RN)
+  [0, 1, 2] === toList (RC 0 (RC 1 (RC 2 RN)))
+  []  === toList (LN @())
+  [0] === toList (LC LN 0)
+  [0, 1, 2] === toList (LC (LC (LC LN 0) 1) 2)
+
+testConcat = scenario do
+  [] === concat (RN @[()])
+  [] === concat (RC [] (RN @[()]))
+  [0] === concat (RC [0] RN)
+  [0, 1] === concat (RC [0] (RC [1] RN))
+  [0, 1, 2, 3] === concat (RC [0, 1] (RC [2, 3] RN))
+  [0, 1, 2, 3] === concat (LC (LC LN [0, 1]) [2, 3])

--- a/compiler/damlc/tests/daml-test-files/List.daml
+++ b/compiler/damlc/tests/daml-test-files/List.daml
@@ -1,20 +1,19 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=128:17-128:32; Use dedup
--- @INFO range=314:10-314:24; Evaluate
--- @INFO range=335:38-335:48; Use sum
--- @INFO range=336:43-336:53; Use sum
--- @INFO range=337:29-337:39; Use sum
--- @INFO range=340:3-340:23; Use head
--- @INFO range=345:29-345:36; Use head
+-- @INFO range=127:17-127:32; Use dedup
+-- @INFO range=313:10-313:24; Evaluate
+-- @INFO range=328:38-328:48; Use sum
+-- @INFO range=329:43-329:53; Use sum
+-- @INFO range=330:29-330:39; Use sum
+-- @INFO range=333:3-333:23; Use head
+-- @INFO range=338:29-338:36; Use head
 
 module List where
 
 import DA.List
 import DA.Assert
 import DA.Optional
-import qualified DA.Foldable as Foldable
 
 data Foo = Foo with x : Int; y : Text
   deriving (Eq, Show)
@@ -324,12 +323,6 @@ testFoldr1 = scenario do
   3.0 === foldr1 (/) ([9.0, 150.0, 50.0] : [Decimal])
   "abc" === foldr1 (<>) ["a", "b", "c"]
   2 === foldr1 (-) [1, 2, 3]
-
-testFoldable = scenario do
-  "abc" === Foldable.foldl1 (<>) ["a", "b", "c"]
-  -4 === Foldable.foldl1 (-) [1, 2, 3]
-  "abc" === Foldable.foldr1 (<>) ["a", "b", "c"]
-  2 === Foldable.foldr1 (-) [1, 2, 3]
 
 testRepeatedly = scenario do
   [15, 12, 5] === repeatedly (\x -> (foldl1 (+) x, drop 2 x)) [1..5]


### PR DESCRIPTION
fixes #14230

CHANGELOG_BEGIN

- [Bug Fix] fix DA.Foldable Standard library. Both DA.Foldable.foldl
  and DA.Foldable.toList were recuring in the wrong direction.

CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
