### PR TITLE
[engine] improve ptx/sbuiltin interface w.r.t. abort handling

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -318,10 +318,10 @@ main =
                     , ".*"
                     , ".*"
                     , ".*"
-                    , "Partial transaction:"
+{-                    , "Partial transaction:" --NICK
                     , "  Sub-transactions:"
                     , "     0"
-                    , ".*create Test:Helper.*"
+                    , ".*create Test:Helper.*" -}
                     ]
                 expectScriptFailure rs (vr "testPartialSubmitMustFail") $ \r ->
                   matchRegex r $ T.unlines

--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -318,10 +318,10 @@ main =
                     , ".*"
                     , ".*"
                     , ".*"
-{-                    , "Partial transaction:" --NICK
+                    , "Partial transaction:"
                     , "  Sub-transactions:"
                     , "     0"
-                    , ".*create Test:Helper.*" -}
+                    , ".*create Test:Helper.*"
                     ]
                 expectScriptFailure rs (vr "testPartialSubmitMustFail") $ \r ->
                   matchRegex r $ T.unlines

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -953,13 +953,13 @@ private[lf] object SBuiltin {
           key = cached.key,
           version = machine.tmplId2TxVersion(cached.templateId),
         ) match {
-        case Left((newPtx, err)) =>
-          onLedger.ptx = newPtx // Seems wrong. But one test in ScriptService requires this.
-          throw convTxError(err)
         case Right((coid, newPtx)) =>
           onLedger.updateCachedContracts(coid, cached)
           onLedger.ptx = newPtx
           machine.returnValue = SContractId(coid)
+        case Left((newPtx, err)) =>
+          onLedger.ptx = newPtx // Seems wrong. But one test in ScriptService requires this.
+          throw convTxError(err)
       }
     }
   }
@@ -1020,10 +1020,11 @@ private[lf] object SBuiltin {
           chosenValue = chosenValue,
           version = machine.tmplId2TxVersion(templateId),
         ) match {
-        case Left(err) => throw convTxError(err)
         case Right(ptx) =>
           onLedger.ptx = ptx
           machine.returnValue = SUnit
+        case Left(err) =>
+          throw convTxError(err)
       }
     }
   }
@@ -1379,10 +1380,11 @@ private[lf] object SBuiltin {
         byKey = byKey,
         version = machine.tmplId2TxVersion(templateId),
       ) match {
-        case Left(err) => throw convTxError(err)
         case Right(ptx) =>
           onLedger.ptx = ptx
           machine.returnValue = SUnit
+        case Left(err) =>
+          throw convTxError(err)
       }
     }
   }
@@ -1423,10 +1425,11 @@ private[lf] object SBuiltin {
         result = mbCoid,
         version = machine.tmplId2TxVersion(templateId),
       ) match {
-        case Left(err) => throw convTxError(err)
         case Right(ptx) =>
           onLedger.ptx = ptx
           machine.returnValue = SV.Unit
+        case Left(err) =>
+          throw convTxError(err)
       }
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -941,7 +941,7 @@ private[lf] object SBuiltin {
             IE.CreateEmptyContractKeyMaintainers(cached.templateId, createArgValue, key)
           )
       }
-      val (coid, newPtx) = onLedger.ptx
+      onLedger.ptx
         .insertCreate(
           submissionTime = machine.submissionTime,
           templateId = cached.templateId,
@@ -952,12 +952,13 @@ private[lf] object SBuiltin {
           stakeholders = cached.stakeholders,
           key = cached.key,
           version = machine.tmplId2TxVersion(cached.templateId),
-        )
-
-      onLedger.updateCachedContracts(coid, cached)
-      onLedger.ptx = newPtx
-      checkAborted(onLedger.ptx)
-      machine.returnValue = SContractId(coid)
+        ) match {
+        case Left(err) => throw convTxError(err)
+        case Right((coid, newPtx)) =>
+          onLedger.updateCachedContracts(coid, cached)
+          onLedger.ptx = newPtx
+          machine.returnValue = SContractId(coid)
+      }
     }
   }
 
@@ -1000,7 +1001,7 @@ private[lf] object SBuiltin {
       onLedger.enforceChoiceObserversLimit(obsrs, coid, templateId, choiceId, chosenValue)
       val mbKey = cached.key
 
-      onLedger.ptx = onLedger.ptx
+      onLedger.ptx
         .beginExercises(
           targetId = coid,
           templateId = templateId,
@@ -1016,9 +1017,12 @@ private[lf] object SBuiltin {
           byKey = byKey,
           chosenValue = chosenValue,
           version = machine.tmplId2TxVersion(templateId),
-        )
-      checkAborted(onLedger.ptx)
-      machine.returnValue = SUnit
+        ) match {
+        case Left(err) => throw convTxError(err)
+        case Right(ptx) =>
+          onLedger.ptx = ptx
+          machine.returnValue = SUnit
+      }
     }
   }
 
@@ -1363,7 +1367,7 @@ private[lf] object SBuiltin {
       val signatories = cached.signatories
       val observers = cached.observers
       val key = cached.key
-      onLedger.ptx = onLedger.ptx.insertFetch(
+      onLedger.ptx.insertFetch(
         coid = coid,
         templateId = templateId,
         optLocation = machine.lastLocation,
@@ -1372,9 +1376,12 @@ private[lf] object SBuiltin {
         key = key,
         byKey = byKey,
         version = machine.tmplId2TxVersion(templateId),
-      )
-      checkAborted(onLedger.ptx)
-      machine.returnValue = SUnit
+      ) match {
+        case Left(err) => throw convTxError(err)
+        case Right(ptx) =>
+          onLedger.ptx = ptx
+          machine.returnValue = SUnit
+      }
     }
   }
 
@@ -1404,7 +1411,7 @@ private[lf] object SBuiltin {
           }
         case _ => crash(s"Non option value when inserting lookup node")
       }
-      onLedger.ptx = onLedger.ptx.insertLookup(
+      onLedger.ptx.insertLookup(
         templateId = templateId,
         optLocation = machine.lastLocation,
         key = Node.KeyWithMaintainers(
@@ -1413,9 +1420,12 @@ private[lf] object SBuiltin {
         ),
         result = mbCoid,
         version = machine.tmplId2TxVersion(templateId),
-      )
-      checkAborted(onLedger.ptx)
-      machine.returnValue = SV.Unit
+      ) match {
+        case Left(err) => throw convTxError(err)
+        case Right(ptx) =>
+          onLedger.ptx = ptx
+          machine.returnValue = SV.Unit
+      }
     }
   }
 
@@ -1934,22 +1944,14 @@ private[lf] object SBuiltin {
 
   }
 
-  // Helpers
-  //
-
-  /** Check whether the partial transaction has been aborted, and
-    * throw if so. The partial transaction abort status must be
-    * checked after every operation on it.
-    */
-  private[speedy] def checkAborted(ptx: PartialTransaction): Unit =
-    ptx.aborted match {
-      case Some(Tx.AuthFailureDuringExecution(nid, fa)) =>
-        throw SErrorDamlException(IE.FailedAuthorization(nid, fa))
-      case Some(Tx.DuplicateContractKey(key)) =>
-        throw SErrorDamlException(IE.DuplicateContractKey(key))
-      case None =>
-        ()
+  private[speedy] def convTxError(err: Tx.TransactionError): SErrorDamlException = {
+    err match {
+      case Tx.AuthFailureDuringExecution(nid, fa) =>
+        SErrorDamlException(IE.FailedAuthorization(nid, fa))
+      case Tx.DuplicateContractKey(key) =>
+        SErrorDamlException(IE.DuplicateContractKey(key))
     }
+  }
 
   private[this] def extractParties(where: String, v: SValue): TreeSet[Party] =
     v match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -953,7 +953,9 @@ private[lf] object SBuiltin {
           key = cached.key,
           version = machine.tmplId2TxVersion(cached.templateId),
         ) match {
-        case Left(err) => throw convTxError(err)
+        case Left((newPtx, err)) =>
+          onLedger.ptx = newPtx // Seems wrong. But one test in ScriptService requires this.
+          throw convTxError(err)
         case Right((coid, newPtx)) =>
           onLedger.updateCachedContracts(coid, cached)
           onLedger.ptx = newPtx

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -14,7 +14,6 @@ import com.daml.lf.speedy.Compiler.{CompilationError, PackageNotFound}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
-import com.daml.lf.speedy.SBuiltin.checkAborted
 import com.daml.lf.transaction.{
   ContractKeyUniquenessMode,
   GlobalKey,
@@ -1486,7 +1485,6 @@ private[lf] object Speedy {
     def execute(exerciseResult: SValue): Unit = {
       machine.withOnLedger("KCloseExercise") { onLedger =>
         onLedger.ptx = onLedger.ptx.endExercises(exerciseResult.toNormalizedValue)
-        checkAborted(onLedger.ptx)
       }
       machine.returnValue = exerciseResult
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/PartialTransactionSpec.scala
@@ -54,25 +54,30 @@ class PartialTransactionSpec extends AnyWordSpec with Matchers with Inside {
           key = None,
           version = TransactionVersion.maxVersion,
         )
+        .toOption
+        .get
         ._2
 
     def beginExercises_ : PartialTransaction =
-      ptx.beginExercises(
-        targetId = cid,
-        templateId = templateId,
-        interfaceId = None,
-        choiceId = choiceId,
-        optLocation = None,
-        consuming = false,
-        actingParties = Set(party),
-        signatories = Set(party),
-        stakeholders = Set.empty,
-        choiceObservers = Set.empty,
-        mbKey = None,
-        byKey = false,
-        chosenValue = Value.ValueUnit,
-        version = TransactionVersion.maxVersion,
-      )
+      ptx
+        .beginExercises(
+          targetId = cid,
+          templateId = templateId,
+          interfaceId = None,
+          choiceId = choiceId,
+          optLocation = None,
+          consuming = false,
+          actingParties = Set(party),
+          signatories = Set(party),
+          stakeholders = Set.empty,
+          choiceObservers = Set.empty,
+          mbKey = None,
+          byKey = false,
+          chosenValue = Value.ValueUnit,
+          version = TransactionVersion.maxVersion,
+        )
+        .toOption
+        .get
 
     def endExercises_ : PartialTransaction =
       ptx.endExercises(_ => Value.ValueNone)


### PR DESCRIPTION
simplify/cleanup
- remove `aborted` field of `PartialTransaction`, together with: `noteAbort`, `checkAborted`
- making the interface between `PartialTransaction` and `SBuiltin` much clearer

Note: There is one remaining strangeness. For `insertCreate`, the `ptx` field of the speedy `Machine` is updated, even in the the case that the `create` is badly authorised.

Part of #14289
