### PR TITLE
Fix CI build on windows (#14279)

### DIFF
--- a/dev-env/windows/manifests/msys2.json
+++ b/dev-env/windows/manifests/msys2.json
@@ -2,7 +2,7 @@
     "homepage": "http://msys2.github.io",
     "version": "20220118",
     "url": [
-        "https://github.com/msys2/msys2-installer/releases/download/2022-01-18/msys2-base-x86_64-20220118.tar.xz",
+        "https://github.com/msys2/msys2-installer/releases/download/2022-01-28/msys2-base-x86_64-20220128.tar.xz",
         "https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-jq-1.6-4-any.pkg.tar.zst#/jq.msys2",
         "https://repo.msys2.org/msys/x86_64/gnu-netcat-0.7.1-1-x86_64.pkg.tar.xz#/netcat.msys2",
         "https://repo.msys2.org/msys/x86_64/patch-2.7.6-1-x86_64.pkg.tar.xz#/patch.msys2",
@@ -24,7 +24,7 @@
         "https://repo.msys2.org/msys/x86_64/xz-5.2.5-1-x86_64.pkg.tar.xz#/xz.msys2"
     ],
     "hash": [
-        "2ec6fe9c3e01ecba10b9ffa708ea13bf1f8c9739e5ce9da853b77f1f3e270034",
+        "b667a7ec3840c0437c718d6851c93794bd8a6837ba642fd90702e8769febad6a",
         "c9903f4bf07402dbecf250d531e6d07748c62560d8d67de487ae56692c14aab0",
         "32fa739d26fd49a3f8c22717ae338472d71d4798844cbc0db5e7780131fe69aa",
         "5c18ce8979e9019d24abd2aee7ddcdf8824e31c4c7e162a204d4dc39b3b73776",


### PR DESCRIPTION
Prior to this change the installation of msys2 would fail because packages fail
to validate their signature:

```
:: File /var/cache/pacman/pkg/perl-HTTP-Cookies-6.10-1-any.pkg.tar.zst is corrupted (invalid or corrupted package (PGP s
ignature)).
Do you want to delete it? [Y/n]
error: perl-Net-SSLeay: signature from "David Macek <david.macek.0@gmail.com>" is unknown trust
:: File /var/cache/pacman/pkg/perl-Net-SSLeay-1.90-1-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP
signature)).
Do you want to delete it? [Y/n]
error: failed to commit transaction (invalid or corrupted package)
```

CHANGELOG_BEGIN
CHANGELOG_END

Co-authored-by: Gary Verhaegen <gary.verhaegen@digitalasset.com>