### PR TITLE
Backport: Fix HA Coordination retry [DPP-1115] (#14363)

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/ha/PreemptableSequence.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/ha/PreemptableSequence.scala
@@ -54,13 +54,15 @@ trait SequenceHelper {
 
   /** Wrap a synchronous call into a Future sequence, which
     * - will be preemptable
-    * - will retry to execute the body if Exception-s thrown
+    * - will retry to execute the body if Exception-s thrown, and the exception is retryable
     *
     * @return the preemptable, retrying Future sequence
     */
-  def retry[T](waitMillisBetweenRetries: Long, maxAmountOfRetries: Long = -1)(
-      body: => T
-  ): Future[T]
+  def retry[T](
+      waitMillisBetweenRetries: Long,
+      maxAmountOfRetries: Long = -1,
+      retryable: Throwable => Boolean = _ => true,
+  )(body: => T): Future[T]
 
   /** Delegate the preemptable-future sequence to another Handle
     * - the completion Future future of the PreemptableSequence will only finish after this Handle finishes,
@@ -128,25 +130,36 @@ object PreemptableSequence {
 
       override def go[T](body: => T): Future[T] = goF[T](Future(body))
 
-      override def retry[T](waitMillisBetweenRetries: Long, maxAmountOfRetries: Long)(
-          body: => T
-      ): Future[T] =
+      override def retry[T](
+          waitMillisBetweenRetries: Long,
+          maxAmountOfRetries: Long = -1,
+          retryable: Throwable => Boolean = _ => true,
+      )(body: => T): Future[T] =
         go(body).transformWith {
-          // since we check countdown to 0, starting from negative means unlimited retries
-          case Failure(ex) if maxAmountOfRetries == 0 =>
-            logger.warn(
-              s"Maximum amount of retries reached ($maxAmountOfRetries) failing permanently.",
-              ex,
-            )
-            Future.failed(ex)
           case Success(t) => Future.successful(t)
+
+          case Failure(ex) if retryable(ex) =>
+            // since we check countdown to 0, starting from negative means unlimited retries
+            if (maxAmountOfRetries == 0) {
+              logger.warn(
+                s"Maximum amount of retries reached ($maxAmountOfRetries). Failing permanently.",
+                ex,
+              )
+              Future.failed(ex)
+            } else {
+              val retriesLeft =
+                if (maxAmountOfRetries < 0) "unlimited"
+                else maxAmountOfRetries - 1
+              logger.debug(s"Retrying (retries left: $retriesLeft). Due to: ${ex.getMessage}")
+              waitFor(waitMillisBetweenRetries).flatMap(_ =>
+                // Note: this recursion is out of stack
+                retry(waitMillisBetweenRetries, maxAmountOfRetries - 1, retryable)(body)
+              )
+            }
+
           case Failure(ex) =>
-            logger.debug(s"Retrying (retires left: ${if (maxAmountOfRetries < 0) "unlimited"
-              else maxAmountOfRetries - 1}). Due to: ${ex.getMessage}")
-            waitFor(waitMillisBetweenRetries).flatMap(_ =>
-              // Note: this recursion is out of stack
-              retry(waitMillisBetweenRetries, maxAmountOfRetries - 1)(body)
-            )
+            logger.warn(s"Failure not retryable.", ex)
+            Future.failed(ex)
         }
 
       override def merge(handle: Handle): Future[Unit] = {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ha/HaCoordinatorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ha/HaCoordinatorSpec.scala
@@ -285,6 +285,34 @@ class HaCoordinatorSpec
     }
   }
 
+  it should "wait for main lock can be interrupted by exception thrown during tryAcquire" in {
+    val dbLock = new TestDBLockStorageBackend
+    val blockingConnection = new TestConnection
+    dbLock.tryAcquire(main, DBLockStorageBackend.LockMode.Exclusive)(blockingConnection).get
+    info("As acquiring the main lock from the outside")
+    val mainConnection = new TestConnection
+    val protectedSetup = setup(
+      dbLock = dbLock,
+      connectionFactory = () => mainConnection,
+    )
+    import protectedSetup._
+    Thread.sleep(200)
+    info("And as waiting for 200 millis")
+    connectionInitializerFuture.isCompleted shouldBe false
+    protectedHandle.completed.isCompleted shouldBe false
+    info("Initialization should be waiting")
+    mainConnection.close()
+    info("As main connection is closed (triggers exception as used for acquiring lock)")
+
+    for {
+      failure <- protectedHandle.completed.failed
+    } yield {
+      info("Protected Handle is completed with a failure")
+      failure.getMessage shouldBe "trying to acquire on a closed connection"
+      connectionInitializerFuture.isCompleted shouldBe false
+    }
+  }
+
   it should "wait if worker lock cannot be acquired due to exclusive blocking" in {
     val dbLock = new TestDBLockStorageBackend
     val blockingConnection = new TestConnection
@@ -368,6 +396,35 @@ class HaCoordinatorSpec
     }
   }
 
+  it should "wait for worker lock can be interrupted by exception thrown during tryAcquire" in {
+    val dbLock = new TestDBLockStorageBackend
+    val blockingConnection = new TestConnection
+    dbLock.tryAcquire(worker, DBLockStorageBackend.LockMode.Shared)(blockingConnection).get
+    info("As acquiring the worker lock from the outside")
+    val mainConnection = new TestConnection
+    val protectedSetup = setup(
+      dbLock = dbLock,
+      connectionFactory = () => mainConnection,
+    )
+    import protectedSetup._
+
+    Thread.sleep(200)
+    info("And as waiting for 200 millis")
+    connectionInitializerFuture.isCompleted shouldBe false
+    protectedHandle.completed.isCompleted shouldBe false
+    info("Initialization should be waiting")
+    mainConnection.close()
+    info("As main connection is closed (triggers exception as used for acquiring lock)")
+
+    for {
+      failure <- protectedHandle.completed.failed
+    } yield {
+      info("Protected Handle completed with a failure")
+      failure.getMessage shouldBe "trying to acquire on a closed connection"
+      connectionInitializerFuture.isCompleted shouldBe false
+    }
+  }
+
   it should "fail if worker lock cannot be acquired in time due to shared blocking" in {
     val dbLock = new TestDBLockStorageBackend
     val blockingConnection = new TestConnection
@@ -384,7 +441,7 @@ class HaCoordinatorSpec
       failure <- protectedHandle.completed.failed
     } yield {
       info("Initialisation should completed with failure")
-      failure.getMessage shouldBe "Cannot acquire lock TestLockId(20) in lock-mode Exclusive: lock busy"
+      failure.getMessage shouldBe "Cannot acquire lock TestLockId(20) in lock-mode Exclusive"
     }
   }
 


### PR DESCRIPTION
* Adds retryGuard to retry mechanism
* Only allow retrying in lock-busy condition

[CHANGELOG_BEGIN]
Fixes issue: network problems can prevent non-leader indexer to be elected as leader.
[CHANGELOG_END]

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
