### PR TITLE
[engine] Cleanup boundary between Machine and PartialTransaction

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -941,10 +941,8 @@ private[lf] object SBuiltin {
             IE.CreateEmptyContractKeyMaintainers(cached.templateId, createArgValue, key)
           )
       }
-      val auth = machine.auth
       val (coid, newPtx) = onLedger.ptx
         .insertCreate(
-          auth = auth,
           templateId = cached.templateId,
           arg = createArgValue,
           agreementText = agreement,
@@ -1000,11 +998,9 @@ private[lf] object SBuiltin {
       val obsrs = extractParties(NameOf.qualifiedNameOfCurrentFunc, args.get(3))
       onLedger.enforceChoiceObserversLimit(obsrs, coid, templateId, choiceId, chosenValue)
       val mbKey = cached.key
-      val auth = machine.auth
 
       onLedger.ptx = onLedger.ptx
         .beginExercises(
-          auth = auth,
           targetId = coid,
           templateId = templateId,
           interfaceId = interfaceId,
@@ -1341,17 +1337,12 @@ private[lf] object SBuiltin {
       val signatories = cached.signatories
       val observers = cached.observers
       val key = cached.key
-      val stakeholders = observers union signatories
-      val contextActors = machine.contextActors
-      val auth = machine.auth
       onLedger.ptx = onLedger.ptx.insertFetch(
-        auth = auth,
         coid = coid,
         templateId = templateId,
         optLocation = machine.lastLocation,
-        actingParties = contextActors intersect stakeholders,
         signatories = signatories,
-        stakeholders = stakeholders,
+        observers = observers,
         key = key,
         byKey = byKey,
         version = machine.tmplId2TxVersion(templateId),
@@ -1387,9 +1378,7 @@ private[lf] object SBuiltin {
           }
         case _ => crash(s"Non option value when inserting lookup node")
       }
-      val auth = machine.auth
       onLedger.ptx = onLedger.ptx.insertLookup(
-        auth = auth,
         templateId = templateId,
         optLocation = machine.lastLocation,
         key = Node.KeyWithMaintainers(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -10,7 +10,6 @@ import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
 import com.daml.lf.interpretation.{Error => IError}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{LookupError, Util => AstUtil}
-import com.daml.lf.ledger.Authorize
 import com.daml.lf.speedy.Compiler.{CompilationError, PackageNotFound}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
@@ -478,13 +477,6 @@ private[lf] object Speedy {
       }
       s.result()
     }
-
-    private[lf] def contextActors: Set[Party] =
-      withOnLedger("ptx") { onLedger =>
-        onLedger.ptx.context.info.authorizers
-      }
-
-    private[lf] def auth: Authorize = Authorize(this.contextActors)
 
     /** Reuse an existing speedy machine to evaluate a new expression.
       *      Do not use if the machine is partway though an existing evaluation.

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -5,7 +5,6 @@ package com.daml.lf
 package speedy
 
 import com.daml.lf.data.ImmArray
-import com.daml.lf.ledger.Authorize
 import com.daml.lf.speedy.PartialTransaction._
 import com.daml.lf.speedy.SValue.{SValue => _, _}
 import com.daml.lf.transaction.{ContractKeyUniquenessMode, Node, TransactionVersion}
@@ -21,7 +20,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   private[this] val choiceId = data.Ref.Name.assertFromString("choice")
   private[this] val cid = Value.ContractId.V1(crypto.Hash.hashPrivateKey("My contract"))
   private[this] val party = data.Ref.Party.assertFromString("Alice")
-  private[this] val committers: Set[data.Ref.Party] = Set.empty
+  private[this] val committers: Set[data.Ref.Party] = Set(party)
 
   private[this] val initialState = PartialTransaction.initial(
     ContractKeyUniquenessMode.Strict,
@@ -45,7 +44,6 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
     def insertCreate_ : PartialTransaction =
       ptx
         .insertCreate(
-          auth = Authorize(Set(party)),
           templateId = templateId,
           arg = Value.ValueUnit,
           agreementText = "agreement",
@@ -59,7 +57,6 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
     def beginExercises_ : PartialTransaction =
       ptx.beginExercises(
-        auth = Authorize(Set(party)),
         targetId = cid,
         templateId = templateId,
         interfaceId = None,


### PR DESCRIPTION
Avoid code in `Machine` digging into `PartialTransaction` for `auth` info, only to pass that info back to `PartialTransaction` via `insertCreate` and friends.
