### PR TITLE
forbid interface choices for createAnd and byKey

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -532,12 +532,14 @@ ifaceDefTempl name mbKeyTy impls choices =
       name <> ", " <>
       tsTypeRef (genType chcArgTy mbSubst) <> ", " <>
       tsTypeRef (genType chcRetTy mbSubst) <> ", " <>
-      keyTy <> ">;" | ChoiceDef{..} <- choices ]
+      keyTy <> "> & " <> choiceFrom <> ";"
+    | ChoiceDef{..} <- choices ]
   , [ "}" ]
   ]
   where
     mbSubst = Nothing
     keyTy = fromMaybe "undefined" mbKeyTy
+    choiceFrom = "damlTypes.ChoiceFrom<damlTypes.Template<" <> name <> ", " <> keyTy <> ">>"
     extension
       | null impls = ""
       | otherwise = "extends " <> implTy'
@@ -581,12 +583,14 @@ ifaceDefIface name mbKeyTy choices =
       name <> ", " <>
       tsTypeRef (genType chcArgTy mbSubst) <> ", " <>
       tsTypeRef (genType chcRetTy mbSubst) <> ", " <>
-      keyTy <> ">;" | ChoiceDef{..} <- choices ]
+      keyTy <> "> & " <> choiceFrom <> ";"
+    | ChoiceDef{..} <- choices ]
   , [ "}" ]
   ]
   where
     mbSubst = Nothing
     keyTy = fromMaybe "undefined" mbKeyTy
+    choiceFrom = "damlTypes.ChoiceFrom<damlTypes.InterfaceCompanion<" <> name <> ", " <> keyTy <> ">>"
 
 data ChoiceDef = ChoiceDef
   { chcName' :: T.Text

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/index.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import Ledger from "@daml/ledger";
-import { ContractId, Party, Template, Choice } from "@daml/types";
+import { ContractId, Party, Template, Choice, ChoiceFrom } from "@daml/types";
 
 // Regression test for #8338, we only care that this compiles.
 
@@ -20,7 +20,8 @@ type Archive = {};
 const X: Template<X, undefined, "pkg-id:M:X"> = undefined!;
 
 const Y: {
-  Archive: Choice<X, Archive, {}, undefined>;
+  Archive: Choice<X, Archive, {}, undefined> &
+    ChoiceFrom<Template<X, undefined>>;
 } = undefined!;
 
 const cid: ContractId<X> = undefined!;

--- a/language-support/ts/daml-ledger/index.test.ts
+++ b/language-support/ts/daml-ledger/index.test.ts
@@ -1,7 +1,13 @@
 // Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Template, Choice, ContractId, registerTemplate } from "@daml/types";
+import {
+  Template,
+  Choice,
+  ChoiceFrom,
+  ContractId,
+  registerTemplate,
+} from "@daml/types";
 import Ledger, { CreateEvent } from "./index";
 import { assert } from "./index";
 import { Event } from "./index";
@@ -105,7 +111,8 @@ const Foo: Template<Foo, string, "foo-id"> = {
   decoder: jtv.object({ key: jtv.string() }),
   encode: o => o,
   // eslint-disable-next-line @typescript-eslint/ban-types
-  Archive: {} as unknown as Choice<Foo, {}, {}, string>,
+  Archive: {} as unknown as Choice<Foo, {}, {}, string> &
+    ChoiceFrom<Template<Foo, string, "foo-id">>,
 };
 
 const fooCreateEvent = (

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
   Choice,
+  ChoiceFrom,
   ContractId,
   List,
   Party,
@@ -1148,7 +1149,7 @@ class Ledger {
    *
    */
   async createAndExercise<T extends object, C, R, K>(
-    choice: Choice<T, C, R, K>,
+    choice: ChoiceFrom<Template<T>> & Choice<T, C, R, K>,
     payload: T,
     argument: C,
   ): Promise<[R, Event<object>[]]> {
@@ -1192,7 +1193,7 @@ class Ledger {
    * as a result of exercising the choice.
    */
   async exerciseByKey<T extends object, C, R, K>(
-    choice: Choice<T, C, R, K>,
+    choice: ChoiceFrom<Template<T, K>> & Choice<T, C, R, K>,
     key: K,
     argument: C,
   ): Promise<[R, Event<object>[]]> {

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -1149,7 +1149,7 @@ class Ledger {
    *
    */
   async createAndExercise<T extends object, C, R, K>(
-    choice: ChoiceFrom<Template<T>> & Choice<T, C, R, K>,
+    choice: ChoiceFrom<Template<T, K>> & Choice<T, C, R, K>,
     payload: T,
     argument: C,
   ): Promise<[R, Event<object>[]]> {

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -63,7 +63,7 @@ export interface Template<
    */
   keyEncode: (k: K) => unknown;
   // eslint-disable-next-line @typescript-eslint/ban-types
-  Archive: Choice<T, {}, {}, K>;
+  Archive: Choice<T, {}, {}, K> & ChoiceFrom<Template<T, K, I>>;
 }
 
 /**
@@ -153,9 +153,7 @@ export interface Choice<T extends object, C, R, K = unknown> {
   /**
    * Returns the template to which this choice belongs.
    */
-  template: () => T extends Interface<infer I>
-    ? InterfaceCompanion<T, K, I & string>
-    : Template<T, K>;
+  readonly template: () => TemplateOrInterface<T, K>;
   /**
    * @internal Returns a decoder to decode the choice arguments.
    *
@@ -176,6 +174,16 @@ export interface Choice<T extends object, C, R, K = unknown> {
    * The choice name.
    */
   choiceName: string;
+}
+
+/**
+ * The origin companion that contained a [[Choice]].
+ *
+ * @typeparam O The type of the template or interface of which
+ *            this [[Choice]] is a member.
+ */
+export interface ChoiceFrom<O> {
+  readonly template: () => O;
 }
 
 function toInterfaceMixin<T extends object, IfU>(): ToInterface<T, IfU> {

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -149,11 +149,8 @@ export interface FromTemplate<If, TX> {
  * @typeparam R The choice return type.
  *
  */
-export interface Choice<T extends object, C, R, K = unknown> {
-  /**
-   * Returns the template to which this choice belongs.
-   */
-  readonly template: () => TemplateOrInterface<T, K>;
+export interface Choice<T extends object, C, R, K = unknown>
+  extends ChoiceFrom<TemplateOrInterface<T, K>> {
   /**
    * @internal Returns a decoder to decode the choice arguments.
    *
@@ -183,6 +180,9 @@ export interface Choice<T extends object, C, R, K = unknown> {
  *            this [[Choice]] is a member.
  */
 export interface ChoiceFrom<O> {
+  /**
+   * Returns the template to which this choice belongs.
+   */
   readonly template: () => O;
 }
 


### PR DESCRIPTION
Fixes #14949.

```rst
CHANGELOG_BEGIN
- [TypeScript] Codegen output now uses the new ``ChoiceFrom`` interface;
  prior output that does not use this interface will not work with this
  version of ``@daml/types``.  If you use the type ``Choice`` in your
  own types and your code no longer type-checks, you must include
  ``ChoiceFrom`` in your declarations as well.
CHANGELOG_END
```

* [x] something that works
* [x] changelog