### PR TITLE
[daml-lf kvsupport] - Add transaction traversal for package party mappings [KVL-1566]

### DIFF
--- a/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionTraversal.scala
+++ b/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionTraversal.scala
@@ -61,10 +61,10 @@ object TransactionTraversal {
       txVersion: TransactionVersion,
       nodes: Map[String, Node],
       toVisit: FrontStack[(RawTransaction.NodeId, Set[Ref.Party])],
-      packagesWithParties: Map[String, Set[Ref.Party]] = Map.empty,
+      packagesToParties: Map[String, Set[Ref.Party]] = Map.empty,
   ): Either[ConversionError, Map[String, Set[Ref.Party]]] = {
     toVisit match {
-      case FrontStack() => Right(packagesWithParties)
+      case FrontStack() => Right(packagesToParties)
       case FrontStackCons((nodeId, parentWitnesses), toVisit) =>
         val node = nodes(nodeId.value)
         informeesOfNode(txVersion, node) match {
@@ -75,7 +75,7 @@ object TransactionTraversal {
               val currentNodePackagesWithWitnesses = Map(
                 templateId.getPackageId -> witnesses
               )
-              packagesWithParties |+| currentNodePackagesWithWitnesses
+              packagesToParties |+| currentNodePackagesWithWitnesses
             }
             node.getNodeTypeCase match {
               case Node.NodeTypeCase.EXERCISE =>
@@ -96,7 +96,7 @@ object TransactionTraversal {
                   txVersion,
                   nodes,
                   next ++: toVisit,
-                  packagesWithParties |+| currentNodePackagesWithWitnesses,
+                  packagesToParties |+| currentNodePackagesWithWitnesses,
                 )
               case Node.NodeTypeCase.FETCH =>
                 traverseWitnessesWithPackages(
@@ -120,11 +120,12 @@ object TransactionTraversal {
                   addPackage(node.getLookupByKey.getTemplateId),
                 )
               case Node.NodeTypeCase.NODETYPE_NOT_SET | Node.NodeTypeCase.ROLLBACK =>
-                traverseWitnessesWithPackages(txVersion, nodes, toVisit, packagesWithParties)
+                traverseWitnessesWithPackages(txVersion, nodes, toVisit, packagesToParties)
             }
         }
     }
   }
+
   @tailrec
   private def traverseWitnesses(
       f: (RawTransaction.NodeId, RawTransaction.Node, Set[Ref.Party]) => Unit,

--- a/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionTraversal.scala
+++ b/daml-lf/kv-support/src/main/scala/com/daml/lf/kv/transactions/TransactionTraversal.scala
@@ -3,15 +3,18 @@
 
 package com.daml.lf.kv.transactions
 
+import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.{FrontStack, FrontStackCons, ImmArray, Ref}
 import com.daml.lf.kv.ConversionError
 import com.daml.lf.transaction.TransactionOuterClass.Node
 import com.daml.lf.transaction.{TransactionCoder, TransactionOuterClass, TransactionVersion}
-import com.daml.lf.value.ValueCoder
+import com.daml.lf.value.{ValueCoder, ValueOuterClass}
 
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
 import scala.util.Try
+import scalaz._
+import Scalaz._
 
 object TransactionTraversal {
 
@@ -21,6 +24,27 @@ object TransactionTraversal {
       f: (RawTransaction.NodeId, RawTransaction.Node, Set[Ref.Party]) => Unit
   ): Either[ConversionError, Unit] =
     for {
+      parsedTransaction <- parseTransaction(rawTx)
+      (txVersion, nodes, initialToVisit) = parsedTransaction
+      _ <- traverseWitnesses(f, txVersion, nodes, initialToVisit)
+    } yield ()
+
+  // Helper to traverse the transaction, top-down, while keeping track of the
+  // witnessing parties of each package.
+  def extractPerPackageWitnesses(
+      rawTx: RawTransaction
+  ): Either[ConversionError, Map[String, Set[Ref.Party]]] =
+    for {
+      parsedTransaction <- parseTransaction(rawTx)
+      (txVersion, nodes, initialToVisit) = parsedTransaction
+      result <- traverseWitnessesWithPackages(txVersion, nodes, initialToVisit)
+    } yield result
+
+  private def parseTransaction(rawTx: RawTransaction): Either[
+    ConversionError,
+    (TransactionVersion, Map[String, Node], FrontStack[(RawTransaction.NodeId, Set[Party])]),
+  ] = {
+    for {
       tx <- Try(TransactionOuterClass.Transaction.parseFrom(rawTx.byteString)).toEither.left.map(
         throwable => ConversionError.ParseError(throwable.getMessage)
       )
@@ -29,11 +53,80 @@ object TransactionTraversal {
       initialToVisit = tx.getRootsList.asScala.view
         .map(RawTransaction.NodeId(_) -> Set.empty[Ref.Party])
         .to(FrontStack)
-      _ <- go(f, txVersion, nodes, initialToVisit)
-    } yield ()
+    } yield { (txVersion, nodes, initialToVisit) }
+  }
 
   @tailrec
-  private def go(
+  private def traverseWitnessesWithPackages(
+      txVersion: TransactionVersion,
+      nodes: Map[String, Node],
+      toVisit: FrontStack[(RawTransaction.NodeId, Set[Ref.Party])],
+      packagesWithParties: Map[String, Set[Ref.Party]] = Map.empty,
+  ): Either[ConversionError, Map[String, Set[Ref.Party]]] = {
+    toVisit match {
+      case FrontStack() => Right(packagesWithParties)
+      case FrontStackCons((nodeId, parentWitnesses), toVisit) =>
+        val node = nodes(nodeId.value)
+        informeesOfNode(txVersion, node) match {
+          case Left(error) => Left(ConversionError.DecodeError(error))
+          case Right(nodeWitnesses) =>
+            val witnesses = parentWitnesses union nodeWitnesses
+            def addPackage(templateId: ValueOuterClass.Identifier) = {
+              val currentNodePackagesWithWitnesses = Map(
+                templateId.getPackageId -> witnesses
+              )
+              packagesWithParties |+| currentNodePackagesWithWitnesses
+            }
+            node.getNodeTypeCase match {
+              case Node.NodeTypeCase.EXERCISE =>
+                val exercise = node.getExercise
+                // Recurse into children (if any).
+                val next = exercise.getChildrenList.asScala.view
+                  .map(RawTransaction.NodeId(_) -> witnesses)
+                  .to(ImmArray)
+                val currentNodePackagesWithWitnesses =
+                  Map(exercise.getTemplateId.getPackageId -> witnesses) ++
+                    Option
+                      .when(exercise.hasInterfaceId)(
+                        exercise.getInterfaceId.getPackageId -> witnesses
+                      )
+                      .toList
+                      .toMap
+                traverseWitnessesWithPackages(
+                  txVersion,
+                  nodes,
+                  next ++: toVisit,
+                  packagesWithParties |+| currentNodePackagesWithWitnesses,
+                )
+              case Node.NodeTypeCase.FETCH =>
+                traverseWitnessesWithPackages(
+                  txVersion,
+                  nodes,
+                  toVisit,
+                  addPackage(node.getFetch.getTemplateId),
+                )
+              case Node.NodeTypeCase.CREATE =>
+                traverseWitnessesWithPackages(
+                  txVersion,
+                  nodes,
+                  toVisit,
+                  addPackage(node.getCreate.getTemplateId),
+                )
+              case Node.NodeTypeCase.LOOKUP_BY_KEY =>
+                traverseWitnessesWithPackages(
+                  txVersion,
+                  nodes,
+                  toVisit,
+                  addPackage(node.getLookupByKey.getTemplateId),
+                )
+              case Node.NodeTypeCase.NODETYPE_NOT_SET | Node.NodeTypeCase.ROLLBACK =>
+                traverseWitnessesWithPackages(txVersion, nodes, toVisit, packagesWithParties)
+            }
+        }
+    }
+  }
+  @tailrec
+  private def traverseWitnesses(
       f: (RawTransaction.NodeId, RawTransaction.Node, Set[Ref.Party]) => Unit,
       txVersion: TransactionVersion,
       nodes: Map[String, Node],
@@ -59,9 +152,9 @@ object TransactionTraversal {
                 val next = node.getExercise.getChildrenList.asScala.view
                   .map(RawTransaction.NodeId(_) -> witnesses)
                   .to(ImmArray)
-                go(f, txVersion, nodes, next ++: toVisit)
+                traverseWitnesses(f, txVersion, nodes, next ++: toVisit)
               case _ =>
-                go(f, txVersion, nodes, toVisit)
+                traverseWitnesses(f, txVersion, nodes, toVisit)
             }
         }
     }
@@ -74,4 +167,5 @@ object TransactionTraversal {
     TransactionCoder
       .protoActionNodeInfo(txVersion, node)
       .map(_.informeesOfNode)
+
 }

--- a/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionTraversalSpec.scala
+++ b/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionTraversalSpec.scala
@@ -6,7 +6,7 @@ package com.daml.lf.kv.transactions
 import com.daml.lf.kv.ConversionError
 import com.daml.lf.transaction.TransactionOuterClass.{Node, NodeRollback, Transaction}
 import com.daml.lf.transaction.TransactionVersion
-import com.daml.lf.value.ValueCoder
+import com.daml.lf.value.{ValueCoder, ValueOuterClass}
 import com.google.protobuf.ByteString
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -15,53 +15,54 @@ import scala.jdk.CollectionConverters._
 
 class TransactionTraversalSpec extends AnyFunSuite with Matchers {
 
+  private val builder = TransactionBuilder()
+
+  // Creation of a contract with Alice as signatory, and Bob is controller of one of the choices.
+  private val createNid = builder.addNode(
+    createNode(List("Alice"), List("Alice", "Bob"))
+  )
+
+  // Exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
+  private val exeNid = builder.addNode(
+    exerciseNode(
+      signatories = List("Alice"),
+      stakeholders = List("Alice", "Charlie"),
+      consuming = true,
+      createNid,
+    )
+  )
+
+  // Non-consuming exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
+  private val nonConsumingExeNid = builder.addNode(
+    exerciseNode(
+      signatories = List("Alice"),
+      stakeholders = List("Alice", "Charlie"),
+      consuming = false,
+    )
+  )
+
+  // A fetch of some contract created by Bob.
+  private val fetchNid = builder.addNode(
+    fetchNode(
+      signatories = List("Bob"),
+      stakeholders = List("Bob"),
+    )
+  )
+
+  // Root node exercising a contract only known to Alice.
+  private val rootNid = builder.addRoot(
+    exerciseNode(
+      signatories = List("Alice"),
+      stakeholders = List("Alice"),
+      consuming = true,
+      fetchNid,
+      nonConsumingExeNid,
+      exeNid,
+    )
+  )
+  private val rawTx = RawTransaction(builder.build.toByteString)
+
   test("traverseTransactionWithWitnesses - consuming nested exercises") {
-    val builder = TransactionBuilder()
-
-    // Creation of a contract with Alice as signatory, and Bob is controller of one of the choices.
-    val createNid = builder.addNode(
-      createNode(List("Alice"), List("Alice", "Bob"))
-    )
-
-    // Exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
-    val exeNid = builder.addNode(
-      exerciseNode(
-        signatories = List("Alice"),
-        stakeholders = List("Alice", "Charlie"),
-        consuming = true,
-        createNid,
-      )
-    )
-
-    // Non-consuming exercise of a contract where Alice as signatory, Charlie has a choice or is an observer.
-    val nonConsumingExeNid = builder.addNode(
-      exerciseNode(
-        signatories = List("Alice"),
-        stakeholders = List("Alice", "Charlie"),
-        consuming = false,
-      )
-    )
-
-    // A fetch of some contract created by Bob.
-    val fetchNid = builder.addNode(
-      fetchNode(
-        signatories = List("Bob"),
-        stakeholders = List("Bob"),
-      )
-    )
-
-    // Root node exercising a contract only known to Alice.
-    val rootNid = builder.addRoot(
-      exerciseNode(
-        signatories = List("Alice"),
-        stakeholders = List("Alice"),
-        consuming = true,
-        fetchNid,
-        nonConsumingExeNid,
-        exeNid,
-      )
-    )
-    val rawTx = RawTransaction(builder.build.toByteString)
 
     TransactionTraversal.traverseTransactionWithWitnesses(rawTx) {
       case (RawTransaction.NodeId(`createNid`), _, witnesses) =>
@@ -86,19 +87,36 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
     } shouldBe Right(())
   }
 
-  test("traverseTransactionWithWitnesses - transaction parsing error") {
-    val rawTx = RawTransaction(ByteString.copyFromUtf8("wrong"))
-    val actual = TransactionTraversal.traverseTransactionWithWitnesses(rawTx)((_, _, _) => ())
-    actual shouldBe Left(ConversionError.ParseError("Protocol message tag had invalid wire type."))
+  test("extractPerPackageWitnesses - extract package witness mapping as expected") {
+    val result = TransactionTraversal.extractPerPackageWitnesses(rawTx)
+    result shouldBe
+      Right(
+        Map(
+          "template_exercise" -> Set("Alice", "Charlie"),
+          "interface_exercise" -> Set("Alice", "Charlie"),
+          "template_create" -> Set("Alice", "Charlie", "Bob"),
+          "template_fetch" -> Set("Alice", "Bob"),
+        )
+      )
   }
 
-  test("traverseTransactionWithWitnesses - transaction version parsing error") {
+  test("traversing transaction parsing error") {
+    val rawTx = RawTransaction(ByteString.copyFromUtf8("wrong"))
+    TransactionTraversal.traverseTransactionWithWitnesses(rawTx)((_, _, _) => ()) shouldBe Left(
+      ConversionError.ParseError("Protocol message tag had invalid wire type.")
+    )
+    TransactionTraversal.extractPerPackageWitnesses(rawTx) shouldBe Left(
+      ConversionError.ParseError("Protocol message tag had invalid wire type.")
+    )
+  }
+
+  test("traversing transaction version parsing error") {
     val rawTx = RawTransaction(Transaction.newBuilder().setVersion("wrong").build.toByteString)
     val actual = TransactionTraversal.traverseTransactionWithWitnesses(rawTx)((_, _, _) => ())
     actual shouldBe Left(ConversionError.ParseError("Unsupported transaction version 'wrong'"))
   }
 
-  test("traverseTransactionWithWitnesses - node decoding error") {
+  test("traversing node decoding error") {
     val rootNodeId = "1"
     val rawTx = RawTransaction(
       Transaction
@@ -111,8 +129,14 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
         .build
         .toByteString
     )
-    val actual = TransactionTraversal.traverseTransactionWithWitnesses(rawTx)((_, _, _) => ())
-    actual shouldBe Left(
+    TransactionTraversal.traverseTransactionWithWitnesses(rawTx)((_, _, _) => ()) shouldBe Left(
+      ConversionError.DecodeError(
+        ValueCoder.DecodeError(
+          "protoActionNodeInfo only supports action nodes but was applied to a rollback node"
+        )
+      )
+    )
+    TransactionTraversal.extractPerPackageWitnesses(rawTx) shouldBe Left(
       ConversionError.DecodeError(
         ValueCoder.DecodeError(
           "protoActionNodeInfo only supports action nodes but was applied to a rollback node"
@@ -167,6 +191,7 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
   private def createNode(signatories: Iterable[String], stakeholders: Iterable[String]) =
     withNodeBuilder {
       _.getCreateBuilder
+        .setTemplateId(ValueOuterClass.Identifier.newBuilder().setPackageId("template_create"))
         .addAllSignatories(signatories.asJava)
         .addAllStakeholders(stakeholders.asJava)
     }
@@ -177,6 +202,7 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
   private def fetchNode(signatories: Iterable[String], stakeholders: Iterable[String]) =
     withNodeBuilder {
       _.getFetchBuilder
+        .setTemplateId(ValueOuterClass.Identifier.newBuilder().setPackageId("template_fetch"))
         .addAllSignatories(signatories.asJava)
         .addAllStakeholders(stakeholders.asJava)
     }
@@ -193,6 +219,8 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
     withNodeBuilder {
       _.getExerciseBuilder
         .setConsuming(consuming)
+        .setTemplateId(ValueOuterClass.Identifier.newBuilder().setPackageId("template_exercise"))
+        .setInterfaceId(ValueOuterClass.Identifier.newBuilder().setPackageId("interface_exercise"))
         .addAllSignatories(signatories.asJava)
         .addAllStakeholders(stakeholders.asJava)
         /* NOTE(JM): Actors are no longer included in exercises by the compiler, hence we don't set them */

--- a/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionTraversalSpec.scala
+++ b/daml-lf/kv-support/src/test/scala/com/daml/lf/kv/transactions/TransactionTraversalSpec.scala
@@ -100,7 +100,7 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
       )
   }
 
-  test("traversing transaction parsing error") {
+  test("traversal - transaction parsing error") {
     val rawTx = RawTransaction(ByteString.copyFromUtf8("wrong"))
     TransactionTraversal.traverseTransactionWithWitnesses(rawTx)((_, _, _) => ()) shouldBe Left(
       ConversionError.ParseError("Protocol message tag had invalid wire type.")
@@ -110,13 +110,13 @@ class TransactionTraversalSpec extends AnyFunSuite with Matchers {
     )
   }
 
-  test("traversing transaction version parsing error") {
+  test("traversal - transaction version parsing error") {
     val rawTx = RawTransaction(Transaction.newBuilder().setVersion("wrong").build.toByteString)
     val actual = TransactionTraversal.traverseTransactionWithWitnesses(rawTx)((_, _, _) => ())
     actual shouldBe Left(ConversionError.ParseError("Unsupported transaction version 'wrong'"))
   }
 
-  test("traversing node decoding error") {
+  test("traversal - node decoding error") {
     val rootNodeId = "1"
     val rawTx = RawTransaction(
       Transaction


### PR DESCRIPTION
- Produces a mapping between used packages and witnessing parties
- This allows us to validate that the given packages were vetted by the participants hosting the parties

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
