### PR TITLE
Support building on linux/arm64

### DIFF
--- a/bazel_tools/os_info.bzl
+++ b/bazel_tools/os_info.bzl
@@ -7,7 +7,7 @@ _os_info_bzl_template = """
 cpu_value = "{CPU_VALUE}"
 is_darwin = cpu_value == "darwin" or cpu_value == "darwin_arm64"
 is_darwin_arm64 = cpu_value == "darwin_arm64"
-is_linux = cpu_value == "k8"
+is_linux = cpu_value == "k8" or cpu_value == "aarch64"
 is_windows = cpu_value == "x64_windows"
 os_name = "macos" if is_darwin else "linux" if is_linux else "windows"
 """
@@ -15,6 +15,7 @@ os_name = "macos" if is_darwin else "linux" if is_linux else "windows"
 def _os_info_impl(repository_ctx):
     cpu = get_cpu_value(repository_ctx)
     known_cpu_values = [
+        "aarch64",
         "darwin",
         "darwin_arm64",
         "k8",

--- a/bazel_tools/rules_haskell-aarch64.patch
+++ b/bazel_tools/rules_haskell-aarch64.patch
@@ -1,0 +1,14 @@
+diff --git a/haskell/nixpkgs.bzl b/haskell/nixpkgs.bzl
+index 9e211076..e342e9dc 100644
+--- a/haskell/nixpkgs.bzl
++++ b/haskell/nixpkgs.bzl
+@@ -149,7 +149,7 @@ def _ghc_nixpkgs_toolchain_impl(repository_ctx):
+     if repository_ctx.attr.target_constraints == [] and repository_ctx.attr.exec_constraints == []:
+         cpu_value = get_cpu_value(repository_ctx)
+         target_constraints = ["@platforms//cpu:{}".format(
+-            "arm64" if "arm64" in cpu_value else "x86_64",
++            "arm64" if ("arm64" in cpu_value or "aarch64" in cpu_value) else "x86_64",
+         )]
+         if repository_ctx.os.name == "linux":
+             target_constraints.append("@platforms//os:linux")
+

--- a/bazel_tools/rules_nixpkgs-aarch64.patch
+++ b/bazel_tools/rules_nixpkgs-aarch64.patch
@@ -1,0 +1,19 @@
+diff --git a/core/util.bzl b/core/util.bzl
+index eff10e7..b90080a 100644
+--- a/core/util.bzl
++++ b/core/util.bzl
+@@ -110,10 +110,13 @@ def default_constraints(repository_ctx):
++    print("cpu: ", cpu_value)
+     cpu = {
+         "darwin": "@platforms//cpu:x86_64",
+         "darwin_arm64": "@platforms//cpu:arm64",
++        "aarch64": "@platforms//cpu:arm64",
+     }.get(cpu_value, "@platforms//cpu:x86_64")
+     os = {
+         "darwin": "@platforms//os:osx",
+         "darwin_arm64": "@platforms//os:osx",
++        "x64_windows": "@platforms//os:windows",
+     }.get(cpu_value, "@platforms//os:linux")
+     return [cpu, os]
+ 
+

--- a/deps.bzl
+++ b/deps.bzl
@@ -42,10 +42,14 @@ rules_haskell_patches = [
     # This should be made configurable in rules_haskell.
     # Remove this patch once that's available.
     "@com_github_digital_asset_daml//bazel_tools:haskell-opt.patch",
+    # This should be upstreamed
+    "@com_github_digital_asset_daml//bazel_tools:rules_haskell-aarch64.patch",
 ]
 rules_nixpkgs_version = "210d30a81cedde04b4281fd163428722278fddfb"
 rules_nixpkgs_sha256 = "61b24e273821a15146f9ae7577e64b53f6aa332d5a7056abe8221ae2c346fdbd"
 rules_nixpkgs_patches = [
+    # this should be upstreamed
+    "@com_github_digital_asset_daml//bazel_tools:rules_nixpkgs-aarch64.patch",
 ]
 
 buildifier_version = "4.0.0"

--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -46,7 +46,8 @@ let shared = rec {
         gnumake
         ncurses
         perl
-        haskell.compiler.ghc865Binary
+        # ghc865Binary is marked broken on aarch64-linux
+        (if system != "aarch64-linux" then haskell.compiler.ghc865Binary else haskell.compiler.ghc884)
         stdenv.cc  # ghc-lib needs `gcc` or `clang`, but Bazel provides `cc`.
         xz
       ] ++ (


### PR DESCRIPTION
# Purpose

This PR lays ground to build the project on a Linux arm64 machine (or on an Apple M1 inside Docker).

It could be used to build a linux/arm64 Docker image for use on an Apple M1.

Note, I did build a release tarball within Docker on an Apple M1, but we might also build this using Docker on Windows or even Linux using the `docker run --platform linux/arm64 ...` support. 

## Questions

Should we upgrade the GHC used to build the ghc-lib sdist to 8.8.4 for all other platforms too? \edit Or, if we do this, upgrade to 8.10.7 if possible since that is the first version of GHC to support Darwin arm64 so that we can stop building ghc-lib under Rosetta.

Should we try to create a CI pipeline which is able to build a linux/arm64 image ? 