### PR TITLE
Update rules_sh and use new sh_binaries

### DIFF
--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -288,13 +288,13 @@ def _dadew_binary_bundle_impl(repository_ctx):
         else:
             missing.append(path_str)
     repository_ctx.file("BUILD.bazel", executable = False, content = """\
-load("@com_github_digital_asset_daml//bazel_tools:bundle.bzl", "binary_bundle")
+load("@rules_sh//sh:sh.bzl", "sh_binaries")
 
 package(default_visibility = ["//visibility:public"])
 
-binary_bundle(
+sh_binaries(
     name = "tools",
-    tools = {tools},
+    srcs = {tools},
 )
 """.format(
         tools = repr(found),
@@ -321,15 +321,13 @@ Items can either be paths relative to the Scoop tool installation path, or colon
     configure = True,
     local = True,
     doc = """\
-Generate a `binary_bundle` containing a set of binaries provided by a Scoop tool.
+Generate a `sh_binaries` containing a set of binaries provided by a Scoop tool.
 
 Use this to import binaries provided by Scoop into the Bazel build in a
 hermetic way. This generates [Scoop shims][scoop-shim] for the specified
-binaries within Bazel's execution root and constructs a `binary_bundle` that
+binaries within Bazel's execution root and constructs a `sh_binaries` that
 contains these shims. The generated PATH make variable will only cover tools
 explicitly listed on this rule.
-
-See [`binary_bundle`](../bundle.bzl) for more information on `binary_bundle`.
 
 [scoop-shim]: https://github.com/ScoopInstaller/Shim#readme
 """,

--- a/bazel_tools/ghc-lib/BUILD.bazel
+++ b/bazel_tools/ghc-lib/BUILD.bazel
@@ -1,8 +1,9 @@
 # Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_sh//sh:sh.bzl", "sh_binaries")
 load("@os_info//:os_info.bzl", "is_windows")
-load("//bazel_tools:bundle.bzl", "binary_bundle", "cc_toolchain_binary_bundle", "library_bundle")
+load("//bazel_tools:bundle.bzl", "cc_toolchain_binary_bundle", "library_bundle")
 
 sh_library(
     name = "sh-lib",
@@ -14,9 +15,9 @@ cc_toolchain_binary_bundle(
     name = "cc-tools",
 )
 
-binary_bundle(
+sh_binaries(
     name = "tools-windows",
-    tools = [
+    deps = [
         "@cabal_win//:tools",
         "@dadew_ghc_lib_deps//:tools",
         "@dadew_ghc_lib_deps_python//:tools",
@@ -24,9 +25,9 @@ binary_bundle(
     ],
 ) if is_windows else None
 
-binary_bundle(
+sh_binaries(
     name = "tools",
-    tools = [
+    srcs = [
         "@stackage-exe//alex",
         "@stackage-exe//happy",
     ],

--- a/bazel_tools/ghc-lib/BUILD.nix-deps
+++ b/bazel_tools/ghc-lib/BUILD.nix-deps
@@ -1,10 +1,11 @@
-load("@com_github_digital_asset_daml//bazel_tools:bundle.bzl", "binary_bundle", "library_bundle")
+load("@rules_sh//sh:sh.bzl", "sh_binaries")
+load("@com_github_digital_asset_daml//bazel_tools:bundle.bzl", "library_bundle")
 
 package(default_visibility = ["//visibility:public"])
 
-binary_bundle(
+sh_binaries(
     name = "tools",
-    tools = glob(["bin/*"]),
+    srcs = glob(["bin/*"]),
 )
 
 library_bundle(

--- a/bazel_tools/ghc-lib/defs.bzl
+++ b/bazel_tools/ghc-lib/defs.bzl
@@ -119,7 +119,7 @@ EXECROOT=$$PWD
 
 SEP="$$(path_list_separtor)"
 export LIBRARY_PATH="$$(make_all_absolute "$(LIBS_LIBRARY_PATH)")"
-export PATH="$$(make_all_absolute "$(TOOLS_PATH)")$$SEP$$PATH"
+export PATH="$$(make_all_absolute "$(_TOOLS_PATH)")$$SEP$$PATH"
 export PATH="$$(abs_dirname "$(execpath :hadrian)")$$SEP$$PATH"
 export LANG={lang}
 export CC="$$(make_absolute $(CC))"

--- a/bazel_tools/ghc-lib/repositories.bzl
+++ b/bazel_tools/ghc-lib/repositories.bzl
@@ -108,10 +108,10 @@ def _ghc_lib_deps_windows():
     http_archive(
         name = "ghc_865_win",
         build_file_content = """\
-load("@com_github_digital_asset_daml//bazel_tools:bundle.bzl", "binary_bundle")
-binary_bundle(
+load("@rules_sh//sh:sh.bzl", "sh_binaries")
+sh_binaries(
     name = "tools",
-    tools = glob(["ghc-8.6.5/bin/*"]),
+    srcs = glob(["ghc-8.6.5/bin/*"]),
     visibility = ["//visibility:public"],
 )
 """,
@@ -122,10 +122,10 @@ binary_bundle(
     http_archive(
         name = "cabal_win",
         build_file_content = """\
-load("@com_github_digital_asset_daml//bazel_tools:bundle.bzl", "binary_bundle")
-binary_bundle(
+load("@rules_sh//sh:sh.bzl", "sh_binaries")
+sh_binaries(
     name = "tools",
-    tools = glob(["cabal.exe"]),
+    srcs = glob(["cabal.exe"]),
     visibility = ["//visibility:public"],
 )
 """,

--- a/deps.bzl
+++ b/deps.bzl
@@ -78,8 +78,8 @@ daml_cheat_sheet_sha256 = "726bfa931c6a39f2bd37a1bf3c3228e7a4ddc65bba0e6c8183fb7
 platforms_version = "0.0.4"
 platforms_sha256 = "2697e95e085c6e1f970637d178e9dfa1231dca3a099d584ff85a7cb9c0af3826"
 
-rules_sh_version = "47b4d823128f484ec1b06aa20349c4898216f486"
-rules_sh_sha256 = "107d4312073d80a9977d3ccff236060d3906bda939fa2fbda4d724268c5b5383"
+rules_sh_version = "f02af9ac549d2a7246a9ee12eb17d113aa218d90"
+rules_sh_sha256 = "9bf2a139af12e290a02411b993007ea5f8dd7cad5d0fe26741df6ef3aaa984bc"
 
 def daml_deps():
     if "platforms" not in native.existing_rules():


### PR DESCRIPTION
With this change `binary_bundle` is upstreamed to `rules_sh`, see https://github.com/tweag/rules_sh/pull/23.

Follow-up steps:
- Upstream the re-usable parts of `dadew_binary_bundle` to `rules_sh`
- Upstream `cc_toolchain_binary_bundle` to `rules_sh`

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
