### PR TITLE
[LLP] Optimized InMemoryState lifecycle management [DPP-1137]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/InMemoryState.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/InMemoryState.scala
@@ -13,86 +13,180 @@ import com.daml.platform.store.cache.{
   InMemoryFanoutBuffer,
   MutableLedgerEndCache,
 }
+import com.daml.platform.store.dao.events.ContractStateEvent
+import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.interning.{StringInterningView, UpdatingStringInterningView}
+import scalaz.Scalaz._
+import scalaz._
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.chaining._
 
-/** Wrapper and life-cycle manager for the in-memory Ledger API state. */
+/** This class encapsulates and mutates the caching in-memory data structures used for
+  * serving Ledger API requests.
+  *
+  * TODO Implement one-at-a-time synchronization for the async public methods in this class.
+  */
 private[platform] class InMemoryState(
     val ledgerEndCache: MutableLedgerEndCache,
     val contractStateCaches: ContractStateCaches,
     val inMemoryFanoutBuffer: InMemoryFanoutBuffer,
     val stringInterningView: StringInterningView,
     val dispatcherState: DispatcherState,
-)(implicit executionContext: ExecutionContext) {
+) {
+  implicit private val offsetEquals: Equal[Offset] = Equal.equalA[Offset]
   private val logger = ContextualizedLogger.get(getClass)
+
   @volatile private var _initialized = false
   @volatile private var _dirty = false
 
+  /** Returns true if the state has already been initialized for the first time.
+    *
+    * This method is designed to synchronize start-up of the IndexService only
+    * after the first initialization triggered by the Indexer.
+    * (see [[com.daml.platform.indexer.JdbcIndexer.Factory.initialized()]]
+    */
   final def initialized: Boolean = _initialized
 
   /** (Re-)initializes the participant in-memory state to a specific ledger end.
     *
-    * NOTE: This method is not thread-safe. Calling it concurrently leads to undefined behavior.
+    * The state is conditionally (re-)initialized depending on:
+    *    - whether it has been already initialized for the first time
+    *    - whether the ledger end cache or the last string interned id have changed
+    *    since the last known state. Note that we additionally check the string interning view's last id,
+    *    since it is updated outside this class (see [[com.daml.platform.indexer.parallel.ParallelIndexerSubscription]]).
+    *    - whether it has been marked dirty. On a successful (re-)initialization, the state is marked not dirty again.
+    *
+    * NOTE:
+    *   - This method is not thread-safe. Calling it concurrently with itself
+    * or with [[update()]] leads to undefined behavior.
+    *   - A failure in this method leaves the state dirty.
     */
-  final def initializeTo(ledgerEnd: LedgerEnd)(
+  final def initializeTo(ledgerEnd: LedgerEnd, executionContext: ExecutionContext)(
       updateStringInterningView: (UpdatingStringInterningView, LedgerEnd) => Future[Unit]
-  )(implicit loggingContext: LoggingContext): Future[Unit] =
+  )(implicit loggingContext: LoggingContext): Future[Unit] = {
+    implicit val ec: ExecutionContext = executionContext
     conditionallyInitialize(ledgerEnd) { () =>
-      for {
-        // First stop the active dispatcher (if exists) to ensure
-        // that Ledger API subscriptions racing with `initializeTo`
-        // do not observe an inconsistent state.
-        _ <- dispatcherState.stopDispatcher()
-        // Reset the string interning view to the latest ledger end
-        _ <- updateStringInterningView(stringInterningView, ledgerEnd)
-        // Reset the Ledger API caches to the latest ledger end
-        _ <- Future {
-          contractStateCaches.reset(ledgerEnd.lastOffset)
-          inMemoryFanoutBuffer.flush()
-          ledgerEndCache.set(ledgerEnd.lastOffset -> ledgerEnd.lastEventSeqId)
+      dirtyWriteSection {
+        for {
+          // Ensure only async execution
+          _ <- Future.unit
+          // First stop the active dispatcher (if exists) to ensure
+          // that Ledger API subscriptions racing with `initializeTo`
+          // do not observe an inconsistent state.
+          _ <- dispatcherState.stopDispatcher()
+          // Reset the string interning view to the latest ledger end
+          _ <- updateStringInterningView(stringInterningView, ledgerEnd)
+          // Reset the Ledger API caches to the latest ledger end
+          _ <- Future {
+            contractStateCaches.reset(ledgerEnd.lastOffset)
+            inMemoryFanoutBuffer.flush()
+            ledgerEndCache.set(ledgerEnd.lastOffset -> ledgerEnd.lastEventSeqId)
+          }
+          // Start a new Ledger API offset dispatcher
+          _ = dispatcherState.startDispatcher(ledgerEnd)
+        } yield {
+          // Set the in-memory state initialized
+          _initialized = true
         }
-        // Start a new Ledger API offset dispatcher
-        _ = dispatcherState.startDispatcher(ledgerEnd)
-      } yield {
-        // Set the in-memory state initialized
-        _initialized = true
-        // Reset the dirty flag
-        _dirty = false
       }
     }
+  }
 
-  final def setDirty(): Unit = _dirty = true
+  /** Updates the in-memory state.
+    *
+    * On failure, the state is marked as dirty, ensuring re-initialization on [[InMemoryState.initializeTo()]].
+    *
+    * NOTE:
+    *   - This method is not thread-safe. Calling it concurrently with itself
+    * or with [[InMemoryState.update()]] leads to undefined behavior.
+    *   - A failure in this method leaves the state dirty.
+    *
+    * @param updates The update batch used to update the the in-memory fan-out buffer and the contract state cache.
+    * @param lastOffset The last offset ingested by the Indexer.
+    * @param lastEventSequentialId The last event sequential id ingested by the Indexer.
+    * @param executionContext The execution context.
+    * @param loggingContext The logging context.
+    */
+  final def update(
+      updates: Vector[(TransactionLogUpdate, Vector[ContractStateEvent])],
+      lastOffset: Offset,
+      lastEventSequentialId: Long,
+  )(implicit executionContext: ExecutionContext, loggingContext: LoggingContext): Future[Unit] =
+    if (!_dirty) {
+      dirtyWriteSection {
+        Future {
+          // Update caches
+          updates.foreach { case (transaction, contractStateEventsBatch) =>
+            // TODO LLP: Batch update caches
+            inMemoryFanoutBuffer.push(transaction.offset, transaction)
+            if (contractStateEventsBatch.nonEmpty) {
+              contractStateCaches.push(contractStateEventsBatch)
+            }
+          }
+
+          // Update ledger end
+          ledgerEndCache.set((lastOffset, lastEventSequentialId))
+          // the order here is very important: first we need to make data available for point-wise lookups
+          // and SQL queries, and only then we can make it available on the streams.
+          // (consider example: completion arrived on a stream, but the transaction cannot be looked up)
+          dispatcherState.getDispatcher.signalNewHead(lastOffset)
+          logger.info(s"Updated ledger end cache at offset $lastOffset - $lastEventSequentialId")
+        }
+      }
+    } else {
+      dirtyUpdateAttempted(lastOffset, lastEventSequentialId)
+    }
+
+  private def dirtyUpdateAttempted(offset: Offset, eventSequentialId: Long)(implicit
+      loggingContext: LoggingContext
+  ): Future[Unit] = {
+    val logMessage =
+      s"Attempted to update a dirty in-memory state at offset ($offset) and event sequential id ($eventSequentialId)."
+
+    logger.error(logMessage)
+    Future.failed(new IllegalStateException(logMessage))
+  }
+
+  private def dirtyWriteSection(mutateState: => Future[Unit]): Future[Unit] = {
+    // On update failure, we can't make assumptions on which part of the state was correctly updated.
+    // Thus, set the in-memory state dirty at the beginning of a mutating operation unset it on success.
+    _dirty = true
+    mutateState.map { _ =>
+      _dirty = false
+      ()
+    }(ExecutionContext.parasitic)
+  }
 
   private def conditionallyInitialize(
       ledgerEnd: LedgerEnd
   )(initialize: () => Future[Unit])(implicit loggingContext: LoggingContext): Future[Unit] =
     if (!_initialized) {
-      logger.info(s"Initializing participant in-memory state to ledger end: $ledgerEnd.")
+      logger.info(s"Initializing the in-memory state to ledger end: $ledgerEnd.")
       initialize()
     } else if (_dirty) {
       logger.warn(
-        s"Dirty state detected on initialization. Re-setting the in-memory state ledger end: $ledgerEnd."
+        s"Dirty state detected on initialization. Re-setting the in-memory state to ledger end: $ledgerEnd."
       )
       initialize()
     } else {
       val currentLedgerEndCache = ledgerEndCache()
       if (
-        loggedEqualityCheck[Offset](
-          ledgerEnd.lastOffset,
-          currentLedgerEndCache._1,
-          "ledger end cache offset",
+        loggedNonEquality[Offset](
+          expected = ledgerEnd.lastOffset,
+          actual = currentLedgerEndCache._1,
+          name = "ledger end cache offset",
         ) ||
-        loggedEqualityCheck[Long](
-          ledgerEnd.lastEventSeqId,
-          currentLedgerEndCache._2,
-          "ledger end cache event sequential id",
-        ) || loggedEqualityCheck[Int](
-          ledgerEnd.lastStringInterningId,
-          stringInterningView.lastId,
-          "last string interning id",
+        loggedNonEquality[Long](
+          expected = ledgerEnd.lastEventSeqId,
+          actual = currentLedgerEndCache._2,
+          name = "ledger end cache event sequential id",
+        ) ||
+        loggedNonEquality[Int](
+          expected = ledgerEnd.lastStringInterningId,
+          actual = stringInterningView.lastId,
+          name = "last string interning id",
         )
       ) {
         logger.warn(
@@ -100,14 +194,16 @@ private[platform] class InMemoryState(
         )
         initialize()
       } else {
+        logger.info("Coherency checks passed. In-memory state re-initialization skipped.")
         Future.unit
       }
     }
 
-  private def loggedEqualityCheck[T](expected: T, actual: T, name: String)(implicit
-      loggingContext: LoggingContext
+  private def loggedNonEquality[T](expected: T, actual: T, name: String)(implicit
+      loggingContext: LoggingContext,
+      safeEquals: Equal[T],
   ): Boolean =
-    (expected != actual)
+    (!safeEquals.equal(expected, actual))
       .tap { notEqual =>
         if (notEqual)
           logger.warn(
@@ -127,27 +223,30 @@ object InMemoryState {
       executionContext: ExecutionContext,
   )(implicit loggingContext: LoggingContext): ResourceOwner[InMemoryState] = {
     val initialLedgerEnd = LedgerEnd.beforeBegin
+    val initialLedgerEndCache = MutableLedgerEndCache()
+      .tap(
+        _.set((initialLedgerEnd.lastOffset, initialLedgerEnd.lastEventSeqId))
+      )
+
+    val contractStateCaches = ContractStateCaches.build(
+      initialLedgerEnd.lastOffset,
+      maxContractStateCacheSize,
+      maxContractKeyStateCacheSize,
+      metrics,
+    )(executionContext, loggingContext)
 
     for {
       dispatcherState <- DispatcherState.owner(apiStreamShutdownTimeout)
     } yield new InMemoryState(
-      ledgerEndCache = MutableLedgerEndCache()
-        .tap(
-          _.set((initialLedgerEnd.lastOffset, initialLedgerEnd.lastEventSeqId))
-        ),
+      ledgerEndCache = initialLedgerEndCache,
       dispatcherState = dispatcherState,
-      contractStateCaches = ContractStateCaches.build(
-        initialLedgerEnd.lastOffset,
-        maxContractStateCacheSize,
-        maxContractKeyStateCacheSize,
-        metrics,
-      )(executionContext, loggingContext),
+      contractStateCaches = contractStateCaches,
       inMemoryFanoutBuffer = new InMemoryFanoutBuffer(
         maxBufferSize = maxTransactionsInMemoryFanOutBufferSize,
         metrics = metrics,
         maxBufferedChunkSize = bufferedStreamsPageSize,
       ),
       stringInterningView = new StringInterningView,
-    )(executionContext)
+    )
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/InMemoryState.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/InMemoryState.scala
@@ -3,6 +3,7 @@
 
 package com.daml.platform
 
+import com.daml.ledger.offset.Offset
 import com.daml.ledger.resources.ResourceOwner
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
@@ -28,6 +29,7 @@ private[platform] class InMemoryState(
 )(implicit executionContext: ExecutionContext) {
   private val logger = ContextualizedLogger.get(getClass)
   @volatile private var _initialized = false
+  @volatile private var _dirty = false
 
   final def initialized: Boolean = _initialized
 
@@ -37,31 +39,81 @@ private[platform] class InMemoryState(
     */
   final def initializeTo(ledgerEnd: LedgerEnd)(
       updateStringInterningView: (UpdatingStringInterningView, LedgerEnd) => Future[Unit]
-  )(implicit loggingContext: LoggingContext): Future[Unit] = {
-    logger.info(s"Initializing participant in-memory state to ledger end: $ledgerEnd")
-
-    // TODO LLP: Reset the in-memory state only if the initialization ledgerEnd
-    //           is different than the ledgerEndCache.
-    for {
-      // First stop the active dispatcher (if exists) to ensure
-      // that Ledger API subscriptions racing with `initializeTo`
-      // do not observe an inconsistent state.
-      _ <- dispatcherState.stopDispatcher()
-      // Reset the string interning view to the latest ledger end
-      _ <- updateStringInterningView(stringInterningView, ledgerEnd)
-      // Reset the Ledger API caches to the latest ledger end
-      _ <- Future {
-        contractStateCaches.reset(ledgerEnd.lastOffset)
-        inMemoryFanoutBuffer.flush()
-        ledgerEndCache.set(ledgerEnd.lastOffset -> ledgerEnd.lastEventSeqId)
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
+    conditionallyInitialize(ledgerEnd) { () =>
+      for {
+        // First stop the active dispatcher (if exists) to ensure
+        // that Ledger API subscriptions racing with `initializeTo`
+        // do not observe an inconsistent state.
+        _ <- dispatcherState.stopDispatcher()
+        // Reset the string interning view to the latest ledger end
+        _ <- updateStringInterningView(stringInterningView, ledgerEnd)
+        // Reset the Ledger API caches to the latest ledger end
+        _ <- Future {
+          contractStateCaches.reset(ledgerEnd.lastOffset)
+          inMemoryFanoutBuffer.flush()
+          ledgerEndCache.set(ledgerEnd.lastOffset -> ledgerEnd.lastEventSeqId)
+        }
+        // Start a new Ledger API offset dispatcher
+        _ = dispatcherState.startDispatcher(ledgerEnd)
+      } yield {
+        // Set the in-memory state initialized
+        _initialized = true
+        // Reset the dirty flag
+        _dirty = false
       }
-      // Start a new Ledger API offset dispatcher
-      _ = dispatcherState.startDispatcher(ledgerEnd)
-    } yield {
-      // Set the in-memory state initialized
-      _initialized = true
     }
-  }
+
+  final def setDirty(): Unit = _dirty = true
+
+  private def conditionallyInitialize(
+      ledgerEnd: LedgerEnd
+  )(initialize: () => Future[Unit])(implicit loggingContext: LoggingContext): Future[Unit] =
+    if (!_initialized) {
+      logger.info(s"Initializing participant in-memory state to ledger end: $ledgerEnd.")
+      initialize()
+    } else if (_dirty) {
+      logger.warn(
+        s"Dirty state detected on initialization. Re-setting the in-memory state ledger end: $ledgerEnd."
+      )
+      initialize()
+    } else {
+      val currentLedgerEndCache = ledgerEndCache()
+      if (
+        loggedEqualityCheck[Offset](
+          ledgerEnd.lastOffset,
+          currentLedgerEndCache._1,
+          "ledger end cache offset",
+        ) ||
+        loggedEqualityCheck[Long](
+          ledgerEnd.lastEventSeqId,
+          currentLedgerEndCache._2,
+          "ledger end cache event sequential id",
+        ) || loggedEqualityCheck[Int](
+          ledgerEnd.lastStringInterningId,
+          stringInterningView.lastId,
+          "last string interning id",
+        )
+      ) {
+        logger.warn(
+          s"Re-initialization ledger end mismatches in-memory state reference. Re-setting the in-memory state ledger end: $ledgerEnd."
+        )
+        initialize()
+      } else {
+        Future.unit
+      }
+    }
+
+  private def loggedEqualityCheck[T](expected: T, actual: T, name: String)(implicit
+      loggingContext: LoggingContext
+  ): Boolean =
+    (expected != actual)
+      .tap { notEqual =>
+        if (notEqual)
+          logger.warn(
+            s"Mismatching state ledger end references for $name: expected ($expected) vs actual ($actual)."
+          )
+      }
 }
 
 object InMemoryState {

--- a/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
@@ -16,7 +16,7 @@ import com.daml.lf.ledger.EventId
 import com.daml.lf.transaction.Node.{Create, Exercise}
 import com.daml.lf.transaction.Transaction.ChildrenRecursion
 import com.daml.lf.transaction.{Node, NodeId}
-import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.index.InMemoryStateUpdater.UpdaterFlow
 import com.daml.platform.store.CompletionFromTransaction
@@ -27,14 +27,12 @@ import com.daml.platform.{Contract, InMemoryState, Key, Party}
 
 import java.util.concurrent.Executors
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
 
 final class InMemoryStateUpdater(
     prepareUpdatesParallelism: Int,
     prepareUpdatesExecutionContext: ExecutionContext,
     updateCachesExecutionContext: ExecutionContext,
 )(
-    updateCaches: Vector[TransactionLogUpdate] => Unit,
     convertTransactionAccepted: (
         Offset,
         Update.TransactionAccepted,
@@ -43,8 +41,12 @@ final class InMemoryStateUpdater(
         Offset,
         Update.CommandRejected,
     ) => TransactionLogUpdate.TransactionRejected,
-    updateLedgerEnd: (Offset, Long) => Unit,
-    setInMemoryStateDirty: () => Unit,
+    convertToContractStateEvents: TransactionLogUpdate => Vector[ContractStateEvent],
+    updateInMemoryState: (
+        Vector[(TransactionLogUpdate, Vector[ContractStateEvent])],
+        Offset,
+        Long,
+    ) => Future[Unit],
 ) {
 
   // TODO LLP: Considering directly returning this flow instead of the wrapper
@@ -62,26 +64,22 @@ final class InMemoryStateUpdater(
         }(prepareUpdatesExecutionContext)
       }
       .async
-      .mapAsync(1) { case (updates, lastOffset, lastEventSequentialId) =>
-        Future {
-          updateCaches(updates)
-          updateLedgerEnd(lastOffset, lastEventSequentialId)
+      .mapAsync(parallelism = 1) { case (updates, lastOffset, lastEventSequentialId) =>
+        Future.delegate {
+          val preprocessedUpdates = updates.map(transactionLogUpdate =>
+            transactionLogUpdate -> convertToContractStateEvents(transactionLogUpdate)
+          )
+          updateInMemoryState(
+            preprocessedUpdates,
+            lastOffset,
+            lastEventSequentialId,
+          )
         }(updateCachesExecutionContext)
-          .transform {
-            case Failure(ex) =>
-              // On update failure, we can't make assumptions on which part of the state was correctly updated.
-              // Thus, set the in-memory state dirty and propagate the failure.
-              setInMemoryStateDirty()
-              Failure(ex)
-            case Success(value) => Success(value)
-          }(updateCachesExecutionContext)
       }
 }
 
 private[platform] object InMemoryStateUpdater {
   type UpdaterFlow = Flow[(Vector[(Offset, Update)], Long), Unit, NotUsed]
-
-  private val logger = ContextualizedLogger.get(getClass)
 
   def owner(
       inMemoryState: InMemoryState,
@@ -102,42 +100,19 @@ private[platform] object InMemoryStateUpdater {
         metrics.daml.lapi.threadpool.indexBypass.updateInMemoryState,
       )
     )
-  } yield new InMemoryStateUpdater(
-    prepareUpdatesParallelism = prepareUpdatesParallelism,
-    prepareUpdatesExecutionContext = ExecutionContext.fromExecutorService(prepareUpdatesExecutor),
-    updateCachesExecutionContext = ExecutionContext.fromExecutorService(updateCachesExecutor),
-  )(
-    updateCaches = updateCaches(inMemoryState),
-    convertTransactionAccepted = convertTransactionAccepted,
-    convertTransactionRejected = convertTransactionRejected,
-    updateLedgerEnd = updateLedgerEnd(inMemoryState),
-    setInMemoryStateDirty = () => inMemoryState.setDirty(),
-  )
-
-  private def updateCaches(inMemoryState: InMemoryState)(
-      updates: Vector[TransactionLogUpdate]
-  ): Unit =
-    updates.foreach { transaction: TransactionLogUpdate =>
-      // TODO LLP: Batch update caches
-      inMemoryState.inMemoryFanoutBuffer.push(transaction.offset, transaction)
-
-      val contractStateEventsBatch = convertToContractStateEvents(transaction)
-      if (contractStateEventsBatch.nonEmpty) {
-        inMemoryState.contractStateCaches.push(contractStateEventsBatch)
-      }
-    }
-
-  private def updateLedgerEnd(
-      inMemoryState: InMemoryState
-  )(lastOffset: Offset, lastEventSequentialId: Long)(implicit
-      loggingContext: LoggingContext
-  ): Unit = {
-    inMemoryState.ledgerEndCache.set((lastOffset, lastEventSequentialId))
-    // the order here is very important: first we need to make data available for point-wise lookups
-    // and SQL queries, and only then we can make it available on the streams.
-    // (consider example: completion arrived on a stream, but the transaction cannot be looked up)
-    inMemoryState.dispatcherState.getDispatcher.signalNewHead(lastOffset)
-    logger.debug(s"Updated ledger end at offset $lastOffset - $lastEventSequentialId")
+  } yield {
+    val updateCachesExecutionContext = ExecutionContext.fromExecutorService(updateCachesExecutor)
+    new InMemoryStateUpdater(
+      prepareUpdatesParallelism = prepareUpdatesParallelism,
+      prepareUpdatesExecutionContext = ExecutionContext.fromExecutorService(prepareUpdatesExecutor),
+      updateCachesExecutionContext = updateCachesExecutionContext,
+    )(
+      convertTransactionAccepted = convertTransactionAccepted,
+      convertTransactionRejected = convertTransactionRejected,
+      convertToContractStateEvents = convertToContractStateEvents,
+      updateInMemoryState =
+        inMemoryState.update(_, _, _)(updateCachesExecutionContext, loggingContext),
+    )
   }
 
   private def convertToContractStateEvents(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
@@ -108,7 +108,7 @@ private[platform] object InMemoryStateUpdater {
   ): Unit =
     updates.foreach { transaction: TransactionLogUpdate =>
       // TODO LLP: Batch update caches
-      inMemoryState.transactionsBuffer.push(transaction.offset, transaction)
+      inMemoryState.inMemoryFanoutBuffer.push(transaction.offset, transaction)
 
       val contractStateEventsBatch = convertToContractStateEvents(transaction)
       if (contractStateEventsBatch.nonEmpty) {

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -95,16 +95,17 @@ object JdbcIndexer {
         ).apply,
         mat = materializer,
         readService = readService,
-        initializeInMemoryState = dbDispatcher =>
+        initializeInMemoryState = (dbDispatcher, executionContext) =>
           ledgerEnd =>
-            inMemoryState.initializeTo(ledgerEnd)((updatingStringInterningView, ledgerEnd) =>
-              updateStringInterningView(
-                stringInterningStorageBackend,
-                metrics,
-                dbDispatcher,
-                updatingStringInterningView,
-                ledgerEnd,
-              )
+            inMemoryState.initializeTo(ledgerEnd, executionContext)(
+              (updatingStringInterningView, ledgerEnd) =>
+                updateStringInterningView(
+                  stringInterningStorageBackend,
+                  metrics,
+                  dbDispatcher,
+                  updatingStringInterningView,
+                  ledgerEnd,
+                )
             ),
         stringInterningView = inMemoryState.stringInterningView,
       )

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -41,7 +41,7 @@ object ParallelIndexerFactory {
       mat: Materializer,
       readService: ReadService,
       stringInterningView: StringInterningView,
-      initializeInMemoryState: DbDispatcher => LedgerEnd => Future[Unit],
+      initializeInMemoryState: (DbDispatcher, ExecutionContext) => LedgerEnd => Future[Unit],
   )(implicit loggingContext: LoggingContext): ResourceOwner[Indexer] =
     for {
       inputMapperExecutor <- asyncPool(
@@ -126,7 +126,7 @@ object ParallelIndexerFactory {
         ) { dbDispatcher =>
           initializeParallelIngestion(
             dbDispatcher = dbDispatcher,
-            additionalInitialization = initializeInMemoryState(dbDispatcher),
+            additionalInitialization = initializeInMemoryState(dbDispatcher, ec),
             readService = readService,
             mat = mat,
             ec = ec,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interning/StringInterningView.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interning/StringInterningView.scala
@@ -27,7 +27,7 @@ trait InternizingStringInterningView {
 
 trait UpdatingStringInterningView {
 
-  /** Update the StringInterningView from persistence
+  /** Update the StringInterningView from persistence.
     *
     * @param lastStringInterningId this is the "version" of the persistent view, which from the StringInterningView can see if it is behind
     * @return a completion Future:
@@ -41,6 +41,9 @@ trait UpdatingStringInterningView {
   def update(lastStringInterningId: Int)(
       loadPrefixedEntries: LoadStringInterningEntries
   )(implicit loggingContext: LoggingContext): Future[Unit]
+
+  /** Get the last interned string id. */
+  def lastId: Int
 }
 
 /** Encapsulate the dependency to load a range of string-interning-entries from persistence
@@ -112,6 +115,8 @@ class StringInterningView()
       loadStringInterningEntries(raw.lastId, lastStringInterningId)(loggingContext)
         .map(updateView)(ExecutionContext.parasitic)
     }
+
+  override def lastId: Int = raw.lastId
 
   private def updateView(newEntries: Iterable[(Int, String)]): Unit = synchronized {
     if (newEntries.nonEmpty) {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
@@ -25,6 +25,18 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
   private val className = classOf[InMemoryState].getSimpleName
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
+  private val initOffset = Offset.fromHexString(Ref.HexString.assertFromString("abcdef"))
+  private val initEventSequentialId = 1337L
+  private val initStringInterningId = 17
+  private val initLedgerEnd = ParameterStorageBackend
+    .LedgerEnd(initOffset, initEventSequentialId, initStringInterningId)
+
+  private val reInitOffset = Offset.fromHexString(Ref.HexString.assertFromString("abeeee"))
+  private val reInitEventSequentialId = 9999L
+  private val reInitStringInterningId = 50
+  private val reInitLedgerEnd = ParameterStorageBackend
+    .LedgerEnd(reInitOffset, reInitEventSequentialId, reInitStringInterningId)
+
   s"$className.initialized" should "return false if not initialized" in withTestFixture {
     case (inMemoryState, _, _, _, _, _, _, _) =>
       inMemoryState.initialized shouldBe false
@@ -41,31 +53,234 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
           updateStringInterningView,
           inOrder,
         ) =>
-      val initOffset = Offset.fromHexString(Ref.HexString.assertFromString("abcdef"))
-      val initEventSequentialId = 1337L
-      val initStringInterningId = 17
-
-      val initLedgerEnd = ParameterStorageBackend
-        .LedgerEnd(initOffset, initEventSequentialId, initStringInterningId)
-
       when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
       when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
 
       for {
-        // INITIALIZED THE STATE
+        // Initialize the state
         _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
-      } yield {
-        // ASSERT STATE INITIALIZED
+        _ = {
+          // Assert the state initialized
+          inOrder.verify(dispatcherState).stopDispatcher()
+          inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
+          inOrder.verify(contractStateCaches).reset(initOffset)
+          inOrder.verify(inMemoryFanoutBuffer).flush()
+          inOrder.verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
+          inOrder.verify(dispatcherState).startDispatcher(initLedgerEnd)
 
-        inOrder.verify(dispatcherState).stopDispatcher()
-        inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
-        inOrder.verify(contractStateCaches).reset(initOffset)
-        inOrder.verify(inMemoryFanoutBuffer).flush()
-        inOrder.verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
-        inOrder.verify(dispatcherState).startDispatcher(initLedgerEnd)
+          inMemoryState.initialized shouldBe true
+        }
 
-        inMemoryState.initialized shouldBe true
-      }
+        _ = {
+          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(initStringInterningId)
+          when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(
+            Future.unit
+          )
+          when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+        }
+
+        // Re-initialize to the same ledger end
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ = {
+          // Ledger end references checks
+          verify(mutableLedgerEndCache).apply()
+          verify(stringInterningView).lastId
+
+          // ASSERT NO EFFECT
+          verifyNoMoreInteractions(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+
+          inMemoryState.initialized shouldBe true
+        }
+      } yield succeed
+  }
+
+  s"$className.initializeTo" should "re-initialize the state on changed ledger end cache" in withTestFixture {
+    case (
+          inMemoryState,
+          mutableLedgerEndCache,
+          contractStateCaches,
+          inMemoryFanoutBuffer,
+          stringInterningView,
+          dispatcherState,
+          updateStringInterningView,
+          inOrder,
+        ) =>
+      when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
+      when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+
+      for {
+        // Initialize the state to the initial ledger end
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+
+        // Reset mocks
+        _ = {
+          reset(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(initStringInterningId)
+          when(updateStringInterningView(stringInterningView, reInitLedgerEnd)).thenReturn(
+            Future.unit
+          )
+          when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+        }
+
+        // Re-initialize to a different ledger end
+        _ <- inMemoryState.initializeTo(reInitLedgerEnd)(updateStringInterningView)
+
+        _ = {
+          // Ledger end references checks
+          verify(mutableLedgerEndCache).apply()
+          // Short-circuited by the failing ledger end cache check
+          verify(stringInterningView, never).lastId
+
+          // Assert state initialized to the new ledger end
+          inOrder.verify(dispatcherState).stopDispatcher()
+          inOrder.verify(updateStringInterningView)(stringInterningView, reInitLedgerEnd)
+          inOrder.verify(contractStateCaches).reset(reInitOffset)
+          inOrder.verify(inMemoryFanoutBuffer).flush()
+          inOrder.verify(mutableLedgerEndCache).set(reInitOffset, reInitEventSequentialId)
+          inOrder.verify(dispatcherState).startDispatcher(reInitLedgerEnd)
+        }
+
+        // Reset mocks
+        _ = {
+          reset(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+          when(mutableLedgerEndCache()).thenReturn(reInitOffset -> reInitEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(reInitStringInterningId)
+        }
+
+        // Attempt to re-initialize to the same ledger end
+        _ <- inMemoryState.initializeTo(reInitLedgerEnd)(updateStringInterningView)
+        _ = {
+          // Assert ledger end reference checks
+          verify(stringInterningView).lastId
+          verify(mutableLedgerEndCache).apply()
+
+          // Assert no effect
+          verifyNoMoreInteractions(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+        }
+      } yield succeed
+  }
+
+  s"$className.initializeTo" should "initialize the on dirty" in withTestFixture {
+    case (
+          inMemoryState,
+          mutableLedgerEndCache,
+          contractStateCaches,
+          inMemoryFanoutBuffer,
+          stringInterningView,
+          dispatcherState,
+          updateStringInterningView,
+          inOrder,
+        ) =>
+      when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
+      when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+
+      for {
+        // Initialize the state
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+
+        // reset mocks
+        _ = {
+          reset(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(initStringInterningId)
+          when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(
+            Future.unit
+          )
+          when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+        }
+
+        // Set dirty
+        _ = inMemoryState.setDirty()
+
+        // Re-initialize the state to the same ledger end
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+
+        _ = {
+          // Ledger end references checks short-circuited by dirty check
+          verify(stringInterningView, never).lastId
+          verify(mutableLedgerEndCache, never).apply()
+
+          // Assert state re-initialized on dirty
+          inOrder.verify(dispatcherState).stopDispatcher()
+          inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
+          inOrder.verify(contractStateCaches).reset(initOffset)
+          inOrder.verify(inMemoryFanoutBuffer).flush()
+          inOrder.verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
+          inOrder.verify(dispatcherState).startDispatcher(initLedgerEnd)
+        }
+
+        // reset mocks
+        _ = {
+          reset(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(initStringInterningId)
+          when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(
+            Future.unit
+          )
+          when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+        }
+
+        // Re-initialize the state to the same ledger end
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ = {
+          // Ledger end references checks
+          verify(mutableLedgerEndCache).apply()
+          verify(stringInterningView).lastId
+
+          // Assert no effect on state not dirty anymore
+          verifyNoMoreInteractions(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+          )
+        }
+      } yield succeed
   }
 
   private def withTestFixture(

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
@@ -13,15 +13,21 @@ import com.daml.platform.store.cache.{
   InMemoryFanoutBuffer,
   MutableLedgerEndCache,
 }
+import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.interning.{StringInterningView, UpdatingStringInterningView}
-import org.mockito.{InOrder, Mockito, MockitoSugar}
+import org.mockito.{ArgumentMatchersSugar, InOrder, Mockito, MockitoSugar}
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
-class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
+class InMemoryStateSpec
+    extends AsyncFlatSpec
+    with MockitoSugar
+    with Matchers
+    with ArgumentMatchersSugar {
   private val className = classOf[InMemoryState].getSimpleName
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
@@ -31,69 +37,49 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
   private val initLedgerEnd = ParameterStorageBackend
     .LedgerEnd(initOffset, initEventSequentialId, initStringInterningId)
 
-  private val reInitOffset = Offset.fromHexString(Ref.HexString.assertFromString("abeeee"))
-  private val reInitEventSequentialId = 9999L
-  private val reInitStringInterningId = 50
-  private val reInitLedgerEnd = ParameterStorageBackend
-    .LedgerEnd(reInitOffset, reInitEventSequentialId, reInitStringInterningId)
-
   s"$className.initialized" should "return false if not initialized" in withTestFixture {
-    case (inMemoryState, _, _, _, _, _, _, _) =>
-      inMemoryState.initialized shouldBe false
+    case (inMemoryState, _, _) => inMemoryState.initialized shouldBe false
   }
 
   s"$className.initializeTo" should "initialize the state" in withTestFixture {
     case (
           inMemoryState,
-          mutableLedgerEndCache,
-          contractStateCaches,
-          inMemoryFanoutBuffer,
-          stringInterningView,
-          dispatcherState,
           updateStringInterningView,
           inOrder,
         ) =>
+      import inMemoryState._
       when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
       when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
 
       for {
         // Initialize the state
-        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ <- inMemoryState.initializeTo(initLedgerEnd, executionContext)(updateStringInterningView)
         _ = {
           // Assert the state initialized
-          inOrder.verify(dispatcherState).stopDispatcher()
-          inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
-          inOrder.verify(contractStateCaches).reset(initOffset)
-          inOrder.verify(inMemoryFanoutBuffer).flush()
-          inOrder.verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
-          inOrder.verify(dispatcherState).startDispatcher(initLedgerEnd)
+          verifyInitializedInOrder(inMemoryState, updateStringInterningView, inOrder, initLedgerEnd)
 
           inMemoryState.initialized shouldBe true
         }
 
         _ = {
-          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(ledgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
           when(stringInterningView.lastId).thenReturn(initStringInterningId)
-          when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(
-            Future.unit
-          )
-          when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
         }
 
         // Re-initialize to the same ledger end
-        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ <- inMemoryState.initializeTo(initLedgerEnd, executionContext)(updateStringInterningView)
         _ = {
           // Ledger end references checks
-          verify(mutableLedgerEndCache).apply()
+          verify(ledgerEndCache).apply()
           verify(stringInterningView).lastId
 
-          // ASSERT NO EFFECT
+          // Assert no effect
           verifyNoMoreInteractions(
             dispatcherState,
             updateStringInterningView,
             contractStateCaches,
             inMemoryFanoutBuffer,
-            mutableLedgerEndCache,
+            ledgerEndCache,
             stringInterningView,
           )
 
@@ -105,33 +91,25 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
   s"$className.initializeTo" should "re-initialize the state on changed ledger end cache" in withTestFixture {
     case (
           inMemoryState,
-          mutableLedgerEndCache,
-          contractStateCaches,
-          inMemoryFanoutBuffer,
-          stringInterningView,
-          dispatcherState,
           updateStringInterningView,
           inOrder,
         ) =>
+      import inMemoryState._
       when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
       when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
 
       for {
         // Initialize the state to the initial ledger end
-        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ <- inMemoryState.initializeTo(initLedgerEnd, executionContext)(updateStringInterningView)
 
+        reInitLedgerEnd = initLedgerEnd.copy(lastOffset =
+          Offset.fromHexString(Ref.HexString.assertFromString("abeeee"))
+        )
         // Reset mocks
         _ = {
-          reset(
-            dispatcherState,
-            updateStringInterningView,
-            contractStateCaches,
-            inMemoryFanoutBuffer,
-            mutableLedgerEndCache,
-            stringInterningView,
-          )
-          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
-          when(stringInterningView.lastId).thenReturn(initStringInterningId)
+          resetMocks(inMemoryState, updateStringInterningView)
+
+          when(ledgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
           when(updateStringInterningView(stringInterningView, reInitLedgerEnd)).thenReturn(
             Future.unit
           )
@@ -139,43 +117,42 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
         }
 
         // Re-initialize to a different ledger end
-        _ <- inMemoryState.initializeTo(reInitLedgerEnd)(updateStringInterningView)
+        _ <- inMemoryState.initializeTo(reInitLedgerEnd, executionContext)(
+          updateStringInterningView
+        )
 
         _ = {
           // Ledger end references checks
-          verify(mutableLedgerEndCache).apply()
+          verify(ledgerEndCache).apply()
           // Short-circuited by the failing ledger end cache check
           verify(stringInterningView, never).lastId
 
           // Assert state initialized to the new ledger end
-          inOrder.verify(dispatcherState).stopDispatcher()
-          inOrder.verify(updateStringInterningView)(stringInterningView, reInitLedgerEnd)
-          inOrder.verify(contractStateCaches).reset(reInitOffset)
-          inOrder.verify(inMemoryFanoutBuffer).flush()
-          inOrder.verify(mutableLedgerEndCache).set(reInitOffset, reInitEventSequentialId)
-          inOrder.verify(dispatcherState).startDispatcher(reInitLedgerEnd)
+          verifyInitializedInOrder(
+            inMemoryState,
+            updateStringInterningView,
+            inOrder,
+            reInitLedgerEnd,
+          )
         }
 
         // Reset mocks
         _ = {
-          reset(
-            dispatcherState,
-            updateStringInterningView,
-            contractStateCaches,
-            inMemoryFanoutBuffer,
-            mutableLedgerEndCache,
-            stringInterningView,
+          resetMocks(inMemoryState, updateStringInterningView)
+          when(ledgerEndCache()).thenReturn(
+            reInitLedgerEnd.lastOffset -> reInitLedgerEnd.lastEventSeqId
           )
-          when(mutableLedgerEndCache()).thenReturn(reInitOffset -> reInitEventSequentialId)
-          when(stringInterningView.lastId).thenReturn(reInitStringInterningId)
+          when(stringInterningView.lastId).thenReturn(reInitLedgerEnd.lastStringInterningId)
         }
 
         // Attempt to re-initialize to the same ledger end
-        _ <- inMemoryState.initializeTo(reInitLedgerEnd)(updateStringInterningView)
+        _ <- inMemoryState.initializeTo(reInitLedgerEnd, executionContext)(
+          updateStringInterningView
+        )
         _ = {
           // Assert ledger end reference checks
           verify(stringInterningView).lastId
-          verify(mutableLedgerEndCache).apply()
+          verify(ledgerEndCache).apply()
 
           // Assert no effect
           verifyNoMoreInteractions(
@@ -183,42 +160,109 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
             updateStringInterningView,
             contractStateCaches,
             inMemoryFanoutBuffer,
-            mutableLedgerEndCache,
+            ledgerEndCache,
             stringInterningView,
           )
         }
       } yield succeed
   }
 
-  s"$className.initializeTo" should "initialize the on dirty" in withTestFixture {
+  s"$className.initializeTo" should "re-initialize the state on changed last string interned id" in withTestFixture {
     case (
           inMemoryState,
-          mutableLedgerEndCache,
-          contractStateCaches,
-          inMemoryFanoutBuffer,
-          stringInterningView,
-          dispatcherState,
           updateStringInterningView,
           inOrder,
         ) =>
+      import inMemoryState._
+      when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
+      when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+
+      for {
+        // Initialize the state to the initial ledger end
+        _ <- inMemoryState.initializeTo(initLedgerEnd, executionContext)(updateStringInterningView)
+
+        newLedgerEnd = initLedgerEnd.copy(lastStringInterningId =
+          initLedgerEnd.lastStringInterningId + 1
+        )
+        // Reset mocks
+        _ = {
+          resetMocks(inMemoryState, updateStringInterningView)
+
+          when(ledgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(updateStringInterningView(stringInterningView, newLedgerEnd)).thenReturn(
+            Future.unit
+          )
+          when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+        }
+
+        // Re-initialize to a different ledger end
+        _ <- inMemoryState.initializeTo(newLedgerEnd, executionContext)(
+          updateStringInterningView
+        )
+
+        _ = {
+          // Ledger end references checks
+          verify(ledgerEndCache).apply()
+          // Short-circuited by the failing ledger end cache check
+          verify(stringInterningView).lastId
+
+          // Assert state initialized to the new ledger end
+          verifyInitializedInOrder(
+            inMemoryState,
+            updateStringInterningView,
+            inOrder,
+            newLedgerEnd,
+          )
+        }
+
+        // Reset mocks
+        _ = {
+          resetMocks(inMemoryState, updateStringInterningView)
+          when(ledgerEndCache()).thenReturn(newLedgerEnd.lastOffset -> newLedgerEnd.lastEventSeqId)
+          when(stringInterningView.lastId).thenReturn(newLedgerEnd.lastStringInterningId)
+        }
+
+        // Attempt to re-initialize to the same ledger end
+        _ <- inMemoryState.initializeTo(newLedgerEnd, executionContext)(
+          updateStringInterningView
+        )
+        _ = {
+          // Assert ledger end reference checks
+          verify(stringInterningView).lastId
+          verify(ledgerEndCache).apply()
+
+          // Assert no effect
+          verifyNoMoreInteractions(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            ledgerEndCache,
+            stringInterningView,
+          )
+        }
+      } yield succeed
+  }
+
+  s"$className.initializeTo" should "re-initialize the state on dirty" in withTestFixture {
+    case (
+          inMemoryState,
+          updateStringInterningView,
+          inOrder,
+        ) =>
+      import inMemoryState._
       when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
       when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
 
       for {
         // Initialize the state
-        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ <- inMemoryState.initializeTo(initLedgerEnd, executionContext)(updateStringInterningView)
 
         // reset mocks
         _ = {
-          reset(
-            dispatcherState,
-            updateStringInterningView,
-            contractStateCaches,
-            inMemoryFanoutBuffer,
-            mutableLedgerEndCache,
-            stringInterningView,
-          )
-          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          resetMocks(inMemoryState, updateStringInterningView)
+
+          when(ledgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
           when(stringInterningView.lastId).thenReturn(initStringInterningId)
           when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(
             Future.unit
@@ -226,37 +270,38 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
           when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
         }
 
-        // Set dirty
-        _ = inMemoryState.setDirty()
+        failingInitOffset = Offset.fromHexString(Ref.HexString.assertFromString("abeeee"))
+        failingInitEventSeqId = 9999L
+        // Set dirty by simulating a failure and an external recovery
+        // while attempting to set the ledger end to reInitOffset and reInitEventSequentialId
+        _ <- failedUpdate(inMemoryState, failingInitOffset, failingInitEventSeqId)
+
+        // Trying to update the state on dirty state fails
+        _ <- recoverToSucceededIf[IllegalStateException] {
+          inMemoryState.update(
+            Vector(mock[TransactionLogUpdate] -> Vector.empty),
+            failingInitOffset,
+            failingInitEventSeqId,
+          )
+        }
 
         // Re-initialize the state to the same ledger end
-        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ <- inMemoryState.initializeTo(initLedgerEnd, executionContext)(updateStringInterningView)
 
         _ = {
           // Ledger end references checks short-circuited by dirty check
           verify(stringInterningView, never).lastId
-          verify(mutableLedgerEndCache, never).apply()
+          verify(ledgerEndCache, never).apply()
 
           // Assert state re-initialized on dirty
-          inOrder.verify(dispatcherState).stopDispatcher()
-          inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
-          inOrder.verify(contractStateCaches).reset(initOffset)
-          inOrder.verify(inMemoryFanoutBuffer).flush()
-          inOrder.verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
-          inOrder.verify(dispatcherState).startDispatcher(initLedgerEnd)
+          verifyInitializedInOrder(inMemoryState, updateStringInterningView, inOrder, initLedgerEnd)
         }
 
         // reset mocks
         _ = {
-          reset(
-            dispatcherState,
-            updateStringInterningView,
-            contractStateCaches,
-            inMemoryFanoutBuffer,
-            mutableLedgerEndCache,
-            stringInterningView,
-          )
-          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          resetMocks(inMemoryState, updateStringInterningView)
+
+          when(ledgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
           when(stringInterningView.lastId).thenReturn(initStringInterningId)
           when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(
             Future.unit
@@ -265,10 +310,10 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
         }
 
         // Re-initialize the state to the same ledger end
-        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ <- inMemoryState.initializeTo(initLedgerEnd, executionContext)(updateStringInterningView)
         _ = {
           // Ledger end references checks
-          verify(mutableLedgerEndCache).apply()
+          verify(ledgerEndCache).apply()
           verify(stringInterningView).lastId
 
           // Assert no effect on state not dirty anymore
@@ -277,25 +322,73 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
             updateStringInterningView,
             contractStateCaches,
             inMemoryFanoutBuffer,
-            mutableLedgerEndCache,
+            ledgerEndCache,
           )
         }
       } yield succeed
   }
 
+  private def verifyInitializedInOrder(
+      inMemoryState: InMemoryState,
+      updateStringInterningView: (UpdatingStringInterningView, LedgerEnd) => Future[Unit],
+      inOrder: InOrder,
+      initLedgerEnd: LedgerEnd,
+  ): Unit = {
+    import inMemoryState._
+
+    inOrder.verify(dispatcherState).stopDispatcher()
+    inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
+    inOrder.verify(contractStateCaches).reset(initLedgerEnd.lastOffset)
+    inOrder.verify(inMemoryFanoutBuffer).flush()
+    inOrder.verify(ledgerEndCache).set(initLedgerEnd.lastOffset, initLedgerEnd.lastEventSeqId)
+    inOrder.verify(dispatcherState).startDispatcher(initLedgerEnd)
+  }
+
+  private def resetMocks(
+      inMemoryState: InMemoryState,
+      updateStringInterningView: (UpdatingStringInterningView, LedgerEnd) => Future[Unit],
+  ): Unit = {
+    import inMemoryState._
+
+    reset(
+      dispatcherState,
+      updateStringInterningView,
+      contractStateCaches,
+      inMemoryFanoutBuffer,
+      ledgerEndCache,
+      stringInterningView,
+    )
+  }
+
+  final def failedUpdate(
+      inMemoryState: InMemoryState,
+      offset: Offset,
+      eventSeqId: Long,
+  ): Future[Unit] = {
+    val failureMessage = "failed"
+    when(inMemoryState.inMemoryFanoutBuffer.push(any[Offset], any[TransactionLogUpdate]))
+      .thenThrow(new RuntimeException(failureMessage))
+
+    inMemoryState
+      .update(
+        updates = Vector(mock[TransactionLogUpdate] -> Vector.empty),
+        lastOffset = offset,
+        lastEventSequentialId = eventSeqId,
+      )
+      .transform {
+        case Failure(ex: RuntimeException) if ex.getMessage == failureMessage => Success(())
+        case other => fail(s"Unexpected $other")
+      }
+  }
+
   private def withTestFixture(
       test: (
           InMemoryState,
-          MutableLedgerEndCache,
-          ContractStateCaches,
-          InMemoryFanoutBuffer,
-          StringInterningView,
-          DispatcherState,
           (UpdatingStringInterningView, LedgerEnd) => Future[Unit],
           InOrder,
       ) => Future[Assertion]
   ): Future[Assertion] = {
-    val mutableLedgerEndCache = mock[MutableLedgerEndCache]
+    val ledgerEndCache = mock[MutableLedgerEndCache]
     val contractStateCaches = mock[ContractStateCaches]
     val inMemoryFanoutBuffer = mock[InMemoryFanoutBuffer]
     val stringInterningView = mock[StringInterningView]
@@ -304,7 +397,7 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
 
     // Mocks should be called in the asserted order
     val inOrderMockCalls = Mockito.inOrder(
-      mutableLedgerEndCache,
+      ledgerEndCache,
       contractStateCaches,
       inMemoryFanoutBuffer,
       stringInterningView,
@@ -313,7 +406,7 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
     )
 
     val inMemoryState = new InMemoryState(
-      ledgerEndCache = mutableLedgerEndCache,
+      ledgerEndCache = ledgerEndCache,
       contractStateCaches = contractStateCaches,
       inMemoryFanoutBuffer = inMemoryFanoutBuffer,
       stringInterningView = stringInterningView,
@@ -322,11 +415,6 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
 
     test(
       inMemoryState,
-      mutableLedgerEndCache,
-      contractStateCaches,
-      inMemoryFanoutBuffer,
-      stringInterningView,
-      dispatcherState,
       updateStringInterningView,
       inOrderMockCalls,
     )

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
@@ -14,7 +14,7 @@ import com.daml.platform.store.cache.{
   MutableLedgerEndCache,
 }
 import com.daml.platform.store.interning.{StringInterningView, UpdatingStringInterningView}
-import org.mockito.MockitoSugar
+import org.mockito.{InOrder, Mockito, MockitoSugar}
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -26,7 +26,7 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
   s"$className.initialized" should "return false if not initialized" in withTestFixture {
-    case (inMemoryState, _, _, _, _, _) =>
+    case (inMemoryState, _, _, _, _, _, _, _) =>
       inMemoryState.initialized shouldBe false
   }
 
@@ -35,9 +35,11 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
           inMemoryState,
           mutableLedgerEndCache,
           contractStateCaches,
-          transactionsBuffer,
+          inMemoryFanoutBuffer,
           stringInterningView,
           dispatcherState,
+          updateStringInterningView,
+          inOrder,
         ) =>
       val initOffset = Offset.fromHexString(Ref.HexString.assertFromString("abcdef"))
       val initEventSequentialId = 1337L
@@ -46,64 +48,24 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
       val initLedgerEnd = ParameterStorageBackend
         .LedgerEnd(initOffset, initEventSequentialId, initStringInterningId)
 
-      val updateStringInterningView = mock[(UpdatingStringInterningView, LedgerEnd) => Future[Unit]]
       when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
+      when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
 
-      when(dispatcherState.reset(initLedgerEnd)).thenReturn(Future.unit)
-      when(dispatcherState.initialized).thenReturn(true)
       for {
         // INITIALIZED THE STATE
         _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
-
+      } yield {
         // ASSERT STATE INITIALIZED
-        _ = {
-          inMemoryState.initialized shouldBe true
 
-          verify(contractStateCaches).reset(initOffset)
-          verify(transactionsBuffer).flush()
-          verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
-          verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
-          verify(dispatcherState).reset(initLedgerEnd)
-        }
+        inOrder.verify(dispatcherState).stopDispatcher()
+        inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
+        inOrder.verify(contractStateCaches).reset(initOffset)
+        inOrder.verify(inMemoryFanoutBuffer).flush()
+        inOrder.verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
+        inOrder.verify(dispatcherState).startDispatcher(initLedgerEnd)
 
-        reInitOffset = Offset.fromHexString(Ref.HexString.assertFromString("abeeee"))
-        reInitEventSequentialId = 9999L
-        reInitStringInterningId = 50
-        reInitLedgerEnd = ParameterStorageBackend
-          .LedgerEnd(reInitOffset, reInitEventSequentialId, reInitStringInterningId)
-
-        // RESET MOCKS
-        _ = {
-          reset(
-            mutableLedgerEndCache,
-            contractStateCaches,
-            transactionsBuffer,
-            updateStringInterningView,
-          )
-          when(updateStringInterningView(stringInterningView, reInitLedgerEnd)).thenReturn(
-            Future.unit
-          )
-          when(dispatcherState.reset(reInitLedgerEnd)).thenReturn(Future.unit)
-        }
-
-        // RE-INITIALIZE THE STATE
-        _ <- inMemoryState.initializeTo(reInitLedgerEnd) {
-          case (`stringInterningView`, ledgerEnd) =>
-            updateStringInterningView(stringInterningView, ledgerEnd)
-          case (other, _) => fail(s"Unexpected stringInterningView reference $other")
-        }
-
-        // ASSERT STATE RE-INITIALIZED
-        _ = {
-          inMemoryState.initialized shouldBe true
-
-          verify(contractStateCaches).reset(reInitOffset)
-          verify(transactionsBuffer).flush()
-          verify(mutableLedgerEndCache).set(reInitOffset, reInitEventSequentialId)
-          verify(updateStringInterningView)(stringInterningView, reInitLedgerEnd)
-          verify(dispatcherState).reset(reInitLedgerEnd)
-        }
-      } yield succeed
+        inMemoryState.initialized shouldBe true
+      }
   }
 
   private def withTestFixture(
@@ -114,20 +76,31 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
           InMemoryFanoutBuffer,
           StringInterningView,
           DispatcherState,
+          (UpdatingStringInterningView, LedgerEnd) => Future[Unit],
+          InOrder,
       ) => Future[Assertion]
   ): Future[Assertion] = {
     val mutableLedgerEndCache = mock[MutableLedgerEndCache]
     val contractStateCaches = mock[ContractStateCaches]
-
-    val transactionsBuffer = mock[InMemoryFanoutBuffer]
+    val inMemoryFanoutBuffer = mock[InMemoryFanoutBuffer]
     val stringInterningView = mock[StringInterningView]
-
     val dispatcherState = mock[DispatcherState]
+    val updateStringInterningView = mock[(UpdatingStringInterningView, LedgerEnd) => Future[Unit]]
+
+    // Mocks should be called in the asserted order
+    val inOrderMockCalls = Mockito.inOrder(
+      mutableLedgerEndCache,
+      contractStateCaches,
+      inMemoryFanoutBuffer,
+      stringInterningView,
+      dispatcherState,
+      updateStringInterningView,
+    )
 
     val inMemoryState = new InMemoryState(
       ledgerEndCache = mutableLedgerEndCache,
       contractStateCaches = contractStateCaches,
-      transactionsBuffer = transactionsBuffer,
+      inMemoryFanoutBuffer = inMemoryFanoutBuffer,
       stringInterningView = stringInterningView,
       dispatcherState = dispatcherState,
     )
@@ -136,9 +109,11 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
       inMemoryState,
       mutableLedgerEndCache,
       contractStateCaches,
-      transactionsBuffer,
+      inMemoryFanoutBuffer,
       stringInterningView,
       dispatcherState,
+      updateStringInterningView,
+      inOrderMockCalls,
     )
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
@@ -126,6 +126,7 @@ class InMemoryStateUpdaterSpec extends AsyncFlatSpec with Matchers with AkkaBefo
       updateLedgerEnd = { case (offset, evtSeqId) =>
         ledgerEndUpdates.addOne(offset -> evtSeqId)
       },
+      setInMemoryStateDirty = () => (),
     )
     test(inMemoryStateUpdater, cacheUpdates, ledgerEndUpdates)
   }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
@@ -10,38 +10,34 @@ import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.v2.Update.CommandRejected.FinalReason
 import com.daml.ledger.participant.state.v2.{CompletionInfo, TransactionMeta, Update}
 import com.daml.lf.crypto
-import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.data.Time.Timestamp
+import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.CommittedTransaction
 import com.daml.lf.transaction.test.TransactionBuilder
-import com.daml.platform.index.InMemoryStateUpdaterSpec.{
-  anotherMetadataChangedUpdate,
-  metadataChangedUpdate,
-  offset,
-  txLogUpdate1,
-  txLogUpdate3,
-  txRejected,
-  update1,
-  update3,
-  update4,
-}
+import com.daml.lf.value.Value.ContractId
+import com.daml.platform.index.InMemoryStateUpdaterSpec._
 import com.daml.platform.indexer.ha.EndlessReadService.configuration
+import com.daml.platform.store.dao.events.ContractStateEvent
 import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.interfaces.TransactionLogUpdate.CompletionDetails
 import com.google.rpc.status.Status
+import org.mockito.MockitoSugar
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.chaining._
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
 
-class InMemoryStateUpdaterSpec extends AsyncFlatSpec with Matchers with AkkaBeforeAndAfterAll {
+class InMemoryStateUpdaterSpec
+    extends AsyncFlatSpec
+    with Matchers
+    with MockitoSugar
+    with AkkaBeforeAndAfterAll {
   behavior of classOf[InMemoryStateUpdater].getSimpleName
 
   "flow" should "correctly process updates" in withFixture {
-    case (inMemoryStateUpdater, cacheUpdates, ledgerEndUpdates) =>
+    case (inMemoryStateUpdater, inMemoryStateUpdates) =>
       val updatesInput =
         Seq(Vector(update1, metadataChangedUpdate) -> 1L, Vector(update3, update4) -> 3L)
 
@@ -49,40 +45,32 @@ class InMemoryStateUpdaterSpec extends AsyncFlatSpec with Matchers with AkkaBefo
         .via(inMemoryStateUpdater.flow)
         .runWith(Sink.ignore)
         .map { _ =>
-          cacheUpdates should contain theSameElementsInOrderAs Seq(
-            Vector(txLogUpdate1),
-            Vector(txLogUpdate3, txRejected),
-          )
-          ledgerEndUpdates should contain theSameElementsInOrderAs Seq(
-            offset(2L) -> 1L,
-            offset(4L) -> 3L,
+          inMemoryStateUpdates should contain theSameElementsInOrderAs Seq(
+            (Vector(txLogUpdate1 -> contractStateEvents1), offset(2L), 1L),
+            (Vector(txLogUpdate3 -> Vector.empty, txRejected -> Vector.empty), offset(4L), 3L),
           )
         }
   }
 
   "flow" should "not process empty input batches" in withFixture {
-    case (inMemoryStateUpdater, cacheUpdates, ledgerEndUpdates) =>
+    case (inMemoryStateUpdater, inMemoryStateUpdates) =>
       val updatesInput =
         Seq(
           // Empty input batch should have not effect
           Vector.empty -> 1L,
-          Vector(update3) -> 3L,
           // Results in empty batch after processing
           // Should still have effect on ledger end updates
-          Vector(anotherMetadataChangedUpdate) -> 3L,
+          Vector(metadataChangedUpdate) -> 3L,
+          Vector(update3) -> 3L,
         )
 
       Source(updatesInput)
         .via(inMemoryStateUpdater.flow)
         .runWith(Sink.ignore)
         .map { _ =>
-          cacheUpdates should contain theSameElementsInOrderAs Seq(
-            Vector(txLogUpdate3),
-            Vector(),
-          )
-          ledgerEndUpdates should contain theSameElementsInOrderAs Seq(
-            offset(3L) -> 3L,
-            offset(5L) -> 3L,
+          inMemoryStateUpdates should contain theSameElementsInOrderAs Seq(
+            (Vector.empty, offset(2L), 3L),
+            (Vector(txLogUpdate3 -> Vector.empty), offset(3L), 3L),
           )
         }
   }
@@ -91,8 +79,9 @@ class InMemoryStateUpdaterSpec extends AsyncFlatSpec with Matchers with AkkaBefo
       test: (
           (
               InMemoryStateUpdater,
-              ArrayBuffer[Vector[TransactionLogUpdate]],
-              ArrayBuffer[(Offset, Long)],
+              ArrayBuffer[
+                (Vector[(TransactionLogUpdate, Vector[ContractStateEvent])], Offset, Long)
+              ],
           )
       ) => Future[Assertion]
   ): Future[Assertion] = {
@@ -109,11 +98,23 @@ class InMemoryStateUpdaterSpec extends AsyncFlatSpec with Matchers with AkkaBefo
       case _ => fail()
     }
 
-    val cacheUpdates = ArrayBuffer.empty[Vector[TransactionLogUpdate]]
-    val cachesUpdateCaptor =
-      (v: Vector[TransactionLogUpdate]) => cacheUpdates.addOne(v).pipe(_ => ())
+    val convertToContractStateEvents: TransactionLogUpdate => Vector[ContractStateEvent] = {
+      case `txLogUpdate1` => contractStateEvents1
+      case `txLogUpdate3` => Vector.empty
+      case `txRejected` => Vector.empty
+      case _ => fail()
+    }
 
-    val ledgerEndUpdates = ArrayBuffer.empty[(Offset, Long)]
+    val inMemoryStateUpdates =
+      ArrayBuffer.empty[(Vector[(TransactionLogUpdate, Vector[ContractStateEvent])], Offset, Long)]
+    val inMemoryStateUpdatesCaptor = (
+        updates: Vector[(TransactionLogUpdate, Vector[ContractStateEvent])],
+        lastOffset: Offset,
+        lastEventSequentialId: Long,
+    ) => {
+      inMemoryStateUpdates.addOne((updates, lastOffset, lastEventSequentialId))
+      Future.unit
+    }
 
     val inMemoryStateUpdater = new InMemoryStateUpdater(
       2,
@@ -122,13 +123,10 @@ class InMemoryStateUpdaterSpec extends AsyncFlatSpec with Matchers with AkkaBefo
     )(
       convertTransactionAccepted = updateToTransactionAccepted,
       convertTransactionRejected = updateToTransactionRejected,
-      updateCaches = cachesUpdateCaptor,
-      updateLedgerEnd = { case (offset, evtSeqId) =>
-        ledgerEndUpdates.addOne(offset -> evtSeqId)
-      },
-      setInMemoryStateDirty = () => (),
+      convertToContractStateEvents = convertToContractStateEvents,
+      updateInMemoryState = inMemoryStateUpdatesCaptor,
     )
-    test(inMemoryStateUpdater, cacheUpdates, ledgerEndUpdates)
+    test(inMemoryStateUpdater, inMemoryStateUpdates)
   }
 }
 
@@ -190,8 +188,6 @@ object InMemoryStateUpdaterSpec {
     ),
     reasonTemplate = FinalReason(new Status()),
   )
-  private val anotherMetadataChangedUpdate =
-    offset(5L) -> metadataChangedUpdate._2.copy(recordTime = Time.Timestamp.assertFromLong(1337L))
 
   private val txLogUpdate1 = TransactionLogUpdate.TransactionAccepted(
     transactionId = "tx1",
@@ -219,6 +215,16 @@ object InMemoryStateUpdaterSpec {
       completionStreamResponse = new CompletionStreamResponse(),
       submitters = Set.empty,
     ),
+  )
+
+  private val contractStateEvents1 = Vector(
+    ContractStateEvent.Archived(
+      contractId = ContractId.assertFromString("00" + "00" * 32 + "c0"),
+      globalKey = None,
+      stakeholders = Set.empty,
+      eventOffset = Offset.beforeBegin,
+      eventSequentialId = 0L,
+    )
   )
 
   private def offset(idx: Long): Offset = {


### PR DESCRIPTION
**Motivation for this PR**
Currently, any Indexer restart leads to a call to `InMemoryState.initializeTo`. This triggers a full clean-up of the in-memory state:
* Flushing all the caches leading to degraded performance until re- warm-up.
* Cancelling all the Ledger API client streams
* (In the future, as envisioned) re-population of the package cache used for interface subscriptions, an operation that can take tens of seconds and even more.

As the Indexer restart can happen quite frequently in setups with choppy DB connections, the full restart of the in-memory state on each transient error can lead to degraded UX.

**Resolution**
 This PR makes actual resetting of the in-memory state conditional and exceptional. The in-memory state is restarted only if a failure could have rendered its state:
* **stale**: when the Indexer Akka streams pipeline fails just after ingesting the persisted ledger end but before the updates are forwarded to the in-memory state.
* **dirty**: when the methods mutating its objects (dispatcher, caches, stringInterningView) fails. 
* **ahead-of-the-indexer**: when an async commit fails in the Indexer after the not-yet-committed-to-persistence updates have been ingested in the in-memory fan-out.

We perform the checks explicitly:
* **stale** and **ahead-of-the-indexer** we check by comparing the ledger end cache against the re-initialization ledger end. Additionally, we check the re-initialization string interning id against the last string interned id in the view (we need to also check this as **dirty** does not cover it since the StringInterningView is updated in the `Indexer`.
* **dirty** we define the `_dirty` flag explicitly that is set on failures in `InitializeTo` and `update`.

P.S. For better encapsulation of the mutable operations with the mutating objects, the objects mutating method is extracted from `InMemoryStateUpdater.flow` to `InMemoryState.update`

P.P.S. This PR does not take care of synchronizing mutating operations on the in-memory state. This synchronization is guaranteed from the outside. However, added a TODO in `InMemoryState` for enabling this synchronization internally. 

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
