### PR TITLE
Load interface and interface instance from packages in the Ledger

### DIFF
--- a/navigator/backend/BUILD.bazel
+++ b/navigator/backend/BUILD.bazel
@@ -86,6 +86,7 @@ da_scala_library(
         "//ledger/metrics",
         "//libs-scala/build-info",
         "//libs-scala/grpc-utils",
+        "//libs-scala/nonempty",
         "//libs-scala/scala-utils",
         "@maven//:com_typesafe_config",
         "@maven//:io_grpc_grpc_netty",

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
@@ -91,7 +91,6 @@ object ModelCodec {
     implicit val PartyListJsonFormat: RootJsonFormat[List[ApiTypes.Party]] =
       listFormat[ApiTypes.Party]
     implicit val choiceFormat: RootJsonFormat[Choice] = jsonFormat4(Choice.apply)
-    implicit val templateFormat: RootJsonFormat[Template] = jsonFormat3(Template.apply)
-
+    implicit val templateFormat: RootJsonFormat[Template] = jsonFormat4(Template.apply)
   }
 }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/json/ModelCodec.scala
@@ -90,7 +90,7 @@ object ModelCodec {
 
     implicit val PartyListJsonFormat: RootJsonFormat[List[ApiTypes.Party]] =
       listFormat[ApiTypes.Party]
-    implicit val choiceFormat: RootJsonFormat[Choice] = jsonFormat4(Choice.apply)
+    implicit val choiceFormat: RootJsonFormat[Choice] = jsonFormat5(Choice.apply)
     implicit val templateFormat: RootJsonFormat[Template] = jsonFormat4(Template.apply)
   }
 }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
@@ -194,13 +194,14 @@ final case class Template(
     id: DamlLfIdentifier,
     choices: List[Choice],
     key: Option[DamlLfType],
+    implementedInterfaces: Set[DamlLfIdentifier]
 ) extends DamlLfNode {
   def topLevelDecl: String = id.qualifiedName.toString()
   def parameter: DamlLfTypeCon = DamlLfTypeCon(DamlLfTypeConName(id), DamlLfImmArraySeq())
 }
 
 /** Interfaces. */
-final case class Interface(
+final case class AstInterface(
     id: DamlLfIdentifier,
     choices: List[Choice],
     key: Option[DamlLfType],

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
@@ -103,7 +103,7 @@ case class DamlLfPackage(
     id: DamlLfRef.PackageId,
     typeDefs: Map[DamlLfIdentifier, DamlLfDefDataType],
     templates: Map[DamlLfIdentifier, Template],
-    astInterfaces: Map[DamlLfIdentifier, AstInterface],
+    interfaces: Map[DamlLfIdentifier, Interface],
 )
 
 /** A boxed DefDataType that also includes the ID of the type.
@@ -202,7 +202,7 @@ final case class Template(
 }
 
 /** Interfaces. */
-final case class AstInterface(
+final case class Interface(
     id: DamlLfIdentifier,
     choices: List[Choice],
 ) extends DamlLfNode

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
@@ -195,7 +195,7 @@ final case class Template(
     id: DamlLfIdentifier,
     choices: List[Choice],
     key: Option[DamlLfType],
-    implementedInterfaces: Set[DamlLfIdentifier] = Set.empty,
+    implementedInterfaces: Set[DamlLfIdentifier],
 ) extends DamlLfNode {
   def topLevelDecl: String = id.qualifiedName.toString()
   def parameter: DamlLfTypeCon = DamlLfTypeCon(DamlLfTypeConName(id), DamlLfImmArraySeq())

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
@@ -103,6 +103,7 @@ case class DamlLfPackage(
     id: DamlLfRef.PackageId,
     typeDefs: Map[DamlLfIdentifier, DamlLfDefDataType],
     templates: Map[DamlLfIdentifier, Template],
+    astInterfaces: Map[DamlLfIdentifier, AstInterface],
 )
 
 /** A boxed DefDataType that also includes the ID of the type.
@@ -194,7 +195,7 @@ final case class Template(
     id: DamlLfIdentifier,
     choices: List[Choice],
     key: Option[DamlLfType],
-    implementedInterfaces: Set[DamlLfIdentifier]
+    implementedInterfaces: Set[DamlLfIdentifier],
 ) extends DamlLfNode {
   def topLevelDecl: String = id.qualifiedName.toString()
   def parameter: DamlLfTypeCon = DamlLfTypeCon(DamlLfTypeConName(id), DamlLfImmArraySeq())
@@ -204,7 +205,6 @@ final case class Template(
 final case class AstInterface(
     id: DamlLfIdentifier,
     choices: List[Choice],
-    key: Option[DamlLfType],
 ) extends DamlLfNode
 
 /** Template choice. */

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
@@ -213,4 +213,5 @@ case class Choice(
     parameter: DamlLfType,
     returnType: DamlLfType,
     consuming: Boolean,
+    inheritedInterface: Option[DamlLfIdentifier] = None,
 )

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
@@ -195,7 +195,7 @@ final case class Template(
     id: DamlLfIdentifier,
     choices: List[Choice],
     key: Option[DamlLfType],
-    implementedInterfaces: Set[DamlLfIdentifier],
+    implementedInterfaces: Set[DamlLfIdentifier] = Set.empty,
 ) extends DamlLfNode {
   def topLevelDecl: String = id.qualifiedName.toString()
   def parameter: DamlLfTypeCon = DamlLfTypeCon(DamlLfTypeConName(id), DamlLfImmArraySeq())

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
@@ -199,6 +199,13 @@ final case class Template(
   def parameter: DamlLfTypeCon = DamlLfTypeCon(DamlLfTypeConName(id), DamlLfImmArraySeq())
 }
 
+/** Interfaces. */
+final case class Interface(
+    id: DamlLfIdentifier,
+    choices: List[Choice],
+    key: Option[DamlLfType],
+) extends DamlLfNode
+
 /** Template choice. */
 case class Choice(
     name: ApiTypes.Choice,

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
@@ -61,9 +61,8 @@ case class PackageRegistry(
     val newPackageStore = packageState.append(interfaces.map(p => p.packageId -> p).toMap)
 
     val newPackages = newPackageStore.packages.values.map { p =>
-      val typeDefs = p.typeDecls.map {
-        case (qname,td) =>
-          DamlLfIdentifier(p.packageId, qname) -> td.`type`
+      val typeDefs = p.typeDecls.map { case (qname, td) =>
+        DamlLfIdentifier(p.packageId, qname) -> td.`type`
       }
       val templates = p.typeDecls.collect {
         case (qname, DamlLfIface.InterfaceType.Template(r @ _, t)) =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
@@ -16,7 +16,7 @@ case class PackageRegistry(
     private val packages: Map[DamlLfRef.PackageId, DamlLfPackage] = Map.empty,
     private val templates: Map[DamlLfIdentifier, Template] = Map.empty,
     private val typeDefs: Map[DamlLfIdentifier, DamlLfDefDataType] = Map.empty,
-    private val astInterfaces: Map[DamlLfIdentifier, AstInterface] = Map.empty,
+    private val interfaces: Map[DamlLfIdentifier, Interface] = Map.empty,
 ) {
   // TODO (#13969) ignores inherited choices; interfaces aren't handled at all
   private[this] def template(
@@ -34,14 +34,14 @@ case class PackageRegistry(
     t.implementedInterfaces.toSet,
   )
 
-  private[this] def astInterface(
+  private[this] def interface(
       packageId: DamlLfRef.PackageId,
       qname: DamlLfQualifiedName,
-      astInterface: DamlLfIface.DefInterface[DamlLfIface.Type],
-  ): AstInterface = {
-    AstInterface(
+      interface: DamlLfIface.DefInterface[DamlLfIface.Type],
+  ): Interface = {
+    Interface(
       DamlLfIdentifier(packageId, qname),
-      astInterface.choices.toList.map(c => choice(c._1, c._2)),
+      interface.choices.toList.map(c => choice(c._1, c._2)),
     )
   }
 
@@ -71,17 +71,17 @@ case class PackageRegistry(
         case (qname, DamlLfIface.InterfaceType.Template(r @ _, t)) =>
           DamlLfIdentifier(p.packageId, qname) -> template(p.packageId, qname, t)
       }
-      val astInterfaces = p.astInterfaces.collect { case (qname, defInterface) =>
-        DamlLfIdentifier(p.packageId, qname) -> astInterface(p.packageId, qname, defInterface)
+      val interfaces = p.astInterfaces.collect { case (qname, defInterface) =>
+        DamlLfIdentifier(p.packageId, qname) -> interface(p.packageId, qname, defInterface)
       }
-      p.packageId -> DamlLfPackage(p.packageId, typeDefs, templates, astInterfaces)
+      p.packageId -> DamlLfPackage(p.packageId, typeDefs, templates, interfaces)
     }.toMap
 
     copy(
       packages = newPackages,
       templates = newPackages.flatMap(_._2.templates),
       typeDefs = newPackages.flatMap(_._2.typeDefs),
-      astInterfaces = newPackages.flatMap(_._2.astInterfaces),
+      interfaces = newPackages.flatMap(_._2.interfaces),
     )
   }
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
@@ -25,7 +25,7 @@ case class PackageRegistry(
     DamlLfIdentifier(packageId, qname),
     t.tChoices.directChoices.toList.map(c => choice(c._1, c._2)),
     t.key,
-    Set.empty,
+    t.implementedInterfaces.toSet
   )
 
   private[this] def astInterface(

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
@@ -61,17 +61,15 @@ case class PackageRegistry(
     val newPackageStore = packageState.append(interfaces.map(p => p.packageId -> p).toMap)
 
     val newPackages = newPackageStore.packages.values.map { p =>
-      val typeDefs = p.typeDecls.collect {
-        case (qname, DamlLfIface.InterfaceType.Normal(t)) =>
-          DamlLfIdentifier(p.packageId, qname) -> t
-        case (qname, DamlLfIface.InterfaceType.Template(r, _)) =>
-          DamlLfIdentifier(p.packageId, qname) -> DamlLfDefDataType(DamlLfImmArraySeq.empty, r)
+      val typeDefs = p.typeDecls.map {
+        case (qname,td) =>
+          DamlLfIdentifier(p.packageId, qname) -> td.`type`
       }
       val templates = p.typeDecls.collect {
         case (qname, DamlLfIface.InterfaceType.Template(r @ _, t)) =>
           DamlLfIdentifier(p.packageId, qname) -> template(p.packageId, qname, t)
       }
-      val interfaces = p.astInterfaces.collect { case (qname, defInterface) =>
+      val interfaces = p.astInterfaces.map { case (qname, defInterface) =>
         DamlLfIdentifier(p.packageId, qname) -> interface(p.packageId, qname, defInterface)
       }
       p.packageId -> DamlLfPackage(p.packageId, typeDefs, templates, interfaces)

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
@@ -13,6 +13,7 @@ case class PackageRegistry(
     private val packages: Map[DamlLfRef.PackageId, DamlLfPackage] = Map.empty,
     private val templates: Map[DamlLfIdentifier, Template] = Map.empty,
     private val typeDefs: Map[DamlLfIdentifier, DamlLfDefDataType] = Map.empty,
+    private val interfaces: Map[DamlLfIdentifier, Interface] = Map.empty,
 ) {
   // TODO (#13969) ignores inherited choices; interfaces aren't handled at all
   private[this] def template(

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
@@ -38,32 +38,6 @@ case class PackageRegistry(
     c.consuming,
   )
 
-  private[this] def resolveRetroImplements(
-    templates: Map[DamlLfIdentifier, Template],
-    sig: DamlLfIface.Interface
-  ): Map[DamlLfIdentifier, Template] = {
-    val templateIdToAstInterfaceIdSet: Map[TypeConName, Set[DamlLfIdentifier]] = (
-      for {
-        (astInterfaceName, astInterface) <- sig.astInterfaces.toSeq
-        templateId <- astInterface.retroImplements
-      } yield templateId -> DamlLfIdentifier(sig.packageId, astInterfaceName)
-    ).groupBy(_._1)
-      .map { case (k, v) => k -> v.map(_._2).toSet }
-
-    templates.map {
-      case (tId, template) =>
-        tId -> (
-          templateIdToAstInterfaceIdSet.get(tId) match {
-            case Some(implementedInterfaceSet) =>
-              val newImplementedInterfaces = template.implementedInterfaces ++ implementedInterfaceSet
-                template.copy(implementedInterfaces = newImplementedInterfaces)
-            case None =>
-              template
-          }
-        )
-    }
-  }
-
   private def resolveRetroImplements(newSigs: List[DamlLfIface.Interface], packageRegistry: PackageRegistry): PackageRegistry = {
     val templateIdToAstInterfaceIdSet: Map[TypeConName, Set[DamlLfIdentifier]] = (
       for {

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageState.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageState.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.navigator.model
+
+import com.daml.lf.data.Ref
+import com.daml.lf.iface
+
+import scala.collection.immutable.Map
+
+case class PackageState(packages: PackageState.PackageStore) {
+  import PackageState.PackageStore
+  def append(diff: PackageStore): PackageState = {
+    val newPackages = resolveChoicesIn(
+      appendAndResolveRetroactiveInterfaces(diff)
+    )
+    copy(packages = newPackages)
+  }
+
+  private[this] def appendAndResolveRetroactiveInterfaces(diff: PackageStore): PackageStore = {
+    def lookupIf(packageStore: PackageStore, pkId: Ref.PackageId) =
+      packages
+        .get(pkId)
+        .map((_, { newSig: iface.Interface => packageStore.updated(pkId, newSig) }))
+
+    val (packageStore2, diffElems) =
+      iface.Interface.resolveRetroImplements(packages, diff.values.toSeq)(lookupIf)
+    packageStore2 ++ diffElems.view.map(p => (p.packageId, p))
+  }
+
+  private[this] def resolveChoicesIn(diff: PackageStore): PackageStore = {
+    def lookupIf(pkgId: Ref.PackageId) = (packages get pkgId) orElse (diff get pkgId)
+    val findIface = iface.Interface.findAstInterface(Function unlift lookupIf)
+    diff.transform((_, iface) => iface resolveChoicesAndFailOnUnresolvableChoices findIface)
+  }
+}
+
+object PackageState {
+  type PackageStore = Map[String, iface.Interface]
+}

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageState.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageState.scala
@@ -8,7 +8,7 @@ import com.daml.lf.iface
 
 import scala.collection.immutable.Map
 
-case class PackageState(packages: PackageState.PackageStore) {
+final case class PackageState(packages: PackageState.PackageStore) {
   import PackageState.PackageStore
   def append(diff: PackageStore): PackageState = {
     val newPackages = resolveChoicesIn(
@@ -19,7 +19,7 @@ case class PackageState(packages: PackageState.PackageStore) {
 
   private[this] def appendAndResolveRetroactiveInterfaces(diff: PackageStore): PackageStore = {
     def lookupIf(packageStore: PackageStore, pkId: Ref.PackageId) =
-      packages
+      packageStore
         .get(pkId)
         .map((_, { newSig: iface.Interface => packageStore.updated(pkId, newSig) }))
 

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractFilterSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractFilterSpec.scala
@@ -34,6 +34,14 @@ class ContractFilterSpec extends AnyFlatSpec with Matchers {
     ),
   )
 
+  val damlLfId3 = DamlLfIdentifier(
+    DamlLfRef.PackageId.assertFromString("hash"),
+    DamlLfQualifiedName(
+      DamlLfDottedName.assertFromString("module"),
+      DamlLfDottedName.assertFromString("I1"),
+    ),
+  )
+
   val damlLfRecord0 = DamlLfDefDataType(
     DamlLfImmArraySeq(),
     DamlLfRecord(
@@ -80,8 +88,8 @@ class ContractFilterSpec extends AnyFlatSpec with Matchers {
     damlLfIdKey -> damlLfRecordKey,
   )
 
-  val template1 = Template(damlLfId0, List.empty, None)
-  val template2 = Template(damlLfId1, List.empty, Some(damlLfKeyType))
+  val template1 = Template(damlLfId0, List.empty, None, Set.empty)
+  val template2 = Template(damlLfId1, List.empty, Some(damlLfKeyType), Set(damlLfId3))
 
   val alice = ApiTypes.Party("Alice")
   val bob = ApiTypes.Party("Bob")

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractSortSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/ContractSortSpec.scala
@@ -63,6 +63,15 @@ class ContractSortSpec extends AnyFlatSpec with Matchers {
       )
     ),
   )
+
+  val damlLfId3 = DamlLfIdentifier(
+    DamlLfRef.PackageId.assertFromString("hash"),
+    DamlLfQualifiedName(
+      DamlLfDottedName.assertFromString("module"),
+      DamlLfDottedName.assertFromString("I1"),
+    ),
+  )
+
   val damlLfEnum = DamlLfDefDataType(
     DamlLfImmArraySeq(),
     DamlLfEnum(DamlLfImmArraySeq(name("North"), name("East"), name("South"), name("West"))),
@@ -95,8 +104,8 @@ class ContractSortSpec extends AnyFlatSpec with Matchers {
     damlLfDirectionId -> damlLfEnum,
   )
 
-  val template1 = Template(damlLfId0, List.empty, None)
-  val template2 = Template(damlLfId1, List.empty, Some(damlLfKeyType))
+  val template1 = Template(damlLfId0, List.empty, None, Set.empty)
+  val template2 = Template(damlLfId1, List.empty, Some(damlLfKeyType), Set(damlLfId3))
 
   val alice = ApiTypes.Party("Alice")
   val bob = ApiTypes.Party("Bob")

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/FilterSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/FilterSpec.scala
@@ -26,7 +26,7 @@ class FilterSpec extends AnyFlatSpec with Matchers {
       false,
     )
   )
-  val template = Template(C.complexRecordId, choices, None , Set.empty)
+  val template = Template(C.complexRecordId, choices, None, Set.empty)
   val contractId = ApiTypes.ContractId("ContractIou")
   val commandId = ApiTypes.CommandId("Cmd")
   val workflowId = ApiTypes.WorkflowId("Workflow")

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/FilterSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/query/FilterSpec.scala
@@ -26,7 +26,7 @@ class FilterSpec extends AnyFlatSpec with Matchers {
       false,
     )
   )
-  val template = Template(C.complexRecordId, choices, None)
+  val template = Template(C.complexRecordId, choices, None , Set.empty)
   val contractId = ApiTypes.ContractId("ContractIou")
   val commandId = ApiTypes.CommandId("Cmd")
   val workflowId = ApiTypes.WorkflowId("Workflow")


### PR DESCRIPTION
For #14756 

CHANGELOG_BEGIN
CHANGELOG_END


- [x] extract interfaces and interfaces instance from the list of iface.Interface (the signatures from package or dar. interface naming is confusing #13669 is fixing this ) 
- [x] Create a new package store in `PackageRegistry` as a source of truth so that we can use `resolveRetroImplements` and  `resolveChoicesAndFailOnUnresolvableChoices` from the signature library.
  - [x] resolve retroactive interface instance (interface instance defined in daml interface)
    - I have decided to use iface.Interface.resolveRetroImplements` to resolve retroactive interface as the internal package.
      - https://github.com/digital-asset/daml/blob/d2c7be9dd895f7e3f788af50626e0583b7ab976c/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/Interface.scala#L216
  - [x] resolve template choices inheritance from interfaces.
  - [x] use `resolvedChoices` instead of `directChoices` on `template.tChoices` to build Template


