### PR TITLE
14796 front end change

### DIFF
--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/data/CommandRow.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/data/CommandRow.scala
@@ -24,6 +24,7 @@ final case class CommandRow(
     template: Option[String],
     recordArgument: Option[String],
     contractId: Option[String],
+    interfaceId: Option[String],
     choice: Option[String],
     argumentValue: Option[String],
 ) {
@@ -58,6 +59,7 @@ final case class CommandRow(
         (for {
           tp <- Try(template.get)
           tid <- Try(parseOpaqueIdentifier(tp).get)
+          iidOp <- Try(interfaceId.map(parseOpaqueIdentifier(_).get))
           t <- Try(types.template(tid).get)
           cId <- Try(contractId.get)
           ch <- Try(choice.get)
@@ -72,6 +74,7 @@ final case class CommandRow(
             Instant.parse(platformTime),
             ApiTypes.ContractId(cId),
             tid,
+            iidOp,
             ApiTypes.Choice(ch),
             arg,
           )
@@ -103,6 +106,7 @@ object CommandRow {
           None,
           None,
           None,
+          None,
         )
       case e: ExerciseCommand =>
         CommandRow(
@@ -114,6 +118,7 @@ object CommandRow {
           Some(e.template.asOpaqueString),
           None,
           Some(e.contract.unwrap),
+          e.interfaceId.map(_.asOpaqueString),
           Some(e.choice.unwrap),
           Some(ApiCodecVerbose.apiValueToJsValue(e.argument).compactPrint),
         )

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/graphql/GraphQLSchema.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/graphql/GraphQLSchema.scala
@@ -166,6 +166,11 @@ final class GraphQLSchema(customEndpoints: Set[CustomEndpoint[_]]) {
       ),
       Field("parameter", JsonType.DamlLfTypeType, resolve = _.value.parameter),
       Field("consuming", BooleanType, resolve = _.value.consuming),
+      Field(
+        "inheritedInterface",
+        OptionType(StringType),
+        resolve = _.value.inheritedInterface.map(_.asOpaqueString),
+      ),
     ),
   )
 
@@ -195,6 +200,11 @@ final class GraphQLSchema(customEndpoints: Set[CustomEndpoint[_]]) {
             SearchArg :: FilterArg :: IncludeArchivedArg :: CountArg :: StartArg :: SortArg :: Nil,
           resolve = context =>
             buildTemplateContractPager(context).fetch(context.ctx.ledger, context.ctx.templates),
+        ),
+        Field(
+          "implementedInterfaces",
+          ListType(StringType),
+          resolve = _.value.implementedInterfaces.toList.map(_.asOpaqueString),
         ),
       ),
   )

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/graphql/GraphQLSchema.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/graphql/GraphQLSchema.scala
@@ -509,6 +509,11 @@ final class GraphQLSchema(customEndpoints: Set[CustomEndpoint[_]]) {
           resolve = context => Tag.unwrap[String, ApiTypes.ContractIdTag](context.value.contract),
         ),
         Field(
+          "interfaceId",
+          OptionType(StringType),
+          resolve = _.value.interfaceId.map(_.asOpaqueString),
+        ),
+        Field(
           "choice",
           StringType,
           resolve = context => Tag.unwrap[String, ApiTypes.ChoiceTag](context.value.choice),
@@ -718,6 +723,7 @@ final class GraphQLSchema(customEndpoints: Set[CustomEndpoint[_]]) {
   val TemplateIdArgument = Argument("templateId", IDType)
   val ContractIdArgument = Argument("contractId", IDType)
   val ChoiceIdArgument = Argument("choiceId", IDType)
+  val InterfaceIdArgument = Argument("interfaceId", OptionInputType(IDType))
   val AnyArgument = Argument("argument", OptionInputType(JsonType.ApiValueType))
 
   val MutationType = ObjectType(
@@ -748,11 +754,13 @@ final class GraphQLSchema(customEndpoints: Set[CustomEndpoint[_]]) {
       Field(
         "exercise",
         CommandIdType,
-        arguments = ContractIdArgument :: ChoiceIdArgument :: AnyArgument :: Nil,
+        arguments =
+          ContractIdArgument :: InterfaceIdArgument :: ChoiceIdArgument :: AnyArgument :: Nil,
         resolve = context => {
           val command = ExerciseChoice(
             context.ctx.party,
             ApiTypes.ContractId(context.arg(ContractIdArgument)),
+            context.arg(InterfaceIdArgument).map(InterfaceStringId(_)),
             ApiTypes.Choice(context.arg(ChoiceIdArgument)),
             context.arg(AnyArgument).orNull,
           )

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Model.scala
@@ -87,6 +87,7 @@ final case class ExerciseCommand(
     platformTime: Instant,
     contract: ApiTypes.ContractId,
     template: DamlLfIdentifier,
+    interfaceId: Option[DamlLfIdentifier],
     choice: ApiTypes.Choice,
     argument: ApiValue,
 ) extends Command

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/package.scala
@@ -19,6 +19,9 @@ package object model extends NavigatorModelAliases[String] {
   type TemplateStringId = String @@ TemplateStringIdTag
   val TemplateStringId = Tag.of[TemplateStringIdTag]
 
+  type InterfaceStringId = String @@ InterfaceStringIdTag
+  val InterfaceStringId = Tag.of[InterfaceStringIdTag]
+
   // ----------------------------------------------------------------------------------------------
   // Types used in the ledger API
   // ----------------------------------------------------------------------------------------------
@@ -100,11 +103,14 @@ package object model extends NavigatorModelAliases[String] {
     }
   }
 
-  def parseOpaqueIdentifier(id: TemplateStringId): Option[DamlLfRef.Identifier] =
+  def parseTemplateOpaqueIdentifier(id: TemplateStringId): Option[DamlLfRef.Identifier] =
     parseOpaqueIdentifier(TemplateStringId.unwrap(id))
 
+  def parseInterfaceOpaqueIdentifier(id: InterfaceStringId): Option[DamlLfRef.Identifier] =
+    parseOpaqueIdentifier(InterfaceStringId.unwrap(id))
 }
 
 package model {
   sealed trait TemplateStringIdTag
+  sealed trait InterfaceStringIdTag
 }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
@@ -48,6 +48,7 @@ object Store {
   case class ExerciseChoice(
       party: PartyState,
       contractId: ApiTypes.ContractId,
+      interfaceId: Option[InterfaceStringId],
       choiceId: ApiTypes.Choice,
       argument: ApiValue,
   )

--- a/navigator/backend/src/test/resources/schema.graphql
+++ b/navigator/backend/src/test/resources/schema.graphql
@@ -2,6 +2,7 @@ type Choice {
   name: String!
   parameter: DamlLfType!
   consuming: Boolean!
+  inheritedInterface: String
 }
 
 interface Command {
@@ -202,6 +203,7 @@ type Template implements Node & DamlLfNode {
   parameterDef: DamlLfDefDataType!
   choices: [Choice!]!
   contracts(search: String, filter: [FilterCriterion!], includeArchived: Boolean, count: Int, start: String, sort: [SortCriterion!]): ContractPagination!
+  implementedInterfaces: [String!]!
 }
 
 type TemplateEdge {

--- a/navigator/backend/src/test/resources/schema.graphql
+++ b/navigator/backend/src/test/resources/schema.graphql
@@ -127,6 +127,7 @@ interface Event {
 type ExerciseCommand implements Node & Command {
   contract: Contract
   contractId: String!
+  interfaceId: String
   choice: String!
   argument: DamlLfValue!
 }
@@ -161,7 +162,7 @@ type LedgerTime {
 type Mutation {
   advanceTime(time: Time!): LedgerTime!
   create(templateId: ID!, argument: DamlLfValue): CommandId!
-  exercise(contractId: ID!, choiceId: ID!, argument: DamlLfValue): CommandId!
+  exercise(contractId: ID!, interfaceId: ID, choiceId: ID!, argument: DamlLfValue): CommandId!
 }
 
 interface Node {

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/data/RowSpec.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/data/RowSpec.scala
@@ -52,6 +52,7 @@ class RowSpec extends AnyWordSpec with Matchers {
         Instant.EPOCH,
         ApiTypes.ContractId("#0:0"),
         C.complexRecordId,
+        Some(C.complexRecordId),
         ApiTypes.Choice("text"),
         C.simpleTextV,
       )

--- a/navigator/frontend/src/api/Queries.ts
+++ b/navigator/frontend/src/api/Queries.ts
@@ -68,6 +68,7 @@ export interface ContractExercise {
 
 export interface ContractExerciseVariables {
   contractId: string;
+  interfaceId?: string | null;
   choiceId: string;
   argument?: OpaqueTypes.DamlLfValue | null;
 }
@@ -100,6 +101,7 @@ export interface ContractsQuery_contracts_edges_node_archiveEvent {
 export interface ContractsQuery_contracts_edges_node_template_choices {
   __typename: "Choice";
   name: string;
+  inheritedInterface: string | null;
 }
 
 export interface ContractsQuery_contracts_edges_node_template {
@@ -238,6 +240,7 @@ export interface ContractsByTemplateQuery_node_Contract {
 export interface ContractsByTemplateQuery_node_Template_choices {
   __typename: "Choice";
   name: string;
+  inheritedInterface: string | null;
 }
 
 export interface ContractsByTemplateQuery_node_Template_contracts_edges_node_createEvent_transaction {
@@ -259,6 +262,7 @@ export interface ContractsByTemplateQuery_node_Template_contracts_edges_node_arc
 export interface ContractsByTemplateQuery_node_Template_contracts_edges_node_template_choices {
   __typename: "Choice";
   name: string;
+  inheritedInterface: string | null;
 }
 
 export interface ContractsByTemplateQuery_node_Template_contracts_edges_node_template {

--- a/navigator/frontend/src/api/Queries.ts
+++ b/navigator/frontend/src/api/Queries.ts
@@ -21,6 +21,7 @@ export interface ContractDetailsById_node_Contract_template_choices {
   __typename: "Choice";
   name: string;
   parameter: OpaqueTypes.DamlLfType;
+  inheritedInterface: string | null;
 }
 
 export interface ContractDetailsById_node_Contract_template {
@@ -325,6 +326,7 @@ export interface TemplatesQuery_templates_edges_node_contracts {
 export interface TemplatesQuery_templates_edges_node {
   __typename: "Template";
   id: string;
+  implementedInterfaces: string[];
   topLevelDecl: string;
   contracts: TemplatesQuery_templates_edges_node_contracts;
 }

--- a/navigator/frontend/src/applets/contract/ContractComponent.tsx
+++ b/navigator/frontend/src/applets/contract/ContractComponent.tsx
@@ -125,8 +125,8 @@ interface Props {
 export default (props: Props): JSX.Element => {
   const toInterfaceModuleAndEntity = (interfaceId: string): string => {
     const matches = interfaceId.match(/^([^:@]+):([^:@]+)@([^:@]+)$/);
-    return matches ? `${matches[1]}:${matches[2]}` : interfaceId
-  }
+    return matches ? `${matches[1]}:${matches[2]}` : interfaceId;
+  };
 
   const { contract, choice, ifc, exercise, choiceLoading, error } = props;
   const choices = contract.template.choices;
@@ -135,8 +135,10 @@ export default (props: Props): JSX.Element => {
   let selectedChoice;
 
   if (choice) {
-    selectedChoice = choices.filter(({ name, inheritedInterface }) =>
-      name === choice && ( ifc ? inheritedInterface === ifc : !inheritedInterface )
+    selectedChoice = choices.filter(
+      ({ name, inheritedInterface }) =>
+        name === choice &&
+        (ifc ? inheritedInterface === ifc : !inheritedInterface),
     )[0];
     const parameter = selectedChoice.parameter;
 
@@ -152,10 +154,14 @@ export default (props: Props): JSX.Element => {
   }
 
   const choicesEl = choices.map(({ name, inheritedInterface }) => {
-    const interfacePrefix = inheritedInterface ? toInterfaceModuleAndEntity(inheritedInterface) + ":" : "";
-    const fullChoiceName = `${interfacePrefix}${name}`
+    const interfacePrefix = inheritedInterface
+      ? toInterfaceModuleAndEntity(inheritedInterface) + ":"
+      : "";
+    const fullChoiceName = `${interfacePrefix}${name}`;
     const isAnyActive = choice !== undefined;
-    const isActive = name === choice && ( ifc ? inheritedInterface === ifc : !inheritedInterface );
+    const isActive =
+      name === choice &&
+      (ifc ? inheritedInterface === ifc : !inheritedInterface);
     return (
       <ChoiceLink
         key={fullChoiceName}
@@ -193,14 +199,14 @@ export default (props: Props): JSX.Element => {
             </Truncate>
           </Breadcrumbs>
         </div>
-        { choice && selectedChoice && selectedChoice.inheritedInterface && (<div>
-          <Breadcrumbs>
-            Interface
-            <Truncate>
-              {selectedChoice.inheritedInterface}
-            </Truncate>
-          </Breadcrumbs>
-        </div>)}
+        {choice && selectedChoice && selectedChoice.inheritedInterface && (
+          <div>
+            <Breadcrumbs>
+              Interface
+              <Truncate>{selectedChoice.inheritedInterface}</Truncate>
+            </Breadcrumbs>
+          </div>
+        )}
         <p>{isArchived ? "ARCHIVED" : null}</p>
         <ColumnContainer>
           <Column>

--- a/navigator/frontend/src/applets/contract/index.tsx
+++ b/navigator/frontend/src/applets/contract/index.tsx
@@ -186,6 +186,7 @@ const query = gql`
           choices {
             name
             parameter
+            inheritedInterface
           }
         }
       }

--- a/navigator/frontend/src/applets/contract/index.tsx
+++ b/navigator/frontend/src/applets/contract/index.tsx
@@ -38,13 +38,15 @@ export const setError = (error: string): Action => ({
 export interface State {
   id: string;
   choice?: string;
+  ifc?: string;
   choiceLoading: boolean;
   error?: string;
 }
 
-export const init = (id: string, choice?: string): State => ({
+export const init = (id: string, choice?: string, ifc?: string): State => ({
   id,
   choice,
+  ifc,
   choiceLoading: false,
 });
 
@@ -158,6 +160,7 @@ class Component extends React.Component<Props, {}> {
         <ContractComponent
           contract={contract}
           choice={state.choice}
+          ifc={state.ifc}
           choiceLoading={state.choiceLoading}
           error={state.error}
           exercise={this.exercise}

--- a/navigator/frontend/src/applets/contracts/columns.tsx
+++ b/navigator/frontend/src/applets/contracts/columns.tsx
@@ -46,10 +46,14 @@ export const columns: ContractColumn<Contract>[] = [
     createCell: ({ cellData }) => (
       <ChoicesButton
         contract={cellData}
-        renderLink={(id, name) => (
+        renderLink={(id, name, inheritedInterface) => (
           <Link
             route={Routes.contract}
-            params={{ id: encodeURIComponent(id), choice: name }}>
+            params={{
+              id: encodeURIComponent(id),
+              choice: name,
+              ifc: inheritedInterface && encodeURIComponent(inheritedInterface),
+            }}>
             <div>{name}</div>
           </Link>
         )}

--- a/navigator/frontend/src/applets/contracts/data.tsx
+++ b/navigator/frontend/src/applets/contracts/data.tsx
@@ -49,6 +49,7 @@ export const query: DocumentNode = gql`
               id
               choices {
                 name
+                inheritedInterface
               }
             }
           }

--- a/navigator/frontend/src/applets/customview/index.tsx
+++ b/navigator/frontend/src/applets/customview/index.tsx
@@ -231,10 +231,16 @@ ColumnConfig<any, any>[] {
                 return (
                   <ChoicesButton
                     contract={props.rowData}
-                    renderLink={(id, name) => (
+                    renderLink={(id, name, inheritedInterface) => (
                       <Link
                         route={Routes.contract}
-                        params={{ id: encodeURIComponent(id), choice: name }}>
+                        params={{
+                          id: encodeURIComponent(id),
+                          choice: name,
+                          ifc:
+                            inheritedInterface &&
+                            encodeURIComponent(inheritedInterface),
+                        }}>
                         <div>{name}</div>
                       </Link>
                     )}

--- a/navigator/frontend/src/applets/templatecontracts/columns.tsx
+++ b/navigator/frontend/src/applets/templatecontracts/columns.tsx
@@ -57,10 +57,14 @@ export default (param: DamlLfRecord): ContractColumn<Contract>[] => [
     createCell: ({ cellData }) => (
       <ChoicesButton
         contract={cellData}
-        renderLink={(id, name) => (
+        renderLink={(id, name, inheritedInterface) => (
           <Link
             route={Routes.contract}
-            params={{ id: encodeURIComponent(id), choice: name }}>
+            params={{
+              id: encodeURIComponent(id),
+              choice: name,
+              ifc: inheritedInterface && encodeURIComponent(inheritedInterface),
+            }}>
             <div>{name}</div>
           </Link>
         )}

--- a/navigator/frontend/src/applets/templatecontracts/data.tsx
+++ b/navigator/frontend/src/applets/templatecontracts/data.tsx
@@ -46,6 +46,7 @@ export const query: DocumentNode = gql`
         id
         choices {
           name
+          inheritedInterface
         }
         contracts(
           search: $search
@@ -73,6 +74,7 @@ export const query: DocumentNode = gql`
                   id
                   choices {
                     name
+                    inheritedInterface
                   }
                 }
               }

--- a/navigator/frontend/src/applets/templates/data.tsx
+++ b/navigator/frontend/src/applets/templates/data.tsx
@@ -25,6 +25,7 @@ export const query: DocumentNode = gql`
         node {
           __typename
           id
+          implementedInterfaces
           ... on Template {
             topLevelDecl
             contracts {

--- a/navigator/frontend/src/routes/index.ts
+++ b/navigator/frontend/src/routes/index.ts
@@ -58,7 +58,7 @@ export const contract = new Route<ContractParams, Action, State>(
       state: Contract.init(
         decodeURIComponent(id),
         choice,
-       ifc && decodeURIComponent(ifc)
+        ifc && decodeURIComponent(ifc),
       ),
     }),
   ({ page }: State) => {

--- a/navigator/frontend/src/routes/index.ts
+++ b/navigator/frontend/src/routes/index.ts
@@ -48,14 +48,18 @@ export const contracts = new Route<{}, Action, State>(
   ({ page }: State) => (page.type === "contracts" ? {} : undefined),
 );
 
-type ContractParams = { id: string; choice?: string };
+type ContractParams = { id: string; choice?: string; ifc?: string };
 
 export const contract = new Route<ContractParams, Action, State>(
-  "/contracts/:id(/)(:choice)",
-  ({ id, choice }) =>
+  "/contracts/:id(/)(:choice)(/)(:ifc)",
+  ({ id, choice, ifc }) =>
     set({
       type: "contract",
-      state: Contract.init(decodeURIComponent(id), choice),
+      state: Contract.init(
+        decodeURIComponent(id),
+        choice,
+       ifc && decodeURIComponent(ifc)
+      ),
     }),
   ({ page }: State) => {
     if (page.type === "contract") {

--- a/navigator/frontend/src/ui-core/src/ChoicesButton/index.tsx
+++ b/navigator/frontend/src/ui-core/src/ChoicesButton/index.tsx
@@ -10,6 +10,7 @@ import Truncate from "../Truncate";
 
 export interface Choice {
   name: string;
+  inheritedInterface: string | null;
 }
 
 export interface Contract {
@@ -37,7 +38,11 @@ const ListItem = styled.li`
 interface ContentProps {
   contract: Contract;
   choices: Choice[];
-  renderLink(contractId: string, choiceName: string): React.ReactNode;
+  renderLink(
+    contractId: string,
+    choiceName: string,
+    inheritedInterface: string | null,
+  ): React.ReactNode;
 }
 
 const Content = ({ contract, choices, renderLink }: ContentProps) => {
@@ -55,7 +60,9 @@ const Content = ({ contract, choices, renderLink }: ContentProps) => {
       <List>
         {contract.template.choices.map(choice => (
           <ListItem key={choice.name}>
-            <Truncate>{renderLink(contract.id, choice.name)}</Truncate>
+            <Truncate>
+              {renderLink(contract.id, choice.name, choice.inheritedInterface)}
+            </Truncate>
           </ListItem>
         ))}
       </List>
@@ -77,7 +84,11 @@ export interface State {
 
 export interface Props {
   contract: Contract;
-  renderLink(contractId: string, choiceName: string): React.ReactNode;
+  renderLink(
+    contractId: string,
+    choiceName: string,
+    inheritedInterface: string | null,
+  ): React.ReactNode;
 }
 
 export default class ChoicesButton extends React.Component<Props, State> {


### PR DESCRIPTION
Fixes #14796 

- [x] Implement graphql schema, queries, and mutations and
- [x] In addition to template choices, render choices which inherited from the interface in contract view.
<img width="1138" alt="Screenshot 2022-08-23 at 20 07 15" src="https://user-images.githubusercontent.com/110462561/186467394-1c4e082b-0ff8-4250-b4d9-e7c43000c64f.png">

- [x] Pass in interface Id instead of templated Id when exercising choice inherited from an interface.
- [x] Render interface choices in contact list view when clicking the gear icon


```rst
changelog_begin
changelog_end
```
