### PR TITLE
Update LF AST protobuf for interface viewtype and implementation view

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -932,6 +932,7 @@ data TemplateImplements = TemplateImplements
   { tpiInterface :: !(Qualified TypeConName)
     -- ^ Interface name for implementation.
   , tpiMethods :: !(NM.NameMap TemplateImplementsMethod)
+  , tpiView :: !Expr
   }
   deriving (Eq, Data, Generic, NFData, Show)
 
@@ -962,6 +963,7 @@ data DefInterface = DefInterface
   , intMethods :: !(NM.NameMap InterfaceMethod)
   , intPrecondition :: !Expr
   , intCoImplements :: !(NM.NameMap InterfaceCoImplements)
+  , intView :: !Type
   }
   deriving (Eq, Data, Generic, NFData, Show)
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -79,9 +79,10 @@ templateExpr f (Template loc tpl param precond signatories observers agreement c
   <*> (NM.traverse . templateImplementsExpr) f implements
 
 templateImplementsExpr :: Traversal' TemplateImplements Expr
-templateImplementsExpr f (TemplateImplements iface methods) =
+templateImplementsExpr f (TemplateImplements iface methods view) =
   TemplateImplements iface
     <$> (NM.traverse . templateImplementsMethodExpr) f methods
+    <*> f view
 
 templateImplementsMethodExpr :: Traversal' TemplateImplementsMethod Expr
 templateImplementsMethodExpr f (TemplateImplementsMethod name body) =

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -634,7 +634,7 @@ pPrintTemplate lvl modName (Template mbLoc tpl param precond signatories observe
       implementsDoc = map (pPrintTemplateImplements lvl) (NM.toList implements)
 
 pPrintTemplateImplements :: PrettyLevel -> TemplateImplements -> Doc ann
-pPrintTemplateImplements lvl (TemplateImplements name methods)
+pPrintTemplateImplements lvl (TemplateImplements name methods _)
   | NM.null methods = keyword_ "implements" <-> pPrintPrec lvl 0 name
   | otherwise = vcat $
       [ keyword_ "implements" <-> pPrintPrec lvl 0 name

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -242,6 +242,7 @@ decodeDefInterface LF1.DefInterface {..} = do
   intMethods <- decodeNM DuplicateMethod decodeInterfaceMethod defInterfaceMethods
   intPrecondition <- mayDecode "defInterfacePrecond" defInterfacePrecond decodeExpr
   intCoImplements <- decodeNM DuplicateCoImplements decodeInterfaceCoImplements defInterfaceCoImplements
+  intView <- mayDecode "defInterfaceView" defInterfaceView decodeType
   pure DefInterface {..}
 
 decodeInterfaceMethod :: LF1.InterfaceMethod -> Decode InterfaceMethod
@@ -342,6 +343,7 @@ decodeDefTemplateImplements :: LF1.DefTemplate_Implements -> Decode TemplateImpl
 decodeDefTemplateImplements LF1.DefTemplate_Implements{..} = TemplateImplements
   <$> mayDecode "defTemplate_ImplementsInterface" defTemplate_ImplementsInterface decodeTypeConName
   <*> decodeNM DuplicateMethod decodeDefTemplateImplementsMethod defTemplate_ImplementsMethods
+  <*> mayDecode "defTemplate_ImplementsView" defTemplate_ImplementsView decodeExpr
 
 decodeDefTemplateImplementsMethod :: LF1.DefTemplate_ImplementsMethod -> Decode TemplateImplementsMethod
 decodeDefTemplateImplementsMethod LF1.DefTemplate_ImplementsMethod{..} = TemplateImplementsMethod

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -952,6 +952,7 @@ encodeTemplateImplements :: TemplateImplements -> Encode P.DefTemplate_Implement
 encodeTemplateImplements TemplateImplements{..} = do
     defTemplate_ImplementsInterface <- encodeQualTypeConName tpiInterface
     defTemplate_ImplementsMethods <- encodeNameMap encodeTemplateImplementsMethod tpiMethods
+    defTemplate_ImplementsView <- encodeExpr tpiView
     pure P.DefTemplate_Implements {..}
 
 encodeTemplateImplementsMethod :: TemplateImplementsMethod -> Encode P.DefTemplate_ImplementsMethod
@@ -1021,6 +1022,7 @@ encodeDefInterface DefInterface{..} = do
     defInterfacePrecond <- encodeExpr intPrecondition
     defInterfaceChoices <- encodeNameMap encodeTemplateChoice intChoices
     defInterfaceCoImplements <- encodeNameMap encodeInterfaceCoImplements intCoImplements
+    defInterfaceView <- encodeType intView
     pure $ P.DefInterface{..}
 
 encodeInterfaceMethod :: InterfaceMethod -> Encode P.InterfaceMethod

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -1539,6 +1539,7 @@ message DefTemplate {
   message Implements {
     TypeConName interface = 1;
     repeated ImplementsMethod methods = 2;
+    Expr view = 3; // *Available in versions >= 1.dev*
   }
 
   // The type constructor for the template, acting as both
@@ -1629,6 +1630,9 @@ message DefInterface {
 
   // Templates which this interface co-implements.
   repeated CoImplements coImplements = 8; // *Available in versions >= 1.dev*
+
+  // View type for this interface
+  Type view = 9; // *Available in versions >= 1.dev*
 }
 
 // Exception definition

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -602,6 +602,7 @@ private[archive] class DecodeV1(minor: LV.Minor) {
       TemplateImplements.build(
         interfaceId = decodeTypeConName(lfImpl.getInterface),
         methods = lfImpl.getMethodsList.asScala.view.map(decodeTemplateImplementsMethod),
+        view = decodeExpr(lfImpl.getView, "TemplateImplements.view"),
       )
 
     private[this] def decodeTemplateImplementsMethod(
@@ -668,7 +669,9 @@ private[archive] class DecodeV1(minor: LV.Minor) {
         choices = lfInterface.getChoicesList.asScala.view.map(decodeChoice(id, _)),
         methods = lfInterface.getMethodsList.asScala.view.map(decodeInterfaceMethod),
         precond = decodeExpr(lfInterface.getPrecond, s"$id:ensure"),
-        coImplements = lfInterface.getCoImplementsList.asScala.view.map(decodeInterfaceCoImplements),
+        coImplements =
+          lfInterface.getCoImplementsList.asScala.view.map(decodeInterfaceCoImplements),
+        view = decodeType(lfInterface.getView),
       )
 
     private[this] def decodeInterfaceMethod(

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -31,6 +31,8 @@ import com.daml.lf.language.Ast.{
   GenTemplateImplements,
   PCUnit,
   PLRoundingMode,
+  TBuiltin,
+  BTUnit,
 }
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{Inside, OptionValues}
@@ -1000,6 +1002,7 @@ class DecodeV1Spec
                 .assertFromString("noPkgId:Mod:Mod.I") -> GenTemplateImplements[EPrimCon](
                 Ref.TypeConName.assertFromString("noPkgId:Mod:Mod.I"),
                 Map(),
+                EPrimCon(PCUnit),
               )
             ),
           )
@@ -1062,6 +1065,7 @@ class DecodeV1Spec
                 Map(),
                 EPrimCon(PCUnit),
                 Map(),
+                TBuiltin(BTUnit),
               )
           ),
           FeatureFlags(),
@@ -1106,6 +1110,7 @@ class DecodeV1Spec
           Map(),
           EPrimCon(PCUnit),
           Map(),
+          TBuiltin(BTUnit),
         )
 
       val requiresDefInterface = {
@@ -1135,6 +1140,7 @@ class DecodeV1Spec
           Map(),
           EPrimCon(PCUnit),
           Map(),
+          TBuiltin(BTUnit),
         )
 
       val methodsDefInterface = {
@@ -1167,6 +1173,7 @@ class DecodeV1Spec
           ),
           EPrimCon(PCUnit),
           Map(),
+          TBuiltin(BTUnit),
         )
       }
 
@@ -1185,6 +1192,7 @@ class DecodeV1Spec
           Map(),
           EPrimCon(PCUnit),
           Map(),
+          TBuiltin(BTUnit),
         )
 
       val interfaceDefTestCases = {

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -803,6 +803,7 @@ private[daml] class EncodeV1(minor: LV.Minor) {
       builder.accumulateLeft(interface.requires)(_ addRequires _)
       builder.setPrecond(interface.precond)
       builder.accumulateLeft(interface.coImplements.sortByKey)(_ addCoImplements _)
+      builder.setView(interface.view)
       builder.build()
     }
 
@@ -921,6 +922,7 @@ private[daml] class EncodeV1(minor: LV.Minor) {
       val b = PLF.DefTemplate.Implements.newBuilder()
       b.setInterface(interface)
       b.accumulateLeft(implements.methods.sortByKey)(_ addMethods _)
+      b.setView(implements.view)
       b.build()
     }
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -705,6 +705,7 @@ object Ast {
       coImplements: Map[TypeConName, GenInterfaceCoImplements[
         E
       ]],
+      view: Type,
   )
 
   final class GenDefInterfaceCompanion[E] {
@@ -716,6 +717,7 @@ object Ast {
         methods: Iterable[InterfaceMethod],
         precond: E,
         coImplements: Iterable[GenInterfaceCoImplements[E]],
+        view: Type,
     ): GenDefInterface[E] = {
       val requiresSet = toSetWithoutDuplicate(
         requires,
@@ -734,7 +736,7 @@ object Ast {
         (templateId: TypeConName) =>
           PackageError(s"repeated interface co-implementation ${templateId.toString}"),
       )
-      GenDefInterface(requiresSet, param, choiceMap, methodMap, precond, coImplementsMap)
+      GenDefInterface(requiresSet, param, choiceMap, methodMap, precond, coImplementsMap, view)
     }
 
     def apply(
@@ -744,8 +746,9 @@ object Ast {
         methods: Map[MethodName, InterfaceMethod],
         precond: E,
         coImplements: Map[TypeConName, GenInterfaceCoImplements[E]],
+        view: Type,
     ): GenDefInterface[E] =
-      GenDefInterface(requires, param, choices, methods, precond, coImplements)
+      GenDefInterface(requires, param, choices, methods, precond, coImplements, view)
 
     def unapply(arg: GenDefInterface[E]): Some[
       (
@@ -755,9 +758,12 @@ object Ast {
           Map[MethodName, InterfaceMethod],
           E,
           Map[TypeConName, GenInterfaceCoImplements[E]],
+          Type,
       )
     ] =
-      Some((arg.requires, arg.param, arg.choices, arg.methods, arg.precond, arg.coImplements))
+      Some(
+        (arg.requires, arg.param, arg.choices, arg.methods, arg.precond, arg.coImplements, arg.view)
+      )
   }
 
   type DefInterface = GenDefInterface[Expr]
@@ -982,6 +988,7 @@ object Ast {
   final case class GenTemplateImplements[E](
       interfaceId: TypeConName,
       methods: Map[MethodName, GenTemplateImplementsMethod[E]],
+      view: E,
   )
 
   final class GenTemplateImplementsCompanion[E] private[Ast] {
@@ -989,6 +996,7 @@ object Ast {
     def build(
         interfaceId: TypeConName,
         methods: Iterable[GenTemplateImplementsMethod[E]],
+        view: E,
     ): GenTemplateImplements[E] =
       new GenTemplateImplements[E](
         interfaceId = interfaceId,
@@ -996,18 +1004,20 @@ object Ast {
           methods.map(m => m.name -> m),
           (name: MethodName) => PackageError(s"repeated method implementation $name"),
         ),
+        view,
       )
 
     def apply(
         interfaceId: TypeConName,
         methods: Map[MethodName, GenTemplateImplementsMethod[E]],
+        view: E,
     ): GenTemplateImplements[E] =
-      new GenTemplateImplements[E](interfaceId, methods)
+      new GenTemplateImplements[E](interfaceId, methods, view)
 
     def unapply(
         arg: GenTemplateImplements[E]
-    ): Some[(TypeConName, Map[MethodName, GenTemplateImplementsMethod[E]])] =
-      Some((arg.interfaceId, arg.methods))
+    ): Some[(TypeConName, Map[MethodName, GenTemplateImplementsMethod[E]], E)] =
+      Some((arg.interfaceId, arg.methods, arg.view))
   }
 
   type TemplateImplements = GenTemplateImplements[Expr]

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Util.scala
@@ -222,10 +222,11 @@ object Util {
 
   private[this] def toSignature(implements: TemplateImplements): TemplateImplementsSignature =
     implements match {
-      case TemplateImplements(name, methods) =>
+      case TemplateImplements(name, methods, _) =>
         TemplateImplementsSignature(
           name,
           methods.transform((_, v) => toSignature(v)),
+          (),
         )
     }
 
@@ -265,7 +266,7 @@ object Util {
 
   private def toSignature(interface: DefInterface): DefInterfaceSignature =
     interface match {
-      case DefInterface(requires, param, choices, methods, _, coImplements) =>
+      case DefInterface(requires, param, choices, methods, _, coImplements, view) =>
         DefInterfaceSignature(
           requires,
           param,
@@ -273,6 +274,7 @@ object Util {
           methods,
           (),
           coImplements.transform((_, v) => toSignature(v)),
+          view,
         )
     }
 

--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
@@ -68,6 +68,7 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
       methods = Map.empty,
       requires = Set.empty,
       coImplements = Map.empty,
+      view = TBuiltin(BTUnit),
     )
 
     def exception = DefException(
@@ -383,6 +384,7 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
         methods = List(ifaceMethod1, ifaceMethod2),
         precond = ETrue,
         coImplements = List.empty,
+        view = TBuiltin(BTUnit),
       )
     }
 
@@ -399,6 +401,7 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
           methods = List.empty,
           precond = ETrue,
           coImplements = List.empty,
+          view = TBuiltin(BTUnit),
         )
       )
     }
@@ -412,6 +415,7 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
           methods = List(ifaceMethod1, ifaceMethod1),
           precond = ETrue,
           coImplements = List.empty,
+          view = TBuiltin(BTUnit),
         )
       )
     }
@@ -424,6 +428,7 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
         methods = List(ifaceMethod1, ifaceMethod2),
         precond = ETrue,
         coImplements = List(ifaceCoImpl1, ifaceCoImpl2),
+        view = TBuiltin(BTUnit),
       )
 
       a[PackageError] shouldBe thrownBy(
@@ -434,6 +439,7 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
           methods = List(ifaceMethod1, ifaceMethod2),
           precond = ETrue,
           coImplements = List(ifaceCoImpl1, ifaceCoImpl1),
+          view = TBuiltin(BTUnit),
         )
       )
     }
@@ -447,10 +453,20 @@ class AstSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
   private val ifaceImpl1 = TemplateImplements(
     interfaceId = TypeConName.assertFromString("pkgId:Mod:I1"),
     methods = Map.empty,
+    view = EAbs(
+      (Name.assertFromString("this"), TBuiltin(BTUnit)),
+      EPrimCon(PCUnit),
+      None,
+    ),
   )
   private val ifaceImpl2 = TemplateImplements(
     interfaceId = TypeConName.assertFromString("pkgId:Mod:I2"),
     methods = Map.empty,
+    view = EAbs(
+      (Name.assertFromString("this"), TBuiltin(BTUnit)),
+      EPrimCon(PCUnit),
+      None,
+    ),
   )
   private val ifaceCoImpl1 = InterfaceCoImplements(
     templateId = TypeConName.assertFromString("pkgId:Mod:T1"),

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -307,10 +307,12 @@ private[daml] class AstRewriter(
       case TemplateImplements(
             interface,
             methods,
+            view,
           ) =>
         TemplateImplements(
           apply(interface),
           methods.transform((_, x) => apply(x)),
+          apply(view),
         )
     }
   def apply(x: TemplateImplementsMethod): TemplateImplementsMethod =
@@ -367,7 +369,7 @@ private[daml] class AstRewriter(
 
   def apply(x: DefInterface): DefInterface =
     x match {
-      case DefInterface(requires, param, choices, methods, precond, coImplements) =>
+      case DefInterface(requires, param, choices, methods, precond, coImplements, view) =>
         DefInterface(
           requires.map(apply(_)),
           param,
@@ -375,6 +377,7 @@ private[daml] class AstRewriter(
           methods.transform((_, v) => apply(v)),
           apply(precond),
           coImplements.map { case (t, x) => (apply(t), apply(x)) },
+          apply(view),
         )
     }
 }

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -130,7 +130,12 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
   private lazy val implements: Parser[TemplateImplements] =
     Id("implements") ~>! fullIdentifier ~ (`{` ~> rep(method <~ `;`) <~ `}`) ^^ {
       case ifaceId ~ methods =>
-        TemplateImplements.build(ifaceId, methods)
+        // TODO: Represent a view method and parse it. Currently hardcoding views to unit
+        TemplateImplements.build(
+          ifaceId,
+          methods,
+          EAbs((Ref.Name.assertFromString("this"), TBuiltin(BTUnit)), EPrimCon(PCUnit), None),
+        )
     }
 
   private lazy val templateDefinition: Parser[TemplDef] =
@@ -212,7 +217,16 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
             coImplements =>
           IfaceDef(
             tycon,
-            DefInterface.build(Set.from(requires), x, choices, methods, precond, coImplements),
+            // TODO: Represent view type and parse it. Currently hardcoding view types to unit
+            DefInterface.build(
+              Set.from(requires),
+              x,
+              choices,
+              methods,
+              precond,
+              coImplements,
+              TBuiltin(BTUnit),
+            ),
           )
       }
   private val interfaceRequires: Parser[Ref.TypeConName] =

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -660,6 +660,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
                   n"age" -> TemplateImplementsMethod(n"age", e"42"),
                   n"alive" -> TemplateImplementsMethod(n"alive", e"True"),
                 ),
+                EAbs((Name.assertFromString("this"), TBuiltin(BTUnit)), EPrimCon(PCUnit), None),
               ),
             referenceable -> TemplateImplements(
               referenceable,
@@ -669,6 +670,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
                   e""""123e4567-e89b-12d3-a456-426614174000"""",
                 )
               ),
+              EAbs((Name.assertFromString("this"), TBuiltin(BTUnit)), EPrimCon(PCUnit), None),
             ),
           ),
         )
@@ -852,6 +854,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
                 ),
               )
           ),
+          view = TBuiltin(BTUnit),
         )
 
       val person = DottedName.assertFromString("Person")

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -463,7 +463,7 @@ private[validation] object Typing {
 
     private[Typing] def checkDefIface(ifaceName: TypeConName, iface: DefInterface): Unit =
       iface match {
-        case DefInterface(requires, param, choices, methods, precond, coImplements) =>
+        case DefInterface(requires, param, choices, methods, precond, coImplements, _) =>
           val env = introExprVar(param, TTyCon(ifaceName))
           if (requires(ifaceName))
             throw ECircularInterfaceRequires(ctx, ifaceName)
@@ -491,7 +491,7 @@ private[validation] object Typing {
         ifaceTcon: TypeConName,
         implMethods: List[(MethodName, Expr)],
     ): Unit = {
-      val DefInterfaceSignature(requires, _, _, methods, _, _) =
+      val DefInterfaceSignature(requires, _, _, methods, _, _, _) =
         handleLookup(ctx, pkgInterface.lookupInterface(ifaceTcon))
 
       requires

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/ExprIterable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/ExprIterable.scala
@@ -194,8 +194,10 @@ private[validation] object ExprIterable {
       case TemplateImplements(
             interface @ _,
             methods,
+            view,
           ) =>
-        methods.values.iterator.flatMap(iterator(_))
+        methods.values.iterator.flatMap(iterator(_)) ++
+          iterator(view)
     }
 
   private[iterable] def iterator(x: TemplateImplementsMethod): Iterator[Expr] =
@@ -221,6 +223,7 @@ private[validation] object ExprIterable {
             methods @ _,
             precond,
             coImplements,
+            view @ _,
           ) =>
         Iterator(precond) ++ choices.values.iterator.flatMap(iterator(_)) ++
           coImplements.values.iterator.flatMap(iterator(_))

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
@@ -244,7 +244,7 @@ private[validation] object TypeIterable {
 
   private[validation] def iterator(impl: TemplateImplements): Iterator[Type] =
     impl match {
-      case TemplateImplements(interface, methods) =>
+      case TemplateImplements(interface, methods, view @ _) =>
         Iterator(TTyCon(interface)) ++
           methods.values.flatMap(iterator(_))
     }
@@ -270,12 +270,13 @@ private[validation] object TypeIterable {
 
   private[validation] def iterator(interface: DefInterface): Iterator[Type] =
     interface match {
-      case DefInterface(requires, _, choices, methods, precond, coImplements) =>
+      case DefInterface(requires, _, choices, methods, precond, coImplements, view) =>
         requires.iterator.map(TTyCon) ++
           iterator(precond) ++
           choices.values.iterator.flatMap(iterator) ++
           methods.values.iterator.flatMap(iterator) ++
-          coImplements.values.flatMap(iterator)
+          coImplements.values.flatMap(iterator) ++
+          iterator(view)
     }
 
   private[validation] def iterator(imethod: InterfaceMethod): Iterator[Type] =


### PR DESCRIPTION
Update LF AST protobuf for interface viewtype and implementation view - not currently linked to the syntax-level changes, all stubbed out in LFConversion.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
