### PR TITLE
rs-grpc-bridge - Close gRPC client call when downstream cancels and no elements were received [KVL-1544]

### DIFF
--- a/ledger-api/rs-grpc-bridge/src/main/java/com/daml/grpc/adapter/client/rs/BufferingResponseObserver.java
+++ b/ledger-api/rs-grpc-bridge/src/main/java/com/daml/grpc/adapter/client/rs/BufferingResponseObserver.java
@@ -75,7 +75,6 @@ class BufferingResponseObserver<Req, Resp> implements ClientResponseObserver<Req
     logger.trace("{}gRPC upstream emitted error.", logPrefix, throwable);
     es.sequence(
         () -> {
-          subscription.onStreamClosure();
           if (!subscription.isCancelled()) {
             if (buffer.hasNoElement()) {
               subscription.getSubscriber().onError(throwable);
@@ -91,7 +90,6 @@ class BufferingResponseObserver<Req, Resp> implements ClientResponseObserver<Req
     logger.trace("{}gRPC upstream completed.", logPrefix);
     es.sequence(
         () -> {
-          subscription.onStreamClosure();
           if (!subscription.isCancelled()) {
             if (buffer.hasNoElement()) {
               subscription.getSubscriber().onComplete();

--- a/ledger-api/rs-grpc-bridge/src/main/java/com/daml/grpc/adapter/client/rs/DownstreamEventBuffer.java
+++ b/ledger-api/rs-grpc-bridge/src/main/java/com/daml/grpc/adapter/client/rs/DownstreamEventBuffer.java
@@ -4,9 +4,7 @@
 package com.daml.grpc.adapter.client.rs;
 
 import io.grpc.stub.ClientCallStreamObserver;
-import java.math.BigInteger;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -19,9 +17,8 @@ import org.slf4j.LoggerFactory;
  * signals - cancellation These events can then be flushed into a ClientCallStreamObserver.
  */
 class DownstreamEventBuffer {
-  private static Logger logger = LoggerFactory.getLogger(DownstreamEventBuffer.class);
-  private static final BigInteger LONG_MAX_AS_BIGINT = BigInteger.valueOf(Long.MAX_VALUE);
-  private static final long INT_MAX_AS_LONG = ((long) Integer.MAX_VALUE);
+  private static final Logger logger = LoggerFactory.getLogger(DownstreamEventBuffer.class);
+  private static final long INT_MAX_AS_LONG = Integer.MAX_VALUE;
 
   @Nonnull private final String logPrefix;
   private long demand = 0L;
@@ -29,19 +26,14 @@ class DownstreamEventBuffer {
 
   enum DownstreamState {
     FLOW_CONTROLLED,
-    UNBOUNDED,
-    CANCELLATION_BUFFERED,
-    CANCELLATION_FLUSHED
+    UNBOUNDED
   }
 
-  private final Consumer<ClientCallStreamObserver> propagateCancellation;
   private final BiConsumer<ClientCallStreamObserver, Integer> propagateDemand;
 
   DownstreamEventBuffer(
-      @Nonnull Consumer<ClientCallStreamObserver> propagateCancellation,
       @Nonnull BiConsumer<ClientCallStreamObserver, Integer> propagateDemand,
       @Nonnull String logPrefix) {
-    this.propagateCancellation = propagateCancellation;
     this.propagateDemand = propagateDemand;
     this.logPrefix = logPrefix;
   }
@@ -73,10 +65,6 @@ class DownstreamEventBuffer {
         break;
       case UNBOUNDED:
         break;
-      case CANCELLATION_BUFFERED:
-        break;
-      case CANCELLATION_FLUSHED:
-        break;
     }
   }
 
@@ -85,27 +73,17 @@ class DownstreamEventBuffer {
    * and stores the remaining amount in the demand variable.
    */
   private int getIntegerChunk() {
-    long chunk = this.demand < INT_MAX_AS_LONG ? this.demand : INT_MAX_AS_LONG;
+    long chunk = Math.min(this.demand, INT_MAX_AS_LONG);
     this.demand -= chunk;
     return (int) chunk;
   }
 
   /**
-   * Takes note of the fact that the downstream cancelled the stream. This will be communicated to
-   * gRPC on the next call to propagateCancellationOrDemand.
-   */
-  void bufferCancellation() {
-    if (!downstreamState.equals(DownstreamState.CANCELLATION_FLUSHED))
-      downstreamState = DownstreamState.CANCELLATION_BUFFERED;
-    logger.trace("{}Cancellation buffered.", logPrefix);
-  }
-
-  /**
-   * Propagates demand or cancellation according to buffered state.
+   * Propagates demand according to buffered state.
    *
    * @return The amount of demand propagated, if any.
    */
-  int propagateCancellationOrDemand(@Nonnull ClientCallStreamObserver requestObserver) {
+  int propagateDemand(@Nonnull ClientCallStreamObserver requestObserver) {
     switch (downstreamState) {
       case FLOW_CONTROLLED:
         int demandToPropagate = getIntegerChunk();
@@ -123,11 +101,6 @@ class DownstreamEventBuffer {
             "{}Flushing demand for Integer.MAX_VALUE elements in unbounded mode.", logPrefix);
         propagateDemand.accept(requestObserver, Integer.MAX_VALUE);
         return Integer.MAX_VALUE;
-      case CANCELLATION_BUFFERED:
-        logger.trace("{}Flushing buffered cancellation.", logPrefix);
-        propagateCancellation.accept(requestObserver);
-        downstreamState = DownstreamState.CANCELLATION_FLUSHED;
-        return 0;
       default:
         return 0;
     }

--- a/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/BufferingSubscriptionTest.scala
+++ b/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/BufferingSubscriptionTest.scala
@@ -39,6 +39,7 @@ class BufferingSubscriptionTest extends AnyWordSpecLike with Matchers {
     }
   }
 }
+
 object BufferingSubscriptionTest {
   class MockClientCallStreamObserver extends ClientCallStreamObserver[String] {
     @volatile

--- a/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/BufferingSubscriptionTest.scala
+++ b/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/BufferingSubscriptionTest.scala
@@ -41,6 +41,7 @@ class BufferingSubscriptionTest extends AnyWordSpecLike with Matchers {
 }
 object BufferingSubscriptionTest {
   class MockClientCallStreamObserver extends ClientCallStreamObserver[String] {
+    @volatile
     var cancelled = false
     override def cancel(message: String, cause: Throwable): Unit = cancelled = true
     override def isReady: Boolean = ???

--- a/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/BufferingSubscriptionTest.scala
+++ b/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/BufferingSubscriptionTest.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.grpc.adapter.client.rs
+
+import com.daml.grpc.adapter.SingleThreadExecutionSequencerPool
+import com.daml.grpc.adapter.client.rs.BufferingSubscriptionTest.MockClientCallStreamObserver
+import io.grpc.stub.ClientCallStreamObserver
+import org.reactivestreams.{Subscriber, Subscription}
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class BufferingSubscriptionTest extends AnyWordSpecLike with Matchers {
+
+  private val sequencePool = new SingleThreadExecutionSequencerPool("test")
+
+  "Buffering subscription" should {
+
+    "propagate cancellation when no elements were sent" in {
+      val observer = new MockClientCallStreamObserver()
+      val subscription = new BufferingSubscription[String](
+        (_: Subscriber[_ >: String]) => (),
+        () => observer,
+        sequencePool.getExecutionSequencer,
+        new Subscriber[String] {
+          override def onSubscribe(s: Subscription): Unit = ???
+          override def onNext(t: String): Unit = ???
+          override def onError(t: Throwable): Unit = ???
+          override def onComplete(): Unit = ???
+        },
+        "test",
+      )
+      subscription.cancel()
+      eventually {
+        subscription.isCancelled should be(true)
+        observer.cancelled should be(true)
+      }
+    }
+  }
+}
+object BufferingSubscriptionTest {
+  class MockClientCallStreamObserver extends ClientCallStreamObserver[String] {
+    var cancelled = false
+    override def cancel(message: String, cause: Throwable): Unit = cancelled = true
+    override def isReady: Boolean = ???
+    override def setOnReadyHandler(onReadyHandler: Runnable): Unit = ???
+    override def request(count: Int): Unit = ???
+    override def setMessageCompression(enable: Boolean): Unit = ???
+    override def disableAutoInboundFlowControl(): Unit = ???
+    override def onNext(value: String): Unit = ???
+    override def onError(t: Throwable): Unit = ???
+    override def onCompleted(): Unit = ???
+  }
+}

--- a/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/BufferingSubscriptionTest.scala
+++ b/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/BufferingSubscriptionTest.scala
@@ -4,7 +4,10 @@
 package com.daml.grpc.adapter.client.rs
 
 import com.daml.grpc.adapter.SingleThreadExecutionSequencerPool
-import com.daml.grpc.adapter.client.rs.BufferingSubscriptionTest.MockClientCallStreamObserver
+import com.daml.grpc.adapter.client.rs.BufferingSubscriptionTest.{
+  MockClientCallStreamObserver,
+  NoOpSubscriber,
+}
 import io.grpc.stub.ClientCallStreamObserver
 import org.reactivestreams.{Subscriber, Subscription}
 import org.scalatest.concurrent.Eventually.eventually
@@ -16,21 +19,20 @@ class BufferingSubscriptionTest extends AnyWordSpecLike with Matchers {
   private val sequencePool = new SingleThreadExecutionSequencerPool("test")
 
   "Buffering subscription" should {
+    "propagate cancellation when elements are sent" in {
+      val observer = new MockClientCallStreamObserver()
+      val subscription = newBufferingSubscription(observer)
+      subscription.onNextElement(observer)
+      subscription.cancel()
+      eventually {
+        subscription.isCancelled should be(true)
+        observer.cancelled should be(true)
+      }
+    }
 
     "propagate cancellation when no elements were sent" in {
       val observer = new MockClientCallStreamObserver()
-      val subscription = new BufferingSubscription[String](
-        (_: Subscriber[_ >: String]) => (),
-        () => observer,
-        sequencePool.getExecutionSequencer,
-        new Subscriber[String] {
-          override def onSubscribe(s: Subscription): Unit = ???
-          override def onNext(t: String): Unit = ???
-          override def onError(t: Throwable): Unit = ???
-          override def onComplete(): Unit = ???
-        },
-        "test",
-      )
+      val subscription = newBufferingSubscription(observer)
       subscription.cancel()
       eventually {
         subscription.isCancelled should be(true)
@@ -38,9 +40,26 @@ class BufferingSubscriptionTest extends AnyWordSpecLike with Matchers {
       }
     }
   }
+  private def newBufferingSubscription(
+      observer: MockClientCallStreamObserver
+  ) = {
+    new BufferingSubscription[String](
+      (_: Subscriber[_ >: String]) => (),
+      () => observer,
+      sequencePool.getExecutionSequencer,
+      NoOpSubscriber,
+      "test",
+    )
+  }
 }
 
 object BufferingSubscriptionTest {
+  object NoOpSubscriber extends Subscriber[String] {
+    override def onSubscribe(s: Subscription): Unit = ???
+    override def onNext(t: String): Unit = ???
+    override def onError(t: Throwable): Unit = ???
+    override def onComplete(): Unit = ???
+  }
   class MockClientCallStreamObserver extends ClientCallStreamObserver[String] {
     @volatile
     var cancelled = false


### PR DESCRIPTION
If the producer for the BufferingSubscription never received elements then the stream was never marked as started.
Following downstream cancellation, the `BufferingSubscription.cancel` handle is called, but as the stream was never marked as running the cancellation is buffered for signaling in the DownstreamEventBuffer. As the DownstreamEventBuffer will flush the cancellation only if an element is received this leads to the stream remaining alive even if the observer was cancelled.

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
