### PR TITLE
Revert "Temporarily disable TXTransientNotObservableNoSubmitters… (#14531)"

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -93,7 +93,6 @@ conformance_test(
             "TLSAtLeastOnePointTwoIT",
             "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # requires pruning not available in canton community
             "DeeplyNestedValueIT",  # FIXME: Too deeply nested values flake with a time out (half of the time)
-            "TransactionServiceStakeholdersIT:TXTransientNotObservableNoSubmitters",  # FIXME: Temporarily disabled as flaky on Canton
         ]),
     ],
 ) if not is_windows else None


### PR DESCRIPTION
Revert "Temporarily disable TXTransientNotObservableNoSubmitters since it is flaky in Canton (#14531)"

This reverts commit af0c86609e00191b43efeb787bbfb109cb2c0325.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
