### PR TITLE
[ETQ-Testing] Prepare Benchtool for extending it to support huge party filters [DPP-1079]

### DIFF
--- a/ledger/ledger-api-bench-tool/BUILD.bazel
+++ b/ledger/ledger-api-bench-tool/BUILD.bazel
@@ -78,6 +78,8 @@ da_scala_library(
     scala_deps = [
         "@maven//:org_scalatest_scalatest_core",
         "@maven//:org_scalactic_scalactic",
+        "@maven//:com_typesafe_akka_akka_actor",
+        "@maven//:com_typesafe_akka_akka_stream",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -87,9 +89,11 @@ da_scala_library(
         "//libs-scala/ports",
         "//ledger/test-common:dar-files-%s-lib" % "1.14",
         "//language-support/scala/bindings",
+        "//ledger-api/rs-grpc-bridge",
         "//ledger/sandbox-on-x",
         "//ledger/sandbox-on-x:sandbox-on-x-test-lib",
         "//ledger/test-common:dar-files-default-lib",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfig.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/config/WorkflowConfig.scala
@@ -39,13 +39,13 @@ object WorkflowConfig {
   final case class FooSubmissionConfig(
       numberOfInstances: Int,
       numberOfObservers: Int,
-      numberOfDivulgees: Int,
-      numberOfExtraSubmitters: Int,
+      numberOfDivulgees: Int = 0,
+      numberOfExtraSubmitters: Int = 0,
       uniqueParties: Boolean,
       instanceDistribution: List[FooSubmissionConfig.ContractDescription],
-      nonConsumingExercises: Option[NonconsumingExercises],
-      consumingExercises: Option[ConsumingExercises],
-      applicationIds: List[FooSubmissionConfig.ApplicationId],
+      nonConsumingExercises: Option[NonconsumingExercises] = None,
+      consumingExercises: Option[ConsumingExercises] = None,
+      applicationIds: List[FooSubmissionConfig.ApplicationId] = List.empty,
       maybeWaitForSubmission: Option[Boolean] = None,
   ) extends SubmissionConfig {
     def waitForSubmission: Boolean = maybeWaitForSubmission.getOrElse(true)
@@ -88,32 +88,35 @@ object WorkflowConfig {
   }
 
   object StreamConfig {
+
+    final case class PartyFilter(party: String, templates: List[String] = List.empty)
+
     final case class TransactionsStreamConfig(
         name: String,
         filters: List[PartyFilter],
-        beginOffset: Option[LedgerOffset],
-        endOffset: Option[LedgerOffset],
-        objectives: Option[StreamConfig.TransactionObjectives],
-        override val maxItemCount: Option[Long],
-        override val timeoutInSecondsO: Option[Long],
+        beginOffset: Option[LedgerOffset] = None,
+        endOffset: Option[LedgerOffset] = None,
+        objectives: Option[StreamConfig.TransactionObjectives] = None,
+        override val maxItemCount: Option[Long] = None,
+        override val timeoutInSecondsO: Option[Long] = None,
     ) extends StreamConfig
 
     final case class TransactionTreesStreamConfig(
         name: String,
         filters: List[PartyFilter],
-        beginOffset: Option[LedgerOffset],
-        endOffset: Option[LedgerOffset],
-        objectives: Option[StreamConfig.TransactionObjectives],
-        override val maxItemCount: Option[Long],
-        override val timeoutInSecondsO: Option[Long],
+        beginOffset: Option[LedgerOffset] = None,
+        endOffset: Option[LedgerOffset] = None,
+        objectives: Option[StreamConfig.TransactionObjectives] = None,
+        override val maxItemCount: Option[Long] = None,
+        override val timeoutInSecondsO: Option[Long] = None,
     ) extends StreamConfig
 
     final case class ActiveContractsStreamConfig(
         name: String,
         filters: List[PartyFilter],
-        objectives: Option[StreamConfig.RateObjectives],
-        override val maxItemCount: Option[Long],
-        override val timeoutInSecondsO: Option[Long],
+        objectives: Option[StreamConfig.RateObjectives] = None,
+        override val maxItemCount: Option[Long] = None,
+        override val timeoutInSecondsO: Option[Long] = None,
     ) extends StreamConfig
 
     final case class CompletionsStreamConfig(
@@ -125,8 +128,6 @@ object WorkflowConfig {
         override val maxItemCount: Option[Long],
         override val timeoutInSecondsO: Option[Long],
     ) extends StreamConfig
-
-    final case class PartyFilter(party: String, templates: List[String])
 
     case class TransactionObjectives(
         maxDelaySeconds: Option[Long],

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/AllocatedParties.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/AllocatedParties.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.submission
+
+import com.daml.ledger.client.binding.Primitive
+
+case class AllocatedParties(
+    signatory: Primitive.Party,
+    observers: List[Primitive.Party],
+    divulgees: List[Primitive.Party],
+    extraSubmitters: List[Primitive.Party],
+) {
+  val allAllocatedParties: List[Primitive.Party] =
+    List(signatory) ++ observers ++ divulgees ++ extraSubmitters
+}
+
+object AllocatedParties {
+  def forExistingParties(parties: List[String]): AllocatedParties = {
+    val partiesPrefixMap: Map[String, List[Primitive.Party]] = parties
+      .groupBy(Names.getPartyNamePrefix)
+      .view
+      .mapValues(_.map(Primitive.Party(_)))
+      .toMap
+    AllocatedParties(
+      signatory = partiesPrefixMap(Names.SignatoryPrefix).head,
+      observers = partiesPrefixMap.getOrElse(Names.ObserverPrefix, List.empty),
+      divulgees = partiesPrefixMap.getOrElse(Names.DivulgeePrefix, List.empty),
+      extraSubmitters = partiesPrefixMap.getOrElse(Names.ExtraSubmitterPrefix, List.empty),
+    )
+  }
+}

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/CommandSubmitter.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/CommandSubmitter.scala
@@ -25,23 +25,15 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.chaining._
 import scala.util.control.NonFatal
 
-case class AllocatedParties(
-    signatory: client.binding.Primitive.Party,
-    observers: List[client.binding.Primitive.Party],
-    divulgees: List[client.binding.Primitive.Party],
-    extraSubmitters: List[client.binding.Primitive.Party],
-) {
-  val allAllocatedParties: List[Primitive.Party] =
-    List(signatory) ++ observers ++ divulgees ++ extraSubmitters
-}
-
 case class CommandSubmitter(
     names: Names,
     benchtoolUserServices: LedgerApiServices,
     adminServices: LedgerApiServices,
+    partyAllocating: PartyAllocating,
     metricRegistry: MetricRegistry,
     metricsManager: MetricsManager[LatencyNanos],
     waitForSubmission: Boolean,
+    commandGenerationParallelism: Int = 8,
 ) {
   private val logger = LoggerFactory.getLogger(getClass)
   private val submitLatencyTimer = if (waitForSubmission) {
@@ -53,31 +45,11 @@ case class CommandSubmitter(
   def prepare(config: SubmissionConfig)(implicit
       ec: ExecutionContext
   ): Future[AllocatedParties] = {
-    val observerPartyNames =
-      names.observerPartyNames(config.numberOfObservers, config.uniqueParties)
-    val divulgeePartyNames =
-      names.divulgeePartyNames(config.numberOfDivulgees, config.uniqueParties)
-    val extraSubmittersPartyNames =
-      names.extraSubmitterPartyNames(config.numberOfExtraSubmitters, config.uniqueParties)
-
-    logger.info("Generating contracts...")
     logger.info(s"Identifier suffix: ${names.identifierSuffix}")
     (for {
-      known <- lookupExistingParties()
-      signatory <- allocateSignatoryParty(known)
-      observers <- allocateParties(observerPartyNames, known)
-      divulgees <- allocateParties(divulgeePartyNames, known)
-      extraSubmitters <- allocateParties(extraSubmittersPartyNames, known)
+      allocatedParties <- partyAllocating.allocateParties(config)
       _ <- uploadTestDars()
-    } yield {
-      logger.info("Prepared command submission.")
-      AllocatedParties(
-        signatory = signatory,
-        observers = observers,
-        divulgees = divulgees,
-        extraSubmitters = extraSubmitters,
-      )
-    })
+    } yield allocatedParties)
       .recoverWith { case NonFatal(ex) =>
         logger.error(
           s"Command submission preparation failed. Details: ${ex.getLocalizedMessage}",
@@ -129,31 +101,6 @@ case class CommandSubmitter(
       }
   }
 
-  private def allocateSignatoryParty(known: Set[String])(implicit
-      ec: ExecutionContext
-  ): Future[Primitive.Party] =
-    lookupOrAllocateParty(names.signatoryPartyName, known)
-
-  private def allocateParties(partyNames: Seq[String], known: Set[String])(implicit
-      ec: ExecutionContext
-  ): Future[List[Primitive.Party]] = {
-    Future.traverse(partyNames.toList)(lookupOrAllocateParty(_, known))
-  }
-
-  private def lookupExistingParties()(implicit ec: ExecutionContext): Future[Set[String]] = {
-    adminServices.partyManagementService.listKnownParties()
-  }
-
-  private def lookupOrAllocateParty(party: String, known: Set[String])(implicit
-      ec: ExecutionContext
-  ): Future[Primitive.Party] = {
-    if (known.contains(party)) {
-      logger.info(s"Found known party: $party")
-      Future.successful(Primitive.Party(party))
-    } else
-      adminServices.partyManagementService.allocateParty(party)
-  }
-
   private def uploadDar(dar: TestDars.DarFile, submissionId: String)(implicit
       ec: ExecutionContext
   ): Future[Unit] =
@@ -162,7 +109,8 @@ case class CommandSubmitter(
       submissionId = submissionId,
     )
 
-  private def uploadTestDars()(implicit ec: ExecutionContext): Future[Unit] =
+  private def uploadTestDars()(implicit ec: ExecutionContext): Future[Unit] = {
+    logger.info("Uploading dars...")
     for {
       dars <- Future.fromTry(TestDars.readAll())
       _ <- Future.sequence {
@@ -171,7 +119,10 @@ case class CommandSubmitter(
             uploadDar(dar, names.darId(index))
           }
       }
-    } yield ()
+    } yield {
+      logger.info("Uplading dars completed")
+    }
+  }
 
   private def submit(
       id: String,
@@ -232,7 +183,7 @@ case class CommandSubmitter(
           _ <- Source
             .fromIterator(() => (1 to config.numberOfInstances).iterator)
             .wireTap(i => if (i == 1) progressMeter.start())
-            .mapAsync(8)(index =>
+            .mapAsync(commandGenerationParallelism)(index =>
               Future.fromTry(
                 generator.next().map(cmd => index -> cmd)
               )

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooCommandGenerator.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/FooCommandGenerator.scala
@@ -3,16 +3,15 @@
 
 package com.daml.ledger.api.benchtool.submission
 
-import com.daml.ledger.api.benchtool.config.WorkflowConfig.FooSubmissionConfig
-import com.daml.ledger.api.v1.commands.Command
-import com.daml.ledger.api.v1.commands.ExerciseByKeyCommand
-import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value}
-import com.daml.ledger.client.binding.Primitive
-import com.daml.ledger.test.benchtool.Foo._
-
 import java.util.concurrent.atomic.AtomicLong
 
+import com.daml.ledger.api.benchtool.config.WorkflowConfig.FooSubmissionConfig
+import com.daml.ledger.api.benchtool.submission.foo.RandomPartySelecting
+import com.daml.ledger.api.v1.commands.{Command, ExerciseByKeyCommand}
+import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value}
 import com.daml.ledger.client.binding
+import com.daml.ledger.client.binding.Primitive
+import com.daml.ledger.test.benchtool.Foo._
 
 import scala.util.control.NonFatal
 import scala.util.{Failure, Try}
@@ -20,11 +19,13 @@ import scala.util.{Failure, Try}
 /** @param divulgeesToDivulgerKeyMap map whose keys are sorted divulgees lists
   */
 final class FooCommandGenerator(
-    randomnessProvider: RandomnessProvider,
     config: FooSubmissionConfig,
     allocatedParties: AllocatedParties,
     divulgeesToDivulgerKeyMap: Map[Set[Primitive.Party], Value],
     names: Names,
+    partySelecting: RandomPartySelecting,
+    defaultRandomnessProvider: RandomnessProvider = RandomnessProvider.Default,
+    consumingEventsRandomnessProvider: RandomnessProvider = RandomnessProvider.Default,
 ) extends CommandGenerator {
   private val contractDescriptions = new Distribution[FooSubmissionConfig.ContractDescription](
     weights = config.instanceDistribution.map(_.weight),
@@ -39,30 +40,20 @@ final class FooCommandGenerator(
       )
     )
 
-  private val observersWithUnlikelihood: List[(Primitive.Party, Int)] = unlikelihoods(
-    allocatedParties.observers
-  )
-  private val divulgeesWithUnlikelihood: List[(Primitive.Party, Int)] = unlikelihoods(
-    allocatedParties.divulgees
-  )
-  private val extraSubmittersWithUnlikelihood: List[(Primitive.Party, Int)] = unlikelihoods(
-    allocatedParties.extraSubmitters
-  )
-
   override def next(): Try[Seq[Command]] =
     (for {
-      (contractDescription, observers, divulgees) <- Try(
+      (contractDescription, partySelection) <- Try(
         (
           pickContractDescription(),
-          pickParties(observersWithUnlikelihood),
-          pickParties(divulgeesWithUnlikelihood).toSet,
+          partySelecting.nextPartiesForContracts(),
         )
       )
+      divulgees = partySelection.divulgees.toSet
       createContractPayload <- Try(randomPayload(contractDescription.payloadSizeBytes))
       command = createCommands(
         templateDescriptor = FooTemplateDescriptor.forName(contractDescription.template),
         signatory = allocatedParties.signatory,
-        observers = observers,
+        observers = partySelection.observers,
         divulgerContractKeyO =
           if (divulgees.isEmpty) None else divulgeesToDivulgerKeyMap.get(divulgees),
         payload = createContractPayload,
@@ -80,23 +71,16 @@ final class FooCommandGenerator(
     applicationIdsDistributionO.fold(
       names.benchtoolApplicationId
     )(applicationIdsDistribution =>
-      applicationIdsDistribution.choose(randomnessProvider.randomDouble()).applicationId
+      applicationIdsDistribution.choose(defaultRandomnessProvider.randomDouble()).applicationId
     )
   }
 
   override def nextExtraCommandSubmitters(): List[Primitive.Party] = {
-    pickParties(extraSubmittersWithUnlikelihood)
+    partySelecting.nextExtraSubmitter()
   }
 
   private def pickContractDescription(): FooSubmissionConfig.ContractDescription =
-    contractDescriptions.choose(randomnessProvider.randomDouble())
-
-  private def pickParties(unlikelihoods: List[(Primitive.Party, Int)]): List[Primitive.Party] =
-    unlikelihoods
-      .collect { case (party, unlikelihood) if randomDraw(unlikelihood) => party }
-
-  private def randomDraw(unlikelihood: Int): Boolean =
-    randomnessProvider.randomNatural(unlikelihood) == 0
+    contractDescriptions.choose(defaultRandomnessProvider.randomDouble())
 
   private def createCommands(
       templateDescriptor: FooTemplateDescriptor,
@@ -133,7 +117,7 @@ final class FooCommandGenerator(
     // Consuming events
     val consumingPayloadO: Option[String] = config.consumingExercises
       .flatMap(config =>
-        if (randomnessProvider.randomDouble() <= config.probability) {
+        if (consumingEventsRandomnessProvider.randomDouble() <= config.probability) {
           Some(randomPayload(config.payloadSizeBytes))
         } else None
       )
@@ -196,7 +180,7 @@ final class FooCommandGenerator(
     val nonconsumingExercisePayloads: Seq[String] =
       config.nonConsumingExercises.fold(Seq.empty[String]) { config =>
         var f = config.probability.toInt
-        if (randomnessProvider.randomDouble() <= config.probability - f) {
+        if (defaultRandomnessProvider.randomDouble() <= config.probability - f) {
           f += 1
         }
         Seq.fill[String](f)(randomPayload(config.payloadSizeBytes))
@@ -282,14 +266,8 @@ final class FooCommandGenerator(
   }
 
   private def randomPayload(sizeBytes: Int): String =
-    FooCommandGenerator.randomPayload(randomnessProvider, sizeBytes)
+    FooCommandGenerator.randomPayload(defaultRandomnessProvider, sizeBytes)
 
-  private def unlikelihoods(orderedParties: List[Primitive.Party]): List[(Primitive.Party, Int)] =
-    orderedParties.zipWithIndex.toMap.view.mapValues(unlikelihood).toList
-
-  /** @return denominator of a 1/(10**i) likelihood
-    */
-  private def unlikelihood(i: Int): Int = math.pow(10.0, i.toDouble).toInt
 }
 
 object FooCommandGenerator {

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/Names.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/Names.scala
@@ -7,33 +7,54 @@ package com.daml.ledger.api.benchtool.submission
   */
 class Names {
 
+  import Names.{
+    SignatoryPrefix,
+    PartyPrefixSeparatorChar,
+    ObserverPrefix,
+    DivulgeePrefix,
+    ExtraSubmitterPrefix,
+  }
+
   val identifierSuffix = f"${System.nanoTime}%x"
   val benchtoolApplicationId = "benchtool"
   val benchtoolUserId: String = benchtoolApplicationId
   val workflowId = s"$benchtoolApplicationId-$identifierSuffix"
-  val signatoryPartyName = s"signatory-$identifierSuffix"
+  val signatoryPartyName = s"$SignatoryPrefix$PartyPrefixSeparatorChar$identifierSuffix"
 
   def observerPartyNames(numberOfObservers: Int, uniqueParties: Boolean): Seq[String] =
-    partyNames("Obs", numberOfObservers, uniqueParties)
+    partyNames(ObserverPrefix, numberOfObservers, uniqueParties)
 
   def divulgeePartyNames(numberOfDivulgees: Int, uniqueParties: Boolean): Seq[String] =
-    partyNames("Div", numberOfDivulgees, uniqueParties)
+    partyNames(DivulgeePrefix, numberOfDivulgees, uniqueParties)
 
   def extraSubmitterPartyNames(numberOfExtraSubmitters: Int, uniqueParties: Boolean): Seq[String] =
-    partyNames("Sub", numberOfExtraSubmitters, uniqueParties)
+    partyNames(ExtraSubmitterPrefix, numberOfExtraSubmitters, uniqueParties)
 
   def commandId(index: Int): String = s"command-$index-$identifierSuffix"
 
   def darId(index: Int) = s"submission-dars-$index-$identifierSuffix"
 
-  private def partyNames(
-      baseName: String,
+  def partyNames(
+      prefix: String,
       numberOfParties: Int,
       uniqueParties: Boolean,
   ): Seq[String] =
-    (0 until numberOfParties).map(i => partyName(baseName, i, uniqueParties))
+    (0 until numberOfParties).map(i => partyName(prefix, i, uniqueParties))
 
   private def partyName(baseName: String, index: Int, uniqueParties: Boolean): String =
-    s"$baseName-$index" + (if (uniqueParties) identifierSuffix else "")
+    s"$baseName$PartyPrefixSeparatorChar$index" + (if (uniqueParties) identifierSuffix else "")
+
+}
+
+object Names {
+  protected val PartyPrefixSeparatorChar: Char = '-'
+  val SignatoryPrefix = "signatory"
+  val ObserverPrefix = "Obs"
+  val DivulgeePrefix = "Div"
+  val ExtraSubmitterPrefix = "Sub"
+
+  def getPartyNamePrefix(partyName: String): String = {
+    partyName.split(Names.PartyPrefixSeparatorChar)(0)
+  }
 
 }

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/PartyAllocating.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/PartyAllocating.scala
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.submission
+
+import com.daml.ledger.api.benchtool.config.WorkflowConfig.SubmissionConfig
+import com.daml.ledger.api.benchtool.services.LedgerApiServices
+import com.daml.ledger.client.binding.Primitive
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class PartyAllocating(
+    names: Names,
+    adminServices: LedgerApiServices,
+) {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def allocateParties(config: SubmissionConfig)(implicit
+      ec: ExecutionContext
+  ): Future[AllocatedParties] = {
+    val observerPartyNames =
+      names.observerPartyNames(config.numberOfObservers, config.uniqueParties)
+    val divulgeePartyNames =
+      names.divulgeePartyNames(config.numberOfDivulgees, config.uniqueParties)
+    val extraSubmittersPartyNames =
+      names.extraSubmitterPartyNames(config.numberOfExtraSubmitters, config.uniqueParties)
+    logger.info("Allocating parties...")
+    for {
+      known <- lookupExistingParties()
+      signatory <- allocateSignatoryParty(known)
+      observers <- allocateParties(observerPartyNames, known)
+      divulgees <- allocateParties(divulgeePartyNames, known)
+      extraSubmitters <- allocateParties(extraSubmittersPartyNames, known)
+    } yield {
+      logger.info("Allocating parties completed")
+      AllocatedParties(
+        signatory = signatory,
+        observers = observers,
+        divulgees = divulgees,
+        extraSubmitters = extraSubmitters,
+      )
+    }
+  }
+
+  def lookupExistingParties()(implicit ec: ExecutionContext): Future[Set[String]] = {
+    adminServices.partyManagementService.listKnownParties()
+  }
+
+  private def allocateSignatoryParty(known: Set[String])(implicit
+      ec: ExecutionContext
+  ): Future[Primitive.Party] =
+    lookupOrAllocateParty(names.signatoryPartyName, known)
+
+  private def allocateParties(partyNames: Seq[String], known: Set[String])(implicit
+      ec: ExecutionContext
+  ): Future[List[Primitive.Party]] = {
+    Future.traverse(partyNames.toList)(lookupOrAllocateParty(_, known))
+  }
+
+  private def lookupOrAllocateParty(party: String, known: Set[String])(implicit
+      ec: ExecutionContext
+  ): Future[Primitive.Party] = {
+    if (known.contains(party)) {
+      logger.info(s"Found known party: $party")
+      Future.successful(Primitive.Party(party))
+    } else
+      adminServices.partyManagementService.allocateParty(party)
+  }
+
+}

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/RandomnessProvider.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/RandomnessProvider.scala
@@ -12,8 +12,12 @@ trait RandomnessProvider {
 }
 
 object RandomnessProvider {
-  object Default extends RandomnessProvider {
-    private val r = new scala.util.Random(System.currentTimeMillis())
+  object Default extends Seeded(System.currentTimeMillis())
+
+  def forSeed(seed: Long) = new Seeded(seed = seed)
+
+  class Seeded(seed: Long) extends RandomnessProvider {
+    private val r = new scala.util.Random(seed)
     override def randomDouble(): Double = r.nextDouble()
     override def randomNatural(n: Int): Int = r.nextInt(n)
     override def randomAsciiString(n: Int): String = {

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/foo/PartiesSelection.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/foo/PartiesSelection.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.submission.foo
+
+import com.daml.ledger.client.binding.Primitive
+
+case class PartiesSelection(
+    observers: List[Primitive.Party],
+    divulgees: List[Primitive.Party],
+)

--- a/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/foo/RandomPartySelecting.scala
+++ b/ledger/ledger-api-bench-tool/src/main/scala/com/daml/ledger/api/benchtool/submission/foo/RandomPartySelecting.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.submission.foo
+
+import com.daml.ledger.api.benchtool.submission.{AllocatedParties, RandomnessProvider}
+import com.daml.ledger.client.binding.Primitive
+
+class RandomPartySelecting(
+    allocatedParties: AllocatedParties,
+    randomnessProvider: RandomnessProvider = RandomnessProvider.Default,
+) {
+
+  private val observersProbability = probabilitiesByPartyIndex(allocatedParties.observers)
+  private val divulgeesProbability = probabilitiesByPartyIndex(allocatedParties.divulgees)
+  private val extraSubmittersProbability = probabilitiesByPartyIndex(
+    allocatedParties.extraSubmitters
+  )
+
+  def nextPartiesForContracts(): PartiesSelection = {
+    PartiesSelection(
+      observers = pickParties(observersProbability),
+      divulgees = pickParties(divulgeesProbability),
+    )
+  }
+
+  def nextExtraSubmitter(): List[Primitive.Party] = pickParties(extraSubmittersProbability)
+
+  private def pickParties(probabilities: List[(Primitive.Party, Double)]): List[Primitive.Party] =
+    probabilities
+      .collect { case (party, probability) if randomBoolean(probability) => party }
+
+  private def randomBoolean(truthProbability: Double): Boolean =
+    randomnessProvider.randomDouble() <= truthProbability
+
+  private def probabilitiesByPartyIndex(
+      orderedParties: List[Primitive.Party]
+  ): List[(Primitive.Party, Double)] =
+    orderedParties.zipWithIndex.toMap.view.mapValues(probabilityBaseTen).toList
+
+  /** @return probability of a 1/(10**i)
+    */
+  private def probabilityBaseTen(i: Int): Double = 1.0 / math.pow(10.0, i.toDouble)
+
+}

--- a/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/BenchtoolSandboxFixture.scala
+++ b/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/BenchtoolSandboxFixture.scala
@@ -5,10 +5,16 @@ package com.daml.ledger.api.benchtool
 
 import java.io.File
 
+import com.codahale.metrics.MetricRegistry
 import com.daml.bazeltools.BazelRunfiles.rlocation
+import com.daml.ledger.api.benchtool.metrics.MetricsManager.NoOpMetricsManager
+import com.daml.ledger.api.benchtool.services.LedgerApiServices
+import com.daml.ledger.api.benchtool.submission.{CommandSubmitter, Names, PartyAllocating}
 import com.daml.ledger.test.BenchtoolTestDar
 import com.daml.platform.sandbox.fixture.SandboxFixture
 import org.scalatest.Suite
+
+import scala.concurrent.{ExecutionContext, Future}
 
 trait BenchtoolSandboxFixture extends SandboxFixture {
   self: Suite =>
@@ -16,5 +22,34 @@ trait BenchtoolSandboxFixture extends SandboxFixture {
   override protected def packageFiles: List[File] = List(
     new File(rlocation(BenchtoolTestDar.path))
   )
+
+  def benchtoolFixture()(implicit
+      ec: ExecutionContext
+  ): Future[(LedgerApiServices, Names, CommandSubmitter)] = {
+    for {
+      ledgerApiServicesF <- LedgerApiServices.forChannel(
+        channel = channel,
+        authorizationHelper = None,
+      )
+      apiServices: LedgerApiServices = ledgerApiServicesF("someUser")
+      names = new Names()
+      submitter = CommandSubmitter(
+        names = names,
+        benchtoolUserServices = apiServices,
+        adminServices = apiServices,
+        metricRegistry = new MetricRegistry,
+        metricsManager = NoOpMetricsManager(),
+        waitForSubmission = true,
+        partyAllocating = new PartyAllocating(
+          names = names,
+          adminServices = apiServices,
+        ),
+      )
+    } yield (
+      apiServices,
+      names,
+      submitter,
+    )
+  }
 
 }

--- a/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/TreeEventsObserver.scala
+++ b/ledger/ledger-api-bench-tool/src/test/lib/scala/com/daml/ledger/api/benchtool/submission/TreeEventsObserver.scala
@@ -80,6 +80,11 @@ case class ObservedEvents(
     expectedTemplateNames.map(name => name -> groups.get(name).fold(0)(_.size)).toMap
   }
 
+  val numberOfNonConsumingExercisesPerTemplateName: Map[String, Int] = {
+    val groups = nonConsumingExercises.groupBy(_.templateName)
+    expectedTemplateNames.map(name => name -> groups.get(name).fold(0)(_.size)).toMap
+  }
+
   val avgSizeOfCreateEventPerTemplateName: Map[String, Int] = {
     val groups = createEvents.groupBy(_.templateName)
     expectedTemplateNames.map { name =>

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/ConfigEnricherSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/ConfigEnricherSpec.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool
+
+import com.daml.ledger.api.benchtool.config.WorkflowConfig.StreamConfig.{
+  PartyFilter,
+  TransactionsStreamConfig,
+}
+import com.daml.ledger.api.benchtool.submission.AllocatedParties
+import com.daml.ledger.client.binding.Primitive
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scalaz.syntax.tag._
+
+class ConfigEnricherSpec extends AnyFlatSpec with Matchers {
+
+  it should "expand party-set filter into a sequence of party filters" in {
+    val partySuffix = "-foo-123"
+
+    def makePartyName(shortName: String): String = s"$shortName$partySuffix"
+    def makeParty(shortName: String): Primitive.Party = Primitive.Party(makePartyName(shortName))
+
+    val desugaring = new ConfigEnricher(
+      allocatedParties = AllocatedParties(
+        signatory = makeParty("Sig-0"),
+        observers = List(makeParty("Obs-0")),
+        divulgees = List(makeParty("Div-0")),
+        extraSubmitters = List(makeParty("Sub-0")),
+      )
+    )
+    val templates: List[String] = List("otherTemplate", "Foo1")
+    val foo1Id = com.daml.ledger.test.benchtool.Foo.Foo1.id.unwrap
+    val enrichedTemplates: List[String] =
+      List("otherTemplate", s"${foo1Id.packageId}:${foo1Id.moduleName}:${foo1Id.entityName}")
+
+    desugaring.enrichStreamConfig(
+      TransactionsStreamConfig(
+        name = "flat",
+        filters = List(
+          PartyFilter(
+            party = "Obs-0",
+            templates = templates,
+          ),
+          PartyFilter(
+            party = "Sig-0",
+            templates = templates,
+          ),
+        ),
+      )
+    ) shouldBe TransactionsStreamConfig(
+      name = "flat",
+      filters = List(
+        PartyFilter(
+          party = "Obs-0-foo-123",
+          templates = enrichedTemplates,
+        ),
+        PartyFilter(
+          party = "Sig-0-foo-123",
+          templates = enrichedTemplates,
+        ),
+      ),
+    )
+  }
+}

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/AllocatedPartiesSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/AllocatedPartiesSpec.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.benchtool.submission
+
+import com.daml.ledger.client.binding.Primitive
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AllocatedPartiesSpec extends AnyFlatSpec with Matchers {
+
+  it should "apportion parties appropriately" in {
+    AllocatedParties.forExistingParties(
+      parties = List(
+        "signatory-123",
+        "Obs-0",
+        "Obs-1",
+        "Div-0",
+        "Sub-0",
+      )
+    ) shouldBe AllocatedParties(
+      signatory = Primitive.Party("signatory-123"),
+      observers = List(
+        Primitive.Party("Obs-0"),
+        Primitive.Party("Obs-1"),
+      ),
+      divulgees = List(Primitive.Party("Div-0")),
+      extraSubmitters = List(Primitive.Party("Sub-0")),
+    )
+  }
+
+  it should "apportion parties appropriately - minimal" in {
+    AllocatedParties.forExistingParties(
+      parties = List(
+        "signatory-123"
+      )
+    ) shouldBe AllocatedParties(
+      signatory = Primitive.Party("signatory-123"),
+      observers = List.empty,
+      divulgees = List.empty,
+      extraSubmitters = List.empty,
+    )
+  }
+
+}

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/FooCommandSubmitterITSpec.scala
@@ -3,14 +3,12 @@
 
 package com.daml.ledger.api.benchtool.submission
 
-import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.benchtool.BenchtoolSandboxFixture
 import com.daml.ledger.api.benchtool.config.WorkflowConfig
 import com.daml.ledger.api.benchtool.config.WorkflowConfig.FooSubmissionConfig.{
   ConsumingExercises,
   NonconsumingExercises,
 }
-import com.daml.ledger.api.benchtool.metrics.MetricsManager.NoOpMetricsManager
 import com.daml.ledger.api.benchtool.services.LedgerApiServices
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
@@ -64,20 +62,7 @@ class FooCommandSubmitterITSpec
     )
 
     for {
-      ledgerApiServicesF <- LedgerApiServices.forChannel(
-        channel = channel,
-        authorizationHelper = None,
-      )
-      apiServices = ledgerApiServicesF("someUser")
-      names = new Names()
-      submitter = CommandSubmitter(
-        names = names,
-        benchtoolUserServices = apiServices,
-        adminServices = apiServices,
-        metricRegistry = new MetricRegistry,
-        metricsManager = NoOpMetricsManager(),
-        waitForSubmission = false,
-      )
+      (apiServices, names, submitter) <- benchtoolFixture()
       allocatedParties <- submitter.prepare(config)
       _ = allocatedParties.divulgees shouldBe empty
       tested = new FooSubmission(

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonStakeholderInformeesITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/NonStakeholderInformeesITSpec.scala
@@ -3,11 +3,9 @@
 
 package com.daml.ledger.api.benchtool.submission
 
-import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.benchtool.BenchtoolSandboxFixture
 import com.daml.ledger.api.benchtool.config.WorkflowConfig
 import com.daml.ledger.api.benchtool.config.WorkflowConfig.FooSubmissionConfig.ConsumingExercises
-import com.daml.ledger.api.benchtool.metrics.MetricsManager.NoOpMetricsManager
 import com.daml.ledger.api.benchtool.services.LedgerApiServices
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
@@ -51,20 +49,7 @@ class NonStakeholderInformeesITSpec
       applicationIds = List.empty,
     )
     for {
-      ledgerApiServicesF <- LedgerApiServices.forChannel(
-        channel = channel,
-        authorizationHelper = None,
-      )
-      apiServices: LedgerApiServices = ledgerApiServicesF("someUser")
-      names = new Names()
-      submitter = CommandSubmitter(
-        names = names,
-        benchtoolUserServices = apiServices,
-        adminServices = apiServices,
-        metricRegistry = new MetricRegistry,
-        metricsManager = NoOpMetricsManager(),
-        waitForSubmission = true,
-      )
+      (apiServices, names, submitter) <- benchtoolFixture()
       allocatedParties <- submitter.prepare(submissionConfig)
       tested = new FooSubmission(
         submitter = submitter,

--- a/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PartyAllocationITSpec.scala
+++ b/ledger/ledger-api-bench-tool/src/test/suite/scala/com/daml/ledger/api/benchtool/submission/PartyAllocationITSpec.scala
@@ -3,11 +3,8 @@
 
 package com.daml.ledger.api.benchtool.submission
 
-import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.benchtool.BenchtoolSandboxFixture
 import com.daml.ledger.api.benchtool.config.WorkflowConfig
-import com.daml.ledger.api.benchtool.metrics.MetricsManager.NoOpMetricsManager
-import com.daml.ledger.api.benchtool.services.LedgerApiServices
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import org.scalatest.AppendedClues
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -35,19 +32,7 @@ class PartyAllocationITSpec
     )
 
     for {
-      ledgerApiServicesF <- LedgerApiServices.forChannel(
-        authorizationHelper = None,
-        channel = channel,
-      )
-      apiServices = ledgerApiServicesF("someUser")
-      submitter = CommandSubmitter(
-        names = new Names(),
-        benchtoolUserServices = apiServices,
-        adminServices = apiServices,
-        metricRegistry = new MetricRegistry,
-        metricsManager = NoOpMetricsManager(),
-        waitForSubmission = false,
-      )
+      (_, _, submitter) <- benchtoolFixture()
       parties1 <- submitter.prepare(config)
       parties2 <- submitter.prepare(config)
     } yield {


### PR DESCRIPTION
Some of the changes:
1. Scan for existing parties even if when there is not submission step configured.
2. Extract party selection for contract creation to a separate class.

changelog_begin
changelog_end
