### PR TITLE
ci: unpin Docker

### DIFF
--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -77,12 +77,7 @@ curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 curl -sSL https://dl.google.com/cloudagents/add-logging-agent-repo.sh | bash -s -- --also-install
 
 #install docker
-DOCKER_VERSION="5:20.10.2~3-0~ubuntu-$(lsb_release -cs)"
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-apt-key fingerprint 0EBFCD88
-add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-apt-get update
-apt-get install -qy docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io
+apt-get install -qy docker-ce docker-ce-cli containerd.io
 
 #Start docker daemon
 systemctl enable docker


### PR DESCRIPTION
When we set this up years ago (#1566), it was a way to get a more recent
Docker version than was then available through the default Ubuntu 16.04
apt repository. Nowadays, this actually makes us lag behind, to the
point where the 2.3.1 image isn't building.

CHANGELOG_BEGIN
CHANGELOG_END