### PR TITLE
[ED] Forward contract metadata in Ledger API streams [DPP-1098]

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -103,8 +103,7 @@ message CreatedEvent {
   google.protobuf.StringValue agreement_text = 6;
 
   // Metadata of the contract. Required for contracts created
-  // after the introduction of explicit disclosure. If explicit disclosure is disabled,
-  // this field will be empty.
+  // after the introduction of explicit disclosure.
   ContractMetadata metadata = 10;
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/InMemoryStateUpdater.scala
@@ -11,6 +11,7 @@ import com.daml.ledger.api.DeduplicationPeriod.{DeduplicationDuration, Deduplica
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.v2.{CompletionInfo, Update}
 import com.daml.ledger.resources.ResourceOwner
+import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref.HexString
 import com.daml.lf.engine.Blinding
 import com.daml.lf.ledger.EventId
@@ -259,6 +260,7 @@ private[platform] object InMemoryStateUpdater {
           createSignatories = create.signatories,
           createObservers = create.stakeholders.diff(create.signatories),
           createAgreementText = Some(create.agreementText).filter(_.nonEmpty),
+          createKeyHash = create.key.map(_.key).map(Hash.safeHashContractKey(create.templateId, _)),
         )
       case (nodeId, exercise: Exercise) =>
         TransactionLogUpdate.ExercisedEvent(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/Conversions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/Conversions.scala
@@ -235,4 +235,7 @@ private[backend] object Conversions {
     override def set(s: PreparedStatement, i: Int, v: Hash): Unit =
       s.setString(i, v.bytes.toHexString)
   }
+
+  def hashFromHexString(name: String): RowParser[Hash] =
+    SqlParser.get[String](name).map(Hash.assertFromString)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/backend/StorageBackend.scala
@@ -9,6 +9,7 @@ import com.daml.ledger.configuration.Configuration
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.MeteringStore.{ParticipantMetering, ReportData}
 import com.daml.ledger.participant.state.index.v2.PackageDetails
+import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.ledger.EventId
 import com.daml.logging.LoggingContext
@@ -31,9 +32,9 @@ import com.daml.platform.store.entries.{ConfigurationEntry, PackageLedgerEntry, 
 import com.daml.platform.store.interfaces.LedgerDaoContractsReader.KeyState
 import com.daml.platform.store.interning.StringInterning
 import com.daml.scalautil.NeverEqualsOverride
+
 import java.sql.Connection
 import javax.sql.DataSource
-
 import com.daml.lf.data.Ref
 
 import scala.annotation.unused
@@ -382,6 +383,7 @@ object EventStorageBackend {
       createObservers: Option[Array[String]],
       createAgreementText: Option[String],
       createKeyValue: Option[Array[Byte]],
+      createKeyHash: Option[Hash],
       createKeyCompression: Option[Int],
       createArgument: Option[Array[Byte]],
       createArgumentCompression: Option[Int],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionLogUpdatesConversions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionLogUpdatesConversions.scala
@@ -3,7 +3,9 @@
 
 package com.daml.platform.store.dao.events
 
+import com.daml.api.util.TimestampConversion
 import com.daml.api.util.TimestampConversion.fromInstant
+import com.daml.ledger.api.v1.contract_metadata.ContractMetadata
 import com.daml.ledger.api.v1.transaction.{
   TransactionTree,
   TreeEvent,
@@ -29,6 +31,7 @@ import com.daml.platform.{ApiOffset, FilterRelation, Value}
 import com.google.protobuf.timestamp.Timestamp
 
 import scala.concurrent.{ExecutionContext, Future}
+import com.google.protobuf.ByteString
 
 private[events] object TransactionLogUpdatesConversions {
   object ToFlatTransaction {
@@ -422,6 +425,15 @@ private[events] object TransactionLogUpdatesConversions {
           signatories = createdEvent.createSignatories.toSeq,
           observers = createdEvent.createObservers.toSeq,
           agreementText = createdEvent.createAgreementText.orElse(Some("")),
+          metadata = Some(
+            ContractMetadata(
+              createdAt = Some(TimestampConversion.fromLf(createdEvent.ledgerEffectiveTime)),
+              contractKeyHash =
+                createdEvent.createKeyHash.fold(ByteString.EMPTY)(_.bytes.toByteString),
+              // TODO ED: Store driver metadata in the database
+              driverMetadata = ByteString.EMPTY,
+            )
+          ),
         )
       )
   }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/TransactionLogUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/interfaces/TransactionLogUpdate.scala
@@ -11,6 +11,7 @@ import com.daml.lf.value.{Value => LfValue}
 import com.daml.platform.{ContractId, Identifier}
 import com.daml.platform.store.cache.MutableCacheBackedContractStore.EventSequentialId
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
+import com.daml.lf.crypto.Hash
 
 /** Generic ledger update event.
   *
@@ -96,6 +97,7 @@ object TransactionLogUpdate {
       createSignatories: Set[Party],
       createObservers: Set[Party],
       createAgreementText: Option[String],
+      createKeyHash: Option[Hash],
   ) extends Event
 
   final case class ExercisedEvent(


### PR DESCRIPTION
This PR 
* populates the `created_at` and `contract_key_hash` in `CreatedEvent.metadata`.  
  * **NOTE**: `driver_metadata` is not populated on purpose. It will be added when needed in the required ledger-side implementation.

changelog_begin
    The `CreatedEvent.metadata` field is populated for `created_at` and `contract_key_hash` (where applicable)
    for active contracts and transactions payloads in Ledger API streams
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
