### PR TITLE
Backport: Add network timeout to Participant HA JDBC calls [DPP-1101]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/ha/HaCoordinator.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/ha/HaCoordinator.scala
@@ -58,6 +58,7 @@ case class HaConfig(
     workerLockAcquireRetryMillis: Long = 500,
     workerLockAcquireMaxRetry: Long = 1000,
     mainLockCheckerPeriodMillis: Long = 1000,
+    mainLockCheckerJdbcNetworkTimeoutMillis: Int = 10000,
     indexerLockId: Int = 0x646d6c0, // note 0x646d6c equals ASCII encoded "dml"
     indexerWorkerLockId: Int = 0x646d6c1,
 )
@@ -73,12 +74,12 @@ object HaCoordinator {
     * - provides a ConnectionInitializer function which is mandatory to execute on all worker connections during execution
     * - will spawn a polling-daemon to observe continuous presence of the main lock
     *
-    * @param connectionFactory to spawn the main connection which keeps the Indexer Main Lock
+    * @param mainConnectionFactory to spawn the main connection which keeps the Indexer Main Lock
     * @param storageBackend is the database-independent abstraction of session/connection level database locking
     * @param executionContext which is use to execute initialisation, will do blocking/IO work, so dedicated execution context is recommended
     */
   def databaseLockBasedHaCoordinator(
-      connectionFactory: () => Connection,
+      mainConnectionFactory: () => Connection,
       storageBackend: DBLockStorageBackend,
       executionContext: ExecutionContext,
       timer: Timer,
@@ -112,7 +113,7 @@ object HaCoordinator {
           import sequenceHelper._
           logger.info("Starting IndexDB HA Coordinator")
           for {
-            mainConnection <- go[Connection](connectionFactory())
+            mainConnection <- go[Connection](mainConnectionFactory())
             _ = logger.debug("Step 1: creating main-connection - DONE")
             _ = registerRelease {
               logger.debug("Releasing main connection...")

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -17,9 +17,9 @@ import com.daml.platform.store.backend.{DBLockStorageBackend, DataSourceStorageB
 import com.daml.platform.store.dao.DbDispatcher
 import com.daml.platform.store.interning.StringInterningView
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-
-import java.util.Timer
+import java.util.{Timer, concurrent}
 import java.util.concurrent.Executors
+
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
@@ -76,7 +76,24 @@ object ParallelIndexerFactory {
             // The life-cycle of such connections matches the life-cycle of a protectedExecution
             dataSource = dataSourceStorageBackend.createDataSource(dbConfig.dataSourceConfig)
           } yield HaCoordinator.databaseLockBasedHaCoordinator(
-            connectionFactory = () => dataSource.getConnection,
+            mainConnectionFactory = () => {
+              val connection = dataSource.getConnection
+              val directExecutor = new concurrent.Executor {
+                override def execute(command: Runnable): Unit = {
+                  // this will execute on the same thread which started the Executor.execute()
+                  command.run()
+                }
+              }
+              // direct executor is beneficial in context of main connection and network timeout:
+              // all socket/Connection closure will be happening on the thread which called the JDBC execute,
+              // instead of happening asynchronously - after error with network timeout the Connection
+              // needs to be closed anyway.
+              connection.setNetworkTimeout(
+                directExecutor,
+                haConfig.mainLockCheckerJdbcNetworkTimeoutMillis,
+              )
+              connection
+            },
             storageBackend = dbLockStorageBackend,
             executionContext = executionContext,
             timer = timer,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ha/HaCoordinatorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/ha/HaCoordinatorSpec.scala
@@ -793,7 +793,7 @@ class HaCoordinatorSpec
 
     val protectedHandle = HaCoordinator
       .databaseLockBasedHaCoordinator(
-        connectionFactory = connectionFactory,
+        mainConnectionFactory = connectionFactory,
         storageBackend = dbLock,
         executionContext = system.dispatcher,
         timer = timer,


### PR DESCRIPTION
* Adds explicit network timeout to main lock acquisition calls.
* Adds mainLockCheckerJdbcNetworkTimeoutMillis configuration with default

[CHANGELOG_BEGIN]
Fixes issue: network problems can cause indexer to stop working until restarting the application.
[CHANGELOG_END]

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
