### PR TITLE
Remove spurious reference to `ledger-parties.json`

### DIFF
--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -204,7 +204,7 @@ party ids that have been allocated by ``allocateParties``:
 ``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:allocateParties --ledger-host localhost --ledger-port 6865 --output-file ledger-parties.json``
 
 The resulting file will look similar to the following but the actual
-party ids will be different each time you run it:
+party IDs will be different each time you run it:
 
 .. literalinclude:: ./template-root/ledger-parties.json
    :language: daml
@@ -215,8 +215,7 @@ specified, the ``--script-name`` flag must point to a function of one
 argument returning a ``Script``, and the function will be called with
 the result of parsing the input file as its argument. For example, we
 can initialize our ledger using the ``initialize`` function defined
-above. It takes a ``LedgerParties`` argument, so a valid file for
-``--input-file`` would look like:
+above.
 
 Using the previosuly created ``-ledger-parties.json`` file, we can
 initialize our ledger as follows:


### PR DESCRIPTION
The reference to the actual file has been moved above the
paragraph I edited. Removing the reference seems to work.

I also replaces an instance of non-capitalized ID since
I was there.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
