### PR TITLE
daily compat: fix BlackDuck invocation

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -212,7 +212,7 @@ jobs:
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=DETECTOR \
           --detect.included.detector.types=YARN,NPM,CLANG \
-          --detect.npm.dependency.types.excluded=NON_PRODUCTION \
+          --detect.npm.dependency.types.excluded=DEV \
           --detect.yarn.dependency.types.excluded=NON_PRODUCTION \
           --detect.follow.symbolic.links=false \
           --detect.excluded.directories=language-support/ts/daml-ledger,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/codegen/tests/ts,bazel-out,bazel-bin,.bazel-cache,bazel-testlogs,bazel-daml,bazel-s,node_modules,dev-env,result-*\


### PR DESCRIPTION
From output of currently failed jobs:

```
The key 'detect.npm.dependency.types.excluded' in property source
'commandLineArgs' contained a value that could not be reasonably
converted to the properties type. The exception was: Unable to parse raw
value 'NON_PRODUCTION' and coerce it into type 'NoneEnum or
NpmDependencyType'. Value was must be one of NONE,DEV,PEER
```

It looks like I was a bit overeager on #14995.

CHANGELOG_BEGIN
CHANGELOG_END