### PR TITLE
[LLP] Conditionally restart in memory state [DPP-1137]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/InMemoryState.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/InMemoryState.scala
@@ -50,8 +50,8 @@ private[platform] class InMemoryState(
   /** (Re-)initializes the participant in-memory state to a specific ledger end.
     *
     * The state is conditionally (re-)initialized depending on:
-    *    - whether it has been already initialized for the first time
-    *    - whether the ledger end cache or the last string interned id have changed
+    *    - whether is it not initialized (i.e. the dispatcher is not running)
+    *    - whether the ledger end cache or the last interned string id have changed
     *    since the last known state. Note that we additionally check the string interning view's last id,
     *    since it is updated outside this class (see [[com.daml.platform.indexer.parallel.ParallelIndexerSubscription]]).
     *    - whether it has been marked dirty. On a successful (re-)initialization, the state is marked not dirty again.

--- a/ledger/participant-integration-api/src/main/scala/platform/InMemoryState.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/InMemoryState.scala
@@ -13,84 +13,176 @@ import com.daml.platform.store.cache.{
   InMemoryFanoutBuffer,
   MutableLedgerEndCache,
 }
+import com.daml.platform.store.dao.events.ContractStateEvent
+import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.interning.{StringInterningView, UpdatingStringInterningView}
+import scalaz.Scalaz._
+import scalaz._
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.chaining._
 
-/** Wrapper and life-cycle manager for the in-memory Ledger API state. */
+/** This class encapsulates and mutates the caching in-memory data structures used for
+  * serving Ledger API requests.
+  *
+  * TODO Implement one-at-a-time synchronization for the async public methods in this class.
+  */
 private[platform] class InMemoryState(
     val ledgerEndCache: MutableLedgerEndCache,
     val contractStateCaches: ContractStateCaches,
     val inMemoryFanoutBuffer: InMemoryFanoutBuffer,
     val stringInterningView: StringInterningView,
     val dispatcherState: DispatcherState,
-)(implicit executionContext: ExecutionContext) {
+) {
+  implicit private val offsetEquals: Equal[Offset] = Equal.equalA[Offset]
   private val logger = ContextualizedLogger.get(getClass)
   @volatile private var _dirty = false
 
+  /** Returns true if the state has been initialized.
+    *
+    * This method is designed to synchronize start-up of the IndexService only
+    * after the first initialization triggered by the Indexer.
+    * (see [[com.daml.platform.indexer.JdbcIndexer.Factory.initialized()]]
+    */
   final def initialized: Boolean = dispatcherState.isRunning
 
   /** (Re-)initializes the participant in-memory state to a specific ledger end.
     *
-    * NOTE: This method is not thread-safe. Calling it concurrently leads to undefined behavior.
+    * The state is conditionally (re-)initialized depending on:
+    *    - whether it has been already initialized for the first time
+    *    - whether the ledger end cache or the last string interned id have changed
+    *    since the last known state. Note that we additionally check the string interning view's last id,
+    *    since it is updated outside this class (see [[com.daml.platform.indexer.parallel.ParallelIndexerSubscription]]).
+    *    - whether it has been marked dirty. On a successful (re-)initialization, the state is marked not dirty again.
+    *
+    * NOTE:
+    *   - This method is not thread-safe. Calling it concurrently with itself
+    * or with [[update()]] leads to undefined behavior.
+    *   - A failure in this method leaves the state dirty.
     */
-  final def initializeTo(ledgerEnd: LedgerEnd)(
+  final def initializeTo(ledgerEnd: LedgerEnd, executionContext: ExecutionContext)(
       updateStringInterningView: (UpdatingStringInterningView, LedgerEnd) => Future[Unit]
-  )(implicit loggingContext: LoggingContext): Future[Unit] =
+  )(implicit loggingContext: LoggingContext): Future[Unit] = {
+    implicit val ec: ExecutionContext = executionContext
     conditionallyInitialize(ledgerEnd) { () =>
-      for {
-        // First stop the active dispatcher (if exists) to ensure
-        // termination of existing Ledger API subscriptions and to also ensure
-        // that new Ledger API subscriptions racing with `initializeTo`
-        // do not observe an inconsistent state.
-        _ <- dispatcherState.stopDispatcher()
-        // Reset the string interning view to the latest ledger end
-        _ <- updateStringInterningView(stringInterningView, ledgerEnd)
-        // Reset the Ledger API caches to the latest ledger end
-        _ <- Future {
-          contractStateCaches.reset(ledgerEnd.lastOffset)
-          inMemoryFanoutBuffer.flush()
-          ledgerEndCache.set(ledgerEnd.lastOffset -> ledgerEnd.lastEventSeqId)
-        }
-        // Start a new Ledger API offset dispatcher
-        _ = dispatcherState.startDispatcher(ledgerEnd.lastOffset)
-      } yield {
-        // Reset the dirty flag
-        _dirty = false
+      dirtyWriteSection {
+        for {
+          // Ensure only async execution
+          _ <- Future.unit
+          // First stop the active dispatcher (if exists) to ensure
+          // termination of existing Ledger API subscriptions and to also ensure
+          // that new Ledger API subscriptions racing with `initializeTo`
+          // do not observe an inconsistent state.
+          _ <- dispatcherState.stopDispatcher()
+          // Reset the string interning view to the latest ledger end
+          _ <- updateStringInterningView(stringInterningView, ledgerEnd)
+          // Reset the Ledger API caches to the latest ledger end
+          _ <- Future {
+            contractStateCaches.reset(ledgerEnd.lastOffset)
+            inMemoryFanoutBuffer.flush()
+            ledgerEndCache.set(ledgerEnd.lastOffset -> ledgerEnd.lastEventSeqId)
+          }
+          // Start a new Ledger API offset dispatcher
+          _ = dispatcherState.startDispatcher(ledgerEnd.lastOffset)
+        } yield ()
       }
     }
+  }
 
-  final def setDirty(): Unit = _dirty = true
+  /** Updates the in-memory state.
+    *
+    * On failure, the state is marked as dirty, ensuring re-initialization on [[InMemoryState.initializeTo()]].
+    *
+    * NOTE:
+    *   - This method is not thread-safe. Calling it concurrently with itself
+    * or with [[InMemoryState.update()]] leads to undefined behavior.
+    *   - A failure in this method leaves the state dirty.
+    *
+    * @param updates The update batch used to update the the in-memory fan-out buffer and the contract state cache.
+    * @param lastOffset The last offset ingested by the Indexer.
+    * @param lastEventSequentialId The last event sequential id ingested by the Indexer.
+    * @param executionContext The execution context.
+    * @param loggingContext The logging context.
+    */
+  final def update(
+      updates: Vector[(TransactionLogUpdate, Vector[ContractStateEvent])],
+      lastOffset: Offset,
+      lastEventSequentialId: Long,
+  )(implicit executionContext: ExecutionContext, loggingContext: LoggingContext): Future[Unit] =
+    if (!_dirty) {
+      dirtyWriteSection {
+        Future {
+          // Update caches
+          updates.foreach { case (transaction, contractStateEventsBatch) =>
+            // TODO LLP: Batch update caches
+            inMemoryFanoutBuffer.push(transaction.offset, transaction)
+            if (contractStateEventsBatch.nonEmpty) {
+              contractStateCaches.push(contractStateEventsBatch)
+            }
+          }
+
+          // Update ledger end
+          ledgerEndCache.set((lastOffset, lastEventSequentialId))
+          // the order here is very important: first we need to make data available for point-wise lookups
+          // and SQL queries, and only then we can make it available on the streams.
+          // (consider example: completion arrived on a stream, but the transaction cannot be looked up)
+          dispatcherState.getDispatcher.signalNewHead(lastOffset)
+          logger.info(s"Updated ledger end cache at offset $lastOffset - $lastEventSequentialId")
+        }
+      }
+    } else {
+      dirtyUpdateAttempted(lastOffset, lastEventSequentialId)
+    }
+
+  private def dirtyUpdateAttempted(offset: Offset, eventSequentialId: Long)(implicit
+      loggingContext: LoggingContext
+  ): Future[Unit] = {
+    val logMessage =
+      s"Attempted to update a dirty in-memory state at offset ($offset) and event sequential id ($eventSequentialId)."
+
+    logger.error(logMessage)
+    Future.failed(new IllegalStateException(logMessage))
+  }
+
+  private def dirtyWriteSection(mutateState: => Future[Unit]): Future[Unit] = {
+    // On update failure, we can't make assumptions on which part of the state was correctly updated.
+    // Thus, set the in-memory state dirty at the beginning of a mutating operation unset it on success.
+    _dirty = true
+    mutateState.map { _ =>
+      _dirty = false
+      ()
+    }(ExecutionContext.parasitic)
+  }
 
   private def conditionallyInitialize(
       ledgerEnd: LedgerEnd
   )(initialize: () => Future[Unit])(implicit loggingContext: LoggingContext): Future[Unit] =
     if (!initialized) {
-      logger.info(s"Initializing participant in-memory state to ledger end: $ledgerEnd.")
+      logger.info(s"Initializing  in-memory state to ledger end: $ledgerEnd.")
       initialize()
     } else if (_dirty) {
       logger.warn(
-        s"Dirty state detected on initialization. Re-setting the in-memory state ledger end: $ledgerEnd."
+        s"Dirty state detected on initialization. Re-setting the in-memory state to ledger end: $ledgerEnd."
       )
       initialize()
     } else {
       val currentLedgerEndCache = ledgerEndCache()
       if (
-        loggedEqualityCheck[Offset](
-          ledgerEnd.lastOffset,
-          currentLedgerEndCache._1,
-          "ledger end cache offset",
+        loggedNonEquality[Offset](
+          expected = ledgerEnd.lastOffset,
+          actual = currentLedgerEndCache._1,
+          name = "ledger end cache offset",
         ) ||
-        loggedEqualityCheck[Long](
-          ledgerEnd.lastEventSeqId,
-          currentLedgerEndCache._2,
-          "ledger end cache event sequential id",
-        ) || loggedEqualityCheck[Int](
-          ledgerEnd.lastStringInterningId,
-          stringInterningView.lastId,
-          "last string interning id",
+        loggedNonEquality[Long](
+          expected = ledgerEnd.lastEventSeqId,
+          actual = currentLedgerEndCache._2,
+          name = "ledger end cache event sequential id",
+        ) ||
+        loggedNonEquality[Int](
+          expected = ledgerEnd.lastStringInterningId,
+          actual = stringInterningView.lastId,
+          name = "last string interning id",
         )
       ) {
         logger.warn(
@@ -98,14 +190,16 @@ private[platform] class InMemoryState(
         )
         initialize()
       } else {
+        logger.info("Coherency checks passed. In-memory state re-initialization skipped.")
         Future.unit
       }
     }
 
-  private def loggedEqualityCheck[T](expected: T, actual: T, name: String)(implicit
-      loggingContext: LoggingContext
+  private def loggedNonEquality[T](expected: T, actual: T, name: String)(implicit
+      loggingContext: LoggingContext,
+      safeEquals: Equal[T],
   ): Boolean =
-    (expected != actual)
+    (!safeEquals.equal(expected, actual))
       .tap { notEqual =>
         if (notEqual)
           logger.warn(
@@ -125,27 +219,30 @@ object InMemoryState {
       executionContext: ExecutionContext,
   )(implicit loggingContext: LoggingContext): ResourceOwner[InMemoryState] = {
     val initialLedgerEnd = LedgerEnd.beforeBegin
+    val initialLedgerEndCache = MutableLedgerEndCache()
+      .tap(
+        _.set((initialLedgerEnd.lastOffset, initialLedgerEnd.lastEventSeqId))
+      )
+
+    val contractStateCaches = ContractStateCaches.build(
+      initialLedgerEnd.lastOffset,
+      maxContractStateCacheSize,
+      maxContractKeyStateCacheSize,
+      metrics,
+    )(executionContext, loggingContext)
 
     for {
       dispatcherState <- DispatcherState.owner(apiStreamShutdownTimeout)
     } yield new InMemoryState(
-      ledgerEndCache = MutableLedgerEndCache()
-        .tap(
-          _.set((initialLedgerEnd.lastOffset, initialLedgerEnd.lastEventSeqId))
-        ),
+      ledgerEndCache = initialLedgerEndCache,
       dispatcherState = dispatcherState,
-      contractStateCaches = ContractStateCaches.build(
-        initialLedgerEnd.lastOffset,
-        maxContractStateCacheSize,
-        maxContractKeyStateCacheSize,
-        metrics,
-      )(executionContext, loggingContext),
+      contractStateCaches = contractStateCaches,
       inMemoryFanoutBuffer = new InMemoryFanoutBuffer(
         maxBufferSize = maxTransactionsInMemoryFanOutBufferSize,
         metrics = metrics,
         maxBufferedChunkSize = bufferedStreamsPageSize,
       ),
       stringInterningView = new StringInterningView,
-    )(executionContext)
+    )
   }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
@@ -99,12 +99,12 @@ private[platform] object InMemoryStateUpdater {
         metrics.daml.lapi.threadpool.indexBypass.updateInMemoryState,
       )
     )
-
+    updateCachesExecutionContext = ExecutionContext.fromExecutorService(updateCachesExecutor)
+    prepareUpdatesExecutionContext = ExecutionContext.fromExecutorService(prepareUpdatesExecutor)
   } yield {
-    val updateCachesExecutionContext = ExecutionContext.fromExecutorService(updateCachesExecutor)
     new InMemoryStateUpdater(
       prepareUpdatesParallelism = prepareUpdatesParallelism,
-      prepareUpdatesExecutionContext = ExecutionContext.fromExecutorService(prepareUpdatesExecutor),
+      prepareUpdatesExecutionContext = prepareUpdatesExecutionContext,
       updateCachesExecutionContext = updateCachesExecutionContext,
       metrics = metrics,
     )(

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -95,16 +95,17 @@ object JdbcIndexer {
         ).apply,
         mat = materializer,
         readService = readService,
-        initializeInMemoryState = dbDispatcher =>
+        initializeInMemoryState = (dbDispatcher, executionContext) =>
           ledgerEnd =>
-            inMemoryState.initializeTo(ledgerEnd)((updatingStringInterningView, ledgerEnd) =>
-              updateStringInterningView(
-                stringInterningStorageBackend,
-                metrics,
-                dbDispatcher,
-                updatingStringInterningView,
-                ledgerEnd,
-              )
+            inMemoryState.initializeTo(ledgerEnd, executionContext)(
+              (updatingStringInterningView, ledgerEnd) =>
+                updateStringInterningView(
+                  stringInterningStorageBackend,
+                  metrics,
+                  dbDispatcher,
+                  updatingStringInterningView,
+                  ledgerEnd,
+                )
             ),
         stringInterningView = inMemoryState.stringInterningView,
       )

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/parallel/ParallelIndexerFactory.scala
@@ -41,7 +41,7 @@ object ParallelIndexerFactory {
       mat: Materializer,
       readService: ReadService,
       stringInterningView: StringInterningView,
-      initializeInMemoryState: DbDispatcher => LedgerEnd => Future[Unit],
+      initializeInMemoryState: (DbDispatcher, ExecutionContext) => LedgerEnd => Future[Unit],
   )(implicit loggingContext: LoggingContext): ResourceOwner[Indexer] =
     for {
       inputMapperExecutor <- asyncPool(
@@ -126,7 +126,7 @@ object ParallelIndexerFactory {
         ) { dbDispatcher =>
           initializeParallelIngestion(
             dbDispatcher = dbDispatcher,
-            additionalInitialization = initializeInMemoryState(dbDispatcher),
+            additionalInitialization = initializeInMemoryState(dbDispatcher, ec),
             readService = readService,
             mat = mat,
             ec = ec,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interning/StringInterningView.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interning/StringInterningView.scala
@@ -27,7 +27,7 @@ trait InternizingStringInterningView {
 
 trait UpdatingStringInterningView {
 
-  /** Update the StringInterningView from persistence
+  /** Update the StringInterningView from persistence.
     *
     * @param lastStringInterningId this is the "version" of the persistent view, which from the StringInterningView can see if it is behind
     * @return a completion Future:
@@ -41,6 +41,9 @@ trait UpdatingStringInterningView {
   def update(lastStringInterningId: Int)(
       loadPrefixedEntries: LoadStringInterningEntries
   )(implicit loggingContext: LoggingContext): Future[Unit]
+
+  /** Get the last interned string id. */
+  def lastId: Int
 }
 
 /** Encapsulate the dependency to load a range of string-interning-entries from persistence
@@ -112,6 +115,8 @@ class StringInterningView()
       loadStringInterningEntries(raw.lastId, lastStringInterningId)(loggingContext)
         .map(updateView)(ExecutionContext.parasitic)
     }
+
+  override def lastId: Int = raw.lastId
 
   private def updateView(newEntries: Iterable[(Int, String)]): Unit = synchronized {
     if (newEntries.nonEmpty) {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/DispatcherStateSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/DispatcherStateSpec.scala
@@ -36,7 +36,7 @@ class DispatcherStateSpec
 
   private val thirdOffset = Offset.fromHexString(Ref.HexString.assertFromString("abcdff"))
 
-  s"$className.{startDispatcher, stopDispatcher}" should "handle correctly the Dispatcher lifecycle" in {
+  s"$className.{startDispatcher, stopDispatcher}" should "correctly handle the Dispatcher lifecycle" in {
     for {
       _ <- Future.unit
       dispatcherState = new DispatcherState(Duration.Zero)(loggingContext)
@@ -98,7 +98,7 @@ class DispatcherStateSpec
       // Getting the Dispatcher while shutdown
       _ = assertNotRunning(dispatcherState)
 
-      // Start a new Dispatcher is not possible in the shutdown state
+      // It is not possible to start a new Dispatcher in the shutdown state
       _ = intercept[IllegalStateException] {
         dispatcherState.startDispatcher(nextOffset)
       }.getMessage shouldBe "Ledger API offset dispatcher state has already shut down."

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/InMemoryStateSpec.scala
@@ -25,6 +25,18 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
   private val className = classOf[InMemoryState].getSimpleName
   private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
+  private val initOffset = Offset.fromHexString(Ref.HexString.assertFromString("abcdef"))
+  private val initEventSequentialId = 1337L
+  private val initStringInterningId = 17
+  private val initLedgerEnd = ParameterStorageBackend
+    .LedgerEnd(initOffset, initEventSequentialId, initStringInterningId)
+
+  private val reInitOffset = Offset.fromHexString(Ref.HexString.assertFromString("abeeee"))
+  private val reInitEventSequentialId = 9999L
+  private val reInitStringInterningId = 50
+  private val reInitLedgerEnd = ParameterStorageBackend
+    .LedgerEnd(reInitOffset, reInitEventSequentialId, reInitStringInterningId)
+
   s"$className.initialized" should "return false if not initialized" in withTestFixture {
     case (inMemoryState, _, _, _, _, _, _, _) =>
       inMemoryState.initialized shouldBe false
@@ -41,75 +53,233 @@ class InMemoryStateSpec extends AsyncFlatSpec with MockitoSugar with Matchers {
           updateStringInterningView,
           inOrder,
         ) =>
-      val initOffset = Offset.fromHexString(Ref.HexString.assertFromString("abcdef"))
-      val initEventSequentialId = 1337L
-      val initStringInterningId = 17
-
-      val initLedgerEnd = ParameterStorageBackend
-        .LedgerEnd(initOffset, initEventSequentialId, initStringInterningId)
-
       when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
       when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
-      when(dispatcherState.isRunning).thenReturn(true)
 
       for {
-        // INITIALIZED THE STATE
+        // Initialize the state
         _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
-
         _ = {
-          // ASSERT STATE INITIALIZED
-
+          // Assert the state initialized
           inOrder.verify(dispatcherState).stopDispatcher()
           inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
           inOrder.verify(contractStateCaches).reset(initOffset)
           inOrder.verify(inMemoryFanoutBuffer).flush()
           inOrder.verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
-          inOrder.verify(dispatcherState).startDispatcher(initLedgerEnd.lastOffset)
+          inOrder.verify(dispatcherState).startDispatcher(initOffset)
 
           inMemoryState.initialized shouldBe true
         }
 
-        reInitOffset = Offset.fromHexString(Ref.HexString.assertFromString("abeeee"))
-        reInitEventSequentialId = 9999L
-        reInitStringInterningId = 50
-        reInitLedgerEnd = ParameterStorageBackend
-          .LedgerEnd(reInitOffset, reInitEventSequentialId, reInitStringInterningId)
-
-        // RESET MOCKS
         _ = {
-          reset(
-            mutableLedgerEndCache,
+          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(initStringInterningId)
+          when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(
+            Future.unit
+          )
+          when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+        }
+
+        // Re-initialize to the same ledger end
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ = {
+          // Ledger end references checks
+          verify(mutableLedgerEndCache).apply()
+          verify(stringInterningView).lastId
+
+          // ASSERT NO EFFECT
+          verifyNoMoreInteractions(
+            dispatcherState,
+            updateStringInterningView,
             contractStateCaches,
             inMemoryFanoutBuffer,
-            updateStringInterningView,
+            mutableLedgerEndCache,
+            stringInterningView,
           )
+
+          inMemoryState.initialized shouldBe true
+        }
+      } yield succeed
+  }
+
+  s"$className.initializeTo" should "re-initialize the state on changed ledger end cache" in withTestFixture {
+    case (
+          inMemoryState,
+          mutableLedgerEndCache,
+          contractStateCaches,
+          inMemoryFanoutBuffer,
+          stringInterningView,
+          dispatcherState,
+          updateStringInterningView,
+          inOrder,
+        ) =>
+      when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
+      when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+      when(dispatcherState.isRunning).thenReturn(true)
+
+      for {
+        // Initialize the state to the initial ledger end
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+
+        // Reset mocks
+        _ = {
+          reset(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(initStringInterningId)
           when(updateStringInterningView(stringInterningView, reInitLedgerEnd)).thenReturn(
             Future.unit
           )
           when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
         }
 
-        // RE-INITIALIZE THE STATE
-        _ <- inMemoryState.initializeTo(reInitLedgerEnd) {
-          case (`stringInterningView`, ledgerEnd) =>
-            updateStringInterningView(stringInterningView, ledgerEnd)
-          case (other, _) => fail(s"Unexpected stringInterningView reference $other")
-        }
+        // Re-initialize to a different ledger end
+        _ <- inMemoryState.initializeTo(reInitLedgerEnd)(updateStringInterningView)
 
-        // ASSERT STATE RE-INITIALIZED
         _ = {
-          inOrder.verify(dispatcherState).stopDispatcher()
+          // Ledger end references checks
+          verify(mutableLedgerEndCache).apply()
+          // Short-circuited by the failing ledger end cache check
+          verify(stringInterningView, never).lastId
 
-          when(dispatcherState.isRunning).thenReturn(false)
-          inMemoryState.initialized shouldBe false
+          // Assert state initialized to the new ledger end
+          inOrder.verify(dispatcherState).stopDispatcher()
           inOrder.verify(updateStringInterningView)(stringInterningView, reInitLedgerEnd)
           inOrder.verify(contractStateCaches).reset(reInitOffset)
           inOrder.verify(inMemoryFanoutBuffer).flush()
           inOrder.verify(mutableLedgerEndCache).set(reInitOffset, reInitEventSequentialId)
           inOrder.verify(dispatcherState).startDispatcher(reInitOffset)
+        }
 
-          when(dispatcherState.isRunning).thenReturn(true)
-          inMemoryState.initialized shouldBe true
+        // Reset mocks
+        _ = {
+          reset(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+          when(mutableLedgerEndCache()).thenReturn(reInitOffset -> reInitEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(reInitStringInterningId)
+        }
+
+        // Attempt to re-initialize to the same ledger end
+        _ <- inMemoryState.initializeTo(reInitLedgerEnd)(updateStringInterningView)
+        _ = {
+          // Assert ledger end reference checks
+          verify(stringInterningView).lastId
+          verify(mutableLedgerEndCache).apply()
+
+          // Assert no effect
+          verifyNoMoreInteractions(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+        }
+      } yield succeed
+  }
+
+  s"$className.initializeTo" should "initialize the on dirty" in withTestFixture {
+    case (
+          inMemoryState,
+          mutableLedgerEndCache,
+          contractStateCaches,
+          inMemoryFanoutBuffer,
+          stringInterningView,
+          dispatcherState,
+          updateStringInterningView,
+          inOrder,
+        ) =>
+      when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(Future.unit)
+      when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+
+      for {
+        // Initialize the state
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+
+        // reset mocks
+        _ = {
+          reset(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(initStringInterningId)
+          when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(
+            Future.unit
+          )
+          when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+        }
+
+        // Set dirty
+        _ = inMemoryState.setDirty()
+
+        // Re-initialize the state to the same ledger end
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+
+        _ = {
+          // Ledger end references checks short-circuited by dirty check
+          verify(stringInterningView, never).lastId
+          verify(mutableLedgerEndCache, never).apply()
+
+          // Assert state re-initialized on dirty
+          inOrder.verify(dispatcherState).stopDispatcher()
+          inOrder.verify(updateStringInterningView)(stringInterningView, initLedgerEnd)
+          inOrder.verify(contractStateCaches).reset(initOffset)
+          inOrder.verify(inMemoryFanoutBuffer).flush()
+          inOrder.verify(mutableLedgerEndCache).set(initOffset, initEventSequentialId)
+          inOrder.verify(dispatcherState).startDispatcher(reInitOffset)
+        }
+
+        // reset mocks
+        _ = {
+          reset(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+            stringInterningView,
+          )
+          when(mutableLedgerEndCache()).thenReturn(initOffset -> initEventSequentialId)
+          when(stringInterningView.lastId).thenReturn(initStringInterningId)
+          when(updateStringInterningView(stringInterningView, initLedgerEnd)).thenReturn(
+            Future.unit
+          )
+          when(dispatcherState.stopDispatcher()).thenReturn(Future.unit)
+        }
+
+        // Re-initialize the state to the same ledger end
+        _ <- inMemoryState.initializeTo(initLedgerEnd)(updateStringInterningView)
+        _ = {
+          // Ledger end references checks
+          verify(mutableLedgerEndCache).apply()
+          verify(stringInterningView).lastId
+
+          // Assert no effect on state not dirty anymore
+          verifyNoMoreInteractions(
+            dispatcherState,
+            updateStringInterningView,
+            contractStateCaches,
+            inMemoryFanoutBuffer,
+            mutableLedgerEndCache,
+          )
         }
       } yield succeed
   }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
@@ -129,6 +129,7 @@ class InMemoryStateUpdaterSpec extends AsyncFlatSpec with Matchers with AkkaBefo
       updateLedgerEnd = { case (offset, evtSeqId) =>
         ledgerEndUpdates.addOne(offset -> evtSeqId)
       },
+      setInMemoryStateDirty = () => (),
     )
     test(inMemoryStateUpdater, cacheUpdates, ledgerEndUpdates)
   }


### PR DESCRIPTION
**Motivation for this PR**
Currently, any Indexer restart leads to a call to `InMemoryState.initializeTo`. This triggers a full clean-up of the in-memory state:
* Flushing all the caches leading to degraded performance until re- warm-up.
* Cancelling all the Ledger API client streams
* (In the future, as envisioned) re-population of the package cache used for interface subscriptions, an operation that can take tens of seconds and even more.

As the Indexer restart can happen quite frequently in setups with choppy DB connections, the full restart of the in-memory state on each transient error can lead to degraded UX.
**Resolution**
 This PR makes actual resetting of the in-memory state conditional and exceptional. The in-memory state is restarted only if a failure could have rendered its state:
* **stale**: when the Indexer Akka streams pipeline fails just after ingesting the persisted ledger end but before the updates are forwarded to the in-memory state.
* **dirty**: when the methods mutating its objects (dispatcher, caches, stringInterningView) fails. 
* **ahead-of-the-indexer**: when an async commit fails in the Indexer after the not-yet-committed-to-persistence updates have been ingested in the in-memory fan-out.

We perform the checks explicitly:
* **stale** and **ahead-of-the-indexer** we check by comparing the ledger end cache against the re-initialization ledger end. Additionally, we check the re-initialization string interning id against the last string interned id in the view (we need to also check this as **dirty** does not cover it since the StringInterningView is updated in the `Indexer`.
* **dirty** we define the `_dirty` flag explicitly that is set on failures in `InitializeTo` and `update`.

P.S. For better encapsulation of the mutable operations with the mutating objects, the objects mutating method is extracted from `InMemoryStateUpdater.flow` to `InMemoryState.update`

P.P.S. This PR does not take care of synchronizing mutating operations on the in-memory state. This synchronization is guaranteed from the outside. However, added a TODO in `InMemoryState` for enabling this synchronization internally. 

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
