### PR TITLE
suggest JSON API/JavaScript users use the bindings and codegen

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -25,7 +25,7 @@ For these and other features, use :doc:`the Ledger API </app-dev/ledger-api>`
 instead.
 
 If you are using this API from JavaScript or TypeScript, we strongly recommend using :doc:`the JavaScript bindings and code generator </app-dev/bindings-ts/index>` rather than invoking these endpoints directly.
-This will both simplify access to the endpoints described here, and with TypeScript, guide you with respect to the JavaScript value format for each of your contracts, choice arguments, and choice results.
+This will both simplify access to the endpoints described here and (with TypeScript) help to provide the correct JavaScript value format for each of your contracts, choice arguments, and choice results.
 
 We welcome feedback about the JSON API on
 `our issue tracker <https://github.com/digital-asset/daml/issues/new/choose>`_, or

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -24,6 +24,9 @@ complicating concerns including, but not limited to:
 For these and other features, use :doc:`the Ledger API </app-dev/ledger-api>`
 instead.
 
+If you are using this API from JavaScript or TypeScript, we strongly recommend using :doc:`the JavaScript bindings and code generator </app-dev/bindings-ts/index>` rather than invoking these endpoints directly.
+This will both simplify access to the endpoints described here, and with TypeScript, guide you with respect to the JavaScript value format for each of your contracts, choice arguments, and choice results.
+
 We welcome feedback about the JSON API on
 `our issue tracker <https://github.com/digital-asset/daml/issues/new/choose>`_, or
 `on our forum <https://discuss.daml.com>`_.

--- a/docs/source/json-api/lf-value-specification.rst
+++ b/docs/source/json-api/lf-value-specification.rst
@@ -11,8 +11,8 @@ JSON output we produce (encoding).
 If you use
 :doc:`the JavaScript code generator </app-dev/bindings-ts/daml2js>`
 with TypeScript, the generated types for templates and choices will
-incorporate the following automatically.  You can use this to observe
-how these rules apply to your templates, or to simply ignore this
+incorporate the following automatically. You can use this to observe
+how these rules apply to your templates, or ignore this
 document and rely on the TypeScript type checker to tell you how to
 encode data for JSON API correctly.
 

--- a/docs/source/json-api/lf-value-specification.rst
+++ b/docs/source/json-api/lf-value-specification.rst
@@ -8,6 +8,14 @@ We describe how to decode and encode Daml-LF values as JSON. For each
 Daml-LF type we explain what JSON inputs we accept (decoding), and what
 JSON output we produce (encoding).
 
+If you use
+:doc:`the JavaScript code generator </app-dev/bindings-ts/daml2js>`
+with TypeScript, the generated types for templates and choices will
+incorporate the following automatically.  You can use this to observe
+how these rules apply to your templates, or to simply ignore this
+document and rely on the TypeScript type checker to tell you how to
+encode data for JSON API correctly.
+
 Codec Library
 *************
 


### PR DESCRIPTION
It may seem to new users that invoking the JSON API endpoints directly will be a simpler onboarding path, but this empirically doesn't hold up. Having types for your own templates instead of having to learn the LF/JSON mapping is a huge benefit to both new and experienced users, not to mention having JavaScript library functions instead of working out request and response payloads manually.

Let's point JSON API-with-JavaScript users to the bindings for that reason.