### PR TITLE
Correct error message for not found templates/interfaces in stream subscriptions [DPP-1220]

### DIFF
--- a/docs/resources/generated-error-pages/error-codes-inventory.rst.inc
+++ b/docs/resources/generated-error-pages/error-codes-inventory.rst.inc
@@ -1285,6 +1285,22 @@ PACKAGE_NOT_FOUND
 
 
 
+.. _error_code_TEMPLATES_OR_INTERFACES_NOT_FOUND:
+
+TEMPLATES_OR_INTERFACES_NOT_FOUND
+---------------------------------------------------------------------------------------------------------------------------------------
+    
+    **Explanation**: The queried template or interface ids do not exist.
+
+    **Category**: InvalidGivenCurrentSystemStateResourceMissing
+
+    **Conveyance**: This error is logged with log-level INFO on the server side. This error is exposed on the API with grpc-status NOT_FOUND including a detailed error message
+
+    **Resolution**: Use valid template or interface ids in your query or ask the participant operator to upload the package containing the necessary interfaces/templates.
+
+
+
+
 .. _error_code_TRANSACTION_NOT_FOUND:
 
 TRANSACTION_NOT_FOUND

--- a/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
+++ b/ledger/error/src/main/scala/com/daml/error/ErrorResource.scala
@@ -31,6 +31,12 @@ object ErrorResource {
   object DalfPackage extends ErrorResource {
     def asString: String = "PACKAGE"
   }
+  object TemplateId extends ErrorResource {
+    def asString: String = "TEMPLATE_ID"
+  }
+  object InterfaceId extends ErrorResource {
+    def asString: String = "INTERFACE_ID"
+  }
   object LedgerId extends ErrorResource {
     def asString: String = "LEDGER_ID"
   }

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -79,6 +79,7 @@ conformance_test_tool_args = [
         "TLSAtLeastOnePointTwoIT",
         "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # requires pruning not available in canton community
         "DeeplyNestedValueIT",  # FIXME: Too deeply nested values flake with a time out (half of the time)
+        "InterfaceSubscriptionsIT:ISTransactionsUnknownTemplateOrInterface",  # FIXME: Remove exclusion after the next Canton SDK upgrade
     ]),
 ]
 

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -79,7 +79,6 @@ conformance_test_tool_args = [
         "TLSAtLeastOnePointTwoIT",
         "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # requires pruning not available in canton community
         "DeeplyNestedValueIT",  # FIXME: Too deeply nested values flake with a time out (half of the time)
-        "InterfaceSubscriptionsIT:ISTransactionsUnknownTemplateOrInterface",  # FIXME: Remove exclusion after the next Canton SDK upgrade
     ]),
 ]
 
@@ -116,6 +115,30 @@ conformance_test(
     extra_runner_args = ["7000"],
     lf_versions = [
         "default",
+        #        "preview", # FIXME: enable once merged with `conformance-test-dev-domain-preview-dev`
+        #        "dev", # FIXME: enable once merged with `conformance-test-dev-domain-preview-dev`
+    ],
+    ports = conformance_test_ports,
+    preview_mod_flag = "",
+    runner = "@//bazel_tools/client_server/runner_with_health_check",
+    server = ":canton-test-runner-with-dependencies",
+    server_args = [
+        "--config=$$(canonicalize_rlocation $(rootpath :canton-dev.conf))",
+        "--bootstrap=$$(canonicalize_rlocation $(rootpath :bootstrap-dev.canton))",
+    ],
+    test_tool_args = conformance_test_tool_args,
+) if not is_windows else None
+
+conformance_test(
+    name = "conformance-test-dev-domain-preview-dev",
+    dev_mod_flag = "",
+    extra_data =
+        conformance_test_extra_data_base + [
+            ":bootstrap-dev.canton",
+            ":canton-dev.conf",
+        ],
+    extra_runner_args = ["7000"],
+    lf_versions = [
         "preview",
         "dev",
     ],
@@ -127,5 +150,22 @@ conformance_test(
         "--config=$$(canonicalize_rlocation $(rootpath :canton-dev.conf))",
         "--bootstrap=$$(canonicalize_rlocation $(rootpath :bootstrap-dev.canton))",
     ],
-    test_tool_args = conformance_test_tool_args,
+    test_tool_args = [
+        "--verbose",
+        "--concurrent-test-runs=1",  # lowered from default #procs to reduce flakes - details in https://github.com/digital-asset/daml/issues/7316
+        "--timeout-scale-factor=2",  # increased to reduce flakes particularly wrt timeouts in TransactionService*IT tests
+        "--exclude=" + ",".join([
+            # dynamic config management not supported by Canton
+            "ConfigManagementServiceIT",
+            "LedgerConfigurationServiceIT",
+            "ClosedWorldIT",  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
+            "ParticipantPruningIT",  # pruning not supported in Canton Community
+            # tests with special config run in canton enterprise-repo
+            "TLSOnePointThreeIT",
+            "TLSAtLeastOnePointTwoIT",
+            "CommandDeduplicationPeriodValidationIT:OffsetPruned",  # requires pruning not available in canton community
+            "DeeplyNestedValueIT",  # FIXME: Too deeply nested values flake with a time out (half of the time)
+            "InterfaceSubscriptionsIT:ISTransactionsUnknownTemplateOrInterface",  # FIXME: Remove exclusion after the next Canton SDK upgrade
+        ]),
+    ],
 ) if not is_windows else None

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
@@ -33,6 +33,7 @@ import com.daml.ledger.test.{
 import com.daml.logging.LoggingContext
 import scalaz.Tag
 
+import java.util.regex.Pattern
 import scala.concurrent.duration._
 
 class InterfaceSubscriptionsIT extends LedgerTestSuite {
@@ -455,8 +456,8 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
     "Subscribing on transaction stream by an unknown template fails",
     allocate(SingleParty),
   )(implicit ec => { case Participants(Participant(ledger, party)) =>
-    val unknownTemplate = TemplateId(Tag.unwrap(I.id).copy(entityName = "IDoesNotExist"))
-    val unknownInterface = TemplateId(Tag.unwrap(I.id).copy(entityName = "IDoesNotExist"))
+    val unknownTemplate = TemplateId(Tag.unwrap(I.id).copy(entityName = "TemplateDoesNotExist"))
+    val unknownInterface = TemplateId(Tag.unwrap(I.id).copy(entityName = "InterfaceDoesNotExist"))
     import ledger._
     for {
       _ <- create(party, T1(party, 1))
@@ -473,15 +474,15 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
       )
         .mustFail("subscribing with an unknown interface")
     } yield {
-      assertGrpcError(
+      assertGrpcErrorRegex(
         failure,
-        LedgerApiErrors.RequestValidation.InvalidArgument,
-        Some(s"Templates do not exist"),
+        LedgerApiErrors.RequestValidation.NotFound.TemplateOrInterfaceIdsNotFound,
+        Some(Pattern.compile("Templates do not exist.*TemplateDoesNotExist]")),
       )
-      assertGrpcError(
+      assertGrpcErrorRegex(
         failure2,
-        LedgerApiErrors.RequestValidation.InvalidArgument,
-        Some(s"Interfaces do not exist"),
+        LedgerApiErrors.RequestValidation.NotFound.TemplateOrInterfaceIdsNotFound,
+        Some(Pattern.compile("Interfaces do not exist.*InterfaceDoesNotExist]")),
       )
     }
   })


### PR DESCRIPTION
changelog_begin
When subscribing to Ledger API transaction streams with unknown template or interface ids
filter, a client is served with a NOT_FOUND/TEMPLATES_OR_INTERFACES_NOT_FOUND error code.
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
