### PR TITLE
Beautify the way a test is coded

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
@@ -49,10 +49,7 @@ class InMemoryStateUpdaterSpec
   behavior of classOf[InMemoryStateUpdater].getSimpleName
 
   "flow" should "correctly process updates" in new Scope {
-    val updatesInput =
-      Seq(Vector(update1, metadataChangedUpdate) -> 1L, Vector(update3, update4) -> 3L)
-
-    Source(updatesInput)
+    Source(Seq(Vector(update1, metadataChangedUpdate) -> 1L, Vector(update3, update4) -> 3L))
       .via(inMemoryStateUpdater.flow)
       .runWith(Sink.ignore)
       .futureValue
@@ -68,7 +65,7 @@ class InMemoryStateUpdaterSpec
   }
 
   "flow" should "not process empty input batches" in new Scope {
-    val updatesInput =
+    Source(
       Seq(
         // Empty input batch should have not effect
         Vector.empty -> 1L,
@@ -77,8 +74,7 @@ class InMemoryStateUpdaterSpec
         // Should still have effect on ledger end updates
         Vector(anotherMetadataChangedUpdate) -> 3L,
       )
-
-    Source(updatesInput)
+    )
       .via(inMemoryStateUpdater.flow)
       .runWith(Sink.ignore)
       .futureValue

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
@@ -34,7 +34,7 @@ import com.daml.platform.indexer.ha.EndlessReadService.configuration
 import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.interfaces.TransactionLogUpdate.CompletionDetails
 import com.google.rpc.status.Status
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -45,6 +45,7 @@ class InMemoryStateUpdaterSpec
     extends AnyFlatSpec
     with Matchers
     with ScalaFutures
+    with IntegrationPatience
     with AkkaBeforeAndAfterAll {
 
   behavior of classOf[InMemoryStateUpdater].getSimpleName

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
@@ -32,7 +32,7 @@ import com.daml.platform.indexer.ha.EndlessReadService.configuration
 import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.interfaces.TransactionLogUpdate.CompletionDetails
 import com.google.rpc.status.Status
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -43,7 +43,6 @@ class InMemoryStateUpdaterSpec
     extends AnyFlatSpec
     with Matchers
     with ScalaFutures
-    with IntegrationPatience
     with AkkaBeforeAndAfterAll {
 
   behavior of classOf[InMemoryStateUpdater].getSimpleName

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/InMemoryStateUpdaterSpec.scala
@@ -3,6 +3,7 @@
 
 package com.daml.platform.index
 
+import akka.Done
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.codahale.metrics.MetricRegistry
@@ -119,7 +120,7 @@ object InMemoryStateUpdaterSpec {
       },
     )
 
-    def runFlow(input: Seq[(Vector[(Offset, Update)], Long)])(implicit mat: Materializer): Unit =
+    def runFlow(input: Seq[(Vector[(Offset, Update)], Long)])(implicit mat: Materializer): Done =
       Source(input)
         .via(inMemoryStateUpdater.flow)
         .runWith(Sink.ignore)


### PR DESCRIPTION
It is an attempt to improve a styling of the tests. 

Main improvements of the approach:

1. The use of trait `org.scalatest.concurrent.ScalaFutures` allows to manipulate values rather than async tests and does not need any syntactic sugar.

2.1. Extracting shared mutable code into `Scope` trait allows to have separate mutable state for each test while still sharing code between tests.

2.2. Getting rid of complicated fixture argument signature:
```
      test: (
          (
              InMemoryStateUpdater,
              ArrayBuffer[Vector[TransactionLogUpdate]],
              ArrayBuffer[(Offset, Long)],
          )
      ) => Future[Assertion]
```
3. (minor) DRY: Extracting out "running the flow" technical code into the method.


CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
