### PR TITLE
Extend daml-doc to support retroactive interface instances and viewtypes

### DIFF
--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -84,7 +84,7 @@ extractDocs extractOpts diagsLogger ideOpts fp = do
             md_anchor = Just (moduleAnchor md_name)
             md_descr = modDoc tcmod
             md_templates = getTemplateDocs ctx typeMap interfaceInstanceMap
-            md_interfaces = getInterfaceDocs ctx typeMap
+            md_interfaces = getInterfaceDocs ctx typeMap interfaceInstanceMap
             md_functions = mapMaybe (getFctDocs ctx) dc_decls
             md_instances = map (getInstanceDocs ctx) dc_insts
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -81,13 +81,13 @@ extractDocs extractOpts diagsLogger ideOpts fp = do
             md_classes = mapMaybe (getClsDocs ctx) dc_decls
 
             interfaceInstanceMap = getInterfaceInstanceMap ctx dc_decls
-            _interfaceViewtypeMap = getInterfaceViewtypeMap ctx dc_insts
+            interfaceViewtypeMap = getInterfaceViewtypeMap ctx dc_insts
 
             md_name = dc_modname
             md_anchor = Just (moduleAnchor md_name)
             md_descr = modDoc tcmod
             md_templates = getTemplateDocs ctx typeMap interfaceInstanceMap
-            md_interfaces = getInterfaceDocs ctx typeMap interfaceInstanceMap
+            md_interfaces = getInterfaceDocs ctx typeMap interfaceViewtypeMap interfaceInstanceMap
             md_functions = mapMaybe (getFctDocs ctx) dc_decls
             md_instances = map (getInstanceDocs ctx) dc_insts
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
@@ -10,7 +10,6 @@ module DA.Daml.Doc.Extract.Templates
     ) where
 
 import DA.Daml.Doc.Types
-import qualified DA.Daml.Doc.Types as DDoc
 import DA.Daml.Doc.Extract.Types
 import DA.Daml.Doc.Extract.Util
 import DA.Daml.Doc.Extract.TypeExpr
@@ -32,10 +31,12 @@ import "ghc-lib-parser" Id
 -- | Build template docs up from ADT and class docs.
 getTemplateDocs ::
     DocCtx
-    -> MS.Map Typename ADTDoc -- ^ maps template names to their ADT docs
-    -> MS.Map Typename (Set.Set DDoc.Type)-- ^ maps template names to their implemented interfaces' types
+    -> MS.Map Typename ADTDoc
+      -- ^ maps type names to their ADT docs
+    -> MS.Map Typename (Set.Set InterfaceInstanceDoc)
+      -- ^ maps type names to the interface instances contained in their declaration.
     -> [TemplateDoc]
-getTemplateDocs DocCtx{..} typeMap templateImplementsMap =
+getTemplateDocs DocCtx{..} typeMap interfaceInstanceMap =
     map mkTemplateDoc $ Set.toList dc_templates
   where
     -- The following functions use the type map and choice map in scope, so
@@ -48,9 +49,8 @@ getTemplateDocs DocCtx{..} typeMap templateImplementsMap =
       , td_payload = getFields tmplADT
       -- assumes exactly one record constructor (syntactic, template syntax)
       , td_choices = map (mkChoiceDoc typeMap) choices
-      , td_impls =
-          ImplDoc <$>
-            Set.toList (MS.findWithDefault mempty name templateImplementsMap)
+      , td_interfaceInstances =
+          Set.toList (MS.findWithDefault mempty name interfaceInstanceMap)
      }
       where
         tmplADT = asADT typeMap name

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
@@ -9,7 +9,7 @@ module DA.Daml.Doc.Extract.Templates
     , stripInstanceSuffix
     ) where
 
-import DA.Daml.Doc.Types
+import DA.Daml.Doc.Types as DDoc
 import DA.Daml.Doc.Extract.Types
 import DA.Daml.Doc.Extract.Util
 import DA.Daml.Doc.Extract.TypeExpr
@@ -61,10 +61,12 @@ getTemplateDocs DocCtx{..} typeMap interfaceInstanceMap =
 getInterfaceDocs :: DocCtx
     -> MS.Map Typename ADTDoc
         -- ^ maps type names to their ADT docs
+    -> MS.Map Typename DDoc.Type
+        -- ^ maps type names to interface viewtypes
     -> MS.Map Typename (Set.Set InterfaceInstanceDoc)
         -- ^ maps type names to the interface instances contained in their declaration.
     -> [InterfaceDoc]
-getInterfaceDocs DocCtx{..} typeMap interfaceInstanceMap =
+getInterfaceDocs DocCtx{..} typeMap interfaceViewtypeMap interfaceInstanceMap =
     map mkInterfaceDoc $ Set.toList dc_interfaces
   where
     -- The following functions use the type map and choice map in scope, so
@@ -78,6 +80,8 @@ getInterfaceDocs DocCtx{..} typeMap interfaceInstanceMap =
       , if_methods = [] -- filled by distributeInstanceDocs
       , if_interfaceInstances =
           Set.toList (MS.findWithDefault mempty name interfaceInstanceMap)
+      , if_viewtype =
+          interfaceViewtypeMap MS.! name
       }
       where
         ifADT = asADT typeMap name

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
@@ -81,6 +81,8 @@ getInterfaceDocs DocCtx{..} typeMap interfaceViewtypeMap interfaceInstanceMap =
       , if_interfaceInstances =
           Set.toList (MS.findWithDefault mempty name interfaceInstanceMap)
       , if_viewtype =
+          -- it's fine to use 'MS.!' here because the compiler doesn't 
+          -- allow declaring an interface without a viewtype.
           interfaceViewtypeMap MS.! name
       }
       where

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract/Templates.hs
@@ -59,9 +59,12 @@ getTemplateDocs DocCtx{..} typeMap interfaceInstanceMap =
 
 -- | Build interface docs up from class docs.
 getInterfaceDocs :: DocCtx
-    -> MS.Map Typename ADTDoc -- ^ maps template names to their ADT docs
+    -> MS.Map Typename ADTDoc
+        -- ^ maps type names to their ADT docs
+    -> MS.Map Typename (Set.Set InterfaceInstanceDoc)
+        -- ^ maps type names to the interface instances contained in their declaration.
     -> [InterfaceDoc]
-getInterfaceDocs DocCtx{..} typeMap =
+getInterfaceDocs DocCtx{..} typeMap interfaceInstanceMap =
     map mkInterfaceDoc $ Set.toList dc_interfaces
   where
     -- The following functions use the type map and choice map in scope, so
@@ -73,6 +76,8 @@ getInterfaceDocs DocCtx{..} typeMap =
       , if_descr = ad_descr ifADT
       , if_choices = map (mkChoiceDoc typeMap) choices
       , if_methods = [] -- filled by distributeInstanceDocs
+      , if_interfaceInstances =
+          Set.toList (MS.findWithDefault mempty name interfaceInstanceMap)
       }
       where
         ifADT = asADT typeMap name

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -74,10 +74,10 @@ instance RenderDoc TemplateDoc where
             , fieldTable td_payload
             , RenderList (map renderDoc td_choices)
             ]
-        , if null td_impls
+        , if null td_interfaceInstances
           then mempty
           else RenderBlock $ mconcat
-                [ RenderList (map renderDoc td_impls)
+                [ RenderList (map renderDoc td_interfaceInstances)
                 ]
         ]
 
@@ -95,10 +95,15 @@ instance RenderDoc InterfaceDoc where
             ]
         ]
 
-instance RenderDoc ImplDoc where
-    renderDoc ImplDoc {..} =
+instance RenderDoc InterfaceInstanceDoc where
+    renderDoc InterfaceInstanceDoc {..} =
         RenderParagraph $
-            renderUnwords [ RenderStrong "implements", renderType impl_iface ]
+            renderUnwords
+                [ RenderStrong "interface instance"
+                , renderType ii_interface
+                , RenderStrong "for"
+                , renderType ii_template
+                ]
 
 instance RenderDoc MethodDoc where
     renderDoc MethodDoc {..} = mconcat

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -90,6 +90,10 @@ instance RenderDoc InterfaceDoc where
             ]
         , RenderBlock $ mconcat
             [ renderDoc if_descr
+            , RenderParagraph . renderUnwords $
+                [ RenderStrong "viewtype"
+                , renderType if_viewtype
+                ]
             , RenderList (map renderDoc if_choices)
             , RenderList (map renderDoc if_methods)
             ]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Output.hs
@@ -93,6 +93,11 @@ instance RenderDoc InterfaceDoc where
             , RenderList (map renderDoc if_choices)
             , RenderList (map renderDoc if_methods)
             ]
+        , if null if_interfaceInstances
+          then mempty
+          else RenderBlock $ mconcat
+                [ RenderList (map renderDoc if_interfaceInstances)
+                ]
         ]
 
 instance RenderDoc InterfaceInstanceDoc where

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -128,6 +128,7 @@ data InterfaceDoc = InterfaceDoc
   , if_methods :: [MethodDoc]
   , if_descr :: Maybe DocText
   , if_interfaceInstances :: [InterfaceInstanceDoc]
+  , if_viewtype :: Type
   }
   deriving (Eq, Show, Generic)
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -117,7 +117,7 @@ data TemplateDoc = TemplateDoc
   , td_descr   :: Maybe DocText
   , td_payload :: [FieldDoc]
   , td_choices :: [ChoiceDoc]
-  , td_impls :: [ImplDoc]
+  , td_interfaceInstances :: [InterfaceInstanceDoc]
   }
   deriving (Eq, Show, Generic)
 
@@ -130,9 +130,11 @@ data InterfaceDoc = InterfaceDoc
   }
   deriving (Eq, Show, Generic)
 
-data ImplDoc = ImplDoc
-  { impl_iface :: Type
-  } deriving (Eq, Show, Generic)
+data InterfaceInstanceDoc = InterfaceInstanceDoc
+  { ii_interface :: Type
+  , ii_template :: Type
+  }
+  deriving (Eq, Ord, Show, Generic)
 
 data ClassDoc = ClassDoc
   { cl_anchor :: Maybe Anchor
@@ -331,10 +333,10 @@ instance ToJSON ChoiceDoc where
 instance FromJSON ChoiceDoc where
     parseJSON = genericParseJSON aesonOptions
 
-instance ToJSON ImplDoc where
+instance ToJSON InterfaceInstanceDoc where
     toJSON = genericToJSON aesonOptions
 
-instance FromJSON ImplDoc where
+instance FromJSON InterfaceInstanceDoc where
     parseJSON = genericParseJSON aesonOptions
 
 instance ToJSON TemplateDoc where

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -127,6 +127,7 @@ data InterfaceDoc = InterfaceDoc
   , if_choices :: [ChoiceDoc]
   , if_methods :: [MethodDoc]
   , if_descr :: Maybe DocText
+  , if_interfaceInstances :: [InterfaceInstanceDoc]
   }
   deriving (Eq, Show, Generic)
 

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
@@ -202,8 +202,10 @@ unitTests =
            (\md -> assertBool
                    ("Expected interface instance, got " <> show md)
                    (isJust $ do t  <- getSingle $ md_templates md
-                                impl <- getSingle $ td_impls t
-                                check $ getTypeAppName (impl_iface impl) == Just "Bar"))
+                                InterfaceInstanceDoc {..} <- getSingle $ td_interfaceInstances t
+                                check $
+                                  getTypeAppName ii_interface == Just "Bar"
+                                  && getTypeAppName ii_template == Just "Foo"))
 
          , damldocExpect
            Nothing

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
@@ -298,6 +298,22 @@ damldocExpect importPathM testname input check =
     doc <- runDamldoc testfile importPathM
     check doc
 
+damldocExpectMany ::
+     Maybe FilePath
+  -> String
+  -> [(String, [T.Text])]
+  -> (Map Modulename ModuleDoc -> Assertion)
+  -> Tasty.TestTree
+damldocExpectMany importPathM testname input check =
+  testCase testname $
+  withTempDir $ \dir -> do
+    testfiles <- forM input $ \(modName, content) -> do
+      let testfile = dir </> modName <.> "daml"
+      T.writeFileUtf8 testfile (T.unlines content)
+      pure testfile
+    docs <- runDamldocMany testfiles importPathM
+    check docs
+
 -- | Generate the docs for a given input file and optional import directory.
 runDamldoc :: FilePath -> Maybe FilePath -> IO ModuleDoc
 runDamldoc testfile importPathM = do

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
@@ -209,6 +209,30 @@ unitTests =
 
          , damldocExpect
            Nothing
+           "Interface instance in interface"
+           [ testModHdr
+           , "data EmptyInterfaceView = EmptyInterfaceView"
+           , "template Foo with"
+           , "    field1 : Party"
+           , "  where"
+           , "    signatory field1"
+           , "interface Bar where"
+           , "  viewtype EmptyInterfaceView"
+           , "  method : Update ()"
+           , "  interface instance Bar for Foo where"
+           , "    view = EmptyInterfaceView"
+           , "    method = pure ()"
+           ]
+           (\md -> assertBool
+                   ("Expected interface instance, got " <> show md)
+                   (isJust $ do i  <- getSingle $ md_interfaces md
+                                InterfaceInstanceDoc {..} <- getSingle $ if_interfaceInstances i
+                                check $
+                                  getTypeAppName ii_interface == Just "Bar"
+                                  && getTypeAppName ii_template == Just "Foo"))
+
+         , damldocExpect
+           Nothing
            "Class doc"
            [ testModHdr
            , "-- | Class description"

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
@@ -233,6 +233,85 @@ unitTests =
                                   getTypeAppName ii_interface == Just "Bar"
                                   && getTypeAppName ii_template == Just "Foo"))
 
+         , damldocExpectMany
+           Nothing
+           "Interface instance with qualified interface"
+           [ (,) "Interface"
+             [ "module Interface where"
+
+             , "data EmptyInterfaceView = EmptyInterfaceView"
+
+             , "interface Bar where"
+             , "  viewtype EmptyInterfaceView"
+             , "  method : Update ()"
+             ]
+           , (,) "Template"
+             [ "module Template where"
+
+             , "import qualified Interface"
+
+             , "template Foo with"
+             , "    field1 : Party"
+             , "  where"
+             , "    signatory field1"
+             , "    interface instance Interface.Bar for Foo where"
+             , "      view = Interface.EmptyInterfaceView"
+             , "      method = pure ()"
+             ]
+           ]
+           (\mds -> assertBool
+                   ("Expected interface instance, got " <> show mds)
+                   (isJust $ do interfaceMod <- Map.lookup (Modulename "Interface") mds
+                                interface <- getSingle $ md_interfaces interfaceMod
+                                interfaceAnchor <- if_anchor interface
+
+                                templateMod <- Map.lookup (Modulename "Template") mds
+                                template <- getSingle $ md_templates templateMod
+                                InterfaceInstanceDoc {..} <- getSingle $ td_interfaceInstances template
+                                check $
+                                  getTypeAppName ii_interface == Just "Bar"
+                                  && getTypeAppName ii_template == Just "Foo"
+                                  && getTypeAppAnchor ii_interface == Just interfaceAnchor))
+
+         , damldocExpectMany
+           Nothing
+           "Interface instance with qualified template"
+           [ (,) "Template"
+             [ "module Template where"
+             , "template Foo with"
+             , "    field1 : Party"
+             , "  where"
+             , "    signatory field1"
+             ]
+           , (,) "Interface"
+             [ "module Interface where"
+
+             , "import qualified Template"
+
+             , "data EmptyInterfaceView = EmptyInterfaceView"
+
+             , "interface Bar where"
+             , "  viewtype EmptyInterfaceView"
+             , "  method : Update ()"
+             , "  interface instance Bar for Template.Foo where"
+             , "    view = EmptyInterfaceView"
+             , "    method = pure ()"
+             ]
+           ]
+           (\mds -> assertBool
+                   ("Expected interface instance, got " <> show mds)
+                   (isJust $ do templateMod <- Map.lookup (Modulename "Template") mds
+                                template <- getSingle $ md_templates templateMod
+                                templateAnchor <- td_anchor template
+
+                                interfaceMod <- Map.lookup (Modulename "Interface") mds
+                                interface <- getSingle $ md_interfaces interfaceMod
+                                InterfaceInstanceDoc {..} <- getSingle $ if_interfaceInstances interface
+                                check $
+                                  getTypeAppName ii_interface == Just "Bar"
+                                  && getTypeAppName ii_template == Just "Foo"
+                                  && getTypeAppAnchor ii_template == Just templateAnchor))
+
          , damldocExpect
            Nothing
            "Class doc"

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
@@ -14,7 +14,7 @@
 >   
 >   (no fields)
 
-> * **implements** [Token](#type-interface-token-10651)
+> * **interface instance** [Token](#type-interface-token-10651) **for** [Asset](#type-interface-asset-25340)
 
 ## Interfaces
 

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.md
@@ -22,6 +22,8 @@
 
 > An interface comment.
 > 
+> **viewtype** [EmptyInterfaceView](#type-interface-emptyinterfaceview-28816)
+> 
 > * **Choice GetRich**
 >   
 >   | Field                                                                          | Type                                                                           | Description |

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
@@ -30,7 +30,7 @@ Templates
   + **Choice Archive**
     
 
-  + **implements** `Token <type-interface-token-10651_>`_
+  + **interface instance** `Token <type-interface-token-10651_>`_ **for** `Asset <type-interface-asset-25340_>`_
 
 Interfaces
 ^^^^^^^^^^

--- a/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Interface.EXPECTED.rst
@@ -41,6 +41,8 @@ Interfaces
 
   An interface comment\.
   
+  **viewtype** `EmptyInterfaceView <type-interface-emptyinterfaceview-28816_>`_
+  
   + **Choice GetRich**
     
     .. list-table::

--- a/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
@@ -14,4 +14,4 @@
 >   
 >   (no fields)
 
-> * **implements** Token
+> * **interface instance** Token **for** [Asset](#type-qualifiedinterface-asset-82061)

--- a/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.md
@@ -1,0 +1,17 @@
+# <a name="module-qualifiedinterface-53968"></a>Module QualifiedInterface
+
+## Templates
+
+<a name="type-qualifiedinterface-asset-82061"></a>**template** [Asset](#type-qualifiedinterface-asset-82061)
+
+> | Field                                                                                   | Type                                                                                    | Description |
+> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+> | issuer                                                                                  | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | owner                                                                                   | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> | amount                                                                                  | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)          |  |
+> 
+> * **Choice Archive**
+>   
+>   (no fields)
+
+> * **implements** Token

--- a/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
@@ -1,0 +1,33 @@
+.. _module-qualifiedinterface-53968:
+
+Module QualifiedInterface
+-------------------------
+
+Templates
+^^^^^^^^^
+
+.. _type-qualifiedinterface-asset-82061:
+
+**template** `Asset <type-qualifiedinterface-asset-82061_>`_
+
+  .. list-table::
+     :widths: 15 10 30
+     :header-rows: 1
+  
+     * - Field
+       - Type
+       - Description
+     * - issuer
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - 
+     * - owner
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+       - 
+     * - amount
+       - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+       - 
+  
+  + **Choice Archive**
+    
+
+  + **implements** Token

--- a/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/QualifiedInterface.EXPECTED.rst
@@ -30,4 +30,4 @@ Templates
   + **Choice Archive**
     
 
-  + **implements** Token
+  + **interface instance** Token **for** `Asset <type-qualifiedinterface-asset-82061_>`_

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
@@ -4,6 +4,8 @@
 
 <a name="type-qualifiedretroactiveinterfaceinstance-token-43978"></a>**interface** [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978)
 
+> **viewtype** [TokenView](#type-qualifiedretroactiveinterfaceinstance-tokenview-25557)
+> 
 > * **Choice GetRich**
 >   
 >   | Field                                                                          | Type                                                                           | Description |

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
@@ -1,0 +1,74 @@
+# <a name="module-qualifiedretroactiveinterfaceinstance-76052"></a>Module QualifiedRetroactiveInterfaceInstance
+
+## Interfaces
+
+<a name="type-qualifiedretroactiveinterfaceinstance-token-43978"></a>**interface** [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978)
+
+> * **Choice GetRich**
+>   
+>   | Field                                                                          | Type                                                                           | Description |
+>   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+>   | byHowMuch                                                                      | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
+> 
+> * **Choice Noop**
+>   
+>   | Field   | Type    | Description |
+>   | :------ | :------ | :---------- |
+>   | nothing | ()      |  |
+> 
+> * **Choice Split**
+>   
+>   An interface choice comment.
+>   
+>   | Field                                                                          | Type                                                                           | Description |
+>   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+>   | splitAmount                                                                    | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) | A choice field comment. |
+> 
+> * **Choice Transfer**
+>   
+>   | Field                                                                                   | Type                                                                                    | Description |
+>   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+>   | newOwner                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> 
+> * **Method noopImpl :** () -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ()
+> 
+> * **Method setAmount :** [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978)
+> 
+> * **Method splitImpl :** [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978))
+> 
+> * **Method transferImpl :** [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978))
+
+## Data Types
+
+<a name="type-qualifiedretroactiveinterfaceinstance-tokenview-25557"></a>**data** [TokenView](#type-qualifiedretroactiveinterfaceinstance-tokenview-25557)
+
+> <a name="constr-qualifiedretroactiveinterfaceinstance-tokenview-72346"></a>[TokenView](#constr-qualifiedretroactiveinterfaceinstance-tokenview-72346)
+> 
+> > | Field                                                                                   | Type                                                                                    | Description |
+> > | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+> > | owner                                                                                   | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> > | amount                                                                                  | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)          |  |
+> 
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978) [TokenView](#type-qualifiedretroactiveinterfaceinstance-tokenview-25557)
+> 
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-52839) "amount" [TokenView](#type-qualifiedretroactiveinterfaceinstance-tokenview-25557) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> 
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-52839) "owner" [TokenView](#type-qualifiedretroactiveinterfaceinstance-tokenview-25557) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+## Functions
+
+<a name="function-qualifiedretroactiveinterfaceinstance-setamount-51253"></a>[setAmount](#function-qualifiedretroactiveinterfaceinstance-setamount-51253)
+
+> : [Implements](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077) t [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978) =\> t -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978)
+
+<a name="function-qualifiedretroactiveinterfaceinstance-splitimpl-65579"></a>[splitImpl](#function-qualifiedretroactiveinterfaceinstance-splitimpl-65579)
+
+> : [Implements](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077) t [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978) =\> t -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978))
+
+<a name="function-qualifiedretroactiveinterfaceinstance-transferimpl-9125"></a>[transferImpl](#function-qualifiedretroactiveinterfaceinstance-transferimpl-9125)
+
+> : [Implements](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077) t [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978) =\> t -\> [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978))
+
+<a name="function-qualifiedretroactiveinterfaceinstance-noopimpl-17100"></a>[noopImpl](#function-qualifiedretroactiveinterfaceinstance-noopimpl-17100)
+
+> : [Implements](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077) t [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978) =\> t -\> () -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ()

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.md
@@ -38,6 +38,8 @@
 > 
 > * **Method transferImpl :** [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978))
 
+> * **interface instance** [Token](#type-qualifiedretroactiveinterfaceinstance-token-43978) **for** Asset
+
 ## Data Types
 
 <a name="type-qualifiedretroactiveinterfaceinstance-tokenview-25557"></a>**data** [TokenView](#type-qualifiedretroactiveinterfaceinstance-tokenview-25557)

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
@@ -72,6 +72,8 @@ Interfaces
   
   + **Method transferImpl \:** `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_)
 
+  + **interface instance** `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_ **for** Asset
+
 Data Types
 ^^^^^^^^^^
 

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
@@ -10,6 +10,8 @@ Interfaces
 
 **interface** `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_
 
+  **viewtype** `TokenView <type-qualifiedretroactiveinterfaceinstance-tokenview-25557_>`_
+  
   + **Choice GetRich**
     
     .. list-table::

--- a/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/QualifiedRetroactiveInterfaceInstance.EXPECTED.rst
@@ -1,0 +1,127 @@
+.. _module-qualifiedretroactiveinterfaceinstance-76052:
+
+Module QualifiedRetroactiveInterfaceInstance
+--------------------------------------------
+
+Interfaces
+^^^^^^^^^^
+
+.. _type-qualifiedretroactiveinterfaceinstance-token-43978:
+
+**interface** `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_
+
+  + **Choice GetRich**
+    
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - byHowMuch
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - 
+  
+  + **Choice Noop**
+    
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - nothing
+         - ()
+         - 
+  
+  + **Choice Split**
+    
+    An interface choice comment\.
+    
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - splitAmount
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - A choice field comment\.
+  
+  + **Choice Transfer**
+    
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - newOwner
+         - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+         - 
+  
+  + **Method noopImpl \:** () \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ ()
+  
+  + **Method setAmount \:** `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_
+  
+  + **Method splitImpl \:** `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_)
+  
+  + **Method transferImpl \:** `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_)
+
+Data Types
+^^^^^^^^^^
+
+.. _type-qualifiedretroactiveinterfaceinstance-tokenview-25557:
+
+**data** `TokenView <type-qualifiedretroactiveinterfaceinstance-tokenview-25557_>`_
+
+  .. _constr-qualifiedretroactiveinterfaceinstance-tokenview-72346:
+  
+  `TokenView <constr-qualifiedretroactiveinterfaceinstance-tokenview-72346_>`_
+  
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - owner
+         - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+         - 
+       * - amount
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - 
+  
+  **instance** `HasInterfaceView <https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_ `TokenView <type-qualifiedretroactiveinterfaceinstance-tokenview-25557_>`_
+  
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-52839>`_ \"amount\" `TokenView <type-qualifiedretroactiveinterfaceinstance-tokenview-25557_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-52839>`_ \"owner\" `TokenView <type-qualifiedretroactiveinterfaceinstance-tokenview-25557_>`_ `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+
+Functions
+^^^^^^^^^
+
+.. _function-qualifiedretroactiveinterfaceinstance-setamount-51253:
+
+`setAmount <function-qualifiedretroactiveinterfaceinstance-setamount-51253_>`_
+  \: `Implements <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077>`_ t `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_ \=\> t \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_
+
+.. _function-qualifiedretroactiveinterfaceinstance-splitimpl-65579:
+
+`splitImpl <function-qualifiedretroactiveinterfaceinstance-splitimpl-65579_>`_
+  \: `Implements <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077>`_ t `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_ \=\> t \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_)
+
+.. _function-qualifiedretroactiveinterfaceinstance-transferimpl-9125:
+
+`transferImpl <function-qualifiedretroactiveinterfaceinstance-transferimpl-9125_>`_
+  \: `Implements <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077>`_ t `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_ \=\> t \-\> `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_)
+
+.. _function-qualifiedretroactiveinterfaceinstance-noopimpl-17100:
+
+`noopImpl <function-qualifiedretroactiveinterfaceinstance-noopimpl-17100_>`_
+  \: `Implements <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077>`_ t `Token <type-qualifiedretroactiveinterfaceinstance-token-43978_>`_ \=\> t \-\> () \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ ()

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
@@ -1,0 +1,74 @@
+# <a name="module-retroactiveinterfaceinstance-60009"></a>Module RetroactiveInterfaceInstance
+
+## Interfaces
+
+<a name="type-retroactiveinterfaceinstance-token-49693"></a>**interface** [Token](#type-retroactiveinterfaceinstance-token-49693)
+
+> * **Choice GetRich**
+>   
+>   | Field                                                                          | Type                                                                           | Description |
+>   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+>   | byHowMuch                                                                      | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) |  |
+> 
+> * **Choice Noop**
+>   
+>   | Field   | Type    | Description |
+>   | :------ | :------ | :---------- |
+>   | nothing | ()      |  |
+> 
+> * **Choice Split**
+>   
+>   An interface choice comment.
+>   
+>   | Field                                                                          | Type                                                                           | Description |
+>   | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+>   | splitAmount                                                                    | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) | A choice field comment. |
+> 
+> * **Choice Transfer**
+>   
+>   | Field                                                                                   | Type                                                                                    | Description |
+>   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+>   | newOwner                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> 
+> * **Method noopImpl :** () -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ()
+> 
+> * **Method setAmount :** [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Token](#type-retroactiveinterfaceinstance-token-49693)
+> 
+> * **Method splitImpl :** [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693))
+> 
+> * **Method transferImpl :** [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693))
+
+## Data Types
+
+<a name="type-retroactiveinterfaceinstance-tokenview-57374"></a>**data** [TokenView](#type-retroactiveinterfaceinstance-tokenview-57374)
+
+> <a name="constr-retroactiveinterfaceinstance-tokenview-95763"></a>[TokenView](#constr-retroactiveinterfaceinstance-tokenview-95763)
+> 
+> > | Field                                                                                   | Type                                                                                    | Description |
+> > | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+> > | owner                                                                                   | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |  |
+> > | amount                                                                                  | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)          |  |
+> 
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) [Token](#type-retroactiveinterfaceinstance-token-49693) [TokenView](#type-retroactiveinterfaceinstance-tokenview-57374)
+> 
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-52839) "amount" [TokenView](#type-retroactiveinterfaceinstance-tokenview-57374) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> 
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-52839) "owner" [TokenView](#type-retroactiveinterfaceinstance-tokenview-57374) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+## Functions
+
+<a name="function-retroactiveinterfaceinstance-setamount-92750"></a>[setAmount](#function-retroactiveinterfaceinstance-setamount-92750)
+
+> : [Implements](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077) t [Token](#type-retroactiveinterfaceinstance-token-49693) =\> t -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Token](#type-retroactiveinterfaceinstance-token-49693)
+
+<a name="function-retroactiveinterfaceinstance-splitimpl-44512"></a>[splitImpl](#function-retroactiveinterfaceinstance-splitimpl-44512)
+
+> : [Implements](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077) t [Token](#type-retroactiveinterfaceinstance-token-49693) =\> t -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693), [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693))
+
+<a name="function-retroactiveinterfaceinstance-transferimpl-49252"></a>[transferImpl](#function-retroactiveinterfaceinstance-transferimpl-49252)
+
+> : [Implements](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077) t [Token](#type-retroactiveinterfaceinstance-token-49693) =\> t -\> [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693))
+
+<a name="function-retroactiveinterfaceinstance-noopimpl-82337"></a>[noopImpl](#function-retroactiveinterfaceinstance-noopimpl-82337)
+
+> : [Implements](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077) t [Token](#type-retroactiveinterfaceinstance-token-49693) =\> t -\> () -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ()

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
@@ -38,6 +38,8 @@
 > 
 > * **Method transferImpl :** [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) [Token](#type-retroactiveinterfaceinstance-token-49693))
 
+> * **interface instance** [Token](#type-retroactiveinterfaceinstance-token-49693) **for** Asset
+
 ## Data Types
 
 <a name="type-retroactiveinterfaceinstance-tokenview-57374"></a>**data** [TokenView](#type-retroactiveinterfaceinstance-tokenview-57374)

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.md
@@ -4,6 +4,8 @@
 
 <a name="type-retroactiveinterfaceinstance-token-49693"></a>**interface** [Token](#type-retroactiveinterfaceinstance-token-49693)
 
+> **viewtype** [TokenView](#type-retroactiveinterfaceinstance-tokenview-57374)
+> 
 > * **Choice GetRich**
 >   
 >   | Field                                                                          | Type                                                                           | Description |

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
@@ -1,0 +1,127 @@
+.. _module-retroactiveinterfaceinstance-60009:
+
+Module RetroactiveInterfaceInstance
+-----------------------------------
+
+Interfaces
+^^^^^^^^^^
+
+.. _type-retroactiveinterfaceinstance-token-49693:
+
+**interface** `Token <type-retroactiveinterfaceinstance-token-49693_>`_
+
+  + **Choice GetRich**
+    
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - byHowMuch
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - 
+  
+  + **Choice Noop**
+    
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - nothing
+         - ()
+         - 
+  
+  + **Choice Split**
+    
+    An interface choice comment\.
+    
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - splitAmount
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - A choice field comment\.
+  
+  + **Choice Transfer**
+    
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - newOwner
+         - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+         - 
+  
+  + **Method noopImpl \:** () \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ ()
+  
+  + **Method setAmount \:** `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Token <type-retroactiveinterfaceinstance-token-49693_>`_
+  
+  + **Method splitImpl \:** `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_)
+  
+  + **Method transferImpl \:** `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_)
+
+Data Types
+^^^^^^^^^^
+
+.. _type-retroactiveinterfaceinstance-tokenview-57374:
+
+**data** `TokenView <type-retroactiveinterfaceinstance-tokenview-57374_>`_
+
+  .. _constr-retroactiveinterfaceinstance-tokenview-95763:
+  
+  `TokenView <constr-retroactiveinterfaceinstance-tokenview-95763_>`_
+  
+    .. list-table::
+       :widths: 15 10 30
+       :header-rows: 1
+    
+       * - Field
+         - Type
+         - Description
+       * - owner
+         - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+         - 
+       * - amount
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+         - 
+  
+  **instance** `HasInterfaceView <https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_ `TokenView <type-retroactiveinterfaceinstance-tokenview-57374_>`_
+  
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-52839>`_ \"amount\" `TokenView <type-retroactiveinterfaceinstance-tokenview-57374_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_
+  
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-52839>`_ \"owner\" `TokenView <type-retroactiveinterfaceinstance-tokenview-57374_>`_ `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_
+
+Functions
+^^^^^^^^^
+
+.. _function-retroactiveinterfaceinstance-setamount-92750:
+
+`setAmount <function-retroactiveinterfaceinstance-setamount-92750_>`_
+  \: `Implements <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077>`_ t `Token <type-retroactiveinterfaceinstance-token-49693_>`_ \=\> t \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Token <type-retroactiveinterfaceinstance-token-49693_>`_
+
+.. _function-retroactiveinterfaceinstance-splitimpl-44512:
+
+`splitImpl <function-retroactiveinterfaceinstance-splitimpl-44512_>`_
+  \: `Implements <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077>`_ t `Token <type-retroactiveinterfaceinstance-token-49693_>`_ \=\> t \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_, `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_)
+
+.. _function-retroactiveinterfaceinstance-transferimpl-49252:
+
+`transferImpl <function-retroactiveinterfaceinstance-transferimpl-49252_>`_
+  \: `Implements <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077>`_ t `Token <type-retroactiveinterfaceinstance-token-49693_>`_ \=\> t \-\> `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_)
+
+.. _function-retroactiveinterfaceinstance-noopimpl-82337:
+
+`noopImpl <function-retroactiveinterfaceinstance-noopimpl-82337_>`_
+  \: `Implements <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-interface-implements-92077>`_ t `Token <type-retroactiveinterfaceinstance-token-49693_>`_ \=\> t \-\> () \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ ()

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
@@ -10,6 +10,8 @@ Interfaces
 
 **interface** `Token <type-retroactiveinterfaceinstance-token-49693_>`_
 
+  **viewtype** `TokenView <type-retroactiveinterfaceinstance-tokenview-57374_>`_
+  
   + **Choice GetRich**
     
     .. list-table::

--- a/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/RetroactiveInterfaceInstance.EXPECTED.rst
@@ -72,6 +72,8 @@ Interfaces
   
   + **Method transferImpl \:** `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932>`_ \-\> `Update <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072>`_ (`ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282>`_ `Token <type-retroactiveinterfaceinstance-token-49693_>`_)
 
+  + **interface instance** `Token <type-retroactiveinterfaceinstance-token-49693_>`_ **for** Asset
+
 Data Types
 ^^^^^^^^^^
 


### PR DESCRIPTION
Closes #14780 