### PR TITLE
Bump GSON dependency in the Java quickstart template

### DIFF
--- a/docs/source/app-dev/bindings-java/quickstart/template-root/pom.xml
+++ b/docs/source/app-dev/bindings-java/quickstart/template-root/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.9.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
changelog_begin
Bumped the GSON dependency in the Java quickstart template to 2.9.0 to avoid users to be exposed to https://www.cve.org/CVERecord?id=CVE-2022-25647 by mistake
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
