### PR TITLE
[ED] Enable explicit disclosure in conformance tests [DPP-1206]

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -278,6 +278,10 @@ final class CommandsValidator(
 }
 
 object CommandsValidator {
+  def apply(ledgerId: LedgerId, explicitDisclosureUnsafeEnabled: Boolean) = new CommandsValidator(
+    ledgerId = ledgerId,
+    validateDisclosedContracts = new ValidateDisclosedContracts(explicitDisclosureUnsafeEnabled),
+  )
 
   /** Effective submitters of a command
     * @param actAs Guaranteed to be non-empty. Will contain exactly one element in most cases.

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandService.scala
@@ -26,6 +26,7 @@ class GrpcCommandService(
     currentUtcTime: () => Instant,
     maxDeduplicationDuration: () => Option[Duration],
     generateSubmissionId: SubmissionIdGenerator,
+    explicitDisclosureUnsafeEnabled: Boolean,
 )(implicit executionContext: ExecutionContext, loggingContext: LoggingContext)
     extends CommandService
     with GrpcApiService
@@ -34,7 +35,7 @@ class GrpcCommandService(
   protected implicit val logger: ContextualizedLogger = ContextualizedLogger.get(getClass)
 
   private[this] val validator = new SubmitAndWaitRequestValidator(
-    new CommandsValidator(ledgerId)
+    CommandsValidator(ledgerId, explicitDisclosureUnsafeEnabled)
   )
 
   override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] =

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandSubmissionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandSubmissionService.scala
@@ -34,6 +34,7 @@ class GrpcCommandSubmissionService(
     maxDeduplicationDuration: () => Option[Duration],
     submissionIdGenerator: SubmissionIdGenerator,
     metrics: Metrics,
+    explicitDisclosureUnsafeEnabled: Boolean,
 )(implicit executionContext: ExecutionContext, loggingContext: LoggingContext)
     extends ApiCommandSubmissionService
     with ProxyCloseable
@@ -41,7 +42,7 @@ class GrpcCommandSubmissionService(
 
   protected implicit val logger: ContextualizedLogger = ContextualizedLogger.get(getClass)
   private val validator = new SubmitRequestValidator(
-    new CommandsValidator(ledgerId)
+    CommandsValidator(ledgerId, explicitDisclosureUnsafeEnabled)
   )
 
   override def submit(request: ApiSubmitRequest): Future[Empty] = {

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.api.testtool.suites.v1_dev
 
 import com.daml.error.definitions.LedgerApiErrors
+import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -100,7 +101,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
         // Create contract with `owner` as only stakeholder
         _ <- ledger.create(owner, WithKey(owner))
         withKeyTxIds <- ledger.flatTransactionsByTemplateId(WithKey.id, owner)
-        withKeyCreate = createdEvents(withKeyTxIds(1)).head
+        withKeyCreate = createdEvents(withKeyTxIds(0)).head
         withKeyDisclosedContract = createEventToDisclosedContract(withKeyCreate)
         exerciseByKeyError <- ledger
           .submitAndWait(
@@ -224,8 +225,8 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
             for {
               contractId <- ledger1.create(party1, Dummy(party1))
 
-              transactions <- ledger1.flatTransactionsByTemplateId(WithKey.id, party1)
-              create = createdEvents(transactions(1)).head
+              transactions <- ledger1.flatTransactionsByTemplateId(Dummy.id, party1)
+              create = createdEvents(transactions(0)).head
               disclosedContract = createEventToDisclosedContract(create)
 
               // Submit concurrently two consuming exercise choices (with and without disclosed contract)
@@ -266,13 +267,14 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     for {
       testContext <- initializeTest(ledger, owner, delegate)
 
-      // Exercise a choice using invalid explicit disclosure (bad contract key)
-      errorBadKey <- testContext
-        .exerciseFetchDelegated(
-          testContext.disclosedContract
-            .update(_.metadata.contractKeyHash := ByteString.copyFromUtf8("badKeyMeta"))
-        )
-        .mustFail("using a mismatching contract key hash in metadata")
+      //      // TODO ED: Enable once the check is implemented in command interpretation
+      //      // Exercise a choice using invalid explicit disclosure (bad contract key)
+      //      errorBadKey <- testContext
+      //        .exerciseFetchDelegated(
+      //          testContext.disclosedContract
+      //            .update(_.metadata.contractKeyHash := ByteString.copyFromUtf8("BadKeyBadKeyBadKeyBadKeyBadKey00"))
+      //        )
+      //        .mustFail("using a mismatching contract key hash in metadata")
 
       // Exercise a choice using invalid explicit disclosure (bad ledger time)
       errorBadLet <- testContext
@@ -290,12 +292,13 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
         )
         .mustFail("using an invalid disclosed contract payload")
     } yield {
-      assertGrpcError(
-        errorBadKey,
-        LedgerApiErrors.ConsistencyErrors.DisclosedContractInvalid,
-        None,
-        checkDefiniteAnswerMetadata = true,
-      )
+      //      // TODO ED: Enable once the check is implemented in command interpretation
+      //      assertGrpcError(
+      //        errorBadKey,
+      //        LedgerApiErrors.ConsistencyErrors.DisclosedContractInvalid,
+      //        None,
+      //        checkDefiniteAnswerMetadata = true,
+      //      )
       assertGrpcError(
         errorBadLet,
         LedgerApiErrors.ConsistencyErrors.DisclosedContractInvalid,
@@ -370,15 +373,15 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
         )
         .mustFail("using a disclosed contract with missing createdAt in contract metadata")
 
-//      // TODO ED: Assert missing contract key hash when ledger side metadata validation is implemented
-//      // Exercise a choice using an invalid disclosed contract (missing key hash in contract metadata for a contract that has a contract key associated)
-//      errorMissingKeyHash <- testContext
-//        .exerciseFetchDelegated(
-//          testContext.disclosedContract.update(_.metadata.contractKeyHash.set(ByteString.EMPTY))
-//        )
-//        .mustFail(
-//          "using a disclosed contract with missing key hash in contract metadata for a contract that has a contract key associated"
-//        )
+      //      // TODO ED: Assert missing contract key hash when ledger side metadata validation is implemented
+      //      // Exercise a choice using an invalid disclosed contract (missing key hash in contract metadata for a contract that has a contract key associated)
+      //      errorMissingKeyHash <- testContext
+      //        .exerciseFetchDelegated(
+      //          testContext.disclosedContract.update(_.metadata.contractKeyHash.set(ByteString.EMPTY))
+      //        )
+      //        .mustFail(
+      //          "using a disclosed contract with missing key hash in contract metadata for a contract that has a contract key associated"
+      //        )
     } yield {
       assertGrpcError(
         errorMalformedPayload,
@@ -430,25 +433,40 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     for {
       testContext <- initializeTest(ledger, owner, delegate)
 
+      _ <- ledger.create(owner, Dummy(owner))
+      dummyTxs <- ledger.flatTransactionsByTemplateId(Dummy.id, owner)
+      dummyCreate = createdEvents(dummyTxs(0)).head
+      dummyDisclosedContract = createEventToDisclosedContract(dummyCreate)
+
       // Exercise a choice using invalid explicit disclosure (bad contract key)
       _ <- testContext
         .exerciseFetchDelegated(
-          testContext.disclosedContract
-            .update(_.metadata.contractKeyHash := ByteString.copyFromUtf8("badKeyMeta"))
+          testContext.disclosedContract,
+          // Provide a superfluous disclosed contract with mismatching key hash
+          dummyDisclosedContract
+            .update(
+              _.metadata.contractKeyHash := ByteString.copyFromUtf8(
+                "BadKeyBadKeyBadKeyBadKeyBadKey00"
+              )
+            ),
         )
 
       // Exercise a choice using invalid explicit disclosure (bad ledger time)
       _ <- testContext
         .exerciseFetchDelegated(
-          testContext.disclosedContract
-            .update(_.metadata.createdAt := com.google.protobuf.timestamp.Timestamp.of(1, 0))
+          testContext.disclosedContract,
+          // Provide a superfluous disclosed contract with mismatching createdAt
+          dummyDisclosedContract
+            .update(_.metadata.createdAt := com.google.protobuf.timestamp.Timestamp.of(1, 0)),
         )
 
       // Exercise a choice using invalid explicit disclosure (bad payload)
       _ <- testContext
         .exerciseFetchDelegated(
-          testContext.disclosedContract
-            .update(_.arguments := Delegated(delegate, testContext.contractKey).arguments)
+          testContext.disclosedContract,
+          // Provide a superfluous disclosed contract with mismatching contract arguments
+          dummyDisclosedContract
+            .update(_.arguments := Dummy(delegate).arguments),
         )
     } yield ()
   })
@@ -554,8 +572,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     "EDFeatureDisabled",
     "Submission fails when disclosed contracts provided on feature disabled",
     allocate(Parties(2)),
-    // TODO ED: Toggle after feature flag implementation
-    //    enabled = feature => !feature.explicitDisclosure,
+    enabled = feature => !feature.explicitDisclosure,
   )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
     for {
       testContext <- initializeTest(ledger, owner, delegate)
@@ -593,7 +610,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
           verbose = !normalizedDisclosedContract,
         )
       )
-      createdEvent = createdEvents(txs(1)).head
+      createdEvent = createdEvents(txs(0)).head
       disclosedContract = createEventToDisclosedContract(createdEvent)
 
       _ <- ledger.submitAndWait(
@@ -749,9 +766,18 @@ object ExplicitDisclosureIT {
           Command.Command.ExerciseByKey(
             ExerciseByKeyCommand(
               Some(WithKey.id.unwrap),
-              Option(Value(Value.Sum.Party(owner.unwrap))),
+              Option(Value(Value.Sum.Party(Party.unwrap(owner)))),
               "WithKey_NoOp",
-              Option(Value(Value.Sum.Party(party.unwrap))),
+              Option(
+                Value(
+                  Value.Sum.Record(
+                    Record(
+                      None,
+                      List(RecordField("", Some(Value(Value.Sum.Party(Party.unwrap(party)))))),
+                    )
+                  )
+                )
+              ),
             )
           )
         ),

--- a/ledger/participant-integration-api/src/main/scala/platform/LedgerApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/LedgerApiServer.scala
@@ -43,6 +43,11 @@ class LedgerApiServer(
     timeServiceBackendO: Option[TimeServiceBackend],
     servicesExecutionContext: ExecutionContextExecutorService,
     metrics: Metrics,
+    // TODO ED: Remove flag once explicit disclosure is deemed stable and all
+    //          backing ledgers implement proper validation against malicious clients.
+    //          Currently, we provide this flag outside the HOCON configuration objects
+    //          in order to ensure that participants cannot be configured to accept explicitly disclosed contracts.
+    explicitDisclosureUnsafeEnabled: Boolean = false,
 )(implicit actorSystem: ActorSystem, materializer: Materializer) {
 
   def owner: ResourceOwner[ApiService] = {
@@ -109,6 +114,7 @@ class LedgerApiServer(
           ledgerId,
           participantConfig.apiServer,
           participantId,
+          explicitDisclosureUnsafeEnabled,
         )
       } yield apiService
     }
@@ -127,6 +133,7 @@ class LedgerApiServer(
       ledgerId: LedgerId,
       apiServerConfig: ApiServerConfig,
       participantId: Ref.ParticipantId,
+      explicitDisclosureUnsafeEnabled: Boolean,
   )(implicit
       actorSystem: ActorSystem,
       loggingContext: LoggingContext,
@@ -155,6 +162,7 @@ class LedgerApiServer(
       participantId = participantId,
       authService = authService,
       jwtTimestampLeeway = participantConfig.jwtTimestampLeeway,
+      explicitDisclosureUnsafeEnabled = explicitDisclosureUnsafeEnabled,
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServiceOwner.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServiceOwner.scala
@@ -55,6 +55,7 @@ object ApiServiceOwner {
       authService: AuthService,
       meteringReportKey: MeteringReportKey = CommunityKey,
       jwtTimestampLeeway: Option[JwtTimestampLeeway],
+      explicitDisclosureUnsafeEnabled: Boolean = false,
   )(implicit
       actorSystem: ActorSystem,
       materializer: Materializer,
@@ -114,6 +115,7 @@ object ApiServiceOwner {
         userManagementConfig = config.userManagement,
         apiStreamShutdownTimeout = config.apiStreamShutdownTimeout,
         meteringReportKey = meteringReportKey,
+        explicitDisclosureUnsafeEnabled = explicitDisclosureUnsafeEnabled,
       )(materializer, executionSequencerFactory, loggingContext)
         .map(_.withServices(otherServices))
       apiService <- new LedgerApiService(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -86,6 +86,7 @@ private[daml] object ApiServices {
       userManagementConfig: UserManagementConfig,
       apiStreamShutdownTimeout: scala.concurrent.duration.Duration,
       meteringReportKey: MeteringReportKey,
+      explicitDisclosureUnsafeEnabled: Boolean,
   )(implicit
       materializer: Materializer,
       esf: ExecutionSequencerFactory,
@@ -259,6 +260,7 @@ private[daml] object ApiServices {
           commandExecutor,
           checkOverloaded,
           metrics,
+          explicitDisclosureUnsafeEnabled = explicitDisclosureUnsafeEnabled,
         )
 
         // Note: the command service uses the command submission, command completion, and transaction
@@ -282,6 +284,7 @@ private[daml] object ApiServices {
           timeProvider = timeProvider,
           ledgerConfigurationSubscription = ledgerConfigurationSubscription,
           metrics = metrics,
+          explicitDisclosureUnsafeEnabled = explicitDisclosureUnsafeEnabled,
         )
 
         val apiPartyManagementService = ApiPartyManagementService.createApiService(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerFeatures.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerFeatures.scala
@@ -18,6 +18,6 @@ case class LedgerFeatures(
     contractIdFeatures: ExperimentalContractIds = ExperimentalContractIds.defaultInstance,
     committerEventLog: ExperimentalCommitterEventLog =
       ExperimentalCommitterEventLog.of(eventLogType = CENTRALIZED),
-    explicitDisclosureUnsafe: ExperimentalExplicitDisclosure =
+    explicitDisclosure: ExperimentalExplicitDisclosure =
       ExperimentalExplicitDisclosure.of(supported = false),
 )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerFeatures.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerFeatures.scala
@@ -8,6 +8,7 @@ import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationFeatures,
   ExperimentalCommitterEventLog,
   ExperimentalContractIds,
+  ExperimentalExplicitDisclosure,
 }
 
 case class LedgerFeatures(
@@ -17,4 +18,6 @@ case class LedgerFeatures(
     contractIdFeatures: ExperimentalContractIds = ExperimentalContractIds.defaultInstance,
     committerEventLog: ExperimentalCommitterEventLog =
       ExperimentalCommitterEventLog.of(eventLogType = CENTRALIZED),
+    explicitDisclosureUnsafe: ExperimentalExplicitDisclosure =
+      ExperimentalExplicitDisclosure.of(supported = false),
 )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -208,6 +208,7 @@ private[apiserver] object ApiCommandService {
       timeProvider: TimeProvider,
       ledgerConfigurationSubscription: LedgerConfigurationSubscription,
       metrics: Metrics,
+      explicitDisclosureUnsafeEnabled: Boolean,
   )(implicit
       materializer: Materializer,
       executionContext: ExecutionContext,
@@ -232,6 +233,7 @@ private[apiserver] object ApiCommandService {
       maxDeduplicationDuration = () =>
         ledgerConfigurationSubscription.latestConfiguration().map(_.maxDeduplicationDuration),
       generateSubmissionId = SubmissionIdGenerator.Random,
+      explicitDisclosureUnsafeEnabled = explicitDisclosureUnsafeEnabled,
     )
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -43,6 +43,7 @@ private[apiserver] object ApiSubmissionService {
       commandExecutor: CommandExecutor,
       checkOverloaded: TelemetryContext => Option[state.SubmissionResult],
       metrics: Metrics,
+      explicitDisclosureUnsafeEnabled: Boolean,
   )(implicit
       executionContext: ExecutionContext,
       loggingContext: LoggingContext,
@@ -65,6 +66,7 @@ private[apiserver] object ApiSubmissionService {
         ledgerConfigurationSubscription.latestConfiguration().map(_.maxDeduplicationDuration),
       submissionIdGenerator = SubmissionIdGenerator.Random,
       metrics = metrics,
+      explicitDisclosureUnsafeEnabled = explicitDisclosureUnsafeEnabled,
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
@@ -74,7 +74,7 @@ private[apiserver] final class ApiVersionService private (
           optionalLedgerId = Some(ExperimentalOptionalLedgerId()),
           contractIds = Some(ledgerFeatures.contractIdFeatures),
           committerEventLog = Some(ledgerFeatures.committerEventLog),
-          explicitDisclosure = None, // TODO[ED]: Wire-up with participant configuration flag
+          explicitDisclosure = Some(ledgerFeatures.explicitDisclosureUnsafe),
         )
       ),
     )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiVersionService.scala
@@ -74,7 +74,7 @@ private[apiserver] final class ApiVersionService private (
           optionalLedgerId = Some(ExperimentalOptionalLedgerId()),
           contractIds = Some(ledgerFeatures.contractIdFeatures),
           committerEventLog = Some(ledgerFeatures.committerEventLog),
-          explicitDisclosure = Some(ledgerFeatures.explicitDisclosureUnsafe),
+          explicitDisclosure = Some(ledgerFeatures.explicitDisclosure),
         )
       ),
     )

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -606,6 +606,13 @@ server_conformance_test(
     test_tool_args = [
         "--verbose",
         "--include=ExplicitDisclosureIT",
+        # TODO ED: Enable the following test once https://github.com/digital-asset/daml/issues/14200 is solved
+        "--exclude=ExplicitDisclosureIT:EDDuplicates",
+        # TODO ED: Enable the following tests once https://github.com/digital-asset/daml/issues/14199 is solved
+        "--exclude=ExplicitDisclosureIT:EDExerciseByKeyDisclosedContract",
+        "--exclude=ExplicitDisclosureIT:EDLocalKeyVisibility",
+        "--exclude=ExplicitDisclosureIT:EDNonNormalizedDisclosedContract",
+        "--exclude=ExplicitDisclosureIT:EDNormalizedDisclosedContract",
     ],
 )
 

--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -575,6 +575,24 @@ server_conformance_test(
     ],
 )
 
+SERVERS_EXPLICIT_DISCLOSURE = {
+    "h2database": {
+        "binary": ":app",
+        "server_args": ["explicit-disclosure-unsafe-enabled run"],
+    },
+    "postgresql": {
+        "binary": ":conformance-test-postgres-bin",
+        "server_args": ["explicit-disclosure-unsafe-enabled run -c $(rootpath :postgres.conf)"],
+        "extra_data": [":postgres.conf"],
+    },
+    "oracle": {
+        "binary": ":conformance-test-oracle-bin",
+        "tags": oracle_tags,
+        "server_args": ["explicit-disclosure-unsafe-enabled run -c $(rootpath :oracle.conf)"],
+        "extra_data": [":oracle.conf"],
+    },
+}
+
 server_conformance_test(
     name = "conformance-test-explicit-disclosure",
     hocon = True,
@@ -584,7 +602,25 @@ server_conformance_test(
     lf_versions = [
         "1.dev",
     ],
-    servers = SERVERS,
+    servers = SERVERS_EXPLICIT_DISCLOSURE,
+    test_tool_args = [
+        "--verbose",
+        "--include=ExplicitDisclosureIT",
+    ],
+)
+
+# Suite asserting that tests targeting disabled explicit disclosure are successful
+# (i.e. test asserting that submissions using disclosed contracts are rejected)
+# TODO ED: Remove once feature deemed stable
+conformance_test(
+    name = "conformance-test-explicit-disclosure-disabled-lf-dev-h2",
+    hocon = True,
+    lf_versions = [
+        "1.dev",
+    ],
+    ports = [6865],
+    server = ":app",
+    server_args = ["run"],
     test_tool_args = [
         "--verbose",
         "--include=ExplicitDisclosureIT",

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
@@ -21,6 +21,7 @@ import com.daml.ledger.api.v1.experimental_features.{
   CommandDeduplicationPeriodSupport,
   CommandDeduplicationType,
   ExperimentalContractIds,
+  ExperimentalExplicitDisclosure,
 }
 import com.daml.ledger.offset.Offset
 import com.daml.ledger.participant.state.index.v2.IndexService
@@ -56,16 +57,20 @@ object SandboxOnXRunner {
       configAdaptor: BridgeConfigAdaptor,
       config: Config,
       bridgeConfig: BridgeConfig,
+      explicitDisclosureUnsafeEnabled: Boolean = false,
   ): ResourceOwner[Port] =
     new ResourceOwner[Port] {
       override def acquire()(implicit context: ResourceContext): Resource[Port] =
-        SandboxOnXRunner.run(bridgeConfig, config, configAdaptor).acquire()
+        SandboxOnXRunner
+          .run(bridgeConfig, config, configAdaptor, explicitDisclosureUnsafeEnabled)
+          .acquire()
     }
 
   def run(
       bridgeConfig: BridgeConfig,
       config: Config,
       configAdaptor: BridgeConfigAdaptor,
+      explicitDisclosureUnsafeEnabled: Boolean,
   ): ResourceOwner[Port] = newLoggingContext { implicit loggingContext =>
     implicit val actorSystem: ActorSystem = ActorSystem(RunnerName)
     implicit val materializer: Materializer = Materializer(actorSystem)
@@ -111,6 +116,8 @@ object SandboxOnXRunner {
           contractIdFeatures = ExperimentalContractIds.of(
             v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED
           ),
+          explicitDisclosureUnsafe =
+            ExperimentalExplicitDisclosure.of(explicitDisclosureUnsafeEnabled),
         ),
         authService = configAdaptor.authService(participantConfig),
         buildWriteService = buildWriteServiceLambda,
@@ -127,6 +134,7 @@ object SandboxOnXRunner {
         timeServiceBackendO = timeServiceBackendO,
         servicesExecutionContext = servicesExecutionContext,
         metrics = metrics,
+        explicitDisclosureUnsafeEnabled = explicitDisclosureUnsafeEnabled,
       )(actorSystem, materializer).owner
     } yield {
       logInitializationHeader(

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/SandboxOnXRunner.scala
@@ -116,8 +116,7 @@ object SandboxOnXRunner {
           contractIdFeatures = ExperimentalContractIds.of(
             v1 = ExperimentalContractIds.ContractIdV1Support.NON_SUFFIXED
           ),
-          explicitDisclosureUnsafe =
-            ExperimentalExplicitDisclosure.of(explicitDisclosureUnsafeEnabled),
+          explicitDisclosure = ExperimentalExplicitDisclosure.of(explicitDisclosureUnsafeEnabled),
         ),
         authService = configAdaptor.authService(participantConfig),
         buildWriteService = buildWriteServiceLambda,


### PR DESCRIPTION
This PR should be reviewed commit by commit. It:
* Adds the possibility of running conformance tests on Sandbox-on-X with explicit disclosure enabled
* Fixes some blindly-written conformance tests.
* Disables conformance tests which are testing unimplemented code (see TODOs in the Bazel target)

changelog_begin
changelog_end

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
