### PR TITLE
Data.NameMap: remove runtime check on HOF name changes

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -2,9 +2,15 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module DA.Daml.LF.Ast.Optics(
     ModuleRef,
     moduleModuleRef,
@@ -31,6 +37,9 @@ import DA.Daml.LF.Ast.Base
 import DA.Daml.LF.Ast.TypeLevelNat
 import DA.Daml.LF.Ast.Recursive
 import DA.Daml.LF.Ast.Version (Version)
+
+import qualified Data.Kind as K (Type, Constraint)
+import GHC.TypeLits
 
 -- | WARNING: The result is not a proper prism.
 -- The intended use case is something along the lines of
@@ -216,8 +225,69 @@ instance MonoTraversable ModuleRef PackageMetadata
 instance MonoTraversable ModuleRef Package
 instance MonoTraversable ModuleRef T.Text where monoTraverse _ = pure
 
-instance (NM.Named a, MonoTraversable ModuleRef a) => MonoTraversable ModuleRef (NM.NameMap a) where
+instance (MonoTraversableNameMap ModuleRef a) => MonoTraversable ModuleRef (NM.NameMap a) where
   monoTraverse = NM.traverse . monoTraverse
+
+type MonoTraversableNameMap e a =
+  ( NM.Named a
+  , MonoTraversable e a
+  , MonoTraversableNameMapName e (NM.Name a) a
+  )
+
+-- | @MonoTraversableNameMapName e n a@ is used to check that a type @a@ such that
+--
+-- > instance NM.Named a where
+-- >   type NM.Name a = n
+-- >   name = (...)
+--
+-- is acceptable for use with
+--
+-- > monoTraverse @e @(NM.NameMap a)
+--
+-- This check is necessary because 'NM.traverse' fails at runtime if the
+-- supplied function changes the names of the items in the map.
+--
+-- An empty instance of this class means that @n@ is an acceptable 'NM.Name'
+-- for @a@ when 'monoTraverse' targets values of type @e@, in other words,
+--
+-- > monoTraverse @e @(NM.NameMap a)
+--
+-- is not expected to change the names of type @n@.
+--
+-- An instance with a constraint 'BadMonoTraversableNameMapName e n a' means
+-- that @n@ is _not_ an acceptable name for @a@, because 'monoTraverse' would
+-- change the names at runtime, causing 'NM.traverse' to fail.
+--
+class MonoTraversableNameMapName e n a
+instance MonoTraversableNameMapName ModuleRef ModuleName a
+instance MonoTraversableNameMapName ModuleRef TypeSynName a
+instance MonoTraversableNameMapName ModuleRef ExprValName a
+instance MonoTraversableNameMapName ModuleRef TypeConName a
+instance MonoTraversableNameMapName ModuleRef MethodName a
+instance MonoTraversableNameMapName ModuleRef ChoiceName a
+
+-- | Given @type NM.Name a = Qualified _@,
+--
+-- > monoTraverse @ModuleRef @(NM.NameMap a)
+--
+-- is very likely to fail because @Qualified x@ is effectively a tuple of
+-- @(ModuleRef, a)@, so any function on @ModuleRef@ would change the names.
+--
+instance BadMonoTraversableNameMapName ModuleRef (Qualified x) a
+      => MonoTraversableNameMapName ModuleRef (Qualified x) a
+
+type family BadMonoTraversableNameMapName (e :: K.Type) (n :: K.Type) (a :: K.Type) :: K.Constraint where
+  BadMonoTraversableNameMapName e n a =
+    TypeError
+      ( 'Text "Cannot use " ':<>: 'ShowType n
+        ':$$: 'Text "as the Name of " ':<>: 'ShowType a
+        ':$$: 'Text "because it would break"
+        ':$$: 'Text "  monoTraverse @"
+          ':<>: 'ShowType e
+          ':<>: 'Text " @("
+          ':<>: 'ShowType (NM.NameMap a)
+          ':<>: 'Text ")"
+      )
 
 -- | Traverse over all references to top-level values in an expression.
 exprValueRef

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Optics.hs
@@ -216,6 +216,9 @@ instance MonoTraversable ModuleRef PackageMetadata
 instance MonoTraversable ModuleRef Package
 instance MonoTraversable ModuleRef T.Text where monoTraverse _ = pure
 
+instance (NM.Named a, MonoTraversable ModuleRef a) => MonoTraversable ModuleRef (NM.NameMap a) where
+  monoTraverse = NM.traverse . monoTraverse
+
 -- | Traverse over all references to top-level values in an expression.
 exprValueRef
   :: forall f. Applicative f

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -126,6 +126,82 @@ testsForDamlcValidate damlc = testGroup "damlc validate-dar"
       exitCode @?= ExitSuccess
       assertInfixOf "DAR is valid" stdout
 
+  , testCaseSteps "Good (interface instance)" $ \step -> withTempDir $ \projDir -> do
+      step "prepare"
+      writeFileUTF8 (projDir </> "daml.yaml") $ unlines
+        [ "sdk-version: " <> sdkVersion
+        , "build-options: [ --target=1.15 ]"
+        , "name: good"
+        , "version: 0.0.1"
+        , "source: ."
+        , "dependencies: [daml-prim, daml-stdlib]"
+        ]
+      writeFileUTF8 (projDir </> "Interface.daml") $ unlines
+        [ "module Interface where"
+        , "data MyIView = MyIView {}"
+        , "interface MyI where"
+        , "  viewtype MyIView"
+        , "  iMethod : ()"
+        ]
+      writeFileUTF8 (projDir </> "Good.daml") $ unlines
+        [ "module Good where"
+        , "import Interface"
+        , "template MyT"
+        , "  with"
+        , "    myParty : Party"
+        , "  where"
+        , "    signatory [myParty]"
+        , "    interface instance MyI for MyT where"
+        , "      view = MyIView"
+        , "      iMethod = ()"
+        ]
+      step "build"
+      callProcessSilent damlc ["build", "--project-root", projDir]
+      let dar = projDir </> ".daml/dist/good-0.0.1.dar"
+      step "validate"
+      (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ["validate-dar", dar] ""
+      stderr @?= ""
+      exitCode @?= ExitSuccess
+      assertInfixOf "DAR is valid" stdout
+
+  , testCaseSteps "Good (retroactive interface instance)" $ \step -> withTempDir $ \projDir -> do
+      step "prepare"
+      writeFileUTF8 (projDir </> "daml.yaml") $ unlines
+        [ "sdk-version: " <> sdkVersion
+        , "build-options: [ --target=1.15 ]"
+        , "name: good"
+        , "version: 0.0.1"
+        , "source: ."
+        , "dependencies: [daml-prim, daml-stdlib]"
+        ]
+      writeFileUTF8 (projDir </> "Template.daml") $ unlines
+        [ "module Template where"
+        , "template MyT"
+        , "  with"
+        , "    myParty : Party"
+        , "  where"
+        , "    signatory [myParty]"
+        ]
+      writeFileUTF8 (projDir </> "Good.daml") $ unlines
+        [ "module Good where"
+        , "import Template"
+        , "data MyIView = MyIView {}"
+        , "interface MyI where"
+        , "  viewtype MyIView"
+        , "  iMethod : ()"
+        , "  interface instance MyI for MyT where"
+        , "    view = MyIView"
+        , "    iMethod = ()"
+        ]
+      step "build"
+      callProcessSilent damlc ["build", "--project-root", projDir]
+      let dar = projDir </> ".daml/dist/good-0.0.1.dar"
+      step "validate"
+      (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ["validate-dar", dar] ""
+      stderr @?= ""
+      exitCode @?= ExitSuccess
+      assertInfixOf "DAR is valid" stdout
+
   , testCaseSteps "Bad, DAR contains a bad DALF" $ \step -> withTempDir $ \projDir -> do
       step "prepare"
       writeFileUTF8 (projDir </> "daml.yaml") $ unlines

--- a/libs-haskell/da-hs-base/src/Data/NameMap.hs
+++ b/libs-haskell/da-hs-base/src/Data/NameMap.hs
@@ -56,7 +56,6 @@ import Prelude hiding (lookup, map, traverse, null)
 import qualified Prelude
 
 import           Control.DeepSeq
-import           Control.Lens.MonoTraversal
 import           Control.Monad (void)
 import           Data.Aeson
 import           Data.Binary
@@ -213,6 +212,3 @@ instance (Named a, Binary a) => Binary (NameMap a) where
   get = fromList <$> get
 
 deriving instance (Data a, Data (Name a), Named a) => Data (NameMap a)
-
-instance (Named a, MonoTraversable e a) => MonoTraversable e (NameMap a) where
-  monoTraverse = traverse . monoTraverse

--- a/libs-haskell/da-hs-base/src/Data/NameMap.hs
+++ b/libs-haskell/da-hs-base/src/Data/NameMap.hs
@@ -43,7 +43,6 @@ module Data.NameMap
   -- * Transformations
   , map
   , traverse
-  , traverseAsList
 
   -- * Conversions
   , toList
@@ -132,13 +131,6 @@ traverse f (NameMap ras _) = build <$> Prelude.traverse f' (reverse ras)
       | otherwise = error $
           "Data.NameMap.traverse: function changed name from " ++ show n ++ " to " ++ show (name y)
     build as = NameMap (reverse as) (HMS.fromList as)
-
--- | @traverseAsList f m@ applies the function @f@ to all elements of @m@ in the
--- order they have been inserted into @m@. Unlike @traverse f m@, it does not
--- fail when there is an element @x@ with @name x /= name (f x)@. It *does* fail
--- when there are two elements @x@, @y@ with @name (f x) == name (f y)@.
-traverseAsList :: (Applicative f, Named a) => (a -> f a) -> NameMap a -> f (NameMap a)
-traverseAsList f = fmap fromList . Prelude.traverse f . toList
 
 instance Foldable NameMap where
   foldr f z (NameMap ras _) = foldl' f' z ras

--- a/libs-haskell/da-hs-base/src/Data/NameMap.hs
+++ b/libs-haskell/da-hs-base/src/Data/NameMap.hs
@@ -43,6 +43,7 @@ module Data.NameMap
   -- * Transformations
   , map
   , traverse
+  , traverseAsList
 
   -- * Conversions
   , toList
@@ -131,6 +132,13 @@ traverse f (NameMap ras _) = build <$> Prelude.traverse f' (reverse ras)
       | otherwise = error $
           "Data.NameMap.traverse: function changed name from " ++ show n ++ " to " ++ show (name y)
     build as = NameMap (reverse as) (HMS.fromList as)
+
+-- | @traverseAsList f m@ applies the function @f@ to all elements of @m@ in the
+-- order they have been inserted into @m@. Unlike @traverse f m@, it does not
+-- fail when there is an element @x@ with @name x /= name (f x)@. It *does* fail
+-- when there are two elements @x@, @y@ with @name (f x) == name (f y)@.
+traverseAsList :: (Applicative f, Named a) => (a -> f a) -> NameMap a -> f (NameMap a)
+traverseAsList f = fmap fromList . Prelude.traverse f . toList
 
 instance Foldable NameMap where
   foldr f z (NameMap ras _) = foldl' f' z ras


### PR DESCRIPTION
Fixes #14901 