### PR TITLE
declare retroactive interface implementations in TypeScript

### DIFF
--- a/language-support/ts/codegen/tests/daml/Retro.daml
+++ b/language-support/ts/codegen/tests/daml/Retro.daml
@@ -1,0 +1,31 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Retro where
+
+import Main (Asset(..))
+import RetroView
+
+interface Retro where
+  viewtype RetroView
+  getOwner : Party
+
+  nonconsuming choice RetroChoice : (Text, ContractId Retro)
+    with
+      echo : Text
+    controller getOwner this
+    do
+      pure $ ("invoked RetroChoice with " <> echo, self)
+
+  interface instance Retro for Asset where
+    view = RetroView 1
+    getOwner = owner
+
+  interface instance Retro for LocalRetro where
+    view = RetroView 2
+    getOwner = owner
+
+template LocalRetro with
+    owner: Party
+  where
+    signatory owner

--- a/language-support/ts/codegen/tests/daml/RetroView.daml
+++ b/language-support/ts/codegen/tests/daml/RetroView.daml
@@ -1,0 +1,7 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module RetroView where
+
+data RetroView = RetroView with
+  unRetroView : Int

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -11,7 +11,7 @@ import Ledger, {
   PartyInfo,
   UserRightHelper,
 } from "@daml/ledger";
-import { Choice, Int, emptyMap, Map } from "@daml/types";
+import { Choice, ContractId, Int, emptyMap, Map } from "@daml/types";
 import pEvent from "p-event";
 import _ from "lodash";
 import WebSocket from "ws";
@@ -638,6 +638,20 @@ describe("interface definition", () => {
       > = tpl[k];
       expect(c).not.toEqual(theChoice(if2[k]));
       expect(c.template()).toBe(tpl);
+    });
+
+    test("retroactive interfaces permit contract ID conversion", () => {
+      const cid = "test" as ContractId<buildAndLint.Main.Asset>;
+      const icid: ContractId<buildAndLint.Retro.Retro> = tpl.toInterface(
+        buildAndLint.Retro.Retro,
+        cid,
+      );
+      const tcid: ContractId<buildAndLint.Main.Asset> = tpl.unsafeFromInterface(
+        buildAndLint.Retro.Retro,
+        icid,
+      );
+      expect(icid).toBe(cid);
+      expect(tcid).toBe(icid);
     });
   });
 });


### PR DESCRIPTION
Fixes #14082.

```rst
CHANGELOG_BEGIN
- [TypeScript codegen] Support for retroactive interface implementations
  included.  Choice inheritance is deprecated and `will be removed
  <https://github.com/digital-asset/daml/issues/14893>`__; to invoke an
  interface choice on a template-typed contract ID, convert it to an
  interface-typed ID with *TemplateName*``.toInterface``.
CHANGELOG_END
```

* [x] test intersection, and separate file reference
* [x] add changelog