### PR TITLE
export LedgerOptions from @daml/ledger

### DIFF
--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -417,7 +417,7 @@ export interface Stream<T extends object, K, I extends string, State> {
 /**
  * Options for creating a handle to a Daml ledger.
  */
-type LedgerOptions = {
+export type LedgerOptions = {
   /** JSON web token used for authentication. */
   token: string;
   /**


### PR DESCRIPTION
Fixes #14073.

```rst
CHANGELOG_BEGIN
- [js] Type ``LedgerOptions``, the type of `new Ledger` arguments, can
  be imported by name from ``@daml/ledger``, and is included in the
  documentation.
CHANGELOG_END
```