### PR TITLE
[engine] avoid exceptions in speedy control

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -26,8 +26,8 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
 
   def classifyMachine(machine: Machine, counts: Counts): Unit = {
     machine.control match {
-      case Control.WeAreUnset() => ()
-      case Control.WeAreComplete() => ()
+      case Control.WeAreUnset => ()
+      case Control.WeAreComplete => ()
       case Control.WeAreHungry(_) => ()
       case Control.Value(_) =>
         // classify a value by the continution it is about to return to

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -26,9 +26,6 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
 
   def classifyMachine(machine: Machine, counts: Counts): Unit = {
     machine.control match {
-      case Control.WeAreUnset => ()
-      case Control.WeAreComplete => ()
-      case Control.WeAreHungry(_) => ()
       case Control.Value(_) =>
         // classify a value by the continution it is about to return to
         counts.ctrlValue += 1
@@ -38,6 +35,7 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
         counts.ctrlExpr += 1
         val expr = exp.getClass.getSimpleName
         val _ = counts.exprs += expr -> (counts.exprs.get(expr).getOrElse(0) + 1)
+      case _ => ()
     }
   }
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -19,8 +19,8 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
 
   def ppCtrl(control: Control): String =
     control match {
-      case Control.WeAreUnset() => "unset"
-      case Control.WeAreComplete() => "complete"
+      case Control.WeAreUnset => "unset"
+      case Control.WeAreComplete => "complete"
       case Control.WeAreHungry(_) => "hungry"
       case Control.Value(v) => s"V-${pp(v)}"
       case Control.Expression(e) => s"E-${pp(e)}"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -20,10 +20,10 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
   def ppCtrl(control: Control): String =
     control match {
       case Control.WeAreUnset => "unset"
-      case Control.WeAreComplete => "complete"
-      case Control.WeAreHungry(_) => "hungry"
       case Control.Value(v) => s"V-${pp(v)}"
       case Control.Expression(e) => s"E-${pp(e)}"
+      case Control.Question(_) => "question"
+      case Control.Complete(_) => "complete"
     }
 
   def ppEnv(env: Env): String = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -38,7 +38,7 @@ import scala.collection.immutable.TreeSet
 /**  Speedy builtins are stratified into two layers:
   *  Parent: `SBuiltin`, (which are effectful), and child: `SBuiltinPure` (which are pure).
   *
-  *  Effectful builtin functions may raise `SpeedyHungry` exceptions or change machine state.
+  *  Effectful builtin functions may ask questions of the ledger or change machine state.
   *  Pure builtins can be treated specially because their evaluation is immediate.
   *  This fact is used by the execution of the ANF expression form: `SELet1Builtin`.
   *
@@ -1572,7 +1572,7 @@ private[lf] object SBuiltin {
             keyMapping match {
               case ContractStateMachine.KeyActive(coid) =>
                 // We do not call directly machine.checkKeyVisibility as it may throw an SError,
-                // and such error cannot be throw inside a SpeedyHungry continuation.
+                // and such error cannot be throw inside a ledger-question continuation.
                 machine.pushKont(
                   KCheckKeyVisibility(machine, gkey, coid, operation.handleKeyFound)
                 )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1136,7 +1136,7 @@ private[lf] object SBuiltin {
               continue(coinst)
 
             case None =>
-              throw SpeedyHungry(
+              Control.Question(
                 SResultNeedContract(
                   coid,
                   onLedger.committers,
@@ -1147,7 +1147,6 @@ private[lf] object SBuiltin {
                 )
               )
           }
-
       }
 
     }
@@ -1598,7 +1597,7 @@ private[lf] object SBuiltin {
               control
 
             case None => {
-              throw SpeedyHungry(
+              Control.Question(
                 SResultNeedKey(
                   GlobalKeyWithMaintainers(gkey, keyWithMaintainers.maintainers),
                   onLedger.committers,
@@ -1642,7 +1641,7 @@ private[lf] object SBuiltin {
           onLedger.dependsOnTime = true
         case OffLedger =>
       }
-      throw SpeedyHungry(
+      Control.Question(
         SResultNeedTime { timestamp =>
           machine.setControl(Control.Value(STimestamp(timestamp)))
         }
@@ -1656,7 +1655,7 @@ private[lf] object SBuiltin {
         machine: Machine,
     ): Control = {
       checkToken(args, 2)
-      throw SpeedyHungry(
+      Control.Question(
         SResultScenarioSubmit(
           committers = extractParties(NameOf.qualifiedNameOfCurrentFunc, args.get(0)),
           commands = args.get(1),
@@ -1689,7 +1688,7 @@ private[lf] object SBuiltin {
     ): Control = {
       checkToken(args, 1)
       val relTime = getSInt64(args, 0)
-      throw SpeedyHungry(
+      Control.Question(
         SResultScenarioPassTime(
           relTime,
           callback = { timestamp =>
@@ -1708,7 +1707,7 @@ private[lf] object SBuiltin {
     ): Control = {
       checkToken(args, 1)
       val name = getSText(args, 0)
-      throw SpeedyHungry(
+      Control.Question(
         SResultScenarioGetParty(
           name,
           callback = { party =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1118,7 +1118,7 @@ private[lf] object SBuiltin {
               case V.ContractInstance(actualTmplId, arg, _) =>
                 SEApp(
                   // The call to ToCachedContractDefRef(actualTmplId) will query package
-                  // of actualTmplId if not know.
+                  // of actualTmplId if not known.
                   SEVal(ToCachedContractDefRef(actualTmplId)),
                   Array(
                     SEImportValue(Ast.TTyCon(actualTmplId), arg),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -554,7 +554,7 @@ private[lf] object Speedy {
         }
         loop()
       } catch {
-        case serr: SError => // NICK: avoid throw which needs this catch
+        case serr: SError => // TODO: prefer Control over throw for SError
           SResultError(serr)
         case ex: RuntimeException =>
           SResultError(SErrorCrash(NameOf.qualifiedNameOfCurrentFunc, s"exception: $ex")) // stop

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -32,8 +32,8 @@ import scala.util.control.NoStackTrace
 private[lf] object Speedy {
 
   // These have zero cost when not enabled. But they are not switchable at runtime.
-  private[this] val enableInstrumentation: Boolean = false
-  private[this] val enableLightweightStepTracing: Boolean = false
+  private val enableInstrumentation: Boolean = false
+  private val enableLightweightStepTracing: Boolean = false
 
   /** Instrumentation counters. */
   final case class Instrumentation(
@@ -518,7 +518,6 @@ private[lf] object Speedy {
     }
 
     /** Run a machine until we get a result: either a final-value or a request for data, with a callback */
-
     def run(): SResult = {
       try {
         // normal exit from this loop is when KFinished.execute throws SpeedyComplete
@@ -532,14 +531,14 @@ private[lf] object Speedy {
             println(s"$steps: ${PrettyLightweight.ppMachine(this)}")
           }
           control match {
-            case Control.WeAreUnset() =>
+            case Control.WeAreUnset =>
               sys.error("**attempt to run a machine with unset control")
-            case Control.WeAreComplete() =>
+            case Control.WeAreComplete =>
               sys.error("**attempt to run a complete machine")
             case Control.WeAreHungry(res) =>
               sys.error(s"**attempt to run a hungry machine (feed me first): $res")
             case Control.Expression(exp) =>
-              setControl(Control.WeAreUnset())
+              setControl(Control.WeAreUnset)
               setControl(exp.execute(this))
               loop()
             case Control.Value(value) =>
@@ -554,7 +553,7 @@ private[lf] object Speedy {
           setControl(Control.WeAreHungry(res))
           res
         case SpeedyComplete(value: SValue) =>
-          setControl(Control.WeAreComplete())
+          setControl(Control.WeAreComplete)
           if (enableInstrumentation) track.print()
           ledgerMode match {
             case OffLedger => SResultFinal(value, None)
@@ -1111,8 +1110,8 @@ private[lf] object Speedy {
   object Control {
     final case class Expression(e: SExpr) extends Control
     final case class Value(v: SValue) extends Control
-    final case class WeAreUnset() extends Control
-    final case class WeAreComplete() extends Control
+    final case object WeAreUnset extends Control
+    final case object WeAreComplete extends Control
     final case class WeAreHungry(res: SResult) extends Control
   }
 


### PR DESCRIPTION
Simplify speedy control:
- (Fix nitpicks in previous PR)
- prefer using simple `Control` return value to `raise` exception, for normal execution control flow
- add: `Control.Question` and `Control.Complete`
- replacing `SpeedyHungy` and `SpeedyComplete`

In a future PR, I would like to avoid `raise SError...` also, but this will be a bigger change.
