### PR TITLE
add operations for non-empty sorted maps

### DIFF
--- a/libs-scala/nonempty/src/main/scala/nonempty/NonEmpty.scala
+++ b/libs-scala/nonempty/src/main/scala/nonempty/NonEmpty.scala
@@ -3,13 +3,13 @@
 
 package com.daml.nonempty
 
-import scala.collection.{Factory, IterableOnce, immutable => imm}, imm.Iterable, imm.Map, imm.Set,
-imm.SortedSet
+import scala.collection.{Factory, IterableOnce, immutable => imm}, imm.Iterable, imm.Map, imm.Set
 import scalaz.Id.Id
 import scalaz.{Foldable, Foldable1, Monoid, OneAnd, Semigroup, Traverse}
 import scalaz.Leibniz, Leibniz.===
 import scalaz.Liskov, Liskov.<~<
 import scalaz.syntax.std.option._
+
 import com.daml.scalautil.FoldableContravariant
 import com.daml.scalautil.Statement.discard
 import NonEmptyCollCompat._
@@ -152,11 +152,9 @@ object NonEmptyColl extends NonEmptyCollInstances {
     private type ESelf = imm.SortedMapOps[K, V, CC, _]
     import NonEmptyColl.Instance.{unsafeNarrow => un}
     def unsorted: NonEmpty[Map[K, V]] = un((self: ESelf).unsorted)
-    // You can't have + because of the dumb string-converting thing in stdlib
     def updated(key: K, value: V): NonEmpty[CC[K, V]] = un((self: ESelf).updated(key, value))
     def transform[W](f: (K, V) => W): NonEmpty[CC[K, W]] = un((self: ESelf).transform(f))
-    // You can't have updateWith here because updateWith can return an empty map
-    def keySet: NonEmpty[SortedSet[K]] = un((self: ESelf).keySet)
+    def keySet: NonEmpty[imm.SortedSet[K]] = un((self: ESelf).keySet)
   }
 
   /** Operations that can ''return'' new maps.  There is no reason to include any other

--- a/libs-scala/nonempty/src/test/scala/nonempty/NonEmptySpec.scala
+++ b/libs-scala/nonempty/src/test/scala/nonempty/NonEmptySpec.scala
@@ -156,6 +156,51 @@ class NonEmptySpec extends AnyWordSpec with Matchers with WordSpecCheckLaws {
       )
       (nhm: NonEmpty[Map[Int, Int]]) should ===(m)
     }
+
+    "preserve sortedness" in {
+      val sm = NonEmpty(imm.SortedMap, 1 -> 2)
+      (sm.updated(1, 2): NonEmpty[imm.SortedMap[Int, Int]]) should ===(sm)
+    }
+  }
+
+  "transform" should {
+    val m = NonEmpty(imm.HashMap, 1 -> 2)
+    "preserve the map type" in {
+      (m.transform((_, _) => 2): NonEmpty[imm.HashMap[Int, Int]]) should ===(m)
+    }
+
+    "preserve a wider map type" in {
+      val nhm = (m: NonEmpty[Map[Int, Int]]).transform((_, _) => 2)
+      illTyped(
+        "nhm: NonEmpty[imm.HashMap[Int, Int]]",
+        "(?s)type mismatch.*?found.*?\\.Map.*?required.*?HashMap.*",
+      )
+      (nhm: NonEmpty[Map[Int, Int]]) should ===(m)
+    }
+
+    "preserve sortedness" in {
+      val sm = NonEmpty(imm.SortedMap, 1 -> 2)
+      (sm.transform((_, _) => 2): NonEmpty[imm.SortedMap[Int, Int]]) should ===(sm)
+    }
+  }
+
+  "keySet" should {
+    "retain nonempty" in {
+      val m = NonEmpty(imm.HashMap, 1 -> 2)
+      (m.keySet: NonEmpty[Set[Int]]) should ===(NonEmpty(Set, 1))
+    }
+
+    "retain sortedness" in {
+      val sm = NonEmpty(imm.SortedMap, 1 -> 2)
+      (sm.keySet: NonEmpty[imm.SortedSet[Int]]) should ===(NonEmpty(imm.SortedSet, 1))
+    }
+  }
+
+  "unsorted" should {
+    "retain nonempty" in {
+      val sm = NonEmpty(imm.SortedMap, 1 -> 2)
+      (sm.unsorted: NonEmpty[Map[Int, Int]]) should ===(sm)
+    }
   }
 
   "to" should {


### PR DESCRIPTION
So that `NonEmpty(SortedMap, ...).updated(k, v)` returns a `NonEmpty[SortedMap[...]]` and not `NonEmpty[Map[...]]`, and similarly for other `SortedMapOps`.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
