### PR TITLE
Fire a warning if both config file and cli opts found.

### DIFF
--- a/ledger-service/http-json-cli/src/main/scala/com/daml/http/OptionParser.scala
+++ b/ledger-service/http-json-cli/src/main/scala/com/daml/http/OptionParser.scala
@@ -203,8 +203,8 @@ class OptionParser(getEnvVar: String => Option[String])(implicit
     if (
       cfg.configFile.isDefined && (cfg.ledgerHost != "" || cfg.ledgerPort != -1 || cfg.httpPort != -1)
     )
-      Left("Found both config file and cli opts for the app, please provide only one of them")
-    else Right(())
+      logger.warn("Found both config file and cli opts for the app, cli options will be ignored")
+    Right(())
   }
 
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
@@ -264,10 +264,12 @@ final class CliSpec extends AnyFreeSpec with Matchers {
       )
     }
 
-    "should fail when config file and cli args both are supplied" in {
+    "should ignore cli args when config file and cli args both are supplied" in {
       configParser(
         Seq("--config", requiredResource(confFile).getAbsolutePath) ++ sharedOptions
-      ) should ===(None)
+      ) shouldBe Some(
+        Config.Empty.copy(httpPort = 7500, ledgerHost = "127.0.0.1", ledgerPort = 6400)
+      )
     }
 
     // TEST_EVIDENCE: Input Validation: TLS configuration is parsed correctly from the config file

--- a/security-evidence.md
+++ b/security-evidence.md
@@ -212,7 +212,7 @@
 - creating and listing 20K users should be possible: [HttpServiceIntegrationTestUserManagement.scala](ledger-service/http-json/src/it/scala/http/HttpServiceIntegrationTestUserManagement.scala#L568)
 
 ## Input Validation:
-- TLS configuration is parsed correctly from the config file: [CliSpec.scala](ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala#L273)
+- TLS configuration is parsed correctly from the config file: [CliSpec.scala](ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala#L275)
 - auth and auth-* should not be set together for the trigger service: [CliConfigTest.scala](triggers/service/src/test-suite/scala/com/daml/lf/engine/trigger/CliConfigTest.scala#L40)
 - ensure builtin operators have the correct type: [TypingSpec.scala](daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala#L48)
 - ensure expression forms have the correct type: [TypingSpec.scala](daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala#L108)


### PR DESCRIPTION
fixes #13943

The existing behavior is ignoring cli opts if a config file is provided. What we need to do is just to change the current check to fire a warning instead of failing the command.

