### PR TITLE
Fix unstable package ids in the presence of data-dependencies

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -466,6 +466,10 @@ setupDamlGHC mbProjectRoot options@Options{..} = do
   defaultCppPath <- liftIO locateCppPath
   modifyDynFlags $ adjustDynFlags options versionHeader tmpDir defaultCppPath
 
+  -- NOTE(MA): This ensures that the name supply inside HscEnv's NameCache
+  -- always starts with the same value (#14936)
+  liftIO $ initUniqSupply 0 1
+
   unless (null optGhcCustomOpts) $ do
     damlDFlags <- getSessionDynFlags
     (dflags', leftover, warns) <- parseDynamicFilePragma damlDFlags $ map noLoc optGhcCustomOpts


### PR DESCRIPTION
Originally [raised on discuss](https://discuss.daml.com/t/what-parts-of-the-daml-directory-are-cached-and-influence-a-build/5172).

The problem seems to be that the first time we build a data-dependency we typecheck the stubbed sources (`usesE TypeCheck files` in `writeIfacesAndHie`), but the second time (after removing the resulting `project-0.0.1.dar` but keeping everything else in the `.daml` directory) there's no typechecking because the result of `usesE TypeCheck files` is cached. This means that by the time we're building the main project, the `NameCache` (and thus its `UniqSupply`) has moved further along in the first case than in the second one.

Now, it may seem impossible that typechecking or not the data-dependencies could affect the main project, since these actions happen in different `withDamlIdeState` handlers, but `UniqSupply` is defined in terms of global variables*, so in reality all `UniqSupply`s use the same counter. Resetting the counter each time we build a new GHC session (through `setupDamlGHC`) then makes them independent.

Finally, it might seem that this does "too much", since `writeIfacesAndHie` (among many others) uses `GhcSession` once per file (not per project). However, the rule for `GhcSession` is defined in terms of `optGhcSession`, which we define as `getDamlGhcSession`, in turn defined in terms of `DamlGhcSession`, but crucially using the project root as key - so all of a project's files end up with the same `DamlGhcSession`.

---

*see [da-ghc/compiler/cbits/genSym.c](https://github.com/digital-asset/ghc/blob/da-master-8.8.1/compiler/cbits/genSym.c#L21-L23); note that `THREADED_RTS` is defined in [ghc-lib.cabal](https://github.com/digital-asset/daml/blob/main/bazel_tools/ghc-lib/ghc-lib/ghc-lib.cabal#L64-L66) and `n_capabilities` is `1` because we never set the `RTS` flag `-Nx` (see [Using Concurrent Haskell](https://downloads.haskell.org/ghc/latest/docs/users_guide/using-concurrent.html#rts-flag--N%20%E2%9F%A8x%E2%9F%A9))