### PR TITLE
Qualify `envInterfaceMethodInstances`

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -976,17 +976,17 @@ convertImplements env tpl = NM.fromList <$>
     convertInterface (originLoc, iface) = withRange originLoc $ do
       let handleIsNotInterface tyCon =
             "cannot implement '" ++ prettyPrint tyCon ++ "' because it is not an interface"
-      con <- convertInterfaceTyCon env handleIsNotInterface iface
+      ifaceCon <- convertInterfaceTyCon env handleIsNotInterface iface
       let mod = nameModule (getName iface)
 
       -- TODO: Stub view, will extract later, https://github.com/digital-asset/daml/pull/14439
-      let view = ETmLam (ExprVarName "this", TCon con) (EBuiltin BEUnit)
+      let view = ETmLam (ExprVarName "this", TCon ifaceCon) (EBuiltin BEUnit)
 
       methods <- convertMethods $ MS.findWithDefault []
-        (mod, qualObject con, tpl)
+        (mod, qualObject ifaceCon, tpl)
         (envInterfaceMethodInstances env)
 
-      pure (TemplateImplements con methods view)
+      pure (TemplateImplements ifaceCon methods view)
 
     convertMethods ms = fmap NM.fromList . sequence $
       [ TemplateImplementsMethod (MethodName k) . (`ETmApp` EVar this) <$> convertExpr env v

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -611,24 +611,22 @@ convertModule envLfVersion envEnableScenarios envPkgMap envStablePackages envIsG
 
         toEnvStage1 :: Env0 -> ConvertM Env
         toEnvStage1 env0 = do
-          envInterfaceMethodInstances <-
-            fmap (MS.fromListWith (++))
-            $ sequence
-            $ [ do
-                  tplTyCon <- convertQualifiedTyCon env0 tpl
-                  ifaceTyCon <- convertQualifiedTyCon env0 iface
-                  pure
-                    ( (tplTyCon, ifaceTyCon)
-                    , [(methodName, untick val)]
-                    )
-              | (name, val) <- binds
-              , TypeCon methodNewtype
-                [ TypeCon tpl []
-                , TypeCon iface []
-                , StrLitTy methodName
-                ] <- [varType name]
-              , NameIn DA_Internal_Desugar "Method" <- [methodNewtype]
-              ]
+          envInterfaceMethodInstances <- MS.fromListWith (++) <$> sequence
+            [ do
+                tplTyCon <- convertQualifiedTyCon env0 tpl
+                ifaceTyCon <- convertQualifiedTyCon env0 iface
+                pure
+                  ( (tplTyCon, ifaceTyCon)
+                  , [(methodName, untick val)]
+                  )
+            | (name, val) <- binds
+            , TypeCon methodNewtype
+              [ TypeCon tpl []
+              , TypeCon iface []
+              , StrLitTy methodName
+              ] <- [varType name]
+            , NameIn DA_Internal_Desugar "Method" <- [methodNewtype]
+            ]
           pure env0
             { envInterfaceMethodInstances
             }


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/14560, in turn part of https://github.com/digital-asset/daml/issues/14047

This was going to be part of a larger LF conversion PR but it's involved enough to warrant its own PR.

While working on LF conversion for retroactive interface implementations, I noticed that the current `envInterfaceMethodInstances` meant things would break when trying to co-implement two identically-named templates from different modules in a given interface. To see why, let's look at the type of `envInterfaceMethodInstances`:

```haskell
  , envInterfaceMethodInstances :: 
      MS.Map                      -- a map from tuples of ...
        ( GHC.Module              --   package id and module name (where the _interface_ was declared),
        , TypeConName             --   the local name of the interface,
        , TypeConName             --   and the local name of the template
        )                         -- ... to
        [                         --   lists of ...
          ( T.Text                --     method name,
          , GHC.Expr GHC.CoreBndr --     and method implementation
          ) 
        ]
```

that is, we have package id and module only for the interfaces, but not for the templates. This miiight still work in most cases, but as soon as we get two templates with the same name from different modules, the map will drop one of the entries. While we could simply add another `GHC.Module` to the key for the template, we already have the LF-specific type `Qualified` for the same purpose (meaning we don't have to use GHC's type) _and_ a handy conversion function 

```haskell
convertQualifiedTyCon :: NamedThing a => Env -> a -> ConvertM (Qualified TypeConName)
```

(we get the `GHC.Module` and the `TypeConName`'s from [`TyCon`](https://hackage.haskell.org/package/ghc-8.8.1/docs/TyCon.html#t:TyCon)s, which are `NamedThing`s)

There is, however, one final problem: we want to use `convertQualifiedTyCon`, which takes an `Env`, to build `envInterfaceMethodInstances`, _one of the fields of `Env`_. Haskell being lazy, we could get away with first setting the `envInterfaceMethodInstances` to `undefined`, and then using the partial `Env` to construct the _real_ `envInterfaceMethodInstances`, which would go into the final `Env`, but only because we "know" that `convertQualifiedTyCon` never looks into that field. 

However, things could change, and we might inadvertently create a loop, so instead this PR encodes the staged construction of the `Env` into the type system in a limited form of [Trees That Grow](https://gitlab.haskell.org/ghc/ghc/-/wikis/implementing-trees-that-grow/trees-that-grow-guidance):

We define a new type `EnvStage` with just two constructors, `EnvStage0` and `EnvStage1`, corresponding to the `Env` before and after the final (non-`undefined`) value of the `envInterfaceMethodInstances` field is constructed. Then, we parametrize the type `Env` with an `EnvStage`-kinded type variable `s`, so now it's `EnvOf s`. We also replace the type of the field `envInterfaceMethodInstances` with a function (type family) on `s`, `EnvInterfaceMethodInstancesOf s`. 

Looking at the definition of `EnvInterfaceMethodInstancesOf`, we see that `EnvInterfaceMethodInstancesOf EnvStage0` is just `()`, since there's no meaningful information, while `EnvInterfaceMethodInstancesOf EnvStage1` is `MS.Map (Qualified TypeConName, Qualified TypeConName) [(T.Text, GHC.Expr GHC.CoreBndr)]`, that is, the same as the current type except changing the key to use `Qualified TypeConName`s instead of plain `TypeConName`s and dropping the now-redundant `GHC.Module`.

For convenience, we also introduce a synonym `Env = EnvOf Stage1`, so we don't have to touch any code that is only needed on/after stage 1.

Now, we can use this more powerful type to show the compiler that `convertQualifiedTyCon` (and the functions it depends on) never look at the `envInterfaceMethodInstances` field, by purposely replacing the `Env` in their types to `EnvOf s`, that is, an environment at an arbitrary stage `s`. 

Finally, we construct the initial `EnvOf Stage0` with exactly the same code as before, except we explicitly set `envInterfaceMethodInstances = ()`. Then, in the body of `convertModule`, we call the new function `toEnvStage1 :: Env0 -> ConvertM Env`, which uses the `Env0` to construct the final field of the `Env`.