### PR TITLE
fix blackduck

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -212,8 +212,8 @@ jobs:
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=YARN,NPM,CLANG \
-          --detect.npm.dependency.types.excluded=DEV \
-          --detect.yarn.dependency.types.excluded=DEV \
+          --detect.npm.dependency.types.excluded=NON_PRODUCTION \
+          --detect.yarn.dependency.types.excluded=NON_PRODUCTION \
           --detect.follow.symbolic.links=false \
           --detect.excluded.directories=language-support/ts/daml-ledger,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/codegen/tests/ts,bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env,result-*\
           --detect.blackduck.signature.scanner.exclusion.name.patterns=language-support/ts/daml-ledger,language-support/ts/daml-types,language-support/ts/daml-react.bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env,result-* \


### PR DESCRIPTION
Output from currently failing tests says:

```
The key 'detect.yarn.dependency.types.excluded' in property source
'commandLineArgs' contained a value that could not be reasonably
converted to the properties type. The exception was: Unable to parse raw
value 'DEV' and coerce it into type 'NoneEnum or YarnDependencyType'.
Value was must be one of NONE,NON_PRODUCTION
```

CHANGELOG_BEGIN
CHANGELOG_END

run-full-compat: true

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
