### PR TITLE
[daml-script] make srcloc test less fragile

### DIFF
--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -14,6 +14,19 @@ import DA.Stack
 import DA.Time
 import Daml.Script
 
+-- `mySubmit` and `stackTrace` are used when testing srcloc within a stack-trace.
+-- If these functions are relocated within this file, the expected locations
+-- in the "stack trace" test in AbstractFuncIT.scala will need to be updated.
+-- By having these two definition at the head of this file, we are less likely to
+-- have to adapt the expected src-locs as new Daml gets added.
+mySubmit : HasCallStack => Party -> Commands a -> Script a -- line 22
+mySubmit p cmds = submit p cmds
+
+stackTrace : Script ()
+stackTrace = do
+  p <- allocateParty "p" -- line 27
+  mySubmit p $ createAndExerciseCmd (C p 42) ShouldFail
+
 template T
   with
     p1 : Party
@@ -388,14 +401,6 @@ tree = do
   fromAnyTemplate c2.argument === Some (MessageSize p1)
   fromAnyTemplate c3.argument === Some (MessageSize p1)
   pure ()
-
-mySubmit : HasCallStack => Party -> Commands a -> Script a
-mySubmit p cmds = submit p cmds
-
-stackTrace : Script ()
-stackTrace = do
-  p <- allocateParty "p"
-  mySubmit p $ createAndExerciseCmd (C p 42) ShouldFail
 
 -- Create a contract only visible to one party to test readAs
 jsonMultiPartySubmissionCreateSingle : Party -> Script (ContractId MultiPartyContract)

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -400,7 +400,7 @@ abstract class AbstractFuncIT
           end,
         )
         e.cmd.stackTrace shouldBe StackTrace(
-          Vector(loc("submit", (392, 18), (392, 31)), loc("mySubmit", (397, 2), (397, 12)))
+          Vector(loc("submit", (22, 18), (22, 31)), loc("mySubmit", (27, 2), (27, 12)))
         )
       }
     }


### PR DESCRIPTION
Avoid surprising test failure when adding unrelated  tests.