### PR TITLE
[LLP] Update some docs and deprecated CLI args [DPP-1057]

### DIFF
--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfig.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/CliConfig.scala
@@ -36,7 +36,6 @@ final case class CliConfig[Extra](
     acsIdPageSize: Int,
     configurationLoadTimeout: Duration,
     commandConfig: CommandConfiguration,
-    enableInMemoryFanOutForLedgerApi: Boolean,
     eventsPageSize: Int,
     bufferedStreamsPageSize: Int,
     eventsProcessingParallelism: Int,
@@ -88,7 +87,6 @@ object CliConfig {
       acsIdPageSize = IndexServiceConfig.DefaultAcsIdPageSize,
       configurationLoadTimeout = Duration.ofSeconds(10),
       commandConfig = CommandConfiguration.Default,
-      enableInMemoryFanOutForLedgerApi = false,
       eventsPageSize = IndexServiceConfig.DefaultEventsPageSize,
       bufferedStreamsPageSize = IndexServiceConfig.DefaultBufferedStreamsPageSize,
       eventsProcessingParallelism = IndexServiceConfig.DefaultEventsProcessingParallelism,
@@ -666,13 +664,12 @@ object CliConfig {
         .hidden()
         .text("Legacy flag with no effect")
         .action((_, config) => config),
+      // TODO remove
       opt[Unit]("buffered-ledger-api-streams")
         .optional()
         .hidden()
-        .text(
-          "Experimental buffer for Ledger API streaming queries. Should not be used in production."
-        )
-        .action((_, config) => config.copy(enableInMemoryFanOutForLedgerApi = true)),
+        .text("Legacy flag with no effect.")
+        .action((_, config) => config),
       opt[Boolean]("enable-user-management")
         .optional()
         .text(

--- a/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/LegacyCliConfigConverter.scala
+++ b/ledger/ledger-runner-common/src/main/scala/com/daml/ledger/runner/common/LegacyCliConfigConverter.scala
@@ -31,7 +31,6 @@ object LegacyCliConfigConverter {
       acsGlobalParallelism = cliConfig.acsGlobalParallelism,
       acsIdFetchingParallelism = cliConfig.acsIdFetchingParallelism,
       acsIdPageSize = cliConfig.acsIdPageSize,
-      enableInMemoryFanOutForLedgerApi = cliConfig.enableInMemoryFanOutForLedgerApi,
       eventsPageSize = cliConfig.eventsPageSize,
       bufferedStreamsPageSize = cliConfig.bufferedStreamsPageSize,
       eventsProcessingParallelism = cliConfig.eventsProcessingParallelism,

--- a/ledger/ledger-runner-common/src/test/lib/com/daml/ledger/runner/common/ArbitraryConfig.scala
+++ b/ledger/ledger-runner-common/src/test/lib/com/daml/ledger/runner/common/ArbitraryConfig.scala
@@ -400,7 +400,6 @@ object ArbitraryConfig {
     maxContractStateCacheSize <- Gen.long
     maxContractKeyStateCacheSize <- Gen.long
     maxTransactionsInMemoryFanOutBufferSize <- Gen.chooseNum(0, Int.MaxValue)
-    enableInMemoryFanOutForLedgerApi <- Gen.oneOf(true, false)
     apiStreamShutdownTimeout <- Gen.finiteDuration
   } yield IndexServiceConfig(
     eventsPageSize,
@@ -415,7 +414,6 @@ object ArbitraryConfig {
     maxContractStateCacheSize,
     maxContractKeyStateCacheSize,
     maxTransactionsInMemoryFanOutBufferSize,
-    enableInMemoryFanOutForLedgerApi,
     apiStreamShutdownTimeout,
   )
 

--- a/ledger/participant-integration-api/rootdoc.txt
+++ b/ledger/participant-integration-api/rootdoc.txt
@@ -3,15 +3,15 @@ This is the documentation for the Daml participant integration API.
 
 Notable interfaces to be implemented by ledger integrations include:
 
-  - [[com.daml.ledger.participant.state.v1.ReadService `ReadService`]] - an interface for reading data from the underlying ledger.
-  - [[com.daml.ledger.participant.state.v1.WriteService `WriteService`]] - an interface for writing data to the underlying ledger.
+  - [[com.daml.ledger.participant.state.v2.ReadService `ReadService`]] - an interface for reading data from the underlying ledger.
+  - [[com.daml.ledger.participant.state.v2.WriteService `WriteService`]] - an interface for writing data to the underlying ledger.
   - [[com.daml.ledger.api.auth.AuthService `AuthService`]] - an interface for authorizing ledger API calls.
 
 Notable classes for running a ledger participant node include:
 
-  - [[com.daml.platform.indexer.StandaloneIndexerServer `StandaloneIndexerServer`]] - the indexer reads data from the
-    [[com.daml.ledger.participant.state.v1.ReadService `ReadService`]] and writes it to an index database.
-  - [[com.daml.platform.apiserver.StandaloneApiServer `StandaloneApiServer`]] - the API server reads data from the index
-    database and serves it over the gRPC ledger API.
+  - [[com.daml.platform.indexer.IndexerServiceOwner `IndexerServiceOwner`]] - the indexer reads data from the
+    [[com.daml.ledger.participant.state.v2.ReadService `ReadService`]] and writes it to an index database.
+  - [[com.daml.platform.apiserver.LedgerApiService `LedgerApiService`]] - the API server reads data from the index
+    database and Indexer (see `com.daml.platform.index.InMemoryStateUpdater`) and serves it over the gRPC ledger API.
 
 See the complete list on the right for details.

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexServiceConfig.scala
@@ -19,8 +19,6 @@ final case class IndexServiceConfig(
     maxContractKeyStateCacheSize: Long = IndexServiceConfig.DefaultMaxContractKeyStateCacheSize,
     maxTransactionsInMemoryFanOutBufferSize: Int =
       IndexServiceConfig.DefaultMaxTransactionsInMemoryFanOutBufferSize,
-    enableInMemoryFanOutForLedgerApi: Boolean =
-      IndexServiceConfig.DefaultEnableInMemoryFanOutForLedgerApi,
     apiStreamShutdownTimeout: Duration = IndexServiceConfig.DefaultApiStreamShutdownTimeout,
     inMemoryStateUpdaterParallelism: Int =
       IndexServiceConfig.DefaultInMemoryStateUpdaterParallelism,
@@ -40,7 +38,6 @@ object IndexServiceConfig {
   val DefaultMaxContractStateCacheSize: Long = 100000L
   val DefaultMaxContractKeyStateCacheSize: Long = 100000L
   val DefaultMaxTransactionsInMemoryFanOutBufferSize: Int = 10000
-  val DefaultEnableInMemoryFanOutForLedgerApi = false
   val DefaultApiStreamShutdownTimeout: Duration = FiniteDuration(5, "seconds")
   val DefaultInMemoryStateUpdaterParallelism: Int = 2
   val DefaultInMemoryFanOutThreadPoolSize: Int = 16

--- a/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
@@ -30,6 +30,12 @@ import com.daml.platform.{Contract, InMemoryState, Key, Party}
 import java.util.concurrent.Executors
 import scala.concurrent.{ExecutionContext, Future}
 
+/** Builder of the in-memory state updater Akka flow.
+  *
+  * This flow is attached at the end of the Indexer pipeline,
+  * consumes the [[com.daml.ledger.participant.state.v2.Update]]s (that have been ingested by the Indexer
+  * into the Index database) for populating the Ledger API server in-memory state (see [[InMemoryState]]).
+  */
 private[platform] object InMemoryStateUpdaterFlow {
   private[index] def apply(
       prepareUpdatesParallelism: Int,


### PR DESCRIPTION
changelog_begin
As a result of the low-latency participant development effort,
the participant deployment mode is restricted to a fused participant,
the equivalent of running the participant with `run-mode=combined` option,
where both the Ledger API service and Indexer service are started as part of the same JVM process.

As a result of this change, the following CLI options are impacted:
- `run-mode` is removed
- `shard-name` is removed
- `buffered-ledger-api-streams` has no effect and is deprecated (as the option becomes always enabled)

changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
