### PR TITLE
cron: do not checkout version Dockerfile

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -81,10 +81,10 @@ jobs:
               echo "${version#v} already exists, skipping."
             else
               echo "Building version ${version#v}..."
-              git checkout "$version"
+              #git checkout "$version"
               cd ci/docker/daml-sdk
               docker build -t digitalasset/daml-sdk:${version#v} --build-arg VERSION=${version#v} .
-              git checkout Dockerfile
+              #git checkout Dockerfile
               # Despite the name not suggesting it at all, this actually signs
               # _and pushes_ the image; see
               # https://docs.docker.com/engine/security/trust/#signing-images-with-docker-content-trust


### PR DESCRIPTION
So that the Docker image file depends on when the image was created
rather than the branch. I think that makes more sense overall, but we
need this to include the OpenSSL bump into 2.3.1.

CHANGELOG_BEGIN
CHANGELOG_END