### PR TITLE
[ED] Implement usage of disclosed contracts in command interpretation [DPP-1096]

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -86,6 +86,7 @@ final class CommandsValidator(ledgerId: LedgerId) {
         ledgerEffectiveTime = ledgerEffectiveTimestamp,
         commandsReference = workflowId.fold("")(_.unwrap),
       ),
+      disclosedContracts = ImmArray.empty,
     )
 
   private def validateLedgerTime(

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -119,6 +119,7 @@ class SubmitRequestValidatorTest
         Time.Timestamp.assertFromInstant(ledgerTime),
         workflowId.unwrap,
       ),
+      disclosedContracts = ImmArray.empty,
     )
   }
 

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -5,8 +5,8 @@ package com.daml.ledger.api
 
 import com.daml.ledger.api.domain.Event.{CreateOrArchiveEvent, CreateOrExerciseEvent}
 import com.daml.ledger.configuration.Configuration
-import com.daml.lf.command.{ApiCommands => LfCommands}
-import com.daml.lf.data.Ref
+import com.daml.lf.command.{DisclosedContract, ApiCommands => LfCommands}
+import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.data.Ref.LedgerString.ordering
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.logging._
@@ -315,6 +315,7 @@ object domain {
       submittedAt: Timestamp,
       deduplicationPeriod: DeduplicationPeriod,
       commands: LfCommands,
+      disclosedContracts: ImmArray[DisclosedContract],
   )
 
   object Commands {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -25,6 +25,7 @@ import com.daml.platform.apiserver.configuration.{
 }
 import com.daml.platform.apiserver.execution.{
   LedgerTimeAwareCommandExecutor,
+  ResolveMaximumLedgerTime,
   StoreBackedCommandExecutor,
   TimedCommandExecutor,
 }
@@ -246,7 +247,7 @@ private[daml] object ApiServices {
               contractStore,
               metrics,
             ),
-            contractStore,
+            new ResolveMaximumLedgerTime(contractStore),
             maxRetries = 3,
             metrics,
           ),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutionResult.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutionResult.scala
@@ -4,7 +4,9 @@
 package com.daml.platform.apiserver.execution
 
 import com.daml.ledger.participant.state.{v2 => state}
-import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction}
+import com.daml.lf.command.DisclosedContract
+import com.daml.lf.data.ImmArray
+import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction, Versioned}
 import com.daml.lf.value.Value
 
 /** The result of command execution.
@@ -19,6 +21,13 @@ import com.daml.lf.value.Value
   *                                 transaction ([[state.TransactionMeta.ledgerEffectiveTime]])
   *                                 can safely be changed after command interpretation.
   * @param interpretationTimeNanos  Wall-clock time that interpretation took for the engine.
+  * @param globalKeyMapping         Input key mapping inferred by interpretation.
+  *                                 The map should contain all contract keys that were used during interpretation.
+  *                                 A value of None means no contract was found with this contract key.
+  * @param usedDisclosedContracts   The disclosed contracts used as part of command interpretation.
+  *                                 Note that this may be a subset of the `disclosed_contracts`
+  *                                 provided as part of the command submission by the client,
+  *                                 as superfluously-provided contracts are discarded by the Daml engine.
   */
 private[apiserver] final case class CommandExecutionResult(
     submitterInfo: state.SubmitterInfo,
@@ -27,4 +36,5 @@ private[apiserver] final case class CommandExecutionResult(
     dependsOnLedgerTime: Boolean,
     interpretationTimeNanos: Long,
     globalKeyMapping: Map[GlobalKey, Option[Value.ContractId]],
+    usedDisclosedContracts: ImmArray[Versioned[DisclosedContract]],
 )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
@@ -6,7 +6,7 @@ package com.daml.platform.apiserver.execution
 import com.daml.error.definitions.ErrorCause
 import com.daml.ledger.api.domain.Commands
 import com.daml.ledger.configuration.Configuration
-import com.daml.ledger.participant.state.index.v2.{ContractStore, MaximumLedgerTime}
+import com.daml.ledger.participant.state.index.v2.MaximumLedgerTime
 import com.daml.lf.crypto
 import com.daml.lf.data.Time
 import com.daml.lf.value.Value.ContractId
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success}
 
 private[apiserver] final class LedgerTimeAwareCommandExecutor(
     delegate: CommandExecutor,
-    contractStore: ContractStore,
+    resolveMaximumLedgerTime: ResolveMaximumLedgerTime,
     maxRetries: Int,
     metrics: Metrics,
 )(implicit
@@ -70,8 +70,7 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
             loop(c, submissionSeed, ledgerConfiguration, retriesLeft - 1)
           }
 
-          contractStore
-            .lookupMaximumLedgerTimeAfterInterpretation(usedContractIds)
+          resolveMaximumLedgerTime(cer.usedDisclosedContracts.map(_.unversioned), usedContractIds)
             .transformWith {
               case Success(MaximumLedgerTime.NotAvailable) =>
                 success(cer)
@@ -99,7 +98,7 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
               case Success(MaximumLedgerTime.Archived(contracts)) =>
                 if (retriesLeft > 0) {
                   logger.info(
-                    s"Some input contracts are archived: ${contracts.mkString("[", ", ", "]")} Restarting the computation."
+                    s"Some input contracts are archived: ${contracts.mkString("[", ", ", "]")}. Restarting the computation."
                   )
                   retry(commands)
                 } else {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/ResolveMaximumLedgerTime.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/ResolveMaximumLedgerTime.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.apiserver.execution
+
+import com.daml.ledger.participant.state.index.v2.{ContractStore, MaximumLedgerTime}
+import com.daml.lf.command.DisclosedContract
+import com.daml.lf.data.ImmArray
+import com.daml.lf.data.Time.Timestamp
+import com.daml.lf.value.Value.ContractId
+import com.daml.logging.LoggingContext
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Computes the maximum ledger time of all used contracts in a submission by:
+  * * Using the client-provided disclosed contracts `createdAt` timestamp
+  * * Falling back to contractStore lookups for contracts that have not been provided
+  * as part of submissions' `disclosed_contracts`
+  *
+  * @param contractStore The contract store.
+  */
+class ResolveMaximumLedgerTime(contractStore: ContractStore) {
+  def apply(
+      usedDisclosedContracts: ImmArray[DisclosedContract],
+      usedContractIds: Set[ContractId],
+  )(implicit lc: LoggingContext): Future[MaximumLedgerTime] = {
+    val usedDisclosedContractIds = usedDisclosedContracts.iterator.map(_.contractId).toSet
+
+    val contractIdsToBeLookedUp = usedContractIds -- usedDisclosedContractIds
+
+    contractStore
+      .lookupMaximumLedgerTimeAfterInterpretation(contractIdsToBeLookedUp)
+      .map(adjustTimeForDisclosedContracts(_, usedDisclosedContracts))(ExecutionContext.parasitic)
+  }
+
+  private def adjustTimeForDisclosedContracts(
+      lookupMaximumLet: MaximumLedgerTime,
+      disclosedContracts: ImmArray[DisclosedContract],
+  ): MaximumLedgerTime =
+    disclosedContracts.iterator
+      .map(_.metadata.createdAt)
+      .maxOption
+      .fold(lookupMaximumLet)(adjust(lookupMaximumLet, _))
+
+  private def adjust(
+      lookedMaximumLet: MaximumLedgerTime,
+      maxDisclosedContractTime: Timestamp,
+  ): MaximumLedgerTime = lookedMaximumLet match {
+    case MaximumLedgerTime.Max(maxUsedTime) =>
+      MaximumLedgerTime.Max(Ordering[Timestamp].max(maxDisclosedContractTime, maxUsedTime))
+    case MaximumLedgerTime.NotAvailable =>
+      MaximumLedgerTime.Max(maxDisclosedContractTime)
+    case other => other
+  }
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -3,9 +3,6 @@
 
 package com.daml.platform.apiserver.execution
 
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicLong
-
 import com.daml.error.definitions.ErrorCause
 import com.daml.ledger.api.domain.{Commands => ApiCommands}
 import com.daml.ledger.configuration.Configuration
@@ -29,6 +26,8 @@ import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.packages.DeduplicatingPackageLoader
 import scalaz.syntax.tag._
 
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.{ExecutionContext, Future}
 
 /** @param ec [[scala.concurrent.ExecutionContext]] that will be used for scheduling CPU-intensive computations
@@ -116,6 +115,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
       dependsOnLedgerTime = meta.dependsOnTime,
       interpretationTimeNanos = interpretationTimeNanos,
       globalKeyMapping = meta.globalKeyMapping,
+      usedDisclosedContracts = meta.disclosures,
     )
   }
 
@@ -140,7 +140,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
           commitAuthorizers,
           commands.readAs,
           commands.commands,
-          ImmArray.empty,
+          commands.disclosedContracts,
           participant,
           submissionSeed,
         )

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutorSpec.scala
@@ -3,8 +3,6 @@
 
 package com.daml.platform.apiserver.execution
 
-import java.time.Duration
-
 import com.codahale.metrics.MetricRegistry
 import com.daml.error.definitions.ErrorCause
 import com.daml.error.definitions.ErrorCause.LedgerTime
@@ -12,20 +10,24 @@ import com.daml.ledger.api.DeduplicationPeriod
 import com.daml.ledger.api.DeduplicationPeriod.DeduplicationDuration
 import com.daml.ledger.api.domain.{CommandId, Commands, LedgerId}
 import com.daml.ledger.configuration.{Configuration, LedgerTimeModel}
-import com.daml.ledger.participant.state.index.v2.{ContractStore, MaximumLedgerTime}
+import com.daml.ledger.participant.state.index.v2.MaximumLedgerTime
 import com.daml.ledger.participant.state.v2.{SubmitterInfo, TransactionMeta}
-import com.daml.lf.command.{ApiCommands => LfCommands}
+import com.daml.lf.command.{ContractMetadata, DisclosedContract, ApiCommands => LfCommands}
 import com.daml.lf.crypto.Hash
+import com.daml.lf.data.Ref.Identifier
 import com.daml.lf.data.{ImmArray, Ref, Time}
+import com.daml.lf.transaction.{TransactionVersion, Versioned}
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
+import java.time.Duration
 import scala.concurrent.Future
 
 class LedgerTimeAwareCommandExecutorSpec
@@ -34,8 +36,10 @@ class LedgerTimeAwareCommandExecutorSpec
     with MockitoSugar
     with ArgumentMatchersSugar {
 
-  val submissionSeed = Hash.hashPrivateKey("a key")
-  val configuration = Configuration(
+  private val loggingContext = LoggingContext.ForTesting
+
+  private val submissionSeed = Hash.hashPrivateKey("a key")
+  private val configuration = Configuration(
     generation = 1,
     timeModel = LedgerTimeModel(
       avgTransactionLatency = Duration.ZERO,
@@ -45,8 +49,8 @@ class LedgerTimeAwareCommandExecutorSpec
     maxDeduplicationDuration = Duration.ZERO,
   )
 
-  val cid = TransactionBuilder.newCid
-  val transaction = TransactionBuilder.justSubmitted(
+  private val cid = TransactionBuilder.newCid
+  private val transaction = TransactionBuilder.justSubmitted(
     TransactionBuilder().fetch(
       TransactionBuilder().create(
         cid,
@@ -61,11 +65,27 @@ class LedgerTimeAwareCommandExecutorSpec
     )
   )
 
+  private val disclosedContracts = ImmArray(
+    Versioned(
+      TransactionVersion.V15,
+      DisclosedContract(
+        templateId = Identifier.assertFromString("some:pkg:identifier"),
+        contractId = cid,
+        argument = Value.ValueNil,
+        metadata = ContractMetadata(
+          createdAt = Time.Timestamp.Epoch,
+          keyHash = None,
+          driverMetadata = ImmArray.empty,
+        ),
+      ),
+    )
+  )
+
   private def runExecutionTest(
       dependsOnLedgerTime: Boolean,
-      contractStoreResults: List[MaximumLedgerTime],
+      resolveMaximumLedgerTimeResults: List[MaximumLedgerTime],
       finalExecutionResult: Either[ErrorCause, Time.Timestamp],
-  ) = {
+  ): Future[Assertion] = {
 
     def commandExecutionResult(let: Time.Timestamp) = CommandExecutionResult(
       SubmitterInfo(
@@ -82,6 +102,7 @@ class LedgerTimeAwareCommandExecutorSpec
       dependsOnLedgerTime,
       5L,
       Map.empty,
+      disclosedContracts,
     )
 
     val mockExecutor = mock[CommandExecutor]
@@ -94,14 +115,17 @@ class LedgerTimeAwareCommandExecutorSpec
         Future.successful(Right(commandExecutionResult(c.commands.ledgerEffectiveTime)))
       )
 
-    val mockContractStore = mock[ContractStore]
-    contractStoreResults.tail.foldLeft(
+    val mockResolveMaximumLedgerTime = mock[ResolveMaximumLedgerTime]
+    resolveMaximumLedgerTimeResults.tail.foldLeft(
       when(
-        mockContractStore.lookupMaximumLedgerTimeAfterInterpretation(any[Set[ContractId]])(
+        mockResolveMaximumLedgerTime(
+          eqTo(disclosedContracts.map(_.unversioned)),
+          any[Set[ContractId]],
+        )(
           any[LoggingContext]
         )
       )
-        .thenReturn(Future.successful(contractStoreResults.head))
+        .thenReturn(Future.successful(resolveMaximumLedgerTimeResults.head))
     ) { case (mock, result) =>
       mock.andThen(Future.successful(result))
     }
@@ -121,45 +145,44 @@ class LedgerTimeAwareCommandExecutorSpec
         ledgerEffectiveTime = Time.Timestamp.Epoch,
         commandsReference = "",
       ),
+      ImmArray.empty,
     )
 
     val instance = new LedgerTimeAwareCommandExecutor(
       mockExecutor,
-      mockContractStore,
+      mockResolveMaximumLedgerTime,
       3,
       new Metrics(new MetricRegistry),
     )
-    LoggingContext.newLoggingContext { implicit context =>
-      instance.execute(commands, submissionSeed, configuration).map { actual =>
-        val expectedResult = finalExecutionResult.map(let =>
-          CommandExecutionResult(
-            SubmitterInfo(
-              Nil,
-              Nil,
-              Ref.ApplicationId.assertFromString("foobar"),
-              Ref.CommandId.assertFromString("foobar"),
-              DeduplicationDuration(Duration.ofMinutes(1)),
-              None,
-              configuration,
-            ),
-            TransactionMeta(let, None, Time.Timestamp.Epoch, submissionSeed, None, None, None),
-            transaction,
-            dependsOnLedgerTime,
-            5L,
-            Map.empty,
-          )
+
+    instance.execute(commands, submissionSeed, configuration)(loggingContext).map { actual =>
+      val expectedResult = finalExecutionResult.map(let =>
+        CommandExecutionResult(
+          SubmitterInfo(
+            Nil,
+            Nil,
+            Ref.ApplicationId.assertFromString("foobar"),
+            Ref.CommandId.assertFromString("foobar"),
+            DeduplicationDuration(Duration.ofMinutes(1)),
+            None,
+            configuration,
+          ),
+          TransactionMeta(let, None, Time.Timestamp.Epoch, submissionSeed, None, None, None),
+          transaction,
+          dependsOnLedgerTime,
+          5L,
+          Map.empty,
+          disclosedContracts,
         )
+      )
 
-        verify(mockExecutor, times(contractStoreResults.size)).execute(
-          any[Commands],
-          any[Hash],
-          any[Configuration],
-        )(any[LoggingContext])
-        verify(mockContractStore, times(contractStoreResults.size))
-          .lookupMaximumLedgerTimeAfterInterpretation(Set(cid))
+      verify(mockExecutor, times(resolveMaximumLedgerTimeResults.size)).execute(
+        any[Commands],
+        any[Hash],
+        any[Configuration],
+      )(any[LoggingContext])
 
-        actual shouldEqual expectedResult
-      }
+      actual shouldEqual expectedResult
     }
   }
 
@@ -171,18 +194,18 @@ class LedgerTimeAwareCommandExecutorSpec
 
   "LedgerTimeAwareCommandExecutor" when {
     "the model doesn't use getTime" should {
-      "not retry if ledger effective time is found in the contract store" in {
+      "not retry if ledger effective time is resolved" in {
         runExecutionTest(
           dependsOnLedgerTime = false,
-          contractStoreResults = List(foundEpoch),
+          resolveMaximumLedgerTimeResults = List(foundEpoch),
           finalExecutionResult = Right(Time.Timestamp.Epoch),
         )
       }
 
-      "not retry if the contract does not have ledger effective time" in {
+      "not retry if the maximum ledger time is not available" in {
         runExecutionTest(
           dependsOnLedgerTime = false,
-          contractStoreResults = List(noLetFound),
+          resolveMaximumLedgerTimeResults = List(noLetFound),
           finalExecutionResult = Right(Time.Timestamp.Epoch),
         )
       }
@@ -190,7 +213,7 @@ class LedgerTimeAwareCommandExecutorSpec
       "retry if the contract cannot be found in the contract store and fail at max retries" in {
         runExecutionTest(
           dependsOnLedgerTime = false,
-          contractStoreResults = List(missingCid, missingCid, missingCid, missingCid),
+          resolveMaximumLedgerTimeResults = List(missingCid, missingCid, missingCid, missingCid),
           finalExecutionResult = Left(LedgerTime(3)),
         )
       }
@@ -198,7 +221,7 @@ class LedgerTimeAwareCommandExecutorSpec
       "succeed if the contract can be found on a retry" in {
         runExecutionTest(
           dependsOnLedgerTime = false,
-          contractStoreResults = List(missingCid, missingCid, missingCid, foundEpoch),
+          resolveMaximumLedgerTimeResults = List(missingCid, missingCid, missingCid, foundEpoch),
           finalExecutionResult = Right(Time.Timestamp.Epoch),
         )
       }
@@ -206,7 +229,7 @@ class LedgerTimeAwareCommandExecutorSpec
       "advance the output time if the contract's LET is in the future" in {
         runExecutionTest(
           dependsOnLedgerTime = false,
-          contractStoreResults = List(foundEpochPlus5),
+          resolveMaximumLedgerTimeResults = List(foundEpochPlus5),
           finalExecutionResult = Right(epochPlus5),
         )
       }
@@ -216,7 +239,7 @@ class LedgerTimeAwareCommandExecutorSpec
       "retry if the contract's LET is in the future" in {
         runExecutionTest(
           dependsOnLedgerTime = true,
-          contractStoreResults = List(
+          resolveMaximumLedgerTimeResults = List(
             // the first lookup of +5s will cause the interpretation to be restarted,
             // in case the usage of getTime with a different LET would result in a different transaction
             foundEpochPlus5,
@@ -230,7 +253,7 @@ class LedgerTimeAwareCommandExecutorSpec
       "retry if the contract's LET is in the future and then retry if the contract is missing" in {
         runExecutionTest(
           dependsOnLedgerTime = true,
-          contractStoreResults = List(
+          resolveMaximumLedgerTimeResults = List(
             // the first lookup of +5s will cause the interpretation to be restarted,
             // in case the usage of getTime with a different LET would result in a different transaction
             foundEpochPlus5,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/ResolveMaximumLedgerTimeSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/ResolveMaximumLedgerTimeSpec.scala
@@ -38,13 +38,10 @@ class ResolveMaximumLedgerTimeSpec
       buildDisclosedContract(cId_2, t2),
     )
 
-    private val actualResult: MaximumLedgerTime =
-      resolveMaximumLedgerTime(disclosedContracts, Set(cId_2, cId_3, cId_4)).futureValue
-
-    actualResult match {
-      case MaximumLedgerTime.Max(actualLedgerTime) => actualLedgerTime shouldBe t4
-      case other => fail(s"Unexpected $other")
-    }
+    resolveMaximumLedgerTime(
+      disclosedContracts,
+      Set(cId_2, cId_3, cId_4),
+    ).futureValue shouldBe MaximumLedgerTime.Max(t4)
   }
 
   it should "resolve maximum ledger time when all contracts are provided as explicitly disclosed" in new TestScope {
@@ -53,23 +50,17 @@ class ResolveMaximumLedgerTimeSpec
       buildDisclosedContract(cId_2, t2),
     )
 
-    private val actualResult: MaximumLedgerTime =
-      resolveMaximumLedgerTime(disclosedContracts, Set(cId_1, cId_2)).futureValue
-
-    actualResult match {
-      case MaximumLedgerTime.Max(actualLedgerTime) => actualLedgerTime shouldBe t2
-      case other => fail(s"Unexpected $other")
-    }
+    resolveMaximumLedgerTime(
+      disclosedContracts,
+      Set(cId_1, cId_2),
+    ).futureValue shouldBe MaximumLedgerTime.Max(t2)
   }
 
   it should "resolve maximum ledger time when no disclosed contracts are provided" in new TestScope {
-    private val actualResult: MaximumLedgerTime =
-      resolveMaximumLedgerTime(ImmArray.empty, Set(cId_1, cId_2)).futureValue
-
-    actualResult match {
-      case MaximumLedgerTime.Max(actualLedgerTime) => actualLedgerTime shouldBe t2
-      case other => fail(s"Unexpected $other")
-    }
+    resolveMaximumLedgerTime(
+      ImmArray.empty,
+      Set(cId_1, cId_2),
+    ).futureValue shouldBe MaximumLedgerTime.Max(t2)
   }
 
   it should "forward contract store lookup result on archived contracts" in new TestScope {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/ResolveMaximumLedgerTimeSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/ResolveMaximumLedgerTimeSpec.scala
@@ -73,13 +73,10 @@ class ResolveMaximumLedgerTimeSpec
   }
 
   it should "forward contract store lookup result on archived contracts" in new TestScope {
-    private val actualResult: MaximumLedgerTime =
-      resolveMaximumLedgerTime(ImmArray.empty, archived.contracts + cId_1).futureValue
-
-    actualResult match {
-      case `archived` => ()
-      case other => fail(s"Unexpected $other")
-    }
+    resolveMaximumLedgerTime(
+      ImmArray.empty,
+      archived.contracts + cId_1,
+    ).futureValue shouldBe archived
   }
 
   private def buildDisclosedContract(cId: ContractId, createdAt: Time.Timestamp) =

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/ResolveMaximumLedgerTimeSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/ResolveMaximumLedgerTimeSpec.scala
@@ -1,0 +1,140 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.apiserver.execution
+
+import com.daml.ledger.participant.state.index.v2.{ContractStore, MaximumLedgerTime}
+import com.daml.lf.command.{ContractMetadata, DisclosedContract}
+import com.daml.lf.crypto.Hash
+import com.daml.lf.data.Ref.Identifier
+import com.daml.lf.data.{ImmArray, Time}
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value.ContractId
+import com.daml.logging.LoggingContext
+import org.mockito.captor.{ArgCaptor, Captor}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.Future
+
+class ResolveMaximumLedgerTimeSpec
+    extends AnyFlatSpec
+    with Matchers
+    with MockitoSugar
+    with ScalaFutures
+    with ArgumentMatchersSugar {
+
+  private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
+
+  behavior of classOf[ResolveMaximumLedgerTime].getSimpleName
+
+  it should "resolve maximum ledger time using disclosed contracts with fallback to contract store lookup" in new TestScope {
+    private val disclosedContracts = ImmArray(
+      buildDisclosedContract(cId_1, t1),
+      buildDisclosedContract(cId_2, t2),
+    )
+
+    private val actualResult: MaximumLedgerTime =
+      resolveMaximumLedgerTime(disclosedContracts, Set(cId_2, cId_3, cId_4)).futureValue
+
+    actualResult match {
+      case MaximumLedgerTime.Max(actualLedgerTime) => actualLedgerTime shouldBe t4
+      case other => fail(s"Unexpected $other")
+    }
+  }
+
+  it should "resolve maximum ledger time when all contracts are provided as explicitly disclosed" in new TestScope {
+    private val disclosedContracts = ImmArray(
+      buildDisclosedContract(cId_1, t1),
+      buildDisclosedContract(cId_2, t2),
+    )
+
+    private val actualResult: MaximumLedgerTime =
+      resolveMaximumLedgerTime(disclosedContracts, Set(cId_1, cId_2)).futureValue
+
+    actualResult match {
+      case MaximumLedgerTime.Max(actualLedgerTime) => actualLedgerTime shouldBe t2
+      case other => fail(s"Unexpected $other")
+    }
+  }
+
+  it should "resolve maximum ledger time when no disclosed contracts are provided" in new TestScope {
+    private val actualResult: MaximumLedgerTime =
+      resolveMaximumLedgerTime(ImmArray.empty, Set(cId_1, cId_2)).futureValue
+
+    actualResult match {
+      case MaximumLedgerTime.Max(actualLedgerTime) => actualLedgerTime shouldBe t2
+      case other => fail(s"Unexpected $other")
+    }
+  }
+
+  it should "forward contract store lookup result on archived contracts" in new TestScope {
+    private val actualResult: MaximumLedgerTime =
+      resolveMaximumLedgerTime(ImmArray.empty, archived.contracts + cId_1).futureValue
+
+    actualResult match {
+      case `archived` => ()
+      case other => fail(s"Unexpected $other")
+    }
+  }
+
+  private def buildDisclosedContract(cId: ContractId, createdAt: Time.Timestamp) =
+    DisclosedContract(
+      templateId = Identifier.assertFromString("some:pkg:identifier"),
+      contractId = cId,
+      argument = Value.ValueNil,
+      metadata = ContractMetadata(
+        createdAt = createdAt,
+        keyHash = None,
+        driverMetadata = ImmArray.empty,
+      ),
+    )
+
+  private def contractId(id: Int): ContractId =
+    ContractId.V1(Hash.hashPrivateKey(id.toString))
+
+  private trait TestScope {
+    val t1: Time.Timestamp = Time.Timestamp.assertFromLong(1L)
+    val t2: Time.Timestamp = Time.Timestamp.assertFromLong(2L)
+    val t3: Time.Timestamp = Time.Timestamp.assertFromLong(3L)
+    val t4: Time.Timestamp = Time.Timestamp.assertFromLong(4L)
+
+    val cId_1: ContractId = contractId(1)
+    val cId_2: ContractId = contractId(2)
+    val cId_3: ContractId = contractId(3)
+    val cId_4: ContractId = contractId(4)
+    val cId_5: ContractId = contractId(5)
+
+    val archived: MaximumLedgerTime.Archived = MaximumLedgerTime.Archived(Set(cId_5))
+
+    def mapping: Map[ContractId, Time.Timestamp] = Map(
+      cId_1 -> t1,
+      cId_2 -> t2,
+      cId_3 -> t3,
+      cId_4 -> t4,
+    )
+
+    val contractStoreMock: ContractStore = mock[ContractStore]
+    val lookedUpCidsCaptor: Captor[Set[ContractId]] = ArgCaptor[Set[ContractId]]
+
+    when(
+      contractStoreMock.lookupMaximumLedgerTimeAfterInterpretation(lookedUpCidsCaptor.capture)(
+        eqTo(loggingContext)
+      )
+    ).delegate.thenAnswer(new Answer[Future[MaximumLedgerTime]]() {
+      override def answer(invocation: InvocationOnMock): Future[MaximumLedgerTime] = {
+        val lookedUpCids = lookedUpCidsCaptor.value
+
+        if (lookedUpCids.isEmpty) Future.successful(MaximumLedgerTime.NotAvailable)
+        else if (archived.contracts.diff(lookedUpCids).isEmpty) Future.successful(archived)
+        else Future.successful(MaximumLedgerTime.Max(lookedUpCids.map(mapping).max))
+      }
+    })
+
+    val resolveMaximumLedgerTime = new ResolveMaximumLedgerTime(contractStoreMock)
+  }
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/ApiSubmissionServiceSpec.scala
@@ -353,6 +353,7 @@ object ApiSubmissionServiceSpec {
         submittedAt = Timestamp.Epoch,
         deduplicationPeriod = DeduplicationPeriod.DeduplicationDuration(Duration.ZERO),
         commands = LfCommands(ImmArray.Empty, Timestamp.MinValue, ""),
+        disclosedContracts = ImmArray.empty,
       )
     )
   }


### PR DESCRIPTION
Implement usage of disclosed contracts in command interpretation

* NOTE: No actual disclosed contracts can be passed at this point to command interpretation since command validation disallows it

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
