### PR TITLE
[engine] improve speedy control

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -24,15 +24,15 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
     }
   }
 
-  def classifyMachine(machine: Machine, counts: Counts): Unit = {
-    if (machine.returnValue != null) {
+  def classifyMachine(machine: Machine, counts: Counts): Unit = { //NICK: use control
+    if (machine.xreturnValue != null) {
       // classify a value by the continution it is about to return to
       counts.ctrlValue += 1
       val kont = machine.kontStack.get(machine.kontStack.size - 1).getClass.getSimpleName
       val _ = counts.konts += kont -> (counts.konts.get(kont).getOrElse(0) + 1)
     } else {
       counts.ctrlExpr += 1
-      val expr = machine.ctrl.getClass.getSimpleName
+      val expr = machine.xctrl.getClass.getSimpleName //NICK
       val _ = counts.exprs += expr -> (counts.exprs.get(expr).getOrElse(0) + 1)
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -25,7 +25,7 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
   }
 
   def classifyMachine(machine: Machine, counts: Counts): Unit = {
-    machine.newControl match {
+    machine.control match {
       case Control.WeAreUnset() => ()
       case Control.WeAreComplete() => ()
       case Control.WeAreHungry(_) => ()

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -14,10 +14,10 @@ import com.daml.lf.speedy.SValue._
 private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK machine states
 
   def ppMachine(m: Machine): String = {
-    s"[${m.envBase}] ${ppEnv(m.env)} -- ${ppCtrl(m.xctrl, m.xreturnValue)} -- ${ppKontStack(m.kontStack)}" //NICK
+    s"[${m.envBase}] ${ppEnv(m.env)} -- ${ppCtrl(m.xctrl, m.xreturnValue)} -- ${ppKontStack(m.kontStack)}" // NICK
   }
 
-  def ppCtrl(e: SExpr, v: SValue): String = //NICK: use control
+  def ppCtrl(e: SExpr, v: SValue): String = // NICK: use control
     if (v != null) {
       s"V-${pp(v)}"
     } else {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -14,7 +14,7 @@ import com.daml.lf.speedy.SValue._
 private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK machine states
 
   def ppMachine(m: Machine): String = {
-    s"[${m.envBase}] ${ppEnv(m.env)} -- ${ppCtrl(m.newControl)} -- ${ppKontStack(m.kontStack)}"
+    s"[${m.envBase}] ${ppEnv(m.env)} -- ${ppCtrl(m.control)} -- ${ppKontStack(m.kontStack)}"
   }
 
   def ppCtrl(control: Control): String =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -14,14 +14,16 @@ import com.daml.lf.speedy.SValue._
 private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK machine states
 
   def ppMachine(m: Machine): String = {
-    s"[${m.envBase}] ${ppEnv(m.env)} -- ${ppCtrl(m.xctrl, m.xreturnValue)} -- ${ppKontStack(m.kontStack)}" // NICK
+    s"[${m.envBase}] ${ppEnv(m.env)} -- ${ppCtrl(m.newControl)} -- ${ppKontStack(m.kontStack)}"
   }
 
-  def ppCtrl(e: SExpr, v: SValue): String = // NICK: use control
-    if (v != null) {
-      s"V-${pp(v)}"
-    } else {
-      s"E-${pp(e)}"
+  def ppCtrl(control: Control): String =
+    control match {
+      case Control.WeAreUnset() => "unset"
+      case Control.WeAreComplete() => "complete"
+      case Control.WeAreHungry(_) => "hungry"
+      case Control.Value(v) => s"V-${pp(v)}"
+      case Control.Expression(e) => s"E-${pp(e)}"
     }
 
   def ppEnv(env: Env): String = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -14,10 +14,10 @@ import com.daml.lf.speedy.SValue._
 private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK machine states
 
   def ppMachine(m: Machine): String = {
-    s"[${m.envBase}] ${ppEnv(m.env)} -- ${ppCtrl(m.ctrl, m.returnValue)} -- ${ppKontStack(m.kontStack)}"
+    s"[${m.envBase}] ${ppEnv(m.env)} -- ${ppCtrl(m.xctrl, m.xreturnValue)} -- ${ppKontStack(m.kontStack)}" //NICK
   }
 
-  def ppCtrl(e: SExpr, v: SValue): String =
+  def ppCtrl(e: SExpr, v: SValue): String = //NICK: use control
     if (v != null) {
       s"V-${pp(v)}"
     } else {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -62,7 +62,10 @@ private[speedy] sealed abstract class SBuiltin(val arity: Int) {
   /** Execute the builtin with 'arity' number of arguments in 'args'.
     * Updates the machine state accordingly.
     */
-  private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control //NICK: needs machine to be passed??
+  private[speedy] def execute(
+      args: util.ArrayList[SValue],
+      machine: Machine,
+  ): Control // NICK: needs machine to be passed??
 
   protected def unexpectedType(i: Int, expected: String, found: SValue) =
     crash(s"type mismatch of argument $i: expect $expected but got $found")
@@ -452,7 +455,10 @@ private[lf] object SBuiltin {
   }
 
   final case object SBContractIdToText extends SBuiltin(1) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val coid = getSContractId(args, 0).coid
       machine.ledgerMode match {
         case OffLedger =>
@@ -559,7 +565,10 @@ private[lf] object SBuiltin {
   }
 
   final case object SBFoldl extends SBuiltin(3) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val func = args.get(0)
       val init = args.get(1)
       val list = getSList(args, 2)
@@ -598,7 +607,10 @@ private[lf] object SBuiltin {
   // However, this would be a breaking change compared to the aforementioned
   // implementation of `foldr`.
   final case object SBFoldr extends SBuiltin(3) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val func = args.get(0).asInstanceOf[SPAP]
       val init = args.get(1)
       val list = getSList(args, 2)
@@ -1077,7 +1089,10 @@ private[lf] object SBuiltin {
 
   // SBCastAnyInterface: ContractId ifaceId -> Any -> ifaceId
   final case class SBCastAnyInterface(ifaceId: TypeConName) extends SBuiltin(2) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       def coid = getSContractId(args, 0)
       val (actualTmplId, _) = getSAnyContract(args, 1)
       if (!implementsOrCoImplements(machine, actualTmplId, ifaceId))
@@ -1101,7 +1116,7 @@ private[lf] object SBuiltin {
         onLedger: OnLedger,
     ): Control = {
 
-      def continueExpression(coinst: V.ContractInstance) : SExpr = {
+      def continueExpression(coinst: V.ContractInstance): SExpr = {
         coinst match {
           case V.ContractInstance(actualTmplId, arg, _) =>
             SEApp(
@@ -1116,12 +1131,12 @@ private[lf] object SBuiltin {
         }
       }
 
-      //println(s"----SBFetchAny") //NICK
+      // println(s"----SBFetchAny") //NICK
 
       val coid = getSContractId(args, 0)
       onLedger.cachedContracts.get(coid) match {
         case Some(cached) =>
-          //println(s"----SBFetchAny,1") //NICK
+          // println(s"----SBFetchAny,1") //NICK
 
           onLedger.ptx.consumedByOrInactive(coid) match {
             case Some(Left(nid)) =>
@@ -1136,30 +1151,29 @@ private[lf] object SBuiltin {
           Control.Value(cached.any)
 
         case None =>
-          //println(s"----SBFetchAny,2") //NICK
+          // println(s"----SBFetchAny,2") //NICK
 
-          def continue(coinst: V.ContractInstance) : Unit = {
-            //println(s"----SBFetchAny,continue()") //NICK
+          def continue(coinst: V.ContractInstance): Unit = {
+            // println(s"----SBFetchAny,continue()") //NICK
             machine.pushKont(KCacheContract(machine, coid))
             val e = continueExpression(coinst)
             machine.ctrl = e
-            machine.setControl("SBFetchAny/continue",Control.Expression(e)) //NICK, yuck !!!
+            machine.setControl("SBFetchAny/continue", Control.Expression(e)) // NICK, yuck !!!
           }
-
 
           machine.disclosureTable.contractById.get(SContractId(coid)) match {
             case Some((templateId, arg)) =>
-              //println(s"----SBFetchAny,3") //NICK
+              // println(s"----SBFetchAny,3") //NICK
               val v = machine.normValue(templateId, arg)
               val coinst = V.ContractInstance(templateId, v, "")
-              //continue(coinst)//NICK
+              // continue(coinst)//NICK
               machine.pushKont(KCacheContract(machine, coid))
               val e = continueExpression(coinst)
               machine.ctrl = e
               Control.Blop("inside:SBFetchAny")
 
             case None =>
-              //println(s"----SBFetchAny,4") //NICK
+              // println(s"----SBFetchAny,4") //NICK
               throw SpeedyHungry(
                 SResultNeedContract(
                   coid,
@@ -1223,7 +1237,7 @@ private[lf] object SBuiltin {
     override private[speedy] def execute(
         args: util.ArrayList[SValue],
         machine: Machine,
-    ) : Control = {
+    ): Control = {
       val contractId = getSContractId(args, 0)
       val (actualTmplId, record @ _) = getSAnyContract(args, 1)
       if (!implementsOrCoImplements(machine, actualTmplId, requiringIfaceId))
@@ -1247,7 +1261,10 @@ private[lf] object SBuiltin {
       consuming: Boolean,
       byKey: Boolean,
   ) extends SBuiltin(1) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val e = SEBuiltin(
         SBUBeginExercise(
           templateId = getSAnyContract(args, 0)._1,
@@ -1263,7 +1280,10 @@ private[lf] object SBuiltin {
   }
 
   final case object SBResolveSBUInsertFetchNode extends SBuiltin(1) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val e = SEBuiltin(
         SBUInsertFetchNode(getSAnyContract(args, 0)._1, byKey = false)
       )
@@ -1274,7 +1294,10 @@ private[lf] object SBuiltin {
 
   // Return a definition matching the templateId of a given payload
   sealed class SBResolveVirtual(toDef: Ref.Identifier => SDefinitionRef) extends SBuiltin(1) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val (ty, record) = getSAnyContract(args, 0)
       val e = SEApp(SEVal(toDef(ty)), Array(SEValue(record)))
       machine.ctrl = e
@@ -1386,7 +1409,10 @@ private[lf] object SBuiltin {
       ifaceId: TypeConName,
       methodName: MethodName,
   ) extends SBuiltin(1) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val (templateId, record) = getSAnyContract(args, 0)
       val ref = getImplementsOrCoImplements(machine, templateId, ifaceId) match {
         case Some(TemplateOrInterface.Template(ImplementsDefRef(_, _))) =>
@@ -1407,7 +1433,10 @@ private[lf] object SBuiltin {
   final case class SBViewInterface(
       ifaceId: TypeConName
   ) extends SBuiltin(1) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       crash(
         s"Tried to run unsupported view with interface ${ifaceId}."
       )
@@ -1511,7 +1540,7 @@ private[lf] object SBuiltin {
     // Callback from the engine returned NotFound
     def handleKeyFound(machine: Machine, cid: V.ContractId): Control
     // We already saw this key, but it was undefined or was archived
-    def handleKeyNotFound(machine: Machine, gkey: GlobalKey): (Control,Boolean)
+    def handleKeyNotFound(machine: Machine, gkey: GlobalKey): (Control, Boolean)
 
     final def handleKnownInputKey(
         machine: Machine,
@@ -1533,7 +1562,7 @@ private[lf] object SBuiltin {
         machine.returnValue = SContractId(cid)
         Control.Value(SContractId(cid))
       }
-      override def handleKeyNotFound(machine: Machine, gkey: GlobalKey): (Control,Boolean) = {
+      override def handleKeyNotFound(machine: Machine, gkey: GlobalKey): (Control, Boolean) = {
         val e = SEDamlException(IE.ContractKeyNotFound(gkey))
         machine.ctrl = e
         (Control.Expression(e), false)
@@ -1545,7 +1574,7 @@ private[lf] object SBuiltin {
         machine.returnValue = SOptional(Some(SContractId(cid)))
         Control.Value(SOptional(Some(SContractId(cid))))
       }
-      override def handleKeyNotFound(machine: Machine, key: GlobalKey): (Control,Boolean) = {
+      override def handleKeyNotFound(machine: Machine, key: GlobalKey): (Control, Boolean) = {
         machine.returnValue = SValue.SValue.None
         (Control.Value(SValue.SValue.None), true)
       }
@@ -1578,51 +1607,54 @@ private[lf] object SBuiltin {
 
       onLedger.ptx.contractState.resolveKey(gkey) match {
         case Right((keyMapping, next)) =>
-          //println("---SBUKeyBuiltin, Right")//NICK
+          // println("---SBUKeyBuiltin, Right")//NICK
           onLedger.ptx = onLedger.ptx.copy(contractState = next)
           keyMapping match {
             case ContractStateMachine.KeyActive(coid) =>
-              //println("---SBUKeyBuiltin, Right, KeyActive")//NICK
+              // println("---SBUKeyBuiltin, Right, KeyActive")//NICK
               machine.checkKeyVisibility(onLedger, gkey, coid, operation.handleKeyFound)
 
             case ContractStateMachine.KeyInactive =>
-              //println("---SBUKeyBuiltin, Right, KeyInActive")//NICK
-              val _ = operation.handleKnownInputKey(machine, gkey, keyMapping) //NICK
+              // println("---SBUKeyBuiltin, Right, KeyInActive")//NICK
+              val _ = operation.handleKnownInputKey(machine, gkey, keyMapping) // NICK
               Control.Blop("inside:SBUKeyBuiltin/A")
           }
 
         case Left(handle) =>
-          //println("---SBUKeyBuiltin, Left")//NICK
-          def continue = { result => //NICK: Control
-            //println("---SBUKeyBuiltin, Left, continue()")//NICK
+          // println("---SBUKeyBuiltin, Left")//NICK
+          def continue = { result => // NICK: Control
+            // println("---SBUKeyBuiltin, Left, continue()")//NICK
             val (keyMapping, next) = handle(result)
             onLedger.ptx = onLedger.ptx.copy(contractState = next)
             keyMapping match {
               case ContractStateMachine.KeyActive(coid) =>
-                //println("---SBUKeyBuiltin, Left, continue(), KeyActive")//NICK
+                // println("---SBUKeyBuiltin, Left, continue(), KeyActive")//NICK
                 // We do not call directly machine.checkKeyVisibility as it may throw an SError,
                 // and such error cannot be throw inside a SpeedyHungry continuation.
                 machine.pushKont(
                   KCheckKeyVisibility(machine, gkey, coid, operation.handleKeyFound)
                 )
                 if (onLedger.cachedContracts.contains(coid)) {
-                  //println("---SBUKeyBuiltin, Left, continue(), KeyActive, if-true(in cache)")//NICK -- TODO, set newControl here
+                  // println("---SBUKeyBuiltin, Left, continue(), KeyActive, if-true(in cache)")//NICK -- TODO, set newControl here
                   machine.returnValue = SUnit
                   machine.setControl("SBUKeyBuiltin/continue/Active/in-cache", Control.Value(SUnit))
                 } else {
                   // SBFetchAny will populate onLedger.cachedContracts with the contract pointed by coid
                   val e = SBFetchAny(SEValue(SContractId(coid)), SBSome(SEValue(skey)))
                   machine.ctrl = e
-                  machine.setControl("SBUKeyBuiltin/continue/Active/out-cache",Control.Expression(e)) //NICK, yuck !!!
+                  machine.setControl(
+                    "SBUKeyBuiltin/continue/Active/out-cache",
+                    Control.Expression(e),
+                  ) // NICK, yuck !!!
                 }
                 true
 
               case ContractStateMachine.KeyInactive =>
-                //println("---SBUKeyBuiltin, Left, continue(), KeyInActive")//NICK
-                val (control,bool) = operation.handleKeyNotFound(machine, gkey)
-                //println("---SBUKeyBuiltin, Left, continue(), KeyInActive/2")//NICK
-                machine.setControl("SBUKeyBuiltin/continue/InActive",control) //NICK, yuck
-                //NICK: TODO unify the above 3x setControl, as... "answer:NeedKey"
+                // println("---SBUKeyBuiltin, Left, continue(), KeyInActive")//NICK
+                val (control, bool) = operation.handleKeyNotFound(machine, gkey)
+                // println("---SBUKeyBuiltin, Left, continue(), KeyInActive/2")//NICK
+                machine.setControl("SBUKeyBuiltin/continue/InActive", control) // NICK, yuck
+                // NICK: TODO unify the above 3x setControl, as... "answer:NeedKey"
                 bool
             }
           }: Option[V.ContractId] => Boolean
@@ -1664,7 +1696,10 @@ private[lf] object SBuiltin {
 
   /** $getTime :: Token -> Timestamp */
   final case object SBGetTime extends SBuiltin(1) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       checkToken(args, 0)
       // $ugettime :: Token -> Timestamp
       machine.ledgerMode match {
@@ -1675,14 +1710,17 @@ private[lf] object SBuiltin {
       throw SpeedyHungry(
         SResultNeedTime { timestamp =>
           machine.returnValue = STimestamp(timestamp)
-          machine.setControl("answer:NeedTime",Control.Value(STimestamp(timestamp)))
+          machine.setControl("answer:NeedTime", Control.Value(STimestamp(timestamp)))
         }
       )
     }
   }
 
   final case class SBSSubmit(optLocation: Option[Location], mustFail: Boolean) extends SBuiltin(3) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       checkToken(args, 2)
       throw SpeedyHungry(
         SResultScenarioSubmit(
@@ -1692,8 +1730,8 @@ private[lf] object SBuiltin {
           mustFail = mustFail,
           callback = { newValue =>
             machine.returnValue = newValue
-            machine.setControl("answer:ScenarioSubmit",Control.Value(newValue))
-          }
+            machine.setControl("answer:ScenarioSubmit", Control.Value(newValue))
+          },
         )
       )
     }
@@ -1701,7 +1739,10 @@ private[lf] object SBuiltin {
 
   /** $pure :: a -> Token -> a */
   final case object SBSPure extends SBuiltin(2) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       checkToken(args, 1)
       val v = args.get(0)
       machine.returnValue = v
@@ -1722,8 +1763,8 @@ private[lf] object SBuiltin {
           relTime,
           callback = { timestamp =>
             machine.returnValue = STimestamp(timestamp)
-            machine.setControl("answer:PassTime",Control.Value(STimestamp(timestamp)))
-          }
+            machine.setControl("answer:PassTime", Control.Value(STimestamp(timestamp)))
+          },
         )
       )
     }
@@ -1742,8 +1783,8 @@ private[lf] object SBuiltin {
           name,
           callback = { party =>
             machine.returnValue = SParty(party)
-            machine.setControl("answer:getParty",Control.Value(SParty(party)))
-          }
+            machine.setControl("answer:getParty", Control.Value(SParty(party)))
+          },
         )
       )
     }
@@ -1770,7 +1811,10 @@ private[lf] object SBuiltin {
 
   /** $throw :: AnyException -> a */
   final case object SBThrow extends SBuiltin(1) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val excep = getSAny(args, 0)
       unwindToHandler(machine, excep)
     }
@@ -1778,7 +1822,10 @@ private[lf] object SBuiltin {
 
   /** $try-handler :: Optional (Token -> a) -> AnyException -> Token -> a (or re-throw) */
   final case object SBTryHandler extends SBuiltin(3) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val opt = getSOptional(args, 0)
       val excep = getSAny(args, 1)
       checkToken(args, 2)
@@ -1793,7 +1840,10 @@ private[lf] object SBuiltin {
 
   /** $any-exception-message :: AnyException -> Text */
   final case object SBAnyExceptionMessage extends SBuiltin(1) {
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val exception = getSAnyException(args, 0)
       exception.id match {
         case ValueArithmeticError.tyCon =>
@@ -2031,7 +2081,10 @@ private[lf] object SBuiltin {
       SPAP(PClosure(Profile.LabelUnset, equalListBody, frame), ArrayList.empty, arity)
     }
 
-    override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine) : Control = {
+    override private[speedy] def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Control = {
       val f = args.get(0)
       val xs = args.get(1)
       val ys = args.get(2)
@@ -2046,7 +2099,10 @@ private[lf] object SBuiltin {
   object SBExperimental {
 
     private object SBExperimentalAnswer extends SBuiltin(1) {
-      override private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine) : Control = {
+      override private[speedy] def execute(
+          args: util.ArrayList[SValue],
+          machine: Machine,
+      ): Control = {
         machine.returnValue = SInt64(42L)
         Control.Value(SInt64(42L))
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1147,7 +1147,7 @@ private[lf] object SBuiltin {
             machine.pushKont(KCacheContract(machine, coid))
             val e = continueExpression(coinst)
             machine.ctrl = e
-            machine.setControl("SBFetchAny/continue", Control.Expression(e))
+            machine.setControl(Control.Expression(e))
           }
 
           machine.disclosureTable.contractById.get(SContractId(coid)) match {
@@ -1643,7 +1643,7 @@ private[lf] object SBuiltin {
                   onLedger.committers,
                   callback = { res =>
                     val (control, bool) = continue(res)
-                    machine.setControl("answer:NeedKey", control)
+                    machine.setControl(control)
                     bool
                   },
                 )
@@ -1684,7 +1684,7 @@ private[lf] object SBuiltin {
       throw SpeedyHungry(
         SResultNeedTime { timestamp =>
           machine.returnValue = STimestamp(timestamp)
-          machine.setControl("answer:NeedTime", Control.Value(STimestamp(timestamp)))
+          machine.setControl(Control.Value(STimestamp(timestamp)))
         }
       )
     }
@@ -1704,7 +1704,7 @@ private[lf] object SBuiltin {
           mustFail = mustFail,
           callback = { newValue =>
             machine.returnValue = newValue
-            machine.setControl("answer:ScenarioSubmit", Control.Value(newValue))
+            machine.setControl(Control.Value(newValue))
           },
         )
       )
@@ -1737,7 +1737,7 @@ private[lf] object SBuiltin {
           relTime,
           callback = { timestamp =>
             machine.returnValue = STimestamp(timestamp)
-            machine.setControl("answer:PassTime", Control.Value(STimestamp(timestamp)))
+            machine.setControl(Control.Value(STimestamp(timestamp)))
           },
         )
       )
@@ -1757,7 +1757,7 @@ private[lf] object SBuiltin {
           name,
           callback = { party =>
             machine.returnValue = SParty(party)
-            machine.setControl("answer:getParty", Control.Value(SParty(party)))
+            machine.setControl(Control.Value(SParty(party)))
           },
         )
       )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -79,7 +79,6 @@ object SExpr {
       _cached = Some((sValue, stack_trace))
 
     def execute(machine: Machine): Control = {
-      // println("----SEVal,execute") //NICK
       machine.lookupVal(this)
     }
   }
@@ -163,7 +162,6 @@ object SExpr {
         discard(actuals.add(v))
         i += 1
       }
-      // println(s"-----SEAppAtomicSaturatedBuiltin, executing builtin: $builtin") //NICK
       builtin.execute(actuals, machine)
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -48,7 +48,7 @@ object SExpr {
     def lookupValue(machine: Machine): SValue
 
     final def execute(machine: Machine): Control = {
-      val v : SValue = lookupValue(machine)
+      val v: SValue = lookupValue(machine)
       machine.returnValue = v
       Control.Value(v)
     }
@@ -79,7 +79,7 @@ object SExpr {
       _cached = Some((sValue, stack_trace))
 
     def execute(machine: Machine): Control = {
-      //println("----SEVal,execute") //NICK
+      // println("----SEVal,execute") //NICK
       machine.lookupVal(this)
     }
   }
@@ -163,7 +163,7 @@ object SExpr {
         discard(actuals.add(v))
         i += 1
       }
-      //println(s"-----SEAppAtomicSaturatedBuiltin, executing builtin: $builtin") //NICK
+      // println(s"-----SEAppAtomicSaturatedBuiltin, executing builtin: $builtin") //NICK
       builtin.execute(actuals, machine)
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -79,6 +79,7 @@ object SExpr {
       _cached = Some((sValue, stack_trace))
 
     def execute(machine: Machine): Control = {
+      //println("----SEVal,execute") //NICK
       machine.lookupVal(this)
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -49,7 +49,7 @@ object SExpr {
 
     final def execute(machine: Machine): Control = {
       val v: SValue = lookupValue(machine)
-      machine.returnValue = v
+      machine.xreturnValue = v
       Control.Value(v)
     }
   }
@@ -113,7 +113,7 @@ object SExpr {
   final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Control = {
       machine.pushKont(KArg(machine, args))
-      machine.ctrl = fun
+      machine.xctrl = fun
       Control.Expression(fun)
     }
   }
@@ -194,7 +194,7 @@ object SExpr {
       }
       val pap =
         SPAP(PClosure(Profile.LabelUnset, body, sValues), ArrayList.empty, arity)
-      machine.returnValue = pap
+      machine.xreturnValue = pap
       Control.Value(pap)
     }
   }
@@ -241,7 +241,7 @@ object SExpr {
   final case class SELet1General(rhs: SExpr, body: SExpr) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Control = {
       machine.pushKont(KPushTo(machine, machine.env, body))
-      machine.ctrl = rhs
+      machine.xctrl = rhs
       Control.Expression(rhs)
     }
   }
@@ -262,7 +262,7 @@ object SExpr {
       }
       val v = builtin.executePure(actuals)
       machine.pushEnv(v) // use pushEnv not env.add so instrumentation is updated
-      machine.ctrl = body
+      machine.xctrl = body
       Control.Expression(body)
     }
   }
@@ -287,7 +287,7 @@ object SExpr {
       builtin.compute(actuals) match {
         case Some(value) =>
           machine.pushEnv(value) // use pushEnv not env.add so instrumentation is updated
-          machine.ctrl = body
+          machine.xctrl = body
           Control.Expression(body)
         case None =>
           unwindToHandler(machine, builtin.buildException(actuals))
@@ -314,7 +314,7 @@ object SExpr {
   final case class SELocation(loc: Location, expr: SExpr) extends SExpr {
     def execute(machine: Machine): Control = {
       machine.pushLocation(loc)
-      machine.ctrl = expr
+      machine.xctrl = expr
       Control.Expression(expr)
     }
   }
@@ -331,7 +331,7 @@ object SExpr {
   final case class SELabelClosure(label: Profile.Label, expr: SExpr) extends SExpr {
     def execute(machine: Machine): Control = {
       machine.pushKont(KLabelClosure(machine, label))
-      machine.ctrl = expr
+      machine.xctrl = expr
       Control.Expression(expr)
     }
   }
@@ -363,7 +363,7 @@ object SExpr {
   final case class SETryCatch(body: SExpr, handler: SExpr) extends SExpr {
     def execute(machine: Machine): Control = {
       machine.pushKont(KTryCatchHandler(machine, handler))
-      machine.ctrl = body
+      machine.xctrl = body
       machine.withOnLedger("SETryCatch") { onLedger =>
         onLedger.ptx = onLedger.ptx.beginTry
       }
@@ -375,7 +375,7 @@ object SExpr {
   final case class SEScopeExercise(body: SExpr) extends SExpr {
     def execute(machine: Machine): Control = {
       machine.pushKont(KCloseExercise(machine))
-      machine.ctrl = body
+      machine.xctrl = body
       Control.Expression(body)
     }
   }
@@ -383,7 +383,7 @@ object SExpr {
   final case class SEPreventCatch(body: SExpr) extends SExpr {
     def execute(machine: Machine): Control = {
       machine.pushKont(KPreventException(machine))
-      machine.ctrl = body
+      machine.xctrl = body
       Control.Expression(body)
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -74,7 +74,7 @@ object SResult {
       key: GlobalKeyWithMaintainers,
       committers: Set[Party],
       // Callback.
-      // In case of failure, the callback sets machine.ctrl to an SErrorDamlException and return false
+      // In case of failure, the callback sets machine control to an SErrorDamlException and return false
       callback: Option[ContractId] => Boolean,
   ) extends SResult
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -33,7 +33,7 @@ private[lf] object Speedy {
 
   var mmm = 0
 
-  var xxe = 0 //NICK
+  var xxe = 0 // NICK
   var xxv = 0
   var xxb = 0
 
@@ -300,7 +300,6 @@ private[lf] object Speedy {
 
   /** The speedy CEK machine. */
   final class Machine(
-
       val me: Int,
 
       /* The control is what the machine should be evaluating. If this is not
@@ -311,7 +310,6 @@ private[lf] object Speedy {
        * been fully evaluated. If this is not null, then `ctrl` must be null.
        */
       var returnValue: SValue,
-
       var newControl: Control,
 
       /* Frame: to access values for a closure's free-vars. */
@@ -523,8 +521,8 @@ private[lf] object Speedy {
       *      i.e. run() has returned an `SResult` requiring a callback.
       */
     def setExpressionToEvaluate(expr: SExpr): Unit = {
-      //println(s"**Speedy.setExpressionToEvaluate() [$me]")//NICK
-      setControl("setExpressionToEvaluate",Control.Expression(expr))
+      // println(s"**Speedy.setExpressionToEvaluate() [$me]")//NICK
+      setControl("setExpressionToEvaluate", Control.Expression(expr))
       ctrl = expr
       kontStack = initialKontStack()
       env = emptyEnv
@@ -535,15 +533,14 @@ private[lf] object Speedy {
 
     def setControl(tag: String, control: Control): Unit = {
       val _ = tag
-      //println(s"**setControl($tag)") //NICK: very useful debug
-      newControl = control //NICK: the once place which may change newControl!!
+      // println(s"**setControl($tag)") //NICK: very useful debug
+      newControl = control // NICK: the once place which may change newControl!!
     }
-
 
     /** Run a machine until we get a result: either a final-value or a request for data, with a callback */
 
     def run(): SResult = {
-      //println(s"**Speedy.run() [$me]")//NICK
+      // println(s"**Speedy.run() [$me]")//NICK
       try {
         // normal exit from this loop is when KFinished.execute throws SpeedyComplete
         @tailrec
@@ -556,9 +553,9 @@ private[lf] object Speedy {
             println(s"$steps: ${PrettyLightweight.ppMachine(this)}")
           }
 
-          //println(s"**[$xxe,$xxv,$xxb] : (Control) $newControl") //NICK: main debug!
+          // println(s"**[$xxe,$xxv,$xxb] : (Control) $newControl") //NICK: main debug!
 
-          newControl match { //NICK: the one place which tests newControl
+          newControl match { // NICK: the one place which tests newControl
             case Control.WeAreComplete() =>
               sys.error("**attempt to run a complete machine")
             case Control.WeAreHungry(res) =>
@@ -572,16 +569,16 @@ private[lf] object Speedy {
               if (expr != e) {
                 ???
               }
-              setControl("unset",Control.WeAreUnset())
+              setControl("unset", Control.WeAreUnset())
               val control = e.execute(this)
-              setControl("step",control)
+              setControl("step", control)
               loop()
 
             case Control.Value(v) =>
               xxv += 1
               val value = returnValue
               if (value != v) {
-                ??? //NICK
+                ??? // NICK
               }
               returnValue = null
               popTempStackToBase()
@@ -595,12 +592,12 @@ private[lf] object Speedy {
                 val value = returnValue
                 returnValue = null
                 popTempStackToBase()
-                setControl("blop(V)/step",popKont().execute(value))
+                setControl("blop(V)/step", popKont().execute(value))
                 ()
               } else {
                 val expr = ctrl
                 ctrl = null
-                setControl("blop(E)/step",expr.execute(this))
+                setControl("blop(E)/step", expr.execute(this))
                 ()
               }
               loop()
@@ -609,12 +606,12 @@ private[lf] object Speedy {
         loop()
       } catch {
         case SpeedyHungry(res: SResult) =>
-          //println(s"**SpeedyHungry: $res")//NICK
-          setControl("hungry",Control.WeAreHungry(res))//NICK
+          // println(s"**SpeedyHungry: $res")//NICK
+          setControl("hungry", Control.WeAreHungry(res)) // NICK
           res
         case SpeedyComplete(value: SValue) =>
-          //println(s"**SpeedyComplete [$me]")//NICK
-          setControl("complete",Control.WeAreComplete())//NICK
+          // println(s"**SpeedyComplete [$me]")//NICK
+          setControl("complete", Control.WeAreComplete()) // NICK
           if (enableInstrumentation) track.print()
           ledgerMode match {
             case OffLedger => SResultFinal(value, None)
@@ -629,7 +626,7 @@ private[lf] object Speedy {
       }
     }
 
-    def lookupVal(eval: SEVal): Control = { //NICK
+    def lookupVal(eval: SEVal): Control = { // NICK
       eval.cached match {
         case Some((v, stack_trace)) =>
           pushStackTrace(stack_trace)
@@ -662,13 +659,13 @@ private[lf] object Speedy {
                     ref.packageId,
                     language.Reference.Package(ref.packageId),
                     callback = { packages =>
-                      //println("----Machine.lookupVal(continue, fixed!)") //NICK
+                      // println("----Machine.lookupVal(continue, fixed!)") //NICK
                       this.compiledPackages = packages
                       // To avoid infinite loop in case the packages are not updated properly by the caller //NICK: wat????
                       assert(compiledPackages.packageIds.contains(ref.packageId))
-                      ctrl = eval //NICK, why eval again??
-                      setControl("answer:NeedPackage",Control.Expression(eval)) //NICK
-                    }
+                      ctrl = eval // NICK, why eval again??
+                      setControl("answer:NeedPackage", Control.Expression(eval)) // NICK
+                    },
                   )
                 )
           }
@@ -973,7 +970,7 @@ private[lf] object Speedy {
         onLedger: OnLedger,
         gkey: GlobalKey,
         coid: V.ContractId,
-        handleKeyFound: (Machine, V.ContractId) => Control, //NICK: just changed
+        handleKeyFound: (Machine, V.ContractId) => Control, // NICK: just changed
     ): Control =
       onLedger.cachedContracts.get(coid) match {
         case Some(cachedContract) =>
@@ -985,7 +982,7 @@ private[lf] object Speedy {
                   .ContractKeyNotVisible(coid, gkey, actAs, readAs, stakeholders)
               )
             case _ =>
-              val _ = handleKeyFound(this, coid) //NICK:Control
+              val _ = handleKeyFound(this, coid) // NICK:Control
               Control.Blop("inside:checkKeyVisibility")
           }
         case None =>
@@ -1208,10 +1205,10 @@ private[lf] object Speedy {
     kontStack
   }
 
-  //private[speedy] //NICK
-  sealed abstract class Control //NICK: more greppable name?
+  // private[speedy] //NICK
+  sealed abstract class Control // NICK: more greppable name?
   object Control {
-    final case class Blop(tag: String) extends Control //NICK: DIE! uses cntl/returnValue
+    final case class Blop(tag: String) extends Control // NICK: DIE! uses cntl/returnValue
     final case class Expression(e: SExpr) extends Control
     final case class Value(v: SValue) extends Control
     final case class WeAreUnset() extends Control
@@ -1331,7 +1328,11 @@ private[lf] object Speedy {
   }
 
   /** The scrutinee of a match has been evaluated, now match the alternatives against it. */
-  private[speedy] def executeMatchAlts(machine: Machine, alts: Array[SCaseAlt], v: SValue): Control = {
+  private[speedy] def executeMatchAlts(
+      machine: Machine,
+      alts: Array[SCaseAlt],
+      v: SValue,
+  ): Control = {
     val altOpt = v match {
       case SValue.SBool(b) =>
         alts.find { alt =>
@@ -1604,11 +1605,11 @@ private[lf] object Speedy {
       machine: Machine,
       gKey: GlobalKey,
       cid: V.ContractId,
-      handleKeyFound: (Machine, V.ContractId) => Control, //NICK: changed!
+      handleKeyFound: (Machine, V.ContractId) => Control, // NICK: changed!
   ) extends Kont {
     def execute(sv: SValue): Control = {
       machine.withOnLedger("KCheckKeyVisibitiy") { onLedger =>
-        val _ = machine.checkKeyVisibility(onLedger, gKey, cid, handleKeyFound) //NICK
+        val _ = machine.checkKeyVisibility(onLedger, gKey, cid, handleKeyFound) // NICK
         ()
       }
       Control.Blop("inside:KCheckKeyVisibitiy")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -585,7 +585,10 @@ private[lf] object Speedy {
               setControl("Control.Value/step", popKont().execute(v))
               loop()
 
-            case Control.Blop(tag) =>
+            /*case Control.Blop(tag) =>
+              println(s"**[$xxe,$xxv,$xxb] : (Control) $newControl") //NICK
+              def xxx : Unit = ???
+              xxx
               val _ = tag
               xxb += 1
               if (returnValue != null) {
@@ -600,7 +603,7 @@ private[lf] object Speedy {
                 setControl("blop(E)/step", expr.execute(this))
                 ()
               }
-              loop()
+              loop()*/
           }
         }
         loop()
@@ -661,7 +664,7 @@ private[lf] object Speedy {
                     callback = { packages =>
                       // println("----Machine.lookupVal(continue, fixed!)") //NICK
                       this.compiledPackages = packages
-                      // To avoid infinite loop in case the packages are not updated properly by the caller //NICK: wat????
+                      // To avoid infinite loop in case the packages are not updated properly by the caller
                       assert(compiledPackages.packageIds.contains(ref.packageId))
                       ctrl = eval // NICK, why eval again??
                       setControl("answer:NeedPackage", Control.Expression(eval)) // NICK
@@ -982,8 +985,8 @@ private[lf] object Speedy {
                   .ContractKeyNotVisible(coid, gkey, actAs, readAs, stakeholders)
               )
             case _ =>
-              val _ = handleKeyFound(this, coid) // NICK:Control
-              Control.Blop("inside:checkKeyVisibility")
+              handleKeyFound(this, coid) // NICK:Control
+            // Control.Blop("inside:checkKeyVisibility")//NICK
           }
         case None =>
           throw SErrorCrash(
@@ -1208,7 +1211,7 @@ private[lf] object Speedy {
   // private[speedy] //NICK
   sealed abstract class Control // NICK: more greppable name?
   object Control {
-    final case class Blop(tag: String) extends Control // NICK: DIE! uses cntl/returnValue
+    // final case class Blop(tag: String) extends Control // NICK: DIE! uses cntl/returnValue
     final case class Expression(e: SExpr) extends Control
     final case class Value(v: SValue) extends Control
     final case class WeAreUnset() extends Control
@@ -1609,10 +1612,9 @@ private[lf] object Speedy {
   ) extends Kont {
     def execute(sv: SValue): Control = {
       machine.withOnLedger("KCheckKeyVisibitiy") { onLedger =>
-        val _ = machine.checkKeyVisibility(onLedger, gKey, cid, handleKeyFound) // NICK
-        ()
+        machine.checkKeyVisibility(onLedger, gKey, cid, handleKeyFound) // NICK
       }
-      Control.Blop("inside:KCheckKeyVisibitiy")
+      // Control.Blop("inside:KCheckKeyVisibitiy") //NICK
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -522,7 +522,7 @@ private[lf] object Speedy {
       track = Instrumentation()
     }
 
-    def setControl(control: Control): Unit = { // NICK: inlne?
+    def setControl(control: Control): Unit = {
       newControl = control
     }
 
@@ -548,12 +548,12 @@ private[lf] object Speedy {
             case Control.WeAreHungry(res) =>
               sys.error(s"**attempt to run a hungry machine (feed me first): $res")
             case Control.Expression(exp) =>
-              xctrl = null // NICK: classification counts
+              xctrl = null
               setControl(Control.WeAreUnset())
               setControl(exp.execute(this))
               loop()
             case Control.Value(value) =>
-              xreturnValue = null // NICK: classification counts
+              xreturnValue = null
               popTempStackToBase()
               setControl(popKont().execute(value))
               loop()
@@ -594,11 +594,9 @@ private[lf] object Speedy {
               defn.cached match {
                 case Some((svalue, stackTrace)) =>
                   eval.setCached(svalue, stackTrace)
-                  xreturnValue = svalue // NICK: why? - caller will do this
                   Control.Value(svalue)
                 case None =>
                   pushKont(KCacheVal(this, eval, defn, Nil))
-                  xctrl = defn.body // NICK: why? -- caller will do this
                   Control.Expression(defn.body)
               }
             case None =>
@@ -1157,9 +1155,9 @@ private[lf] object Speedy {
   object Control {
     final case class Expression(e: SExpr) extends Control
     final case class Value(v: SValue) extends Control
-    final case class WeAreUnset() extends Control // NICK: kill?
-    final case class WeAreComplete() extends Control // NICK: kill?
-    final case class WeAreHungry(res: SResult) extends Control // NICK: kill?
+    final case class WeAreUnset() extends Control
+    final case class WeAreComplete() extends Control
+    final case class WeAreHungry(res: SResult) extends Control
   }
 
   /** Kont, or continuation. Describes the next step for the machine

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -31,7 +31,7 @@ import scala.util.control.NoStackTrace
 
 private[lf] object Speedy {
 
-  // Would like these to have zero cost when not enabled. Better still, to be switchable at runtime.
+  // These have zero cost when not enabled. But they are not switchable at runtime.
   private[this] val enableInstrumentation: Boolean = false
   private[this] val enableLightweightStepTracing: Boolean = false
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
@@ -1329,7 +1329,7 @@ class EvaluationOrderTest extends AnyFreeSpec with Matchers with Inside {
         }
 
         // TEST_EVIDENCE: Semantics: Evaluation order of exercise_by_key of a wrongly typed cached global contract
-        "wrongly typed contract" in {
+        "wrongly typed contract NICK" in {
           val (res, msgs) = evalUpdateApp(
             pkgs,
             e"""\(exercisingParty : Party) (cId: ContractId M:T) (sig: Party) ->

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/EvaluationOrderTest.scala
@@ -1329,7 +1329,7 @@ class EvaluationOrderTest extends AnyFreeSpec with Matchers with Inside {
         }
 
         // TEST_EVIDENCE: Semantics: Evaluation order of exercise_by_key of a wrongly typed cached global contract
-        "wrongly typed contract NICK" in {
+        "wrongly typed contract" in {
           val (res, msgs) = evalUpdateApp(
             pkgs,
             e"""\(exercisingParty : Party) (cId: ContractId M:T) (sig: Party) ->

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -484,7 +484,6 @@ object Repl {
             }
             val endTime = System.nanoTime()
             val diff = (endTime - startTime) / 1000 / 1000
-            machine.print(1)
             println(s"time: ${diff}ms")
             valueOpt match {
               case None => ()

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -245,10 +245,9 @@ object ScenarioRunner {
         readAs: Set[Party],
         callback: Option[ContractId] => Boolean,
     ): Either[Error, Unit] =
-      handleUnsafe(lookupKeyUnsafe(machine: Speedy.Machine, gk, actAs, readAs, callback))
+      handleUnsafe(lookupKeyUnsafe(gk, actAs, readAs, callback))
 
     private def lookupKeyUnsafe(
-        machine: Speedy.Machine,//NICK: dont pass
         gk: GlobalKey,
         actAs: Set[Party],
         readAs: Set[Party],
@@ -260,7 +259,6 @@ object ScenarioRunner {
 
       def missingWith(err: Error) =
         if (!callback(None)) {
-          val _ = machine//NICK
           throw err
         }
 

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/ScenarioRunner.scala
@@ -248,7 +248,7 @@ object ScenarioRunner {
       handleUnsafe(lookupKeyUnsafe(machine: Speedy.Machine, gk, actAs, readAs, callback))
 
     private def lookupKeyUnsafe(
-        machine: Speedy.Machine,
+        machine: Speedy.Machine,//NICK: dont pass
         gk: GlobalKey,
         actAs: Set[Party],
         readAs: Set[Party],
@@ -260,8 +260,7 @@ object ScenarioRunner {
 
       def missingWith(err: Error) =
         if (!callback(None)) {
-          machine.returnValue = null
-          machine.ctrl = null
+          val _ = machine//NICK
           throw err
         }
 

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -61,7 +61,7 @@ class CollectAuthorityState {
       compiledPackages,
       expr,
     )
-    the_sexpr = machine.ctrl
+    the_sexpr = machine.xctrl //NICK
 
     // fill the caches!
     setup()

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -61,7 +61,7 @@ class CollectAuthorityState {
       compiledPackages,
       expr,
     )
-    the_sexpr = machine.newControl match {
+    the_sexpr = machine.control match {
       case Control.Expression(exp) => exp
       case x => crash(s"expected Control.Expression, got: $x")
     }

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -16,7 +16,7 @@ import com.daml.lf.transaction.{GlobalKey, NodeId, SubmittedTransaction}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.lf.scenario.{ScenarioLedger, ScenarioRunner}
-import com.daml.lf.speedy.Speedy.Machine
+import com.daml.lf.speedy.Speedy.{Machine, Control}
 import com.daml.logging.LoggingContext
 
 import java.io.File
@@ -61,7 +61,10 @@ class CollectAuthorityState {
       compiledPackages,
       expr,
     )
-    the_sexpr = machine.xctrl //NICK
+    the_sexpr = machine.newControl match {
+      case Control.Expression(exp) => exp
+      case x => crash(s"expected Control.Expression, got: $x")
+    }
 
     // fill the caches!
     setup()
@@ -153,9 +156,8 @@ class CollectAuthorityState {
     }
   }
 
-  def crash(reason: String) = {
-    System.err.println("Benchmark failed: " + reason)
-    System.exit(1)
+  def crash[T](reason: String): T = {
+    sys.error("Benchmark failed: " + reason)
   }
 
 }


### PR DESCRIPTION
Improve handling of control within the speedy machine.
- Intro dedicated `Control` type, and single machine component `control: Control`
- Replacing old machine components: `returnValue`/`ctrl`
- Code which is expected to _take a step_ and update the control, can now return `Control`
- Instead of side-effecting `returnValue`/`ctrl`, and returning `Unit`

This final result is much clearer code intent; with far less chance to forget to update `control`
You can forget to make an assignment; you can't forget a `return` value.
The only remaining danger is in the `SpeedyHungry` `callback`s, which must remember to call `setControl`.

We previously shied away from making this change because of some notion that it would be less efficient.
`Control` is variant type, essentially `Either[SExpr,SValue]`, and we worried this was expensive.
Turns out not to be!
I ran perf on our big production example, and saw that the diff is tiny; well within the noise;
And anyway, the numbers are better after the change!

HEAD:
```
    Result "com.daml.lf.speedy.SpeedyCompilationBench.bench":
      2.092 ±(99.9%) 0.055 s/op [Average]
      (min, avg, max) = (1.996, 2.092, 2.222), stdev = 0.064
      CI (99.9%): [2.036, 2.147] (assumes normal distribution)
```
BASE:
```
    Result "com.daml.lf.speedy.SpeedyCompilationBench.bench":
      2.114 ±(99.9%) 0.048 s/op [Average]
      (min, avg, max) = (2.028, 2.114, 2.211), stdev = 0.055
      CI (99.9%): [2.067, 2.162] (assumes normal distribution)
```
