### PR TITLE
make getInterfaceId optional

### DIFF
--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.rxjava.grpc.helpers
 
 import java.time.Instant
 import java.util
-import java.util.{Collections, Optional}
+import java.util.Collections
 
 import com.daml.ledger.javaapi.data
 import com.daml.ledger.rxjava.grpc.helpers.TransactionsServiceImpl.LedgerItem
@@ -20,6 +20,7 @@ import com.google.protobuf.timestamp.{Timestamp => ScalaTimestamp}
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
 
 @SuppressWarnings(
   Array(
@@ -206,8 +207,8 @@ object TransactionGenerator {
       javaTemplateId,
       contractId,
       javaRecord,
-      agreementText.map(Optional.of[String]).getOrElse(Optional.empty()),
-      contractKey.fold(Optional.empty[data.Value])(c => Optional.of[data.Value](c._2)),
+      agreementText.toJava,
+      contractKey.map(_._2).toJava,
       signatories.toSet.asJava,
       observers.toSet.asJava,
     ),
@@ -257,7 +258,7 @@ object TransactionGenerator {
       witnessParties.asJava,
       eventId,
       javaTemplateId,
-      javaInterfaceId.orNull,
+      javaInterfaceId.toJava,
       contractId,
       choice,
       javaChoiceArgument,

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-public class ExercisedEvent implements TreeEvent {
+public final class ExercisedEvent implements TreeEvent {
 
   private final List<String> witnessParties;
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
@@ -124,10 +124,12 @@ public class ExercisedEvent implements TreeEvent {
         && Objects.equals(witnessParties, that.witnessParties)
         && Objects.equals(eventId, that.eventId)
         && Objects.equals(templateId, that.templateId)
+        && Objects.equals(interfaceId, that.interfaceId)
         && Objects.equals(contractId, that.contractId)
         && Objects.equals(choice, that.choice)
         && Objects.equals(choiceArgument, that.choiceArgument)
         && Objects.equals(actingParties, that.actingParties)
+        && Objects.equals(childEventIds, that.childEventIds)
         && Objects.equals(exerciseResult, that.exerciseResult);
   }
 
@@ -138,10 +140,12 @@ public class ExercisedEvent implements TreeEvent {
         witnessParties,
         eventId,
         templateId,
+        interfaceId,
         contractId,
         choice,
         choiceArgument,
         actingParties,
+        childEventIds,
         consuming,
         exerciseResult);
   }
@@ -156,6 +160,8 @@ public class ExercisedEvent implements TreeEvent {
         + '\''
         + ", templateId="
         + templateId
+        + ", interfaceId="
+        + interfaceId
         + ", contractId='"
         + contractId
         + '\''

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/ExercisedEvent.java
@@ -6,6 +6,7 @@ package com.daml.ledger.javaapi.data;
 import com.daml.ledger.api.v1.EventOuterClass;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class ExercisedEvent implements TreeEvent {
@@ -16,7 +17,7 @@ public class ExercisedEvent implements TreeEvent {
 
   private final Identifier templateId;
 
-  private final Identifier interfaceId;
+  private final Optional<Identifier> interfaceId;
 
   private final String contractId;
 
@@ -36,7 +37,7 @@ public class ExercisedEvent implements TreeEvent {
       @NonNull List<@NonNull String> witnessParties,
       @NonNull String eventId,
       @NonNull Identifier templateId,
-      Identifier interfaceId,
+      @NonNull Optional<Identifier> interfaceId,
       @NonNull String contractId,
       @NonNull String choice,
       @NonNull Value choiceArgument,
@@ -75,11 +76,8 @@ public class ExercisedEvent implements TreeEvent {
     return templateId;
   }
 
-  public boolean hasInterfaceId() {
-    return interfaceId != null;
-  }
-
-  public Identifier getInterfaceId() {
+  @NonNull
+  public Optional<Identifier> getInterfaceId() {
     return interfaceId;
   }
 
@@ -185,7 +183,7 @@ public class ExercisedEvent implements TreeEvent {
     builder.setConsuming(isConsuming());
     builder.setContractId(getContractId());
     builder.setTemplateId(getTemplateId().toProto());
-    if (hasInterfaceId()) builder.setInterfaceId(getInterfaceId().toProto());
+    interfaceId.ifPresent(i -> builder.setInterfaceId(i.toProto()));
     builder.addAllActingParties(getActingParties());
     builder.addAllWitnessParties(getWitnessParties());
     builder.addAllChildEventIds(getChildEventIds());
@@ -198,9 +196,9 @@ public class ExercisedEvent implements TreeEvent {
         exercisedEvent.getWitnessPartiesList(),
         exercisedEvent.getEventId(),
         Identifier.fromProto(exercisedEvent.getTemplateId()),
-        (exercisedEvent.hasInterfaceId()
-            ? Identifier.fromProto(exercisedEvent.getInterfaceId())
-            : null),
+        exercisedEvent.hasInterfaceId()
+            ? Optional.of(Identifier.fromProto(exercisedEvent.getInterfaceId()))
+            : Optional.empty(),
         exercisedEvent.getContractId(),
         exercisedEvent.getChoice(),
         Value.fromProto(exercisedEvent.getChoiceArgument()),


### PR DESCRIPTION
Aside from changing the type of `getInterfaceId`, we also mark the class final, and fix some missing properties in the `equals`/`hashCode`/`toString` methods.

```rst
CHANGELOG_BEGIN
- [Java bindings] ``ExercisedEvent#getInterfaceId`` has a different type
  since 2.3.x, indicating its optionality.
CHANGELOG_END
```

Fixes #14483.