### PR TITLE
docker: bump base image

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -83,8 +83,6 @@ jobs:
               echo "Building version ${version#v}..."
               git checkout "$version"
               cd ci/docker/daml-sdk
-              # The internet changed from under us: 11 now means 11-jammy, and curl breaks
-              sed -i '1s/^FROM eclipse-temurin:11$/FROM eclipse-temurin:11-focal/' Dockerfile
               docker build -t digitalasset/daml-sdk:${version#v} --build-arg VERSION=${version#v} .
               git checkout Dockerfile
               # Despite the name not suggesting it at all, this actually signs

--- a/ci/docker/daml-sdk/Dockerfile
+++ b/ci/docker/daml-sdk/Dockerfile
@@ -1,4 +1,7 @@
-FROM eclipse-temurin:11-focal
+FROM ubuntu:kinetic
+RUN apt-get update \
+ && apt-get install -y curl openjdk-11-jre-headless \
+ && rm -rf /var/lib/apt/lists/*
 ARG VERSION
 # This is needed to get the DNS requests
 # from Haskell binaries to succeed.


### PR DESCRIPTION
CHANGELOG_BEGIN

- The base image used by the `digital-asset/daml-sdk` Docker image has
  been bumped from Ubuntu Focal to Ubuntu Kinetic. Please remember that
  this image is meant for demonstration purposes only and is not supported
  for use in any kind of production setup.

CHANGELOG_END

Fixes #14430 by getting us to OpenSSL `3.0.4-1ubuntu1`.