### PR TITLE
Remove scale from RST source in Daml Studio page

### DIFF
--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -117,7 +117,7 @@ contract id. The columns afterwards represent the fields of the
 contract and finally you get one column per party with an ``X`` if the
 party can see the contract or a ``-`` if not.
 
-.. image:: daml-studio/images/daml_studio_script_table.png
+.. figure:: daml-studio/images/daml_studio_script_table.png
    :alt: The table as described above, with the associated script in the left panel.
 
 If you want more details, you can click on the *Show archived* checkbox, which extends
@@ -138,7 +138,7 @@ archived ``Bank`` contract and the active ``Bank`` contract whose creation
 ``Alice`` has witnessed by virtue of being an actor on the ``exercise`` that
 created it.
 
-.. image:: daml-studio/images/daml_studio_script_table_detailed.png
+.. figure:: daml-studio/images/daml_studio_script_table_detailed.png
    :alt: The table as described above, with the associated script in the left panel. "Show archived" and "Show detailed disclosure" are now selected.
 
 If you want to see the detailed transaction graph you can click on the
@@ -149,7 +149,7 @@ fetches of contracts.
 
 For example a script for the :download:`Iou<daml-studio/daml/Iou.daml>` module looks as follows:
 
-.. image:: daml-studio/images/daml_studio_script_transaction.png
+.. figure:: daml-studio/images/daml_studio_script_transaction.png
    :alt: The graph transaction view as described above, with the associated script in the left panel.
 
    Script results

--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -117,9 +117,7 @@ contract id. The columns afterwards represent the fields of the
 contract and finally you get one column per party with an ``X`` if the
 party can see the contract or a ``-`` if not.
 
-.. figure:: daml-studio/images/daml_studio_script_table.png
-   :scale: 70%
-   :align: center
+.. image:: daml-studio/images/daml_studio_script_table.png
    :alt: The table as described above, with the associated script in the left panel.
 
 If you want more details, you can click on the *Show archived* checkbox, which extends
@@ -140,9 +138,7 @@ archived ``Bank`` contract and the active ``Bank`` contract whose creation
 ``Alice`` has witnessed by virtue of being an actor on the ``exercise`` that
 created it.
 
-.. figure:: daml-studio/images/daml_studio_script_table_detailed.png
-   :scale: 70%
-   :align: center
+.. image:: daml-studio/images/daml_studio_script_table_detailed.png
    :alt: The table as described above, with the associated script in the left panel. "Show archived" and "Show detailed disclosure" are now selected.
 
 If you want to see the detailed transaction graph you can click on the
@@ -153,9 +149,7 @@ fetches of contracts.
 
 For example a script for the :download:`Iou<daml-studio/daml/Iou.daml>` module looks as follows:
 
-.. figure:: daml-studio/images/daml_studio_script_transaction.png
-   :scale: 70%
-   :align: center
+.. image:: daml-studio/images/daml_studio_script_transaction.png
    :alt: The graph transaction view as described above, with the associated script in the left panel.
 
    Script results


### PR DESCRIPTION
changelog_begin
changelog_end

It ended up causing the images to be stretched. The formatting is taken
care of in the CSS and doesn't need to be adjusted in the RST.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
