### PR TITLE
widen @daml/react types to admit querying interfaces

### DIFF
--- a/language-support/ts/daml-react/createLedgerContext.ts
+++ b/language-support/ts/daml-react/createLedgerContext.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useContext, useEffect, useMemo, useState } from "react";
-import { ContractId, Party, Template } from "@daml/types";
+import { ContractId, Party, Template, TemplateOrInterface } from "@daml/types";
 import Ledger, {
   CreateEvent,
   Query,
@@ -75,12 +75,12 @@ export type LedgerContext = {
   useUser: () => User;
   useLedger: () => Ledger;
   useQuery: <T extends object, K, I extends string>(
-    template: Template<T, K, I>,
+    template: TemplateOrInterface<T, K, I>,
     queryFactory?: () => Query<T>,
     queryDeps?: readonly unknown[],
   ) => QueryResult<T, K, I>;
   useFetch: <T extends object, K, I extends string>(
-    template: Template<T, K, I>,
+    template: TemplateOrInterface<T, K, I>,
     contractId: ContractId<T>,
   ) => FetchResult<T, K, I>;
   useFetchByKey: <T extends object, K, I extends string>(
@@ -89,13 +89,13 @@ export type LedgerContext = {
     keyDeps: readonly unknown[],
   ) => FetchResult<T, K, I>;
   useStreamQuery: <T extends object, K, I extends string>(
-    template: Template<T, K, I>,
+    template: TemplateOrInterface<T, K, I>,
     queryFactory?: () => Query<T>,
     queryDeps?: readonly unknown[],
     closeHandler?: (e: StreamCloseEvent) => void,
   ) => QueryResult<T, K, I>;
   useStreamQueries: <T extends object, K, I extends string>(
-    template: Template<T, K, I>,
+    template: TemplateOrInterface<T, K, I>,
     queryFactory?: () => Query<T>[],
     queryDeps?: readonly unknown[],
     closeHandler?: (e: StreamCloseEvent) => void,
@@ -193,7 +193,7 @@ export function createLedgerContext(
   };
 
   function useQuery<T extends object, K, I extends string>(
-    template: Template<T, K, I>,
+    template: TemplateOrInterface<T, K, I>,
     queryFactory?: () => Query<T>,
     queryDeps?: readonly unknown[],
   ): QueryResult<T, K, I> {
@@ -217,7 +217,7 @@ export function createLedgerContext(
   }
 
   function useFetch<T extends object, K, I extends string>(
-    template: Template<T, K, I>,
+    template: TemplateOrInterface<T, K, I>,
     contractId: ContractId<T>,
   ): FetchResult<T, K, I> {
     const state = useDamlState();
@@ -265,7 +265,7 @@ export function createLedgerContext(
   // private
   interface StreamArgs<T extends object, K, I extends string, S, Result> {
     name: string;
-    template: Template<T, K, I>;
+    template: TemplateOrInterface<T, K, I>;
     init: Result;
     mkStream: (state: DamlLedgerState) => [Stream<T, K, I, S>, object];
     setLoading: (r: Result, loading: boolean) => Result;
@@ -318,7 +318,7 @@ export function createLedgerContext(
   }
 
   function useStreamQuery<T extends object, K, I extends string>(
-    template: Template<T, K, I>,
+    template: TemplateOrInterface<T, K, I>,
     queryFactory?: () => Query<T>,
     queryDeps?: readonly unknown[],
     closeHandler?: (e: StreamCloseEvent) => void,
@@ -346,7 +346,7 @@ export function createLedgerContext(
   }
 
   function useStreamQueries<T extends object, K, I extends string>(
-    template: Template<T, K, I>,
+    template: TemplateOrInterface<T, K, I>,
     queryFactory?: () => Query<T>[],
     queryDeps?: readonly unknown[],
     closeHandler?: (e: StreamCloseEvent) => void,

--- a/language-support/ts/daml-react/defaultLedgerContext.ts
+++ b/language-support/ts/daml-react/defaultLedgerContext.ts
@@ -8,7 +8,7 @@ import {
   LedgerProps,
   FetchByKeysResult,
 } from "./createLedgerContext";
-import { ContractId, Party, Template } from "@daml/types";
+import { ContractId, Party, Template, TemplateOrInterface } from "@daml/types";
 import Ledger, { Query, StreamCloseEvent, User } from "@daml/ledger";
 
 /**
@@ -51,26 +51,26 @@ export function useLedger(): Ledger {
 /**
  * React Hook for a ``query`` against the ledger.
  *
- * @typeparam T The contract template type of the query.
+ * @typeparam T The contract template or interface type of the query.
  * @typeparam K The contract key type of the query.
  * @typeparam I The template id type.
  *
- * @param template The contract template to filter for.
+ * @param template The contract template or interface to filter for.
  * @param queryFactory A function returning a query. If the query is omitted, all visible contracts of the given template are returned.
  * @param queryDeps The dependencies of the query (which trigger a reload when changed).
  *
  * @return The result of the query.
  */
 export function useQuery<T extends object, K, I extends string>(
-  template: Template<T, K, I>,
+  template: TemplateOrInterface<T, K, I>,
   queryFactory: () => Query<T>,
   queryDeps: readonly unknown[],
 ): QueryResult<T, K, I>;
 export function useQuery<T extends object, K, I extends string>(
-  template: Template<T, K, I>,
+  template: TemplateOrInterface<T, K, I>,
 ): QueryResult<T, K, I>;
 export function useQuery<T extends object, K, I extends string>(
-  template: Template<T, K, I>,
+  template: TemplateOrInterface<T, K, I>,
   queryFactory?: () => Query<T>,
   queryDeps?: readonly unknown[],
 ): QueryResult<T, K, I> {
@@ -90,7 +90,7 @@ export function useQuery<T extends object, K, I extends string>(
  * @return The fetched contract.
  */
 export function useFetch<T extends object, K, I extends string>(
-  template: Template<T, K, I>,
+  template: TemplateOrInterface<T, K, I>,
   contractId: ContractId<T>,
 ): FetchResult<T, K, I> {
   return ledgerContext.useFetch(template, contractId);
@@ -134,7 +134,7 @@ export function useFetchByKey<T extends object, K, I extends string>(
  * @return The matching contracts.
  */
 export function useStreamQuery<T extends object, K, I extends string>(
-  template: Template<T, K, I>,
+  template: TemplateOrInterface<T, K, I>,
   queryFactory?: () => Query<T>,
   queryDeps?: readonly unknown[],
   closeHandler?: (e: StreamCloseEvent) => void,
@@ -162,7 +162,7 @@ export function useStreamQuery<T extends object, K, I extends string>(
  * @return The matching contracts.
  */
 export function useStreamQueries<T extends object, K, I extends string>(
-  template: Template<T, K, I>,
+  template: TemplateOrInterface<T, K, I>,
   queryFactory?: () => Query<T>[],
   queryDeps?: readonly unknown[],
   closeHandler?: (e: StreamCloseEvent) => void,


### PR DESCRIPTION
A bit of an oversight from #14920. There are no possible behavior changes here, hence no tests.

```rst
CHANGELOG_BEGIN
- [JS] ``@daml/react`` functions like ``useQuery`` allow interfaces to
  be queried, where JSON API supports this.
CHANGELOG_END
```

* [x] wait for #14920 to merge
* [x] rebase and change target to `main`