### PR TITLE
2 -  In memory stores for party record and user management to support update operations [DPP-1198]

### DIFF
--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -398,10 +398,35 @@ object domain {
       value => value.unwrap
   }
 
+  final case class ObjectMeta(
+      resourceVersionO: Option[String],
+      annotations: Map[String, String],
+  )
+
+  object ObjectMeta {
+    def empty: ObjectMeta = ObjectMeta(
+      resourceVersionO = None,
+      annotations = Map.empty,
+    )
+  }
+
   final case class User(
       id: Ref.UserId,
       primaryParty: Option[Ref.Party],
+      // TODO um-for-hub: Remove default values
+      // NOTE: Do not set 'isDeactivated' and 'metadata'. These are work-in-progress features.
+      isDeactivated: Boolean = false,
+      metadata: ObjectMeta = ObjectMeta.empty,
   )
+
+  object ParticipantParty {
+
+    final case class PartyRecord(
+        party: Ref.Party,
+        metadata: ObjectMeta,
+    )
+
+  }
 
   sealed abstract class UserRight extends Product with Serializable
   object UserRight {

--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -312,6 +312,7 @@ da_scala_test_suite(
         "@maven//:ch_qos_logback_logback_core",
         "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_google_api_grpc_proto_google_common_protos",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_typesafe_config",
         "@maven//:com_zaxxer_HikariCP",
         "@maven//:commons_io_commons_io",

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiUserManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiUserManagementService.scala
@@ -199,6 +199,13 @@ private[apiserver] final class ApiUserManagementService(
             .Reject(operation, id: String)
             .asGrpcError
         )
+      case Left(UserManagementStore.ConcurrentUserUpdate(_)) =>
+        // TODO um-for-hub: Use different error code
+        Future.failed(
+          LedgerApiErrors.UnsupportedOperation
+            .Reject("Updating users is unsupported")
+            .asGrpcError
+        )
 
       case scala.util.Right(t) =>
         Future.successful(t)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/UserManagementStorageBackendImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/common/UserManagementStorageBackendImpl.scala
@@ -54,7 +54,7 @@ object UserManagementStorageBackendImpl extends UserManagementStorageBackend {
       id: UserId
   )(connection: Connection): Option[UserManagementStorageBackend.DbUserWithId] = {
     SQL"""
-       SELECT internal_id, user_id, primary_party,  created_at
+       SELECT internal_id, user_id, primary_party, created_at
        FROM participant_users
        WHERE user_id = ${id: String}
        """

--- a/ledger/participant-integration-api/src/main/scala/platform/usermanagement/CachedUserManagementStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/usermanagement/CachedUserManagementStore.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.{CompletableFuture, Executor}
 import com.daml.caching.CaffeineCache
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.domain.User
-import com.daml.ledger.participant.state.index.v2.UserManagementStore
+import com.daml.ledger.participant.state.index.v2.{UserManagementStore, UserUpdate}
 import com.daml.ledger.participant.state.index.v2.UserManagementStore.{Result, UserInfo}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.UserId
@@ -61,10 +61,18 @@ class CachedUserManagementStore(
 
   override def createUser(user: User, rights: Set[domain.UserRight])(implicit
       loggingContext: LoggingContext
-  ): Future[Result[Unit]] =
+  ): Future[Result[User]] =
     delegate
       .createUser(user, rights)
       .andThen(invalidateOnSuccess(user.id))
+
+  override def updateUser(
+      userUpdate: UserUpdate
+  )(implicit loggingContext: LoggingContext): Future[Result[User]] = {
+    delegate
+      .updateUser(userUpdate)
+      .andThen(invalidateOnSuccess(userUpdate.id))
+  }
 
   override def deleteUser(
       id: UserId

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsUserManagement.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/backend/StorageBackendTestsUserManagement.scala
@@ -7,7 +7,7 @@ import java.sql.SQLException
 import java.util.UUID
 
 import com.daml.ledger.api.domain.UserRight.{CanActAs, CanReadAs, ParticipantAdmin}
-import com.daml.ledger.api.domain.{User, UserRight}
+import com.daml.ledger.api.domain.{UserRight}
 import com.daml.lf.data.Ref
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -31,18 +31,18 @@ private[backend] trait StorageBackendTestsUserManagement
   private def tested = backend.userManagement
 
   it should "handle created_at and granted_at attributes correctly" in {
-    val user = newUniqueUser()
-    val internalId = executeSql(tested.createUser(user, createdAt = 123))
+    val user = newDbUser(createdAt = 123)
+    val internalId = executeSql(tested.createUser(user))
     executeSql(tested.addUserRight(internalId, right1, grantedAt = 234))
-    executeSql(tested.getUser(user.id)).map(_.createdAt) shouldBe Some(123)
+    executeSql(tested.getUser(user.id)).map(_.payload.createdAt) shouldBe Some(123)
     executeSql(tested.getUserRights(internalId)).headOption.map(_.grantedAt) shouldBe Some(234)
   }
 
   it should "count number of user rights per user" in {
-    val userA = newUniqueUser()
-    val userB = newUniqueUser()
-    val idA: Int = executeSql(tested.createUser(userA, createdAt = zeroMicros))
-    val idB: Int = executeSql(tested.createUser(userB, createdAt = zeroMicros))
+    val userA = newDbUser()
+    val userB = newDbUser()
+    val idA: Int = executeSql(tested.createUser(userA))
+    val idB: Int = executeSql(tested.createUser(userB))
 
     def countA: Int = executeSql(tested.countUserRights(idA))
 
@@ -118,27 +118,27 @@ private[backend] trait StorageBackendTestsUserManagement
   }
 
   it should "create user (createUser)" in {
-    val user1 = newUniqueUser()
-    val user2 = newUniqueUser()
-    val internalId1 = executeSql(tested.createUser(user1, createdAt = zeroMicros))
+    val user1 = newDbUser()
+    val user2 = newDbUser()
+    val internalId1 = executeSql(tested.createUser(user1))
     // Attempting to add a duplicate user
-    assertThrows[SQLException](executeSql(tested.createUser(user1, createdAt = zeroMicros)))
-    val internalId2 = executeSql(tested.createUser(user2, createdAt = zeroMicros))
+    assertThrows[SQLException](executeSql(tested.createUser(user1)))
+    val internalId2 = executeSql(tested.createUser(user2))
     val _ =
-      executeSql(tested.createUser(newUniqueUser(emptyPrimaryParty = true), createdAt = zeroMicros))
+      executeSql(tested.createUser(newDbUser(primaryPartyOverride = Some(None))))
     internalId1 should not equal internalId2
   }
 
   it should "handle user ops (getUser, deleteUser)" in {
-    val user1 = newUniqueUser()
-    val user2 = newUniqueUser()
-    val _ = executeSql(tested.createUser(user1, createdAt = zeroMicros))
+    val user1 = newDbUser()
+    val user2 = newDbUser()
+    val _ = executeSql(tested.createUser(user1))
     val getExisting = executeSql(tested.getUser(user1.id))
     val deleteExisting = executeSql(tested.deleteUser(user1.id))
     val deleteNonexistent = executeSql(tested.deleteUser(user2.id))
     val getDeleted = executeSql(tested.getUser(user1.id))
     val getNonexistent = executeSql(tested.getUser(user2.id))
-    getExisting.value.domainUser shouldBe user1
+    getExisting.value.payload shouldBe user1
     deleteExisting shouldBe true
     deleteNonexistent shouldBe false
     getDeleted shouldBe None
@@ -146,18 +146,20 @@ private[backend] trait StorageBackendTestsUserManagement
   }
 
   it should "get all users (getUsers) ordered by id" in {
-    val user1 = newUniqueUser(userId = "user_id_1")
-    val user2 = newUniqueUser(userId = "user_id_2")
-    val user3 = newUniqueUser(userId = "user_id_3")
+    val user1 = newDbUser(userId = "user_id_1")
+    val user2 = newDbUser(userId = "user_id_2")
+    val user3 = newDbUser(userId = "user_id_3")
     executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 10)) shouldBe empty
-    val _ = executeSql(tested.createUser(user3, createdAt = zeroMicros))
-    val _ = executeSql(tested.createUser(user1, createdAt = zeroMicros))
-    executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 10)) shouldBe Seq(
+    val _ = executeSql(tested.createUser(user3))
+    val _ = executeSql(tested.createUser(user1))
+    executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 10))
+      .map(_.payload) shouldBe Seq(
       user1,
       user3,
     )
-    val _ = executeSql(tested.createUser(user2, createdAt = zeroMicros))
-    executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 10)) shouldBe Seq(
+    val _ = executeSql(tested.createUser(user2))
+    executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 10))
+      .map(_.payload) shouldBe Seq(
       user1,
       user2,
       user3,
@@ -165,41 +167,43 @@ private[backend] trait StorageBackendTestsUserManagement
   }
 
   it should "get all users (getUsers) ordered by id using binary collation" in {
-    val user1 = newUniqueUser(userId = "a")
-    val user2 = newUniqueUser(userId = "a!")
-    val user3 = newUniqueUser(userId = "b")
-    val user4 = newUniqueUser(userId = "a_")
-    val user5 = newUniqueUser(userId = "!a")
-    val user6 = newUniqueUser(userId = "_a")
+    val user1 = newDbUser(userId = "a")
+    val user2 = newDbUser(userId = "a!")
+    val user3 = newDbUser(userId = "b")
+    val user4 = newDbUser(userId = "a_")
+    val user5 = newDbUser(userId = "!a")
+    val user6 = newDbUser(userId = "_a")
     val users = Seq(user1, user2, user3, user4, user5, user6)
-    users.foreach(user => executeSql(tested.createUser(user, createdAt = zeroMicros)))
+    users.foreach(user => executeSql(tested.createUser(user)))
     executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 10))
-      .map(_.id) shouldBe Seq("!a", "_a", "a", "a!", "a_", "b")
+      .map(_.payload.id) shouldBe Seq("!a", "_a", "a", "a!", "a_", "b")
   }
 
   it should "get a page of users (getUsers) ordered by id" in {
-    val user1 = newUniqueUser(userId = "user_id_1")
-    val user2 = newUniqueUser(userId = "user_id_2")
-    val user3 = newUniqueUser(userId = "user_id_3")
+    val user1 = newDbUser(userId = "user_id_1")
+    val user2 = newDbUser(userId = "user_id_2")
+    val user3 = newDbUser(userId = "user_id_3")
     // Note: user4 doesn't exist and won't be created
-    val user5 = newUniqueUser(userId = "user_id_5")
-    val user6 = newUniqueUser(userId = "user_id_6")
-    val user7 = newUniqueUser(userId = "user_id_7")
+    val user5 = newDbUser(userId = "user_id_5")
+    val user6 = newDbUser(userId = "user_id_6")
+    val user7 = newDbUser(userId = "user_id_7")
     executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 10)) shouldBe empty
     // Creating users in a random order
-    val _ = executeSql(tested.createUser(user5, createdAt = zeroMicros))
-    val _ = executeSql(tested.createUser(user1, createdAt = zeroMicros))
-    val _ = executeSql(tested.createUser(user7, createdAt = zeroMicros))
-    val _ = executeSql(tested.createUser(user3, createdAt = zeroMicros))
-    val _ = executeSql(tested.createUser(user6, createdAt = zeroMicros))
-    val _ = executeSql(tested.createUser(user2, createdAt = zeroMicros))
+    val _ = executeSql(tested.createUser(user5))
+    val _ = executeSql(tested.createUser(user1))
+    val _ = executeSql(tested.createUser(user7))
+    val _ = executeSql(tested.createUser(user3))
+    val _ = executeSql(tested.createUser(user6))
+    val _ = executeSql(tested.createUser(user2))
     // Get first 2 elements
-    executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 2)) shouldBe Seq(
+    executeSql(tested.getUsersOrderedById(fromExcl = None, maxResults = 2))
+      .map(_.payload) shouldBe Seq(
       user1,
       user2,
     )
     // Get 3 users after user1
-    executeSql(tested.getUsersOrderedById(maxResults = 3, fromExcl = Some(user1.id))) shouldBe Seq(
+    executeSql(tested.getUsersOrderedById(maxResults = 3, fromExcl = Some(user1.id)))
+      .map(_.payload) shouldBe Seq(
       user2,
       user3,
       user5,
@@ -207,7 +211,7 @@ private[backend] trait StorageBackendTestsUserManagement
     // Get up to 10000 users after user1
     executeSql(
       tested.getUsersOrderedById(maxResults = 10000, fromExcl = Some(user1.id))
-    ) shouldBe Seq(
+    ) map (_.payload) shouldBe Seq(
       user2,
       user3,
       user5,
@@ -220,7 +224,7 @@ private[backend] trait StorageBackendTestsUserManagement
         maxResults = 2,
         fromExcl = Some(Ref.UserId.assertFromString("user_id_4")),
       )
-    ) shouldBe Seq(user5, user6)
+    ).map(_.payload) shouldBe Seq(user5, user6)
     // Get no users when requesting with after set the last existing user
     executeSql(tested.getUsersOrderedById(maxResults = 2, fromExcl = Some(user7.id))) shouldBe empty
     // Get no users when requesting with after set beyond the last existing user
@@ -241,11 +245,11 @@ private[backend] trait StorageBackendTestsUserManagement
   }
 
   it should "handle adding duplicate rights" in {
-    val user1 = newUniqueUser()
+    val user1 = newDbUser()
     val adminRight = ParticipantAdmin
     val readAsRight = CanReadAs(Ref.Party.assertFromString("party_read_as_1"))
     val actAsRight = CanActAs(Ref.Party.assertFromString("party_act_as_1"))
-    val internalId = executeSql(tested.createUser(user = user1, createdAt = zeroMicros))
+    val internalId = executeSql(tested.createUser(user = user1))
     executeSql(tested.addUserRight(internalId, adminRight, grantedAt = zeroMicros))
     // Attempting to add a duplicate user admin right
     assertThrows[SQLException](
@@ -264,8 +268,8 @@ private[backend] trait StorageBackendTestsUserManagement
   }
 
   it should "handle removing absent rights" in {
-    val user1 = newUniqueUser()
-    val internalId = executeSql(tested.createUser(user1, createdAt = zeroMicros))
+    val user1 = newDbUser()
+    val internalId = executeSql(tested.createUser(user1))
     val delete1 = executeSql(tested.deleteUserRight(internalId, right1))
     val delete2 = executeSql(tested.deleteUserRight(internalId, right2))
     val delete3 = executeSql(tested.deleteUserRight(internalId, right3))
@@ -275,8 +279,8 @@ private[backend] trait StorageBackendTestsUserManagement
   }
 
   it should "handle multiple rights (getUserRights, addUserRight, deleteUserRight)" in {
-    val user1 = newUniqueUser()
-    val internalId = executeSql(tested.createUser(user1, createdAt = zeroMicros))
+    val user1 = newDbUser()
+    val internalId = executeSql(tested.createUser(user1))
     val rights1 = executeSql(tested.getUserRights(internalId))
     executeSql(tested.addUserRight(internalId, right1, grantedAt = zeroMicros))
     executeSql(tested.addUserRight(internalId, right2, grantedAt = zeroMicros))
@@ -295,8 +299,8 @@ private[backend] trait StorageBackendTestsUserManagement
   }
 
   it should "add and delete a single right (userRightExists, addUserRight, deleteUserRight, getUserRights)" in {
-    val user1 = newUniqueUser()
-    val internalId = executeSql(tested.createUser(user1, createdAt = zeroMicros))
+    val user1 = newDbUser()
+    val internalId = executeSql(tested.createUser(user1))
     // no rights
     val rightExists0 = executeSql(tested.userRightExists(internalId, right1))
     val rights0 = executeSql(tested.getUserRights(internalId))
@@ -319,20 +323,20 @@ private[backend] trait StorageBackendTestsUserManagement
     rights2 shouldBe empty
   }
 
-  private def newUniqueUser(
-      emptyPrimaryParty: Boolean = false,
+  private def newDbUser(
       userId: String = "",
-  ): User = {
+      primaryPartyOverride: Option[Option[Ref.Party]] = None,
+      createdAt: Long = zeroMicros,
+  ): UserManagementStorageBackend.DbUserPayload = {
     val uuid = UUID.randomUUID.toString
-    val primaryParty =
-      if (emptyPrimaryParty)
-        None
-      else
-        Some(Ref.Party.assertFromString(s"primary_party_${uuid}"))
+    val primaryParty = primaryPartyOverride.getOrElse(
+      Some(Ref.Party.assertFromString(s"primary_party_${uuid}"))
+    )
     val userIdStr = if (userId != "") userId else s"user_id_${uuid}"
-    User(
+    UserManagementStorageBackend.DbUserPayload(
       id = Ref.UserId.assertFromString(userIdStr),
-      primaryParty = primaryParty,
+      primaryPartyO = primaryParty,
+      createdAt = createdAt,
     )
   }
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/interning/MockStringInterning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/interning/MockStringInterning.scala
@@ -65,7 +65,7 @@ class MockStringInterning extends StringInterning {
         rawStringInterning.tryExternalize(id).map(Party.assertFromString)
     }
 
-  private[store] def reset(): Unit = synchronized {
+  def reset(): Unit = synchronized {
     idToString = Map.empty
     stringToId = Map.empty
     lastId = 0

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/interning/MockStringInterning.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/interning/MockStringInterning.scala
@@ -65,7 +65,7 @@ class MockStringInterning extends StringInterning {
         rawStringInterning.tryExternalize(id).map(Party.assertFromString)
     }
 
-  def reset(): Unit = synchronized {
+  private[store] def reset(): Unit = synchronized {
     idToString = Map.empty
     stringToId = Map.empty
     lastId = 0

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/platform/partymanagement/ParticipantPartyStoreTests.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/platform/partymanagement/ParticipantPartyStoreTests.scala
@@ -1,0 +1,281 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.platform.partymanagement
+
+import com.daml.ledger.api.domain.{ObjectMeta, ParticipantParty}
+import com.daml.ledger.participant.state.index.v2.AnnotationsUpdate.{Merge, Replace}
+import com.daml.ledger.participant.state.index.v2.ParticipantPartyRecordStore.{
+  PartyRecordExists,
+  PartyRecordNotFound,
+}
+import com.daml.ledger.participant.state.index.v2.{
+  ObjectMetaUpdate,
+  ParticipantPartyRecordStore,
+  PartyRecordUpdate,
+}
+import com.daml.ledger.resources.TestResourceContext
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.Party
+import com.daml.logging.LoggingContext
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{Assertion, EitherValues}
+
+import scala.concurrent.Future
+import scala.language.implicitConversions
+
+/** Common tests for implementations of [[ParticipantPartyRecordStore]]
+  */
+trait ParticipantPartyStoreTests extends TestResourceContext with Matchers with EitherValues {
+  self: AsyncFreeSpec =>
+
+  implicit val lc: LoggingContext = LoggingContext.ForTesting
+
+  private implicit def toParty(s: String): Party =
+    Party.assertFromString(s)
+
+  def testIt(f: ParticipantPartyRecordStore => Future[Assertion]): Future[Assertion]
+
+  def newPartyRecord(
+      name: String,
+      annotations: Map[String, String] = Map.empty,
+  ): ParticipantParty.PartyRecord =
+    ParticipantParty.PartyRecord(
+      party = name,
+      metadata = ObjectMeta(None, annotations = annotations),
+    )
+
+  def createdPartyRecord(
+      name: String,
+      annotations: Map[String, String] = Map.empty,
+      resourceVersion: String = "0",
+  ): ParticipantParty.PartyRecord =
+    ParticipantParty.PartyRecord(
+      party = name,
+      metadata = ObjectMeta(
+        resourceVersionO = Some(resourceVersion),
+        annotations = annotations,
+      ),
+    )
+
+  def resetResourceVersion(
+      partyRecord: ParticipantParty.PartyRecord
+  ): ParticipantParty.PartyRecord =
+    partyRecord.copy(metadata = partyRecord.metadata.copy(resourceVersionO = None))
+
+  "participant party management" - {
+
+    "creating" - {
+      "allow creating a fresh party record" in {
+        testIt { tested =>
+          for {
+            create1 <- tested.createPartyRecord(newPartyRecord("party1"))
+            create2 <- tested.createPartyRecord(newPartyRecord("party2"))
+          } yield {
+            create1.value shouldBe createdPartyRecord("party1")
+            create2.value shouldBe createdPartyRecord("party2")
+          }
+        }
+      }
+
+      "disallow re-creating an existing party record" in {
+        testIt { tested =>
+          for {
+            create1 <- tested.createPartyRecord(newPartyRecord("party1"))
+            create1b <- tested.createPartyRecord(newPartyRecord("party1"))
+          } yield {
+            create1.value shouldBe createdPartyRecord("party1")
+            create1b.left.value shouldBe PartyRecordExists(create1.value.party)
+          }
+        }
+      }
+    }
+
+    "getting" - {
+      "find a freshly created party record" in {
+        testIt { tested =>
+          val newPr = newPartyRecord("party1")
+          for {
+            create1 <- tested.createPartyRecord(newPr)
+            get1 <- tested.getPartyRecord(newPr.party)
+          } yield {
+            create1.value shouldBe createdPartyRecord("party1")
+            get1.value shouldBe createdPartyRecord("party1")
+          }
+        }
+      }
+
+      "not find a non-existent party record" in {
+        testIt { tested =>
+          val party = Ref.Party.assertFromString("party1")
+          for {
+            get1 <- tested.getPartyRecord(party)
+          } yield {
+            get1.left.value shouldBe PartyRecordNotFound(party)
+          }
+        }
+      }
+    }
+
+    "updating" - {
+      "update an existing party record" in {
+        testIt { tested =>
+          val pr1 = newPartyRecord("party1")
+          for {
+            create1 <- tested.createPartyRecord(pr1)
+            _ = create1.value shouldBe createdPartyRecord("party1")
+            update1 <- tested.updatePartyRecord(
+              partyRecordUpdate = PartyRecordUpdate(
+                party = pr1.party,
+                metadataUpdate = ObjectMetaUpdate(
+                  resourceVersionO = create1.value.metadata.resourceVersionO,
+                  annotationsUpdateO = Some(Merge.fromNonEmpty(Map("k1" -> "v1"))),
+                ),
+              ),
+              ledgerPartyExists = _ =>
+                Future(
+                  fail(
+                    "Unexpected ledger party existence check while updating an existing participant party record"
+                  )
+                ),
+            )
+            _ = resetResourceVersion(update1.value) shouldBe newPartyRecord(
+              "party1",
+              annotations = Map("k1" -> "v1"),
+            )
+          } yield succeed
+        }
+      }
+      "should succeed when updating a non-existing party record for which a ledger party exists" in {
+        testIt { tested =>
+          val party = Ref.Party.assertFromString("party1")
+          for {
+            update1 <- tested.updatePartyRecord(
+              partyRecordUpdate = PartyRecordUpdate(
+                party = party,
+                metadataUpdate = ObjectMetaUpdate(
+                  resourceVersionO = None,
+                  annotationsUpdateO = Some(
+                    Merge.fromNonEmpty(
+                      Map(
+                        "k1" -> "v1",
+                        "k2" -> "v2",
+                      )
+                    )
+                  ),
+                ),
+              ),
+              ledgerPartyExists = _ => Future.successful(true),
+            )
+            _ = update1.value shouldBe createdPartyRecord(
+              "party1",
+              resourceVersion = "1",
+              annotations = Map("k1" -> "v1", "k2" -> "v2"),
+            )
+          } yield succeed
+        }
+      }
+
+      "should update metadata annotations with both merge and replace semantics" in {
+        testIt { tested =>
+          val pr = createdPartyRecord("party1", annotations = Map("k1" -> "v1", "k2" -> "v2"))
+          for {
+            create1 <- tested.createPartyRecord(
+              partyRecord = pr
+            )
+            _ = create1.value shouldBe createdPartyRecord(
+              "party1",
+              resourceVersion = "0",
+              annotations = Map("k1" -> "v1", "k2" -> "v2"),
+            )
+            // first update: with merge annotations semantics
+            update1 <- tested.updatePartyRecord(
+              partyRecordUpdate = PartyRecordUpdate(
+                party = pr.party,
+                metadataUpdate = ObjectMetaUpdate(
+                  resourceVersionO = None,
+                  annotationsUpdateO = Some(
+                    Merge.fromNonEmpty(
+                      Map(
+                        "k1" -> "v1b",
+                        "k3" -> "v3",
+                      )
+                    )
+                  ),
+                ),
+              ),
+              ledgerPartyExists = _ => Future.successful(true),
+            )
+            _ = update1.value shouldBe createdPartyRecord(
+              "party1",
+              resourceVersion = "1",
+              annotations = Map("k1" -> "v1b", "k2" -> "v2", "k3" -> "v3"),
+            )
+            // second update: with replace annotations semantics
+            update2 <- tested.updatePartyRecord(
+              partyRecordUpdate = PartyRecordUpdate(
+                party = pr.party,
+                metadataUpdate = ObjectMetaUpdate(
+                  resourceVersionO = None,
+                  annotationsUpdateO = Some(
+                    Replace(
+                      Map(
+                        "k1" -> "v1c",
+                        "k4" -> "v4",
+                      )
+                    )
+                  ),
+                ),
+              ),
+              ledgerPartyExists = _ => Future.successful(true),
+            )
+            _ = update2.value shouldBe createdPartyRecord(
+              "party1",
+              resourceVersion = "2",
+              annotations = Map("k1" -> "v1c", "k4" -> "v4"),
+            )
+            // third update: with replace annotations semantics - effectively deleting all annotations
+            update3 <- tested.updatePartyRecord(
+              partyRecordUpdate = PartyRecordUpdate(
+                party = pr.party,
+                metadataUpdate = ObjectMetaUpdate(
+                  resourceVersionO = None,
+                  annotationsUpdateO = Some(Replace(Map.empty)),
+                ),
+              ),
+              ledgerPartyExists = _ => Future.successful(true),
+            )
+            _ = update3.value shouldBe createdPartyRecord(
+              "party1",
+              resourceVersion = "3",
+              annotations = Map.empty,
+            )
+          } yield {
+            succeed
+          }
+        }
+      }
+
+      "should raise an error when updating a non-existing party record for which a ledger party doesn't exist" in {
+        testIt { tested =>
+          val party = Ref.Party.assertFromString("party")
+          for {
+            res1 <- tested.updatePartyRecord(
+              partyRecordUpdate = PartyRecordUpdate(
+                party = party,
+                metadataUpdate = ObjectMetaUpdate(
+                  resourceVersionO = None,
+                  annotationsUpdateO = Some(Merge.fromNonEmpty(Map("k1" -> "v1"))),
+                ),
+              ),
+              ledgerPartyExists = _ => Future.successful(false),
+            )
+            _ = res1.left.value shouldBe ParticipantPartyRecordStore.PartyNotFound(party)
+          } yield succeed
+        }
+      }
+    }
+  }
+
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/platform/usermanagement/UserManagementStoreTests.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/platform/usermanagement/UserManagementStoreTests.scala
@@ -3,8 +3,13 @@
 
 package com.daml.platform.store.platform.usermanagement
 
-import com.daml.ledger.api.domain.{User, UserRight}
-import com.daml.ledger.participant.state.index.v2.UserManagementStore
+import com.daml.ledger.api.domain.{ObjectMeta, User, UserRight}
+import com.daml.ledger.participant.state.index.v2.AnnotationsUpdate.{Merge, Replace}
+import com.daml.ledger.participant.state.index.v2.{
+  ObjectMetaUpdate,
+  UserManagementStore,
+  UserUpdate,
+}
 import com.daml.ledger.participant.state.index.v2.UserManagementStore.{
   UserExists,
   UserNotFound,
@@ -17,8 +22,8 @@ import com.daml.logging.LoggingContext
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, EitherValues}
-import scala.language.implicitConversions
 
+import scala.language.implicitConversions
 import scala.concurrent.Future
 
 /** Common tests for implementations of [[UserManagementStore]]
@@ -36,27 +41,58 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
 
   def testIt(f: UserManagementStore => Future[Assertion]): Future[Assertion]
 
+  def newUser(name: String, annotations: Map[String, String] = Map.empty): User = User(
+    id = name,
+    primaryParty = None,
+    isDeactivated = false,
+    metadata = ObjectMeta(
+      resourceVersionO = None,
+      annotations = annotations,
+    ),
+  )
+
+  def createdUser(
+      name: String,
+      resourceVersion: String = "0",
+      annotations: Map[String, String] = Map.empty,
+  ): User =
+    User(
+      id = name,
+      primaryParty = None,
+      isDeactivated = false,
+      metadata = ObjectMeta(
+        resourceVersionO = Some(resourceVersion),
+        annotations = annotations,
+      ),
+    )
+
+  def resetResourceVersion(
+      user: User
+  ): User =
+    user.copy(metadata = user.metadata.copy(resourceVersionO = None))
+
   "user management" - {
+
     "allow creating a fresh user" in {
       testIt { tested =>
         for {
-          res1 <- tested.createUser(User(s"user1", None), Set.empty)
-          res2 <- tested.createUser(User("user2", None), Set.empty)
+          res1 <- tested.createUser(newUser(s"user1"), Set.empty)
+          res2 <- tested.createUser(newUser("user2"), Set.empty)
         } yield {
-          res1 shouldBe Right(())
-          res2 shouldBe Right(())
+          res1 shouldBe Right(createdUser("user1"))
+          res2 shouldBe Right(createdUser("user2"))
         }
       }
     }
 
     "disallow re-creating an existing user" in {
       testIt { tested =>
-        val user = User("user1", None)
+        val user = newUser("user1")
         for {
           res1 <- tested.createUser(user, Set.empty)
           res2 <- tested.createUser(user, Set.empty)
         } yield {
-          res1 shouldBe Right(())
+          res1 shouldBe Right(createdUser("user1"))
           res2 shouldBe Left(UserExists(user.id))
         }
       }
@@ -64,13 +100,13 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
 
     "find a freshly created user" in {
       testIt { tested =>
-        val user = User("user1", None)
+        val user = newUser("user1")
         for {
           res1 <- tested.createUser(user, Set.empty)
           user1 <- tested.getUser(user.id)
         } yield {
-          res1 shouldBe Right(())
-          user1 shouldBe Right(user)
+          res1 shouldBe Right(createdUser("user1"))
+          user1 shouldBe res1
         }
       }
     }
@@ -87,15 +123,15 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
     }
     "not find a deleted user" in {
       testIt { tested =>
-        val user = User("user1", None)
+        val user = newUser("user1")
         for {
           res1 <- tested.createUser(user, Set.empty)
           user1 <- tested.getUser("user1")
           res2 <- tested.deleteUser("user1")
           user2 <- tested.getUser("user1")
         } yield {
-          res1 shouldBe Right(())
-          user1 shouldBe Right(user)
+          res1 shouldBe Right(createdUser("user1"))
+          user1 shouldBe res1
           res2 shouldBe Right(())
           user2 shouldBe Left(UserNotFound("user1"))
         }
@@ -103,15 +139,15 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
     }
     "allow recreating a deleted user" in {
       testIt { tested =>
-        val user = User("user1", None)
+        val user = newUser("user1")
         for {
           res1 <- tested.createUser(user, Set.empty)
           res2 <- tested.deleteUser(user.id)
           res3 <- tested.createUser(user, Set.empty)
         } yield {
-          res1 shouldBe Right(())
+          res1 shouldBe Right(createdUser("user1"))
           res2 shouldBe Right(())
-          res3 shouldBe Right(())
+          res3 shouldBe Right(createdUser("user1"))
         }
 
       }
@@ -125,22 +161,29 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
         }
       }
     }
+
     "list created users" in {
       testIt { tested =>
         for {
-          _ <- tested.createUser(User("user1", None), Set.empty)
-          _ <- tested.createUser(User("user2", None), Set.empty)
-          _ <- tested.createUser(User("user3", None), Set.empty)
-          _ <- tested.createUser(User("user4", None), Set.empty)
+          _ <- tested.createUser(newUser("user1"), Set.empty)
+          _ <- tested.createUser(newUser("user2"), Set.empty)
+          _ <- tested.createUser(newUser("user3"), Set.empty)
+          _ <- tested.createUser(newUser("user4"), Set.empty)
           list1 <- tested.listUsers(fromExcl = None, maxResults = 3)
           _ = list1 shouldBe Right(
-            UsersPage(Seq(User("user1", None), User("user2", None), User("user3", None)))
+            UsersPage(
+              Seq(
+                createdUser("user1"),
+                createdUser("user2"),
+                createdUser("user3"),
+              )
+            )
           )
           list2 <- tested.listUsers(
             fromExcl = list1.getOrElse(fail("Expecting a Right()")).lastUserIdOption,
             maxResults = 4,
           )
-          _ = list2 shouldBe Right(UsersPage(Seq(User("user4", None))))
+          _ = list2 shouldBe Right(UsersPage(Seq(createdUser("user4"))))
         } yield {
           succeed
         }
@@ -149,17 +192,24 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
     "not list deleted users" in {
       testIt { tested =>
         for {
-          res1 <- tested.createUser(User("user1", None), Set.empty)
-          res2 <- tested.createUser(User("user2", None), Set.empty)
+          res1 <- tested.createUser(newUser("user1"), Set.empty)
+          res2 <- tested.createUser(newUser("user2"), Set.empty)
           users1 <- tested.listUsers(fromExcl = None, maxResults = 10000)
           res3 <- tested.deleteUser("user1")
           users2 <- tested.listUsers(fromExcl = None, maxResults = 10000)
         } yield {
-          res1 shouldBe Right(())
-          res2 shouldBe Right(())
-          users1 shouldBe Right(UsersPage(Seq(User("user1", None), User("user2", None))))
+          res1 shouldBe Right(createdUser("user1"))
+          res2 shouldBe Right(createdUser("user2"))
+          users1 shouldBe Right(
+            UsersPage(
+              Seq(
+                createdUser("user1"),
+                createdUser("user2"),
+              )
+            )
+          )
           res3 shouldBe Right(())
-          users2 shouldBe Right(UsersPage(Seq(User("user2", None))))
+          users2 shouldBe Right(UsersPage(Seq(createdUser("user2"))))
 
         }
       }
@@ -171,17 +221,17 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
     "listUserRights should find the rights of a freshly created user" in {
       testIt { tested =>
         for {
-          res1 <- tested.createUser(User("user1", None), Set.empty)
+          res1 <- tested.createUser(newUser("user1"), Set.empty)
           rights1 <- tested.listUserRights("user1")
           user2 <- tested.createUser(
-            User("user2", None),
+            newUser("user2"),
             Set(ParticipantAdmin, CanActAs("party1"), CanReadAs("party2")),
           )
           rights2 <- tested.listUserRights("user2")
         } yield {
-          res1 shouldBe Right(())
+          res1 shouldBe Right(createdUser("user1"))
           rights1 shouldBe Right(Set.empty)
-          user2 shouldBe Right(())
+          user2 shouldBe Right(createdUser("user2"))
           rights2 shouldBe Right(
             Set(ParticipantAdmin, CanActAs("party1"), CanReadAs("party2"))
           )
@@ -200,13 +250,13 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
     "grantUserRights should add new rights" in {
       testIt { tested =>
         for {
-          res1 <- tested.createUser(User("user1", None), Set.empty)
+          res1 <- tested.createUser(newUser("user1"), Set.empty)
           rights1 <- tested.grantRights("user1", Set(ParticipantAdmin))
           rights2 <- tested.grantRights("user1", Set(ParticipantAdmin))
           rights3 <- tested.grantRights("user1", Set(CanActAs("party1"), CanReadAs("party2")))
           rights4 <- tested.listUserRights("user1")
         } yield {
-          res1 shouldBe Right(())
+          res1 shouldBe Right(createdUser("user1"))
           rights1 shouldBe Right(Set(ParticipantAdmin))
           rights2 shouldBe Right(Set.empty)
           rights3 shouldBe Right(
@@ -232,7 +282,7 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
       testIt { tested =>
         for {
           res1 <- tested.createUser(
-            User("user1", None),
+            newUser("user1"),
             Set(ParticipantAdmin, CanActAs("party1"), CanReadAs("party2")),
           )
           rights1 <- tested.listUserRights("user1")
@@ -242,7 +292,7 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
           rights5 <- tested.revokeRights("user1", Set(CanActAs("party1"), CanReadAs("party2")))
           rights6 <- tested.listUserRights("user1")
         } yield {
-          res1 shouldBe Right(())
+          res1 shouldBe Right(createdUser("user1"))
           rights1 shouldBe Right(
             Set(ParticipantAdmin, CanActAs("party1"), CanReadAs("party2"))
           )
@@ -265,6 +315,127 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
         }
       }
     }
+  }
+
+  "updating" - {
+    "update an existing user" in {
+      testIt { tested =>
+        val pr1 = newUser("user1")
+        for {
+          create1 <- tested.createUser(pr1, Set.empty)
+          _ = create1.value shouldBe createdUser("user1")
+          update1 <- tested.updateUser(
+            userUpdate = UserUpdate(
+              id = pr1.id,
+              // TODO um-for-hub: Test primaryPartyUpdate and isDeactivatedUpdate
+              primaryPartyUpdateO = None,
+              isDeactivatedUpdateO = None,
+              metadataUpdate = ObjectMetaUpdate(
+                resourceVersionO = create1.value.metadata.resourceVersionO,
+                annotationsUpdateO = Some(Merge.fromNonEmpty(Map("k1" -> "v1"))),
+              ),
+            )
+          )
+          _ = resetResourceVersion(update1.value) shouldBe newUser(
+            "user1",
+            annotations = Map("k1" -> "v1"),
+          )
+        } yield succeed
+      }
+    }
+
+    "should update metadata annotations with merge and replace semantics" in {
+      testIt { tested =>
+        val user = createdUser("user1", annotations = Map("k1" -> "v1", "k2" -> "v2"))
+        for {
+          create1 <- tested.createUser(user, Set.empty)
+          _ = create1.value shouldBe createdUser(
+            "user1",
+            annotations = Map("k1" -> "v1", "k2" -> "v2"),
+          )
+          // first update: with merge annotations semantics
+          update1 <- tested.updateUser(
+            UserUpdate(
+              id = user.id,
+              metadataUpdate = ObjectMetaUpdate(
+                resourceVersionO = None,
+                annotationsUpdateO = Some(
+                  Merge.fromNonEmpty(
+                    Map(
+                      "k1" -> "v1b",
+                      "k3" -> "v3",
+                    )
+                  )
+                ),
+              ),
+            )
+          )
+          _ = update1.value shouldBe createdUser(
+            "user1",
+            resourceVersion = "1",
+            annotations = Map("k1" -> "v1b", "k2" -> "v2", "k3" -> "v3"),
+          )
+          // second update: with replace annotations semantics
+          update2 <- tested.updateUser(
+            UserUpdate(
+              id = user.id,
+              metadataUpdate = ObjectMetaUpdate(
+                resourceVersionO = None,
+                annotationsUpdateO = Some(
+                  Replace(
+                    Map(
+                      "k1" -> "v1c",
+                      "k4" -> "v4",
+                    )
+                  )
+                ),
+              ),
+            )
+          )
+          _ = update2.value shouldBe createdUser(
+            "user1",
+            resourceVersion = "2",
+            annotations = Map("k1" -> "v1c", "k4" -> "v4"),
+          )
+          // third update: with replace annotations semantics - effectively deleting all annotations
+          update3 <- tested.updateUser(
+            UserUpdate(
+              id = user.id,
+              metadataUpdate = ObjectMetaUpdate(
+                resourceVersionO = None,
+                annotationsUpdateO = Some(Replace(Map.empty)),
+              ),
+            )
+          )
+          _ = update3.value shouldBe createdUser(
+            "user1",
+            resourceVersion = "3",
+            annotations = Map.empty,
+          )
+        } yield {
+          succeed
+        }
+      }
+    }
+
+    "should raise error when updating a non-existing user" in {
+      testIt { tested =>
+        val userId = Ref.UserId.assertFromString("user")
+        for {
+          res1 <- tested.updateUser(
+            UserUpdate(
+              id = userId,
+              metadataUpdate = ObjectMetaUpdate(
+                resourceVersionO = None,
+                annotationsUpdateO = Some(Merge.fromNonEmpty(Map("k1" -> "v1"))),
+              ),
+            )
+          )
+          _ = res1.left.value shouldBe UserManagementStore.UserNotFound(userId)
+        } yield succeed
+      }
+    }
+
   }
 
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/platform/usermanagement/UserManagementStoreTests.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/platform/usermanagement/UserManagementStoreTests.scala
@@ -436,6 +436,25 @@ trait UserManagementStoreTests extends TestResourceContext with Matchers with Ei
       }
     }
 
+    "should raise an error on resource version mismatch" in {
+      testIt { tested =>
+        val user = createdUser("user1")
+        for {
+          _ <- tested.createUser(user, Set.empty)
+          res1 <- tested.updateUser(
+            UserUpdate(
+              id = user.id,
+              metadataUpdate = ObjectMetaUpdate(
+                resourceVersionO = Some("100"),
+                annotationsUpdateO = Some(Merge.fromNonEmpty(Map("k1" -> "v1"))),
+              ),
+            )
+          )
+          _ = res1.left.value shouldBe UserManagementStore.ConcurrentUserUpdate(user.id)
+        } yield succeed
+      }
+    }
+
   }
 
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/partymanagement/InMemoryParticipantPartyRecordStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/partymanagement/InMemoryParticipantPartyRecordStoreSpec.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.partymanagement
+
+import com.daml.ledger.participant.state.index.impl.inmemory.InMemoryParticipantPartyRecordStore
+import com.daml.ledger.participant.state.index.v2.ParticipantPartyRecordStore
+import com.daml.platform.store.platform.partymanagement.ParticipantPartyStoreTests
+import org.scalatest.Assertion
+import org.scalatest.freespec.AsyncFreeSpec
+
+import scala.concurrent.Future
+
+class InMemoryParticipantPartyRecordStoreSpec
+    extends AsyncFreeSpec
+    with ParticipantPartyStoreTests {
+
+  override def testIt(f: ParticipantPartyRecordStore => Future[Assertion]): Future[Assertion] = {
+    f(
+      new InMemoryParticipantPartyRecordStore(
+        executionContext = executionContext
+      )
+    )
+  }
+
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/usermanagement/CachedUserManagementStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/usermanagement/CachedUserManagementStoreSpec.scala
@@ -4,9 +4,13 @@
 package com.daml.platform.usermanagement
 
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.api.domain.{User, UserRight}
+import com.daml.ledger.api.domain.{ObjectMeta, User, UserRight}
 import com.daml.ledger.participant.state.index.impl.inmemory.InMemoryUserManagementStore
-import com.daml.ledger.participant.state.index.v2.UserManagementStore
+import com.daml.ledger.participant.state.index.v2.{
+  ObjectMetaUpdate,
+  UserManagementStore,
+  UserUpdate,
+}
 import com.daml.ledger.participant.state.index.v2.UserManagementStore.{
   UserInfo,
   UserNotFound,
@@ -35,12 +39,25 @@ class CachedUserManagementStoreSpec
   private val user = User(
     id = Ref.UserId.assertFromString("user_id1"),
     primaryParty = Some(Ref.Party.assertFromString("primary_party1")),
+    false,
+    ObjectMeta.empty,
   )
+  private val createdUser1 = User(
+    id = Ref.UserId.assertFromString("user_id1"),
+    primaryParty = Some(Ref.Party.assertFromString("primary_party1")),
+    false,
+    ObjectMeta(
+      resourceVersionO = Some("0"),
+      annotations = Map.empty,
+    ),
+  )
+
   private val right1 = UserRight.CanActAs(Ref.Party.assertFromString("party_id1"))
   private val right2 = UserRight.ParticipantAdmin
   private val right3 = UserRight.CanActAs(Ref.Party.assertFromString("party_id2"))
   private val rights = Set(right1, right2)
   private val userInfo = UserInfo(user, rights)
+  private val createdUserInfo = UserInfo(createdUser1, rights)
 
   "test user-not-found cache result gets invalidated after user creation" in {
     val delegate = spy(new InMemoryUserManagementStore())
@@ -50,8 +67,8 @@ class CachedUserManagementStoreSpec
       _ <- tested.createUser(userInfo.user, userInfo.rights)
       get <- tested.getUserInfo(user.id)
     } yield {
-      getYetNonExistent shouldBe Left(UserNotFound(userInfo.user.id))
-      get shouldBe Right(userInfo)
+      getYetNonExistent shouldBe Left(UserNotFound(createdUserInfo.user.id))
+      get shouldBe Right(createdUserInfo)
     }
   }
 
@@ -69,10 +86,10 @@ class CachedUserManagementStoreSpec
       verify(delegate, times(1)).createUser(userInfo.user, userInfo.rights)
       verify(delegate, times(1)).getUserInfo(userInfo.user.id)
       verifyNoMoreInteractions(delegate)
-      get1 shouldBe Right(userInfo)
-      get2 shouldBe Right(userInfo)
-      getUser shouldBe Right(userInfo.user)
-      listRights shouldBe Right(userInfo.rights)
+      get1 shouldBe Right(createdUserInfo)
+      get2 shouldBe Right(createdUserInfo)
+      getUser shouldBe Right(createdUserInfo.user)
+      listRights shouldBe Right(createdUserInfo.rights)
     }
   }
 
@@ -89,8 +106,17 @@ class CachedUserManagementStoreSpec
       get2 <- tested.getUserInfo(user.id)
       _ <- tested.revokeRights(user.id, Set(right3))
       get3 <- tested.getUserInfo(user.id)
-      _ <- tested.deleteUser(user.id)
+      _ <- tested.updateUser(
+        UserUpdate(
+          id = user.id,
+          primaryPartyUpdateO = Some(Some(Ref.Party.assertFromString("newPp"))),
+          metadataUpdate = ObjectMetaUpdate.empty,
+        )
+      )
       get4 <- tested.getUserInfo(user.id)
+      _ <- tested.deleteUser(user.id)
+      get5 <- tested.getUserInfo(user.id)
+
     } yield {
       val order = inOrder(delegate)
       order.verify(delegate, times(1)).createUser(user, userInfo.rights)
@@ -103,13 +129,16 @@ class CachedUserManagementStoreSpec
         .verify(delegate, times(1))
         .revokeRights(eqTo(user.id), any[Set[UserRight]])(any[LoggingContext])
       order.verify(delegate, times(1)).getUserInfo(userInfo.user.id)
+      order.verify(delegate, times(1)).updateUser(any[UserUpdate])(any[LoggingContext])
+      order.verify(delegate, times(1)).getUserInfo(userInfo.user.id)
       order.verify(delegate, times(1)).deleteUser(userInfo.user.id)
       order.verify(delegate, times(1)).getUserInfo(userInfo.user.id)
       order.verifyNoMoreInteractions()
-      get1 shouldBe Right(userInfo)
-      get2 shouldBe Right(userInfo)
-      get3 shouldBe Right(userInfo)
-      get4 shouldBe Left(UserNotFound(user.id))
+      get1 shouldBe Right(createdUserInfo)
+      get2 shouldBe Right(createdUserInfo)
+      get3 shouldBe Right(createdUserInfo)
+      get4.value.user.primaryParty shouldBe Some(Ref.Party.assertFromString("newPp"))
+      get5 shouldBe Left(UserNotFound(createdUser1.id))
     }
   }
 
@@ -126,9 +155,9 @@ class CachedUserManagementStoreSpec
       order.verify(delegate, times(1)).createUser(user, rights)
       order.verify(delegate, times(2)).listUsers(fromExcl = None, maxResults = 100)
       order.verifyNoMoreInteractions()
-      res0 shouldBe Right(())
-      res1 shouldBe Right(UsersPage(Seq(user)))
-      res2 shouldBe Right(UsersPage(Seq(user)))
+      res0 shouldBe Right(createdUser1)
+      res1 shouldBe Right(UsersPage(Seq(createdUser1)))
+      res2 shouldBe Right(UsersPage(Seq(createdUser1)))
     }
   }
 
@@ -150,10 +179,10 @@ class CachedUserManagementStoreSpec
         .createUser(any[User], any[Set[UserRight]])(any[LoggingContext])
       order.verify(delegate, times(2)).getUserInfo(any[Ref.UserId])(any[LoggingContext])
       order.verifyNoMoreInteractions()
-      create1 shouldBe Right(())
-      get1 shouldBe Right(userInfo)
-      get2 shouldBe Right(userInfo)
-      get3 shouldBe Right(userInfo)
+      create1 shouldBe Right(createdUser1)
+      get1 shouldBe Right(createdUserInfo)
+      get2 shouldBe Right(createdUserInfo)
+      get3 shouldBe Right(createdUserInfo)
     }
   }
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/usermanagement/PersistentUserManagementStoreSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/usermanagement/PersistentUserManagementStoreSpec.scala
@@ -11,10 +11,12 @@ import com.daml.platform.store.PersistentStoreSpecBase
 import com.daml.platform.store.backend.StorageBackendProviderPostgres
 import com.daml.platform.store.platform.usermanagement.UserManagementStoreTests
 import org.scalatest.freespec.AsyncFreeSpec
-import org.scalatest.Assertion
+import org.scalatest.{Assertion, Ignore}
 
 import scala.concurrent.Future
 
+// TODO um-for-hub: Implement PersistentUserManagementStore changes
+@Ignore
 class PersistentUserManagementStoreSpec
     extends AsyncFreeSpec
     with UserManagementStoreTests

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/impl/inmemory/InMemoryParticipantPartyRecordStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/impl/inmemory/InMemoryParticipantPartyRecordStore.scala
@@ -1,0 +1,187 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.impl.inmemory
+
+import com.daml.ledger.api.domain
+import com.daml.ledger.api.domain.{ObjectMeta, ParticipantParty}
+import com.daml.ledger.participant.state.index.v2.ParticipantPartyRecordStore.{
+  PartyRecordExists,
+  PartyRecordNotFound,
+  PartyRecordNotFoundOnUpdateException,
+  Result,
+}
+import com.daml.ledger.participant.state.index.v2.{
+  AnnotationsUpdate,
+  LedgerPartyExists,
+  ParticipantPartyRecordStore,
+  PartyRecordUpdate,
+}
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.Party
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+
+object InMemoryParticipantPartyRecordStore {
+  case class PartyRecordInfo(
+      party: Ref.Party,
+      resourceVersion: Int,
+      annotations: Map[String, String],
+  )
+
+  def toPartyRecord(info: PartyRecordInfo): ParticipantParty.PartyRecord =
+    ParticipantParty.PartyRecord(
+      party = info.party,
+      metadata = ObjectMeta(
+        resourceVersionO = Some(info.resourceVersion.toString),
+        annotations = info.annotations,
+      ),
+    )
+
+}
+
+class InMemoryParticipantPartyRecordStore(executionContext: ExecutionContext)
+    extends ParticipantPartyRecordStore {
+  import InMemoryParticipantPartyRecordStore._
+
+  implicit private val ec: ExecutionContext = executionContext
+  private val logger = ContextualizedLogger.get(getClass)
+
+  private val state: mutable.TreeMap[Ref.Party, PartyRecordInfo] = mutable.TreeMap()
+
+  override def getPartyRecord(
+      party: Party
+  )(implicit loggingContext: LoggingContext): Future[Result[ParticipantParty.PartyRecord]] = {
+    withState(withPartyRecord[ParticipantParty.PartyRecord](party)(toPartyRecord))
+  }
+
+  override def createPartyRecord(
+      partyRecord: ParticipantParty.PartyRecord
+  )(implicit loggingContext: LoggingContext): Future[Result[ParticipantParty.PartyRecord]] = {
+    withState(withoutPartyRecord(partyRecord.party) {
+      val info = doCreatePartyRecord(partyRecord)
+      toPartyRecord(info)
+    })
+  }
+
+  override def updatePartyRecord(
+      partyRecordUpdate: PartyRecordUpdate,
+      ledgerPartyExists: LedgerPartyExists,
+  )(implicit loggingContext: LoggingContext): Future[Result[ParticipantParty.PartyRecord]] = {
+    val party = partyRecordUpdate.party
+    val attemptedUpdateF = withState(
+      state.get(party) match {
+        case Some(info) =>
+          val updatedInfo: PartyRecordInfo = doUpdatePartyRecord(
+            partyRecordUpdate = partyRecordUpdate,
+            party = party,
+            info = info,
+          )
+          Right(toPartyRecord(updatedInfo))
+        case None =>
+          throw PartyRecordNotFoundOnUpdateException
+      }
+    ).map(tapSuccess { updatePartyRecord =>
+      logger.info(s"Updated party record in a participant local store: ${updatePartyRecord}")
+    })
+    attemptedUpdateF.recoverWith[Result[domain.ParticipantParty.PartyRecord]] {
+      case PartyRecordNotFoundOnUpdateException =>
+        for {
+          partyExistsOnLedger <- ledgerPartyExists.exists(party)
+          createdPartyRecord <-
+            if (partyExistsOnLedger) {
+              withState {
+                val newPartyRecord = domain.ParticipantParty.PartyRecord(
+                  party = party,
+                  metadata = domain.ObjectMeta.empty,
+                )
+                for {
+                  _ <- withoutPartyRecord(party = newPartyRecord.party) {
+                    doCreatePartyRecord(newPartyRecord)
+                  }
+                  _ <- withPartyRecord(party) { info =>
+                    val updatedInfo: PartyRecordInfo = doUpdatePartyRecord(
+                      partyRecordUpdate = partyRecordUpdate,
+                      party = party,
+                      info = info,
+                    )
+                    toPartyRecord(updatedInfo)
+                  }
+                  updatePartyRecord <- {
+                    withPartyRecord(party) { updatedInfo =>
+                      toPartyRecord(updatedInfo)
+                    }
+                  }
+                } yield updatePartyRecord
+              }.map(tapSuccess { newPartyRecord =>
+                logger.error(
+                  s"Created a new party record in a participant local store: ${newPartyRecord}"
+                )
+              })(scala.concurrent.ExecutionContext.parasitic)
+            } else {
+              Future.successful(
+                Left(ParticipantPartyRecordStore.PartyNotFound(party))
+              )
+            }
+        } yield createdPartyRecord
+    }
+  }
+
+  private def doUpdatePartyRecord(
+      partyRecordUpdate: PartyRecordUpdate,
+      party: Party,
+      info: PartyRecordInfo,
+  ): PartyRecordInfo = {
+    val existingAnnotations = info.annotations
+    val updatedAnnotations =
+      partyRecordUpdate.metadataUpdate.annotationsUpdateO.fold(existingAnnotations) {
+        case AnnotationsUpdate.Merge(newAnnotations) => existingAnnotations.concat(newAnnotations)
+        case AnnotationsUpdate.Replace(newAnnotations) => newAnnotations
+      }
+    val updatedInfo = PartyRecordInfo(
+      party = party,
+      resourceVersion = info.resourceVersion + 1,
+      annotations = updatedAnnotations,
+    )
+    state.put(party, updatedInfo)
+    updatedInfo
+  }
+
+  private def doCreatePartyRecord(
+      partyRecord: ParticipantParty.PartyRecord
+  ): PartyRecordInfo = {
+    val info = PartyRecordInfo(
+      party = partyRecord.party,
+      resourceVersion = 0,
+      annotations = partyRecord.metadata.annotations,
+    )
+    state.update(partyRecord.party, info)
+    info
+  }
+
+  private def withState[T](t: => T): Future[T] =
+    state.synchronized(
+      Future(t)
+    )
+
+  private def withPartyRecord[T](
+      party: Ref.Party
+  )(f: InMemoryParticipantPartyRecordStore.PartyRecordInfo => T): Result[T] =
+    state.get(party) match {
+      case Some(partyRecord) => Right(f(partyRecord))
+      case None => Left(PartyRecordNotFound(party))
+    }
+
+  private def withoutPartyRecord[T](party: Ref.Party)(t: => T): Result[T] =
+    state.get(party) match {
+      case Some(_) => Left(PartyRecordExists(party))
+      case None => Right(t)
+    }
+
+  private def tapSuccess[T](f: T => Unit)(r: Result[T]): Result[T] = {
+    r.foreach(f)
+    r
+  }
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/impl/inmemory/InMemoryUserManagementStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/impl/inmemory/InMemoryUserManagementStore.scala
@@ -3,8 +3,12 @@
 
 package com.daml.ledger.participant.state.index.impl.inmemory
 
-import com.daml.ledger.api.domain.{User, UserRight}
-import com.daml.ledger.participant.state.index.v2.UserManagementStore
+import com.daml.ledger.api.domain.{ObjectMeta, User, UserRight}
+import com.daml.ledger.participant.state.index.v2.{
+  AnnotationsUpdate,
+  UserManagementStore,
+  UserUpdate,
+}
 import com.daml.ledger.participant.state.index.v2.UserManagementStore._
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.UserId
@@ -32,10 +36,46 @@ class InMemoryUserManagementStore(createAdmin: Boolean = true) extends UserManag
 
   override def createUser(user: User, rights: Set[UserRight])(implicit
       loggingContext: LoggingContext
-  ): Future[Result[Unit]] =
+  ): Future[Result[User]] =
     withoutUser(user.id) {
-      state.update(user.id, UserInfo(user, rights))
+      val userWithResourceVersion =
+        user.copy(metadata = user.metadata.copy(resourceVersionO = Some("0")))
+      state.update(user.id, UserInfo(userWithResourceVersion, rights))
+      userWithResourceVersion
     }
+
+  override def updateUser(
+      userUpdate: UserUpdate
+  )(implicit loggingContext: LoggingContext): Future[Result[User]] = {
+    withUser(userUpdate.id) { userInfo =>
+      val updatedPrimaryParty = userUpdate.primaryPartyUpdateO.getOrElse(userInfo.user.primaryParty)
+      val existingAnnotations = userInfo.user.metadata.annotations
+      val updatedAnnotations =
+        userUpdate.metadataUpdate.annotationsUpdateO.fold(existingAnnotations) {
+          case AnnotationsUpdate.Merge(newAnnotations) => existingAnnotations.concat(newAnnotations)
+          case AnnotationsUpdate.Replace(newAnnotations) => newAnnotations
+        }
+      val newResourceVersion = (userInfo.user.metadata.resourceVersionO
+        // TODO um-for-hub: Use error codes
+        .getOrElse(
+          sys.error(
+            s"Could not find resource version on user: ${userInfo.user}. All created users must have a resource version"
+          )
+        )
+        .toLong + 1).toString
+      val updatedUserInfo = userInfo.copy(
+        user = userInfo.user.copy(
+          primaryParty = updatedPrimaryParty,
+          metadata = ObjectMeta(
+            resourceVersionO = Some(newResourceVersion),
+            annotations = updatedAnnotations,
+          ),
+        )
+      )
+      state.update(userUpdate.id, updatedUserInfo)
+      updatedUserInfo.user
+    }
+  }
 
   override def deleteUser(
       id: Ref.UserId
@@ -91,7 +131,7 @@ class InMemoryUserManagementStore(createAdmin: Boolean = true) extends UserManag
   }
 
   private def withState[T](t: => T): Future[T] =
-    synchronized(
+    state.synchronized(
       Future.successful(t)
     )
 
@@ -127,8 +167,13 @@ class InMemoryUserManagementStore(createAdmin: Boolean = true) extends UserManag
 object InMemoryUserManagementStore {
 
   private val AdminUser = UserInfo(
-    user =
-      User(Ref.UserId.assertFromString(UserManagementStore.DefaultParticipantAdminUserId), None),
+    user = User(
+      id = Ref.UserId.assertFromString(UserManagementStore.DefaultParticipantAdminUserId),
+      primaryParty = None,
+      isDeactivated = false,
+      // TODO um-for-hub: Fill resource version
+      metadata = ObjectMeta.empty,
+    ),
     rights = Set(UserRight.ParticipantAdmin),
   )
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ParticipantPartyRecordStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ParticipantPartyRecordStore.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.index.v2
+
+import com.daml.ledger.api.domain
+import com.daml.lf.data.Ref
+import com.daml.logging.LoggingContext
+
+import scala.concurrent.Future
+
+trait LedgerPartyExists {
+
+  /** @return Whether a party is known to this participant
+    */
+  def exists(party: Ref.Party): Future[Boolean]
+}
+
+trait ParticipantPartyRecordStore {
+  import ParticipantPartyRecordStore._
+
+  def createPartyRecord(partyRecord: domain.ParticipantParty.PartyRecord)(implicit
+      loggingContext: LoggingContext
+  ): Future[Result[domain.ParticipantParty.PartyRecord]]
+
+  def updatePartyRecord(partyRecordUpdate: PartyRecordUpdate, ledgerPartyExists: LedgerPartyExists)(
+      implicit loggingContext: LoggingContext
+  ): Future[Result[domain.ParticipantParty.PartyRecord]]
+
+  def getPartyRecord(party: Ref.Party)(implicit
+      loggingContext: LoggingContext
+  ): Future[Result[domain.ParticipantParty.PartyRecord]]
+
+}
+
+object ParticipantPartyRecordStore {
+  type Result[T] = Either[Error, T]
+
+  final case object PartyRecordNotFoundOnUpdateException extends RuntimeException
+
+  sealed trait Error extends RuntimeException
+
+  final case class PartyNotFound(party: Ref.Party) extends Error
+  final case class PartyRecordNotFound(party: Ref.Party) extends Error
+  final case class PartyRecordExists(party: Ref.Party) extends Error
+  final case class ConcurrentPartyUpdate(party: Ref.Party) extends Error
+  final case class ExplicitMergeUpdateWithDefaultValue(party: Ref.Party) extends Error
+
+}

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ParticipantPartyRecordStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ParticipantPartyRecordStore.scala
@@ -16,6 +16,11 @@ trait LedgerPartyExists {
   def exists(party: Ref.Party): Future[Boolean]
 }
 
+case class PartyRecordUpdate(
+    party: Ref.Party,
+    metadataUpdate: ObjectMetaUpdate,
+)
+
 trait ParticipantPartyRecordStore {
   import ParticipantPartyRecordStore._
 
@@ -44,6 +49,5 @@ object ParticipantPartyRecordStore {
   final case class PartyRecordNotFound(party: Ref.Party) extends Error
   final case class PartyRecordExists(party: Ref.Party) extends Error
   final case class ConcurrentPartyUpdate(party: Ref.Party) extends Error
-  final case class ExplicitMergeUpdateWithDefaultValue(party: Ref.Party) extends Error
 
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/UserManagementStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/UserManagementStore.scala
@@ -16,11 +16,6 @@ case class UserUpdate(
     metadataUpdate: ObjectMetaUpdate,
 )
 
-case class PartyRecordUpdate(
-    party: Ref.Party,
-    metadataUpdate: ObjectMetaUpdate,
-)
-
 sealed trait AnnotationsUpdate {
   def annotations: Map[String, String]
 }
@@ -131,4 +126,5 @@ object UserManagementStore {
   final case class UserNotFound(userId: Ref.UserId) extends Error
   final case class UserExists(userId: Ref.UserId) extends Error
   final case class TooManyUserRights(userId: Ref.UserId) extends Error
+  final case class ConcurrentUserUpdate(party: Ref.UserId) extends Error
 }


### PR DESCRIPTION
changelog_begin
changelog_end


Depends on https://github.com/digital-asset/daml/pull/14793

(Extracted from https://github.com/digital-asset/daml/pull/14623/)