### PR TITLE
[engine] small cleanups in PartialTransaction

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -364,7 +364,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
       time: Time.Timestamp,
   ): Result[(SubmittedTransaction, Tx.Metadata)] = machine.withOnLedger("Daml Engine") { onLedger =>
     def detailMsg = Some(
-      s"Last location: ${Pretty.prettyLoc(machine.lastLocation).render(80)}, partial transaction: ${onLedger.ptxInternal.nodesToString}"
+      s"Last location: ${Pretty.prettyLoc(machine.lastLocation).render(80)}, partial transaction: ${onLedger.nodesToString}"
     )
     def versionDisclosedContract(d: speedy.DisclosedContract): Versioned[DisclosedContract] = {
       val version = machine.tmplId2TxVersion(d.templateId)
@@ -439,7 +439,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
         deps(tx).flatMap { deps =>
           val meta = Tx.Metadata(
             submissionSeed = None,
-            submissionTime = onLedger.ptxInternal.submissionTime,
+            submissionTime = machine.submissionTime,
             usedPackages = deps,
             dependsOnTime = onLedger.dependsOnTime,
             nodeSeeds = nodeSeeds,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -943,6 +943,7 @@ private[lf] object SBuiltin {
       }
       val (coid, newPtx) = onLedger.ptx
         .insertCreate(
+          submissionTime = machine.submissionTime,
           templateId = cached.templateId,
           arg = createArgValue,
           agreementText = agreement,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -138,8 +138,8 @@ private[lf] object Speedy {
         SVisibleToStakeholders.fromSubmitters(committers, readAs)
       }
     private[lf] def finish: PartialTransaction.Result = ptx.finish
-    private[lf] def ptxInternal: PartialTransaction = ptx // deprecated
     private[lf] def incompleteTransaction: IncompleteTransaction = ptx.finishIncomplete
+    private[lf] def nodesToString: String = ptx.nodesToString
 
     private[speedy] def updateCachedContracts(cid: V.ContractId, contract: CachedContract): Unit = {
       enforceLimit(
@@ -311,6 +311,7 @@ private[lf] object Speedy {
          Triggers. It is safe to use on ledger for off ledger code but
          not the other way around.
        */
+      val submissionTime: Time.Timestamp,
       val ledgerMode: LedgerMode,
       val disclosureTable: DisclosureTable,
   ) {
@@ -922,12 +923,12 @@ private[lf] object Speedy {
         envBase = 0,
         kontStack = initialKontStack(),
         lastLocation = None,
+        submissionTime = submissionTime,
         ledgerMode = OnLedger(
           validating = validating,
           ptx = PartialTransaction
             .initial(
               contractKeyUniqueness,
-              submissionTime,
               initialSeeding,
               committers,
               disclosedContracts,
@@ -1045,6 +1046,7 @@ private[lf] object Speedy {
         envBase = 0,
         kontStack = initialKontStack(),
         lastLocation = None,
+        submissionTime = Time.Timestamp.Epoch,
         ledgerMode = OffLedger,
         traceLog = traceLog,
         warningLog = warningLog,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/InitialSeeding.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/InitialSeeding.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import com.daml.lf.data.ImmArray
+
+private[lf] sealed abstract class InitialSeeding extends Product with Serializable
+
+private[lf] object InitialSeeding {
+  // NoSeed may be used to initialize machines that are not intended to create transactions
+  // e.g. trigger and script runners, tests
+  final case object NoSeed extends InitialSeeding
+  final case class TransactionSeed(seed: crypto.Hash) extends InitialSeeding
+  final case class RootNodeSeeds(seeds: ImmArray[Option[crypto.Hash]]) extends InitialSeeding
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -173,12 +173,10 @@ private[lf] object PartialTransaction {
 
   def initial(
       contractKeyUniqueness: ContractKeyUniquenessMode,
-      submissionTime: Time.Timestamp,
       initialSeeds: InitialSeeding,
       committers: Set[Party],
       disclosedContracts: ImmArray[DisclosedContract],
   ) = PartialTransaction(
-    submissionTime = submissionTime,
     nextNodeIdx = 0,
     nodes = HashMap.empty,
     actionNodeSeeds = BackStack.empty,
@@ -230,7 +228,6 @@ private[lf] object PartialTransaction {
   *   @param disclosedContracts contracts that have been explicitly disclosed
   */
 private[speedy] case class PartialTransaction(
-    submissionTime: Time.Timestamp,
     nextNodeIdx: Int,
     nodes: HashMap[NodeId, Node],
     actionNodeSeeds: BackStack[crypto.Hash],
@@ -350,6 +347,7 @@ private[speedy] case class PartialTransaction(
     * contract instance.
     */
   def insertCreate(
+      submissionTime: Time.Timestamp,
       templateId: Ref.Identifier,
       arg: Value,
       agreementText: String,
@@ -707,14 +705,4 @@ private[speedy] case class PartialTransaction(
     go(this)
   }
 
-}
-
-private[lf] sealed abstract class InitialSeeding extends Product with Serializable
-
-private[lf] object InitialSeeding {
-  // NoSeed may be used to initialize machines that are not intended to create transactions
-  // e.g. trigger and script runners, tests
-  final case object NoSeed extends InitialSeeding
-  final case class TransactionSeed(seed: crypto.Hash) extends InitialSeeding
-  final case class RootNodeSeeds(seeds: ImmArray[Option[crypto.Hash]]) extends InitialSeeding
 }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -24,7 +24,6 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
   private[this] val initialState = PartialTransaction.initial(
     ContractKeyUniquenessMode.Strict,
-    data.Time.Timestamp.Epoch,
     InitialSeeding.TransactionSeed(transactionSeed),
     committers,
     ImmArray.Empty,
@@ -44,6 +43,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
     def insertCreate_ : PartialTransaction =
       ptx
         .insertCreate(
+          submissionTime = data.Time.Timestamp.Epoch,
           templateId = templateId,
           arg = Value.ValueUnit,
           agreementText = "agreement",

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -410,7 +410,7 @@ object ScenarioRunner {
     def go(): SubmissionResult[R] = {
       ledgerMachine.run() match {
         case SResult.SResultFinalValue(resultValue) =>
-          onLedger.ptxInternal.finish match {
+          onLedger.finish match {
             case PartialTransaction.CompleteTransaction(tx, locationInfo, _, _, _) =>
               ledger.commit(committers, readAs, location, enrich(tx), locationInfo) match {
                 case Left(err) =>


### PR DESCRIPTION
Small cleanup to `PartialTransaction`
- move `submissionTime` field out into enclosing execution Machine (passing as needed to `insertCreate`)
- remove deprecated `ptxInternal`  in `Speedy.OnLedger`
- move `InitialSeeding` class to own file
