### PR TITLE
Cleanup metering report proto now clients have switched to using JSON [DPP-1203]

### DIFF
--- a/buf-ledger-api.yaml
+++ b/buf-ledger-api.yaml
@@ -16,3 +16,5 @@ breaking:
     - FILE
   except:
     - FILE_NO_DELETE # Avoids errors due to refactored `buf` modules.
+  ignore:
+    - com/daml/ledger/api/v1/admin/metering_report_service.proto

--- a/language-support/hs/bindings/src/DA/Ledger/Services/MeteringReportService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/MeteringReportService.hs
@@ -105,7 +105,7 @@ toRawStructValue (A.Bool b) = S.Value $ Just $ S.ValueKindBoolValue b
 toRawStructValue A.Null = S.Value Nothing
 
 raiseGetMeteringReportResponse :: LL.GetMeteringReportResponse -> Perhaps A.Value
-raiseGetMeteringReportResponse (LL.GetMeteringReportResponse _ _ _ (Just reportStruct)) =
+raiseGetMeteringReportResponse (LL.GetMeteringReportResponse _ _ (Just reportStruct)) =
   Right $ toRawAesonValue $ S.Value $ Just $ S.ValueKindStructValue reportStruct
 raiseGetMeteringReportResponse response = Left $ Unexpected ("raiseMeteredReport unable to parse response: " <> show response)
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/metering_report_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/metering_report_service.proto
@@ -12,7 +12,6 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1.Admin";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";
 
-
 // Experimental API to retrieve metering reports.
 //
 // Metering reports aim to provide the information necessary for billing participant
@@ -46,8 +45,8 @@ message GetMeteringReportResponse {
     // The actual request that was executed.
     GetMeteringReportRequest request = 1;
 
-    // The computed report.
-    ParticipantMeteringReport participant_report = 2;
+    // Metering report json now used
+    reserved "participant_report"; reserved 2;
 
     // The time at which the report was computed.
     google.protobuf.Timestamp report_generation_time = 3;
@@ -56,30 +55,3 @@ message GetMeteringReportResponse {
     google.protobuf.Struct metering_report_json = 4;
 }
 
-
-// Report representation
-////////////////////////
-
-message ParticipantMeteringReport {
-
-    // The reporting participant
-    string participant_id = 1;
-
-    // If the report is final it has been generated based on aggregated data
-    // so will never change in the future.
-    bool is_final = 2;
-
-    // Per application reports.
-    repeated ApplicationMeteringReport application_reports = 3;
-
-}
-
-message ApplicationMeteringReport {
-
-    // The application Id
-    string application_id = 1;
-
-    // The event count for the application; i.e., the number of fetch, lookup-by-key, create, and exercise events
-    // in transactions issued by this application.
-    int64 event_count = 2;
-}

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/meteringreport/MeteringReportGenerator.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/meteringreport/MeteringReportGenerator.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.participant.state.index.v2.MeteringStore.ReportData
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.ApplicationId
 import com.daml.lf.data.Time.Timestamp
-import com.daml.platform.apiserver.meteringreport.MeteringReport.{ApplicationReport, _}
+import com.daml.platform.apiserver.meteringreport.MeteringReport._
 import com.google.protobuf.struct.Struct
 import com.google.protobuf.timestamp.{Timestamp => ProtoTimestamp}
 import scalapb.json4s.JsonFormat
@@ -29,7 +29,6 @@ class MeteringReportGenerator(participantId: Ref.ParticipantId, key: Key) {
     genMeteringReportJson(from, to, applicationId, reportData).map { reportJson =>
       GetMeteringReportResponse(
         request = Some(request),
-        participantReport = Some(genParticipantReport(reportData)),
         reportGenerationTime = Some(generationTime),
         meteringReportJson = Some(reportJson),
       )
@@ -62,15 +61,4 @@ class MeteringReportGenerator(participantId: Ref.ParticipantId, key: Key) {
     }
   }
 
-  private def genParticipantReport(reportData: ReportData) = {
-    val applicationMeteringReports = reportData.applicationData.toList
-      .sortBy(_._1)
-      .map((ApplicationMeteringReport.apply _).tupled)
-
-    ParticipantMeteringReport(
-      participantId,
-      isFinal = reportData.isFinal,
-      applicationMeteringReports,
-    )
-  }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/meteringreport/MeteringReportGeneratorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/meteringreport/MeteringReportGeneratorSpec.scala
@@ -4,10 +4,8 @@
 package com.daml.platform.apiserver.meteringreport
 
 import com.daml.ledger.api.v1.admin.metering_report_service.{
-  ApplicationMeteringReport,
   GetMeteringReportRequest,
   GetMeteringReportResponse,
-  ParticipantMeteringReport,
 }
 import com.daml.ledger.participant.state.index.v2.MeteringStore.ReportData
 import com.daml.lf.data.Ref
@@ -62,18 +60,8 @@ class MeteringReportGeneratorSpec extends AsyncWordSpec with Matchers {
 
       val generationTime = toProtoTimestamp(Timestamp.now())
 
-      val expectedReport = ParticipantMeteringReport(
-        participantId = someParticipantId,
-        isFinal = false,
-        applicationReports = Seq(
-          ApplicationMeteringReport(appIdA, 4),
-          ApplicationMeteringReport(appIdB, 2),
-        ),
-      )
-
       val expected = GetMeteringReportResponse(
         request = Some(request),
-        participantReport = Some(expectedReport),
         reportGenerationTime = Some(generationTime),
         meteringReportJson = Some(reportJsonStruct),
       )


### PR DESCRIPTION
Note that this change includes a breaking .proto change which has been explicitly excluded from the `buf breaking` check.

changelog_begin
changelog_end

