### PR TITLE
release: restore macOS artifact names

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -106,11 +106,13 @@ jobs:
 
 - template: macOS.yml
   parameters:
-    name: macOS
+    job_name: macOS
+    name: macos
     assignment: default
 
 - template: macOS.yml
   parameters:
+    job_name: m1
     name: m1
     assignment: m1-builds
 

--- a/ci/macOS.yml
+++ b/ci/macOS.yml
@@ -4,16 +4,17 @@
 parameters:
 - name: name
 - name: assignment
+- name: job_name
 
 jobs:
-- job: ${{parameters.name}}
+- job: ${{parameters.job_name}}
   dependsOn:
     - check_for_release
   timeoutInMinutes: 360
   pool:
     name: macOS-pool
     demands: assignment -equals ${{parameters.assignment}}
-  condition: or(eq('${{parameters.name}}', 'macOS'),
+  condition: or(eq('${{parameters.name}}', 'macos'),
                 eq(variables['Build.SourceBranchName'], 'main'))
   variables:
     - name: release_sha


### PR DESCRIPTION
In #14622, I inadvertently changed the artifact names from using `macos`
to using `macOS`, which may break any number of external references,
from Canton's dependency (which is how I found out) to the assembly
script and the `daml install` command. This reverts that.

CHANGELOG_BEGIN
CHANGELOG_END