### PR TITLE
`SResultNeedKey` callback takes error argument

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -27,7 +27,6 @@ import com.daml.lf.language.{PackageInterface, LanguageVersion, LookupError, Sta
 import com.daml.lf.validation.Validation
 import com.daml.logging.LoggingContext
 import com.daml.nameof.NameOf
-import com.daml.scalautil.Statement.discard
 
 /** Allows for evaluating [[Commands]] and validating [[Transaction]]s.
   * <p>
@@ -411,7 +410,7 @@ class Engine(val config: EngineConfig = Engine.StableConfig) {
 
         case SResultNeedKey(gk, _, cb) =>
           def continueWithCoid = (result: Option[ContractId]) => {
-            discard[Boolean](cb(result))
+            cb(None, result)
             interpretLoop(machine, time)
           }
           return ResultNeedKey(

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -59,7 +59,6 @@ da_scala_library(
         "//daml-lf/transaction",
         "//daml-lf/validation",
         "//libs-scala/contextualized-logging",
-        "//libs-scala/scala-utils",
     ],
 )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1496,18 +1496,6 @@ private[lf] object SBuiltin {
     def handleKeyFound(machine: Machine, cid: V.ContractId): Control
     // We already saw this key, but it was undefined or was archived
     def handleKeyNotFound(machine: Machine, err: () => IE): Control
-
-    final def handleKnownInputKey(
-        machine: Machine,
-        gkey: GlobalKey,
-        keyMapping: ContractStateMachine.KeyMapping,
-    ): Control =
-      keyMapping match {
-        case ContractStateMachine.KeyActive(cid) =>
-          handleKeyFound(machine, cid)
-        case ContractStateMachine.KeyInactive =>
-          handleKeyNotFound(machine, () => IE.ContractKeyNotFound(gkey))
-      }
   }
 
   private[this] object KeyOperation {
@@ -1563,7 +1551,7 @@ private[lf] object SBuiltin {
               machine.checkKeyVisibility(onLedger, gkey, coid, operation.handleKeyFound)
 
             case ContractStateMachine.KeyInactive =>
-              operation.handleKnownInputKey(machine, gkey, keyMapping)
+              operation.handleKeyNotFound(machine, () => IE.ContractKeyNotFound(gkey))
           }
 
         case Left(handle) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -6,6 +6,7 @@ package speedy
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
+import com.daml.lf.interpretation.{Error => IE}
 import com.daml.lf.transaction.GlobalKeyWithMaintainers
 import com.daml.lf.speedy.SError._
 import com.daml.lf.value.Value
@@ -74,8 +75,10 @@ object SResult {
       key: GlobalKeyWithMaintainers,
       committers: Set[Party],
       // Callback.
-      // In case of failure, the callback sets machine control to an SErrorDamlException and return false
-      callback: Option[ContractId] => Boolean,
+      // In case of failure, the callback sets machine control to 'SEDamlException(ie)'
+      // where 'ie' is the interpretation error in the first argument (if 'Some') or
+      // 'ContractKeyNotFound(key)' otherwise.
+      callback: (Option[() => IE], Option[ContractId]) => Unit,
   ) extends SResult
 
   sealed abstract class SVisibleToStakeholders

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTestLib.scala
@@ -14,7 +14,6 @@ import com.daml.lf.validation.{Validation, ValidationError}
 import com.daml.logging.LoggingContext
 import transaction.{GlobalKeyWithMaintainers, SubmittedTransaction}
 import value.Value
-import scalautil.Statement.discard
 
 import scala.annotation.tailrec
 
@@ -86,7 +85,7 @@ private[speedy] object SpeedyTestLib {
               throw UnknownPackage(pkg)
           }
         case SResultNeedKey(key, _, callback) =>
-          discard(callback(getKey.lift(key)))
+          callback(None, getKey.lift(key))
           loop
         case fv: SResultFinal =>
           Right(fv)

--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -34,7 +34,6 @@ da_scala_library(
         "//daml-lf/transaction",
         "//libs-scala/contextualized-logging",
         "//libs-scala/nameof",
-        "//libs-scala/scala-utils",
     ],
 )
 

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -9,6 +9,7 @@ import com.daml.bazeltools.BazelRunfiles._
 import com.daml.lf.archive.UniversalArchiveDecoder
 import com.daml.lf.data.Ref.{Identifier, Location, Party, QualifiedName}
 import com.daml.lf.data.Time
+import com.daml.lf.interpretation.{Error => IE}
 import com.daml.lf.language.Ast.EVal
 import com.daml.lf.speedy.SExpr.{SEValue, SExpr}
 import com.daml.lf.speedy.SResult._
@@ -202,7 +203,7 @@ class CannedLedgerApi(
       gk: GlobalKey,
       actAs: Set[Party],
       readAs: Set[Party],
-      callback: Option[ContractId] => Boolean,
+      callback: (Option[() => IE], Option[ContractId]) => Unit,
   ) =
     throw new RuntimeException("Keys are not supported in the benchmark")
   override def currentTime = throw new RuntimeException("getTime is not supported in the benchmark")


### PR DESCRIPTION
Currently, `SResultNeedKey`'s callback, unlike any other `SResult*`'s, returns a `Boolean`. All handlers of `SResultNeedKey` ignore the value returned by the callback, except for the one in `ScenarioRunner` (via `missingWith`), which uses it to choose what to do in an error condition:
* When the return value is `true`, no exception is thrown and control goes back to the engine.
* When the return value is `false`, an exception for the error condition is thrown _in the handler_.
    * This only happens for `KeyOperation.Fetch`, independently of the input to the callback. 
    * We also know that `KeyOperation.Fetch.handleKeyNotFound` sets control to `SEDamlException(IE.ContractKeyNotFound(_))`
    * This means the only thing that would change if `ScenarionRunner`'s handler ignored the `Boolean` would be that execution would fail with that `SEDamlException` rather than the `ScenarioRunner` exceptions.

The idea here is that this callback, rather than return a `Boolean` for the ledger to decide whether to use a custom error or a default `SEDamlException(IE.ContractKeyNotFound(_))`, now takes that (optional) custom error as an argument. In case of error, the callback sets execution control to the custom error, if set, or otherwise to the default error. This only happens for `KeyOperation.Fetch`, since that's the only case that returned `false`, and `true` just hands control back to the engine. Meanwhile, `KeyOperation.Lookup` just ignores the custom error, since all it needs to do is return `None`.

All the places that used to discard the result of this callback now call it with the custom error set to `None`, which means that `KeyOperation.Fetch` will fail with the default error (and `KeyOperation.Lookup` will simply return `None`), as before. The single place that treated `false` differently, `ScenarioRunner`'s `missingWith`, now calls the callback with the `Some` custom errors.

As a final point, note that the custom error argument has type `Option[() => IE]` rather than just `Option[IE]`. This is because the `missingWith` errors are not `IE`s (= `interpretation.Error`s), so that wouldn't type check, but we also don't want to `throw` them from `ScenarioRunner` because, if the underlying operation is a `KeyOperation.Lookup`, execution should carry on. Making the error call-by-name allows us to sneak those values in, so the error is thrown only when `KeyOperation.Fetch.handleKeyNotFound` tries to evaluate the `() => IE`.