### PR TITLE
[LLP] Two stage resetting DispatcherState [DPP-1137]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
@@ -108,7 +108,7 @@ private[platform] object InMemoryStateUpdater {
   ): Unit =
     updates.foreach { transaction: TransactionLogUpdate =>
       // TODO LLP: Batch update caches
-      inMemoryState.transactionsBuffer.push(transaction.offset, transaction)
+      inMemoryState.inMemoryFanoutBuffer.push(transaction.offset, transaction)
 
       val contractStateEventsBatch = convertToContractStateEvents(transaction)
       if (contractStateEventsBatch.nonEmpty) {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
@@ -14,7 +14,7 @@ import com.daml.platform.store.cache.{
   MutableLedgerEndCache,
 }
 import com.daml.platform.store.interning.{StringInterningView, UpdatingStringInterningView}
-import org.mockito.MockitoSugar
+import org.mockito.{InOrder, Mockito, MockitoSugar}
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -26,7 +26,7 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
   s"$className.initialized" should "return false if not initialized" in withTestFixture {
-    case (inMemoryState, _, _, _, _, _) =>
+    case (inMemoryState, _, _, _, _, _, _, _) =>
       inMemoryState.initialized shouldBe false
   }
 
@@ -35,9 +35,11 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
           inMemoryState,
           mutableLedgerEndCache,
           contractStateCaches,
-          transactionsBuffer,
+          inMemoryFanoutBuffer,
           stringInterningView,
           dispatcherState,
+          updateStringInterningView,
+          inOrder,
         ) =>
       val initOffset = Offset.fromHexString(Ref.HexString.assertFromString("abcdef"))
       val initEventSequentialId = 1337L
@@ -46,64 +48,24 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
       val initLedgerEnd = ParameterStorageBackend
         .LedgerEnd(initOffset, initEventSequentialId, initStringInterningId)
 
-      val updateStringInterningView = mock[(UpdatingStringInterningView, LedgerEnd) => Future[Unit]]
       when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
+      when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
 
-      when(dispatcherState.reset(initLedgerEnd)).thenReturn(Future.unit)
-      when(dispatcherState.initialized).thenReturn(true)
       for {
         // INITIALIZED THE STATE
         _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
-
+      } yield {
         // ASSERT STATE INITIALIZED
-        _ = {
-          inMemoryState.initialized shouldBe true
 
-          verify(contractStateCaches).reset(initOffset)
-          verify(transactionsBuffer).flush()
-          verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
-          verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
-          verify(dispatcherState).reset(initLedgerEnd)
-        }
+        inOrder.verify(dispatcherState).stopDispatcher()
+        inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
+        inOrder.verify(contractStateCaches).reset(initOffset)
+        inOrder.verify(inMemoryFanoutBuffer).flush()
+        inOrder.verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
+        inOrder.verify(dispatcherState).startDispatcher(initLedgerEnd)
 
-        reInitOffset = Offset.fromHexString(Ref.HexString.assertFromString("abeeee"))
-        reInitEventSequentialId = 9999L
-        reInitStringInterningId = 50
-        reInitLedgerEnd = ParameterStorageBackend
-          .LedgerEnd(reInitOffset, reInitEventSequentialId, reInitStringInterningId)
-
-        // RESET MOCKS
-        _ = {
-          reset(
-            mutableLedgerEndCache,
-            contractStateCaches,
-            transactionsBuffer,
-            updateStringInterningView,
-          )
-          when(updateStringInterningView(stringInterningView, reInitLedgerEnd)).thenReturn(
-            Future.unit
-          )
-          when(dispatcherState.reset(reInitLedgerEnd)).thenReturn(Future.unit)
-        }
-
-        // RE-INITIALIZE THE STATE
-        _ <- inMemoryState.initializeTo(reInitLedgerEnd) {
-          case (`stringInterningView`, ledgerEnd) =>
-            updateStringInterningView(stringInterningView, ledgerEnd)
-          case (other, _) => fail(s"Unexpected stringInterningView reference $other")
-        }
-
-        // ASSERT STATE RE-INITIALIZED
-        _ = {
-          inMemoryState.initialized shouldBe true
-
-          verify(contractStateCaches).reset(reInitOffset)
-          verify(transactionsBuffer).flush()
-          verify(mutableLedgerEndCache).set(reInitOffset, reInitEventSequentialId)
-          verify(updateStringInterningView)(stringInterningView, reInitLedgerEnd)
-          verify(dispatcherState).reset(reInitLedgerEnd)
-        }
-      } yield succeed
+        inMemoryState.initialized shouldBe true
+      }
   }
 
   private def withTestFixture(
@@ -114,20 +76,31 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
           InMemoryFanoutBuffer,
           StringInterningView,
           DispatcherState,
+          (UpdatingStringInterningView, LedgerEnd) => Future[Unit],
+          InOrder,
       ) => Future[Assertion]
   ): Future[Assertion] = {
     val mutableLedgerEndCache = mock[MutableLedgerEndCache]
     val contractStateCaches = mock[ContractStateCaches]
-
-    val transactionsBuffer = mock[InMemoryFanoutBuffer]
+    val inMemoryFanoutBuffer = mock[InMemoryFanoutBuffer]
     val stringInterningView = mock[StringInterningView]
-
     val dispatcherState = mock[DispatcherState]
+    val updateStringInterningView = mock[(UpdatingStringInterningView, LedgerEnd) => Future[Unit]]
+
+    // Mocks should be called in the asserted order
+    val inOrderMockCalls = Mockito.inOrder(
+      mutableLedgerEndCache,
+      contractStateCaches,
+      inMemoryFanoutBuffer,
+      stringInterningView,
+      dispatcherState,
+      updateStringInterningView,
+    )
 
     val inMemoryState = new InMemoryState(
       ledgerEndCache = mutableLedgerEndCache,
       contractStateCaches = contractStateCaches,
-      transactionsBuffer = transactionsBuffer,
+      inMemoryFanoutBuffer = inMemoryFanoutBuffer,
       stringInterningView = stringInterningView,
       dispatcherState = dispatcherState,
     )
@@ -136,9 +109,11 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
       inMemoryState,
       mutableLedgerEndCache,
       contractStateCaches,
-      transactionsBuffer,
+      inMemoryFanoutBuffer,
       stringInterningView,
       dispatcherState,
+      updateStringInterningView,
+      inOrderMockCalls,
     )
   }
 }


### PR DESCRIPTION
This PR disables the possibility of a client subscribing to Ledger API streams during a in-memory state re-initialization. This is achieved by changing the rest of the DispatcherState to a two step process. Then, the re-initialization of the in-memory state follows the steps:
1. Stop the current Dispatcher
2. Reset the state
3. Start a new Dispatcher

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
