### PR TITLE
[engine] Fix handling for throw within handler

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -2010,6 +2010,33 @@ class EngineTest
         case Left(Interpretation(DamlException(interpretation.Error.ContractNotFound(_)), _)) =>
       }
     }
+    "ThrowInHandler" in {
+      val command = ApiCommand.CreateAndExercise(
+        tId,
+        ValueRecord(None, ImmArray((None, ValueParty(party)))),
+        "ThrowInHandler",
+        ValueRecord(None, ImmArray.empty),
+      )
+      run(command) shouldBe a[Right[_, _]]
+    }
+    "ThrowPureInHandler" in {
+      val command = ApiCommand.CreateAndExercise(
+        tId,
+        ValueRecord(None, ImmArray((None, ValueParty(party)))),
+        "ThrowPureInHandler",
+        ValueRecord(None, ImmArray.empty),
+      )
+      run(command) shouldBe a[Right[_, _]]
+    }
+    "ThrowPureInHandlerPattern" in {
+      val command = ApiCommand.CreateAndExercise(
+        tId,
+        ValueRecord(None, ImmArray((None, ValueParty(party)))),
+        "ThrowPureInHandlerPattern",
+        ValueRecord(None, ImmArray.empty),
+      )
+      run(command) shouldBe a[Right[_, _]]
+    }
   }
 
   "action node seeds" should {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1651,15 +1651,11 @@ private[lf] object SBuiltin {
       val opt = getSOptional(args, 0)
       val excep = getSAny(args, 1)
       checkToken(args, 2)
-      machine.withOnLedger("SBTryHandler") { onLedger =>
-        opt match {
-          case None =>
-            onLedger.ptx = onLedger.ptx.abortTry
-            unwindToHandler(machine, excep) // re-throw
-          case Some(handler) =>
-            onLedger.ptx = onLedger.ptx.rollbackTry(excep)
-            machine.enterApplication(handler, Array(SEValue(SToken)))
-        }
+      opt match {
+        case None =>
+          unwindToHandler(machine, excep) // re-throw
+        case Some(handler) =>
+          machine.enterApplication(handler, Array(SEValue(SToken)))
       }
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1558,6 +1558,9 @@ private[lf] object Speedy {
       } else {
         machine.popKont() match {
           case handler: KTryCatchHandler =>
+            machine.withOnLedger("unwindToHandler/KTryCatchHandler") { onLedger =>
+              onLedger.ptx = onLedger.ptx.rollbackTry(excep)
+            }
             Some(handler)
           case _: KCloseExercise =>
             machine.withOnLedger("unwindToHandler/KCloseExercise") { onLedger =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -576,7 +576,7 @@ private[speedy] case class PartialTransaction(
   }
 
   /** Open a Try context.
-    *  Must be closed by `endTry`, `abortTry`, or `rollbackTry`.
+    *  Must be closed by `endTry` or `rollbackTry`.
     */
   def beginTry: PartialTransaction = {
     val nid = NodeId(nextNodeIdx)
@@ -607,13 +607,6 @@ private[speedy] case class PartialTransaction(
           "endTry called in non-catch context",
         )
     }
-
-  /** Close abruptly a try context, due to an uncaught exception,
-    * i.e. an exception was thrown inside the context but the catch associated to the try context did not handle it.
-    * Must match a `beginTry`.
-    */
-  def abortTry: PartialTransaction =
-    endTry
 
   /** Close a try context, by catching an exception,
     * i.e. a exception was thrown inside the context, and the catch associated to the try context did handle it.
@@ -700,7 +693,7 @@ private[speedy] case class PartialTransaction(
     @tailrec
     def go(ptx: PartialTransaction): PartialTransaction = ptx.context.info match {
       case _: PartialTransaction.ExercisesContextInfo => go(ptx.abortExercises)
-      case _: PartialTransaction.TryContextInfo => go(ptx.abortTry)
+      case _: PartialTransaction.TryContextInfo => go(ptx.endTry)
       case _: PartialTransaction.RootContextInfo => ptx
     }
     go(this)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -241,8 +241,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
       ("expression", "expected"),
       ("M:innerCatch", 377),
       ("M:outerCatch", 188),
-      // TODO https://github.com/digital-asset/daml/issues/14431
-      // ("M:throwWhileInnerHandlerDecides", 188),
+      ("M:throwWhileInnerHandlerDecides", 188),
     )
 
     forEvery(testCases) { (exp: String, num: Long) =>
@@ -311,8 +310,7 @@ class ExceptionTest extends AnyWordSpec with Inside with Matchers with TableDriv
       ("expression", "expected"),
       ("M:maybeInnerCatch True False", 1377),
       ("M:maybeInnerCatch False False", 1188),
-      // TODO https://github.com/digital-asset/daml/issues/14431
-      // ("M:maybeInnerCatch False True", 2188),
+      ("M:maybeInnerCatch False True", 2188),
     )
 
     forEvery(testCases) { (exp: String, num: Long) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -157,7 +157,7 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
           .beginTry // open a second try context
           .insertCreate_ // create the contract cid_1_2
           // an exception is thrown
-          .abortTry // the second try context does not handle the exception
+          .rollbackTry_ // the second try context does not handle the exception
           .abortExercises // close abruptly the exercise due to an uncaught exception
           .rollbackTry_ // the first try context does handle the exception
           .insertCreate_ // create the contract cid_2

--- a/daml-lf/tests/Exceptions.daml
+++ b/daml-lf/tests/Exceptions.daml
@@ -4,7 +4,7 @@
 module Exceptions where
 
 import DA.Assert
-import DA.Exception (throw)
+import DA.Exception (throw,throwPure)
 
 exception E
   where
@@ -102,6 +102,33 @@ template T
           cid <- create (K p 1 "")
           throw (Ecid cid)
         catch (Ecid cid) -> archive cid
+
+    nonconsuming choice ThrowInHandler : ()
+      controller p
+      do
+        try
+          try throw E
+          catch E -> throw E
+        catch
+          E -> pure ()
+
+    nonconsuming choice ThrowPureInHandler : ()
+      controller p
+      do
+        try
+          try throw E
+          catch E -> throwPure E
+        catch
+          E -> pure ()
+
+    nonconsuming choice ThrowPureInHandlerPattern : ()
+      controller p
+      do
+        try
+          try throw E
+          catch E | throwPure E -> pure ()
+        catch
+          E -> pure ()
 
 -- This template is used to test that the
 -- engine only ever looks up a global key once.


### PR DESCRIPTION
Fix handling for throw within handler
- we remove the call to `rollbackTry` / `abortTry` from `SBTryHandler` 
- (we remove `abortTry`, an alias for `endTry` completely)
- the call to `rollbackTry` is now made from `unwindToHandler`before the handler is executed

This address issue: #14431

_observation_: It is fine to call `rollbackTry` regardless of whether a handler applies to a given exception or not. 

Because a handler which fails to match...
```
          try ...
          catch _ | False -> ...
```
should be semantically equivalent to a handler which always matches, and then rethrows.
```
          try ...
          catch e -> throw e
```
