### PR TITLE
Make emphasis visible

### DIFF
--- a/docs/theme/sass/_theme_layout.sass
+++ b/docs/theme/sass/_theme_layout.sass
@@ -520,7 +520,7 @@ body
 
     a
       position: relative
-      font-weight: $weight-bold
+      font-weight: $weight-body
       color: $link-color
 
       span
@@ -1152,7 +1152,7 @@ body
 
         a
           margin-left: 5px
-          font-weight: $weight-bold
+          font-weight: $weight-body
 
       ul
         max-height: 155px

--- a/docs/theme/sass/_theme_variables.sass
+++ b/docs/theme/sass/_theme_variables.sass
@@ -72,6 +72,6 @@ $btn-font-family:                     "Roboto Mono", "Lato", Helvetica,Arial,san
 
 $weight-title:                        400
 $weight-body:                         400
-$weight-bold:                         500
+$weight-bold:                         700
 $weight-code:                         400
 $weight-btn:                          400


### PR DESCRIPTION
Setting the font weight to 500 makes it effectively invisible, at least
in certain configurations (my setup is an Ubuntu 20.04 with Chrome 103).

In my experiments, 600 is the minimal font weight that makes the difference
visible on my setup. In order to keep the appearance of links unchanged,
I also decreased the font weight for links to the same as the body.

Another possibility to make a compromise that could work for different
setups could be to lower the font weight for bold to 600 and have a weight
specific for links at 500. This allows emphasis to appear clearly on setups
with less sophisticated font management but not to exagerated it for links.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
