### PR TITLE
[engine] always perform ANF transformation for simpler evaluation

### DIFF
--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -22,14 +22,14 @@ evTyAbsErasableErr = scenario do
 
 -- @ERROR overApply OK
 overApply = scenario do
-  let f x = error "overApply OK"
-  let _ = f 1 (error "overApply Failed")
+  let f x = error "overApply Failed"
+  let _ = f 1 (error "overApply OK")
   let _ = f 1 2
   pure ()
 
 -- @ERROR EvExpAppErr1 OK
 evExpAppErr1 = scenario do
-  let _ = (error "EvExpAppErr1 OK") (error "EvExpAppErr1 failed")
+  let _ = (error "EvExpAppErr1 failed") (error "EvExpAppErr1 OK")
   pure ()
 
 -- @ERROR EvExpAppErr2 OK
@@ -153,10 +153,10 @@ evExpFoldrErr2 = scenario do
 
 -- @ERROR EvExpFoldrErr3 OK
 evExpFoldrErr3 = scenario do
-  pure (foldr f identity [1] (error "EvExpFoldrErr3 failed"))
+  pure (foldr f identity [1] (error "EvExpFoldrErr3 OK"))
   where
     f: Int -> (Int -> Int) -> (Int -> Int)
-    f _ _ = error "EvExpFoldrErr3 OK"
+    f _ _ = error "EvExpFoldrErr3 failed"
 
 -- @ERROR EvExpFoldlErr1 OK
 evExpFoldlErr1 = scenario do
@@ -174,10 +174,10 @@ evExpFoldlErr2 = scenario do
 
 -- @ERROR EvExpFoldlErr3 OK
 evExpFoldlErr3 = scenario do
-  pure (foldl f identity [1] (error "EvExpFoldlErr3 failed"))
+  pure (foldl f identity [1] (error "EvExpFoldlErr3 OK"))
   where
     f: (Int -> Int) -> Int -> (Int -> Int)
-    f _ _ = error "EvExpFoldlErr3 OK"
+    f _ _ = error "EvExpFoldlErr3 failed"
 
 -- @ERROR EvExpUpPureErr OK
 evExpUpPureErr = scenario do

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -18,8 +18,6 @@ import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SBuiltin._
 
-import scala.annotation.nowarn
-
 //
 // Pretty-printer for the interpreter errors and the scenario ledger
 //
@@ -487,7 +485,6 @@ private[lf] object Pretty {
       case SELocF(i) => char('F') + str(i)
     }
 
-    @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
     def prettySExpr(index: Int)(e: SExpr): Doc =
       e match {
         case SEVal(defId) =>
@@ -531,10 +528,6 @@ private[lf] object Pretty {
             case SBGetTime => text("$getTime")
             case _ => str(x)
           }
-        case SEAppOnlyFunIsAtomic(fun, args) =>
-          val prefix = prettySExpr(index)(fun) + text("@N(")
-          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
-            .tightBracketBy(prefix, char(')'))
         case SEAppAtomicGeneral(fun, args) =>
           val prefix = prettySExpr(index)(fun) + text("@A(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -10,8 +10,6 @@ import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 
-import scala.annotation.nowarn
-
 private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK machine states
 
   def ppMachine(m: Machine): String = {
@@ -48,11 +46,9 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     s"${x.ref.qualifiedName.name}"
   }
 
-  @nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
   def pp(e: SExpr): String = e match {
     case SEValue(v) => s"(VALUE)${pp(v)}"
     case loc: SELoc => pp(loc)
-    case SEAppOnlyFunIsAtomic(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicGeneral(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
     case SEAppAtomicSaturatedBuiltin(b, args) => s"@B(${pp(SEBuiltin(b))},${commas(args.map(pp))})"
     case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(pp))}]\\$arity.${pp(body)}"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -99,6 +99,7 @@ object SExpr {
 
   object SEValue extends SValueContainer[SEValue] // used by Compiler
 
+  // NICK, kill this...
   /** Function application with general arguments (deprecated)
     * Although 'fun' is atomic, 'args' are still any kind of expression.
     * This case would not exist if we performed a full/standard ANF pass.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -99,23 +99,6 @@ object SExpr {
 
   object SEValue extends SValueContainer[SEValue] // used by Compiler
 
-  // NICK, kill this...
-  /** Function application with general arguments (deprecated)
-    * Although 'fun' is atomic, 'args' are still any kind of expression.
-    * This case would not exist if we performed a full/standard ANF pass.
-    * Because this case exists we must retain the complicated/slow path in the
-    * speedy-machine: executeApplication
-    */
-  @deprecated("Prefer SEAppAtomic or SEApp helper instead.")
-  final case class SEAppOnlyFunIsAtomic(fun: SExprAtomic, args: Array[SExpr])
-      extends SExpr
-      with SomeArrayEquals {
-    def execute(machine: Machine): Control = {
-      val vfun = fun.lookupValue(machine)
-      machine.executeApplication(vfun, args)
-    }
-  }
-
   object SEApp {
     // Helper: build an application of an unrestricted expression, to value-arguments.
     def apply(fun: SExpr, args: Array[SValue]): SExpr = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr0.scala
@@ -38,7 +38,7 @@ package speedy
   * - In SExpr{1,}: SELocA, SELocF, SELocS, SEMakeClo, SELet1General,
   *
   * - In SExpr: SEAppAtomicGeneral, SEAppAtomicSaturatedBuiltin, SECaseAtomic,
-  *   SELet1Builtin, SELet1BuiltinArithmetic, SEAppOnlyFunIsAtomic
+  *   SELet1Builtin, SELet1BuiltinArithmetic
   *
   * - In SExpr (runtime only, i.e. rejected by validate): SEDamlException, SEImportValue
   */

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -567,7 +567,7 @@ private[lf] object Speedy {
     /** This function is used to enter an ANF application.  The function has been evaluated to
       *      a value, and so have the arguments - they just need looking up
       */
-    // TODO: share common code with executeApplication
+    // TODO: share common code with executeApplication //NICK
     private[speedy] def enterApplication(vfun: SValue, newArgs: Array[SExprAtomic]): Control = {
       vfun match {
         case SValue.SPAP(prim, actualsSoFar, arity) =>
@@ -626,6 +626,7 @@ private[lf] object Speedy {
       }
     }
 
+    // NICK.. kill..
     /** The function has been evaluated to a value, now start evaluating the arguments. */
     private[speedy] def executeApplication(vfun: SValue, newArgs: Array[SExpr]): Control = {
       vfun match {
@@ -1078,6 +1079,7 @@ private[lf] object Speedy {
     }
   }
 
+  // NICK, kill this..
   /** The function has been evaluated to a value. Now restore the environment and execute the application */
   private[speedy] final case class KArg(
       machine: Machine,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -5,17 +5,14 @@ package com.daml.lf.speedy.iterable
 
 import com.daml.lf.speedy.{SExpr, SValue}
 import com.daml.lf.speedy.SExpr.SExpr
-import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 // Iterates only over immediate children similar to Haskell’s
 // uniplate.
-@nowarn("cat=deprecation&origin=com.daml.lf.speedy.SExpr.SEAppOnlyFunIsAtomic")
 private[speedy] object SExprIterable {
   that =>
   private[iterable] def iterator(e: SExpr): Iterator[SExpr] = e match {
     case SExpr.SEVal(_) => Iterator.empty
-    case SExpr.SEAppOnlyFunIsAtomic(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicGeneral(fun, args) => Iterator(fun) ++ args.iterator
     case SExpr.SEAppAtomicSaturatedBuiltin(_, args) => args.iterator
     case SExpr.SEMakeClo(_, _, body) => Iterator(body)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
@@ -57,7 +57,7 @@ class TailCallTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
       """
   )
 
-  val small: Option[Int] = Some(5)
+  val small: Option[Int] = Some(6)
   val unbounded: Option[Int] = None
 
   "A *non* tail-recursive definition requires an unbounded env-stack, and an unbounded kont-stack" in {


### PR DESCRIPTION
# Summary
This PR explores the benefits and consequences of performing a universal ANF transformation. These are:
- performance improvement
- big simplification of speedy evaluation code
- change in evaluation order as demonstrated by four artificial tests.

# Background

Currently the ANF transformation is limited to two _safe_ cases, which vastly limits it's applicability:
- the function is known to be a builtin, which is not over-applied
- there is exactly one argument

This restriction is necessary because the order of effects is not preserved by unrestricted ANF, given the existing evaluation order: _function-before-arguments; arguments:left->right_.

This PR changes the evaluation order to: _arguments-before-function; arguments:left->right_. With this evaluation order, the order of effects is unchanged by unrestricted ANF.

# Simplification

The core of the simplification is that we can remove `SEAppOnlyFunIsAtomic` from `SExpr.scala`,  and consequently we can remove `executeApplication` and `KArg` from `Speedy.scala`. We also can eliminate a bunch of tests from `AnfTest.scala` which were only in place to test that ANF was not happenning.

# Performance

About a 5% gain on the CollectAuthority benchmark. 5 runs (here/base/here/base/here) on ad-hoc machine:
```
CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt   10  10.321 ± 0.050  ms/op
CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt   10  10.907 ± 0.056  ms/op
CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt   10  10.316 ± 0.035  ms/op
CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt   10  10.819 ± 0.036  ms/op
CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt   10  10.401 ± 0.048  ms/op

```

# Evaluation Order

Since we continue to evaluate arguments form let to right, and only change that the function is evaluated last, this makes a very limited change to the evaluation order. Normally the function will be a simple identifier, and only by constructing artificial examples can the change in evaluation order even be witnessed.
