### PR TITLE
Fix indent that creates an unneeded subparagraph

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -94,7 +94,7 @@ The installer will setup the ``PATH`` variable for you. In order for it to take 
 log out and log in again.
 
 If the ``daml`` command is not available in your terminal after logging out and logging in again, you need to set the ``PATH`` environment variable
-  manually. You can find instructions on how to do this :doc:`here <path-variables>`.
+manually. You can find instructions on how to do this :doc:`here <path-variables>`.
 
 .. _installing_daml_enterprise:
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
The [Getting Started doc](https://docs.daml.com/getting-started/installation.html#mac-and-linux) incorrectly shows a subparagraph in the middle of a sentence.

CHANGELOG_BEGIN
CHANGELOG_END