### PR TITLE
LF conversion: split `Env`

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -485,7 +485,7 @@ runRepl importPkgs opts replClient logger ideState = do
             PackageMap pkgMap <- useE' GeneratePackageMap file
             stablePkgs <- lift $ useNoFile_ GenerateStablePackages
             let modIface = hm_iface (tmrModInfo tm)
-            case convertModule lfVersion envEnableScenarios pkgMap (Map.map LF.dalfPackageId stablePkgs) False file core modIface details of
+            case convertModule lfVersion envEnableScenarios pkgMap (Map.map LF.dalfPackageId stablePkgs) file core modIface details of
                 Left diag -> handleIdeResult ([diag], Nothing)
                 Right v -> do
                    pkgs <- lift $ getExternalPackages file

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -259,10 +259,10 @@ generateRawDalfRule =
                     -- Generate the map from package names to package hashes
                     PackageMap pkgMap <- use_ GeneratePackageMap file
                     stablePkgs <- useNoFile_ GenerateStablePackages
-                    DamlEnv{envIsGenerated, envEnableScenarios} <- getDamlServiceEnv
+                    DamlEnv{envEnableScenarios} <- getDamlServiceEnv
                     modIface <- hm_iface . tmrModInfo <$> use_ TypeCheck file
                     -- GHC Core to Daml-LF
-                    case convertModule lfVersion envEnableScenarios pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core modIface details of
+                    case convertModule lfVersion envEnableScenarios pkgMap (Map.map LF.dalfPackageId stablePkgs) file core modIface details of
                         Left e -> return ([e], Nothing)
                         Right v -> do
                             WhnfPackage pkg <- use_ GeneratePackageDeps file
@@ -410,11 +410,11 @@ generateSerializedDalfRule options =
                             -- lf conversion
                             PackageMap pkgMap <- use_ GeneratePackageMap file
                             stablePkgs <- useNoFile_ GenerateStablePackages
-                            DamlEnv{envIsGenerated, envEnableScenarios} <- getDamlServiceEnv
+                            DamlEnv{envEnableScenarios} <- getDamlServiceEnv
                             let modInfo = tmrModInfo tm
                                 details = hm_details modInfo
                                 modIface = hm_iface modInfo
-                            case convertModule lfVersion envEnableScenarios pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core modIface details of
+                            case convertModule lfVersion envEnableScenarios pkgMap (Map.map LF.dalfPackageId stablePkgs) file core modIface details of
                                 Left e -> pure ([e], Nothing)
                                 Right rawDalf -> do
                                     -- LF postprocessing

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -54,7 +54,6 @@ data DamlEnv = DamlEnv
   -- This is used to avoid unnecessary GC calls.
   , envDamlLfVersion :: LF.Version
   , envSkipScenarioValidation :: SkipScenarioValidation
-  , envIsGenerated :: Bool
   , envEnableScenarios :: EnableScenarios
   , envTestFilter :: T.Text -> Bool
   }
@@ -73,7 +72,6 @@ mkDamlEnv opts scenarioService = do
         , envPreviousScenarioContexts = previousScenarioContextsVar
         , envDamlLfVersion = optDamlLfVersion opts
         , envSkipScenarioValidation = optSkipScenarioValidation opts
-        , envIsGenerated = optIsGenerated opts
         , envEnableScenarios = optEnableScenarios opts
         , envTestFilter = optTestFilter opts
         }

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -621,6 +621,13 @@ convertModule lfVersion enableScenarios pkgMap stablePackages isGenerated file c
     let
       env = mkEnv lfVersion enableScenarios pkgMap stablePackages isGenerated (cm_module coreModule)
       mc = extractModuleContents env coreModule modIface details
+    defs <- convertModuleContents env mc
+    pure (LF.moduleFromDefinitions (envLFModuleName env) (Just $ fromNormalizedFilePath file) flags defs)
+    where
+        flags = LF.daml12FeatureFlags
+
+convertModuleContents :: Env -> ModuleContents -> ConvertM [Definition]
+convertModuleContents env mc = do
     definitions <- convertBinds env mc
     types <- convertTypeDefs env mc
     depOrphanModules <- convertDepOrphanModules env mc
@@ -638,9 +645,7 @@ convertModule lfVersion enableScenarios pkgMap stablePackages isGenerated file c
             ++ depOrphanModules
             ++ exports
             ++ fixities
-    pure (LF.moduleFromDefinitions (envLFModuleName env) (Just $ fromNormalizedFilePath file) flags defs)
-    where
-        flags = LF.daml12FeatureFlags
+    pure defs
 
 data Consuming = PreConsuming
                | Consuming

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -173,7 +173,6 @@ data Env = Env
     -- Once data dependencies are well-supported we might want to remove this if the number of GHC
     -- packages does not cause performance issues.
     ,envLfVersion :: LF.Version
-    ,envIsGenerated :: Bool
     ,envEnableScenarios :: EnableScenarios
     ,envTypeVars :: !(MS.Map Var TypeVarName)
         -- ^ Maps GHC type variables in scope to their LF type variable names
@@ -187,10 +186,9 @@ mkEnv ::
   -> EnableScenarios
   -> MS.Map UnitId DalfPackage
   -> MS.Map (UnitId, LF.ModuleName) PackageId
-  -> Bool
   -> GHC.Module
   -> Env
-mkEnv envLfVersion envEnableScenarios envPkgMap envStablePackages envIsGenerated ghcModule = do
+mkEnv envLfVersion envEnableScenarios envPkgMap envStablePackages ghcModule = do
   let
     envGHCModuleName = GHC.moduleName ghcModule
     envModuleUnitId = GHC.moduleUnitId ghcModule
@@ -610,16 +608,15 @@ convertModule
     -> EnableScenarios
     -> MS.Map UnitId DalfPackage
     -> MS.Map (GHC.UnitId, LF.ModuleName) LF.PackageId
-    -> Bool
     -> NormalizedFilePath
     -> CoreModule
     -> ModIface
       -- ^ Only used for information that isn't available in ModDetails.
     -> ModDetails
     -> Either FileDiagnostic LF.Module
-convertModule lfVersion enableScenarios pkgMap stablePackages isGenerated file coreModule modIface details = runConvertM (ConversionEnv file Nothing) $ do
+convertModule lfVersion enableScenarios pkgMap stablePackages file coreModule modIface details = runConvertM (ConversionEnv file Nothing) $ do
     let
-      env = mkEnv lfVersion enableScenarios pkgMap stablePackages isGenerated (cm_module coreModule)
+      env = mkEnv lfVersion enableScenarios pkgMap stablePackages (cm_module coreModule)
       mc = extractModuleContents env coreModule modIface details
     defs <- convertModuleContents env mc
     pure (LF.moduleFromDefinitions (envLFModuleName env) (Just $ fromNormalizedFilePath file) flags defs)

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -580,7 +580,7 @@ convertModule
 convertModule envLfVersion envEnableScenarios envPkgMap envStablePackages envIsGenerated file coreModule modIface details = runConvertM (ConversionEnv file Nothing) $ do
     let mc = extractModuleContents env binds details coreModule
     definitions <- convertBinds env mc binds
-    types <- concatMapM (convertTypeDef env) (eltsUFM (cm_types coreModule))
+    types <- convertTypeDefs env (eltsUFM (cm_types coreModule))
     depOrphanModules <- convertDepOrphanModules env (getDepOrphanModules modIface)
     templates <- convertTemplateDefs env mc
     exceptions <- convertExceptionDefs env mc
@@ -626,6 +626,9 @@ data Consuming = PreConsuming
                | NonConsuming
                | PostConsuming
                deriving (Eq)
+
+convertTypeDefs :: Env -> [TyThing] -> ConvertM [Definition]
+convertTypeDefs env = concatMapM (convertTypeDef env)
 
 convertTypeDef :: Env -> TyThing -> ConvertM [Definition]
 convertTypeDef env o@(ATyCon t) = withRange (convNameLoc t) $ if

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -251,7 +251,6 @@ data ModuleContents = ModuleContents
   , mcImplements :: MS.Map TypeConName [(Maybe LF.SourceLoc, GHC.TyCon)]
   , mcRequires :: MS.Map TypeConName [(Maybe LF.SourceLoc, GHC.TyCon)]
   , mcInterfaceMethodInstances :: MS.Map (GHC.Module, TypeConName, TypeConName) [(T.Text, GHC.Expr GHC.CoreBndr)]
-  , mcInterfaceChoiceData :: MS.Map TypeConName [ChoiceData]
   , mcInterfaces :: MS.Map TypeConName GHC.TyCon
   , mcModInstanceInfo :: !ModInstanceInfo
   , mcDepOrphanModules :: [GHC.Module]
@@ -313,12 +312,6 @@ extractModuleContents env@Env{..} coreModule modIface details = do
         | (name, v) <- mcBinds
         , "_choice_" `T.isPrefixOf` getOccText name
         , ty@(TypeCon _ [_, _, TypeCon _ [TypeCon tplTy _], _]) <- [varType name]
-        ]
-    mcInterfaceChoiceData = MS.fromListWith (++)
-        [ (mkTypeCon [getOccText tplTy], [ChoiceData ty v])
-        | (name, v) <- mcBinds
-        , "_interface_choice_" `T.isPrefixOf` getOccText name
-        , ty@(TypeCon _ [_, TypeCon _ [TypeCon tplTy _]]) <- [varType name]
         ]
     mcTemplateBinds = scrapeTemplateBinds mcBinds
     mcInterfaceBinds = scrapeInterfaceBinds mcBinds

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -579,7 +579,7 @@ convertModule
     -> Either FileDiagnostic LF.Module
 convertModule envLfVersion envEnableScenarios envPkgMap envStablePackages envIsGenerated file coreModule modIface details = runConvertM (ConversionEnv file Nothing) $ do
     let mc = extractModuleContents env binds details coreModule
-    definitions <- concatMapM (\bind -> resetFreshVarCounters >> convertBind env mc bind) binds
+    definitions <- convertBinds env mc binds
     types <- concatMapM (convertTypeDef env) (eltsUFM (cm_types coreModule))
     depOrphanModules <- convertDepOrphanModules env (getDepOrphanModules modIface)
     templates <- convertTemplateDefs env mc
@@ -1062,6 +1062,9 @@ convertChoice env tbinds (ChoiceData ty expr) = do
       where
         applyThisAndArg func = func `ETmApp` EVar this `ETmApp` EVar arg
 
+convertBinds :: Env -> ModuleContents -> [(Var, GHC.Expr Var)] -> ConvertM [Definition]
+convertBinds env mc =
+  concatMapM (\bind -> resetFreshVarCounters >> convertBind env mc bind)
 
 convertBind :: Env -> ModuleContents -> (Var, GHC.Expr Var) -> ConvertM [Definition]
 convertBind env mc (name, x)

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -173,15 +173,6 @@ data Env = Env
     -- Once data dependencies are well-supported we might want to remove this if the number of GHC
     -- packages does not cause performance issues.
     ,envLfVersion :: LF.Version
-    ,envTemplateBinds :: MS.Map TypeConName TemplateBinds
-    ,envInterfaceBinds :: MS.Map TypeConName InterfaceBinds
-    ,envExceptionBinds :: MS.Map TypeConName ExceptionBinds
-    ,envChoiceData :: MS.Map TypeConName [ChoiceData]
-    ,envImplements :: MS.Map TypeConName [(Maybe LF.SourceLoc, GHC.TyCon)]
-    ,envRequires :: MS.Map TypeConName [(Maybe LF.SourceLoc, GHC.TyCon)]
-    ,envInterfaceMethodInstances :: MS.Map (GHC.Module, TypeConName, TypeConName) [(T.Text, GHC.Expr GHC.CoreBndr)]
-    ,envInterfaceChoiceData :: MS.Map TypeConName [ChoiceData]
-    ,envInterfaces :: MS.Map TypeConName GHC.TyCon
     ,envIsGenerated :: Bool
     ,envEnableScenarios :: EnableScenarios
     ,envTypeVars :: !(MS.Map Var TypeVarName)
@@ -189,13 +180,7 @@ data Env = Env
     ,envTypeVarNames :: !(S.Set TypeVarName)
         -- ^ The set of LF type variable names in scope (i.e. the set of
         -- values of 'envTypeVars').
-    , envModInstanceInfo :: !ModInstanceInfo
     }
-
-data ChoiceData = ChoiceData
-  { _choiceDatTy :: GHC.Type
-  , _choiceDatExpr :: GHC.Expr GHC.CoreBndr
-  }
 
 -- v is an alias for x
 envInsertAlias :: Var -> LF.Expr -> Env -> Env
@@ -234,6 +219,86 @@ envLookupTypeVar x = MS.lookup x . envTypeVars
 
 envHasTypeVarName :: TypeVarName -> Env -> Bool
 envHasTypeVarName x = S.member x . envTypeVarNames
+
+---------------------------------------------------------------------
+-- EXTRACTION
+
+-- | Information extracted from the GHC representation of the module as an
+-- initial step of conversion.
+data ModuleContents = ModuleContents
+  { mcTemplateBinds :: MS.Map TypeConName TemplateBinds
+  , mcInterfaceBinds :: MS.Map TypeConName InterfaceBinds
+  , mcExceptionBinds :: MS.Map TypeConName ExceptionBinds
+  , mcChoiceData :: MS.Map TypeConName [ChoiceData]
+  , mcImplements :: MS.Map TypeConName [(Maybe LF.SourceLoc, GHC.TyCon)]
+  , mcRequires :: MS.Map TypeConName [(Maybe LF.SourceLoc, GHC.TyCon)]
+  , mcInterfaceMethodInstances :: MS.Map (GHC.Module, TypeConName, TypeConName) [(T.Text, GHC.Expr GHC.CoreBndr)]
+  , mcInterfaceChoiceData :: MS.Map TypeConName [ChoiceData]
+  , mcInterfaces :: MS.Map TypeConName GHC.TyCon
+  , mcModInstanceInfo :: !ModInstanceInfo
+  }
+
+data ChoiceData = ChoiceData
+  { _choiceDatTy :: GHC.Type
+  , _choiceDatExpr :: GHC.Expr GHC.CoreBndr
+  }
+
+extractModuleContents :: Env -> [(Var, GHC.Expr CoreBndr)] -> ModDetails -> CoreModule -> ModuleContents
+extractModuleContents env@Env{..} binds details coreModule = do
+  let
+    mcInterfaces = interfaceNames envLfVersion (eltsUFM (cm_types coreModule))
+    mcImplements = MS.fromListWith (++)
+      [ (mkTypeCon [getOccText tpl], [(convNameLoc name, iface)])
+      | (name, _val) <- binds
+      , "_implements_" `T.isPrefixOf` getOccText name
+      , TypeCon implementsT [TypeCon tpl [], TypeCon iface []] <- [varType name]
+      , NameIn DA_Internal_Desugar "ImplementsT" <- [implementsT]
+      ]
+    mcRequires = MS.fromListWith (++)
+      [ (mkTypeCon [getOccText iface1], [(convNameLoc name, iface2)])
+      | (name, _val) <- binds
+      , "_requires_" `T.isPrefixOf` getOccText name
+      , TypeCon requiresT [TypeCon iface1 [], TypeCon iface2 []] <- [varType name]
+      , NameIn DA_Internal_Desugar "RequiresT" <- [requiresT]
+      ]
+    mcInterfaceMethodInstances :: MS.Map (GHC.Module, TypeConName, TypeConName) [(T.Text, GHC.Expr GHC.CoreBndr)]
+    mcInterfaceMethodInstances = MS.fromListWith (++)
+      [
+        ( (mod, mkTypeCon [getOccText iface], mkTypeCon [getOccText tpl])
+        , [(methodName, untick val)]
+        )
+      | (name, val) <- binds
+      , TypeCon methodNewtype
+        [ TypeCon tpl []
+        , TypeCon iface []
+        , StrLitTy methodName
+        ] <- [varType name]
+      , NameIn DA_Internal_Desugar "Method" <- [methodNewtype]
+      , Just mod <- [nameModule_maybe (getName iface)]
+      ]
+    mcChoiceData = MS.fromListWith (++)
+        [ (mkTypeCon [getOccText tplTy], [ChoiceData ty v])
+        | (name, v) <- binds
+        , "_choice_" `T.isPrefixOf` getOccText name
+        , ty@(TypeCon _ [_, _, TypeCon _ [TypeCon tplTy _], _]) <- [varType name]
+        ]
+    mcInterfaceChoiceData = MS.fromListWith (++)
+        [ (mkTypeCon [getOccText tplTy], [ChoiceData ty v])
+        | (name, v) <- binds
+        , "_interface_choice_" `T.isPrefixOf` getOccText name
+        , ty@(TypeCon _ [_, TypeCon _ [TypeCon tplTy _]]) <- [varType name]
+        ]
+    mcTemplateBinds = scrapeTemplateBinds binds
+    mcInterfaceBinds = scrapeInterfaceBinds binds
+    mcExceptionBinds
+        | envLfVersion `supports` featureExceptions =
+            scrapeExceptionBinds binds
+        | otherwise =
+            MS.empty
+
+    mcModInstanceInfo = modInstanceInfoFromDetails details
+
+  ModuleContents {..}
 
 ---------------------------------------------------------------------
 -- CONVERSION
@@ -446,13 +511,13 @@ convertInterfaceTyCon env errHandler tycon
     | otherwise =
         conversionError $ errHandler tycon
 
-convertInterfaces :: Env -> [(Var, GHC.Expr Var)] -> ConvertM [Definition]
-convertInterfaces env binds = interfaceDefs
+convertInterfaces :: Env -> ModuleContents -> [(Var, GHC.Expr Var)] -> ConvertM [Definition]
+convertInterfaces env mc binds = interfaceDefs
   where
     interfaceDefs :: ConvertM [Definition]
     interfaceDefs = sequence
         [ DInterface <$> convertInterface name tycon
-        | (name, tycon) <- MS.toList (envInterfaces env)
+        | (name, tycon) <- MS.toList (mcInterfaces mc)
         ]
 
     convertInterface :: LF.TypeConName -> GHC.TyCon -> ConvertM DefInterface
@@ -460,14 +525,14 @@ convertInterfaces env binds = interfaceDefs
         let intLocation = convNameLoc (GHC.tyConName tyCon)
         let intParam = this
         let precond = fromMaybe (error $ "Missing precondition for interface " <> show intName)
-                        $ (MS.lookup intName $ envInterfaceBinds env) >>= ibEnsure
+                        $ (MS.lookup intName $ mcInterfaceBinds mc) >>= ibEnsure
         withRange intLocation $ do
             let handleIsNotInterface tyCon =
                   "cannot require '" ++ prettyPrint tyCon ++ "' because it is not an interface"
             intRequires <- fmap S.fromList $ mapM (\(mloc, iface) -> withRange mloc $ convertInterfaceTyCon env handleIsNotInterface iface) $
-                MS.findWithDefault [] intName (envRequires env)
+                MS.findWithDefault [] intName (mcRequires mc)
             intMethods <- NM.fromList <$> convertMethods tyCon
-            intChoices <- convertChoices env intName emptyTemplateBinds
+            intChoices <- convertChoices env mc intName emptyTemplateBinds
             intPrecondition <- useSingleMethodDict env precond (`ETmApp` EVar intParam)
             let intCoImplements = NM.empty -- TODO: https://github.com/digital-asset/daml/issues/14047
             let intView = TBuiltin BTUnit -- TODO: Stub view, will extract later, https://github.com/digital-asset/daml/pull/14439
@@ -513,12 +578,13 @@ convertModule
     -> ModDetails
     -> Either FileDiagnostic LF.Module
 convertModule envLfVersion envEnableScenarios envPkgMap envStablePackages envIsGenerated file x modIface details = runConvertM (ConversionEnv file Nothing) $ do
-    definitions <- concatMapM (\bind -> resetFreshVarCounters >> convertBind env bind) binds
+    let mc = extractModuleContents env binds details x
+    definitions <- concatMapM (\bind -> resetFreshVarCounters >> convertBind env mc bind) binds
     types <- concatMapM (convertTypeDef env) (eltsUFM (cm_types x))
     depOrphanModules <- convertDepOrphanModules env (getDepOrphanModules modIface)
-    templates <- convertTemplateDefs env
-    exceptions <- convertExceptionDefs env
-    interfaces <- convertInterfaces env binds
+    templates <- convertTemplateDefs env mc
+    exceptions <- convertExceptionDefs env mc
+    interfaces <- convertInterfaces env mc binds
     exports <- convertExports env (md_exports details)
     let fixities = convertFixities (mi_fixities modIface)
         defs =
@@ -546,60 +612,10 @@ convertModule envLfVersion envEnableScenarios envPkgMap envStablePackages envIsG
                 | otherwise -> [(name, body)]
               Rec binds -> binds
           ]
-        envInterfaces = interfaceNames envLfVersion (eltsUFM (cm_types x))
-        envImplements = MS.fromListWith (++)
-          [ (mkTypeCon [getOccText tpl], [(convNameLoc name, iface)])
-          | (name, _val) <- binds
-          , "_implements_" `T.isPrefixOf` getOccText name
-          , TypeCon implementsT [TypeCon tpl [], TypeCon iface []] <- [varType name]
-          , NameIn DA_Internal_Desugar "ImplementsT" <- [implementsT]
-          ]
-        envRequires = MS.fromListWith (++)
-          [ (mkTypeCon [getOccText iface1], [(convNameLoc name, iface2)])
-          | (name, _val) <- binds
-          , "_requires_" `T.isPrefixOf` getOccText name
-          , TypeCon requiresT [TypeCon iface1 [], TypeCon iface2 []] <- [varType name]
-          , NameIn DA_Internal_Desugar "RequiresT" <- [requiresT]
-          ]
-        envInterfaceMethodInstances :: MS.Map (GHC.Module, TypeConName, TypeConName) [(T.Text, GHC.Expr GHC.CoreBndr)]
-        envInterfaceMethodInstances = MS.fromListWith (++)
-          [
-            ( (mod, mkTypeCon [getOccText iface], mkTypeCon [getOccText tpl])
-            , [(methodName, untick val)]
-            )
-          | (name, val) <- binds
-          , TypeCon methodNewtype
-            [ TypeCon tpl []
-            , TypeCon iface []
-            , StrLitTy methodName
-            ] <- [varType name]
-          , NameIn DA_Internal_Desugar "Method" <- [methodNewtype]
-          , Just mod <- [nameModule_maybe (getName iface)]
-          ]
-        envChoiceData = MS.fromListWith (++)
-            [ (mkTypeCon [getOccText tplTy], [ChoiceData ty v])
-            | (name, v) <- binds
-            , "_choice_" `T.isPrefixOf` getOccText name
-            , ty@(TypeCon _ [_, _, TypeCon _ [TypeCon tplTy _], _]) <- [varType name]
-            ]
-        envInterfaceChoiceData = MS.fromListWith (++)
-            [ (mkTypeCon [getOccText tplTy], [ChoiceData ty v])
-            | (name, v) <- binds
-            , "_interface_choice_" `T.isPrefixOf` getOccText name
-            , ty@(TypeCon _ [_, TypeCon _ [TypeCon tplTy _]]) <- [varType name]
-            ]
-        envTemplateBinds = scrapeTemplateBinds binds
-        envInterfaceBinds = scrapeInterfaceBinds binds
-        envExceptionBinds
-            | envLfVersion `supports` featureExceptions =
-                scrapeExceptionBinds binds
-            | otherwise =
-                MS.empty
 
         envAliases = MS.empty
         envTypeVars = MS.empty
         envTypeVarNames = S.empty
-        envModInstanceInfo = modInstanceInfoFromDetails details
         env = Env {..}
 
 getDepOrphanModules :: ModIface -> [GHC.Module]
@@ -876,14 +892,14 @@ self = mkVar "self"
 arg = mkVar "arg"
 res = mkVar "res"
 
-convertTemplateDefs :: Env -> ConvertM [Definition]
-convertTemplateDefs env =
-    forM (MS.toList (envTemplateBinds env)) $ \(tname, tbinds) -> do
+convertTemplateDefs :: Env -> ModuleContents -> ConvertM [Definition]
+convertTemplateDefs env mc =
+    forM (MS.toList (mcTemplateBinds mc)) $ \(tname, tbinds) -> do
         resetFreshVarCounters
-        DTemplate <$> convertTemplate env tname tbinds
+        DTemplate <$> convertTemplate env mc tname tbinds
 
-convertTemplate :: Env -> LF.TypeConName -> TemplateBinds -> ConvertM Template
-convertTemplate env tplTypeCon tbinds@TemplateBinds{..}
+convertTemplate :: Env -> ModuleContents -> LF.TypeConName -> TemplateBinds -> ConvertM Template
+convertTemplate env mc tplTypeCon tbinds@TemplateBinds{..}
     | Just tplTyCon <- tbTyCon
     , Just fSignatory <- tbSignatory
     , Just fObserver <- tbObserver
@@ -896,9 +912,9 @@ convertTemplate env tplTypeCon tbinds@TemplateBinds{..}
         tplObservers <- useSingleMethodDict env fObserver (`ETmApp` EVar this)
         tplPrecondition <- useSingleMethodDict env fEnsure (wrapPrecondition . (`ETmApp` EVar this))
         tplAgreement <- useSingleMethodDict env fAgreement (`ETmApp` EVar this)
-        tplChoices <- convertChoices env tplTypeCon tbinds
+        tplChoices <- convertChoices env mc tplTypeCon tbinds
         tplKey <- convertTemplateKey env tplTypeCon tbinds
-        tplImplements <- convertImplements env tplTypeCon
+        tplImplements <- convertImplements env mc tplTypeCon
         pure Template {..}
 
     | otherwise =
@@ -945,9 +961,9 @@ convertTemplateKey env tname TemplateBinds{..}
     | otherwise
     = pure Nothing
 
-convertExceptionDefs :: Env -> ConvertM [Definition]
-convertExceptionDefs env =
-    forM (MS.toList (envExceptionBinds env)) $ \(ename, ebinds) -> do
+convertExceptionDefs :: Env -> ModuleContents -> ConvertM [Definition]
+convertExceptionDefs env mc =
+    forM (MS.toList (mcExceptionBinds mc)) $ \(ename, ebinds) -> do
         resetFreshVarCounters
         DException <$> convertDefException env ename ebinds
 
@@ -968,9 +984,9 @@ useSingleMethodDict env (Cast ghcExpr _) f = do
 useSingleMethodDict env x _ =
     unhandled "useSingleMethodDict: not a single method type class dictionary" x
 
-convertImplements :: Env -> LF.TypeConName -> ConvertM (NM.NameMap TemplateImplements)
-convertImplements env tpl = NM.fromList <$>
-  mapM convertInterface (MS.findWithDefault [] tpl (envImplements env))
+convertImplements :: Env -> ModuleContents -> LF.TypeConName -> ConvertM (NM.NameMap TemplateImplements)
+convertImplements env mc tpl = NM.fromList <$>
+  mapM convertInterface (MS.findWithDefault [] tpl (mcImplements mc))
   where
     convertInterface :: (Maybe LF.SourceLoc, GHC.TyCon) -> ConvertM TemplateImplements
     convertInterface (originLoc, iface) = withRange originLoc $ do
@@ -984,7 +1000,7 @@ convertImplements env tpl = NM.fromList <$>
 
       methods <- convertMethods $ MS.findWithDefault []
         (mod, qualObject con, tpl)
-        (envInterfaceMethodInstances env)
+        (mcInterfaceMethodInstances mc)
 
       pure (TemplateImplements con methods view)
 
@@ -993,10 +1009,10 @@ convertImplements env tpl = NM.fromList <$>
       | (k, v) <- ms
       ]
 
-convertChoices :: Env -> LF.TypeConName -> TemplateBinds -> ConvertM (NM.NameMap TemplateChoice)
-convertChoices env tplTypeCon tbinds =
+convertChoices :: Env -> ModuleContents -> LF.TypeConName -> TemplateBinds -> ConvertM (NM.NameMap TemplateChoice)
+convertChoices env mc tplTypeCon tbinds =
     NM.fromList <$> traverse (convertChoice env tbinds)
-        (MS.findWithDefault [] tplTypeCon (envChoiceData env))
+        (MS.findWithDefault [] tplTypeCon (mcChoiceData mc))
 
 convertChoice :: Env -> TemplateBinds -> ChoiceData -> ConvertM TemplateChoice
 convertChoice env tbinds (ChoiceData ty expr) = do
@@ -1047,8 +1063,8 @@ convertChoice env tbinds (ChoiceData ty expr) = do
         applyThisAndArg func = func `ETmApp` EVar this `ETmApp` EVar arg
 
 
-convertBind :: Env -> (Var, GHC.Expr Var) -> ConvertM [Definition]
-convertBind env (name, x)
+convertBind :: Env -> ModuleContents -> (Var, GHC.Expr Var) -> ConvertM [Definition]
+convertBind env mc (name, x)
     -- This is inlined in the choice in the template so we can just drop this.
     | "_choice_" `T.isPrefixOf` getOccText name
     = pure []
@@ -1073,7 +1089,7 @@ convertBind env (name, x)
 
     -- Remove interface worker.
     | Just iface <- T.stripPrefix "$W" (getOccText name)
-    , mkTypeCon [iface] `MS.member` envInterfaces env = pure []
+    , mkTypeCon [iface] `MS.member` mcInterfaces mc = pure []
 
     -- NOTE(MH): Our inline return type syntax produces a local letrec for
     -- recursive functions. We currently don't support local letrecs.
@@ -1106,7 +1122,7 @@ convertBind env (name, x)
     , let (lets, body2) = collectNonRecLets body1
     , Let (Rec [(f, Lam v y)]) (Var f') <- body2
     , f == f'
-    = convertBind env $ (,) name $ mkLams params $ makeNonRecLets lets $
+    = convertBind env mc $ (,) name $ mkLams params $ makeNonRecLets lets $
         Lam v $ Let (NonRec f $ mkVarApps (Var name) params) y
 
     -- Constraint tuple projections are turned into LF struct projections at use site.
@@ -1135,7 +1151,7 @@ convertBind env (name, x)
     -- OVERLAP* annotations
     let overlapModeName' = overlapModeName (fst name')
         overlapModeDef = maybeToList $ do
-            overlapMode <- MS.lookup name (envModInstanceInfo env)
+            overlapMode <- MS.lookup name (mcModInstanceInfo mc)
             overlapModeType <- encodeOverlapMode overlapMode
             Just (DValue (mkMetadataStub overlapModeName' overlapModeType))
 


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/14560, in turn part of https://github.com/digital-asset/daml/issues/14047

This replaces PR https://github.com/digital-asset/daml/pull/14551. Rather than parametrizing the `Env` type with two stages (which I couldn't really justify as logical stages), here I took the more "simple Haskell" approach of splitting the `Env` type into two, at the cost of a larger diff. I made an effort to split the PR into small self-contained commits, so **I recommend reviewing it commit-by-commit rather than just looking at the diff with `main`**.

The new `Env` type keeps the old type's fields with information _about the module_ and the compilation environment, as well as compiler state such as local aliases and a fresh tyvar name supply

The new `ModuleContents` type gets the fields from old `Env` which are extracted from type, class and function declarations _in the module_ being converted. Importantly, the `Env` is completely defined before the `ModuleContents`, so it can be used while constructing the latter.

Additionally, I added some fields to `ModuleContents` which weren't part of the old `Env`, since morally they are contents of the module.