### PR TITLE
[engine] stack-safe alpha equivalence

### DIFF
--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/AlphaEquiv.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/AlphaEquiv.scala
@@ -46,15 +46,15 @@ private[validation] object AlphaEquiv {
           }
         case (TStruct(fs1), TStruct(fs2)) =>
           (fs1.names sameElements fs2.names) && {
-            val more = (fs1.values zip fs2.values).toList.map { case (x1, x2) => (env, x1, x2) }
-            alphaEquivList(more ++ trips)
+            val more = (fs1.values zip fs2.values).map { case (x1, x2) => (env, x1, x2) }
+            alphaEquivList(more ++: trips)
           }
         case (TSynApp(f, xs), TSynApp(g, ys)) =>
           // We treat type synonyms nominally here. If alpha equivalence
           // fails, we expand all of them and try again.
           f == g && xs.length == ys.length && {
-            val more = (xs.iterator zip ys.iterator).toList.map { case (x1, x2) => (env, x1, x2) }
-            alphaEquivList(more ++ trips)
+            val more = (xs.iterator zip ys.iterator).map { case (x1, x2) => (env, x1, x2) }
+            alphaEquivList(more ++: trips)
           }
         case _ =>
           false

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/AlphaEquiv.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/AlphaEquiv.scala
@@ -5,39 +5,59 @@ package com.daml.lf.validation
 
 import com.daml.lf.language.Ast._
 
+import scala.annotation.tailrec
+
 private[validation] object AlphaEquiv {
 
-  def alphaEquiv(t1: Type, t2: Type): Boolean = Env().alphaEquiv(t1, t2)
+  def alphaEquiv(t1: Type, t2: Type): Boolean = alphaEquivList(List((Env(), t1, t2)))
 
   private case class Env(
       currentDepth: Int = 0,
       binderDepthLhs: Map[TypeVarName, Int] = Map.empty,
       binderDepthRhs: Map[TypeVarName, Int] = Map.empty,
   ) {
+    def extend(varName1: TypeVarName, varName2: TypeVarName) = Env(
+      currentDepth + 1,
+      binderDepthLhs + (varName1 -> currentDepth),
+      binderDepthRhs + (varName2 -> currentDepth),
+    )
+  }
 
-    def alphaEquiv(t1: Type, t2: Type): Boolean = (t1, t2) match {
-      case (TVar(x1), TVar(x2)) =>
-        binderDepthLhs.get(x1).toLeft(t1) == binderDepthRhs.get(x2).toLeft(t2)
-      case (TNat(n1), TNat(n2)) => n1 == n2
-      case (TTyCon(c1), TTyCon(c2)) => c1 == c2
-      case (TApp(f1, a1), TApp(f2, a2)) => alphaEquiv(f1, f2) && alphaEquiv(a1, a2)
-      case (TBuiltin(b1), TBuiltin(b2)) => b1 == b2
-      case (TForall((varName1, kind1), b1), TForall((varName2, kind2), b2)) =>
-        kind1 == kind2 &&
-        Env(
-          currentDepth + 1,
-          binderDepthLhs + (varName1 -> currentDepth),
-          binderDepthRhs + (varName2 -> currentDepth),
-        ).alphaEquiv(b1, b2)
-      case (TStruct(fs1), TStruct(fs2)) =>
-        (fs1.names sameElements fs2.names) &&
-        (fs1.values zip fs2.values).forall((alphaEquiv _).tupled)
-      case (TSynApp(f, xs), TSynApp(g, ys)) =>
-        // We treat type synonyms nominally here. If alpha equivalence
-        // fails, we expand all of them and try again.
-        f == g && xs.length == ys.length &&
-        (xs.iterator zip ys.iterator).forall((alphaEquiv _).tupled)
-      case _ => false
-    }
+  @tailrec
+  private def alphaEquivList(trips: List[(Env, Type, Type)]): Boolean = trips match {
+    case Nil => true
+    case (env, t1, t2) :: trips =>
+      (t1, t2) match {
+        case (TVar(x1), TVar(x2)) =>
+          env.binderDepthLhs.get(x1).toLeft(t1) == env.binderDepthRhs.get(x2).toLeft(t2) &&
+          alphaEquivList(trips)
+        case (TNat(n1), TNat(n2)) =>
+          n1 == n2 && alphaEquivList(trips)
+        case (TTyCon(c1), TTyCon(c2)) =>
+          c1 == c2 && alphaEquivList(trips)
+        case (TApp(f1, a1), TApp(f2, a2)) =>
+          alphaEquivList((env, f1, f2) :: (env, a1, a2) :: trips)
+        case (TBuiltin(b1), TBuiltin(b2)) =>
+          b1 == b2 && alphaEquivList(trips)
+        case (TForall((varName1, kind1), b1), TForall((varName2, kind2), b2)) =>
+          kind1 == kind2 && {
+            val envExtended = env.extend(varName1, varName2)
+            alphaEquivList((envExtended, b1, b2) :: trips)
+          }
+        case (TStruct(fs1), TStruct(fs2)) =>
+          (fs1.names sameElements fs2.names) && {
+            val more = (fs1.values zip fs2.values).toList.map { case (x1, x2) => (env, x1, x2) }
+            alphaEquivList(more ++ trips)
+          }
+        case (TSynApp(f, xs), TSynApp(g, ys)) =>
+          // We treat type synonyms nominally here. If alpha equivalence
+          // fails, we expand all of them and try again.
+          f == g && xs.length == ys.length && {
+            val more = (xs.iterator zip ys.iterator).toList.map { case (x1, x2) => (env, x1, x2) }
+            alphaEquivList(more ++ trips)
+          }
+        case _ =>
+          false
+      }
   }
 }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -547,7 +547,6 @@ private[validation] object Typing {
       checkType(method.returnType, KStar)
     }
 
-    // TODO https://github.com/digital-asset/daml/issues/13410 -- ensure alphaEquiv is stack-safe
     private def alphaEquiv(t1: Type, t2: Type) =
       AlphaEquiv.alphaEquiv(t1, t2) ||
         AlphaEquiv.alphaEquiv(expandTypeSynonyms(t1), expandTypeSynonyms(t2))
@@ -707,6 +706,7 @@ private[validation] object Typing {
       }
     }
 
+    // TODO https://github.com/digital-asset/daml/issues/13410 -- make expandTypeSynonyms be stack-safe
     private[lf] def expandTypeSynonyms(typ0: Type): Type = typ0 match {
       case TSynApp(syn, args) =>
         val ty = expandSynApp(syn, args)

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/StackSafeTyping.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/StackSafeTyping.scala
@@ -47,7 +47,7 @@ class StackSafeTyping extends AnyFreeSpec with Matchers with TableDrivenProperty
 
   "alpha equivalence (stack-safety)" - {
 
-    val testCases100 = {
+    val testCases = {
       Table[String, Type => Type](
         ("name", "recursion-point"),
         ("forall", forall),
@@ -57,34 +57,10 @@ class StackSafeTyping extends AnyFreeSpec with Matchers with TableDrivenProperty
         ("struct2", struct2),
       )
     }
-    val testCases10k = { // NICK: make these work!
-      Table[String, Type => Type](
-        ("name", "recursion-point")
-        // ("forall", forall),
-        // ("arrowRight", arrowRight),
-        // ("arrowLeft", arrowLeft),
-        // ("struct1", struct1),
-        // ("struct2", struct2),
-      )
-    }
-    {
-      val depth = 100
-      s"alpha equivalence, (SMALL) depth = $depth" - {
-        forEvery(testCases100) { (name: String, recursionPoint: Type => Type) =>
-          name in {
-            val a = Name.assertFromString("A")
-            val b = Name.assertFromString("B")
-            val tyA = TForall((a, KStar), makeAst(depth, TVar(a), recursionPoint))
-            val tyB = TForall((b, KStar), makeAst(depth, TVar(b), recursionPoint))
-            AlphaEquiv.alphaEquiv(tyA, tyB) shouldBe true
-          }
-        }
-      }
-    }
     {
       val depth = 10000
       s"alpha equivalence, (BIG) depth = $depth" - {
-        forEvery(testCases10k) { (name: String, recursionPoint: Type => Type) =>
+        forEvery(testCases) { (name: String, recursionPoint: Type => Type) =>
           name in {
             val a = Name.assertFromString("A")
             val b = Name.assertFromString("B")

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/StackSafeTyping.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/StackSafeTyping.scala
@@ -18,28 +18,86 @@ import scala.annotation.tailrec
 
 class StackSafeTyping extends AnyFreeSpec with Matchers with TableDrivenPropertyChecks {
 
+  def unitT: Type = TBuiltin(BTUnit)
+  def theType: Type = unitT
+  def arrow(ty1: Type, ty2: Type): Type = TApp(TApp(TBuiltin(BTArrow), ty1), ty2)
+  def tyvar: TypeVarName = Name.assertFromString("T")
+
+  def field: FieldName = Name.assertFromString("field")
+  def field2: FieldName = Name.assertFromString("field2")
+  def makeStruct(ty1: Type, ty2: Type): Type = TStruct(
+    Struct.assertFromSeq(List((field, ty1), (field2, ty2)))
+  )
+
+  def forall(x: Type): Type = TForall((tyvar, KStar), x)
+  def arrowRight(x: Type) = arrow(theType, x)
+  def arrowLeft(x: Type) = arrow(x, theType)
+  def struct1(x: Type) = makeStruct(x, theType)
+  def struct2(x: Type) = makeStruct(theType, x)
+
   /* We test stack-safety by building deep expressions through different recursion points
    * of an AST, then check we can run the 'code under test', without blowing the stack.
    */
-  def runTest[Ast, Res](depth: Int, init: Ast, cons: Ast => Ast, check: Ast => Res): Res = {
+  def makeAst[Ast](depth: Int, init: Ast, cons: Ast => Ast): Ast = {
     // Make an AST by iterating the 'cons' function, 'depth' times, starting from 'init'
     @tailrec def loop(x: Ast, n: Int): Ast = if (n == 0) x else loop(cons(x), n - 1)
     val ast: Ast = loop(init, depth)
-    check(ast)
+    ast
+  }
+
+  "alpha equivalence (stack-safety)" - {
+
+    val testCases100 = {
+      Table[String, Type => Type](
+        ("name", "recursion-point"),
+        ("forall", forall),
+        ("arrowRight", arrowRight),
+        ("arrowLeft", arrowLeft),
+        ("struct1", struct1),
+        ("struct2", struct2),
+      )
+    }
+    val testCases10k = { // NICK: make these work!
+      Table[String, Type => Type](
+        ("name", "recursion-point")
+        // ("forall", forall),
+        // ("arrowRight", arrowRight),
+        // ("arrowLeft", arrowLeft),
+        // ("struct1", struct1),
+        // ("struct2", struct2),
+      )
+    }
+    {
+      val depth = 100
+      s"alpha equivalence, (SMALL) depth = $depth" - {
+        forEvery(testCases100) { (name: String, recursionPoint: Type => Type) =>
+          name in {
+            val a = Name.assertFromString("A")
+            val b = Name.assertFromString("B")
+            val tyA = TForall((a, KStar), makeAst(depth, TVar(a), recursionPoint))
+            val tyB = TForall((b, KStar), makeAst(depth, TVar(b), recursionPoint))
+            AlphaEquiv.alphaEquiv(tyA, tyB) shouldBe true
+          }
+        }
+      }
+    }
+    {
+      val depth = 10000
+      s"alpha equivalence, (BIG) depth = $depth" - {
+        forEvery(testCases10k) { (name: String, recursionPoint: Type => Type) =>
+          name in {
+            val a = Name.assertFromString("A")
+            val b = Name.assertFromString("B")
+            val tyA = TForall((a, KStar), makeAst(depth, TVar(a), recursionPoint))
+            val tyB = TForall((b, KStar), makeAst(depth, TVar(b), recursionPoint))
+            AlphaEquiv.alphaEquiv(tyA, tyB) shouldBe true
+          }
+        }
+      }
+    }
   }
 
   "kind checking (stack-safety)" - {
-
-    def unitT: Type = TBuiltin(BTUnit)
-    def theType: Type = unitT
-    def arrow(ty1: Type, ty2: Type): Type = TApp(TApp(TBuiltin(BTArrow), ty1), ty2)
-    def tyvar: TypeVarName = Name.assertFromString("T")
-
-    def field: FieldName = Name.assertFromString("field")
-    def field2: FieldName = Name.assertFromString("field2")
-    def makeStruct(ty1: Type, ty2: Type): Type = TStruct(
-      Struct.assertFromSeq(List((field, ty1), (field2, ty2)))
-    )
 
     // This is the code under test...
     def kindCheck(typ: Type): Option[ValidationError] = {
@@ -55,12 +113,6 @@ class StackSafeTyping extends AnyFreeSpec with Matchers with TableDrivenProperty
         case e: ValidationError => Some(e)
       }
     }
-
-    def forall(x: Type): Type = TForall((tyvar, KStar), x)
-    def arrowRight(x: Type) = arrow(theType, x)
-    def arrowLeft(x: Type) = arrow(x, theType)
-    def struct1(x: Type) = makeStruct(x, theType)
-    def struct2(x: Type) = makeStruct(theType, x)
 
     val testCases = {
       Table[String, Type => Type](
@@ -78,12 +130,11 @@ class StackSafeTyping extends AnyFreeSpec with Matchers with TableDrivenProperty
         forEvery(testCases) { (name: String, recursionPoint: Type => Type) =>
           name in {
             // ensure examples can be kind-checked and are well-kinded
-            runTest(depth, theType, recursionPoint, kindCheck) shouldBe None
+            kindCheck(makeAst(depth, theType, recursionPoint)) shouldBe None
           }
         }
       }
     }
-
   }
 
   "typing (stack-safety)" - {
@@ -312,7 +363,7 @@ class StackSafeTyping extends AnyFreeSpec with Matchers with TableDrivenProperty
         forEvery(testCases) { (name: String, recursionPoint: Expr => Expr) =>
           name in {
             // ensure examples can be typechecked and are well-typed
-            runTest(depth, theExp, recursionPoint, typecheck) shouldBe None
+            typecheck(makeAst(depth, theExp, recursionPoint)) shouldBe None
           }
         }
       }


### PR DESCRIPTION
Make alpha equivalence be stack-safe:
- [x] new test-cases to demonstrate stack-overflow
- [x] fix stack-overflow

This advances https://github.com/digital-asset/daml/issues/13410