### PR TITLE
ci/cron: fix Wednesday

### DIFF
--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -32,12 +32,11 @@ steps:
         fi
     }
     open_pr() {
-      local branch title body out pr_number header output
+      local branch title body pr_number header output
       branch="$1"
       title="$2"
       body="${3:-}"
-      out="${4:-/dev/stdout}"
-      pr_number="${5:-}"
+      pr_number="${4:-}"
       header=$(mktemp)
       output=$(mktemp)
 
@@ -61,9 +60,7 @@ steps:
                --output "$output" \
                -d @- \
                https://api.github.com/repos/digital-asset/daml/pulls
-      if [ -n "$out" ]; then
-          cat "$header" "$output" > "$out"
-      fi
+      cat "$header" "$output"
       if [ -n "$pr_number" ]; then
           jq '.number' "$output" > "$pr_number"
       fi

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -48,6 +48,6 @@ jobs:
 
       rotate
       git add .
-      open_pr "$BRANCH" "$TITLE" "$BODY" "/dev/null" "$PR_NUMBER"
+      open_pr "$BRANCH" "$TITLE" "$BODY" "$PR_NUMBER"
       trigger_azure $(System.AccessToken) "PRs" --branch $BRANCH
       request_pr_review $(cat "$PR_NUMBER") "$NEXT_GH"


### PR DESCRIPTION
There's a small, subtle bug that made its way into #14287: apparently `/dev/stdout` is not defined on CI.

On the bright side, we don't actually need the `out` parameter, so removing it seems like the easiest fix here.

CHANGELOG_BEGIN
CHANGELOG_END