### PR TITLE
docs: fix code snippets in daml/reference/functions

### DIFF
--- a/docs/source/daml/code-snippets/Functions.daml
+++ b/docs/source/daml/code-snippets/Functions.daml
@@ -9,6 +9,7 @@ import Daml.Script
 import DA.Assert
 import DA.Text
 
+-- PARTIAL_APPLICATION_START
 multiplyThreeNumbers : Int -> Int -> Int -> Int
 multiplyThreeNumbers xx yy zz =
   xx * yy * zz
@@ -18,13 +19,16 @@ multiplyTwoNumbersWith7 = multiplyThreeNumbers 7
 multiplyWith21 = multiplyTwoNumbersWith7 3
 
 multiplyWith18 = multiplyThreeNumbers 3 6
+-- PARTIAL_APPLICATION_END
 
+-- PARTIAL_LAMBDA_START
 multiplyWith18_v2 : Int -> Int
-multiplyWith18_v2 xx = 
+multiplyWith18_v2 xx =
   multiplyThreeNumbers 3 6 xx
+-- PARTIAL_LAMBDA_END
 
 
--- Higher order function
+-- HIGHER_ORDER_START
 applyFilter (filter : Int -> Int -> Bool)
     (x : Int)
     (y : Int) = filter x y
@@ -39,12 +43,11 @@ compute = script do
     explode "me" === ["m", "e"]
 
     applyFilter (\a b -> a /= b) 3 2 === True
+-- HIGHER_ORDER_END
 
-
-
-
+-- GENERIC_FUNCTION_START
 compose (f : b -> c) (g : a -> b) (x : a) : c = f (g x)
-
+-- GENERIC_FUNCTION_END
 
 t = script do
   compose ((+) 4) ((*) 2) 3 === 10

--- a/docs/source/daml/reference/functions.rst
+++ b/docs/source/daml/reference/functions.rst
@@ -38,13 +38,15 @@ If you only apply a few arguments to the function, this is called *partial appli
 
 .. literalinclude:: ../code-snippets/Functions.daml
    :language: daml
-   :lines: 10-18
+   :start-after: PARTIAL_APPLICATION_START
+   :end-before: PARTIAL_APPLICATION_END
 
 You could also define equivalent lambda functions:
 
 .. literalinclude:: ../code-snippets/Functions.daml
    :language: daml
-   :lines: 20-22
+   :start-after: PARTIAL_LAMBDA_START
+   :end-before: PARTIAL_LAMBDA_END
 
 Functions are Values
 ********************
@@ -63,7 +65,8 @@ This means a function can take another function as an argument. For example, def
 
 .. literalinclude:: ../code-snippets/Functions.daml
    :language: daml
-   :lines: 26-39
+   :start-after: HIGHER_ORDER_START
+   :end-before: HIGHER_ORDER_END
 
 The :ref:`daml-ref-folding` section looks into two useful built-in functions, ``foldl`` and ``foldr``, that also take a function as an argument.
 
@@ -76,7 +79,8 @@ A function is *parametrically polymorphic* if it behaves uniformly for all types
 
 .. literalinclude:: ../code-snippets/Functions.daml
    :language: daml
-   :lines: 44
+   :start-after: GENERIC_FUNCTION_START
+   :end-before: GENERIC_FUNCTION_END
 
 where ``a``, ``b``, and ``c`` are any data types. Both ``compose ((+) 4) ((*) 2) 3 == 10`` and ``compose not ((&&) True) False`` evaluate to ``True``. Note that ``((+) 4)`` has type ``Int -> Int``, whereas ``not`` has type ``Bool -> Bool``.
 


### PR DESCRIPTION
A couple snippets seemed to have drifted. Rather than fix the line
numbers and risk having them drift again, this PR switches the references
to using comments instead, which should hopefully be more future-proof.

CHANGELOG_BEGIN
CHANGELOG_END