### PR TITLE
data-dependencies: qualify `HasMethod` interface

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -613,10 +613,9 @@ generateSrcFromLf env = noLoc mod
     interfaceDecls :: [Gen (LHsDecl GhcPs)]
     interfaceDecls = do
         interface <- NM.toList $ LF.moduleInterfaces $ envMod env
-        [interfaceName] <- [LF.unTypeConName $ LF.intName interface]
-        let interfaceType = HsTyVar noExt NotPromoted $ mkRdrName interfaceName
         meth <- NM.toList $ LF.intMethods interface
         pure $ do
+            interfaceType <- convType env reexportedClasses . LF.TCon . qualify . LF.intName $ interface
             methodType <- convType env reexportedClasses $ LF.ifmType meth
             cls <- mkDesugarType env "HasMethod"
             let methodNameSymbol = HsTyLit noExt $ HsStrTy NoSourceText $ fsFromText $ LF.unMethodName $ LF.ifmName meth

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -1670,6 +1670,26 @@ tests tools@Tools{damlc,validate,oldProjDar} = testGroup "Data Dependencies" $
         , "  None -> False"
         ]
 
+    , dataDependenciesTestOptions "Homonymous interface doesn't trigger 'ambiguous occurrence' error"
+        [ "--target=1.dev" ]
+        [   (,) "A.daml"
+            [ "module A where"
+            , "data Instrument = Instrument {}"
+            ]
+        ,   (,) "B.daml"
+            [ "module B where"
+            , "import qualified A"
+
+            , "interface Instrument where"
+            , "  f : ()"
+            , "x = A.Instrument"
+            ]
+        ]
+        [   (,) "Main.daml"
+            [ "module Main where"
+            ]
+        ]
+
     , dataDependenciesTestOptions "implement interface from data-dependency"
         [ "--target=1.dev" ]
         [   (,) "Lib.daml"


### PR DESCRIPTION
Closes https://github.com/digital-asset/daml/issues/14268

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
