### PR TITLE
LF: use Value instead KeyWithMaintainers in ContractStateMachine

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -380,7 +380,7 @@ private[speedy] case class PartialTransaction(
     CheckAuthorization.authorizeCreate(optLocation, createNode)(auth) match {
       case fa :: _ => Left((ptx, Tx.AuthFailureDuringExecution(nid, fa)))
       case Nil =>
-        ptx.contractState.visitCreate(templateId, cid, key) match {
+        ptx.contractState.visitCreate(templateId, cid, key.map(_.key)) match {
           case Right(next) =>
             val nextPtx = ptx.copy(contractState = next)
             Right((cid, nextPtx))
@@ -418,7 +418,7 @@ private[speedy] case class PartialTransaction(
     mustBeActive(NameOf.qualifiedNameOfCurrentFunc, coid) {
       val newContractState = assertRightKey(
         // evaluation order tests require visitFetch proceeds authorizeFetch
-        contractState.visitFetch(templateId, coid, key, byKey)
+        contractState.visitFetch(templateId, coid, key.map(_.key), byKey)
       )
       CheckAuthorization.authorizeFetch(optLocation, node)(auth) match {
         case fa :: _ => Left(Tx.AuthFailureDuringExecution(nid, fa))
@@ -500,7 +500,7 @@ private[speedy] case class PartialTransaction(
       // important: the semantics of Daml dictate that contracts are immediately
       // inactive as soon as you exercise it. therefore, mark it as consumed now.
       val newContractState = assertRightKey(
-        contractState.visitExercise(nid, templateId, targetId, mbKey, byKey, consuming)
+        contractState.visitExercise(nid, templateId, targetId, mbKey.map(_.key), byKey, consuming)
       )
       CheckAuthorization.authorizeExercise(optLocation, makeExNode(ec))(auth) match {
         case fa :: _ => Left(Tx.AuthFailureDuringExecution(nid, fa))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -104,6 +104,8 @@ object Node {
     def versionedCoinst: Value.VersionedContractInstance = versioned(coinst)
 
     def versionedKey: Option[VersionedKeyWithMaintainers] = key.map(versioned)
+
+    def keyValue: Option[Value] = key.map(_.key)
   }
 
   @deprecated("use Node.Fetch", since = "1.18.0")
@@ -134,6 +136,8 @@ object Node {
       copy(coid = f(coid), key = key.map(_.mapCid(f)))
 
     def versionedKey: Option[VersionedKeyWithMaintainers] = key.map(versioned)
+
+    def keyValue: Option[Value] = key.map(_.key)
   }
 
   @deprecated("use Node.Exercise", since = "1.18.0")
@@ -188,6 +192,8 @@ object Node {
     def versionedExerciseResult: Option[Value.VersionedValue] = exerciseResult.map(versioned)
 
     def versionedKey: Option[VersionedKeyWithMaintainers] = key.map(versioned)
+
+    def keyValue: Option[Value] = key.map(_.key)
   }
 
   @deprecated("use Node.LookupByKey", since = "1.18.0")
@@ -217,6 +223,8 @@ object Node {
       copy(version = version)
 
     def versionedKey: VersionedKeyWithMaintainers = versioned(key)
+
+    def keyValue: Value = key.key
   }
 
   final case class KeyWithMaintainers(key: Value, maintainers: Set[Party])


### PR DESCRIPTION
To simplify a bit

CHANGELOG_BEGIN
CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
