### PR TITLE
M1 build setup using Packer & Tart

### DIFF
--- a/infra/macos/m1-build/README.md
+++ b/infra/macos/m1-build/README.md
@@ -1,0 +1,37 @@
+[![Daml logo](daml-logo.png)](https://www.digitalasset.com/developers)
+
+[![Download](https://img.shields.io/github/release/digital-asset/daml.svg?label=Download&sort=semver)](https://docs.daml.com/getting-started/installation.html)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/digital-asset/daml/blob/main/LICENSE)
+[![Build](https://dev.azure.com/digitalasset/daml/_apis/build/status/digital-asset.daml?branchName=main&label=Build)](https://dev.azure.com/digitalasset/daml/_build/latest?definitionId=4&branchName=main)
+
+Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+
+# Build using Apple Mac OS on M1
+
+## Pre-requisites
+
+```
+brew install packer
+brew install cirruslabs/cli/tart
+```
+
+## initial Base Image
+```
+tart create --from-ipsw=latest monterey-base
+tart run monterey-base
+```
+Follow steps under create from Scratch: https://github.com/cirruslabs/tart
+
+## Build Node using Packer
+
+```
+packer build -only=init-1.tart-cli.init-1 daml-build.pkr.hcl
+packer build -only=init-2.tart-cli.init-2 daml-build.pkr.hcl
+packer build -only=init-3.tart-cli.init-3 daml-build.pkr.hcl
+```
+
+
+
+
+

--- a/infra/macos/m1-build/README.md
+++ b/infra/macos/m1-build/README.md
@@ -33,5 +33,3 @@ packer build -only=init-3.tart-cli.init-3 daml-build.pkr.hcl
 
 
 
-
-

--- a/infra/macos/m1-build/daml-build.pkr.hcl
+++ b/infra/macos/m1-build/daml-build.pkr.hcl
@@ -1,0 +1,104 @@
+packer {
+  required_plugins {
+    tart = {
+      version = ">= 0.3.1"
+      source  = "github.com/cirruslabs/tart"
+    }
+  }
+}
+
+
+variable "vsts_token" {
+  type = string
+}
+
+variable "guest_name" {
+  type = string
+}
+
+source "tart-cli" "init-1" {
+  cpu_count    = 4
+  memory_gb    = 10
+  ssh_password = "admin"
+  ssh_timeout  = "240s"
+  ssh_username = "admin"
+  vm_base_name = "monterey-base"
+  vm_name      = "monterey-init-1"
+}
+
+source "tart-cli" "init-2" {
+  cpu_count    = 8
+  memory_gb    = 14
+  disk_size_gb = 100
+  ssh_password = "admin"
+  ssh_timeout  = "240s"
+  ssh_username = "admin"
+  vm_base_name = "monterey-init-1"
+  vm_name      = "monterey-init-2"
+}
+
+source "tart-cli" "init-3" {
+  disk_size_gb = 200
+  ssh_password = "admin"
+  ssh_timeout  = "240s"
+  ssh_username = "admin"
+  vm_base_name = "monterey-init-2"
+  vm_name      = "monterey-init-3"
+}
+
+build {
+  name = "init-1"
+  sources = ["source.tart-cli.init-1"]
+
+  provisioner "file" {
+    sources     = ["init-1.sh"]
+    destination = "~/"
+  }
+
+  provisioner "shell" {
+    expect_disconnect = true
+    inline = [
+      "sudo bash -c ~/init-1.sh",
+    ]
+  }
+}
+
+build {
+  name = "init-2"
+  sources = ["source.tart-cli.init-2"]
+
+  provisioner "file" {
+    sources     = ["init-2.sh"]
+    destination = "~/"
+  }
+
+  provisioner "shell" {
+    inline = [
+      "/usr/sbin/softwareupdate --install-rosetta --agree-to-license",
+    ]
+  }
+
+  provisioner "shell" {
+    expect_disconnect = true
+    inline = [
+      "sudo bash -c ~/init-2.sh",
+    ]
+  }
+}
+
+build {
+  name = "init-3"
+  sources = ["source.tart-cli.init-3"]
+
+  provisioner "file" {
+    sources     = ["init-3.sh"]
+    destination = "~/"
+  }
+
+  provisioner "shell" {
+    expect_disconnect = true
+    inline = [
+      join(" ", ["sudo bash -c \"", "~/init-3.sh", var.vsts_token, var.guest_name, "\""])
+    ]
+  }
+}

--- a/infra/macos/m1-build/init-1.sh
+++ b/infra/macos/m1-build/init-1.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+echo "nix" > "$1/private/etc/synthetic.conf"
+
+# Increase shared memory allocation for PostGresQL on MacOS
+cat > "$1/private/etc/sysctl.conf" <<END
+kern.sysv.shmmax=16777216
+kern.sysv.shmmin=1
+kern.sysv.shmmni=128
+kern.sysv.shmseg=32
+kern.sysv.shmall=4096
+END

--- a/infra/macos/m1-build/init-2.sh
+++ b/infra/macos/m1-build/init-2.sh
@@ -123,7 +123,14 @@ echo "created cache partitions"
 su -l vsts <<'END'
 set -euo pipefail
 export PATH="/usr/sbin:$PATH"
-bash <(curl -sSfL https://releases.nixos.org/nix/nix-2.3.16/install)
+(
+cd $(mktemp -d)
+curl https://releases.nixos.org/nix/nix-2.10.3/nix-2.10.3-aarch64-darwin.tar.xz > tarball
+tar xzf tarball
+cd nix-2.10.3-aarch64-darwin
+printf '64d\nw\n' | ed -s install
+./install --no-daemon
+)
 source /Users/vsts/.nix-profile/etc/profile.d/nix.sh
 nix upgrade-nix
 echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc

--- a/infra/macos/m1-build/init-2.sh
+++ b/infra/macos/m1-build/init-2.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Note: this script is ran as root on VM creation as per the Vagrantfile.
+
+set -euo pipefail
+
+echo "Starting init script."
+
+# macOS equivalent of useradd & groupadd
+dscl . -create /Users/vsts
+dscl . -create /Users/vsts UserShell /bin/bash
+dscl . -create /Users/vsts RealName "Azure Agent"
+# Any number is fine here, but it should not exist already.
+USER_ID=3000
+if id $USER_ID 2>/dev/null; then
+    echo "User ID 3000 already exists. Provisioning should only be ran once; if"
+    echo "this is the first time you run it, you need to amend the script."
+    exit 1
+fi
+dscl . -create /Users/vsts UniqueID "$USER_ID"
+# 20 is the groupid for the "staff" group, which is the default group for
+# non-admin users. Unlike on Linux, on macOS users do not get their own group
+# by default.
+dscl . -create /Users/vsts PrimaryGroupID 20
+dscl . -create /Users/vsts NFSHomeDirectory /Users/vsts
+mkdir -p /Users/vsts
+chown vsts:staff /Users/vsts
+# END: macOS equivalent of useradd & groupadd
+
+echo "Done creating user vsts."
+
+# Homebrew must be installed by an admin, and I would rather not make vsts one.
+# So we need a little dance here.
+su -l admin <<'HOMEBREW_INSTALL'
+set -euo pipefail
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" < /dev/null
+HOMEBREW_INSTALL
+# /usr/local itself belongs to root and cannot be changed, but we can change
+# the subdirs
+chown -R vsts /opt/homebrew
+chown -R vsts /opt/homebrew/*
+
+echo "Done installing Homebrew."
+
+# Install jq
+su -l vsts <<'TOOLS_INSTALL'
+set -euo pipefail
+cat << BASHRC >> /Users/vsts/.bashrc
+if [ -d /opt/homebrew/bin ]; then
+    export PATH="/opt/homebrew/bin:\$PATH"
+fi
+BASHRC
+/opt/homebrew/bin/brew install jq netcat xz
+TOOLS_INSTALL
+
+echo "Done installing tools through Homebrew."
+
+# Install Rosetta 
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+
+# create /nix partition
+hdiutil create -size 60g -fs 'Case-sensitive APFS' -volname Nix -type SPARSE /System/Volumes/Data/Nix.dmg
+hdiutil attach /System/Volumes/Data/Nix.dmg.sparseimage -mountpoint /nix
+
+echo "Created /nix partition."
+
+## cache
+
+CACHE_SCRIPT=/Users/vsts/reset_caches.sh
+
+cat <<'RESET_CACHES' > $CACHE_SCRIPT
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+reset_cache() {
+    local file mount_point
+    file=$1
+    mount_point=$2
+
+    echo "Cleaning up '$mount_point'..."
+    if [ -d "$mount_point" ]; then
+        for pid in $(pgrep -a -f bazel | awk '{print $1}'); do
+            echo "Killing $pid..."
+            kill -s KILL $pid
+        done
+        for pid in $(lsof $mount_point | sed 1d | awk '{print $2}' | sort -u); do
+            echo "Killing $pid..."
+            kill -s KILL $pid
+        done
+        if hdiutil info | grep $mount_point; then
+            hdiutil detach "$mount_point"
+        fi
+        rm -rf $mount_point
+    fi
+
+    rm -f "${file}.sparseimage"
+    hdiutil create -size 200g -fs APFS -volname "$file" -type SPARSE "$file"
+    mkdir -p $mount_point
+    hdiutil attach "${file}.sparseimage" -mountpoint "$mount_point"
+    echo "Done."
+}
+
+reset_cache /var/tmp/bazel_cache.dmg /var/tmp/_bazel_vsts
+reset_cache /var/tmp/disk_cache.dmg /Users/vsts/.bazel-cache
+RESET_CACHES
+chown vsts:staff $CACHE_SCRIPT
+chmod +x $CACHE_SCRIPT
+
+su -l vsts <<END
+/Users/vsts/reset_caches.sh
+END
+
+echo "created cache partitions"
+
+# Note: installing Nix in single-user mode with /nix already existing and
+# writeable does not require sudoer access
+# Single-user install is no longer available in the 2.4+ installer, so we pin
+# _the installer_ to 2.3.16 then upgrade to nix 2.4.x.
+su -l vsts <<'END'
+set -euo pipefail
+export PATH="/usr/sbin:$PATH"
+bash <(curl -sSfL https://releases.nixos.org/nix/nix-2.3.16/install)
+source /Users/vsts/.nix-profile/etc/profile.d/nix.sh
+nix upgrade-nix
+echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
+END
+
+echo "Done installing nix."
+
+# This one is allowed to fail; the goal here is to initialize /nix and
+# ~/.bazel-cache. If this fails, we probably still have a useful node, though
+# it may be slower on its first job.
+su -l vsts <<'END'
+cd $(mktemp -d)
+git clone https://github.com/digital-asset/daml.git
+cd daml
+#./ci/dev-env-install.sh
+#./build.sh "_$(uname)"
+cd ..
+rm -rf daml
+exit 0
+END
+
+echo "Done initializing nix store & Bazel cache."
+echo "Machine setup complete; shutting down."
+
+#shutdown -h now
+exit 0

--- a/infra/macos/m1-build/init-3.sh
+++ b/infra/macos/m1-build/init-3.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Note: this script is ran as root on VM creation as per the Vagrantfile.
+
+set -euo pipefail
+
+if [ "$1" = "unset" ] || [ "$2" = "unset" ]; then
+    echo "Please set the VSTS_TOKEN and GUEST_NAME env vars before running \`vagrant up\`." >&2
+    exit 1
+fi
+
+LOGFILE=/Users/admin/run.log
+touch $LOGFILE
+chmod a+w $LOGFILE
+
+log () {
+    echo $(/bin/date -u +%Y-%m-%dT%H:%M:%S%z) [$SECONDS] $1 >> $LOGFILE
+}
+
+log "Starting init script."
+
+su -l vsts <<AGENT_SETUP
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:\$PATH"
+
+VSTS_ACCOUNT=digitalasset
+VSTS_POOL=macOS-pool
+VSTS_TOKEN=$1
+
+mkdir -p ~/agent
+cd ~/agent
+echo 'assignment=m1-builds' > .capabilities
+
+echo Determining matching VSTS agent...
+VSTS_AGENT_RESPONSE=\$(curl -sSfL \
+  -u "user:\$VSTS_TOKEN" \
+  -H 'Accept:application/json;api-version=3.0-preview' \
+  "https://\$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=osx-x64")
+
+VSTS_AGENT_URL=\$(echo "\$VSTS_AGENT_RESPONSE" \
+  | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+
+if [ -z "\$VSTS_AGENT_URL" -o "\$VSTS_AGENT_URL" == "null" ]; then
+  echo 1>&2 error: could not determine a matching VSTS agent - check that account \\'\$VSTS_ACCOUNT\\' is correct and the token is valid for that account
+  exit 1
+fi
+
+echo Downloading and installing VSTS agent...
+curl -sSfL "\$VSTS_AGENT_URL" | tar -xz --no-same-owner
+
+set +u
+source ./env.sh
+set -u
+
+./config.sh \
+  --acceptTeeEula \
+  --agent "$2" \
+  --auth PAT \
+  --pool "\$VSTS_POOL" \
+  --replace \
+  --token "\$VSTS_TOKEN" \
+  --unattended \
+  --url "https://\$VSTS_ACCOUNT.visualstudio.com"
+AGENT_SETUP
+
+## Remount Nix partition
+hdiutil attach /System/Volumes/Data/Nix.dmg.sparseimage -mountpoint /nix
+
+su -l vsts <<END
+hdiutil attach /var/tmp/bazel_cache.dmg.sparseimage -mountpoint /var/tmp/_bazel_vsts
+hdiutil attach /var/tmp/disk_cache.dmg.sparseimage -mountpoint /Users/vsts/.bazel-cache
+END
+
+## Hardening
+chown -R root:wheel /Users/vsts/agent/{*.sh,bin,externals}
+
+log "Done installing VSTS agent."
+
+# run the fake local webserver, taken from the docker image
+web-server() {
+  while true; do
+    printf 'HTTP/1.1 302 Found\r\nLocation: https://%s.visualstudio.com/_admin/_AgentPool\r\n\r\n' "digitalasset" | /opt/homebrew/bin/nc -l -p 80 > /dev/null
+  done
+}
+web-server &
+
+log "Started web server."
+
+# Start the VSTS agent
+log "Starting agent..."
+su -l vsts <<END
+cd /Users/vsts/agent
+./run.sh >> $LOGFILE &
+END


### PR DESCRIPTION
<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->

CHANGELOG_BEGIN
CHANGELOG_END


- On  Apple M1 switch to using tart and packer to run virtualized node.
- tart manages link to MacOS Virtualization Framework
- packer used to perform same steps as original to setup build node

NOTE: This still has step 2 commenting out caching build until full build is working