### PR TITLE
interface subscriptions from Java bindings

### DIFF
--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TransactionsClientImplTest.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/TransactionsClientImplTest.scala
@@ -60,7 +60,7 @@ final class TransactionsClientImplTest
 
         val transactionFilter = new data.FiltersByParty(
           Map[String, data.Filter](
-            "Alice" -> new data.InclusiveFilter(
+            "Alice" -> data.InclusiveFilter.ofTemplateIds(
               Set(
                 new data.Identifier("p1", "m1", "e1"),
                 new data.Identifier("p2", "m2", "e2"),
@@ -123,9 +123,9 @@ final class TransactionsClientImplTest
         val begin = new data.LedgerOffset.Absolute("1")
         val end = new data.LedgerOffset.Absolute("2")
 
-        val trasnactionFilter = new data.FiltersByParty(
+        val transactionFilter = new data.FiltersByParty(
           Map[String, data.Filter](
-            "Alice" -> new data.InclusiveFilter(
+            "Alice" -> data.InclusiveFilter.ofTemplateIds(
               Set(
                 new data.Identifier("p1", "m1", "e1"),
                 new data.Identifier("p2", "m2", "e2"),
@@ -135,7 +135,7 @@ final class TransactionsClientImplTest
         )
 
         transactionClient
-          .getTransactionsTrees(begin, end, trasnactionFilter, true)
+          .getTransactionsTrees(begin, end, transactionFilter, true)
           .toList()
           .blockingGet()
 

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/DataLayerHelpers.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/DataLayerHelpers.scala
@@ -54,6 +54,6 @@ trait DataLayerHelpers {
 
   def filterFor(party: String): FiltersByParty =
     new FiltersByParty(
-      Map(party -> new InclusiveFilter(Set.empty[Identifier].asJava).asInstanceOf[Filter]).asJava
+      Map(party -> (InclusiveFilter.ofTemplateIds(Set.empty[Identifier].asJava): Filter)).asJava
     )
 }

--- a/language-support/java/bindings/BUILD.bazel
+++ b/language-support/java/bindings/BUILD.bazel
@@ -96,6 +96,7 @@ da_scala_library(
     ],
     deps = [
         ":bindings-java",
+        "@maven//:com_google_api_grpc_proto_google_common_protos",
         "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
@@ -117,6 +118,7 @@ da_scala_test_suite(
     deps = [
         ":bindings-java",
         ":bindings-java-tests-lib",
+        "@maven//:com_google_api_grpc_proto_google_common_protos",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_scalatest_scalatest_compatible",
     ],

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
@@ -5,7 +5,10 @@ package com.daml.ledger.javaapi.data;
 
 import com.daml.ledger.api.v1.EventOuterClass;
 import com.google.protobuf.StringValue;
+import com.google.rpc.Status;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class CreatedEvent implements Event, TreeEvent {
@@ -19,6 +22,11 @@ public final class CreatedEvent implements Event, TreeEvent {
   private final String contractId;
 
   private final DamlRecord arguments;
+
+  private final @NonNull Map<@NonNull Identifier, @NonNull DamlRecord> interfaceViews;
+
+  private final @NonNull Map<@NonNull Identifier, com.google.rpc.@NonNull Status>
+      failedInterfaceViews;
 
   private final Optional<String> agreementText;
 
@@ -34,6 +42,8 @@ public final class CreatedEvent implements Event, TreeEvent {
       @NonNull Identifier templateId,
       @NonNull String contractId,
       @NonNull DamlRecord arguments,
+      @NonNull Map<@NonNull Identifier, @NonNull DamlRecord> interfaceViews,
+      @NonNull Map<@NonNull Identifier, com.google.rpc.@NonNull Status> failedInterfaceViews,
       @NonNull Optional<String> agreementText,
       @NonNull Optional<Value> contractKey,
       @NonNull Collection<@NonNull String> signatories,
@@ -43,10 +53,41 @@ public final class CreatedEvent implements Event, TreeEvent {
     this.templateId = templateId;
     this.contractId = contractId;
     this.arguments = arguments;
+    this.interfaceViews = Collections.unmodifiableMap(interfaceViews);
+    this.failedInterfaceViews = Collections.unmodifiableMap(failedInterfaceViews);
     this.agreementText = agreementText;
     this.contractKey = contractKey;
     this.signatories = Collections.unmodifiableSet(new HashSet<>(signatories));
     this.observers = Collections.unmodifiableSet(new HashSet<>(observers));
+  }
+
+  /**
+   * @deprecated Pass {@code interfaceViews} and {@code failedInterfaceViews} arguments; empty maps
+   *     are reasonable defaults. Since Daml 2.4.0
+   */
+  @Deprecated
+  public CreatedEvent(
+      @NonNull List<@NonNull String> witnessParties,
+      @NonNull String eventId,
+      @NonNull Identifier templateId,
+      @NonNull String contractId,
+      @NonNull DamlRecord arguments,
+      @NonNull Optional<String> agreementText,
+      @NonNull Optional<Value> contractKey,
+      @NonNull Collection<@NonNull String> signatories,
+      @NonNull Collection<@NonNull String> observers) {
+    this(
+        witnessParties,
+        eventId,
+        templateId,
+        contractId,
+        arguments,
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        agreementText,
+        contractKey,
+        signatories,
+        observers);
   }
 
   @NonNull
@@ -79,6 +120,16 @@ public final class CreatedEvent implements Event, TreeEvent {
   }
 
   @NonNull
+  public Map<Identifier, DamlRecord> getInterfaceViews() {
+    return interfaceViews;
+  }
+
+  @NonNull
+  public Map<Identifier, Status> getFailedInterfaceViews() {
+    return failedInterfaceViews;
+  }
+
+  @NonNull
   public Optional<String> getAgreementText() {
     return agreementText;
   }
@@ -108,6 +159,8 @@ public final class CreatedEvent implements Event, TreeEvent {
         && Objects.equals(templateId, that.templateId)
         && Objects.equals(contractId, that.contractId)
         && Objects.equals(arguments, that.arguments)
+        && Objects.equals(interfaceViews, that.interfaceViews)
+        && Objects.equals(failedInterfaceViews, that.failedInterfaceViews)
         && Objects.equals(agreementText, that.agreementText)
         && Objects.equals(contractKey, that.contractKey)
         && Objects.equals(signatories, that.signatories)
@@ -122,6 +175,8 @@ public final class CreatedEvent implements Event, TreeEvent {
         templateId,
         contractId,
         arguments,
+        interfaceViews,
+        failedInterfaceViews,
         agreementText,
         contractKey,
         signatories,
@@ -143,10 +198,13 @@ public final class CreatedEvent implements Event, TreeEvent {
         + '\''
         + ", arguments="
         + arguments
+        + ", interfaceViews="
+        + interfaceViews
+        + ", failedInterfaceViews="
+        + failedInterfaceViews
         + ", agreementText='"
         + agreementText
-        + '\''
-        + ", contractKey="
+        + "', contractKey="
         + contractKey
         + ", signatories="
         + signatories
@@ -160,6 +218,23 @@ public final class CreatedEvent implements Event, TreeEvent {
         EventOuterClass.CreatedEvent.newBuilder()
             .setContractId(this.getContractId())
             .setCreateArguments(this.getArguments().toProtoRecord())
+            .addAllInterfaceViews(
+                Stream.concat(
+                        interfaceViews.entrySet().stream()
+                            .map(
+                                e ->
+                                    EventOuterClass.InterfaceView.newBuilder()
+                                        .setInterfaceId(e.getKey().toProto())
+                                        .setViewValue(e.getValue().toProtoRecord())
+                                        .build()),
+                        failedInterfaceViews.entrySet().stream()
+                            .map(
+                                e ->
+                                    EventOuterClass.InterfaceView.newBuilder()
+                                        .setInterfaceId(e.getKey().toProto())
+                                        .setViewStatus(e.getValue())
+                                        .build()))
+                    .collect(Collectors.toUnmodifiableList()))
             .setEventId(this.getEventId())
             .setTemplateId(this.getTemplateId().toProto())
             .addAllWitnessParties(this.getWitnessParties())
@@ -171,12 +246,15 @@ public final class CreatedEvent implements Event, TreeEvent {
   }
 
   public static CreatedEvent fromProto(EventOuterClass.CreatedEvent createdEvent) {
+    var splitInterfaceViews = createdEvent.getInterfaceViewsList().stream().collect(Collectors.partitioningBy(EventOuterClass.InterfaceView::hasViewValue));
     return new CreatedEvent(
         createdEvent.getWitnessPartiesList(),
         createdEvent.getEventId(),
         Identifier.fromProto(createdEvent.getTemplateId()),
         createdEvent.getContractId(),
         DamlRecord.fromProto(createdEvent.getCreateArguments()),
+        splitInterfaceViews.get(true).stream().collect(Collectors.toUnmodifiableMap(iv -> Identifier.fromProto(iv.getInterfaceId()), iv -> DamlRecord.fromProto(iv.getViewValue()))),
+        splitInterfaceViews.get(false).stream().collect(Collectors.toUnmodifiableMap(iv -> Identifier.fromProto(iv.getInterfaceId()), EventOuterClass.InterfaceView::getViewStatus)),
         createdEvent.hasAgreementText()
             ? Optional.of(createdEvent.getAgreementText().getValue())
             : Optional.empty(),

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
@@ -48,17 +48,17 @@ public final class CreatedEvent implements Event, TreeEvent {
       @NonNull Optional<Value> contractKey,
       @NonNull Collection<@NonNull String> signatories,
       @NonNull Collection<@NonNull String> observers) {
-    this.witnessParties = Collections.unmodifiableList(new ArrayList<>(witnessParties));
+    this.witnessParties = List.copyOf(witnessParties);
     this.eventId = eventId;
     this.templateId = templateId;
     this.contractId = contractId;
     this.arguments = arguments;
-    this.interfaceViews = Collections.unmodifiableMap(interfaceViews);
-    this.failedInterfaceViews = Collections.unmodifiableMap(failedInterfaceViews);
+    this.interfaceViews = Map.copyOf(interfaceViews);
+    this.failedInterfaceViews = Map.copyOf(failedInterfaceViews);
     this.agreementText = agreementText;
     this.contractKey = contractKey;
-    this.signatories = Collections.unmodifiableSet(new HashSet<>(signatories));
-    this.observers = Collections.unmodifiableSet(new HashSet<>(observers));
+    this.signatories = Set.copyOf(signatories);
+    this.observers = Set.copyOf(observers);
   }
 
   /**

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
@@ -251,15 +251,25 @@ public final class CreatedEvent implements Event, TreeEvent {
   }
 
   public static CreatedEvent fromProto(EventOuterClass.CreatedEvent createdEvent) {
-    var splitInterfaceViews = createdEvent.getInterfaceViewsList().stream().collect(Collectors.partitioningBy(EventOuterClass.InterfaceView::hasViewValue));
+    var splitInterfaceViews =
+        createdEvent.getInterfaceViewsList().stream()
+            .collect(Collectors.partitioningBy(EventOuterClass.InterfaceView::hasViewValue));
     return new CreatedEvent(
         createdEvent.getWitnessPartiesList(),
         createdEvent.getEventId(),
         Identifier.fromProto(createdEvent.getTemplateId()),
         createdEvent.getContractId(),
         DamlRecord.fromProto(createdEvent.getCreateArguments()),
-        splitInterfaceViews.get(true).stream().collect(Collectors.toUnmodifiableMap(iv -> Identifier.fromProto(iv.getInterfaceId()), iv -> DamlRecord.fromProto(iv.getViewValue()))),
-        splitInterfaceViews.get(false).stream().collect(Collectors.toUnmodifiableMap(iv -> Identifier.fromProto(iv.getInterfaceId()), EventOuterClass.InterfaceView::getViewStatus)),
+        splitInterfaceViews.get(true).stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    iv -> Identifier.fromProto(iv.getInterfaceId()),
+                    iv -> DamlRecord.fromProto(iv.getViewValue()))),
+        splitInterfaceViews.get(false).stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    iv -> Identifier.fromProto(iv.getInterfaceId()),
+                    EventOuterClass.InterfaceView::getViewStatus)),
         createdEvent.hasAgreementText()
             ? Optional.of(createdEvent.getAgreementText().getValue())
             : Optional.empty(),

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/CreatedEvent.java
@@ -27,8 +27,7 @@ public final class CreatedEvent implements Event, TreeEvent {
 
   private final @NonNull Map<@NonNull Identifier, @NonNull DamlRecord> interfaceViews;
 
-  private final @NonNull Map<@NonNull Identifier, com.google.rpc.@NonNull Status>
-      failedInterfaceViews;
+  private final @NonNull Map<@NonNull Identifier, @NonNull Status> failedInterfaceViews;
 
   private final Optional<String> agreementText;
 
@@ -122,12 +121,12 @@ public final class CreatedEvent implements Event, TreeEvent {
   }
 
   @NonNull
-  public Map<Identifier, DamlRecord> getInterfaceViews() {
+  public Map<@NonNull Identifier, @NonNull DamlRecord> getInterfaceViews() {
     return interfaceViews;
   }
 
   @NonNull
-  public Map<Identifier, Status> getFailedInterfaceViews() {
+  public Map<@NonNull Identifier, @NonNull Status> getFailedInterfaceViews() {
     return failedInterfaceViews;
   }
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
@@ -4,7 +4,6 @@
 package com.daml.ledger.javaapi.data;
 
 import com.daml.ledger.api.v1.TransactionFilterOuterClass;
-import java.util.Objects;
 
 public abstract class Filter {
 
@@ -18,12 +17,23 @@ public abstract class Filter {
 
   public abstract TransactionFilterOuterClass.Filters toProto();
 
-  // TODO #14537 this is just one bool now.  Is it likely to change?  If not, inline.
+  /**
+   * Settings for including an interface in {@link InclusiveFilter}. There are two values: {@link
+   * #INCLUDE_VIEW} and {@link #HIDE_VIEW}.
+   */
   public static final class Interface {
     public final boolean includeInterfaceView;
+    // add equals and hashCode if adding more fields
 
-    public Interface(boolean includeInterfaceView) {
+    public static final Interface INCLUDE_VIEW = new Interface(true);
+    public static final Interface HIDE_VIEW = new Interface(false);
+
+    private Interface(boolean includeInterfaceView) {
       this.includeInterfaceView = includeInterfaceView;
+    }
+
+    private static Interface includeInterfaceView(boolean includeInterfaceView) {
+      return includeInterfaceView ? INCLUDE_VIEW : HIDE_VIEW;
     }
 
     public TransactionFilterOuterClass.InterfaceFilter toProto(Identifier interfaceId) {
@@ -34,24 +44,11 @@ public abstract class Filter {
     }
 
     static Interface fromProto(TransactionFilterOuterClass.InterfaceFilter proto) {
-      return new Interface(proto.getIncludeInterfaceView());
+      return includeInterfaceView(proto.getIncludeInterfaceView());
     }
 
     Interface merge(Interface other) {
-      return new Interface(includeInterfaceView || other.includeInterfaceView);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      Interface that = (Interface) o;
-      return includeInterfaceView == that.includeInterfaceView;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(includeInterfaceView);
+      return includeInterfaceView(includeInterfaceView || other.includeInterfaceView);
     }
 
     @Override

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
@@ -33,6 +33,10 @@ public abstract class Filter {
           .build();
     }
 
+    static Interface fromProto(TransactionFilterOuterClass.InterfaceFilter proto) {
+      return new Interface(proto.getIncludeInterfaceView());
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
@@ -53,7 +53,7 @@ public abstract class Filter {
 
     @Override
     public String toString() {
-      return "Interface{" + "includeInterfaceView=" + includeInterfaceView + '}';
+      return "Filter.Interface{" + "includeInterfaceView=" + includeInterfaceView + '}';
     }
   }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
@@ -18,11 +18,19 @@ public abstract class Filter {
 
   public abstract TransactionFilterOuterClass.Filters toProto();
 
+  // TODO #14537 this is just one bool now.  Is it likely to change?  If not, inline.
   public static final class Interface {
-    public final boolean includeInterfaceViews;
+    public final boolean includeInterfaceView;
 
-    public Interface(boolean includeInterfaceViews) {
-      this.includeInterfaceViews = includeInterfaceViews;
+    public Interface(boolean includeInterfaceView) {
+      this.includeInterfaceView = includeInterfaceView;
+    }
+
+    public TransactionFilterOuterClass.InterfaceFilter toProto(Identifier interfaceId) {
+      return TransactionFilterOuterClass.InterfaceFilter.newBuilder()
+          .setInterfaceId(interfaceId.toProto())
+          .setIncludeInterfaceView(includeInterfaceView)
+          .build();
     }
 
     @Override
@@ -30,17 +38,17 @@ public abstract class Filter {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       Interface that = (Interface) o;
-      return includeInterfaceViews == that.includeInterfaceViews;
+      return includeInterfaceView == that.includeInterfaceView;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(includeInterfaceViews);
+      return Objects.hash(includeInterfaceView);
     }
 
     @Override
     public String toString() {
-      return "Interface{" + "includeInterfaceViews=" + includeInterfaceViews + '}';
+      return "Interface{" + "includeInterfaceView=" + includeInterfaceView + '}';
     }
   }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
@@ -4,6 +4,7 @@
 package com.daml.ledger.javaapi.data;
 
 import com.daml.ledger.api.v1.TransactionFilterOuterClass;
+import java.util.Objects;
 
 public abstract class Filter {
 
@@ -16,4 +17,30 @@ public abstract class Filter {
   }
 
   public abstract TransactionFilterOuterClass.Filters toProto();
+
+  public static final class Interface {
+    public final boolean includeInterfaceViews;
+
+    public Interface(boolean includeInterfaceViews) {
+      this.includeInterfaceViews = includeInterfaceViews;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Interface that = (Interface) o;
+      return includeInterfaceViews == that.includeInterfaceViews;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(includeInterfaceViews);
+    }
+
+    @Override
+    public String toString() {
+      return "Interface{" + "includeInterfaceViews=" + includeInterfaceViews + '}';
+    }
+  }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/Filter.java
@@ -37,6 +37,10 @@ public abstract class Filter {
       return new Interface(proto.getIncludeInterfaceView());
     }
 
+    Interface merge(Interface other) {
+      return new Interface(includeInterfaceView || other.includeInterfaceView);
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
@@ -6,22 +6,47 @@ package com.daml.ledger.javaapi.data;
 import com.daml.ledger.api.v1.TransactionFilterOuterClass;
 import com.daml.ledger.api.v1.ValueOuterClass;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class InclusiveFilter extends Filter {
 
   private Set<Identifier> templateIds;
+  private Map<@NonNull Identifier, Filter.Interface> interfaceIds;
 
+  /**
+   * @deprecated Use {@link #ofTemplateIds} instead; {@code templateIds} must not include interface
+   *     IDs
+   */
+  @Deprecated
   public InclusiveFilter(@NonNull Set<@NonNull Identifier> templateIds) {
+    this(templateIds, Collections.emptyMap());
+  }
+
+  public InclusiveFilter(
+      @NonNull Set<@NonNull Identifier> templateIds,
+      @NonNull Map<@NonNull Identifier, Filter.Interface> interfaceIds) {
     this.templateIds = templateIds;
+    this.interfaceIds = interfaceIds;
+  }
+
+  public static InclusiveFilter ofTemplateIds(@NonNull Set<@NonNull Identifier> templateIds) {
+    return new InclusiveFilter(templateIds, Collections.emptyMap());
   }
 
   @NonNull
   public Set<@NonNull Identifier> getTemplateIds() {
     return templateIds;
+  }
+
+  @NonNull
+  public Map<@NonNull Identifier, Filter.Interface> getInterfaceIds() {
+    return interfaceIds;
   }
 
   @Override
@@ -33,6 +58,10 @@ public class InclusiveFilter extends Filter {
     TransactionFilterOuterClass.InclusiveFilters inclusiveFilter =
         TransactionFilterOuterClass.InclusiveFilters.newBuilder()
             .addAllTemplateIds(templateIds)
+            .addAllInterfaceFilters(
+                interfaceIds.entrySet().stream()
+                    .map(idFilt -> idFilt.getValue().toProto(idFilt.getKey()))
+                    .collect(Collectors.toUnmodifiableList()))
             .build();
     return TransactionFilterOuterClass.Filters.newBuilder().setInclusive(inclusiveFilter).build();
   }
@@ -43,12 +72,24 @@ public class InclusiveFilter extends Filter {
     for (ValueOuterClass.Identifier templateId : inclusiveFilters.getTemplateIdsList()) {
       templateIds.add(Identifier.fromProto(templateId));
     }
-    return new InclusiveFilter(templateIds);
+    // TODO #14537 merge like filters
+    var interfaceIds =
+        inclusiveFilters.getInterfaceFiltersList().stream()
+            .collect(
+                Collectors.toMap(
+                    ifFilt -> Identifier.fromProto(ifFilt.getInterfaceId()),
+                    Filter.Interface::fromProto));
+    return new InclusiveFilter(templateIds, interfaceIds);
   }
 
   @Override
   public String toString() {
-    return "InclusiveFilter{" + "templateIds=" + templateIds + '}';
+    return "InclusiveFilter{"
+        + "templateIds="
+        + templateIds
+        + ", interfaceIds="
+        + interfaceIds
+        + '}';
   }
 
   @Override
@@ -56,12 +97,12 @@ public class InclusiveFilter extends Filter {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     InclusiveFilter that = (InclusiveFilter) o;
-    return Objects.equals(templateIds, that.templateIds);
+    return Objects.equals(templateIds, that.templateIds)
+        && Objects.equals(interfaceIds, that.interfaceIds);
   }
 
   @Override
   public int hashCode() {
-
-    return Objects.hash(templateIds);
+    return Objects.hash(templateIds, interfaceIds);
   }
 }

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
@@ -17,11 +17,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public final class InclusiveFilter extends Filter {
 
   private Set<Identifier> templateIds;
-  private Map<@NonNull Identifier, Filter.Interface> interfaceIds;
+  private Map<@NonNull Identifier, Filter.@NonNull Interface> interfaceIds;
 
   /**
    * @deprecated Use {@link #ofTemplateIds} instead; {@code templateIds} must not include interface
-   *     IDs
+   *     IDs. Since Daml 2.4.0
    */
   @Deprecated
   public InclusiveFilter(@NonNull Set<@NonNull Identifier> templateIds) {
@@ -30,7 +30,7 @@ public final class InclusiveFilter extends Filter {
 
   public InclusiveFilter(
       @NonNull Set<@NonNull Identifier> templateIds,
-      @NonNull Map<@NonNull Identifier, Filter.Interface> interfaceIds) {
+      @NonNull Map<@NonNull Identifier, Filter.@NonNull Interface> interfaceIds) {
     this.templateIds = templateIds;
     this.interfaceIds = interfaceIds;
   }
@@ -45,7 +45,7 @@ public final class InclusiveFilter extends Filter {
   }
 
   @NonNull
-  public Map<@NonNull Identifier, Filter.Interface> getInterfaceIds() {
+  public Map<@NonNull Identifier, Filter.@NonNull Interface> getInterfaceIds() {
     return interfaceIds;
   }
 

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-public class InclusiveFilter extends Filter {
+public final class InclusiveFilter extends Filter {
 
   private Set<Identifier> templateIds;
   private Map<@NonNull Identifier, Filter.Interface> interfaceIds;

--- a/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
+++ b/language-support/java/bindings/src/main/java/com/daml/ledger/javaapi/data/InclusiveFilter.java
@@ -72,13 +72,13 @@ public final class InclusiveFilter extends Filter {
     for (ValueOuterClass.Identifier templateId : inclusiveFilters.getTemplateIdsList()) {
       templateIds.add(Identifier.fromProto(templateId));
     }
-    // TODO #14537 merge like filters
     var interfaceIds =
         inclusiveFilters.getInterfaceFiltersList().stream()
             .collect(
-                Collectors.toMap(
+                Collectors.toUnmodifiableMap(
                     ifFilt -> Identifier.fromProto(ifFilt.getInterfaceId()),
-                    Filter.Interface::fromProto));
+                    Filter.Interface::fromProto,
+                    Filter.Interface::merge));
     return new InclusiveFilter(templateIds, interfaceIds);
   }
 

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
@@ -28,9 +28,10 @@ class EventSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyC
   "CreatedEvents" should "be protected from mutations of the parameters" in forAll(
     createdEventGen
   ) { e =>
-    val mutatingWitnesses = new java.util.ArrayList[String](e.getWitnessPartiesList)
-    val mutatingSignatories = new java.util.ArrayList[String](e.getSignatoriesList)
-    val mutatingObservers = new java.util.ArrayList[String](e.getObserversList)
+    def mcopy[X](xs: java.util.Collection[_ <: X]) = new java.util.ArrayList[X](xs)
+    val mutatingWitnesses = mcopy(e.getWitnessPartiesList)
+    val mutatingSignatories = mcopy(e.getSignatoriesList)
+    val mutatingObservers = mcopy(e.getObserversList)
 
     val event = new CreatedEvent(
       mutatingWitnesses,

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
@@ -36,8 +36,12 @@ class EventSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyC
     val mutatingWitnesses = mutList(e.getWitnessPartiesList)
     val mutatingSignatories = mutList(e.getSignatoriesList)
     val mutatingObservers = mutList(e.getObserversList)
+    val extraIVJ = Identifier fromProto extraIV
+    val extraFIVJ = Identifier fromProto extraFIV
     val mutatingIVs = mutMap(base.getInterfaceViews)
     val mutatingFIVs = mutMap(base.getFailedInterfaceViews)
+    mutatingIVs.remove(extraIVJ)
+    mutatingIVs.remove(extraFIVJ)
 
     val event = new CreatedEvent(
       mutatingWitnesses,
@@ -56,8 +60,6 @@ class EventSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyC
     mutatingWitnesses.add("INTRUDER!")
     mutatingSignatories.add("INTRUDER!")
     mutatingObservers.add("INTRUDER!")
-    val extraIVJ = Identifier fromProto extraIV
-    val extraFIVJ = Identifier fromProto extraFIV
     mutatingIVs.put(extraIVJ, base.getArguments)
     mutatingFIVs.put(extraFIVJ, com.google.rpc.Status.getDefaultInstance)
 

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/EventSpec.scala
@@ -71,17 +71,7 @@ class EventSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyC
   }
 
   "CreatedEvents" should "disallow mutation of its mutable fields" in forAll(createdEventGen) { e =>
-    val event = new CreatedEvent(
-      e.getWitnessPartiesList,
-      e.getEventId,
-      Identifier.fromProto(e.getTemplateId),
-      e.getContractId,
-      DamlRecord.fromProto(e.getCreateArguments),
-      java.util.Optional.empty(),
-      java.util.Optional.empty(),
-      e.getSignatoriesList,
-      e.getObserversList,
-    )
+    val event = CreatedEvent fromProto e
 
     an[UnsupportedOperationException] shouldBe thrownBy(event.getWitnessParties.add("INTRUDER!"))
     an[UnsupportedOperationException] shouldBe thrownBy(event.getSignatories.add("INTRUDER!"))

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
@@ -8,6 +8,7 @@ import java.time.{Instant, LocalDate}
 import com.daml.ledger.api.v1._
 import com.google.protobuf.Empty
 import org.scalacheck.{Arbitrary, Gen}
+import Arbitrary.arbitrary
 
 import scala.jdk.CollectionConverters._
 
@@ -320,10 +321,21 @@ object Generators {
   def inclusiveGen: Gen[TransactionFilterOuterClass.InclusiveFilters] =
     for {
       templateIds <- Gen.listOf(identifierGen)
+      interfaceFilters <- Gen.listOf(interfaceFilterGen)
     } yield TransactionFilterOuterClass.InclusiveFilters
       .newBuilder()
       .addAllTemplateIds(templateIds.asJava)
+      .addAllInterfaceFilters(interfaceFilters.asJava)
       .build()
+
+  private[this] def interfaceFilterGen: Gen[TransactionFilterOuterClass.InterfaceFilter] =
+    Gen.zip(identifierGen, arbitrary[Boolean]).map { case (interfaceId, includeInterfaceView) =>
+      TransactionFilterOuterClass.InterfaceFilter
+        .newBuilder()
+        .setInterfaceId(interfaceId)
+        .setIncludeInterfaceView(includeInterfaceView)
+        .build()
+    }
 
   def getActiveContractRequestGen: Gen[ActiveContractsServiceOuterClass.GetActiveContractsRequest] =
     for {

--- a/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
+++ b/language-support/java/bindings/src/test/scala/com/daml/ledger/javaapi/data/Generators.scala
@@ -240,6 +240,7 @@ object Generators {
       .setContractId(contractId)
       .setTemplateId(templateId)
       .setCreateArguments(createArgument)
+      // TODO #14537 addAllInterfaceViews
       .setEventId(eventId)
       .addAllWitnessParties(witnessParties.asJava)
       .addAllSignatories(signatories.asJava)


### PR DESCRIPTION
Part of #14067. See https://github.com/digital-asset/daml/issues/14067#issuecomment-1164998509 for design.

```rst
CHANGELOG_BEGIN
- [Java bindings] The existing ``CreatedEvent`` constructor has been
  deprecated in favor of a new one that includes new interface-related
  arguments.  Most users should not be using this constructor directly,
  preferring ``fromProto`` instead, but the remainder should pass in
  empty maps as the new arguments.

  Likewise, the ``InclusiveFilter`` constructor has been deprecated.
  Existing callers should use the ``ofTemplateIds`` static method
  instead to replace current calls, keeping in mind that it will not be
  valid to pass ``Identifier``s representing interface IDs to this
  method.
CHANGELOG_END
```

* [x] `Filter.Interface`, or not
* [x] `InclusiveFilter` extension
* [x] `CreatedEvent` extension
* [ ] check against #14448?
* [x] #14033
* [x] rebase and change target to main
* [x] changelog