### PR TITLE
daily: disable http/pg perf test

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -174,8 +174,8 @@ jobs:
     timeoutInMinutes: 120
     strategy:
       matrix:
-        postgres:
-          querystore: postgres
+        #postgres:
+        #  querystore: postgres
         oracle:
           querystore: oracle
     pool:


### PR DESCRIPTION
Since yesterday, this test is failing with an OOM error. I hoped I'd have time to investigate today, but since I didn't and I'm off next week disabling the test for now seems like the best option to let the overall daily tests succeed.

The last known success was on 0bf28176a7cfb6accccbde8c0efcd8970832d1de, and the first failure was on 444fff1fcff405eb2a958ff751176e89e439f21d. We don't test every commit, so any commit in-between could be the cause  of the issue.

Note that the failure does not seem to be flaky, but further testing may be warranted.

CHANGELOG_BEGIN
CHANGELOG_END