### PR TITLE
Remove unused `--wall-clock-time` from `daml-intro-7` template

### DIFF
--- a/docs/source/daml/intro/daml/daml-intro-7/daml.yaml.template
+++ b/docs/source/daml/intro/daml/daml-intro-7/daml.yaml.template
@@ -6,5 +6,3 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
-sandbox-options:
-  - --wall-clock-time


### PR DESCRIPTION
Apart from not being actually used in any part of the relative
chapter of "An Introduction to Daml" (https://docs.daml.com/2.3.2/daml/intro/7_Composing.html),
where the transaction view actually shows the usage of static time,
the options has been dropped when we switched to a Canton-based
sandbox as part of Daml 2.0 and causes an error when running
`daml start`, as part of the ninth chapter of "An Introduction to Daml"
(https://docs.daml.com/2.3.2/daml/intro/9_Dependencies.html#hashes-and-identifiers).

Fixes #14654

Tested manually by going through chapters 7 and 9 of "An Introduction to Daml"

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
