### PR TITLE
[engine] Transmit completed transaction via SResultFinalValue.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -432,16 +432,6 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
     }
 
     finalValue match {
-
-      case SResultFinalValue(_, None) =>
-        return ResultError(
-          Error.Interpretation.Internal(
-            NameOf.qualifiedNameOfCurrentFunc,
-            s"unexpected final value with missing transaction",
-            None,
-          )
-        )
-
       case SResultFinalValue(
             _,
             Some(
@@ -472,6 +462,14 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
           }
           ResultDone((tx, meta))
         }
+      case SResultFinalValue(_, None) =>
+        ResultError(
+          Error.Interpretation.Internal(
+            NameOf.qualifiedNameOfCurrentFunc,
+            "Interpretation error: completed transaction expected",
+            None,
+          )
+        )
     }
   }
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -375,12 +375,12 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
     }
 
     var finished: Boolean = false
-    var finalValue: SResultFinalValue = null
+    var finalValue: SResultFinal = null
 
     while (!finished) {
       machine.run() match {
 
-        case fv: SResultFinalValue =>
+        case fv: SResultFinal =>
           finished = true
           finalValue = fv
 
@@ -432,7 +432,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
     }
 
     finalValue match {
-      case SResultFinalValue(
+      case SResultFinal(
             _,
             Some(
               PartialTransaction.Result(
@@ -462,7 +462,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
           }
           ResultDone((tx, meta))
         }
-      case SResultFinalValue(_, None) =>
+      case SResultFinal(_, None) =>
         ResultError(
           Error.Interpretation.Internal(
             NameOf.qualifiedNameOfCurrentFunc,
@@ -543,7 +543,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
   )(implicit loggingContext: LoggingContext): Result[Versioned[Value]] = {
     def interpret(machine: Machine): Result[SValue] = {
       machine.run() match {
-        case SResultFinalValue(v, _) => ResultDone(v)
+        case SResultFinal(v, _) => ResultDone(v)
         case SResultError(err) => handleError(err, None)
         case err @ (_: SResultNeedPackage | _: SResultNeedContract | _: SResultNeedKey |
             _: SResultNeedTime | _: SResultScenarioGetParty | _: SResultScenarioPassTime |

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -73,7 +73,7 @@ object PlaySpeedy {
     println(s"example name: $name")
 
     machine.run() match {
-      case SResultFinalValue(value) =>
+      case SResultFinalValue(value, _) =>
         println(s"final-value: $value")
         value match {
           case SInt64(got) =>

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -73,7 +73,7 @@ object PlaySpeedy {
     println(s"example name: $name")
 
     machine.run() match {
-      case SResultFinalValue(value, _) =>
+      case SResultFinal(value, _) =>
         println(s"final-value: $value")
         value match {
           case SInt64(got) =>

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -103,7 +103,7 @@ object PlaySpeedy {
     val result: SValue = {
       println("Run...")
       machine.run() match {
-        case SResultFinalValue(value) => value
+        case SResultFinalValue(value, _) => value
         case res => throw new MachineProblem(s"Unexpected result from machine $res")
       }
     }

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -103,7 +103,7 @@ object PlaySpeedy {
     val result: SValue = {
       println("Run...")
       machine.run() match {
-        case SResultFinalValue(value, _) => value
+        case SResultFinal(value, _) => value
         case res => throw new MachineProblem(s"Unexpected result from machine $res")
       }
     }

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -42,7 +42,7 @@ object LoadDarFunction extends App {
       val machine = Machine.fromPureSExpr(compiledPackages, expr)
 
       machine.run() match {
-        case SResultFinalValue(SInt64(result), _) => result
+        case SResultFinal(SInt64(result), _) => result
         case res => throw new RuntimeException(s"Unexpected result from machine $res")
       }
     }

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -42,7 +42,7 @@ object LoadDarFunction extends App {
       val machine = Machine.fromPureSExpr(compiledPackages, expr)
 
       machine.run() match {
-        case SResultFinalValue(SInt64(result)) => result
+        case SResultFinalValue(SInt64(result), _) => result
         case res => throw new RuntimeException(s"Unexpected result from machine $res")
       }
     }

--- a/daml-lf/interpreter/src/bench/com/daml/lf/interpreter/StructProjBench.scala
+++ b/daml-lf/interpreter/src/bench/com/daml/lf/interpreter/StructProjBench.scala
@@ -64,7 +64,7 @@ class StructProjBench {
   def bench(): SValue = {
     val machine = Speedy.Machine.fromPureSExpr(compiledPackages, sexpr)
     machine.run() match {
-      case SResult.SResultFinalValue(v) =>
+      case SResult.SResultFinalValue(v, _) =>
         v
       case otherwise =>
         throw new UnknownError(otherwise.toString)

--- a/daml-lf/interpreter/src/bench/com/daml/lf/interpreter/StructProjBench.scala
+++ b/daml-lf/interpreter/src/bench/com/daml/lf/interpreter/StructProjBench.scala
@@ -64,7 +64,7 @@ class StructProjBench {
   def bench(): SValue = {
     val machine = Speedy.Machine.fromPureSExpr(compiledPackages, sexpr)
     machine.run() match {
-      case SResult.SResultFinalValue(v, _) =>
+      case SResult.SResultFinal(v, _) =>
         v
       case otherwise =>
         throw new UnknownError(otherwise.toString)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -20,8 +20,11 @@ sealed abstract class SResult extends Product with Serializable
 object SResult {
   final case class SResultError(err: SError) extends SResult
 
-  /** The speedy machine has completed evaluation to reach a final value. */
-  final case class SResultFinalValue(v: SValue) extends SResult
+  /** The speedy machine has completed evaluation to reach a final value.
+    * And, if the evaluation was on-ledger, a completed transaction.
+    */
+  final case class SResultFinalValue(v: SValue, tx: Option[PartialTransaction.Result])
+      extends SResult
 
   /** Update or scenario interpretation requires the current
     * ledger time.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -23,8 +23,7 @@ object SResult {
   /** The speedy machine has completed evaluation to reach a final value.
     * And, if the evaluation was on-ledger, a completed transaction.
     */
-  final case class SResultFinalValue(v: SValue, tx: Option[PartialTransaction.Result])
-      extends SResult
+  final case class SResultFinal(v: SValue, tx: Option[PartialTransaction.Result]) extends SResult
 
   /** Update or scenario interpretation requires the current
     * ledger time.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -524,10 +524,10 @@ private[lf] object Speedy {
         case SpeedyComplete(value: SValue) =>
           if (enableInstrumentation) track.print()
           ledgerMode match {
-            case OffLedger => SResultFinalValue(value, None)
+            case OffLedger => SResultFinal(value, None)
             case onLedger: OnLedger =>
               val ctx = onLedger.ptx.finish
-              SResultFinalValue(value, Some(ctx))
+              SResultFinal(value, Some(ctx))
           }
         case serr: SError =>
           SResultError(serr)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -519,6 +519,8 @@ private[lf] object Speedy {
         }
         loop()
       } catch {
+        case SpeedyHungry(res: SResult) =>
+          res
         case SpeedyComplete(value: SValue) =>
           if (enableInstrumentation) track.print()
           ledgerMode match {
@@ -527,9 +529,6 @@ private[lf] object Speedy {
               val ctx = onLedger.ptx.finish
               SResultFinalValue(value, Some(ctx))
           }
-
-        case SpeedyHungry(res: SResult) =>
-          res
         case serr: SError =>
           SResultError(serr)
         case ex: RuntimeException =>
@@ -1644,17 +1643,13 @@ private[lf] object Speedy {
     */
   private[speedy] final case class SpeedyHungry(result: SResult)
       extends RuntimeException
-      with NoStackTrace {
-    override def toString = s"SpeedyHungry($result)"
-  }
+      with NoStackTrace
 
   /** Internal exception thrown when execution has reached a final value.
     */
   private[speedy] final case class SpeedyComplete(value: SValue)
       extends RuntimeException
-      with NoStackTrace {
-    override def toString = s"SpeedyComplete($value)"
-  }
+      with NoStackTrace
 
   private[speedy] def deriveTransactionSeed(
       submissionSeed: crypto.Hash,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -204,8 +204,7 @@ private[lf] object PartialTransaction {
       seeds: NodeSeeds,
       globalKeyMapping: Map[GlobalKey, KeyMapping],
       disclosedContracts: ImmArray[DisclosedContract],
-  ) extends Product
-      with Serializable
+  )
 }
 
 /** A transaction under construction
@@ -325,7 +324,10 @@ private[speedy] case class PartialTransaction(
           disclosedContracts,
         )
       case _ =>
-        sys.error("ptx.finish: expected RootContextInfo")
+        InternalError.runtimeException(
+          NameOf.qualifiedNameOfCurrentFunc,
+          "ptx.finish: expected RootContextInfo",
+        )
     }
 
   // construct an IncompleteTransaction from the partial-transaction

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -241,7 +241,8 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
       ("expression", "expected"),
       ("M:innerCatch", 377),
       ("M:outerCatch", 188),
-      // ("M:throwWhileInnerHandlerDecides", 188), // NICK: unclosed TryContextInfo
+      // TODO https://github.com/digital-asset/daml/issues/14431
+      // ("M:throwWhileInnerHandlerDecides", 188),
     )
 
     forEvery(testCases) { (exp: String, num: Long) =>
@@ -310,7 +311,8 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
       ("expression", "expected"),
       ("M:maybeInnerCatch True False", 1377),
       ("M:maybeInnerCatch False False", 1188),
-      // ("M:maybeInnerCatch False True", 2188), // NICK: unclosed TryContextInfo
+      // TODO https://github.com/digital-asset/daml/issues/14431
+      // ("M:maybeInnerCatch False True", 2188),
     )
 
     forEvery(testCases) { (exp: String, num: Long) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -9,7 +9,7 @@ import com.daml.lf.data.Ref.{PackageId, Party}
 import com.daml.lf.interpretation.{Error => IE}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{LanguageVersion, StablePackage}
-import com.daml.lf.speedy.SResult.{SResultError, SResultFinalValue}
+import com.daml.lf.speedy.SResult.{SResultError, SResultFinal}
 import com.daml.lf.speedy.SError.{SError, SErrorDamlException}
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue.{SParty, SUnit}
@@ -126,7 +126,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinalValue(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -163,7 +163,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinalValue(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -247,7 +247,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinalValue(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -317,7 +317,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinalValue(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -389,7 +389,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, num: Long) =>
       s"eval[$exp] --> $num" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinalValue(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
           v shouldBe SValue.SInt64(num)
         }
       }
@@ -470,7 +470,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
 
     forEvery(testCases) { (exp: String, str: String) =>
       s"eval[$exp] --> $str" in {
-        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinalValue(v, _) =>
+        inside(runUpdateExpr(pkgs)(e"$exp")) { case SResultFinal(v, _) =>
           v shouldBe SValue.SText(str)
         }
       }
@@ -532,7 +532,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
           .fromUpdateSExpr(pkgs, transactionSeed, applyToParty(pkgs, expr, party), Set(party))
           .run()
         if (caught)
-          inside(res) { case SResultFinalValue(SUnit, _) =>
+          inside(res) { case SResultFinal(SUnit, _) =>
           }
         else
           inside(res) { case SResultError(SErrorDamlException(err)) =>
@@ -553,7 +553,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
       val res = Speedy.Machine
         .fromUpdateSExpr(pkgs, transactionSeed, applyToParty(pkgs, example, party), Set(party))
         .run()
-      inside(res) { case SResultFinalValue(SUnit, _) =>
+      inside(res) { case SResultFinal(SUnit, _) =>
       }
     }
 
@@ -761,7 +761,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
     "create rollback when old contacts are not within try-catch context" in {
       val res =
         Speedy.Machine.fromUpdateSExpr(pkgs, transactionSeed, causeRollback, Set(party)).run()
-      inside(res) { case SResultFinalValue(SUnit, _) =>
+      inside(res) { case SResultFinal(SUnit, _) =>
       }
     }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -29,7 +29,7 @@ class InterpreterTest extends AnyWordSpec with Inside with Matchers with TableDr
   private def runExpr(e: Expr): SValue = {
     val machine = Speedy.Machine.fromPureExpr(PureCompiledPackages.Empty, e)
     machine.run() match {
-      case SResultFinalValue(v, _) => v
+      case SResultFinal(v, _) => v
       case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
     }
   }
@@ -138,7 +138,7 @@ class InterpreterTest extends AnyWordSpec with Inside with Matchers with TableDr
     }
     "interpret" in {
       val value = machine.run() match {
-        case SResultFinalValue(v, _) => v
+        case SResultFinal(v, _) => v
         case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }
       value match {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -29,7 +29,7 @@ class InterpreterTest extends AnyWordSpec with Inside with Matchers with TableDr
   private def runExpr(e: Expr): SValue = {
     val machine = Speedy.Machine.fromPureExpr(PureCompiledPackages.Empty, e)
     machine.run() match {
-      case SResultFinalValue(v) => v
+      case SResultFinalValue(v, _) => v
       case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
     }
   }
@@ -138,7 +138,7 @@ class InterpreterTest extends AnyWordSpec with Inside with Matchers with TableDr
     }
     "interpret" in {
       val value = machine.run() match {
-        case SResultFinalValue(v) => v
+        case SResultFinalValue(v, _) => v
         case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }
       value match {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -5,7 +5,7 @@ package com.daml.lf
 package speedy
 
 import com.daml.lf.data.ImmArray
-import com.daml.lf.speedy.PartialTransaction._
+import com.daml.lf.speedy.PartialTransaction
 import com.daml.lf.speedy.SValue.{SValue => _, _}
 import com.daml.lf.transaction.{ContractKeyUniquenessMode, Node, TransactionVersion}
 import com.daml.lf.value.Value
@@ -30,11 +30,12 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
   )
 
   private[this] def contractIdsInOrder(ptx: PartialTransaction): Seq[Value.ContractId] = {
-    inside(ptx.finish) { case CompleteTransaction(tx, _, _, _, _) =>
-      tx.fold(Vector.empty[Value.ContractId]) {
-        case (acc, (_, create: Node.Create)) => acc :+ create.coid
-        case (acc, _) => acc
-      }
+    ptx.finish match {
+      case PartialTransaction.Result(tx, _, _, _, _) =>
+        tx.fold(Vector.empty[Value.ContractId]) {
+          case (acc, (_, create: Node.Create)) => acc :+ create.coid
+          case (acc, _) => acc
+        }
     }
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
@@ -6,7 +6,6 @@ package speedy
 
 import com.daml.lf.data._
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.PartialTransaction._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SResult._
@@ -74,16 +73,10 @@ class ProfilerTest extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
       Speedy.Machine.fromUpdateSExpr(compiledPackages, transactionSeed, example, Set(party))
     val res = machine.run()
     res match {
-      case _: SResultFinalValue =>
-        machine.withOnLedger("RollbackTest") { onLedger =>
-          onLedger.ptx.finish match {
-            case IncompleteTransaction(_) =>
-              sys.error("unexpected IncompleteTransaction")
-            case CompleteTransaction(_, _, _, _, _) =>
-              machine.profile.events.asScala.toList.map(ev => (ev.open, ev.rawLabel))
-          }
-        }
-      case _ => sys.error(s"Unexpected res: $res")
+      case SResultFinalValue(_, _) =>
+        machine.profile.events.asScala.toList.map(ev => (ev.open, ev.rawLabel))
+      case _ =>
+        sys.error(s"Unexpected res: $res")
     }
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
@@ -73,7 +73,7 @@ class ProfilerTest extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
       Speedy.Machine.fromUpdateSExpr(compiledPackages, transactionSeed, example, Set(party))
     val res = machine.run()
     res match {
-      case SResultFinalValue(_, Some(_)) =>
+      case SResultFinal(_, Some(_)) =>
         machine.profile.events.asScala.toList.map(ev => (ev.open, ev.rawLabel))
       case _ =>
         sys.error(s"Unexpected res: $res")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ProfilerTest.scala
@@ -73,7 +73,7 @@ class ProfilerTest extends AnyWordSpec with Matchers with ScalaCheckDrivenProper
       Speedy.Machine.fromUpdateSExpr(compiledPackages, transactionSeed, example, Set(party))
     val res = machine.run()
     res match {
-      case SResultFinalValue(_, _) =>
+      case SResultFinalValue(_, Some(_)) =>
         machine.profile.events.asScala.toList.map(ev => (ev.open, ev.rawLabel))
       case _ =>
         sys.error(s"Unexpected res: $res")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -43,8 +43,23 @@ private[speedy] object SpeedyTestLib {
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
       getTime: PartialFunction[Unit, Time.Timestamp] = PartialFunction.empty,
   ): Either[SError.SError, SValue] = {
+    runTx(machine, getPkg, getContract, getKey, getTime) match {
+      case Left(e) => Left(e)
+      case Right(SResultFinalValue(v, _)) => Right(v)
+    }
+  }
+
+  @throws[SError.SErrorCrash]
+  def runTx(
+      machine: Speedy.Machine,
+      getPkg: PartialFunction[PackageId, CompiledPackages] = PartialFunction.empty,
+      getContract: PartialFunction[Value.ContractId, Value.VersionedContractInstance] =
+        PartialFunction.empty,
+      getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
+      getTime: PartialFunction[Unit, Time.Timestamp] = PartialFunction.empty,
+  ): Either[SError.SError, SResultFinalValue] = {
     @tailrec
-    def loop: Either[SError.SError, SValue] = {
+    def loop: Either[SError.SError, SResultFinalValue] = {
       machine.run() match {
         case SResultNeedTime(callback) =>
           getTime.lift(()) match {
@@ -73,11 +88,12 @@ private[speedy] object SpeedyTestLib {
         case SResultNeedKey(key, _, callback) =>
           discard(callback(getKey.lift(key)))
           loop
-        case SResultFinalValue(v) =>
-          Right(v)
+        case fv: SResultFinalValue =>
+          Right(fv)
         case SResultError(err) =>
           Left(err)
-        case _: SResultScenarioGetParty | _: SResultScenarioPassTime | _: SResultScenarioSubmit =>
+        case _: SResultFinalValue | _: SResultScenarioGetParty | _: SResultScenarioPassTime |
+            _: SResultScenarioSubmit =>
           throw UnexpectedSResultScenarioX
       }
     }
@@ -94,15 +110,13 @@ private[speedy] object SpeedyTestLib {
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
       getTime: PartialFunction[Unit, Time.Timestamp] = PartialFunction.empty,
   ): Either[SError.SError, SubmittedTransaction] =
-    run(machine, getPkg, getContract, getKey, getTime) match {
-      case Right(_) =>
-        machine.withOnLedger("buildTransaction") { onLedger =>
-          onLedger.ptx.finish match {
-            case PartialTransaction.IncompleteTransaction(_) =>
-              throw SError.SErrorCrash("buildTransaction", "unexpected IncompleteTransaction")
-            case PartialTransaction.CompleteTransaction(tx, _, _, _, _) =>
-              Right(tx)
-          }
+    runTx(machine, getPkg, getContract, getKey, getTime) match {
+      case Right(SResultFinalValue(_, None)) =>
+        sys.error("buildTransaction expects to be run on-ledger")
+      case Right(SResultFinalValue(_, Some(ctx))) =>
+        ctx match {
+          case PartialTransaction.Result(tx, _, _, _, _) =>
+            Right(tx)
         }
       case Left(err) =>
         Left(err)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -112,7 +112,7 @@ private[speedy] object SpeedyTestLib {
   ): Either[SError.SError, SubmittedTransaction] =
     runTx(machine, getPkg, getContract, getKey, getTime) match {
       case Right(SResultFinalValue(_, None)) =>
-        sys.error("buildTransaction expects to be run on-ledger")
+        throw SError.SErrorCrash("buildTransaction", "unexpected missing transaction")
       case Right(SResultFinalValue(_, Some(ctx))) =>
         ctx match {
           case PartialTransaction.Result(tx, _, _, _, _) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -45,7 +45,7 @@ private[speedy] object SpeedyTestLib {
   ): Either[SError.SError, SValue] = {
     runTx(machine, getPkg, getContract, getKey, getTime) match {
       case Left(e) => Left(e)
-      case Right(SResultFinalValue(v, _)) => Right(v)
+      case Right(SResultFinal(v, _)) => Right(v)
     }
   }
 
@@ -57,9 +57,9 @@ private[speedy] object SpeedyTestLib {
         PartialFunction.empty,
       getKey: PartialFunction[GlobalKeyWithMaintainers, Value.ContractId] = PartialFunction.empty,
       getTime: PartialFunction[Unit, Time.Timestamp] = PartialFunction.empty,
-  ): Either[SError.SError, SResultFinalValue] = {
+  ): Either[SError.SError, SResultFinal] = {
     @tailrec
-    def loop: Either[SError.SError, SResultFinalValue] = {
+    def loop: Either[SError.SError, SResultFinal] = {
       machine.run() match {
         case SResultNeedTime(callback) =>
           getTime.lift(()) match {
@@ -88,11 +88,11 @@ private[speedy] object SpeedyTestLib {
         case SResultNeedKey(key, _, callback) =>
           discard(callback(getKey.lift(key)))
           loop
-        case fv: SResultFinalValue =>
+        case fv: SResultFinal =>
           Right(fv)
         case SResultError(err) =>
           Left(err)
-        case _: SResultFinalValue | _: SResultScenarioGetParty | _: SResultScenarioPassTime |
+        case _: SResultFinal | _: SResultScenarioGetParty | _: SResultScenarioPassTime |
             _: SResultScenarioSubmit =>
           throw UnexpectedSResultScenarioX
       }
@@ -111,9 +111,9 @@ private[speedy] object SpeedyTestLib {
       getTime: PartialFunction[Unit, Time.Timestamp] = PartialFunction.empty,
   ): Either[SError.SError, SubmittedTransaction] =
     runTx(machine, getPkg, getContract, getKey, getTime) match {
-      case Right(SResultFinalValue(_, None)) =>
+      case Right(SResultFinal(_, None)) =>
         throw SError.SErrorCrash("buildTransaction", "unexpected missing transaction")
-      case Right(SResultFinalValue(_, Some(ctx))) =>
+      case Right(SResultFinal(_, Some(ctx))) =>
         ctx match {
           case PartialTransaction.Result(tx, _, _, _, _) =>
             Right(tx)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
@@ -128,7 +128,7 @@ class TailCallTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     }
     // run the machine
     machine.run() match {
-      case SResultFinalValue(v) => v
+      case SResultFinalValue(v, _) => v
       case res => crash(s"runExpr, unexpected result $res")
     }
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/TailCallTest.scala
@@ -7,7 +7,7 @@ package speedy
 import java.util
 
 import com.daml.lf.language.Ast
-import com.daml.lf.speedy.SResult.SResultFinalValue
+import com.daml.lf.speedy.SResult.SResultFinal
 import com.daml.lf.testing.parser.Implicits._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
@@ -128,7 +128,7 @@ class TailCallTest extends AnyWordSpec with Matchers with TableDrivenPropertyChe
     }
     // run the machine
     machine.run() match {
-      case SResultFinalValue(v, _) => v
+      case SResultFinal(v, _) => v
       case res => crash(s"runExpr, unexpected result $res")
     }
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -193,7 +193,7 @@ class OrderingSpec
     )
 
     machine.run() match {
-      case SResultFinalValue(value) => value
+      case SResultFinalValue(value, _) => value
       case _ => throw new Error(s"error while translating value $v")
     }
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -193,7 +193,7 @@ class OrderingSpec
     )
 
     machine.run() match {
-      case SResultFinalValue(value, _) => value
+      case SResultFinal(value, _) => value
       case _ => throw new Error(s"error while translating value $v")
     }
   }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -477,7 +477,7 @@ object Repl {
               case SResultError(err) =>
                 println(prettyError(err).render(128))
                 None
-              case SResultFinalValue(v) =>
+              case SResultFinalValue(v, _) =>
                 Some(v)
               case other =>
                 sys.error("unimplemented callback: " + other.toString)

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -477,7 +477,7 @@ object Repl {
               case SResultError(err) =>
                 println(prettyError(err).render(128))
                 None
-              case SResultFinalValue(v, _) =>
+              case SResultFinal(v, _) =>
                 Some(v)
               case other =>
                 sys.error("unimplemented callback: " + other.toString)

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -409,8 +409,6 @@ object ScenarioRunner {
     @tailrec
     def go(): SubmissionResult[R] = {
       ledgerMachine.run() match {
-        case SResult.SResultFinalValue(_, None) =>
-          crash("SResultFinalValue(_, None)")
         case SResult.SResultFinalValue(resultValue, Some(ctx)) =>
           ctx match {
             case PartialTransaction.Result(tx, locationInfo, _, _, _) =>
@@ -421,6 +419,8 @@ object ScenarioRunner {
                   Commit(r, resultValue, enrich(onLedger.incompleteTransaction))
               }
           }
+        case SResult.SResultFinalValue(_, None) =>
+          throw new RuntimeException(s"Unexpected missing transaction")
         case SResultError(err) =>
           SubmissionError(Error.RunnerException(err), enrich(onLedger.incompleteTransaction))
         case SResultNeedContract(coid, committers, callback) =>

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -49,7 +49,7 @@ final class ScenarioRunner private (
       steps += 1 // this counts the number of external `Need` interactions
       val res: SResult = machine.run()
       res match {
-        case SResultFinalValue(v, _) =>
+        case SResultFinal(v, _) =>
           finalValue = v
 
         case SResultError(err) =>
@@ -409,7 +409,7 @@ object ScenarioRunner {
     @tailrec
     def go(): SubmissionResult[R] = {
       ledgerMachine.run() match {
-        case SResult.SResultFinalValue(resultValue, Some(ctx)) =>
+        case SResult.SResultFinal(resultValue, Some(ctx)) =>
           ctx match {
             case PartialTransaction.Result(tx, locationInfo, _, _, _) =>
               ledger.commit(committers, readAs, location, enrich(tx), locationInfo) match {
@@ -419,7 +419,7 @@ object ScenarioRunner {
                   Commit(r, resultValue, enrich(onLedger.incompleteTransaction))
               }
           }
-        case SResult.SResultFinalValue(_, None) =>
+        case SResult.SResultFinal(_, None) =>
           throw new RuntimeException(s"Unexpected missing transaction")
         case SResultError(err) =>
           SubmissionError(Error.RunnerException(err), enrich(onLedger.incompleteTransaction))

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -49,7 +49,7 @@ final class ScenarioRunner private (
       steps += 1 // this counts the number of external `Need` interactions
       val res: SResult = machine.run()
       res match {
-        case SResultFinalValue(v) =>
+        case SResultFinalValue(v, _) =>
           finalValue = v
 
         case SResultError(err) =>
@@ -409,17 +409,17 @@ object ScenarioRunner {
     @tailrec
     def go(): SubmissionResult[R] = {
       ledgerMachine.run() match {
-        case SResult.SResultFinalValue(resultValue) =>
-          onLedger.finish match {
-            case PartialTransaction.CompleteTransaction(tx, locationInfo, _, _, _) =>
+        case SResult.SResultFinalValue(_, None) =>
+          crash("SResultFinalValue(_, None)")
+        case SResult.SResultFinalValue(resultValue, Some(ctx)) =>
+          ctx match {
+            case PartialTransaction.Result(tx, locationInfo, _, _, _) =>
               ledger.commit(committers, readAs, location, enrich(tx), locationInfo) match {
                 case Left(err) =>
                   SubmissionError(err, enrich(onLedger.incompleteTransaction))
                 case Right(r) =>
                   Commit(r, resultValue, enrich(onLedger.incompleteTransaction))
               }
-            case PartialTransaction.IncompleteTransaction(ptx) =>
-              throw new RuntimeException(s"Unexpected abort: $ptx")
           }
         case SResultError(err) =>
           SubmissionError(Error.RunnerException(err), enrich(onLedger.incompleteTransaction))

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -101,7 +101,7 @@ class CollectAuthorityState {
           }
         case SResultNeedContract(_, _, _) =>
           crash("Off-ledger need contract callback")
-        case SResultFinalValue(v, _) => finalValue = v
+        case SResultFinal(v, _) => finalValue = v
         case r => crash(s"bench run: unexpected result from speedy: ${r}")
       }
     }
@@ -145,7 +145,7 @@ class CollectAuthorityState {
               cachedContract ++= api.cachedContract
               step = api.step
           }
-        case SResultFinalValue(v, _) =>
+        case SResultFinal(v, _) =>
           finalValue = v
         case r =>
           crash(s"setup run: unexpected result from speedy: ${r}")

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -101,7 +101,7 @@ class CollectAuthorityState {
           }
         case SResultNeedContract(_, _, _) =>
           crash("Off-ledger need contract callback")
-        case SResultFinalValue(v) => finalValue = v
+        case SResultFinalValue(v, _) => finalValue = v
         case r => crash(s"bench run: unexpected result from speedy: ${r}")
       }
     }
@@ -145,7 +145,7 @@ class CollectAuthorityState {
               cachedContract ++= api.cachedContract
               step = api.step
           }
-        case SResultFinalValue(v) =>
+        case SResultFinalValue(v, _) =>
           finalValue = v
         case r =>
           crash(s"setup run: unexpected result from speedy: ${r}")

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -345,7 +345,7 @@ object Converter {
         Script.DummyLoggingContext
       )
     machine.run() match {
-      case SResultFinalValue(v, _) =>
+      case SResultFinal(v, _) =>
         v match {
           case SStruct(_, values) if values.size == 2 =>
             Right((values.get(fstOutputIdx), values.get(sndOutputIdx)))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -345,7 +345,7 @@ object Converter {
         Script.DummyLoggingContext
       )
     machine.run() match {
-      case SResultFinalValue(v) =>
+      case SResultFinalValue(v, _) =>
         v match {
           case SStruct(_, values) if values.size == 2 =>
             Right((values.get(fstOutputIdx), values.get(sndOutputIdx)))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -437,7 +437,7 @@ private[lf] class Runner(
 
     def stepToValue(): Either[RuntimeException, SValue] =
       machine.run() match {
-        case SResultFinalValue(v) =>
+        case SResultFinalValue(v, _) =>
           Right(v)
         case SResultError(err) =>
           Left(Runner.InterpretationError(err))

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -437,7 +437,7 @@ private[lf] class Runner(
 
     def stepToValue(): Either[RuntimeException, SValue] =
       machine.run() match {
-        case SResultFinalValue(v, _) =>
+        case SResultFinal(v, _) =>
           Right(v)
         case SResultError(err) =>
           Left(Runner.InterpretationError(err))

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -82,7 +82,7 @@ object Machine extends StrictLogging {
   // Run speedy until we arrive at a value.
   def stepToValue(machine: Speedy.Machine): SValue = {
     machine.run() match {
-      case SResultFinalValue(v) => v
+      case SResultFinalValue(v, _) => v
       case SResultError(err) => {
         logger.error(Pretty.prettyError(err).render(80))
         throw err

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -82,7 +82,7 @@ object Machine extends StrictLogging {
   // Run speedy until we arrive at a value.
   def stepToValue(machine: Speedy.Machine): SValue = {
     machine.run() match {
-      case SResultFinalValue(v, _) => v
+      case SResultFinal(v, _) => v
       case SResultError(err) => {
         logger.error(Pretty.prettyError(err).render(80))
         throw err


### PR DESCRIPTION
Refactor to transmit completed transaction along with final `SValue` inside `SResultFinalValue`.

- extend `SResultFinalValue` to transmit completed transaction
- remove `OnLedger.finish`
- distinguish `SpeedyComplete` from `SpeedyHungry`
- remove need for `PartialTransaction.IncompletedTransaction`
- `PartialTransaction.finish` is now `private[speedy]`

During this refactor, the following issue/bug was discovered: https://github.com/digital-asset/daml/issues/14431
