### PR TITLE
Test retro implements in java codegen

### DIFF
--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -106,7 +106,10 @@ daml_compile(
 
 daml_compile(
     name = "test-contract-id-daml",
-    srcs = ["src/test/daml/Bar.daml", "src/test/daml/Retro.daml"],
+    srcs = [
+        "src/test/daml/Bar.daml",
+        "src/test/daml/Retro.daml",
+    ],
     # TODO(#13296) change to "latest" when interfaces released
     target = lf_version_configuration.get("dev"),
 )

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -87,6 +87,7 @@ da_scala_test(
     deps = [
         ":lib",
         ":test-daml-java.jar",
+        ":test-interface-retro-implements-daml-java.jar",
         "//bazel_tools/runfiles:scala_runfiles",
         "//daml-lf/api-type-signature",
         "//daml-lf/archive:daml_lf_archive_reader",
@@ -112,6 +113,19 @@ daml_compile(
 dar_to_java(
     name = "test-daml-java",
     src = ":test-contract-id-daml.dar",
+    package_prefix = "ut",
+)
+
+daml_compile(
+    name = "test-interface-retro-implements-daml",
+    srcs = ["src/test/daml/Retro.daml"],
+    # TODO(#13296) change to "latest" when interfaces released
+    target = lf_version_configuration.get("dev"),
+)
+
+dar_to_java(
+    name = "test-interface-retro-implements-daml-java",
+    src = ":test-interface-retro-implements-daml.dar",
     package_prefix = "ut",
 )
 

--- a/language-support/java/codegen/BUILD.bazel
+++ b/language-support/java/codegen/BUILD.bazel
@@ -87,7 +87,6 @@ da_scala_test(
     deps = [
         ":lib",
         ":test-daml-java.jar",
-        ":test-interface-retro-implements-daml-java.jar",
         "//bazel_tools/runfiles:scala_runfiles",
         "//daml-lf/api-type-signature",
         "//daml-lf/archive:daml_lf_archive_reader",
@@ -107,25 +106,14 @@ daml_compile(
 
 daml_compile(
     name = "test-contract-id-daml",
-    srcs = ["src/test/daml/Bar.daml"],
-)
-
-dar_to_java(
-    name = "test-daml-java",
-    src = ":test-contract-id-daml.dar",
-    package_prefix = "ut",
-)
-
-daml_compile(
-    name = "test-interface-retro-implements-daml",
-    srcs = ["src/test/daml/Retro.daml"],
+    srcs = ["src/test/daml/Bar.daml", "src/test/daml/Retro.daml"],
     # TODO(#13296) change to "latest" when interfaces released
     target = lf_version_configuration.get("dev"),
 )
 
 dar_to_java(
-    name = "test-interface-retro-implements-daml-java",
-    src = ":test-interface-retro-implements-daml.dar",
+    name = "test-daml-java",
+    src = ":test-contract-id-daml.dar",
     package_prefix = "ut",
 )
 

--- a/language-support/java/codegen/src/test/daml/Retro.daml
+++ b/language-support/java/codegen/src/test/daml/Retro.daml
@@ -1,0 +1,36 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Retro where
+
+template TemplateRetro
+  with
+    issuer : Party
+    owner : Party
+    amount : Int
+  where
+    signatory issuer, owner
+
+
+data TokenView = TokenView with
+  owner : Party
+  amount : Int
+
+interface InterfaceRetro where
+  viewtype TokenView
+
+  transferImpl : Party -> Update (ContractId InterfaceRetro)
+
+  choice Transfer : ContractId InterfaceRetro
+    with
+      newOwner : Party
+    controller (view this).owner, newOwner
+    do
+      transferImpl this newOwner
+
+  interface instance InterfaceRetro for TemplateRetro where
+    view = TokenView with owner, amount
+
+    transferImpl newOwner = do
+      cid <- create this with owner = newOwner
+      pure (toInterfaceContractId @InterfaceRetro cid)

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceRetroImplementsSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceRetroImplementsSpec.scala
@@ -13,7 +13,8 @@ final class InterfaceRetroImplementsSpec extends AnyWordSpec with Matchers {
   "TemplateRetro.ContractId where `TemplateRetro` is implementing `InterfaceRetro` retroactively" should {
     "be able to convert to a interface id of `InterfaceRetro`" in {
       val contractId = new TemplateRetro.ContractId("SomeID")
-      val contractViaInterface: InterfaceRetro.ContractId = contractId.toInterface(InterfaceRetro.INTERFACE)
+      val contractViaInterface: InterfaceRetro.ContractId =
+        contractId.toInterface(InterfaceRetro.INTERFACE)
       val cmd = contractViaInterface.exerciseTransfer("newOwner")
       cmd.getContractId shouldEqual contractId.contractId
       cmd.getTemplateId shouldEqual InterfaceRetro.TEMPLATE_ID

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceRetroImplementsSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceRetroImplementsSpec.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.codegen.backend.java
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import retro.InterfaceRetro
+import ut.retro.TemplateRetro
+
+final class InterfaceRetroImplementsSpec extends AnyWordSpec with Matchers {
+
+  "TemplateRetro.ContractId where `TemplateRetro` is implementing `InterfaceRetro` retroactively" should {
+    "be able to convert to a interface id of `InterfaceRetro`" in {
+      val contractId = new TemplateRetro.ContractId("SomeID")
+      val contractViaInterface: InterfaceRetro.ContractId = contractId.toInterface(InterfaceRetro.INTERFACE)
+      val cmd = contractViaInterface.exerciseTransfer("newOwner")
+      cmd.getContractId shouldEqual contractId.contractId
+      cmd.getTemplateId shouldEqual "failed"
+    }
+  }
+}

--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceRetroImplementsSpec.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/backend/java/InterfaceRetroImplementsSpec.scala
@@ -16,7 +16,7 @@ final class InterfaceRetroImplementsSpec extends AnyWordSpec with Matchers {
       val contractViaInterface: InterfaceRetro.ContractId = contractId.toInterface(InterfaceRetro.INTERFACE)
       val cmd = contractViaInterface.exerciseTransfer("newOwner")
       cmd.getContractId shouldEqual contractId.contractId
-      cmd.getTemplateId shouldEqual "failed"
+      cmd.getTemplateId shouldEqual InterfaceRetro.TEMPLATE_ID
     }
   }
 }


### PR DESCRIPTION
fixes #14822, added test case to ensure retroactive implements works in java code gen

CHANGELOG_BEGIN
CHANGELOG_END