### PR TITLE
fix: add activeness check in scenario runner

### DIFF
--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -345,6 +345,15 @@ prettyScenarioErrorError (Just err) =  do
         , nest 2 (prettyMay "<missing template id>" (prettyDefName world) (globalKeyTemplateId gk))
         ]
 
+    ScenarioErrorErrorScenarioCommitError (CommitError (Just (CommitErrorSumContractNotActive (CommitError_ContractNotActive ref)))) -> do
+      pure $ vcat
+        [ "Attempt to exercise/fetch a contract that was not active."
+        , "Contract:"
+            <-> prettyMay "<missing contract>"
+                  (prettyContractRef world)
+                  ref
+        ]
+
     ScenarioErrorErrorUnknownContext ctxId ->
       pure $ "Unknown script interpretation context:" <-> string (show ctxId)
     ScenarioErrorErrorUnknownScenario name ->

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -539,9 +539,14 @@ message GlobalKey {
 }
 
 message CommitError {
+  message ContractNotActive {
+    ContractRef contract_ref = 1;
+  }
+
   oneof sum {
     FailedAuthorizations failed_authorizations = 1;
     GlobalKey unique_key_violation = 2;
+    ContractNotActive contract_not_active = 3;
   }
 }
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -295,6 +295,11 @@ final class Conversions(
     commitError match {
       case ScenarioLedger.CommitError.UniqueKeyViolation(gk) =>
         builder.setUniqueKeyViolation(convertGlobalKey(gk.gk))
+      case ScenarioLedger.CommitError.ContractNotActive(err) =>
+        builder.setContractNotActive(
+          proto.CommitError.ContractNotActive.newBuilder
+            .setContractRef(mkContractRef(err.contractId, err.templateId))
+        )
     }
     builder.build
   }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/Pretty.scala
@@ -55,12 +55,21 @@ private[lf] object Pretty {
             stakeholders.map(prettyParty),
           ) + char('.')
 
-      case Error.CommitError(ScenarioLedger.CommitError.UniqueKeyViolation(gk)) =>
-        (text("Scenario failed due to unique key violation for key:") & prettyValue(false)(
-          gk.gk.key
-        ) & text(
-          "for template"
-        ) & prettyIdentifier(gk.gk.templateId))
+      case Error.CommitError(err) =>
+        err match {
+          case ScenarioLedger.CommitError.UniqueKeyViolation(gk) =>
+            (text("Scenario failed due to unique key violation for key:") & prettyValue(false)(
+              gk.gk.key
+            ) & text(
+              "for template"
+            ) & prettyIdentifier(gk.gk.templateId))
+
+          case ScenarioLedger.CommitError.ContractNotActive(e) =>
+            text(
+              "Scenario failed due to a fetch/exercise on an inactive contract"
+            ) & prettyContractId(e.contractId) &
+              char('(') + (prettyIdentifier(e.templateId)) + text(").")
+        }
 
       case Error.MustFailSucceeded(tx @ _) =>
         // TODO(JM): Further info needed. Location annotations?

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -436,16 +436,16 @@ sealed abstract class HasTxNodes {
 
   /** Returns the IDs of all input contracts that are used by this transaction.
     */
-  final def inputContracts[Cid2 >: ContractId]: Set[Cid2] =
-    fold(Set.empty[Cid2]) {
-      case (acc, (_, Node.Exercise(coid, _, _, _, _, _, _, _, _, _, _, _, _, _, _))) =>
-        acc + coid
-      case (acc, (_, Node.Fetch(coid, _, _, _, _, _, _, _))) =>
-        acc + coid
-      case (acc, (_, Node.LookupByKey(_, _, Some(coid), _))) =>
-        acc + coid
+  final def inputContracts[Cid2 >: ContractId]: Set[(Cid2, Identifier)] =
+    fold(Set.empty[(Cid2, Identifier)]) {
+      case (acc, (_, Node.Exercise(coid, tid, _, _, _, _, _, _, _, _, _, _, _, _, _))) =>
+        acc + ((coid, tid))
+      case (acc, (_, Node.Fetch(coid, tid, _, _, _, _, _, _))) =>
+        acc + ((coid, tid))
+      case (acc, (_, Node.LookupByKey(tid, _, Some(coid), _))) =>
+        acc + ((coid, tid))
       case (acc, _) => acc
-    } -- localContracts.keySet
+    }.filterNot(x => localContracts.keySet.contains(x._1))
 
   /** Return all the contract keys referenced by this transaction.
     * This includes the keys created, exercised, fetched, or looked up, even those

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -436,16 +436,16 @@ sealed abstract class HasTxNodes {
 
   /** Returns the IDs of all input contracts that are used by this transaction.
     */
-  final def inputContracts[Cid2 >: ContractId]: Set[(Cid2, Identifier)] =
-    fold(Set.empty[(Cid2, Identifier)]) {
-      case (acc, (_, Node.Exercise(coid, tid, _, _, _, _, _, _, _, _, _, _, _, _, _))) =>
-        acc + ((coid, tid))
-      case (acc, (_, Node.Fetch(coid, tid, _, _, _, _, _, _))) =>
-        acc + ((coid, tid))
-      case (acc, (_, Node.LookupByKey(tid, _, Some(coid), _))) =>
-        acc + ((coid, tid))
+  final def inputContracts[Cid2 >: ContractId]: Set[Cid2] =
+    fold(Set.empty[Cid2]) {
+      case (acc, (_, Node.Exercise(coid, _, _, _, _, _, _, _, _, _, _, _, _, _, _))) =>
+        acc + coid
+      case (acc, (_, Node.Fetch(coid, _, _, _, _, _, _, _))) =>
+        acc + coid
+      case (acc, (_, Node.LookupByKey(_, _, Some(coid), _))) =>
+        acc + coid
       case (acc, _) => acc
-    }.filterNot(x => localContracts.keySet.contains(x._1))
+    } -- localContracts.keySet
 
   /** Return all the contract keys referenced by this transaction.
     * This includes the keys created, exercised, fetched, or looked up, even those


### PR DESCRIPTION
This adds an activeness check for disclosed contracts.

This only becomes relevant, when the disclosure PoC branch gets merged into main.

TODO: Tests?

Fixes #14186.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
