### PR TITLE
docs: fix top-level update

### DIFF
--- a/ci/cron/src/Docs.hs
+++ b/ci/cron/src/Docs.hs
@@ -39,6 +39,7 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Ord
 import qualified Data.Set as Set
 import qualified System.Directory.Extra as Directory
+import qualified System.FilePath as FilePath
 import qualified System.Environment
 import qualified System.Exit as Exit
 import System.FilePath.Posix ((</>))
@@ -71,7 +72,9 @@ shell_ cmd = do
     Control.void $ shell cmd
 
 proc_ :: [String] -> IO ()
-proc_ args = Control.void $ proc args
+proc_ args = Control.void $ do
+    print args
+    proc args
 
 shell_env_ :: [(String, String)] -> String -> IO ()
 shell_env_ env cmd = do
@@ -163,20 +166,24 @@ update_s3 opts temp vs = do
 
 update_top_level :: DocOptions -> FilePath -> Version -> Maybe Version -> IO ()
 update_top_level opts temp new mayOld = do
-    new_files <- Set.fromList <$> Directory.listFilesRecursive (temp </> show new)
+    new_files <- Set.fromList <$> files_under new
     old_files <- case mayOld of
         Nothing -> pure Set.empty
-        Just old -> Set.fromList <$> Directory.listFilesRecursive (temp </> show old)
+        Just old -> Set.fromList <$> files_under old
     let to_delete = Set.toList $ old_files `Set.difference` new_files
     Control.when (not $ null to_delete) $ do
         putStrLn $ "Deleting top-level files: " <> show to_delete
         Data.Foldable.for_ to_delete (\f -> do
-            proc_ ["aws", "s3", "rm", s3Path opts f, "--recursive"])
+            proc_ ["aws", "s3", "rm", s3Path opts f])
         putStrLn "Done."
     putStrLn $ "Pushing " <> show new <> " to top-level..."
-    let path = s3Path opts "" <> "/"
-    proc_ ["aws", "s3", "cp", temp </> show new, path, "--recursive", "--acl", "public-read"]
+    let root = s3Path opts "" <> "/"
+    proc_ ["aws", "s3", "cp", temp </> show new, root, "--recursive", "--acl", "public-read"]
     putStrLn "Done."
+  where files_under folder = do
+          let root = temp </> show folder
+          full_paths <- Directory.listFilesRecursive root
+          return $ map (FilePath.makeRelative root) full_paths
 
 reset_cloudfront :: IO ()
 reset_cloudfront = do


### PR DESCRIPTION
There were two issues:

1. The `Directory.listFilesRecursive` function returns paths that include its first argument, so there was never any overlap between the sets.
2. That full path doesn't exist on AWS, and was given to AWS because `s3Path opts f` returns just `f` if it starts with `/`.

This means that, on the one hand, the script tried to delete _everything_ from the top-level, which is a bit bad, but, on the other hand, the script did not actually manage to delete anything at all, which is basically the status quo.

Note that deleting everything isn't _that_ bad as we reupload right after and we have a cache in front on the site, so this would only impact users if they were the first to try and view a given page in that small time window between deletion and reupload.

This PR should fix both issues by removing the version-specific prefix.

CHANGELOG_BEGIN
CHANGELOG_END