### PR TITLE
Add damlc internal command `debug-ide-span-info`

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -18,8 +18,8 @@ load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 load("//bazel_tools/ghc-lib:repositories.bzl", "ghc_lib_and_dependencies")
 
-GHCIDE_REV = "0572146d4b792c6c67affe461e0bd07d49d9df72"
-GHCIDE_SHA256 = "7de56b15d08eab19d325a93c4f43d0ca3d634bb1a1fdc0d18fe4ab4a021cc697"
+GHCIDE_REV = "d54267ac4ee420e31de7e387822a67df5ec58d99"
+GHCIDE_SHA256 = "be236e684c3799951074bde26381a763e50752ff5b0362feede25a52c38ab60e"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"
 JS_FLOT_VERSION = "0.8.3"

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -3,6 +3,7 @@
 module Development.IDE.Core.Rules.Daml
     ( module Development.IDE.Core.Rules
     , module Development.IDE.Core.Rules.Daml
+    , module Development.IDE.Core.Rules.Daml.SpanInfo
     ) where
 
 import Outputable (showSDoc)
@@ -103,6 +104,8 @@ import qualified DA.Pretty as Pretty
 import SdkVersion (damlStdlib)
 
 import Language.Haskell.HLint4
+
+import Development.IDE.Core.Rules.Daml.SpanInfo
 
 -- | Get thr URI that corresponds to a virtual resource. The VS Code has a
 -- document provider that will handle our special documents.

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml/SpanInfo.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml/SpanInfo.hs
@@ -1,0 +1,107 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Development.IDE.Core.Rules.Daml.SpanInfo
+    ( SpansInfo (..)
+    , SpanInfo (..)
+    , SpanType (..)
+    , SpanSource (..)
+    , SpanDoc (..)
+    , getSpanInfo
+    ) where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import Development.IDE.Core.Shake (use_)
+import Development.IDE.Types.Location (NormalizedFilePath)
+import Development.Shake (Action)
+import GHC.Generics (Generic)
+
+import "ghc-lib-parser" DynFlags (DynFlags)
+import "ghc-lib-parser" Outputable (showPpr)
+import "ghc-lib-parser" TyCoRep (Type)
+
+import qualified Data.Text as T
+import qualified Development.IDE.Core.RuleTypes as IDE
+import qualified Development.IDE.Spans.Common as IDE
+import qualified Development.IDE.Spans.Type as IDE
+
+getSpanInfo :: DynFlags -> NormalizedFilePath -> Action SpansInfo
+getSpanInfo dflags inputFile =
+  convertSpansInfo dflags <$> use_ IDE.GetSpanInfo inputFile
+
+convertSpansInfo :: DynFlags -> IDE.SpansInfo -> SpansInfo
+convertSpansInfo dflags = convertSpansInfo'
+  where
+    convertSpansInfo' :: IDE.SpansInfo -> SpansInfo
+    convertSpansInfo' spansInfo = SpansInfo
+      { expressions = convertSpanInfo <$> IDE.spansExprs spansInfo
+      , constraints = convertSpanInfo <$> IDE.spansConstraints spansInfo
+      }
+
+    convertSpanInfo :: IDE.SpanInfo -> SpanInfo
+    convertSpanInfo spanInfo = SpanInfo
+      { startLine = IDE.spaninfoStartLine spanInfo
+      , startCol = IDE.spaninfoStartCol spanInfo
+      , endLine = IDE.spaninfoEndLine spanInfo
+      , endCol = IDE.spaninfoEndCol spanInfo
+      , type_ = convertSpanType (IDE.spaninfoType spanInfo)
+      , source = convertSpanSource (IDE.spaninfoSource spanInfo)
+      , doc = convertSpanDoc (IDE.spaninfoDocs spanInfo)
+      }
+
+    convertSpanType :: Maybe Type -> SpanType
+    convertSpanType = SpanType . \case
+      Nothing -> "<missing>"
+      Just ty -> T.pack (showPpr dflags ty)
+
+    convertSpanSource :: IDE.SpanSource -> SpanSource
+    convertSpanSource = \case
+      IDE.Named name -> Named (T.pack (showPpr dflags name))
+      IDE.SpanS span -> Span (T.pack (showPpr dflags span))
+      IDE.Lit lit -> Lit (T.pack lit)
+      IDE.NoSource -> NoSource
+
+    convertSpanDoc :: IDE.SpanDoc -> SpanDoc
+    convertSpanDoc = SpanDoc . \case
+      IDE.SpanDocString ds -> T.lines (T.pack (showPpr dflags ds))
+      IDE.SpanDocText ts -> ts
+
+data SpansInfo = SpansInfo
+  { expressions :: ![SpanInfo]
+  , constraints :: ![SpanInfo]
+  }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data SpanInfo = SpanInfo
+  { startLine :: !Int
+  , startCol :: !Int
+  , endLine :: !Int
+  , endCol :: !Int
+  , type_ :: !SpanType
+  , source :: !SpanSource
+  , doc :: !SpanDoc
+  }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+newtype SpanType = SpanType Text
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (FromJSON, ToJSON)
+
+data SpanSource
+  = Named !Text
+  | Span !Text
+  | Lit !Text
+  | NoSource
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+newtype SpanDoc = SpanDoc [Text]
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (FromJSON, ToJSON)


### PR DESCRIPTION
daml-ghcide PR: https://github.com/digital-asset/daml-ghcide/pull/22

This PR adds an internal command `debug-ide-span-info` to `damlc`. The purpose of this is to aid in debugging the 'text on hover' and 'jump to definition' features of the IDE without needing to actually run the IDE. Since it's for internal consumption, the output is just a JSON object.

Originally I was thinking of adding golden tests for the output of this command, but a simple file easily results in a ~10k line output so I decided against that.