### PR TITLE
Java bindings interface id blind booleans

### DIFF
--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
@@ -76,7 +76,7 @@ public class ExercisedEvent implements TreeEvent {
   }
 
   public boolean hasInterfaceId() {
-    return interfaceId == null;
+    return interfaceId != null;
   }
 
   public Identifier getInterfaceId() {
@@ -199,8 +199,8 @@ public class ExercisedEvent implements TreeEvent {
         exercisedEvent.getEventId(),
         Identifier.fromProto(exercisedEvent.getTemplateId()),
         (exercisedEvent.hasInterfaceId()
-            ? null
-            : Identifier.fromProto(exercisedEvent.getInterfaceId())),
+            ? Identifier.fromProto(exercisedEvent.getInterfaceId())
+            : null),
         exercisedEvent.getContractId(),
         exercisedEvent.getChoice(),
         Value.fromProto(exercisedEvent.getChoiceArgument()),

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
@@ -20,6 +20,11 @@ class EventSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyC
     Event.fromProtoEvent(converted.toProtoEvent) shouldEqual converted
   }
 
+  "ExercisedEvent.fromProto" should "roundtrip with protoc" in forAll(exercisedEventGen) { event =>
+    val converted = ExercisedEvent fromProto event
+    ExercisedEvent fromProto converted.toProto shouldEqual converted
+  }
+
   "CreatedEvents" should "be protected from mutations of the parameters" in forAll(
     createdEventGen
   ) { e =>


### PR DESCRIPTION
Fix a likely regression in 2.3.0 with #13660.

I confirmed that the added test will not pass unless both of the boolean flips here are made.

```rst
CHANGELOG_BEGIN
- [Java bindings] Fix a regression found in 2.3.0 RC with the
  introduction of interface IDs in ``ExercisedEvent``s.
CHANGELOG_END
```