### PR TITLE
Add performance warning to queryContractId & queryContractKey

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -201,6 +201,11 @@ data QueryContractIdPayload a = QueryContractIdPayload
 -- | Query for the contract with the given contract id.
 --
 -- Returns `None` if there is no active contract the party is a stakeholder on.
+--
+-- WARNING: Over the gRPC and with the JSON API
+-- in-memory backend this performs a linear search so only use this if the number of
+-- active contracts is small.
+--
 -- This is semantically equivalent to calling `query`
 -- and filtering on the client side.
 queryContractId : forall t p. (Template t, IsParties p) => HasCallStack => p -> ContractId t -> Script (Optional t)
@@ -219,8 +224,13 @@ data QueryContractKeyPayload a = QueryContractKeyPayload
   , locations : [(Text, SrcLoc)]
   } deriving Functor
 
--- Returns `None` if there is no active contract with the given key that
+-- | Returns `None` if there is no active contract with the given key that
 -- the party is a stakeholder on.
+--
+-- WARNING: Over the gRPC and with the JSON API
+-- in-memory backend this performs a linear search so only use this if the number of
+-- active contracts is small.
+--
 -- This is semantically equivalent to calling `query`
 -- and filtering on the client side.
 queryContractKey : forall t k p. HasCallStack => (TemplateKey t k, IsParties p) => p -> k -> Script (Optional (ContractId t, t))


### PR DESCRIPTION
Turns out people use that when they have tens of thousands if not
hundreds of thousands of contracts and then I have to debug why their
scripts are slow.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
