### PR TITLE
remove choice inheritance from TypeScript codegen

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -672,7 +672,7 @@ describe("interfaces", () => {
     };
   }
 
-  test("inherited exercise events", async () => {
+  test("interface companion choice exercise", async () => {
     const {
       aliceLedger,
       assetPayload,
@@ -681,7 +681,7 @@ describe("interfaces", () => {
 
     expect(ifaceContract.payload).toEqual(assetPayload);
     const [, events1] = await aliceLedger.exercise(
-      Asset.Transfer,
+      Token.Transfer,
       Asset.toInterface(Token, ifaceContract.contractId),
       { newOwner: BOB_PARTY },
     );
@@ -692,36 +692,6 @@ describe("interfaces", () => {
           templateId: buildAndLint.Main.Asset.templateId,
           signatories: [ALICE_PARTY],
           payload: { issuer: ALICE_PARTY, owner: BOB_PARTY },
-        },
-      },
-    ]);
-  });
-
-  test("interface companion choice exercise", async () => {
-    const bobLedger = new Ledger({
-      token: BOB_TOKEN,
-      httpBaseUrl: httpBaseUrl(),
-    });
-    const assetPayload2 = {
-      issuer: BOB_PARTY,
-      owner: BOB_PARTY,
-    };
-    const ifaceContract2 = await bobLedger.create(
-      buildAndLint.Main.Asset,
-      assetPayload2,
-    );
-    const [, events2] = await bobLedger.exercise(
-      buildAndLint.Main.Token.Transfer,
-      Asset.toInterface(Token, ifaceContract2.contractId),
-      { newOwner: ALICE_PARTY },
-    );
-    expect(events2).toMatchObject([
-      { archived: { templateId: buildAndLint.Main.Asset.templateId } },
-      {
-        created: {
-          templateId: buildAndLint.Main.Asset.templateId,
-          signatories: [BOB_PARTY],
-          payload: { issuer: BOB_PARTY, owner: ALICE_PARTY },
         },
       },
     ]);

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -604,18 +604,6 @@ describe("interface definition", () => {
     // statically assert that an expression is a choice
     const theChoice = <T extends object, C, R, K>(c: Choice<T, C, R, K>) => c;
 
-    // Something is inherited
-    test("unambiguous inherited is inherited", () => {
-      const c: Choice<
-        buildAndLint.Lib.Mod.Other,
-        buildAndLint.Lib.Mod.Something,
-        {},
-        undefined
-      > = tpl.Something;
-      expect(c).toBeDefined();
-      expect(c).toEqual(theChoice(if2.Something));
-      expect(c.template()).toBe(if2);
-    });
     test("choice from two interfaces is not inherited", () => {
       const k = "PeerIfaceOverload";
       expect(theChoice(if2[k])).toBeDefined();

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -193,23 +193,14 @@ function toInterfaceMixin<T extends object, IfU>(): ToInterface<T, IfU> {
 /**
  * @internal
  */
-export function assembleTemplate<T extends object, IfU>(
-  template: Template<T>,
-  ...interfaces: FromTemplate<IfU, unknown>[]
-): Template<T> & ToInterface<T, IfU> {
-  const combined = {};
-  const overloaded: string[] = [];
-  for (const iface of interfaces) {
-    _.mergeWith(combined, iface, (left, right, k) => {
-      if (left !== undefined && right !== undefined) overloaded.push(k);
-      return undefined;
-    });
-  }
-  return Object.assign(
-    _.omit(combined, overloaded),
-    toInterfaceMixin<T, IfU>(),
-    template,
-  );
+export function assembleTemplate<T extends object, TC extends Template<T>, IfU>(
+  template: TC,
+  ..._: FromTemplate<IfU, unknown>[]
+): TC & ToInterface<T, IfU> {
+  return {
+    ...toInterfaceMixin<T, IfU>(),
+    ...template,
+  };
 }
 
 /**

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -195,7 +195,7 @@ function toInterfaceMixin<T extends object, IfU>(): ToInterface<T, IfU> {
  */
 export function assembleTemplate<T extends object, TC extends Template<T>, IfU>(
   template: TC,
-  ..._: FromTemplate<IfU, unknown>[]
+  ..._interfaces: FromTemplate<IfU, unknown>[] // eslint-disable-line @typescript-eslint/no-unused-vars
 ): TC & ToInterface<T, IfU> {
   return {
     ...toInterfaceMixin<T, IfU>(),


### PR DESCRIPTION
Fixes #14893.

```rst
CHANGELOG_BEGIN
- [codegen js] Interface choices are no longer inherited by implementing
  templates.  Instead, refer to the choice directly on the interface.
CHANGELOG_END
```

* [x] #14920 
* [x] rebase to main, change target