### PR TITLE
infra: tighten TLS security

### DIFF
--- a/infra/bazel_cache.tf
+++ b/infra/bazel_cache.tf
@@ -16,6 +16,7 @@ module "bazel_cache" {
   project              = local.project
   region               = local.region
   ssl_certificate      = "https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/bazel-cache"
+  ssl_policy           = google_compute_ssl_policy.ssl_policy.self_link
   cache_retention_days = 60
 }
 

--- a/infra/binaries.tf
+++ b/infra/binaries.tf
@@ -46,7 +46,7 @@ resource "google_storage_bucket_iam_member" "binaries-ci-read" {
 }
 
 
-output binaries_ip {
+output "binaries_ip" {
   description = "The external IP assigned to the global fowarding rule."
   value       = google_compute_global_address.binaries.address
 }
@@ -90,6 +90,7 @@ resource "google_compute_target_https_proxy" "binaries" {
   name             = "binaries-https-proxy"
   url_map          = google_compute_url_map.binaries.self_link
   ssl_certificates = ["https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/daml-binaries"]
+  ssl_policy       = google_compute_ssl_policy.ssl_policy.self_link
 }
 
 resource "google_compute_global_forwarding_rule" "https" {

--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -304,6 +304,7 @@ resource "google_compute_target_https_proxy" "hoogle-https" {
   url_map = google_compute_url_map.hoogle-https.self_link
 
   ssl_certificates = [local.ssl_certificate_hoogle]
+  ssl_policy       = google_compute_ssl_policy.ssl_policy.self_link
 }
 
 resource "google_compute_global_forwarding_rule" "hoogle_https" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -68,3 +68,9 @@ locals {
 }
 
 resource "secret_resource" "vsts-token" {}
+
+resource "google_compute_ssl_policy" "ssl_policy" {
+  name            = "ssl-policy"
+  profile         = "MODERN"
+  min_tls_version = "TLS_1_2"
+}

--- a/infra/modules/gcp_cdn_bucket/google_compute.tf
+++ b/infra/modules/gcp_cdn_bucket/google_compute.tf
@@ -40,6 +40,7 @@ resource "google_compute_target_https_proxy" "default" {
   name             = "${var.name}-https-proxy"
   url_map          = google_compute_url_map.default.self_link
   ssl_certificates = [var.ssl_certificate]
+  ssl_policy       = var.ssl_policy
 }
 
 resource "google_compute_global_forwarding_rule" "https" {

--- a/infra/modules/gcp_cdn_bucket/variables.tf
+++ b/infra/modules/gcp_cdn_bucket/variables.tf
@@ -7,7 +7,7 @@ variable "name" {
 
 variable "labels" {
   description = "Labels to apply on all the resources"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 
@@ -21,6 +21,10 @@ variable "region" {
 
 variable "ssl_certificate" {
   description = "A reference to the SSL certificate, google managed or not"
+}
+
+variable "ssl_policy" {
+  description = "The url of an SSL policy to use."
 }
 
 variable "cache_retention_days" {

--- a/infra/nix_cache.tf
+++ b/infra/nix_cache.tf
@@ -16,6 +16,7 @@ module "nix_cache" {
   project              = local.project
   region               = local.region
   ssl_certificate      = "https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/nix-cache"
+  ssl_policy           = google_compute_ssl_policy.ssl_policy.self_link
   cache_retention_days = 360
 }
 


### PR DESCRIPTION
This tightens our TLS configuration a bit, mostly by dropping support for SSL3, TLS1.0 and TLS1.1 on https://hoogle.daml.com, https://bazel-cache.da-ext.net, https://nix-cache.da-ext.net and the daml-binaries front (which I don't think we still use).

CHANGELOG_BEGIN
CHANGELOG_END