### PR TITLE
Removed Canton from installation.rst

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -112,9 +112,6 @@ can install it as follows:
   :ref:`global daml-config.yaml <global_daml_config>` and add an entry
   with your Artifactory API key. The API key can be found in your
   Artifactory user profile.
-  - The Enterprise edition includes Canton. You can download Canton from this `repository <https://digitalasset.jfrog.io/artifactory/canton-enterprise/>`_ 
-  , or use the Canton Enterprise Docker images as described in our `Docker instructions <https://www.canton.io/docs/dev/user-manual/usermanual/docker.html#docker-instructions>`_. 
-  - After downloading Canton, unpack it in the directory you want or `follow the instructions found here <https://www.canton.io/docs/dev/user-manual/usermanual/docker.html#starting-canton>`_ to run in Docker.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Removed reference to installing Canton, per conversation in #product-docs on June 21.

[CHANGELOG_BEGIN]
[CHANGELOG_END]

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
