### PR TITLE
onboarding: add Chun Lok to release rotation

### DIFF
--- a/infra/data_bucket.tf
+++ b/infra/data_bucket.tf
@@ -48,6 +48,7 @@ resource "google_storage_bucket_iam_member" "data_read" {
 // allow read access for appr team, as requested by Moritz
 locals {
   appr_team = [
+    "user:chunlok.ling@digitalasset.com",
     "user:gary.verhaegen@digitalasset.com",
     "user:moritz.kiefer@digitalasset.com",
     "user:raymond.roestenburg@digitalasset.com",

--- a/release/rotation
+++ b/release/rotation
@@ -2,6 +2,7 @@
 # to access an ad-hoc machine for Windows testing. This can be done by opening a PR
 # like the following: https://github.com/DACH-NY/daml-language-ad-hoc/pull/37
 U031SN81CQG ray-roestenburg-da
+U03SB9342N5 chunlokling-da
 U021DSF26BS victormueller-da
 U03K3A3UAGY carlpulley-da
 UHHMLCNGM nickchapman-da


### PR DESCRIPTION
And to our infrastructure's notion of "the ledger clients team" (obviously abbreviated to "appr").

CHANGELOG_BEGIN
CHANGELOG_END