### PR TITLE
[LF] minor refactoring of the type chect to reduce stack consumption

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -153,13 +153,16 @@ object Ast {
   /** Extract the payload from an AnyException if it matches the given exception type */
   final case class EFromAnyException(typ: Type, value: Expr) extends Expr
 
+  // We use this type to reduce depth of pattern matching
+  sealed abstract class ExprInterface extends Expr
+
   /** Convert template payload to interface it implements */
   final case class EToInterface(interfaceId: TypeConName, templateId: TypeConName, value: Expr)
-      extends Expr
+      extends ExprInterface
 
   /** Convert interface back to template payload if possible */
   final case class EFromInterface(interfaceId: TypeConName, templateId: TypeConName, value: Expr)
-      extends Expr
+      extends ExprInterface
 
   /** Convert interface back to template payload,
     * or raise a WronglyTypedContracg error if not possible
@@ -169,21 +172,21 @@ object Ast {
       templateId: TypeConName,
       contractIdExpr: Expr,
       ifaceExpr: Expr,
-  ) extends Expr
+  ) extends ExprInterface
 
   /** Upcast from an interface payload to an interface it requires. */
   final case class EToRequiredInterface(
       requiredIfaceId: TypeConName,
       requiringIfaceId: TypeConName,
       body: Expr,
-  ) extends Expr
+  ) extends ExprInterface
 
   /** Downcast from an interface payload to an interface that requires it, if possible. */
   final case class EFromRequiredInterface(
       requiredIfaceId: TypeConName,
       requiringIfaceId: TypeConName,
       body: Expr,
-  ) extends Expr
+  ) extends ExprInterface
 
   /** Downcast from an interface payload to an interface that requires it,
     * or raise a WronglyTypedContract error if not possible.
@@ -193,35 +196,35 @@ object Ast {
       requiringIfaceId: TypeConName,
       contractIdExpr: Expr,
       ifaceExpr: Expr,
-  ) extends Expr
+  ) extends ExprInterface
 
   /** Invoke an interface method */
   final case class ECallInterface(interfaceId: TypeConName, methodName: MethodName, value: Expr)
-      extends Expr
+      extends ExprInterface
 
   /** Obtain the type representation of a contract's template through an interface. */
   final case class EInterfaceTemplateTypeRep(
       ifaceId: TypeConName,
       body: Expr,
-  ) extends Expr
+  ) extends ExprInterface
 
   /** Obtain the signatories of a contract through an interface. */
   final case class ESignatoryInterface(
       ifaceId: TypeConName,
       body: Expr,
-  ) extends Expr
+  ) extends ExprInterface
 
   /** Obtain the observers of a contract through an interface. */
   final case class EObserverInterface(
       ifaceId: TypeConName,
       body: Expr,
-  ) extends Expr
+  ) extends ExprInterface
 
   /** Obtain the view of an interface. */
   final case class EViewInterface(
       ifaceId: TypeConName,
       expr: Expr,
-  ) extends Expr
+  ) extends ExprInterface
 
   //
   // Kinds

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -651,7 +651,7 @@ private[validation] object Typing {
           val (exprFieldNames, fieldExprs) = recordExpr.unzip
           val (typeFieldNames, fieldTypes) = recordType.unzip
           if (exprFieldNames != typeFieldNames) throw EFieldMismatch(ctx, typ, recordExpr)
-          (fieldExprs zip fieldTypes).foreach((checkExpr _).tupled)
+          (fieldExprs zip fieldTypes).foreach { case (e, f) => checkExpr(e, f) }
         case _ =>
           throw EExpectedRecordType(ctx, typ)
       }
@@ -903,6 +903,61 @@ private[validation] object Typing {
         checkType(typ0, KStar)
         val _ = resolveExprType(bound, typ0)
         typeOf(body)
+    }
+
+    private[this] def typOfExprInterface(expr: ExprInterface): Type = expr match {
+      case EToInterface(iface, tpl, value) =>
+        checkImplements(tpl, iface)
+        checkExpr(value, TTyCon(tpl))
+        TTyCon(iface)
+      case EFromInterface(iface, tpl, value) =>
+        checkImplements(tpl, iface)
+        checkExpr(value, TTyCon(iface))
+        TOptional(TTyCon(tpl))
+      case EUnsafeFromInterface(iface, tpl, cid, value) =>
+        checkImplements(tpl, iface)
+        checkExpr(cid, TContractId(TTyCon(iface)))
+        checkExpr(value, TTyCon(iface))
+        TTyCon(tpl)
+      case EToRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
+        val requiringIface = handleLookup(ctx, pkgInterface.lookupInterface(requiringIfaceId))
+        if (!requiringIface.requires.contains(requiredIfaceId))
+          throw EWrongInterfaceRequirement(ctx, requiringIfaceId, requiredIfaceId)
+        checkExpr(body, TTyCon(requiringIfaceId))
+        TTyCon(requiredIfaceId)
+      case EFromRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
+        val requiringIface = handleLookup(ctx, pkgInterface.lookupInterface(requiringIfaceId))
+        if (!requiringIface.requires.contains(requiredIfaceId))
+          throw EWrongInterfaceRequirement(ctx, requiringIfaceId, requiredIfaceId)
+        checkExpr(body, TTyCon(requiredIfaceId))
+        TOptional(TTyCon(requiringIfaceId))
+      case EUnsafeFromRequiredInterface(requiredIfaceId, requiringIfaceId, cid, body) =>
+        val requiringIface = handleLookup(ctx, pkgInterface.lookupInterface(requiringIfaceId))
+        if (!requiringIface.requires.contains(requiredIfaceId))
+          throw EWrongInterfaceRequirement(ctx, requiringIfaceId, requiredIfaceId)
+        checkExpr(cid, TContractId(TTyCon(requiredIfaceId)))
+        checkExpr(body, TTyCon(requiredIfaceId))
+        TTyCon(requiringIfaceId)
+      case ECallInterface(iface, methodName, value) =>
+        val method = handleLookup(ctx, pkgInterface.lookupInterfaceMethod(iface, methodName))
+        checkExpr(value, TTyCon(iface))
+        method.returnType
+      case EInterfaceTemplateTypeRep(ifaceId, body) =>
+        discard(handleLookup(ctx, pkgInterface.lookupInterface(ifaceId)))
+        checkExpr(body, TTyCon(ifaceId))
+        TTypeRep
+      case ESignatoryInterface(ifaceId, body) =>
+        discard(handleLookup(ctx, pkgInterface.lookupInterface(ifaceId)))
+        checkExpr(body, TTyCon(ifaceId))
+        TList(TParty)
+      case EObserverInterface(ifaceId, body) =>
+        discard(handleLookup(ctx, pkgInterface.lookupInterface(ifaceId)))
+        checkExpr(body, TTyCon(ifaceId))
+        TList(TParty)
+      case EViewInterface(ifaceId, expr) =>
+        val iface = handleLookup(ctx, pkgInterface.lookupInterface(ifaceId))
+        checkExpr(expr, TTyCon(ifaceId))
+        iface.view
     }
 
     private def checkCons(elemType: Type, front: ImmArray[Expr], tailExpr: Expr): Unit = {
@@ -1187,7 +1242,7 @@ private[validation] object Typing {
         newLocation(loc).typeOf(expr)
       case ESome(typ, body) =>
         checkType(typ, KStar)
-        val _ = checkExpr(body, typ)
+        checkExpr(body, typ)
         TOptional(typ)
       case EToAny(typ, body) =>
         checkAnyType(typ)
@@ -1213,58 +1268,8 @@ private[validation] object Typing {
         checkExceptionType(typ)
         checkExpr(value, TAnyException)
         TOptional(typ)
-      case EToInterface(iface, tpl, value) =>
-        checkImplements(tpl, iface)
-        checkExpr(value, TTyCon(tpl))
-        TTyCon(iface)
-      case EFromInterface(iface, tpl, value) =>
-        checkImplements(tpl, iface)
-        checkExpr(value, TTyCon(iface))
-        TOptional(TTyCon(tpl))
-      case EUnsafeFromInterface(iface, tpl, cid, value) =>
-        checkImplements(tpl, iface)
-        checkExpr(cid, TContractId(TTyCon(iface)))
-        checkExpr(value, TTyCon(iface))
-        TTyCon(tpl)
-      case EToRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
-        val requiringIface = handleLookup(ctx, pkgInterface.lookupInterface(requiringIfaceId))
-        if (!requiringIface.requires.contains(requiredIfaceId))
-          throw EWrongInterfaceRequirement(ctx, requiringIfaceId, requiredIfaceId)
-        checkExpr(body, TTyCon(requiringIfaceId))
-        TTyCon(requiredIfaceId)
-      case EFromRequiredInterface(requiredIfaceId, requiringIfaceId, body) =>
-        val requiringIface = handleLookup(ctx, pkgInterface.lookupInterface(requiringIfaceId))
-        if (!requiringIface.requires.contains(requiredIfaceId))
-          throw EWrongInterfaceRequirement(ctx, requiringIfaceId, requiredIfaceId)
-        checkExpr(body, TTyCon(requiredIfaceId))
-        TOptional(TTyCon(requiringIfaceId))
-      case EUnsafeFromRequiredInterface(requiredIfaceId, requiringIfaceId, cid, body) =>
-        val requiringIface = handleLookup(ctx, pkgInterface.lookupInterface(requiringIfaceId))
-        if (!requiringIface.requires.contains(requiredIfaceId))
-          throw EWrongInterfaceRequirement(ctx, requiringIfaceId, requiredIfaceId)
-        checkExpr(cid, TContractId(TTyCon(requiredIfaceId)))
-        checkExpr(body, TTyCon(requiredIfaceId))
-        TTyCon(requiringIfaceId)
-      case ECallInterface(iface, methodName, value) =>
-        val method = handleLookup(ctx, pkgInterface.lookupInterfaceMethod(iface, methodName))
-        checkExpr(value, TTyCon(iface))
-        method.returnType
-      case EInterfaceTemplateTypeRep(ifaceId, body) =>
-        discard(handleLookup(ctx, pkgInterface.lookupInterface(ifaceId)))
-        checkExpr(body, TTyCon(ifaceId))
-        TTypeRep
-      case ESignatoryInterface(ifaceId, body) =>
-        discard(handleLookup(ctx, pkgInterface.lookupInterface(ifaceId)))
-        checkExpr(body, TTyCon(ifaceId))
-        TList(TParty)
-      case EObserverInterface(ifaceId, body) =>
-        discard(handleLookup(ctx, pkgInterface.lookupInterface(ifaceId)))
-        checkExpr(body, TTyCon(ifaceId))
-        TList(TParty)
-      case EViewInterface(ifaceId, expr) =>
-        val iface = handleLookup(ctx, pkgInterface.lookupInterface(ifaceId))
-        checkExpr(expr, TTyCon(ifaceId))
-        iface.view
+      case expr: ExprInterface =>
+        typOfExprInterface(expr)
       case EExperimental(_, typ) =>
         typ
     }
@@ -1276,9 +1281,8 @@ private[validation] object Typing {
       exprType
     }
 
-    private def checkExpr(expr: Expr, typ0: Type): Unit = {
+    private def checkExpr(expr: Expr, typ0: Type): Unit =
       discard[Type](resolveExprType(expr, typ0))
-    }
 
     private def toStruct(t: Type): TStruct =
       t match {


### PR DESCRIPTION
After this change //daml-lf/tests:test-scenario-stable-many-fields
does not seem to stack overflow anymore.

This is a workaround until we make the type checker stack safe, See #13410.

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
