### PR TITLE
Add insertWith to DA.Map

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Map.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Map.daml
@@ -46,6 +46,7 @@ module DA.Map
     , filterWithKey
     , delete
     , insert
+    , insertWith
     , alter
     , union
     , unionWith
@@ -151,6 +152,15 @@ delete = primitive @"BEGenMapDelete"
 -- supplied value.
 insert : Ord k => k -> v -> Map k v -> Map k v
 insert = primitive @"BEGenMapInsert"
+
+-- | Insert a new key/value pair in the map. If the key is already
+-- present in the map, it is combined with the previous value using the given function
+-- `f new_value old_value`.
+insertWith : Ord k => (v -> v -> v) -> k -> v -> Map k v -> Map k v
+insertWith f k v m =
+  case lookup k m of
+    None -> insert k v m
+    Some v' -> insert k (f v v') m
 
 -- | Update the value in `m` at `k` with `f`, inserting or deleting as
 -- required.  `f` will be called with either the value at `k`, or `None`

--- a/compiler/damlc/tests/daml-test-files/Map.daml
+++ b/compiler/damlc/tests/daml-test-files/Map.daml
@@ -84,4 +84,7 @@ testUnionWith = scenario do
   unionWith (-) m1 m2
     === fromList [(1, -2), (2, -3), (3, 3), (4, 7)]
 
+testInsertWith = scenario do
+  insertWith (-) 1 2 (fromList []) === fromList [(1, 2)]
+  insertWith (-) 1 2 (fromList [(1,1)]) === fromList [(1, 2-1)]
 -- @ENABLE-SCENARIOS


### PR DESCRIPTION
changelog_begin

- [Daml Stdlib] Add `insertWith` to `DA.Map` which allows combining
  the newly inserted value with the existing value (if any).

changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
