### PR TITLE
daily compat: reduce flakiness

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -116,7 +116,7 @@ jobs:
           artifactName: perf-speedy
 
   - job: check_releases
-    timeoutInMinutes: 360
+    timeoutInMinutes: 480
     pool:
       name: ubuntu_20_04
       demands: assignment -equals default

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -1289,5 +1289,5 @@ def sdk_platform_test(sdk_version, platform_version):
             size = "large",
             # Yarn gets really unhappy if it is called in parallel
             # so we mark this exclusive for now.
-            tags = extra_tags(sdk_version, platform_version) + ["exclusive"],
+            tags = extra_tags(sdk_version, platform_version) + ["exclusive", "dont-run-on-darwin"],
         )

--- a/compatibility/test.sh
+++ b/compatibility/test.sh
@@ -111,9 +111,13 @@ fi
 
 bazel build //...
 
-BAZEL_ARGS=""
+
+tag_filter=""
+if [[ "$(uname)" == "Darwin" ]]; then
+  tag_filter="${tag_filter}-dont-run-on-darwin,"
+fi
 if [ "${1:-}" = "--quick" ]; then
-    BAZEL_ARGS="--test_tag_filters +head-quick"
+  tag_filter="${tag_filter}+head-quick,"
 fi
 
 bazel test //... \
@@ -124,4 +128,4 @@ bazel test //... \
   --test_env "ORACLE_USERNAME=${ORACLE_USERNAME}" \
   --test_env "ORACLE_PWD=${ORACLE_PWD}" \
   --test_env "ORACLE_DOCKER_PATH=${ORACLE_DOCKER_PATH}" \
-  $BAZEL_ARGS
+  --test_tag_filters "${tag_filter%,}"


### PR DESCRIPTION
- The `check_releases` job seems to take between 4.5h and `TIMEOUT` these days, with no clear cause for the large span in running time. Hopefully bumping the limit from 4.5 to 8 hours will give us some breathing room (this is not by any means a long-term solution, I'm well aware of that).
- I couldn't find anybody who seemed to care about running the `create-daml-app` compatibility tests on macOS, and they're super flaky (typically requiring 5 reruns to succeed).

CHANGELOG_BEGIN
CHANGELOG_END

run-full-compat: true