### PR TITLE
Add EViewInterface to LF - stub compilation/interpretation in speedy

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -284,11 +284,9 @@ alphaExpr' env = \case
     ELocation _ e1 -> \case
         ELocation _ e2 -> alphaExpr' env e1 e2
         _ -> False
-    EViewInterface iface1 template1 view1 expr1 -> \case
-        EViewInterface iface2 template2 view2 expr2
+    EViewInterface iface1 expr1 -> \case
+        EViewInterface iface2 expr2
             -> alphaTypeCon iface1 iface2
-            && alphaTypeCon template1 template2
-            && alphaType' env view1 view2
             && alphaExpr' env expr1 expr2
         _ -> False
     EExperimental n1 t1 -> \case

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -284,6 +284,13 @@ alphaExpr' env = \case
     ELocation _ e1 -> \case
         ELocation _ e2 -> alphaExpr' env e1 e2
         _ -> False
+    EViewInterface iface1 template1 view1 expr1 -> \case
+        EViewInterface iface2 template2 view2 expr2
+            -> alphaTypeCon iface1 iface2
+            && alphaTypeCon template1 template2
+            && alphaType' env view1 view2
+            && alphaExpr' env expr1 expr2
+        _ -> False
     EExperimental n1 t1 -> \case
         EExperimental n2 t2 -> n1 == n2 && alphaType t1 t2
         _ -> False

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -606,8 +606,6 @@ data Expr
   -- | Obtain an interface view
   | EViewInterface
     { viewInterfaceInterface :: !(Qualified TypeConName)
-    , viewInterfaceTemplate :: !(Qualified TypeConName)
-    , viewInterfaceViewtype :: !Type
     , viewInterfaceExpr :: !Expr
     }
   -- | Experimental Expression Hook

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -603,6 +603,13 @@ data Expr
   | EScenario !Scenario
   -- | An expression annotated with a source location.
   | ELocation !SourceLoc !Expr
+  -- | Obtain an interface view
+  | EViewInterface
+    { viewInterfaceInterface :: !(Qualified TypeConName)
+    , viewInterfaceTemplate :: !(Qualified TypeConName)
+    , viewInterfaceViewtype :: !Type
+    , viewInterfaceExpr :: !Expr
+    }
   -- | Experimental Expression Hook
   | EExperimental !T.Text !Type
   deriving (Eq, Data, Generic, NFData, Ord, Show)

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
@@ -114,6 +114,7 @@ freeVarsStep = \case
     EInterfaceTemplateTypeRepF _ e -> e
     ESignatoryInterfaceF _ e -> e
     EObserverInterfaceF _ e -> e
+    EViewInterfaceF _ _ t e -> freeVarsInType t <> e
     EExperimentalF _ t -> freeVarsInType t
 
   where

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
@@ -114,7 +114,7 @@ freeVarsStep = \case
     EInterfaceTemplateTypeRepF _ e -> e
     ESignatoryInterfaceF _ e -> e
     EObserverInterfaceF _ e -> e
-    EViewInterfaceF _ _ t e -> freeVarsInType t <> e
+    EViewInterfaceF _ e -> e
     EExperimentalF _ t -> freeVarsInType t
 
   where

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -552,8 +552,8 @@ instance Pretty Expr where
         [interfaceArg ty, TmArg expr]
     EObserverInterface ty expr -> pPrintAppKeyword lvl prec "observer_interface"
         [interfaceArg ty, TmArg expr]
-    EViewInterface iface template view expr -> pPrintAppKeyword lvl prec "view"
-        [interfaceArg iface, interfaceArg template, TyArg view, TmArg expr]
+    EViewInterface iface expr -> pPrintAppKeyword lvl prec "view"
+        [interfaceArg iface, TmArg expr]
     EExperimental name _ ->  pPrint $ "$" <> name
 
 instance Pretty DefTypeSyn where

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -552,6 +552,8 @@ instance Pretty Expr where
         [interfaceArg ty, TmArg expr]
     EObserverInterface ty expr -> pPrintAppKeyword lvl prec "observer_interface"
         [interfaceArg ty, TmArg expr]
+    EViewInterface iface template view expr -> pPrintAppKeyword lvl prec "view"
+        [interfaceArg iface, interfaceArg template, TyArg view, TmArg expr]
     EExperimental name _ ->  pPrint $ "$" <> name
 
 instance Pretty DefTypeSyn where

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -60,7 +60,7 @@ data ExprF expr
   | EInterfaceTemplateTypeRepF !(Qualified TypeConName) !expr
   | ESignatoryInterfaceF !(Qualified TypeConName) !expr
   | EObserverInterfaceF !(Qualified TypeConName) !expr
-  | EViewInterfaceF !(Qualified TypeConName) !(Qualified TypeConName) !Type !expr
+  | EViewInterfaceF !(Qualified TypeConName) !expr
   | EExperimentalF !T.Text !Type
   deriving (Foldable, Functor, Traversable)
 
@@ -222,7 +222,7 @@ instance Recursive Expr where
     EInterfaceTemplateTypeRep a b -> EInterfaceTemplateTypeRepF a b
     ESignatoryInterface a b -> ESignatoryInterfaceF a b
     EObserverInterface a b -> EObserverInterfaceF a b
-    EViewInterface a b c d -> EViewInterfaceF a b c d
+    EViewInterface a b -> EViewInterfaceF a b
     EExperimental a b -> EExperimentalF a b
 
 instance Corecursive Expr where
@@ -267,5 +267,5 @@ instance Corecursive Expr where
     EInterfaceTemplateTypeRepF a b -> EInterfaceTemplateTypeRep a b
     ESignatoryInterfaceF a b -> ESignatoryInterface a b
     EObserverInterfaceF a b -> EObserverInterface a b
-    EViewInterfaceF a b c d -> EViewInterface a b c d
+    EViewInterfaceF a b -> EViewInterface a b
     EExperimentalF a b -> EExperimental a b

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -60,6 +60,7 @@ data ExprF expr
   | EInterfaceTemplateTypeRepF !(Qualified TypeConName) !expr
   | ESignatoryInterfaceF !(Qualified TypeConName) !expr
   | EObserverInterfaceF !(Qualified TypeConName) !expr
+  | EViewInterfaceF !(Qualified TypeConName) !(Qualified TypeConName) !Type !expr
   | EExperimentalF !T.Text !Type
   deriving (Foldable, Functor, Traversable)
 
@@ -221,6 +222,7 @@ instance Recursive Expr where
     EInterfaceTemplateTypeRep a b -> EInterfaceTemplateTypeRepF a b
     ESignatoryInterface a b -> ESignatoryInterfaceF a b
     EObserverInterface a b -> EObserverInterfaceF a b
+    EViewInterface a b c d -> EViewInterfaceF a b c d
     EExperimental a b -> EExperimentalF a b
 
 instance Corecursive Expr where
@@ -265,4 +267,5 @@ instance Corecursive Expr where
     EInterfaceTemplateTypeRepF a b -> EInterfaceTemplateTypeRep a b
     ESignatoryInterfaceF a b -> ESignatoryInterface a b
     EObserverInterfaceF a b -> EObserverInterface a b
+    EViewInterfaceF a b c d -> EViewInterface a b c d
     EExperimentalF a b -> EExperimental a b

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
@@ -221,6 +221,11 @@ applySubstInExpr subst@Subst{..} = \case
     ELocation l e -> ELocation
         l
         (applySubstInExpr subst e)
+    EViewInterface iface template view expr -> EViewInterface
+        iface
+        template
+        (applySubstInType subst view)
+        (applySubstInExpr subst expr)
     EExperimental name ty ->
         EExperimental name (applySubstInType subst ty)
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
@@ -221,10 +221,8 @@ applySubstInExpr subst@Subst{..} = \case
     ELocation l e -> ELocation
         l
         (applySubstInExpr subst e)
-    EViewInterface iface template view expr -> EViewInterface
+    EViewInterface iface expr -> EViewInterface
         iface
-        template
-        (applySubstInType subst view)
         (applySubstInExpr subst expr)
     EExperimental name ty ->
         EExperimental name (applySubstInType subst ty)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -709,6 +709,11 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
   LF1.ExprSumObserverInterface LF1.Expr_ObserverInterface {..} -> EObserverInterface
     <$> mayDecode "expr_ObserverInterfaceInterface" expr_ObserverInterfaceInterface decodeTypeConName
     <*> mayDecode "expr_ObserverInterfaceExpr" expr_ObserverInterfaceExpr decodeExpr
+  LF1.ExprSumViewInterface LF1.Expr_ViewInterface {..} -> EViewInterface
+    <$> mayDecode "expr_ViewInterfaceInterface" expr_ViewInterfaceInterface decodeTypeConName
+    <*> mayDecode "expr_ViewInterfaceTemplate" expr_ViewInterfaceTemplate decodeTypeConName
+    <*> mayDecode "expr_ViewInterfaceViewtype" expr_ViewInterfaceViewtype decodeType
+    <*> mayDecode "expr_ViewInterfaceExpr" expr_ViewInterfaceExpr decodeExpr
   LF1.ExprSumExperimental (LF1.Expr_Experimental name mbType) -> do
     ty <- mayDecode "expr_Experimental" mbType decodeType
     pure $ EExperimental (decodeString name) ty

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -711,8 +711,6 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
     <*> mayDecode "expr_ObserverInterfaceExpr" expr_ObserverInterfaceExpr decodeExpr
   LF1.ExprSumViewInterface LF1.Expr_ViewInterface {..} -> EViewInterface
     <$> mayDecode "expr_ViewInterfaceInterface" expr_ViewInterfaceInterface decodeTypeConName
-    <*> mayDecode "expr_ViewInterfaceTemplate" expr_ViewInterfaceTemplate decodeTypeConName
-    <*> mayDecode "expr_ViewInterfaceViewtype" expr_ViewInterfaceViewtype decodeType
     <*> mayDecode "expr_ViewInterfaceExpr" expr_ViewInterfaceExpr decodeExpr
   LF1.ExprSumExperimental (LF1.Expr_Experimental name mbType) -> do
     ty <- mayDecode "expr_Experimental" mbType decodeType

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -736,6 +736,12 @@ encodeExpr' = \case
         expr_ObserverInterfaceInterface <- encodeQualTypeConName ty
         expr_ObserverInterfaceExpr <- encodeExpr val
         pureExpr $ P.ExprSumObserverInterface P.Expr_ObserverInterface{..}
+    EViewInterface iface template view expr -> do
+        expr_ViewInterfaceInterface <- encodeQualTypeConName iface
+        expr_ViewInterfaceTemplate <- encodeQualTypeConName template
+        expr_ViewInterfaceViewtype <- encodeType view
+        expr_ViewInterfaceExpr <- encodeExpr expr
+        pureExpr $ P.ExprSumViewInterface P.Expr_ViewInterface{..}
     EExperimental name ty -> do
         let expr_ExperimentalName = encodeString name
         expr_ExperimentalType <- encodeType ty

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -736,10 +736,8 @@ encodeExpr' = \case
         expr_ObserverInterfaceInterface <- encodeQualTypeConName ty
         expr_ObserverInterfaceExpr <- encodeExpr val
         pureExpr $ P.ExprSumObserverInterface P.Expr_ObserverInterface{..}
-    EViewInterface iface template view expr -> do
+    EViewInterface iface expr -> do
         expr_ViewInterfaceInterface <- encodeQualTypeConName iface
-        expr_ViewInterfaceTemplate <- encodeQualTypeConName template
-        expr_ViewInterfaceViewtype <- encodeType view
         expr_ViewInterfaceExpr <- encodeExpr expr
         pureExpr $ P.ExprSumViewInterface P.Expr_ViewInterface{..}
     EExperimental name ty -> do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -217,7 +217,7 @@ safetyStep = \case
   EInterfaceTemplateTypeRepF _ s -> s <> Safe 0
   ESignatoryInterfaceF _ s -> s <> Safe 0
   EObserverInterfaceF _ s -> s <> Safe 0
-  EViewInterfaceF _ _ _ _ -> Unsafe
+  EViewInterfaceF _ _ -> Unsafe
   EExperimentalF _ _ -> Unsafe
 
 isTypeClassDictionary :: DefValue -> Bool

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -217,6 +217,7 @@ safetyStep = \case
   EInterfaceTemplateTypeRepF _ s -> s <> Safe 0
   ESignatoryInterfaceF _ s -> s <> Safe 0
   EObserverInterfaceF _ s -> s <> Safe 0
+  EViewInterfaceF _ _ _ _ -> Unsafe
   EExperimentalF _ _ -> Unsafe
 
 isTypeClassDictionary :: DefValue -> Bool

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -793,6 +793,13 @@ typeOf' = \case
   EUpdate upd -> typeOfUpdate upd
   EScenario scen -> typeOfScenario scen
   ELocation _ expr -> typeOf' expr
+  EViewInterface iface template viewtype expr -> do
+    checkImplements template iface
+    iface <- inWorld (lookupInterface iface)
+    unless (alphaType (intView iface) viewtype) $
+      throwWithContext ETypeMismatch{foundType = viewtype, expectedType = intView iface, expr = Nothing}
+    checkExpr expr (TCon template)
+    pure viewtype
   EExperimental name ty -> do
     checkFeature featureExperimental
     checkExperimentalType name ty

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -793,13 +793,10 @@ typeOf' = \case
   EUpdate upd -> typeOfUpdate upd
   EScenario scen -> typeOfScenario scen
   ELocation _ expr -> typeOf' expr
-  EViewInterface iface template viewtype expr -> do
-    checkImplements template iface
-    iface <- inWorld (lookupInterface iface)
-    unless (alphaType (intView iface) viewtype) $
-      throwWithContext ETypeMismatch{foundType = viewtype, expectedType = intView iface, expr = Nothing}
-    checkExpr expr (TCon template)
-    pure viewtype
+  EViewInterface ifaceId expr -> do
+    iface <- inWorld (lookupInterface ifaceId)
+    checkExpr expr (TCon ifaceId)
+    pure (intView iface)
   EExperimental name ty -> do
     checkFeature featureExperimental
     checkExperimentalType name ty

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1193,6 +1193,8 @@ internalFunctions = listToUFM $ map (bimap mkModuleNameFS mkUniqSet)
         ])
     , ("DA.Internal.Desugar",
         [ "mkMethod"
+        , "mkInterfaceView"
+        , "view"
         ])
     ]
 

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
@@ -4,7 +4,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE AllowAmbiguousTypes #-}
 
 -- | HIDE Automatically imported qualified in every module.
 module DA.Internal.Desugar (
@@ -118,21 +117,3 @@ newtype Method t i (m : Symbol) = Method ()
 -- it's extracted unmodified.
 mkMethod : (Implements t i, HasMethod i m r) => (t -> r) -> Method t i m
 mkMethod = magic @"mkMethod"
-
--- Read: Interface `i` has a view of type `r`
-class HasInterfaceView i v | i -> v
-
--- | This is only a marker for the container, it doesn't contain the
--- actual implementation of the view.
-newtype InterfaceView t i = InterfaceView ()
-
--- | This is used to check that the argument has the correct
--- return type `r` for the given `t i v` type arguments.
--- At runtime, the argument is ignored, but at compile time,
--- it's extracted unmodified.
-mkInterfaceView : (Implements t i, HasInterfaceView i v) => (t -> v) -> InterfaceView t i
-mkInterfaceView = magic @"mkInterfaceView"
-
--- | Function for views
-view : forall i t v. (Implements t i, HasInterfaceView i v) => t -> v
-view = magic @"view" -- deleted by the compiler

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
@@ -4,6 +4,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 
 -- | HIDE Automatically imported qualified in every module.
 module DA.Internal.Desugar (
@@ -117,3 +118,21 @@ newtype Method t i (m : Symbol) = Method ()
 -- it's extracted unmodified.
 mkMethod : (Implements t i, HasMethod i m r) => (t -> r) -> Method t i m
 mkMethod = magic @"mkMethod"
+
+-- Read: Interface `i` has a view of type `r`
+class HasInterfaceView i v | i -> v
+
+-- | This is only a marker for the container, it doesn't contain the
+-- actual implementation of the view.
+newtype InterfaceView t i = InterfaceView ()
+
+-- | This is used to check that the argument has the correct
+-- return type `r` for the given `t i v` type arguments.
+-- At runtime, the argument is ignored, but at compile time,
+-- it's extracted unmodified.
+mkInterfaceView : (Implements t i, HasInterfaceView i v) => (t -> v) -> InterfaceView t i
+mkInterfaceView = magic @"mkInterfaceView"
+
+-- | Function for views
+view : forall i t v. (Implements t i, HasInterfaceView i v) => t -> v
+view = magic @"view" -- deleted by the compiler

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -975,9 +975,7 @@ message Expr {
   // *Available in versions >= 1.dev*
   message ViewInterface {
     TypeConName interface = 1;
-    TypeConName template = 2;
-    Type viewtype = 3;
-    Expr expr = 4;
+    Expr expr = 2;
   }
 
   // Obtain the type representation of a contract through an interface

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -971,6 +971,15 @@ message Expr {
     Expr interface_expr = 3;
   }
 
+  // Obtain an interface view
+  // *Available in versions >= 1.dev*
+  message ViewInterface {
+    TypeConName interface = 1;
+    TypeConName template = 2;
+    Type viewtype = 3;
+    Expr expr = 4;
+  }
+
   // Obtain the type representation of a contract through an interface
   // *Available in versions >= 1.dev*
   message InterfaceTemplateTypeRep {
@@ -1136,6 +1145,10 @@ message Expr {
     UnsafeFromInterface unsafe_from_interface = 44;
     // Unsafe downcast interface payloads.
     UnsafeFromRequiredInterface unsafe_from_required_interface = 45;
+
+    // Invoke an interface method.
+    // *Available in versions >= 1.dev*
+    ViewInterface view_interface = 46;
 
     Experimental experimental = 9999; // *Available only in 1.dev*
   }

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1232,8 +1232,6 @@ private[archive] class DecodeV1(minor: LV.Minor) {
           val viewInterface = lfExpr.getViewInterface
           EViewInterface(
             ifaceId = decodeTypeConName(viewInterface.getInterface),
-            templateId = decodeTypeConName(viewInterface.getTemplate),
-            viewtype = decodeType(viewInterface.getViewtype),
             expr = decodeExpr(viewInterface.getExpr, definition),
           )
 

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1227,6 +1227,16 @@ private[archive] class DecodeV1(minor: LV.Minor) {
         case PLF.Expr.SumCase.SUM_NOT_SET =>
           throw Error.Parsing("Expr.SUM_NOT_SET")
 
+        case PLF.Expr.SumCase.VIEW_INTERFACE =>
+          assertSince(LV.Features.interfaces, "Expr.view_interface")
+          val viewInterface = lfExpr.getViewInterface
+          EViewInterface(
+            ifaceId = decodeTypeConName(viewInterface.getInterface),
+            templateId = decodeTypeConName(viewInterface.getTemplate),
+            viewtype = decodeType(viewInterface.getViewtype),
+            expr = decodeExpr(viewInterface.getExpr, definition),
+          )
+
         case PLF.Expr.SumCase.EXPERIMENTAL =>
           assertSince(LV.v1_dev, "Expr.experimental")
           val experimental = lfExpr.getExperimental

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
@@ -367,6 +367,10 @@ private[lf] final class PhaseOne(
         compileExp(env, exp) { exp =>
           Return(SBObserverInterface(ifaceId)(exp))
         }
+      case EViewInterface(ifaceId, templateId, view, exp) =>
+        compileExp(env, exp) { exp =>
+          Return(SBViewInterface(ifaceId, templateId, view)(exp))
+        }
       case EExperimental(name, _) =>
         Return(SBExperimental(name))
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PhaseOne.scala
@@ -367,9 +367,9 @@ private[lf] final class PhaseOne(
         compileExp(env, exp) { exp =>
           Return(SBObserverInterface(ifaceId)(exp))
         }
-      case EViewInterface(ifaceId, templateId, view, exp) =>
+      case EViewInterface(ifaceId, exp) =>
         compileExp(env, exp) { exp =>
-          Return(SBViewInterface(ifaceId, templateId, view)(exp))
+          Return(SBViewInterface(ifaceId)(exp))
         }
       case EExperimental(name, _) =>
         Return(SBExperimental(name))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1338,6 +1338,18 @@ private[lf] object SBuiltin {
     }
   }
 
+  final case class SBViewInterface(
+      ifaceId: TypeConName,
+      templateId: TypeConName,
+      viewtype: Ast.Type,
+  ) extends SBuiltin(1) {
+    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
+      crash(
+        s"Tried to run unsupported view with interface ${ifaceId}, template ${templateId}, viewtype ${viewtype}."
+      )
+    }
+  }
+
   /** $insertFetch[tid]
     *    :: ContractId a
     *    -> List Party    (signatories)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1340,12 +1340,10 @@ private[lf] object SBuiltin {
 
   final case class SBViewInterface(
       ifaceId: TypeConName,
-      templateId: TypeConName,
-      viewtype: Ast.Type,
   ) extends SBuiltin(1) {
     override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       crash(
-        s"Tried to run unsupported view with interface ${ifaceId}, template ${templateId}, viewtype ${viewtype}."
+        s"Tried to run unsupported view with interface ${ifaceId}."
       )
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1339,7 +1339,7 @@ private[lf] object SBuiltin {
   }
 
   final case class SBViewInterface(
-      ifaceId: TypeConName,
+      ifaceId: TypeConName
   ) extends SBuiltin(1) {
     override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       crash(

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -220,8 +220,6 @@ object Ast {
   /** Obtain the view of an interface. */
   final case class EViewInterface(
       ifaceId: TypeConName,
-      templateId: TypeConName,
-      viewtype: Type,
       expr: Expr,
   ) extends Expr
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -217,6 +217,14 @@ object Ast {
       body: Expr,
   ) extends Expr
 
+  /** Obtain the view of an interface. */
+  final case class EViewInterface(
+      ifaceId: TypeConName,
+      templateId: TypeConName,
+      viewtype: Type,
+      expr: Expr,
+  ) extends Expr
+
   //
   // Kinds
   //

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -148,6 +148,8 @@ private[daml] class AstRewriter(
           EInterfaceTemplateTypeRep(apply(ifaceId), apply(body))
         case ESignatoryInterface(ifaceId, body) =>
           ESignatoryInterface(apply(ifaceId), apply(body))
+        case EViewInterface(ifaceId, templateId, viewtype, expr) =>
+          EViewInterface(apply(ifaceId), apply(templateId), apply(viewtype), apply(expr))
         case EObserverInterface(ifaceId, body) =>
           EObserverInterface(apply(ifaceId), apply(body))
       }

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/AstRewriter.scala
@@ -148,8 +148,8 @@ private[daml] class AstRewriter(
           EInterfaceTemplateTypeRep(apply(ifaceId), apply(body))
         case ESignatoryInterface(ifaceId, body) =>
           ESignatoryInterface(apply(ifaceId), apply(body))
-        case EViewInterface(ifaceId, templateId, viewtype, expr) =>
-          EViewInterface(apply(ifaceId), apply(templateId), apply(viewtype), apply(expr))
+        case EViewInterface(ifaceId, expr) =>
+          EViewInterface(apply(ifaceId), apply(expr))
         case EObserverInterface(ifaceId, body) =>
           EObserverInterface(apply(ifaceId), apply(body))
       }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -1261,6 +1261,13 @@ private[validation] object Typing {
         discard(handleLookup(ctx, pkgInterface.lookupInterface(ifaceId)))
         checkExpr(body, TTyCon(ifaceId))
         TList(TParty)
+      case EViewInterface(ifaceId @ _, templateId, view, expr) =>
+        checkImplements(templateId, ifaceId)
+        val iface = handleLookup(ctx, pkgInterface.lookupInterface(ifaceId))
+        if (!alphaEquiv(iface.view, view))
+          throw ETypeMismatch(ctx, foundType = view, expectedType = iface.view, expr = None)
+        checkExpr(expr, TTyCon(templateId))
+        view
       case EExperimental(_, typ) =>
         typ
     }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -1261,13 +1261,10 @@ private[validation] object Typing {
         discard(handleLookup(ctx, pkgInterface.lookupInterface(ifaceId)))
         checkExpr(body, TTyCon(ifaceId))
         TList(TParty)
-      case EViewInterface(ifaceId @ _, templateId, view, expr) =>
-        checkImplements(templateId, ifaceId)
+      case EViewInterface(ifaceId, expr) =>
         val iface = handleLookup(ctx, pkgInterface.lookupInterface(ifaceId))
-        if (!alphaEquiv(iface.view, view))
-          throw ETypeMismatch(ctx, foundType = view, expectedType = iface.view, expr = None)
-        checkExpr(expr, TTyCon(templateId))
-        view
+        checkExpr(expr, TTyCon(ifaceId))
+        iface.view
       case EExperimental(_, typ) =>
         typ
     }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/ExprIterable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/ExprIterable.scala
@@ -82,7 +82,7 @@ private[validation] object ExprIterable {
         iterator(body)
       case ESignatoryInterface(iface @ _, body) =>
         iterator(body)
-      case EViewInterface(ifaceId @ _, templateId @ _, view @ _, expr) =>
+      case EViewInterface(ifaceId @ _, expr) =>
         iterator(expr)
       case EObserverInterface(iface @ _, body) =>
         iterator(body)

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/ExprIterable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/ExprIterable.scala
@@ -82,6 +82,8 @@ private[validation] object ExprIterable {
         iterator(body)
       case ESignatoryInterface(iface @ _, body) =>
         iterator(body)
+      case EViewInterface(ifaceId @ _, templateId @ _, view @ _, expr) =>
+        iterator(expr)
       case EObserverInterface(iface @ _, body) =>
         iterator(body)
     }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
@@ -99,10 +99,8 @@ private[validation] object TypeIterable {
         Iterator(TTyCon(ifaceId)) ++ iterator(body)
       case EObserverInterface(ifaceId, body) =>
         Iterator(TTyCon(ifaceId)) ++ iterator(body)
-      case EViewInterface(ifaceId, templateId, view, expr) =>
+      case EViewInterface(ifaceId, expr) =>
         Iterator(TTyCon(ifaceId)) ++
-          Iterator(TTyCon(templateId)) ++
-          iterator(view) ++
           iterator(expr)
       case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EApp(_, _) | ECase(_, _) |
           ELocation(_, _) | EStructCon(_) | EStructProj(_, _) | EStructUpd(_, _, _) | ETyAbs(_, _) |

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/iterable/TypeIterable.scala
@@ -99,6 +99,11 @@ private[validation] object TypeIterable {
         Iterator(TTyCon(ifaceId)) ++ iterator(body)
       case EObserverInterface(ifaceId, body) =>
         Iterator(TTyCon(ifaceId)) ++ iterator(body)
+      case EViewInterface(ifaceId, templateId, view, expr) =>
+        Iterator(TTyCon(ifaceId)) ++
+          Iterator(TTyCon(templateId)) ++
+          iterator(view) ++
+          iterator(expr)
       case EVar(_) | EVal(_) | EBuiltin(_) | EPrimCon(_) | EPrimLit(_) | EApp(_, _) | ECase(_, _) |
           ELocation(_, _) | EStructCon(_) | EStructProj(_, _) | EStructUpd(_, _, _) | ETyAbs(_, _) |
           EExperimental(_, _) =>


### PR DESCRIPTION
This add EViewInterface as a possible expression type.
Calls to `view` will be desugared to this construct in a separate PR, https://github.com/digital-asset/daml/pull/14456 .

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
