### PR TITLE
Backport: Track only local creates in ActiveLedgerState

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
@@ -104,10 +104,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
       * - None if we know no mapping for that key.
       */
     def lookupActiveKey(key: GlobalKey): Option[ContractStateMachine.KeyMapping] =
-      activeState.getLocalActiveKey(key) match {
-        case None => lookupActiveGlobalKeyInput(key)
-        case Some(mapping) => Some(mapping)
-      }
+      activeState.getLocalActiveKey(key).orElse(lookupActiveGlobalKeyInput(key))
 
     def lookupActiveGlobalKeyInput(key: GlobalKey): Option[ContractStateMachine.KeyMapping] =
       globalKeyInputs.get(key).map {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
@@ -98,6 +98,17 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
 
     def mode: ContractKeyUniquenessMode = ContractStateMachine.this.mode
 
+    /** Lookup the given key k. Returns
+      * - Some(KeyActive(cid)) if k maps to cid and cid is active.
+      * - Some(KeyInactive) if there is no active contract with the given key.
+      * - None if we know no mapping for that key.
+      */
+    def lookupActiveKey(key: GlobalKey): Option[ContractStateMachine.KeyMapping] =
+      activeState.getLocalActiveKey(key) match {
+        case None => lookupActiveGlobalKeyInput(key)
+        case Some(mapping) => Some(mapping)
+      }
+
     def lookupActiveGlobalKeyInput(key: GlobalKey): Option[ContractStateMachine.KeyMapping] =
       globalKeyInputs.get(key).map {
         case Transaction.KeyActive(cid) if !activeState.consumedBy.contains(cid) =>
@@ -129,38 +140,9 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
         case Some(kWithM) =>
           val ck = GlobalKey(templateId, kWithM.key)
 
-          // Note (MK) Duplicate key checks in Speedy
-          // When run in ContractKeyUniquenessMode.On speedy detects duplicate contract keys errors.
-          //
-          // Just like for modifying `keys` and `globalKeyInputs` we only consider
-          // by-key operations, i.e., lookup, exercise and fetch by key, and creates with a key
-          // as well as archives if the key has been brought into scope before.
-          //
-          // In the end, those checks mean that ledgers with unique-contract-key semantics
-          // only have to look at inputs and outputs of the transaction and check for conflicts
-          // on that while speedy checks for internal conflicts.
-          //
-          // We have to consider the following cases for conflicts:
-          // 1. Create of a new local contract
-          //    1.1. KeyInactive in `keys`. This means we saw an archive so the create is valid.
-          //    1.2. KeyActive(_) in `keys`. This can either be local contract or a global contract. Both are an error.
-          //    1.3. No entry in `keys` and no entry in `globalKeyInputs`. This is valid. Note that the ledger here will then
-          //         have to check when committing that there is no active contract with this key before the transaction.
-          //    1.4. No entry in `keys` and `KeyInactive` in `globalKeyInputs`. This is valid. Ledgers need the same check
-          //         as for 1.3.
-          //    1.5. No entry in `keys` and `KeyActive(_)` in `globalKeyInputs`. This is an error. Note that the case where
-          //         the global contract has already been archived falls under 1.2.
-          // 2. Global key lookups
-          //    2.1. Conflicts with other global contracts cannot arise as we query a key at most once.
-          //    2.2. Conflicts with local contracts also cannot arise: A successful create will either
-          //         2.2.1: Set `globalKeyInputs` to `KeyInactive`.
-          //         2.2.2: Not modify `globalKeyInputs` if there already was an entry.
-          //         For both of those cases `globalKeyInputs` already had an entry which means
-          //         we would use that as a cached result and not query the ledger.
-          val keys = me.activeState.keys
-          val conflict = keys.get(ck) match {
+          val conflict = lookupActiveKey(ck) match {
             case Some(keyMapping) => keyMapping.isDefined
-            case None => lookupActiveGlobalKeyInput(ck).exists(_ != KeyInactive)
+            case None => false
           }
 
           val newKeyInputs =
@@ -169,7 +151,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
           Either.cond(
             !conflict || mode == ContractKeyUniquenessMode.Off,
             me.copy(
-              activeState = me.activeState.copy(keys = keys.updated(ck, KeyActive(contractId))),
+              activeState = me.activeState.createKey(ck, contractId),
               globalKeyInputs = newKeyInputs,
             ),
             DuplicateContractKey(ck),
@@ -202,30 +184,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
       } yield {
         if (consuming) {
           val consumedState = state.activeState.consume(targetId, nodeId)
-          val newActiveState = mbKey match {
-            case Some(kWithM) =>
-              val gkey = GlobalKey(templateId, kWithM.key)
-              val keys = consumedState.keys
-              val updatedKeys = keys.updated(gkey, KeyInactive)
-
-              // If the key was brought in scope before, we must update `keys`
-              // independently of whether this exercise is by-key because it affects later key lookups.
-              if (mode != ContractKeyUniquenessMode.Strict) {
-                keys.get(gkey).orElse(state.lookupActiveGlobalKeyInput(gkey)) match {
-                  // An archive can only mark a key as inactive
-                  // if it was brought into scope before.
-                  case Some(KeyActive(cid)) if cid == targetId =>
-                    consumedState.copy(keys = updatedKeys)
-                  // If the key was not in scope or mapped to a different cid, we don’t change keys. Instead we will do
-                  // an activeness check when looking it up later.
-                  case _ => consumedState
-                }
-              } else {
-                consumedState.copy(keys = updatedKeys)
-              }
-            case None => consumedState
-          }
-          state.copy(activeState = newActiveState)
+          state.copy(activeState = consumedState)
         } else state
       }
     }
@@ -285,45 +244,25 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
     private[lf] def resolveKey(
         gkey: GlobalKey
     ): Either[Option[ContractId] => (KeyMapping, State), (KeyMapping, State)] = {
-      val keys = activeState.keys
-      keys.get(gkey) match {
+      lookupActiveKey(gkey) match {
         case Some(keyMapping) => Right(keyMapping -> this)
         case None =>
-          // Check if we have a cached key input.
-          lookupActiveGlobalKeyInput(gkey) match {
-            case Some(keyMapping) =>
-              Right(
-                keyMapping -> this.copy(
-                  activeState = activeState.copy(keys = keys.updated(gkey, keyMapping))
-                )
-              )
-            case None =>
-              // if we cannot find it here, send help, and make sure to update keys after
-              // that.
-              def handleResult(result: Option[ContractId]): (KeyMapping, State) = {
-                // Update key inputs. Create nodes never call this method,
-                // so NegativeKeyLookup is the right choice for the global key input.
-                val keyInput = result.fold[KeyInput](NegativeKeyLookup)(Transaction.KeyActive)
-                val newKeyInputs = globalKeyInputs.updated(gkey, keyInput)
-
-                result match {
-                  case Some(cid) if !activeState.consumedBy.contains(cid) =>
-                    val active = KeyActive(cid)
-                    active -> this.copy(
-                      activeState = activeState.copy(keys = keys.updated(gkey, active)),
-                      globalKeyInputs = newKeyInputs,
-                    )
-                  case _ =>
-                    KeyInactive -> this.copy(
-                      activeState = activeState.copy(
-                        keys = keys.updated(gkey, KeyInactive)
-                      ),
-                      globalKeyInputs = newKeyInputs,
-                    )
-                }
-              }
-              Left(handleResult)
+          // if we cannot find it here, send help, and make sure to update keys after
+          // that.
+          def handleResult(result: Option[ContractId]): (KeyMapping, State) = {
+            // Update key inputs. Create nodes never call this method,
+            // so NegativeKeyLookup is the right choice for the global key input.
+            val keyInput = result.fold[KeyInput](NegativeKeyLookup)(Transaction.KeyActive)
+            val newKeyInputs = globalKeyInputs.updated(gkey, keyInput)
+            val state = this.copy(globalKeyInputs = newKeyInputs)
+            result match {
+              case Some(cid) if !activeState.consumedBy.contains(cid) =>
+                KeyActive(cid) -> state
+              case _ =>
+                KeyInactive -> state
+            }
           }
+          Left(handleResult)
       }
     }
 
@@ -418,22 +357,18 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
         "Cannot lift a state over a substate with unfinished rollback scopes",
       )
 
-      def keyMappingFor(key: GlobalKey): Option[KeyMapping] = {
-        this.activeState.keys.get(key).orElse(this.lookupActiveGlobalKeyInput(key))
-      }
-
       // We want consistent key lookups within an action in any contract key mode.
       def consistentGlobalKeyInputs: Either[KeyInputError, Unit] = {
         substate.globalKeyInputs
           .collectFirst {
             case (key, KeyCreate)
-                if keyMappingFor(key).exists(_ != KeyInactive) &&
+                if lookupActiveKey(key).exists(_ != KeyInactive) &&
                   mode == ContractKeyUniquenessMode.Strict =>
               Right(DuplicateContractKey(key))
-            case (key, NegativeKeyLookup) if keyMappingFor(key).exists(_ != KeyInactive) =>
+            case (key, NegativeKeyLookup) if lookupActiveKey(key).exists(_ != KeyInactive) =>
               Left(InconsistentContractKey(key))
             case (key, Transaction.KeyActive(cid))
-                if keyMappingFor(key).exists(km => km != KeyActive(cid)) =>
+                if lookupActiveKey(key).exists(km => km != KeyActive(cid)) =>
               Left(InconsistentContractKey(key))
           }
           .toLeft(())
@@ -442,12 +377,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
       for {
         _ <- consistentGlobalKeyInputs
       } yield {
-        val next = ActiveLedgerState(
-          locallyCreatedThisTimeline = this.activeState.locallyCreatedThisTimeline
-            .union(substate.activeState.locallyCreatedThisTimeline),
-          consumedBy = this.activeState.consumedBy ++ substate.activeState.consumedBy,
-          keys = this.activeState.keys.concat(substate.activeState.keys),
-        )
+        val next = this.activeState.advance(substate.activeState)
         val globalKeyInputs =
           if (mode == ContractKeyUniquenessMode.Strict)
             // In strict mode, `key`'s state is the same at `this` as at the beginning
@@ -484,10 +414,12 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
 
     /** @see advance */
     def projectKeyResolver(resolver: KeyResolver): KeyResolver = {
-      val keys = activeState.keys
       val consumed = activeState.consumedBy.keySet
       resolver.map { case (key, keyMapping) =>
-        val newKeyInput = keys.getOrElse(key, keyMapping.filterNot(consumed.contains))
+        val newKeyInput = activeState.getLocalActiveKey(key) match {
+          case None => keyMapping.filterNot(consumed.contains)
+          case Some(localMapping) => localMapping
+        }
         key -> newKeyInput
       }
     }
@@ -520,39 +452,57 @@ object ContractStateMachine {
     *
     * @param consumedBy [[com.daml.lf.value.Value.ContractId]]s of all contracts
     *                   that have been consumed by nodes up to now.
-    * @param keys
-    *   A local store of the contract keys used for lookups and fetches by keys
-    *   (including exercise by key). Each of those operations will be resolved
-    *   against this map first. Only if there is no entry in here
-    *   (but not if there is an entry mapped to [[KeyInactive]]), will we ask the ledger.
-    *
-    *   How this map is mutated depends on the [[com.daml.lf.transaction.ContractKeyUniquenessMode]]:
-    *
-    *   - In mode [[com.daml.lf.transaction.ContractKeyUniquenessMode.Strict]],
-    *     the current state reflects the result of applying all nodes (create, fetch, exercise, lookup)
-    *     on contracts with a key (regardless of whether they were byKey or not) excluding
-    *     nodes under a rollback.
-    *
-    *   - In mode [[com.daml.lf.transaction.ContractKeyUniquenessMode.Off]]
-    *     the following operations mutate this map:
-    *     1. fetch-by-key/lookup-by-key/exercise-by-key/create-contract-with-key will insert an
-    *        an entry in the map if there wasn’t already one (i.e., if they queried the ledger).
-    *     2. ACS mutating operations if the corresponding contract has a key update the entry. Specifically,
-    *        2.1. A create will set the corresponding map entry to KeyActive(cid) if the contract has a key.
-    *        2.2. A consuming exercise on cid will set the corresponding map entry to KeyInactive
-    *             iff we had a KeyActive(cid) entry for the same key before. If not, keys
-    *             will not be modified.
-    *             Later lookups have an activeness check
-    *             that can then set this to KeyInactive if the result of the
-    *             lookup was already archived.
+    * @param localKeys
+    *   A store of the latest local contract that has been created with the given key in this timeline.
+    *   Later creates overwrite earlier ones. Note that this does not track whether the contract
+    *   was consumed or not. That information is stored in consumedBy.
+    *   It also _only_ includes local contracts not global contracts.
     */
   final case class ActiveLedgerState[+Nid](
       locallyCreatedThisTimeline: Set[ContractId],
       consumedBy: Map[ContractId, Nid],
-      keys: Map[GlobalKey, KeyMapping],
+      private val localKeys: Map[GlobalKey, Value.ContractId],
   ) {
     def consume[Nid2 >: Nid](contractId: ContractId, nodeId: Nid2): ActiveLedgerState[Nid2] =
       this.copy(consumedBy = consumedBy.updated(contractId, nodeId))
+
+    def createKey(key: GlobalKey, cid: Value.ContractId): ActiveLedgerState[Nid] =
+      this.copy(localKeys = localKeys.updated(key, cid))
+
+    /** Equivalence relative to locallyCreatedThisTimeline, consumedBy & localActiveKeys.
+      */
+    def isEquivalent[Nid2 >: Nid](other: ActiveLedgerState[Nid2]): Boolean =
+      this.locallyCreatedThisTimeline == other.locallyCreatedThisTimeline &&
+        this.consumedBy == other.consumedBy &&
+        this.localActiveKeys == other.localActiveKeys
+
+    /** See docs of [[ContractStateMachine.advance]]
+      */
+    private[ContractStateMachine] def advance[Nid2 >: Nid](
+        substate: ActiveLedgerState[Nid2]
+    ): ActiveLedgerState[Nid2] =
+      ActiveLedgerState(
+        locallyCreatedThisTimeline = this.locallyCreatedThisTimeline
+          .union(substate.locallyCreatedThisTimeline),
+        consumedBy = this.consumedBy ++ substate.consumedBy,
+        localKeys = this.localKeys.concat(substate.localKeys),
+      )
+
+    /** localKeys filter by whether contracts have been consumed already.
+      */
+    def localActiveKeys: Map[GlobalKey, KeyMapping] =
+      localKeys.map { case (k, v) =>
+        k -> (if (consumedBy.contains(v)) KeyInactive else KeyActive(v))
+      }
+
+    /** Lookup in localActiveKeys.
+      */
+    def getLocalActiveKey(key: GlobalKey): Option[KeyMapping] =
+      localKeys.get(key) match {
+        case None => None
+        case Some(cid) =>
+          Some(if (consumedBy.contains(cid)) KeyInactive else KeyActive(cid))
+      }
   }
 
   object ActiveLedgerState {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
@@ -368,7 +368,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
             case (key, NegativeKeyLookup) if lookupActiveKey(key).exists(_ != KeyInactive) =>
               Left(InconsistentContractKey(key))
             case (key, Transaction.KeyActive(cid))
-                if lookupActiveKey(key).exists(km => km != KeyActive(cid)) =>
+                if lookupActiveKey(key).exists(_ != KeyActive(cid)) =>
               Left(InconsistentContractKey(key))
           }
           .toLeft(())

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/ContractStateMachine.scala
@@ -137,10 +137,7 @@ class ContractStateMachine[Nid](mode: ContractKeyUniquenessMode) {
         case Some(kWithM) =>
           val ck = GlobalKey(templateId, kWithM.key)
 
-          val conflict = lookupActiveKey(ck) match {
-            case Some(keyMapping) => keyMapping.isDefined
-            case None => false
-          }
+          val conflict = lookupActiveKey(ck).exists(_ != KeyInactive)
 
           val newKeyInputs =
             if (globalKeyInputs.contains(ck)) globalKeyInputs

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/ContractStateMachineSpec.scala
@@ -152,7 +152,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     val tx = builder.build()
     val expected = Right(
       Map(gkey("key1") -> KeyCreate) ->
-        ActiveLedgerState(Set(1), Map.empty, Map(gkey("key1") -> KeyActive(1)))
+        ActiveLedgerState(Set(1), Map.empty, Map(gkey("key1") -> 1))
     )
     TestCase(
       "Create|Rb-Ex-LBK|LBK",
@@ -185,7 +185,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
         ActiveLedgerState(
           Set.empty,
           Map(cid(0) -> (), cid(1) -> ()),
-          Map(gkey("key1") -> KeyInactive),
+          Map.empty,
         )
     )
     TestCase(
@@ -216,7 +216,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     val tx = builder.build()
     val expected = Right(
       Map(gkey("key1") -> Transaction.KeyActive(1), gkey("key2") -> Transaction.KeyActive(2)) ->
-        ActiveLedgerState(Set.empty, Map(cid(1) -> ()), Map(gkey("key1") -> KeyInactive))
+        ActiveLedgerState(Set.empty, Map(cid(1) -> ()), Map.empty)
     )
     TestCase(
       "nested rollback",
@@ -247,7 +247,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
       Map(gkey("key") -> Transaction.KeyActive(2)) -> ActiveLedgerState(
         Set(3),
         Map(cid(1) -> (), cid(2) -> ()),
-        Map(gkey("key") -> KeyActive(3)),
+        Map(gkey("key") -> cid(3)),
       )
     )
     TestCase(
@@ -274,7 +274,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     val resolver = Map(gkey("key1") -> None)
     val expected = Right(
       Map(gkey("key1") -> KeyCreate) ->
-        ActiveLedgerState(Set.empty, Map(cid(1) -> ()), Map(gkey("key1") -> KeyInactive))
+        ActiveLedgerState(Set.empty, Map(cid(1) -> ()), Map.empty)
     )
     TestCase(
       "RbExeCreateLbkDivulged",
@@ -298,7 +298,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     val tx = builder.build()
     val expected = Right(
       Map(gkey("key1") -> Transaction.KeyActive(2)) ->
-        ActiveLedgerState(Set.empty, Map(cid(1) -> ()), Map(gkey("key1") -> KeyActive(cid(2))))
+        ActiveLedgerState(Set.empty, Map(cid(1) -> ()), Map.empty)
     )
     TestCase(
       "RbExeCreateFbk",
@@ -325,7 +325,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
           Set(2, 3),
           Map.empty,
           Map(
-            gkey("key1") -> KeyActive(3) // Latest create wins
+            gkey("key1") -> cid(3) // Latest create wins
           ),
         )
     )
@@ -348,7 +348,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     val tx = builder.build()
     val expected = Right(
       Map(gkey("key1") -> NegativeKeyLookup) ->
-        ActiveLedgerState(Set.empty, Map.empty, Map(gkey("key1") -> KeyInactive))
+        ActiveLedgerState(Set.empty, Map.empty, Map.empty)
     )
     TestCase(
       "DivulgedLookup",
@@ -395,7 +395,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     val tx = builder.build()
     val expected = Right(
       Map(gkey("key1") -> Transaction.KeyActive(2)) ->
-        ActiveLedgerState(Set.empty, Map(cid(3) -> ()), Map(gkey("key1") -> KeyActive(cid(2))))
+        ActiveLedgerState(Set.empty, Map(cid(3) -> ()), Map.empty)
     )
     TestCase(
       "Archive other contract with key",
@@ -417,7 +417,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
     val tx = builder.build()
     val expected = Right(
       Map(gkey("key1") -> KeyCreate) ->
-        ActiveLedgerState(Set(3), Map.empty, Map(gkey("key1") -> KeyActive(cid(3))))
+        ActiveLedgerState(Set(3), Map.empty, Map(gkey("key1") -> cid(3)))
     )
     TestCase(
       "CreateAfterRbExercise",
@@ -468,7 +468,7 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
         ActiveLedgerState(
           Set(1, 3, 4, 5),
           Map.empty,
-          Map(gkey("key1") -> KeyActive(cid(4)), gkey("key2") -> KeyActive(cid(5))),
+          Map(gkey("key1") -> cid(4), gkey("key2") -> cid(5)),
         )
     )
     TestCase(
@@ -571,6 +571,50 @@ class ContractStateMachineSpec extends AnyWordSpec with Matchers with TableDrive
           }
         }
       }
+    }
+  }
+
+  "ActiveLedgerState.isEquivalent" should {
+    val s = ActiveLedgerState(
+      Set(1, 2, 3, 4, 5),
+      Map[ContractId, Unit]((2, ()), (5, ())),
+      Map(gkey("key1") -> 2, gkey("key2") -> 4),
+    )
+    "succeed on identical states" in {
+      assert(s.isEquivalent(s))
+    }
+    "succeed if localKeys differ but localActiveKeys is identical" in {
+      // Different entry that is also not active.
+      val tweakedS = ActiveLedgerState(
+        Set(1, 2, 3, 4, 5),
+        Map[ContractId, Unit]((2, ()), (5, ())),
+        Map(gkey("key1") -> 5, gkey("key2") -> 4),
+      )
+      assert(s.isEquivalent(tweakedS))
+    }
+    "fail if locallyCreatedThisTimeline is different" in {
+      val tweakedS = s.copy(locallyCreatedThisTimeline = Set(1, 2, 3, 4))
+      assert(!s.isEquivalent(tweakedS))
+    }
+    "fail if consumedBy is different" in {
+      val tweakedS = s.copy(consumedBy = Map[ContractId, Unit]((2, ())))
+      assert(!s.isEquivalent(tweakedS))
+    }
+    "fail it localActiveKeys is different" in {
+      // No entry
+      var tweakedS = ActiveLedgerState(
+        Set(1, 2, 3, 4, 5),
+        Map[ContractId, Unit]((2, ()), (5, ())),
+        Map(gkey("key2") -> 4),
+      )
+      assert(!s.isEquivalent(tweakedS))
+      // Different entry that is still active
+      tweakedS = ActiveLedgerState(
+        Set(1, 2, 3, 4, 5),
+        Map[ContractId, Unit]((2, ()), (5, ())),
+        Map(gkey("key1") -> 3, gkey("key2") -> 4),
+      )
+      assert(!s.isEquivalent(tweakedS))
     }
   }
 


### PR DESCRIPTION
This PR simplifies the ContractStateMachine by dropping the very
complex tracking of `keys` and instead tracking only `localKeys` which
stores the latest create with a given key.

This is fully backwards compatible for uck & non-uck semantics.

Backport from #14265

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
