### PR TITLE
Add --ghc-repo-override flag to override GHC used in daml-sdk-head build

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -210,7 +210,7 @@ if [[ "$SKIP_JARS" -eq 0 ]]; then
     }
     trap cleanup EXIT
 
-    bazel build //release:release
+    bazel build ${BAZEL_MODE_FLAGS[@]:-} //release:release
     tmp="$(mktemp -d)"
     RELEASE_ARGS=(--release-dir "$tmp" --install-head-jars --no-ts)
     if [[ "$SKIP_JAR_DOCS" -eq 1 ]]; then


### PR DESCRIPTION
This is useful for development, when testing the daml-sdk with edits that require changes to our fork of ghc.

CHANGELOG_BEGIN
CHANGELOG_END
