### PR TITLE
Test cases to ensure retroactive implements works in json-api

### DIFF
--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -199,6 +199,7 @@ daml_compile(
     srcs = ["src/it/daml/%s.daml" % m for m in [
         "CIou",
         "IIou",
+        "RIIou",
         "Transferrable",
     ]],
     target = lf_version_configuration.get("dev"),  # TODO(SC #13296) remove when interfaces in default

--- a/ledger-service/http-json/src/it/daml/RIIou.daml
+++ b/ledger-service/http-json/src/it/daml/RIIou.daml
@@ -1,0 +1,26 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module RIIou where
+
+import CIou
+
+data EmptyInterfaceView = EmptyInterfaceView {}
+
+interface RIIou where
+  viewtype EmptyInterfaceView
+  getOwner : Party
+  choice TransferPlease : Text with
+      echo : Text
+    controller getOwner this
+    do
+      pure $ echo <> " invoked RIIou.TransferPlease"
+  choice Ambiguous : Text with
+      echo : Text
+    controller getOwner this
+    do
+      pure $ echo <> " invoked RIIou.Ambiguous"
+
+  interface instance RIIou for CIou where
+    view = EmptyInterfaceView
+    getOwner = owner

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -216,19 +216,6 @@ abstract class HttpServiceIntegrationTest
             raw"Cannot resolve Choice Argument type, given: \(TemplateId\([0-9a-f]{64},CIou,CIou\), Ambiguous\)")
       }
     }
-    "templateId = interface ID, retroactive implements choice" in withHttpService { fixture =>
-      for {
-        _ <- uploadPackage(fixture)(ciouDar)
-        result <- createIouAndExerciseTransfer(
-          fixture,
-          initialTplId = CIou.CIou,
-          exerciseTid = TpId.RIIou.RIIou,
-          choice = tExercise(choiceName = "TransferPlease", choiceArgType = echoTextVA)(
-            echoTextSample
-          ),
-        ) map exerciseSucceeded
-      } yield result should ===("Bob invoked RIIou.TransferPlease")
-    }
 
     "templateId = template ID, retroactive implements choice" in withHttpService { fixture =>
       for {
@@ -242,25 +229,6 @@ abstract class HttpServiceIntegrationTest
           ),
         ) map exerciseSucceeded
       } yield result should ===("Bob invoked RIIou.TransferPlease")
-    }
-
-    "templateId = template ID, choiceInterfaceId = interface ID, retroactive implements choice" in withHttpService {
-      fixture =>
-        for {
-          _ <- uploadPackage(fixture)(ciouDar)
-          result <- createIouAndExerciseTransfer(
-            fixture,
-            initialTplId = CIou.CIou,
-            exerciseTid = CIou.CIou,
-            choice = tExercise(
-              choiceInterfaceId = Some(TpId.RIIou.RIIou),
-              choiceName = "TransferPlease",
-              choiceArgType = echoTextVA,
-            )(
-              echoTextSample
-            ),
-          ) map exerciseSucceeded
-        } yield result should ===("Bob invoked RIIou.TransferPlease")
     }
   }
 

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTest.scala
@@ -216,6 +216,52 @@ abstract class HttpServiceIntegrationTest
             raw"Cannot resolve Choice Argument type, given: \(TemplateId\([0-9a-f]{64},CIou,CIou\), Ambiguous\)")
       }
     }
+    "templateId = interface ID, retroactive implements choice" in withHttpService { fixture =>
+      for {
+        _ <- uploadPackage(fixture)(ciouDar)
+        result <- createIouAndExerciseTransfer(
+          fixture,
+          initialTplId = CIou.CIou,
+          exerciseTid = TpId.RIIou.RIIou,
+          choice = tExercise(choiceName = "TransferPlease", choiceArgType = echoTextVA)(
+            echoTextSample
+          ),
+        ) map exerciseSucceeded
+      } yield result should ===("Bob invoked RIIou.TransferPlease")
+    }
+
+    "templateId = template ID, retroactive implements choice" in withHttpService { fixture =>
+      for {
+        _ <- uploadPackage(fixture)(ciouDar)
+        result <- createIouAndExerciseTransfer(
+          fixture,
+          initialTplId = CIou.CIou,
+          exerciseTid = CIou.CIou,
+          choice = tExercise(choiceName = "TransferPlease", choiceArgType = echoTextVA)(
+            echoTextSample
+          ),
+        ) map exerciseSucceeded
+      } yield result should ===("Bob invoked RIIou.TransferPlease")
+    }
+
+    "templateId = template ID, choiceInterfaceId = interface ID, retroactive implements choice" in withHttpService {
+      fixture =>
+        for {
+          _ <- uploadPackage(fixture)(ciouDar)
+          result <- createIouAndExerciseTransfer(
+            fixture,
+            initialTplId = CIou.CIou,
+            exerciseTid = CIou.CIou,
+            choice = tExercise(
+              choiceInterfaceId = Some(TpId.RIIou.RIIou),
+              choiceName = "TransferPlease",
+              choiceArgType = echoTextVA,
+            )(
+              echoTextSample
+            ),
+          ) map exerciseSucceeded
+        } yield result should ===("Bob invoked RIIou.TransferPlease")
+    }
   }
 
   "fail to exercise by key with interface ID" in withHttpService { fixture =>

--- a/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
+++ b/ledger-service/http-json/src/itlib/scala/http/AbstractHttpServiceIntegrationTestFuns.scala
@@ -411,6 +411,9 @@ trait AbstractHttpServiceIntegrationTestFuns
     object IIou {
       val IIou: IId = CtId.Interface(None, "IIou", "IIou")
     }
+    object RIIou {
+      val RIIou: IId = CtId.Interface(None, "RIIou", "RIIou")
+    }
 
     def unsafeCoerce[Like[T] <: CtId[T], T](ctId: CtId[T])(implicit
         Like: CtId.Like[Like]


### PR DESCRIPTION
fixes #14821, added test case to ensure retroactive implements works in json-api

CHANGELOG_BEGIN
CHANGELOG_END
