### PR TITLE
cron: revert docker change

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -81,10 +81,9 @@ jobs:
               echo "${version#v} already exists, skipping."
             else
               echo "Building version ${version#v}..."
-              #git checkout "$version"
+              git checkout "$version"
               cd ci/docker/daml-sdk
               docker build -t digitalasset/daml-sdk:${version#v} --build-arg VERSION=${version#v} .
-              #git checkout Dockerfile
               # Despite the name not suggesting it at all, this actually signs
               # _and pushes_ the image; see
               # https://docs.docker.com/engine/security/trust/#signing-images-with-docker-content-trust


### PR DESCRIPTION
I believe depending on main for the Dockerfile makes sense, but it's a bit of a finicky change so I can see the wisdom in not rushing it, especially since I'm on holiday and don't have my full attention here.

This should be merged _after_ the 2.3.1 Docker release has been completed (presumably around 16h Zurich time today).

CHANGELOG_BEGIN
CHANGELOG_END