### PR TITLE
Improve the sample dot command call

### DIFF
--- a/docs/source/tools/visual.rst
+++ b/docs/source/tools/visual.rst
@@ -12,7 +12,7 @@ You can generate visual graphs for the contracts in your Daml project. To do thi
 2. Open a terminal and navigate to your project root directory.
 3. Generate a DAR from your project by running ``daml build -o project.dar``.
 4. Generate a `dot file <https://en.wikipedia.org/wiki/DOT_(graph_description_language)>`_ from that DAR by running ``daml damlc visual project.dar --dot project.dot``
-5. Generate the visual graph with Graphviz by running ``dot -Tpng project.dot > project.png``
+5. Generate the visual graph with Graphviz by running ``dot -T png project.dot -o project.png``
 
 You can of course choose different names for the files, as long as you're consistent between file creation and point of use.
 


### PR DESCRIPTION
In Windows PowerShell, the command `dot -Tpng .\daml-project.dot > daml-project.png` does not create a valid PNG file. Apparently, the `>` of the binary file did not work properly. Instead I used `dot -T png .\daml-project.dot -o daml-project.png` with `-o` instead of `>`. That is probably the preferred way.

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
