### PR TITLE
use defaultSandboxPorts for assistant defaults

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -466,10 +466,10 @@ commandParser = subparser $ fold
 
     cantonReplOpt = do
         host <- option str (long "host" <> value "127.0.0.1")
-        ledgerApi <- option auto (long "port" <> value 6865)
-        adminApi <- option auto (long "admin-api-port" <> value 6866)
-        domainPublicApi <- option auto (long "domain-public-port" <> value 6867)
-        domainAdminApi <- option auto (long "domain-admin-port" <> value 6868)
+        ledgerApi <- option auto (long "port" <> value (ledger defaultSandboxPorts))
+        adminApi <- option auto (long "admin-api-port" <> value (admin defaultSandboxPorts))
+        domainPublicApi <- option auto (long "domain-public-port" <> value (domainPublic defaultSandboxPorts))
+        domainAdminApi <- option auto (long "domain-admin-port" <> value (domainAdmin defaultSandboxPorts))
         pure $ CantonReplOptions
             [ CantonReplParticipant
                 { crpName = "sandbox"


### PR DESCRIPTION
This is already done just a few lines earlier in the same file; we consistently remove the magic numbers.