### PR TITLE
Request review for release rotation PR

### DIFF
--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -68,6 +68,21 @@ steps:
           jq '.number' "$output" > "$pr_number"
       fi
     }
+    request_pr_review() {
+      local pr_number reviewer
+      pr_number="$1"
+      reviewer="$2"
+
+      jq -n --arg reviewer "$reviewer" \
+            '{"reviewers": [$reviewer]}' \
+        | curl -H "Content-Type: application/json" \
+               -H "$(get_gh_auth_header)" \
+               --fail \
+               --silent \
+               --location \
+               -d @- \
+               "https://api.github.com/repos/digital-asset/daml/pulls/$pr_number/requested_reviewers"
+    }
     user_slack_handle() {
         local email sha
         sha=$1

--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -32,27 +32,41 @@ steps:
         fi
     }
     open_pr() {
-      local branch title
+      local branch title body out pr_number header output
       branch="$1"
       title="$2"
+      body="${3:-}"
+      out="${4:-/dev/stdout}"
+      pr_number="${5:-}"
+      header=$(mktemp)
+      output=$(mktemp)
+
       git branch -D $branch || true
       git checkout -b $branch
       git -c user.name="Azure Pipelines Daml Build" \
           -c user.email="support@digitalasset.com" \
           commit \
-          -m "$(printf "$title\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n")"
+          -m "$(printf "$title\n\n$body\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n")"
       git push origin $branch:$branch
       jq -n --arg title "$title" \
             --arg branch "$branch" \
-            '{"title": $title, "head": $branch, "base": "main"}' \
+            --arg body "$(printf "$body")" \
+            '{"title": $title, "head": $branch, "base": "main", "body": $body}' \
         | curl -H "Content-Type: application/json" \
                -H "$(get_gh_auth_header)" \
                --fail \
                --silent \
-               --include \
                --location \
+               --dump-header "$header" \
+               --output "$output" \
                -d @- \
                https://api.github.com/repos/digital-asset/daml/pulls
+      if [ -n "$out" ]; then
+          cat "$header" "$output" > "$out"
+      fi
+      if [ -n "$pr_number" ]; then
+          jq '.number' "$output" > "$pr_number"
+      fi
     }
     user_slack_handle() {
         local email sha

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -31,10 +31,6 @@ jobs:
 
       BASE_SHA=$(git rev-parse HEAD)
 
-      reset() {
-          git checkout -f $BASE_SHA
-          git reset --hard
-      }
       rotate() {
           local tmp next
           tmp=$(mktemp)

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -50,3 +50,4 @@ jobs:
       git add .
       open_pr "$BRANCH" "$TITLE" "$BODY" "/dev/null" "$PR_NUMBER"
       trigger_azure $(System.AccessToken) "PRs" --branch $BRANCH
+      request_pr_review $(cat "$PR_NUMBER") "$NEXT_GH"

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -29,50 +29,11 @@ jobs:
       eval "$(./dev-env/bin/dade-assist)"
       source "$(bash_lib)"
 
-      AUTH="$(get_gh_auth_header)"
-
       BASE_SHA=$(git rev-parse HEAD)
-      az extension add --name azure-devops
-      echo "$(System.AccessToken)" | az devops login --org "https://dev.azure.com/digitalasset"
 
       reset() {
           git checkout -f $BASE_SHA
           git reset --hard
-      }
-      open_pr() {
-          local branch title body out pr_number
-          branch=$1
-          title="$2"
-          body="$3"
-          out="${4:-}"
-          git branch -D $branch || true
-          git checkout -b $branch
-          git add .
-          git -c user.name="Azure Pipelines Daml Build" \
-              -c user.email="support@digitalasset.com" \
-              commit \
-              -m "$(printf "$title\n\n$body\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n")"
-          git push origin $branch:$branch
-          pr_number=$(jq -n \
-                         --arg branch "$branch" \
-                         --arg title "$title" \
-                         --arg body "$(printf "$body")" \
-                         '{"title": $title, "head": $branch, "base": "main", "body": $body}' \
-                    | curl -H "Content-Type: application/json" \
-                           -H "$AUTH" \
-                           --silent \
-                           --location \
-                           -d @- \
-                           https://api.github.com/repos/digital-asset/daml/pulls \
-                    | jq '.number')
-          az pipelines build queue \
-              --branch $branch \
-              --definition-name "PRs" \
-              --org "https://dev.azure.com/digitalasset" \
-              --project daml
-          if [ -n "$out" ]; then
-              echo $pr_number > $out
-          fi
       }
       rotate() {
           local tmp next
@@ -84,8 +45,12 @@ jobs:
       }
 
       NEXT_GH=$(next_in_rotation_github)
+      BRANCH="rotate-after-release-$(date -I)"
+      TITLE="rotate release duty after $(date -I)"
+      BODY="@$NEXT_GH is taking care of [testing](https://github.com/digital-asset/daml/blob/main/release/RELEASE.md) today's release, so they get pushed back to the end of the line.\n\nPlease do not merge this before the release is fully tested."
+      PR_NUMBER=$(mktemp)
 
       rotate
-      open_pr "rotate-after-release-$(date -I)" \
-              "rotate release duty after $(date -I)" \
-              "@$NEXT_GH is taking care of [testing](https://github.com/digital-asset/daml/blob/main/release/RELEASE.md) today's release, so they get pushed back to the end of the line.\n\nPlease do not merge this before the release is fully tested."
+      git add .
+      open_pr "$BRANCH" "$TITLE" "$BODY" "/dev/null" "$PR_NUMBER"
+      trigger_azure $(System.AccessToken) "PRs" --branch $BRANCH


### PR DESCRIPTION
The core of the change is defining the `request_pr_review` function in `ci/bash-lib.yml` and calling it from `ci/cron/wednesday.yml` after the PR is created. Tagging the current release person should ensure that they don't miss the PR.

I also took the chance to refactor the very similar `open_pr` functions into a single one. 