### PR TITLE
deprecate interface library names; use new names downstream

### DIFF
--- a/daml-lf/api-type-signature/src/main/scala/lf/iface/package.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/iface/package.scala
@@ -42,7 +42,7 @@ package object iface {
   // @deprecated("moved to typesig.DefTemplate", since = "2.4.0")
   final val DefTemplate = typesig.DefTemplate
 
-  // @deprecated("moved to typesig.TemplateChoices", since = "2.4.0")
+  @deprecated("moved to typesig.TemplateChoices", since = "2.4.0")
   type TemplateChoices[+Ty] = typesig.TemplateChoices[Ty]
   // @deprecated("moved to typesig.TemplateChoices", since = "2.4.0")
   final val TemplateChoices = typesig.TemplateChoices
@@ -76,11 +76,11 @@ package object iface {
   type Type = typesig.Type
   // @deprecated("moved to typesig.Type", since = "2.4.0")
   final val Type = typesig.Type
-  // @deprecated("moved to typesig.TypeCon", since = "2.4.0")
+  @deprecated("moved to typesig.TypeCon", since = "2.4.0")
   type TypeCon = typesig.TypeCon
   // @deprecated("moved to typesig.TypeCon", since = "2.4.0")
   final val TypeCon = typesig.TypeCon
-  // @deprecated("moved to typesig.TypeNumeric", since = "2.4.0")
+  @deprecated("moved to typesig.TypeNumeric", since = "2.4.0")
   type TypeNumeric = typesig.TypeNumeric
   // @deprecated("moved to typesig.TypeNumeric", since = "2.4.0")
   final val TypeNumeric = typesig.TypeNumeric
@@ -96,7 +96,7 @@ package object iface {
   // @deprecated("moved to typesig.TypeConNameOrPrimType", since = "2.4.0")
   type TypeConNameOrPrimType = typesig.TypeConNameOrPrimType
 
-  // @deprecated("moved to typesig.TypeConName", since = "2.4.0")
+  @deprecated("moved to typesig.TypeConName", since = "2.4.0")
   type TypeConName = typesig.TypeConName
   // @deprecated("moved to typesig.TypeConName", since = "2.4.0")
   final val TypeConName = typesig.TypeConName
@@ -130,6 +130,6 @@ package object iface {
   // @deprecated("moved to typesig.PrimTypeGenMap", since = "2.4.0")
   final val PrimTypeGenMap = typesig.PrimTypeGenMap
 
-  // @deprecated("moved to typesig.PrimTypeVisitor", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeVisitor", since = "2.4.0")
   type PrimTypeVisitor[+Z] = typesig.PrimTypeVisitor[Z]
 }

--- a/daml-lf/api-type-signature/src/main/scala/lf/iface/package.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/iface/package.scala
@@ -4,130 +4,130 @@
 package com.daml.lf
 
 package object iface {
-  // @deprecated("renamed to typesig.EnvironmentSignature", since = "2.4.0")
+  @deprecated("renamed to typesig.EnvironmentSignature", since = "2.4.0")
   type EnvironmentInterface = typesig.EnvironmentSignature
-  // @deprecated("renamed to typesig.EnvironmentSignature", since = "2.4.0")
+  @deprecated("renamed to typesig.EnvironmentSignature", since = "2.4.0")
   final val EnvironmentInterface = typesig.EnvironmentSignature
 
-  // @deprecated("renamed to typesig.FieldWithType", since = "2.4.0")
+  @deprecated("renamed to typesig.FieldWithType", since = "2.4.0")
   type FieldWithType = typesig.FieldWithType
 
-  // @deprecated("moved to typesig.DefDataType", since = "2.4.0")
+  @deprecated("moved to typesig.DefDataType", since = "2.4.0")
   type DefDataType[+RF, +VF] = typesig.DefDataType[RF, VF]
-  // @deprecated("moved to typesig.DefDataType", since = "2.4.0")
+  @deprecated("moved to typesig.DefDataType", since = "2.4.0")
   final val DefDataType = typesig.DefDataType
 
-  // @deprecated("moved to typesig.DataType", since = "2.4.0")
+  @deprecated("moved to typesig.DataType", since = "2.4.0")
   type DataType[+RT, +VT] = typesig.DataType[RT, VT]
-  // @deprecated("moved to typesig.DataType", since = "2.4.0")
+  @deprecated("moved to typesig.DataType", since = "2.4.0")
   final val DataType = typesig.DataType
 
-  // @deprecated("moved to typesig.Record", since = "2.4.0")
+  @deprecated("moved to typesig.Record", since = "2.4.0")
   type Record[+RT] = typesig.Record[RT]
-  // @deprecated("moved to typesig.Record", since = "2.4.0")
+  @deprecated("moved to typesig.Record", since = "2.4.0")
   final val Record = typesig.Record
 
-  // @deprecated("moved to typesig.Variant", since = "2.4.0")
+  @deprecated("moved to typesig.Variant", since = "2.4.0")
   type Variant[+VT] = typesig.Variant[VT]
-  // @deprecated("moved to typesig.Variant", since = "2.4.0")
+  @deprecated("moved to typesig.Variant", since = "2.4.0")
   final val Variant = typesig.Variant
 
-  // @deprecated("moved to typesig.Enum", since = "2.4.0")
+  @deprecated("moved to typesig.Enum", since = "2.4.0")
   type Enum = typesig.Enum
-  // @deprecated("moved to typesig.Enum", since = "2.4.0")
+  @deprecated("moved to typesig.Enum", since = "2.4.0")
   final val Enum = typesig.Enum
 
-  // @deprecated("moved to typesig.DefTemplate", since = "2.4.0")
+  @deprecated("moved to typesig.DefTemplate", since = "2.4.0")
   type DefTemplate[+Ty] = typesig.DefTemplate[Ty]
-  // @deprecated("moved to typesig.DefTemplate", since = "2.4.0")
+  @deprecated("moved to typesig.DefTemplate", since = "2.4.0")
   final val DefTemplate = typesig.DefTemplate
 
   @deprecated("moved to typesig.TemplateChoices", since = "2.4.0")
   type TemplateChoices[+Ty] = typesig.TemplateChoices[Ty]
-  // @deprecated("moved to typesig.TemplateChoices", since = "2.4.0")
+  @deprecated("moved to typesig.TemplateChoices", since = "2.4.0")
   final val TemplateChoices = typesig.TemplateChoices
 
-  // @deprecated("moved to typesig.TemplateChoice", since = "2.4.0")
+  @deprecated("moved to typesig.TemplateChoice", since = "2.4.0")
   type TemplateChoice[+Ty] = typesig.TemplateChoice[Ty]
-  // @deprecated("moved to typesig.TemplateChoice", since = "2.4.0")
+  @deprecated("moved to typesig.TemplateChoice", since = "2.4.0")
   final val TemplateChoice = typesig.TemplateChoice
 
-  // @deprecated("moved to typesig.DefInterface", since = "2.4.0")
+  @deprecated("moved to typesig.DefInterface", since = "2.4.0")
   type DefInterface[+Ty] = typesig.DefInterface[Ty]
-  // @deprecated("moved to typesig.DefInterface", since = "2.4.0")
+  @deprecated("moved to typesig.DefInterface", since = "2.4.0")
   final val DefInterface = typesig.DefInterface
 
-  // @deprecated("renamed to typesig.PackageSignature.TypeDecl", since = "2.4.0")
+  @deprecated("renamed to typesig.PackageSignature.TypeDecl", since = "2.4.0")
   type InterfaceType = typesig.PackageSignature.TypeDecl
-  // @deprecated("renamed to typesig.PackageSignature.TypeDecl", since = "2.4.0")
+  @deprecated("renamed to typesig.PackageSignature.TypeDecl", since = "2.4.0")
   final val InterfaceType = typesig.PackageSignature.TypeDecl
 
-  // @deprecated("moved to typesig.PackageMetadata", since = "2.4.0")
+  @deprecated("moved to typesig.PackageMetadata", since = "2.4.0")
   type PackageMetadata = typesig.PackageMetadata
-  // @deprecated("moved to typesig.PackageMetadata", since = "2.4.0")
+  @deprecated("moved to typesig.PackageMetadata", since = "2.4.0")
   final val PackageMetadata = typesig.PackageMetadata
 
-  // @deprecated("renamed to typesig.PackageSignature", since = "2.4.0")
+  @deprecated("renamed to typesig.PackageSignature", since = "2.4.0")
   type Interface = typesig.PackageSignature
-  // @deprecated("renamed to typesig.PackageSignature", since = "2.4.0")
+  @deprecated("renamed to typesig.PackageSignature", since = "2.4.0")
   final val Interface = typesig.PackageSignature
 
-  // @deprecated("moved to typesig.Type", since = "2.4.0")
+  @deprecated("moved to typesig.Type", since = "2.4.0")
   type Type = typesig.Type
-  // @deprecated("moved to typesig.Type", since = "2.4.0")
+  @deprecated("moved to typesig.Type", since = "2.4.0")
   final val Type = typesig.Type
   @deprecated("moved to typesig.TypeCon", since = "2.4.0")
   type TypeCon = typesig.TypeCon
-  // @deprecated("moved to typesig.TypeCon", since = "2.4.0")
+  @deprecated("moved to typesig.TypeCon", since = "2.4.0")
   final val TypeCon = typesig.TypeCon
   @deprecated("moved to typesig.TypeNumeric", since = "2.4.0")
   type TypeNumeric = typesig.TypeNumeric
-  // @deprecated("moved to typesig.TypeNumeric", since = "2.4.0")
+  @deprecated("moved to typesig.TypeNumeric", since = "2.4.0")
   final val TypeNumeric = typesig.TypeNumeric
-  // @deprecated("moved to typesig.TypePrim", since = "2.4.0")
+  @deprecated("moved to typesig.TypePrim", since = "2.4.0")
   type TypePrim = typesig.TypePrim
-  // @deprecated("moved to typesig.TypePrim", since = "2.4.0")
+  @deprecated("moved to typesig.TypePrim", since = "2.4.0")
   final val TypePrim = typesig.TypePrim
-  // @deprecated("moved to typesig.TypeVar", since = "2.4.0")
+  @deprecated("moved to typesig.TypeVar", since = "2.4.0")
   type TypeVar = typesig.TypeVar
-  // @deprecated("moved to typesig.TypeVar", since = "2.4.0")
+  @deprecated("moved to typesig.TypeVar", since = "2.4.0")
   final val TypeVar = typesig.TypeVar
 
-  // @deprecated("moved to typesig.TypeConNameOrPrimType", since = "2.4.0")
+  @deprecated("moved to typesig.TypeConNameOrPrimType", since = "2.4.0")
   type TypeConNameOrPrimType = typesig.TypeConNameOrPrimType
 
   @deprecated("moved to typesig.TypeConName", since = "2.4.0")
   type TypeConName = typesig.TypeConName
-  // @deprecated("moved to typesig.TypeConName", since = "2.4.0")
+  @deprecated("moved to typesig.TypeConName", since = "2.4.0")
   final val TypeConName = typesig.TypeConName
-  // @deprecated("moved to typesig.PrimType", since = "2.4.0")
+  @deprecated("moved to typesig.PrimType", since = "2.4.0")
   type PrimType = typesig.PrimType
-  // @deprecated("moved to typesig.PrimType", since = "2.4.0")
+  @deprecated("moved to typesig.PrimType", since = "2.4.0")
   final val PrimType = typesig.PrimType
 
-  // @deprecated("moved to typesig.PrimTypeBool", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeBool", since = "2.4.0")
   final val PrimTypeBool = typesig.PrimTypeBool
-  // @deprecated("moved to typesig.PrimTypeInt", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeInt", since = "2.4.0")
   final val PrimTypeInt64 = typesig.PrimTypeInt64
-  // @deprecated("moved to typesig.PrimTypeText", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeText", since = "2.4.0")
   final val PrimTypeText = typesig.PrimTypeText
-  // @deprecated("moved to typesig.PrimTypeDate", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeDate", since = "2.4.0")
   final val PrimTypeDate = typesig.PrimTypeDate
-  // @deprecated("moved to typesig.PrimTypeTimestamp", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeTimestamp", since = "2.4.0")
   final val PrimTypeTimestamp = typesig.PrimTypeTimestamp
-  // @deprecated("moved to typesig.PrimTypeParty", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeParty", since = "2.4.0")
   final val PrimTypeParty = typesig.PrimTypeParty
-  // @deprecated("moved to typesig.PrimTypeContractId", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeContractId", since = "2.4.0")
   final val PrimTypeContractId = typesig.PrimTypeContractId
-  // @deprecated("moved to typesig.PrimTypeList", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeList", since = "2.4.0")
   final val PrimTypeList = typesig.PrimTypeList
-  // @deprecated("moved to typesig.PrimTypeUnit", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeUnit", since = "2.4.0")
   final val PrimTypeUnit = typesig.PrimTypeUnit
-  // @deprecated("moved to typesig.PrimTypeOptional", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeOptional", since = "2.4.0")
   final val PrimTypeOptional = typesig.PrimTypeOptional
-  // @deprecated("moved to typesig.PrimTypeTextMap", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeTextMap", since = "2.4.0")
   final val PrimTypeTextMap = typesig.PrimTypeTextMap
-  // @deprecated("moved to typesig.PrimTypeGenMap", since = "2.4.0")
+  @deprecated("moved to typesig.PrimTypeGenMap", since = "2.4.0")
   final val PrimTypeGenMap = typesig.PrimTypeGenMap
 
   @deprecated("moved to typesig.PrimTypeVisitor", since = "2.4.0")

--- a/daml-lf/api-type-signature/src/main/scala/lf/iface/reader/package.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/iface/reader/package.scala
@@ -6,7 +6,7 @@ package com.daml.lf.iface
 import com.daml.lf.typesig.{reader => tsr}
 
 package object reader {
-  // @deprecated("moved to typesig.reader.DamlLfArchiveReader", since = "2.4.0")
+  @deprecated("moved to typesig.reader.DamlLfArchiveReader", since = "2.4.0")
   final val DamlLfArchiveReader = tsr.DamlLfArchiveReader
 
   // @deprecated("moved to typesig.reader.Errors", since = "2.4.0")
@@ -15,6 +15,6 @@ package object reader {
   final val Errors = tsr.Errors
   // @deprecated("renamed to typesig.reader.SignatureReader", since = "2.4.0")
   final val InterfaceReader = tsr.SignatureReader
-  // @deprecated("renamed to typesig.reader.SignatureReaderMain", since = "2.4.0")
+  @deprecated("renamed to typesig.reader.SignatureReaderMain", since = "2.4.0")
   final val InterfaceReaderMain = tsr.SignatureReaderMain
 }

--- a/daml-lf/api-type-signature/src/main/scala/lf/iface/reader/package.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/iface/reader/package.scala
@@ -9,11 +9,11 @@ package object reader {
   @deprecated("moved to typesig.reader.DamlLfArchiveReader", since = "2.4.0")
   final val DamlLfArchiveReader = tsr.DamlLfArchiveReader
 
-  // @deprecated("moved to typesig.reader.Errors", since = "2.4.0")
+  @deprecated("moved to typesig.reader.Errors", since = "2.4.0")
   type Errors[K, A] = tsr.Errors[K, A]
-  // @deprecated("moved to typesig.reader.Errors", since = "2.4.0")
+  @deprecated("moved to typesig.reader.Errors", since = "2.4.0")
   final val Errors = tsr.Errors
-  // @deprecated("renamed to typesig.reader.SignatureReader", since = "2.4.0")
+  @deprecated("renamed to typesig.reader.SignatureReader", since = "2.4.0")
   final val InterfaceReader = tsr.SignatureReader
   @deprecated("renamed to typesig.reader.SignatureReaderMain", since = "2.4.0")
   final val InterfaceReaderMain = tsr.SignatureReaderMain

--- a/daml-lf/api-type-signature/src/main/scala/lf/typesig/EnvironmentSignature.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/typesig/EnvironmentSignature.scala
@@ -84,7 +84,7 @@ object EnvironmentSignature {
   def fromPackageSignatures(dar: Dar[PackageSignature]): EnvironmentSignature =
     fromPackageSignatures(dar.main, dar.dependencies: _*)
 
-  // @deprecated("renamed to fromPackageSignatures", since = "2.4.0")
+  @deprecated("renamed to fromPackageSignatures", since = "2.4.0")
   def fromReaderInterfaces(all: Iterable[PackageSignature]): EnvironmentSignature =
     fromPackageSignatures(all)
 

--- a/daml-lf/api-type-signature/src/main/scala/lf/typesig/EnvironmentSignature.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/typesig/EnvironmentSignature.scala
@@ -21,7 +21,7 @@ final case class EnvironmentSignature(
 ) {
   import PackageSignature.TypeDecl
 
-  // @deprecated("renamed to interfaces", since = "2.4.0")
+  @deprecated("renamed to interfaces", since = "2.4.0")
   def astInterfaces: interfaces.type = interfaces
 
   /** Replace all resolvable `inheritedChoices` in `typeDecls` with concrete
@@ -70,14 +70,14 @@ final case class EnvironmentSignature(
 }
 
 object EnvironmentSignature {
-  // @deprecated("renamed to fromPackageSignatures", since = "2.4.0")
+  @deprecated("renamed to fromPackageSignatures", since = "2.4.0")
   def fromReaderInterfaces(i: PackageSignature, o: PackageSignature*): EnvironmentSignature =
     fromPackageSignatures(i, o: _*)
 
   def fromPackageSignatures(i: PackageSignature, o: PackageSignature*): EnvironmentSignature =
     fromPackageSignatures(i +: o)
 
-  // @deprecated("renamed to fromPackageSignatures", since = "2.4.0")
+  @deprecated("renamed to fromPackageSignatures", since = "2.4.0")
   def fromReaderInterfaces(dar: Dar[PackageSignature]): EnvironmentSignature =
     fromPackageSignatures(dar)
 

--- a/daml-lf/api-type-signature/src/main/scala/lf/typesig/PackageSignature.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/typesig/PackageSignature.scala
@@ -38,7 +38,7 @@ final case class PackageSignature(
 ) {
   import PackageSignature.TypeDecl
 
-  // @deprecated("renamed to interfaces", since = "2.4.0")
+  @deprecated("renamed to interfaces", since = "2.4.0")
   def astInterfaces: interfaces.type = interfaces
   @deprecated("renamed to getInterfaces", since = "2.4.0")
   def getAstInterfaces: j.Map[QualifiedName, DefInterface.FWT] = getInterfaces
@@ -247,7 +247,7 @@ object PackageSignature {
     }
   }
 
-  // @deprecated("renamed to findInterface", since = "2.4.0")
+  @deprecated("renamed to findInterface", since = "2.4.0")
   def findAstInterface(
       findPackage: PartialFunction[PackageId, PackageSignature]
   ): PartialFunction[Ref.TypeConName, DefInterface.FWT] =

--- a/daml-lf/api-type-signature/src/main/scala/lf/typesig/PackageSignature.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/typesig/PackageSignature.scala
@@ -40,7 +40,7 @@ final case class PackageSignature(
 
   // @deprecated("renamed to interfaces", since = "2.4.0")
   def astInterfaces: interfaces.type = interfaces
-  // @deprecated("renamed to getInterfaces", since = "2.4.0")
+  @deprecated("renamed to getInterfaces", since = "2.4.0")
   def getAstInterfaces: j.Map[QualifiedName, DefInterface.FWT] = getInterfaces
 
   def getTypeDecls: j.Map[QualifiedName, TypeDecl] = typeDecls.asJava

--- a/daml-lf/api-type-signature/src/main/scala/lf/typesig/reader/SignatureReader.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/typesig/reader/SignatureReader.scala
@@ -82,7 +82,7 @@ object SignatureReader {
       )
   }
 
-  // @deprecated("renamed to readPackageSignature", since = "2.4.0")
+  @deprecated("renamed to readPackageSignature", since = "2.4.0")
   def readInterface(
       lf: DamlLf.Archive
   ): (Errors[ErrorLoc, InvalidDataTypeDefinition], typesig.PackageSignature) =
@@ -95,7 +95,7 @@ object SignatureReader {
   ): (Errors[ErrorLoc, InvalidDataTypeDefinition], typesig.PackageSignature) =
     readPackageSignature(packageId, damlLf)
 
-  // @deprecated("renamed to readPackageSignature", since = "2.4.0")
+  @deprecated("renamed to readPackageSignature", since = "2.4.0")
   def readInterface(
       payload: ArchivePayload
   ): (Errors[ErrorLoc, InvalidDataTypeDefinition], typesig.PackageSignature) =

--- a/daml-lf/api-type-signature/src/main/scala/lf/typesig/reader/SignatureReader.scala
+++ b/daml-lf/api-type-signature/src/main/scala/lf/typesig/reader/SignatureReader.scala
@@ -25,9 +25,9 @@ object SignatureReader {
   import Errors._
   import PackageSignature.TypeDecl
 
-  // @deprecated("renamed to SignatureReader.Error", since = "2.4.0")
+  @deprecated("renamed to SignatureReader.Error", since = "2.4.0")
   type InterfaceReaderError = Error
-  // @deprecated("renamed to SignatureReader.Error", since = "2.4.0")
+  @deprecated("renamed to SignatureReader.Error", since = "2.4.0")
   final val InterfaceReaderError = Error
 
   sealed abstract class Error extends Product with Serializable
@@ -88,7 +88,7 @@ object SignatureReader {
   ): (Errors[ErrorLoc, InvalidDataTypeDefinition], typesig.PackageSignature) =
     readPackageSignature(lf)
 
-  // @deprecated("renamed to readPackageSignature", since = "2.4.0")
+  @deprecated("renamed to readPackageSignature", since = "2.4.0")
   def readInterface(
       packageId: Ref.PackageId,
       damlLf: DamlLf.ArchivePayload,
@@ -121,7 +121,7 @@ object SignatureReader {
 
   private val dummyInterface = typesig.PackageSignature(dummyPkgId, None, Map.empty, Map.empty)
 
-  // @deprecated("renamed to readPackageSignature", since = "2.4.0")
+  @deprecated("renamed to readPackageSignature", since = "2.4.0")
   def readInterface(
       f: () => String \/ (PackageId, Ast.Package)
   ): (Errors[ErrorLoc, InvalidDataTypeDefinition], typesig.PackageSignature) =

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -51,20 +51,20 @@ class OrderingSpec
     case typesig.TypeNumeric(scale) =>
       AstUtil.TNumeric(Ast.TNat(scale))
     case typesig.TypePrim(prim, typArgs) =>
-      import typesig.PrimType._
+      import typesig.{PrimType => P}
       val init = prim match {
-        case Bool => AstUtil.TBool
-        case Int64 => AstUtil.TInt64
-        case Text => AstUtil.TText
-        case Date => AstUtil.TDate
-        case Timestamp => AstUtil.TTimestamp
-        case Party => AstUtil.TParty
-        case ContractId => AstUtil.TContractId.cons
-        case List => AstUtil.TList.cons
-        case Unit => AstUtil.TUnit
-        case Optional => AstUtil.TOptional.cons
-        case TextMap => AstUtil.TTextMap.cons
-        case GenMap => AstUtil.TGenMap.cons
+        case P.Bool => AstUtil.TBool
+        case P.Int64 => AstUtil.TInt64
+        case P.Text => AstUtil.TText
+        case P.Date => AstUtil.TDate
+        case P.Timestamp => AstUtil.TTimestamp
+        case P.Party => AstUtil.TParty
+        case P.ContractId => AstUtil.TContractId.cons
+        case P.List => AstUtil.TList.cons
+        case P.Unit => AstUtil.TUnit
+        case P.Optional => AstUtil.TOptional.cons
+        case P.TextMap => AstUtil.TTextMap.cons
+        case P.GenMap => AstUtil.TGenMap.cons
       }
       typArgs.foldLeft[Ast.Type](init)((acc, typ) => Ast.TApp(acc, toAstType(typ)))
     case typesig.TypeVar(name) =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -12,8 +12,6 @@ import com.daml.ledger.api.validation.NoLoggingValueValidator
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
 import com.daml.lf.engine.script.ledgerinteraction.ScriptLedgerClient
-import com.daml.lf.iface.EnvironmentInterface
-import com.daml.lf.iface.reader.InterfaceReader
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.StablePackage
 import com.daml.lf.speedy.SBuiltin._
@@ -22,6 +20,8 @@ import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.{ArrayList, Pretty, SValue, Speedy}
 import com.daml.lf.speedy.SExpr.SExpr
+import com.daml.lf.typesig.EnvironmentSignature
+import com.daml.lf.typesig.reader.SignatureReader
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.platform.participant.util.LfEngineToApi.toApiIdentifier
@@ -784,21 +784,21 @@ object Converter {
   def toIfaceType(
       ctx: QualifiedName,
       astTy: Type,
-  ): Either[String, iface.Type] =
-    InterfaceReader.toIfaceType(ctx, astTy) match {
+  ): Either[String, typesig.Type] =
+    SignatureReader.toIfaceType(ctx, astTy) match {
       case -\/(e) => Left(e.toString)
       case \/-(ty) => Right(ty)
     }
 
   def fromJsonValue(
       ctx: QualifiedName,
-      environmentInterface: EnvironmentInterface,
+      environmentSignature: EnvironmentSignature,
       compiledPackages: CompiledPackages,
       ty: Type,
       jsValue: JsValue,
   ): Either[String, SValue] = {
-    def damlLfTypeLookup(id: Identifier): Option[iface.DefDataType.FWT] =
-      environmentInterface.typeDecls.get(id).map(_.`type`)
+    def damlLfTypeLookup(id: Identifier): Option[typesig.DefDataType.FWT] =
+      environmentSignature.typeDecls.get(id).map(_.`type`)
     for {
       paramIface <- Converter
         .toIfaceType(ctx, ty)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/JsonLedgerClient.scala
@@ -28,9 +28,10 @@ import com.daml.lf.command
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.engine.script.{Converter, LfValueCodec}
-import com.daml.lf.iface.{EnvironmentInterface, InterfaceType}
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SValue
+import com.daml.lf.typesig.EnvironmentSignature
+import com.daml.lf.typesig.PackageSignature.TypeDecl
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import io.grpc.{Status, StatusRuntimeException}
@@ -56,7 +57,7 @@ import scala.util.{Failure, Success}
 class JsonLedgerClient(
     uri: Uri,
     token: Jwt,
-    envIface: EnvironmentInterface,
+    envIface: EnvironmentSignature,
     actorSystem: ActorSystem,
 ) extends ScriptLedgerClient {
   import JsonLedgerClient.JsonProtocol._
@@ -454,7 +455,7 @@ class JsonLedgerClient(
   private[this] def lookupChoice(tplId: Identifier, choice: ChoiceName) =
     envIface
       .typeDecls(tplId)
-      .asInstanceOf[InterfaceType.Template]
+      .asInstanceOf[TypeDecl.Template]
       .template
       .tChoices
       .assumeNoOverloadedChoices(githubIssue = 13973)(choice)

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -54,11 +54,11 @@ import com.daml.lf.engine.script.ledgerinteraction.{
   ScriptLedgerClient,
   ScriptTimeMode,
 }
-import com.daml.lf.iface.EnvironmentInterface
-import com.daml.lf.iface.reader.InterfaceReader
 import com.daml.lf.language.Ast.Package
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.typesig.EnvironmentSignature
+import com.daml.lf.typesig.reader.SignatureReader
 import com.daml.lf.value.json.ApiCodecCompressed
 import com.daml.logging.LoggingContextOf
 import com.daml.metrics.{Metrics, MetricsReporter}
@@ -229,10 +229,10 @@ final class JsonApiIt
     with SandboxRequiringAuthorizationFuns
     with TryValues {
 
-  private def readDar(file: File): (Dar[(PackageId, Package)], EnvironmentInterface) = {
+  private def readDar(file: File): (Dar[(PackageId, Package)], EnvironmentSignature) = {
     val dar = DarDecoder.assertReadArchiveFromFile(file)
-    val ifaceDar = dar.map(pkg => InterfaceReader.readInterface(() => \/-(pkg))._2)
-    val envIface = EnvironmentInterface.fromReaderInterfaces(ifaceDar)
+    val ifaceDar = dar.map(pkg => SignatureReader.readPackageSignature(() => \/-(pkg))._2)
+    val envIface = EnvironmentSignature.fromPackageSignatures(ifaceDar)
     (dar, envIface)
   }
 
@@ -244,7 +244,7 @@ final class JsonApiIt
       defaultParty: Option[String] = None,
       admin: Boolean = false,
       applicationId: Option[ApplicationId] = None,
-      envIface: EnvironmentInterface = envIface,
+      envIface: EnvironmentSignature = envIface,
   ) = {
     // We give the default participant some nonsense party so the checks for party mismatch fail
     // due to the mismatch and not because the token does not allow inferring a party
@@ -277,7 +277,7 @@ final class JsonApiIt
       parties: List[String],
       readAs: List[String] = List(),
       applicationId: Option[ApplicationId] = None,
-      envIface: EnvironmentInterface = envIface,
+      envIface: EnvironmentSignature = envIface,
   ) = {
     // We give the default participant some nonsense party so the checks for party mismatch fail
     // due to the mismatch and not because the token does not allow inferring a party
@@ -294,7 +294,7 @@ final class JsonApiIt
 
   private def getUserClients(
       user: UserId,
-      envIface: EnvironmentInterface = envIface,
+      envIface: EnvironmentSignature = envIface,
   ) = {
     // We give the default participant some nonsense party so the checks for party mismatch fail
     // due to the mismatch and not because the token does not allow inferring a party

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractParticipantsFixture.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractParticipantsFixture.scala
@@ -11,8 +11,8 @@ import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Ref.{Identifier, Name, PackageId, QualifiedName}
 import com.daml.lf.engine.script.ledgerinteraction.{ScriptLedgerClient, ScriptTimeMode}
 import com.daml.lf.engine.script.{Participants, Runner}
-import com.daml.lf.iface.EnvironmentInterface
-import com.daml.lf.iface.reader.InterfaceReader
+import com.daml.lf.typesig.EnvironmentSignature
+import com.daml.lf.typesig.reader.SignatureReader
 import com.daml.lf.language.Ast.Package
 import com.daml.lf.language.StablePackage
 import com.daml.lf.speedy.{ArrayList, SValue}
@@ -29,10 +29,10 @@ trait AbstractScriptTest extends AkkaBeforeAndAfterAll {
   self: Suite =>
   protected def timeMode: ScriptTimeMode
 
-  protected def readDar(file: File): (Dar[(PackageId, Package)], EnvironmentInterface) = {
+  protected def readDar(file: File): (Dar[(PackageId, Package)], EnvironmentSignature) = {
     val dar = DarDecoder.assertReadArchiveFromFile(file)
-    val ifaceDar = dar.map(pkg => InterfaceReader.readInterface(() => \/-(pkg))._2)
-    val envIface = EnvironmentInterface.fromReaderInterfaces(ifaceDar)
+    val ifaceDar = dar.map(pkg => SignatureReader.readPackageSignature(() => \/-(pkg))._2)
+    val envIface = EnvironmentSignature.fromPackageSignatures(ifaceDar)
     (dar, envIface)
   }
 

--- a/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/NodeType.scala
+++ b/language-support/codegen-common/src/main/scala/com/digitalasset/daml/lf/codegen/dependencygraph/NodeType.scala
@@ -3,7 +3,7 @@
 
 package com.daml.lf.codegen.dependencygraph
 
-import com.daml.lf.iface.{DefTemplate, DefInterface, DefDataType, Record}
+import com.daml.lf.typesig.{DefTemplate, DefInterface, DefDataType, Record}
 
 sealed abstract class NodeType extends Product with Serializable
 

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/UtilSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/UtilSpec.scala
@@ -6,7 +6,8 @@ package codegen
 
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref.Identifier
-import com.daml.lf.iface._
+import typesig._
+import PackageSignature.TypeDecl
 import com.daml.lf.value.test.ValueGenerators.idGen
 
 import org.scalatest.matchers.should.Matchers
@@ -24,7 +25,7 @@ class UtilSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyCh
 
     "delete all templates given impossible regex" in forAll(trivialDeclarations) { declarations =>
       val noTemplates = declarations transform {
-        case (_, tmpl @ InterfaceType.Template(_, _)) => InterfaceType.Normal(tmpl.`type`)
+        case (_, tmpl @ TypeDecl.Template(_, _)) => TypeDecl.Normal(tmpl.`type`)
         case (_, v) => v
       }
       filterTemplatesBy(Seq("(?!a)a".r))(declarations) should ===(noTemplates)
@@ -40,10 +41,10 @@ object UtilSpec {
   import org.scalacheck.{Arbitrary, Gen}
   import Arbitrary.arbitrary
 
-  val trivialDeclarations: Gen[Map[Identifier, InterfaceType]] = {
+  val trivialDeclarations: Gen[Map[Identifier, TypeDecl]] = {
     val fooRec = Record(ImmArraySeq.empty)
-    val fooTmpl = InterfaceType.Template(fooRec, DefTemplate.Empty)
-    val fooNorm = InterfaceType.Normal(DefDataType(ImmArraySeq.empty, fooRec))
+    val fooTmpl = TypeDecl.Template(fooRec, DefTemplate.Empty)
+    val fooNorm = TypeDecl.Normal(DefDataType(ImmArraySeq.empty, fooRec))
     implicit val idArb: Arbitrary[Identifier] = Arbitrary(idGen)
     arbitrary[Map[Identifier, Boolean]] map {
       _ transform { (_, isTemplate) =>

--- a/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraphSpec.scala
+++ b/language-support/codegen-common/src/test/scala/com/digitalasset/daml/lf/codegen/dependencygraph/DependencyGraphSpec.scala
@@ -6,7 +6,8 @@ package com.daml.lf.codegen.dependencygraph
 import com.daml.lf.codegen.Util
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.{Ref, ImmArray}
-import com.daml.lf.iface._
+import com.daml.lf.typesig._
+import PackageSignature.TypeDecl
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scalaz.syntax.std.map._
@@ -28,11 +29,11 @@ final class DependencyGraphSpec extends AnyWordSpec with Matchers {
       val quux = Ref.Identifier.assertFromString("a:b:Quux")
       val vt = Ref.Identifier.assertFromString("a:b:Vt")
       val minimalRecord =
-        InterfaceType.Normal(DefDataType(ImmArraySeq.empty, Record(ImmArraySeq.empty)))
+        TypeDecl.Normal(DefDataType(ImmArraySeq.empty, Record(ImmArraySeq.empty)))
       DependencyGraph
         .orderedDependencies(
           serializableTypes = Map(
-            foo -> InterfaceType.Normal(
+            foo -> TypeDecl.Normal(
               DefDataType(
                 ImmArray(bar.qualifiedName.name.segments.last).toSeq,
                 Record(ImmArraySeq.empty),
@@ -74,7 +75,7 @@ object DependencyGraphSpec {
   private[this] val fooRec = Record(ImmArraySeq.empty)
   private val typeDecls =
     Map(
-      "a:b:HasKey" -> InterfaceType.Template(
+      "a:b:HasKey" -> TypeDecl.Template(
         fooRec,
         DefTemplate(
           TemplateChoices.Resolved(Map.empty),
@@ -82,9 +83,8 @@ object DependencyGraphSpec {
           Seq.empty,
         ),
       ),
-      "a:b:NoKey" -> InterfaceType
-        .Template(fooRec, DefTemplate.Empty),
-      "a:b:It" -> InterfaceType.Normal(DefDataType(ImmArraySeq.empty, fooRec)),
+      "a:b:NoKey" -> TypeDecl.Template(fooRec, DefTemplate.Empty),
+      "a:b:It" -> TypeDecl.Normal(DefDataType(ImmArraySeq.empty, fooRec)),
     ) mapKeys Ref.Identifier.assertFromString
 
 }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassForType.scala
@@ -44,7 +44,7 @@ object ClassForType extends StrictLogging {
       packagePrefixes: Map[PackageId, String],
   ): List[JavaFile] =
     for {
-      (interfaceName, interface) <- typeWithContext.interface.astInterfaces.toList
+      (interfaceName, interface) <- typeWithContext.interface.interfaces.toList
       className = ClassName.bestGuess(fullyQualifiedName(interfaceName))
       packageName = className.packageName()
       interfaceClass =

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ClassGenUtils.scala
@@ -8,7 +8,7 @@ import com.daml.lf.typesig.{DefDataType, Record, TypeCon}
 import com.daml.lf.typesig.PackageSignature.TypeDecl
 
 import java.util.Optional
-import com.daml.lf.iface._
+import com.daml.lf.typesig._
 import com.squareup.javapoet._
 import com.daml.ledger.javaapi
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractClass.scala
@@ -6,7 +6,7 @@ package com.daml.lf.codegen.backend.java.inner
 import com.daml.ledger.javaapi
 import ClassGenUtils.{companionFieldName, optional, optionalString, setOfStrings}
 import com.daml.lf.data.Ref.PackageId
-import com.daml.lf.iface.Type
+import com.daml.lf.typesig.Type
 import com.squareup.javapoet._
 import scalaz.syntax.std.option._
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ContractIdClass.scala
@@ -27,7 +27,7 @@ object ContractIdClass {
 
   def builder(
       templateClassName: ClassName,
-      choices: Map[ChoiceName, TemplateChoice[com.daml.lf.iface.Type]],
+      choices: Map[ChoiceName, TemplateChoice[typesig.Type]],
       kind: For,
       packagePrefixes: Map[PackageId, String],
   ) = Builder.create(
@@ -244,7 +244,7 @@ object ContractIdClass {
 
     def create(
         templateClassName: ClassName,
-        choices: Map[ChoiceName, TemplateChoice[com.daml.lf.iface.Type]],
+        choices: Map[ChoiceName, TemplateChoice[typesig.Type]],
         kind: For,
         packagePrefixes: Map[PackageId, String],
     ): Builder = {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordClass.scala
@@ -4,7 +4,7 @@
 package com.daml.lf.codegen.backend.java.inner
 
 import com.daml.lf.data.Ref.PackageId
-import com.daml.lf.iface.Record
+import com.daml.lf.typesig.Record
 import com.squareup.javapoet.{ClassName, TypeSpec, TypeVariableName}
 import com.typesafe.scalalogging.StrictLogging
 import javax.lang.model.element.Modifier

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.javaapi
 import com.daml.lf.codegen.backend.java.{JavaEscaper, Types}
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref.PackageId
-import com.daml.lf.iface._
+import com.daml.lf.typesig._
 import com.squareup.javapoet._
 import javax.lang.model.element.Modifier
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantClass.scala
@@ -7,8 +7,8 @@ import com.daml.ledger.javaapi
 import com.daml.lf.codegen.TypeWithContext
 import com.daml.lf.codegen.backend.java.JavaEscaper
 import com.daml.lf.data.Ref.{Identifier, PackageId}
-import com.daml.lf.iface._
-import InterfaceType.Normal
+import com.daml.lf.typesig._
+import PackageSignature.TypeDecl.Normal
 import com.squareup.javapoet._
 import com.typesafe.scalalogging.StrictLogging
 import javax.lang.model.element.Modifier
@@ -49,7 +49,7 @@ private[inner] object VariantClass extends StrictLogging {
       (variantType, constructors)
     }
 
-  private def isRecord(interfaceType: InterfaceType): Boolean =
+  private def isRecord(interfaceType: PackageSignature.TypeDecl): Boolean =
     interfaceType.`type`.dataType match {
       case _: Record[_] => true
       case _: Variant[_] | _: Enum => false

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantConstructorClass.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/VariantConstructorClass.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.javaapi.data
 import com.daml.ledger.javaapi.data.Value
 import com.daml.lf.codegen.backend.java.{JavaEscaper, ObjectMethods}
 import com.daml.lf.data.Ref.PackageId
-import com.daml.lf.iface._
+import com.daml.lf.typesig.{Type, TypeVar}
 import com.squareup.javapoet._
 import com.typesafe.scalalogging.StrictLogging
 import javax.lang.model.element.Modifier

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.javaapi.data.codegen.ContractId
 import com.daml.ledger.javaapi.data.{DamlGenMap, DamlList, DamlOptional, DamlTextMap}
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName}
-import com.daml.lf.iface._
+import com.daml.lf.typesig._
 import com.squareup.javapoet._
 import javax.lang.model.element.Modifier
 

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
@@ -9,7 +9,7 @@ import com.daml.bazeltools.BazelRunfiles
 import com.daml.lf.archive.DarReader
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref._
-import com.daml.lf.iface._
+import com.daml.lf.typesig._
 import com.daml.lf.codegen.conf.PackageReference
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
@@ -120,16 +120,17 @@ object CodeGenRunnerTests {
   private val testDar = Path.of(BazelRunfiles.rlocation(testDarPath))
   private val dar = DarReader.assertReadArchiveFromFile(testDar.toFile)
 
-  private def interface(pkgId: String, modNames: String*): Interface =
+  private def interface(pkgId: String, modNames: String*): PackageSignature =
     interface(pkgId, None, modNames: _*)
 
   private def interface(
       pkgId: String,
       metadata: Option[PackageMetadata],
       modNames: String*
-  ): Interface = {
-    val dummyType = InterfaceType.Normal(DefDataType(ImmArraySeq.empty, Record(ImmArraySeq.empty)))
-    Interface(
+  ): PackageSignature = {
+    val dummyType =
+      PackageSignature.TypeDecl.Normal(DefDataType(ImmArraySeq.empty, Record(ImmArraySeq.empty)))
+    PackageSignature(
       PackageId.assertFromString(pkgId),
       metadata,
       modNames.view

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/InterfaceTreeSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/InterfaceTreeSpec.scala
@@ -6,7 +6,8 @@ package com.daml.lf.codegen
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref.{DottedName, QualifiedName, PackageId}
-import com.daml.lf.iface.{DefDataType, Interface, InterfaceType, Record, Variant}
+import com.daml.lf.typesig.{DefDataType, PackageSignature, Record, Variant}
+import PackageSignature.TypeDecl
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -20,7 +21,7 @@ class InterfaceTreeSpec extends AnyFlatSpec with Matchers {
     val interfaceTree =
       InterfaceTree(
         Map.empty,
-        Interface(PackageId.assertFromString("packageid"), None, Map.empty, Map.empty),
+        PackageSignature(PackageId.assertFromString("packageid"), None, Map.empty, Map.empty),
       )
     interfaceTree.bfs(0)((x, _) => x + 1) shouldEqual 0
   }
@@ -30,23 +31,24 @@ class InterfaceTreeSpec extends AnyFlatSpec with Matchers {
       DottedName.assertFromSegments(ImmArray("foo").toSeq),
       DottedName.assertFromSegments(ImmArray("bar").toSeq),
     )
-    val record1 = InterfaceType.Normal(DefDataType(ImmArraySeq(), Record(ImmArraySeq())))
+    val record1 = TypeDecl.Normal(DefDataType(ImmArraySeq(), Record(ImmArraySeq())))
     val qualifiedName2 =
       QualifiedName(
         DottedName.assertFromSegments(ImmArray("foo").toSeq),
         DottedName.assertFromSegments(ImmArray("bar", "baz").toSeq),
       )
-    val variant1 = InterfaceType.Normal(DefDataType(ImmArraySeq(), Variant(ImmArraySeq())))
+    val variant1 = TypeDecl.Normal(DefDataType(ImmArraySeq(), Variant(ImmArraySeq())))
     val qualifiedName3 = QualifiedName(
       DottedName.assertFromSegments(ImmArray("foo").toSeq),
       DottedName.assertFromSegments(ImmArray("qux").toSeq),
     )
-    val record2 = InterfaceType.Normal(DefDataType(ImmArraySeq(), Record(ImmArraySeq())))
+    val record2 = TypeDecl.Normal(DefDataType(ImmArraySeq(), Record(ImmArraySeq())))
     val typeDecls =
       Map(qualifiedName1 -> record1, qualifiedName2 -> variant1, qualifiedName3 -> record2)
-    val interface = Interface(PackageId.assertFromString("packageId2"), None, typeDecls, Map.empty)
+    val interface =
+      PackageSignature(PackageId.assertFromString("packageId2"), None, typeDecls, Map.empty)
     val tree = InterfaceTree.fromInterface(interface)
-    val result = tree.bfs(ArrayBuffer.empty[InterfaceType])((ab, n) =>
+    val result = tree.bfs(ArrayBuffer.empty[TypeDecl])((ab, n) =>
       n match {
         case ModuleWithContext(interface @ _, modulesLineage @ _, name @ _, module @ _) => ab
         case TypeWithContext(interface @ _, modulesLineage @ _, typesLineage @ _, name @ _, typ) =>
@@ -64,12 +66,13 @@ class InterfaceTreeSpec extends AnyFlatSpec with Matchers {
         DottedName.assertFromSegments(ImmArray("foo", "bar").toSeq),
         DottedName.assertFromSegments(ImmArray("baz", "quux").toSeq),
       )
-    val record = InterfaceType.Normal(DefDataType(ImmArraySeq(), Record(ImmArraySeq())))
+    val record = TypeDecl.Normal(DefDataType(ImmArraySeq(), Record(ImmArraySeq())))
 
     val typeDecls = Map(bazQuux -> record)
-    val interface = Interface(PackageId.assertFromString("pkgid"), None, typeDecls, Map.empty)
+    val interface =
+      PackageSignature(PackageId.assertFromString("pkgid"), None, typeDecls, Map.empty)
     val tree = InterfaceTree.fromInterface(interface)
-    val result = tree.bfs(ArrayBuffer.empty[InterfaceType])((types, n) =>
+    val result = tree.bfs(ArrayBuffer.empty[TypeDecl])((types, n) =>
       n match {
         case _: ModuleWithContext => types
         case TypeWithContext(_, _, _, _, tpe) =>

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordFieldsSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordFieldsSpec.scala
@@ -6,7 +6,7 @@ package com.daml.lf.codegen.backend.java.inner
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{DottedName, Identifier, QualifiedName}
-import com.daml.lf.iface._
+import com.daml.lf.typesig._
 import com.squareup.javapoet.{ClassName, TypeName}
 import javax.lang.model.element.Modifier
 import org.scalatest.matchers.should.Matchers

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordLikeMethodsSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/RecordLikeMethodsSpec.scala
@@ -6,7 +6,7 @@ package com.daml.lf.codegen.backend.java.inner
 import com.daml.ledger.javaapi
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref
-import com.daml.lf.iface.{PrimTypeBool, TypePrim}
+import com.daml.lf.typesig.{PrimTypeBool, TypePrim}
 import com.squareup.javapoet._
 import javax.lang.model.element.Modifier
 import org.scalatest.{OptionValues, TryValues}

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlContractTemplateGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlContractTemplateGen.scala
@@ -8,7 +8,7 @@ import java.io.File
 import com.daml.lf.codegen.lf.LFUtil
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref, Ref.{Identifier, QualifiedName}
-import com.daml.lf.iface
+import com.daml.lf.typesig
 import com.typesafe.scalalogging.Logger
 import scalaz.syntax.std.option._
 
@@ -101,7 +101,7 @@ object DamlContractTemplateGen {
 
   private[lf] def genChoiceImplicitClass(
       util: LFUtil
-  )(templateName: util.DamlScalaName, choices: Map[Ref.ChoiceName, iface.TemplateChoice.FWT]) = {
+  )(templateName: util.DamlScalaName, choices: Map[Ref.ChoiceName, typesig.TemplateChoice.FWT]) = {
     val templateChoiceMethods = choices.flatMap { case (id, interface) =>
       util.genTemplateChoiceMethods(
         templateType = tq"${TypeName(templateName.name)}",

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlInterfaceGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DamlInterfaceGen.scala
@@ -6,7 +6,7 @@ package com.daml.lf.codegen.lf
 import java.io.File
 
 import com.daml.lf.data.Ref
-import com.daml.lf.iface
+import com.daml.lf.typesig
 import com.typesafe.scalalogging.Logger
 
 import LFUtil.domainApiAlias
@@ -15,7 +15,7 @@ import DamlContractTemplateGen.{genChoiceImplicitClass, generateTemplateIdDef}
 import scala.reflect.runtime.universe._
 
 object DamlInterfaceGen {
-  type DataType = iface.DefInterface.FWT
+  type DataType = typesig.DefInterface.FWT
 
   def generate(
       util: LFUtil,

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DefTemplateWithRecord.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/DefTemplateWithRecord.scala
@@ -3,7 +3,7 @@
 
 package com.daml.lf.codegen.lf
 
-import com.daml.lf.iface.{DefTemplate, Record, Type}
+import com.daml.lf.typesig.{DefTemplate, Record, Type}
 
 final case class DefTemplateWithRecord(
     `type`: Record[Type],

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/LFUtil.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/LFUtil.scala
@@ -8,7 +8,8 @@ import com.daml.lf.data.Ref
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import parent.exception.UnsupportedDamlTypeException
 import com.daml.lf.iface
-import iface.{Type => IType, PrimType => PT, _}
+import com.daml.lf.typesig
+import typesig.{Type => IType, PrimType => PT, _}
 import com.daml.lf.iface.InterfaceType
 import java.io.File
 
@@ -25,7 +26,7 @@ import scalaz.syntax.std.option._
   */
 final case class LFUtil(
     packageName: String,
-    iface: EnvironmentInterface,
+    iface: EnvironmentSignature,
     outputDir: File,
 ) {
 

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/LFUtil.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/LFUtil.scala
@@ -7,10 +7,9 @@ import com.daml.lf.{codegen => parent}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import parent.exception.UnsupportedDamlTypeException
-import com.daml.lf.iface
 import com.daml.lf.typesig
 import typesig.{Type => IType, PrimType => PT, _}
-import com.daml.lf.iface.InterfaceType
+import PackageSignature.TypeDecl
 import java.io.File
 
 import com.daml.lf.codegen.dependencygraph.TransitiveClosure
@@ -256,7 +255,7 @@ final case class LFUtil(
         case TypeCon(TypeConName(tyCon), _) =>
           val dn =
             iface.typeDecls get tyCon collect {
-              case InterfaceType.Normal(DefDataType(ImmArraySeq(), Record(fields))) => fields
+              case TypeDecl.Normal(DefDataType(ImmArraySeq(), Record(fields))) => fields
             }
           dn map { fields =>
             val orecArgNames = fields.foldMap { case (fn, _) => Set(fn) }
@@ -440,15 +439,15 @@ object LFUtil {
   final case class WriteParams(
       templateIds: Map[Ref.Identifier, DefTemplateWithRecord],
       definitions: Vector[ScopedDataType.FWT],
-      interfaces: Map[Ref.Identifier, iface.DefInterface.FWT],
+      interfaces: Map[Ref.Identifier, typesig.DefInterface.FWT],
   )
 
   object WriteParams {
     def apply(tc: TransitiveClosure): WriteParams = {
       val (templateIds, typeDeclarations) = tc.serializableTypes.partitionMap { // TODO(#13349)
-        case (id, InterfaceType.Template(record, template)) =>
+        case (id, TypeDecl.Template(record, template)) =>
           Left(id -> DefTemplateWithRecord(record, template))
-        case (id, InterfaceType.Normal(t)) =>
+        case (id, TypeDecl.Normal(t)) =>
           Right(ScopedDataType(id, t.typeVars, t.dataType))
       }
       WriteParams(

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/PackageIDsGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/PackageIDsGen.scala
@@ -19,7 +19,7 @@ object PackageIDsGen {
     val imports: Seq[Tree] = Seq()
 
     val packageIdsByModule: Map[ModuleName, PackageId] =
-      (util.iface.typeDecls.keySet ++ util.iface.astInterfaces.keys).view
+      (util.iface.typeDecls.keySet ++ util.iface.interfaces.keys).view
         .map(id => (id.qualifiedName.module, id.packageId))
         .toMap
     val packageIdBindings = packageIdsByModule.toSeq.sortBy(_._1.dottedName) map { case (mn, pid) =>

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/ScopedDataType.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/ScopedDataType.scala
@@ -6,7 +6,7 @@ package lf
 
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref
-import com.daml.lf.iface.DataType
+import com.daml.lf.typesig.DataType
 
 import scalaz.{Apply, Comonad, Traverse1}
 import scalaz.syntax.functor._

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/VarianceCache.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/lf/codegen/lf/VarianceCache.scala
@@ -6,23 +6,24 @@ package com.daml.lf.codegen.lf
 import com.daml.lf.codegen.Util
 import com.daml.lf.codegen.lf.UsedTypeParams.Variance
 import com.daml.lf.data.ImmArray.ImmArraySeq
-import com.daml.lf.iface.{EnvironmentInterface, InterfaceType}
+import com.daml.lf.typesig.EnvironmentSignature
+import com.daml.lf.typesig.PackageSignature.TypeDecl
 import scalaz.syntax.foldable._
 import scalaz.std.set._
 
-final class VarianceCache(interface: EnvironmentInterface) {
+final class VarianceCache(interface: EnvironmentSignature) {
 
-  private[this] def foldTemplateReferencedTypeDeclRoots[Z](interface: EnvironmentInterface, z: Z)(
+  private[this] def foldTemplateReferencedTypeDeclRoots[Z](interface: EnvironmentSignature, z: Z)(
       f: (Z, ScopedDataType.Name) => Z
   ): Z =
     interface.typeDecls.foldLeft(z) {
-      case (z, (id, InterfaceType.Template(_, tpl))) =>
+      case (z, (id, TypeDecl.Template(_, tpl))) =>
         tpl.foldMap(typ => Util.genTypeTopLevelDeclNames(typ).toSet).foldLeft(f(z, id))(f)
       case (z, _) => z
     }
 
   protected[this] def precacheVariance(
-      interface: EnvironmentInterface
+      interface: EnvironmentSignature
   ): ScopedDataType.Name => ImmArraySeq[Variance] = {
     import UsedTypeParams.ResolvedVariance
     val resolved = foldTemplateReferencedTypeDeclRoots(interface, ResolvedVariance.Empty) {

--- a/language-support/scala/codegen/src/test/scala/com/digitalasset/lf/codegen/UtilTest.scala
+++ b/language-support/scala/codegen/src/test/scala/com/digitalasset/lf/codegen/UtilTest.scala
@@ -8,7 +8,7 @@ import com.daml.lf.data.Ref.{QualifiedName, PackageId}
 import java.io.IOException
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
-import com.daml.lf.{iface => I}
+import com.daml.lf.{typesig => S}
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
@@ -18,7 +18,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 class UtilTest extends UtilTestHelpers with ScalaCheckDrivenPropertyChecks {
 
   val packageInterface =
-    I.Interface(
+    S.PackageSignature(
       packageId = PackageId.assertFromString("abcdef"),
       metadata = None,
       typeDecls = Map.empty,
@@ -29,7 +29,7 @@ class UtilTest extends UtilTestHelpers with ScalaCheckDrivenPropertyChecks {
   val util =
     lf.LFUtil(
       scalaPackage,
-      I.EnvironmentInterface fromReaderInterfaces packageInterface,
+      S.EnvironmentSignature fromPackageSignatures packageInterface,
       outputDir.toFile,
     )
 

--- a/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
+++ b/ledger-service/http-json/src/bench/scala/com/daml/http/dbbackend/QueryPayloadBenchmark.scala
@@ -5,7 +5,7 @@ package com.daml.http.dbbackend
 
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref
-import com.daml.lf.iface
+import com.daml.lf.typesig
 import com.daml.http.dbbackend.Queries.SurrogateTpId
 import com.daml.http.domain.{Party, ContractTypeId}
 import com.daml.http.query.ValuePredicate
@@ -32,17 +32,20 @@ trait QueryPayloadBenchmark extends ContractDaoBenchmark {
     dummyPackageId,
     Ref.QualifiedName.assertFromString("Foo:Bar"),
   )
-  private[this] val dummyTypeCon = iface.TypeCon(iface.TypeConName(dummyId), ImmArraySeq.empty)
+  private[this] val dummyTypeCon = typesig.TypeCon(typesig.TypeConName(dummyId), ImmArraySeq.empty)
 
   val predicate = ValuePredicate.fromJsObject(
     Map("v" -> JsNumber(0)),
     dummyTypeCon,
     Map(
-      dummyId -> iface.DefDataType(
+      dummyId -> typesig.DefDataType(
         ImmArraySeq.empty,
-        iface.Record(
+        typesig.Record(
           ImmArraySeq(
-            (Ref.Name.assertFromString("v"), iface.TypePrim(iface.PrimType.Int64, ImmArraySeq()))
+            (
+              Ref.Name.assertFromString("v"),
+              typesig.TypePrim(typesig.PrimType.Int64, ImmArraySeq()),
+            )
           )
         ),
       )

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -5,7 +5,7 @@ package com.daml.http
 
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import com.daml.ledger.api.domain.User
-import com.daml.lf.iface
+import com.daml.lf.typesig
 import com.daml.ledger.api.refinements.{ApiTypes => lar}
 import com.daml.ledger.api.{v1 => lav1}
 import com.daml.nonempty.NonEmpty
@@ -50,7 +50,7 @@ package object domain extends com.daml.fetchcontracts.domain.Aliases {
   type SubmissionId = String @@ SubmissionIdTag
   val SubmissionId = Tag.of[SubmissionIdTag]
 
-  type LfType = iface.Type
+  type LfType = typesig.Type
 
   type RetryInfoDetailDuration = scala.concurrent.duration.Duration @@ RetryInfoDetailDurationTag
   val RetryInfoDetailDuration = Tag.of[RetryInfoDetailDurationTag]

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsValueToApiValueConverter.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsValueToApiValueConverter.scala
@@ -4,7 +4,7 @@
 package com.daml.http.json
 
 import com.daml.lf
-import com.daml.lf.iface
+import com.daml.lf.typesig
 import com.daml.http.domain
 import com.daml.http.json.JsValueToApiValueConverter.LfTypeLookup
 import com.daml.http.json.JsonProtocol.LfValueCodec
@@ -26,7 +26,7 @@ class JsValueToApiValueConverter(lfTypeLookup: LfTypeLookup) {
     )(identity).liftErr(JsonError)
 
   def jsValueToLfValue(
-      lfType: iface.Type,
+      lfType: typesig.Type,
       jsValue: JsValue,
   ): JsonError \/ lf.value.Value =
     \/.attempt(
@@ -43,7 +43,7 @@ class JsValueToApiValueConverter(lfTypeLookup: LfTypeLookup) {
 object JsValueToApiValueConverter {
   import com.daml.http.util.ErrorOps._
 
-  type LfTypeLookup = lf.data.Ref.Identifier => Option[lf.iface.DefDataType.FWT]
+  type LfTypeLookup = lf.data.Ref.Identifier => Option[lf.typesig.DefDataType.FWT]
 
   def lfValueToApiValue(lfValue: domain.LfValue): JsonError \/ lav1.value.Value =
     \/.fromEither(LfEngineToApi.lfValueToApiValue(verbose = true, lfValue)).liftErr(JsonError)

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -9,7 +9,7 @@ import com.daml.lf.data.{Decimal, ImmArray, Numeric, Ref, SortedLookupList, Time
 import ImmArray.ImmArraySeq
 import com.codahale.metrics.MetricRegistry
 import com.daml.http.dbbackend.SurrogateTemplateIdCache
-import com.daml.lf.iface
+import com.daml.lf.typesig
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.test.TypedValueGenerators.{genAddendNoListMap, ValueAddend => VA}
 import com.daml.lf.value.test.ValueGenerators.coidGen
@@ -57,17 +57,17 @@ class ValuePredicateTest
     qn("Foo:Bar"),
   )
   private[this] val dummyFieldName = Ref.Name assertFromString "foo"
-  private[this] val dummyTypeCon = iface.TypeCon(iface.TypeConName(dummyId), ImmArraySeq.empty)
+  private[this] val dummyTypeCon = typesig.TypeCon(typesig.TypeConName(dummyId), ImmArraySeq.empty)
   private[this] val (eitherId, (eitherDDT, eitherVA)) = eitherT
   private[this] def valueAndTypeInObject(
       v: V,
-      ty: iface.Type,
+      ty: typesig.Type,
   ): (V, ValuePredicate.TypeLookup) =
     (V.ValueRecord(Some(dummyId), ImmArray((Some(dummyFieldName), v))), typeInObject(ty))
-  private[this] def typeInObject(ty: iface.Type): ValuePredicate.TypeLookup =
+  private[this] def typeInObject(ty: typesig.Type): ValuePredicate.TypeLookup =
     Map(
-      dummyId -> iface
-        .DefDataType(ImmArraySeq.empty, iface.Record(ImmArraySeq((dummyFieldName, ty)))),
+      dummyId -> typesig
+        .DefDataType(ImmArraySeq.empty, typesig.Record(ImmArraySeq((dummyFieldName, ty)))),
       eitherId -> eitherDDT,
       tuple3Id -> tuple3DDT,
     ).lift

--- a/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
+++ b/ledger-service/lf-value-json/src/test/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressedSpec.scala
@@ -508,9 +508,10 @@ class ApiCodecCompressedSpec
     }
 
     "dealing with Contract Key" should {
+      import typesig.PackageSignature.TypeDecl.{Template => TDTemplate}
 
       "decode type Key = Party from JSON" in {
-        val templateDef: iface.InterfaceType.Template = mustBeOne(
+        val templateDef: TDTemplate = mustBeOne(
           MetadataReader.templateByName(darMetadata)(
             Ref.QualifiedName.assertFromString("JsonEncodingTest:KeyedByParty")
           )
@@ -523,7 +524,7 @@ class ApiCodecCompressedSpec
       }
 
       "decode type Key = (Party, Int) from JSON" in {
-        val templateDef: iface.InterfaceType.Template = mustBeOne(
+        val templateDef: TDTemplate = mustBeOne(
           MetadataReader.templateByName(darMetadata)(
             Ref.QualifiedName.assertFromString("JsonEncodingTest:KeyedByPartyInt")
           )
@@ -553,7 +554,7 @@ class ApiCodecCompressedSpec
       }
 
       "decode type Key = (Party, (Int, Foo, BazRecord)) from JSON" in {
-        val templateDef: iface.InterfaceType.Template = mustBeOne(
+        val templateDef: TDTemplate = mustBeOne(
           MetadataReader.templateByName(darMetadata)(
             Ref.QualifiedName.assertFromString("JsonEncodingTest:KeyedByVariantAndRecord")
           )

--- a/ledger-service/utils/src/main/scala/com/digitalasset/ledger/service/MetadataReader.scala
+++ b/ledger-service/utils/src/main/scala/com/digitalasset/ledger/service/MetadataReader.scala
@@ -8,7 +8,7 @@ import java.io.File
 import com.daml.lf.archive.{ArchivePayload, Dar, DarReader}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.PackageId
-import com.daml.lf.{iface, typesig}
+import com.daml.lf.typesig
 import com.daml.scalautil.ExceptionOps._
 import scalaz.std.list._
 import scalaz.syntax.traverse._
@@ -63,7 +63,7 @@ object MetadataReader {
         }
       }
 
-  def typeLookup(metaData: LfMetadata)(id: Ref.Identifier): Option[iface.DefDataType.FWT] =
+  def typeLookup(metaData: LfMetadata)(id: Ref.Identifier): Option[typesig.DefDataType.FWT] =
     for {
       iface <- metaData.get(id.packageId)
       ifaceType <- iface.typeDecls.get(id.qualifiedName)
@@ -71,7 +71,7 @@ object MetadataReader {
 
   def typeByName(
       metaData: LfMetadata
-  )(name: Ref.QualifiedName): Seq[(Ref.PackageId, iface.DefDataType.FWT)] =
+  )(name: Ref.QualifiedName): Seq[(Ref.PackageId, typesig.DefDataType.FWT)] =
     metaData.values.iterator
       .map(interface => interface.typeDecls.get(name).map(x => (interface.packageId, x.`type`)))
       .collect { case Some(x) => x }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PackageRegistry.scala
@@ -5,7 +5,7 @@ package com.daml.navigator.model
 
 import com.daml.navigator.{model => Model}
 import com.daml.ledger.api.refinements.ApiTypes
-import com.daml.lf.{iface => DamlLfIface}
+import com.daml.lf.{typesig => DamlLfIface}
 import com.daml.lf.data.{Ref => DamlLfRef}
 
 /** Manages a set of known Daml-LF packages. */
@@ -57,7 +57,7 @@ case class PackageRegistry(
     inheritedInterface,
   )
 
-  def withPackages(interfaces: List[DamlLfIface.Interface]): PackageRegistry = {
+  def withPackages(interfaces: List[DamlLfIface.PackageSignature]): PackageRegistry = {
     val newPackageStore = packageState.append(interfaces.map(p => p.packageId -> p).toMap)
 
     val newPackages = newPackageStore.packages.values.map { p =>
@@ -65,10 +65,10 @@ case class PackageRegistry(
         DamlLfIdentifier(p.packageId, qname) -> td.`type`
       }
       val templates = p.typeDecls.collect {
-        case (qname, DamlLfIface.InterfaceType.Template(r @ _, t)) =>
+        case (qname, DamlLfIface.PackageSignature.TypeDecl.Template(r @ _, t)) =>
           DamlLfIdentifier(p.packageId, qname) -> template(p.packageId, qname, t)
       }
-      val interfaces = p.astInterfaces.map { case (qname, defInterface) =>
+      val interfaces = p.interfaces.map { case (qname, defInterface) =>
         DamlLfIdentifier(p.packageId, qname) -> interface(p.packageId, qname, defInterface)
       }
       p.packageId -> DamlLfPackage(p.packageId, typeDefs, templates, interfaces)

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/PartyState.scala
@@ -4,7 +4,7 @@
 package com.daml.navigator.model
 
 import java.util.concurrent.atomic.AtomicReference
-import com.daml.lf.{iface => DamlLfIface}
+import com.daml.lf.{typesig => DamlLfIface}
 import com.daml.ledger.api.refinements.ApiTypes
 
 import scala.collection.immutable.LazyList
@@ -48,7 +48,7 @@ class PartyState(
     ()
   }
 
-  def addPackages(packs: List[DamlLfIface.Interface]): Unit = {
+  def addPackages(packs: List[DamlLfIface.PackageSignature]): Unit = {
     stateRef.updateAndGet(state =>
       state.copy(packageRegistry = packageRegistry.withPackages(packs))
     )

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
@@ -6,7 +6,7 @@ package com.daml.navigator.model.converter
 import java.time.Instant
 import com.daml.lf.data.Ref
 import com.daml.lf.data.LawlessTraversals._
-import com.daml.lf.iface
+import com.daml.lf.typesig
 import com.daml.lf.value.{Value => V}
 import com.daml.ledger.api.{v1 => V1}
 import com.daml.ledger.api.refinements.ApiTypes
@@ -282,8 +282,9 @@ case object LedgerApiV1 {
         .damlLfDefDataType(typeCon.name.identifier)
         .toRight(GenericConversionError(s"Unknown type ${typeCon.name.identifier}"))
       dt <- typeCon.instantiate(ddt) match {
-        case r @ iface.Record(_) => Right(r)
-        case iface.Variant(_) | iface.Enum(_) => Left(GenericConversionError(s"Record expected"))
+        case r @ typesig.Record(_) => Right(r)
+        case typesig.Variant(_) | typesig.Enum(_) =>
+          Left(GenericConversionError(s"Record expected"))
       }
       fields <- value.fields.toSeq zip dt.fields traverseEitherStrictly {
         case ((von, vv), (tn, fieldType)) =>
@@ -384,8 +385,8 @@ case object LedgerApiV1 {
         .damlLfDefDataType(typeCon.name.identifier)
         .toRight(GenericConversionError(s"Unknown type ${typeCon.name.identifier}"))
       dt <- typeCon.instantiate(ddt) match {
-        case v @ iface.Variant(_) => Right(v)
-        case iface.Record(_) | iface.Enum(_) =>
+        case v @ typesig.Variant(_) => Right(v)
+        case typesig.Record(_) | typesig.Enum(_) =>
           Left(GenericConversionError(s"Variant expected"))
       }
       constructor = variant.variant

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/package.scala
@@ -6,7 +6,7 @@ package com.daml.navigator
 import scalaz.{@@, Tag}
 import com.daml.lf.{data => DamlLfData}
 import com.daml.lf.data.{Ref => DamlLfRef}
-import com.daml.lf.{iface => DamlLfIface}
+import com.daml.lf.{typesig => DamlLfIface}
 import com.daml.lf.value.json.NavigatorModelAliases
 import com.daml.ledger.api.{v1 => ApiV1}
 import com.daml.ledger.api.refinements.ApiTypes

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformSubscriber.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformSubscriber.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.client.services.commands.CommandSubmission
 import com.daml.ledger.client.services.commands.tracker.CompletionResponse
 import com.daml.lf.archive.ArchivePayloadParser
 import com.daml.lf.data.{Ref => DamlLfRef}
-import com.daml.lf.iface.reader.{Errors, InterfaceReader}
+import com.daml.lf.typesig.reader.{Errors, SignatureReader}
 import com.daml.navigator.model._
 import com.daml.navigator.model.converter.TypeNotFoundError
 import com.daml.navigator.store.Store._
@@ -314,7 +314,7 @@ class PlatformSubscriber(
   private def decodePackage(res: v1.package_service.GetPackageResponse) = {
     val payload = ArchivePayloadParser.assertFromByteString(res.archivePayload)
     val (errors, out) =
-      InterfaceReader.readInterface(DamlLfRef.PackageId.assertFromString(res.hash), payload)
+      SignatureReader.readPackageSignature(DamlLfRef.PackageId.assertFromString(res.hash), payload)
     if (!errors.equals(Errors.zeroErrors)) {
       log.error("Errors loading package {}: {}", res.hash, errors.toString)
     }

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/DamlConstants.scala
@@ -11,7 +11,7 @@ import com.daml.lf.data.{
   Ref => DamlLfRef,
 }
 import com.daml.navigator.model._
-import com.daml.lf.{iface => DamlLfIface}
+import com.daml.lf.{typesig => DamlLfIface}
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.json.ApiValueImplicits._
 
@@ -281,7 +281,7 @@ case object DamlConstants {
   private val choiceNonconsuming = DamlLfRef.Name.assertFromString("nonconsuming")
   private val ChoiceReplace = DamlLfRef.Name.assertFromString("replace")
 
-  val simpleRecordTemplate = DamlLfIface.InterfaceType.Template(
+  val simpleRecordTemplate = DamlLfIface.PackageSignature.TypeDecl.Template(
     simpleRecordT,
     DamlLfIface.DefTemplate(
       DamlLfIface.TemplateChoices.Resolved fromDirect Map(
@@ -294,7 +294,7 @@ case object DamlConstants {
       Seq.empty,
     ),
   )
-  val complexRecordTemplate = DamlLfIface.InterfaceType.Template(
+  val complexRecordTemplate = DamlLfIface.PackageSignature.TypeDecl.Template(
     complexRecordT,
     DamlLfIface.DefTemplate(
       DamlLfIface.TemplateChoices.Resolved fromDirect Map(
@@ -307,7 +307,7 @@ case object DamlConstants {
       Seq.empty,
     ),
   )
-  val treeNodeTemplate = DamlLfIface.InterfaceType.Template(
+  val treeNodeTemplate = DamlLfIface.PackageSignature.TypeDecl.Template(
     treeNodeT,
     DamlLfIface.DefTemplate(
       DamlLfIface.TemplateChoices.Resolved fromDirect Map(
@@ -332,15 +332,16 @@ case object DamlConstants {
     )
   )
 
-  val iface = DamlLfIface.Interface(
+  val iface = DamlLfIface.PackageSignature(
     packageId0,
     None,
     Map(
-      emptyRecordId.qualifiedName -> DamlLfIface.InterfaceType.Normal(emptyRecordGC),
-      simpleRecordId.qualifiedName -> DamlLfIface.InterfaceType.Normal(simpleRecordGC),
-      simpleVariantId.qualifiedName -> DamlLfIface.InterfaceType.Normal(simpleVariantGC),
-      treeId.qualifiedName -> DamlLfIface.InterfaceType.Normal(treeGC),
-      treeNodeId.qualifiedName -> DamlLfIface.InterfaceType.Normal(treeNodeGC),
+      emptyRecordId.qualifiedName -> DamlLfIface.PackageSignature.TypeDecl.Normal(emptyRecordGC),
+      simpleRecordId.qualifiedName -> DamlLfIface.PackageSignature.TypeDecl.Normal(simpleRecordGC),
+      simpleVariantId.qualifiedName -> DamlLfIface.PackageSignature.TypeDecl
+        .Normal(simpleVariantGC),
+      treeId.qualifiedName -> DamlLfIface.PackageSignature.TypeDecl.Normal(treeGC),
+      treeNodeId.qualifiedName -> DamlLfIface.PackageSignature.TypeDecl.Normal(treeNodeGC),
       simpleRecordTemplateId.qualifiedName -> simpleRecordTemplate,
       complexRecordId.qualifiedName -> complexRecordTemplate,
       treeNodeId.qualifiedName -> treeNodeTemplate,


### PR DESCRIPTION
Part of #13669. Fix names used in:

* daml-script
* json-api
* Scala codegen
* Java codegen
* interpreter tests

```rst
CHANGELOG_BEGIN
- [Scala API] ``com.daml.lf.iface`` has been deprecated, as discussed
  further in
  `issue #14783 <https://github.com/digital-asset/daml/pull/14783>`__.
  Use the deprecation warnings as guidance to the new names.
CHANGELOG_END
```