### PR TITLE
PoC: Custom errors, for Interfaces

### DIFF
--- a/bazel_tools/ghc-lib/version.bzl
+++ b/bazel_tools/ghc-lib/version.bzl
@@ -9,7 +9,7 @@ GHC_LIB_PATCHES = [
 ]
 
 GHC_REPO_URL = "https://github.com/digital-asset/ghc"
-GHC_REV = "070d4382959bd8cbaf40585ec051237246a58a6b"
+GHC_REV = "494567f32149bf95e4a91dd7b1f661a64b2c4556"
 GHC_PATCHES = [
 ]
 


### PR DESCRIPTION
Proof of concept that we can override the typechecking mechanism in GHC - here we use it to provide nicer error messages when trying to get views or exercises on non-interfaces.

https://github.com/digital-asset/ghc/pull/133