### PR TITLE
Contract Argument Blob API change for the Explicit Disclosure [DPP-1162]

### DIFF
--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionGenerator.scala
@@ -221,6 +221,7 @@ object TransactionGenerator {
         Some(scalaTemplateId),
         contractKey.map(_._1),
         Some(scalaRecord),
+        None,
         interfaceViews.map(_._1),
         signatories ++ observers,
         signatories,

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -8,6 +8,7 @@ package com.daml.ledger.api.v1;
 import "com/daml/ledger/api/v1/contract_metadata.proto";
 import "com/daml/ledger/api/v1/value.proto";
 
+import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 
@@ -217,9 +218,15 @@ message DisclosedContract {
   // The contract id
   // Required
   string contract_id = 2;
+
   // The contract arguments
-  // Required
-  Record arguments = 3;
+  oneof arguments {
+    Record record = 3;
+    // Contract argument accessible at ``com.daml.ledger.api.v1.CreatedEvent.create_arguments_blob``
+    // should be specified here.
+    google.protobuf.Any blob = 5;
+  }
+
   // The contract metadata from the create event.
   // Required
   ContractMetadata metadata = 4;

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -224,8 +224,8 @@ message DisclosedContract {
     // The contract arguments as typed Record
     Record record = 3;
 
-    // Contract argument accessible at ``com.daml.ledger.api.v1.CreatedEvent.create_arguments_blob``
-    // should be specified here.
+    // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
+    // of a ``com.daml.ledger.api.v1.CreatedEvent``.
     google.protobuf.Any blob = 5;
   }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -221,7 +221,9 @@ message DisclosedContract {
 
   // The contract arguments
   oneof arguments {
+    // The contract arguments as typed Record
     Record record = 3;
+
     // Contract argument accessible at ``com.daml.ledger.api.v1.CreatedEvent.create_arguments_blob``
     // should be specified here.
     google.protobuf.Any blob = 5;

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/commands.proto
@@ -222,11 +222,11 @@ message DisclosedContract {
   // The contract arguments
   oneof arguments {
     // The contract arguments as typed Record
-    Record record = 3;
+    Record create_arguments = 3;
 
     // The contract arguments specified using an opaque blob extracted from the ``create_arguments_blob`` field
     // of a ``com.daml.ledger.api.v1.CreatedEvent``.
-    google.protobuf.Any blob = 5;
+    google.protobuf.Any create_arguments_blob = 5;
   }
 
   // The contract metadata from the create event.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -68,6 +68,12 @@ message CreatedEvent {
   // Optional
   Record create_arguments = 4;
 
+  // Opaque representation of contract payload intended for forwarding
+  // to an API server as a contract disclosed as part of a command
+  // submission.
+  // Optional
+  google.protobuf.Any create_arguments_blob = 12;
+
   // Interface views specified in the transaction filter.
   // Includes an ``InterfaceView`` for each interface for which there is a ``InterfaceFilter`` with
   //   - its party in the ``witness_parties`` of this event,

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -69,4 +69,11 @@ message InterfaceFilter {
   // Use this to access contract data in a uniform manner in your API client.
   // Optional
   bool include_interface_view = 2;
+
+  // Whether to include a ``create_arguments_blob`` in the returned
+  // ``CreateEvent``.
+  // Use this to access the complete contract data in your API client
+  // for submitting it as a disclosed contract with future commands.
+  // Optional
+  bool include_create_arguments_blob = 3;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -56,13 +56,6 @@ message InclusiveFilters {
   // the available packages at the time of the query.
   // Optional
   repeated InterfaceFilter interface_filters = 2;
-
-  // Whether to include a ``create_arguments_blob`` in the returned
-  // ``CreateEvent``.
-  // Use this to access the complete contract data in your API client
-  // for submitting it as a disclosed contract with future commands.
-  // Optional
-  bool include_create_arguments_blob = 3;
 }
 
 // This filter matches contracts that implement a specific interface.
@@ -76,4 +69,11 @@ message InterfaceFilter {
   // Use this to access contract data in a uniform manner in your API client.
   // Optional
   bool include_interface_view = 2;
+
+  // Whether to include a ``create_arguments_blob`` in the returned
+  // ``CreateEvent``.
+  // Use this to access the complete contract data in your API client
+  // for submitting it as a disclosed contract with future commands.
+  // Optional
+  bool include_create_arguments_blob = 3;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_filter.proto
@@ -56,6 +56,13 @@ message InclusiveFilters {
   // the available packages at the time of the query.
   // Optional
   repeated InterfaceFilter interface_filters = 2;
+
+  // Whether to include a ``create_arguments_blob`` in the returned
+  // ``CreateEvent``.
+  // Use this to access the complete contract data in your API client
+  // for submitting it as a disclosed contract with future commands.
+  // Optional
+  bool include_create_arguments_blob = 3;
 }
 
 // This filter matches contracts that implement a specific interface.
@@ -69,11 +76,4 @@ message InterfaceFilter {
   // Use this to access contract data in a uniform manner in your API client.
   // Optional
   bool include_interface_view = 2;
-
-  // Whether to include a ``create_arguments_blob`` in the returned
-  // ``CreateEvent``.
-  // Use this to access the complete contract data in your API client
-  // for submitting it as a disclosed contract with future commands.
-  // Optional
-  bool include_create_arguments_blob = 3;
 }

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -32,6 +32,7 @@ da_scala_library(
         "//daml-lf/data",
         "//daml-lf/engine",
         "//daml-lf/transaction",
+        "//daml-lf/transaction:value_proto_java",
         "//language-support/scala/bindings",
         "//ledger-api/rs-grpc-bridge",
         "//ledger/error",

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
@@ -48,13 +48,7 @@ object TransactionFilterValidator {
             validatedInterfaces <-
               inclusive.interfaceFilters.toList traverse validateInterfaceFilter
           } yield domain.Filters(
-            Some(
-              InclusiveFilters(
-                templateIds = validatedIdents.toSet,
-                interfaceFilters = validatedInterfaces.toSet,
-                includeCreateArgumentsBlob = inclusive.includeCreateArgumentsBlob,
-              )
-            )
+            Some(InclusiveFilters(validatedIdents.toSet, validatedInterfaces.toSet))
           )
       }
   }
@@ -68,6 +62,7 @@ object TransactionFilterValidator {
     } yield domain.InterfaceFilter(
       interfaceId = validatedId,
       includeView = filter.includeInterfaceView,
+      includeCreateArgumentsBlob = filter.includeCreateArgumentsBlob,
     )
   }
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
@@ -48,7 +48,13 @@ object TransactionFilterValidator {
             validatedInterfaces <-
               inclusive.interfaceFilters.toList traverse validateInterfaceFilter
           } yield domain.Filters(
-            Some(InclusiveFilters(validatedIdents.toSet, validatedInterfaces.toSet))
+            Some(
+              InclusiveFilters(
+                templateIds = validatedIdents.toSet,
+                interfaceFilters = validatedInterfaces.toSet,
+                includeCreateArgumentsBlob = inclusive.includeCreateArgumentsBlob,
+              )
+            )
           )
       }
   }
@@ -62,7 +68,6 @@ object TransactionFilterValidator {
     } yield domain.InterfaceFilter(
       interfaceId = validatedId,
       includeView = filter.includeInterfaceView,
-      includeCreateArgumentsBlob = filter.includeCreateArgumentsBlob,
     )
   }
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
@@ -60,8 +60,9 @@ object TransactionFilterValidator {
       interfaceId <- requirePresence(filter.interfaceId, "interfaceId")
       validatedId <- validateIdentifier(interfaceId)
     } yield domain.InterfaceFilter(
-      validatedId,
-      filter.includeInterfaceView,
+      interfaceId = validatedId,
+      includeView = filter.includeInterfaceView,
+      includeCreateArgumentsBlob = filter.includeCreateArgumentsBlob,
     )
   }
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContracts.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContracts.scala
@@ -77,12 +77,12 @@ class ValidateDisclosedContracts(explicitDisclosureFeatureEnabled: Boolean) {
       contextualizedErrorLogger: ContextualizedErrorLogger
   ): Either[StatusRuntimeException, Value] =
     arguments match {
-      case ProtoDisclosedContract.Arguments.Record(value) =>
+      case ProtoDisclosedContract.Arguments.CreateArguments(value) =>
         for {
           recordId <- validateOptionalIdentifier(value.recordId)
           validatedRecordField <- validateRecordFields(value.fields)
         } yield ValueRecord(recordId, validatedRecordField)
-      case ProtoDisclosedContract.Arguments.Blob(value) =>
+      case ProtoDisclosedContract.Arguments.CreateArgumentsBlob(value) =>
         for {
           protoAny <- validateProtoAny(value)
           versionedValue <- validateVersionedValue(protoAny)

--- a/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
+++ b/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
@@ -58,9 +58,9 @@ trait ValidatorTestUtils extends Matchers with Inside with OptionValues { self: 
                   ),
                 ),
                 includeView = true,
+                includeCreateArgumentsBlob = true,
               )
             ),
-            includeCreateArgumentsBlob = true,
           )
         )
       )

--- a/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
+++ b/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
@@ -58,6 +58,7 @@ trait ValidatorTestUtils extends Matchers with Inside with OptionValues { self: 
                   ),
                 ),
                 includeView = true,
+                includeCreateArgumentsBlob = true,
               )
             ),
           )

--- a/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
+++ b/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
@@ -58,9 +58,9 @@ trait ValidatorTestUtils extends Matchers with Inside with OptionValues { self: 
                   ),
                 ),
                 includeView = true,
-                includeCreateArgumentsBlob = true,
               )
             ),
+            includeCreateArgumentsBlob = true,
           )
         )
       )

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
@@ -252,7 +252,7 @@ class TransactionServiceRequestValidatorTest
         inside(
           validator.validate(
             txReq.update(_.filter.filtersByParty.modify(_.map { case (p, f) =>
-              p -> f.update(_.inclusive := InclusiveFilters(Nil, Nil, true))
+              p -> f.update(_.inclusive := InclusiveFilters(Nil, Nil))
             })),
             ledgerEnd,
           )

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
@@ -58,6 +58,7 @@ class TransactionServiceRequestValidatorTest
                         )
                       ),
                       includeInterfaceView = true,
+                      includeCreateArgumentsBlob = true,
                     )
                   ),
                 )

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
@@ -58,9 +58,9 @@ class TransactionServiceRequestValidatorTest
                         )
                       ),
                       includeInterfaceView = true,
-                      includeCreateArgumentsBlob = true,
                     )
                   ),
+                  includeCreateArgumentsBlob = true,
                 )
               )
             )
@@ -264,7 +264,7 @@ class TransactionServiceRequestValidatorTest
           filtersByParty should have size 1
           inside(filtersByParty.headOption.value) { case (p, filters) =>
             p shouldEqual party
-            filters shouldEqual domain.Filters(Some(domain.InclusiveFilters(Set(), Set())))
+            filters shouldEqual domain.Filters(Some(domain.InclusiveFilters(Set(), Set(), true)))
           }
           req.verbose shouldEqual verbose
         }

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
@@ -58,9 +58,9 @@ class TransactionServiceRequestValidatorTest
                         )
                       ),
                       includeInterfaceView = true,
+                      includeCreateArgumentsBlob = true,
                     )
                   ),
-                  includeCreateArgumentsBlob = true,
                 )
               )
             )
@@ -264,7 +264,7 @@ class TransactionServiceRequestValidatorTest
           filtersByParty should have size 1
           inside(filtersByParty.headOption.value) { case (p, filters) =>
             p shouldEqual party
-            filters shouldEqual domain.Filters(Some(domain.InclusiveFilters(Set(), Set(), true)))
+            filters shouldEqual domain.Filters(Some(domain.InclusiveFilters(Set(), Set())))
           }
           req.verbose shouldEqual verbose
         }

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
@@ -252,7 +252,7 @@ class TransactionServiceRequestValidatorTest
         inside(
           validator.validate(
             txReq.update(_.filter.filtersByParty.modify(_.map { case (p, f) =>
-              p -> f.update(_.inclusive := InclusiveFilters(Nil, Nil))
+              p -> f.update(_.inclusive := InclusiveFilters(Nil, Nil, true))
             })),
             ledgerEnd,
           )

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
@@ -135,14 +135,16 @@ class ValidateDisclosedContractsTest extends AnyFlatSpec with Matchers with Vali
 
   it should "fail validation on invalid create arguments record field" in {
     def invalidateArguments(arguments: ProtoArguments): ProtoArguments =
-      ProtoArguments.Record(
-        arguments.record.get.update(_.fields.set(scala.Seq(ProtoRecordField("something", None))))
+      ProtoArguments.CreateArguments(
+        arguments.createArguments.get.update(
+          _.fields.set(scala.Seq(ProtoRecordField("something", None)))
+        )
       )
     val withInvalidRecordField =
       ProtoCommands(disclosedContracts =
         scala.Seq(
           api.protoDisclosedContract.update(
-            _.arguments.modify(argumentsUpdate)
+            _.arguments.modify(invalidateArguments)
           )
         )
       )
@@ -222,7 +224,7 @@ class ValidateDisclosedContractsTest extends AnyFlatSpec with Matchers with Vali
       ProtoCommands(disclosedContracts =
         scala.Seq(
           api.protoDisclosedContract.update(
-            _.arguments := ProtoArguments.Blob(
+            _.arguments := ProtoArguments.CreateArgumentsBlob(
               com.google.protobuf.any.Any("crap", ByteString.EMPTY)
             )
           )
@@ -264,7 +266,7 @@ object ValidateDisclosedContractsTest {
     val protoDisclosedContract: ProtoDisclosedContract = ProtoDisclosedContract(
       templateId = Some(templateId),
       contractId = contractId,
-      arguments = ProtoArguments.Record(contractArgumentsRecord),
+      arguments = ProtoArguments.CreateArguments(contractArgumentsRecord),
       metadata = Some(contractMetadata),
     )
     val protoCommands: ProtoCommands =

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.api.v1.commands.{
   Commands => ProtoCommands,
   DisclosedContract => ProtoDisclosedContract,
 }
-//import ProtoDisclosedContract.{Arguments => ProtoArguments}
+import ProtoDisclosedContract.{Arguments => ProtoArguments}
 import com.daml.ledger.api.v1.contract_metadata.{ContractMetadata => ProtoContractMetadata}
 import com.daml.ledger.api.v1.value.{
   Identifier => ProtoIdentifier,
@@ -134,11 +134,15 @@ class ValidateDisclosedContractsTest extends AnyFlatSpec with Matchers with Vali
   }
 
   it should "fail validation on invalid create arguments record field" in {
+    def argumentsUpdate(arguments: ProtoArguments): ProtoArguments =
+      ProtoArguments.Record(
+        arguments.record.get.update(_.fields.set(scala.Seq(ProtoRecordField("something", None))))
+      )
     val withInvalidRecordField =
       ProtoCommands(disclosedContracts =
         scala.Seq(
           api.protoDisclosedContract.update(
-            // _.arguments.fields.set(scala.Seq(ProtoRecordField("something", None)))
+            _.arguments.modify(argumentsUpdate)
           )
         )
       )
@@ -239,6 +243,7 @@ object ValidateDisclosedContractsTest {
     val protoDisclosedContract: ProtoDisclosedContract = ProtoDisclosedContract(
       templateId = Some(templateId),
       contractId = contractId,
+      arguments = ProtoArguments.Record(contractArgumentsRecord),
       metadata = Some(contractMetadata),
     )
     val protoCommands: ProtoCommands =

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
@@ -216,6 +216,27 @@ class ValidateDisclosedContractsTest extends AnyFlatSpec with Matchers with Vali
       metadata = Map.empty,
     )
   }
+
+  it should "fail validation on unexpected create arguments blob" in {
+    val withCrappyArguments =
+      ProtoCommands(disclosedContracts =
+        scala.Seq(
+          api.protoDisclosedContract.update(
+            _.arguments := ProtoArguments.Blob(
+              com.google.protobuf.any.Any("crap", ByteString.EMPTY)
+            )
+          )
+        )
+      )
+
+    requestMustFailWith(
+      request = validateDisclosedContracts(withCrappyArguments),
+      code = Status.Code.INVALID_ARGUMENT,
+      description =
+        "INVALID_FIELD(8,0): The submitted command has a field with invalid value: Invalid field blob: Type of the Any message does not match the given class.",
+      metadata = Map.empty,
+    )
+  }
 }
 
 object ValidateDisclosedContractsTest {

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
@@ -134,7 +134,7 @@ class ValidateDisclosedContractsTest extends AnyFlatSpec with Matchers with Vali
   }
 
   it should "fail validation on invalid create arguments record field" in {
-    def argumentsUpdate(arguments: ProtoArguments): ProtoArguments =
+    def invalidateArguments(arguments: ProtoArguments): ProtoArguments =
       ProtoArguments.Record(
         arguments.record.get.update(_.fields.set(scala.Seq(ProtoRecordField("something", None))))
       )

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/ValidateDisclosedContractsTest.scala
@@ -8,6 +8,7 @@ import com.daml.ledger.api.v1.commands.{
   Commands => ProtoCommands,
   DisclosedContract => ProtoDisclosedContract,
 }
+//import ProtoDisclosedContract.{Arguments => ProtoArguments}
 import com.daml.ledger.api.v1.contract_metadata.{ContractMetadata => ProtoContractMetadata}
 import com.daml.ledger.api.v1.value.{
   Identifier => ProtoIdentifier,
@@ -137,7 +138,7 @@ class ValidateDisclosedContractsTest extends AnyFlatSpec with Matchers with Vali
       ProtoCommands(disclosedContracts =
         scala.Seq(
           api.protoDisclosedContract.update(
-            _.arguments.fields.set(scala.Seq(ProtoRecordField("something", None)))
+            // _.arguments.fields.set(scala.Seq(ProtoRecordField("something", None)))
           )
         )
       )
@@ -226,7 +227,7 @@ object ValidateDisclosedContractsTest {
       ProtoIdentifier("package", moduleName = "module", entityName = "entity")
     val contractId: String = "00" + "00" * 31 + "ef"
     val keyHash: Hash = Hash.assertFromString("00" * 31 + "ff")
-    val contractArguments: ProtoRecord = ProtoRecord(
+    val contractArgumentsRecord: ProtoRecord = ProtoRecord(
       Some(templateId),
       scala.Seq(ProtoRecordField("something", Some(ProtoValue(ProtoValue.Sum.Bool(true))))),
     )
@@ -238,7 +239,6 @@ object ValidateDisclosedContractsTest {
     val protoDisclosedContract: ProtoDisclosedContract = ProtoDisclosedContract(
       templateId = Some(templateId),
       contractId = contractId,
-      arguments = Some(contractArguments),
       metadata = Some(contractMetadata),
     )
     val protoCommands: ProtoCommands =

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -48,12 +48,12 @@ object domain {
   final case class InterfaceFilter(
       interfaceId: Ref.Identifier,
       includeView: Boolean,
+      includeCreateArgumentsBlob: Boolean,
   )
 
   final case class InclusiveFilters(
       templateIds: immutable.Set[Ref.Identifier],
       interfaceFilters: immutable.Set[InterfaceFilter],
-      includeCreateArgumentsBlob: Boolean,
   )
 
   sealed abstract class LedgerOffset extends Product with Serializable

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -48,6 +48,7 @@ object domain {
   final case class InterfaceFilter(
       interfaceId: Ref.Identifier,
       includeView: Boolean,
+      includeCreateArgumentsBlob: Boolean
   )
 
   final case class InclusiveFilters(

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -48,7 +48,7 @@ object domain {
   final case class InterfaceFilter(
       interfaceId: Ref.Identifier,
       includeView: Boolean,
-      includeCreateArgumentsBlob: Boolean
+      includeCreateArgumentsBlob: Boolean,
   )
 
   final case class InclusiveFilters(

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -48,12 +48,12 @@ object domain {
   final case class InterfaceFilter(
       interfaceId: Ref.Identifier,
       includeView: Boolean,
-      includeCreateArgumentsBlob: Boolean,
   )
 
   final case class InclusiveFilters(
       templateIds: immutable.Set[Ref.Identifier],
       interfaceFilters: immutable.Set[InterfaceFilter],
+      includeCreateArgumentsBlob: Boolean,
   )
 
   sealed abstract class LedgerOffset extends Product with Serializable

--- a/ledger/ledger-api-tests/suites/deps.bzl
+++ b/ledger/ledger-api-tests/suites/deps.bzl
@@ -10,6 +10,7 @@ def deps(lf_version):
         "//ledger/test-common:carbonv3-tests-%s.scala" % lf_version,
     ]
     additional_tests = carbon_tests if (versions.gte(lf_version, "1.15")) else []
+    additional_dev_tests = ["//ledger/test-common:modelext-tests-%s.scala" % lf_version] if (versions.gte(lf_version, "1.dev")) else []
     return [
         "//daml-lf/data",
         "//daml-lf/transaction",
@@ -36,4 +37,4 @@ def deps(lf_version):
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_netty_netty_handler",
         "@maven//:org_slf4j_slf4j_api",
-    ] + additional_tests
+    ] + additional_tests + additional_dev_tests

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_15/InterfaceSubscriptionsIT.scala
@@ -19,12 +19,7 @@ import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.v1.event.Event.Event
 import com.daml.ledger.api.v1.event.{CreatedEvent, InterfaceView}
 import com.daml.ledger.api.v1.transaction.Transaction
-import com.daml.ledger.api.v1.transaction_filter.{
-  Filters,
-  InclusiveFilters,
-  InterfaceFilter,
-  TransactionFilter,
-}
+import com.daml.ledger.api.v1.transaction_filter.TransactionFilter
 import com.daml.ledger.api.v1.value.{Identifier, Record}
 import com.daml.ledger.test.semantic.InterfaceViews._
 import com.daml.ledger.test.{
@@ -65,32 +60,6 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
       )
       events = transactions.flatMap(createdEvents)
     } yield basicAssertions(c1.toString, c2.toString, c3.toString, events)
-  })
-
-  test(
-    "ISTransactionsCreateArgumentsBlob",
-    "Subscribing on transaction stream by interface with createArgumentsBlob",
-    allocate(SingleParty),
-  )(implicit ec => { case Participants(Participant(ledger, party)) =>
-    import ledger._
-    for {
-      _ <- create(party, T1(party, 1))
-      transactionsWithBlob <- flatTransactions(
-        getTransactionsRequest(interfaceFilter(party.toString, includeCreateArgumentsBlob = true))
-      )
-      transactionsWithoutBlob <- flatTransactions(
-        getTransactionsRequest(interfaceFilter(party.toString, includeCreateArgumentsBlob = false))
-      )
-    } yield {
-      assertIsBlobProduced(
-        transactionsWithBlob.flatMap(createdEvents),
-        createArgumentsBlobNonEmpty = true,
-      )
-      assertIsBlobProduced(
-        transactionsWithoutBlob.flatMap(createdEvents),
-        createArgumentsBlobNonEmpty = false,
-      )
-    }
   })
 
   test(
@@ -140,11 +109,6 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
       "Create event 1 createArguments must NOT be empty",
       createdEvent1.createArguments.isEmpty,
       false,
-    )
-    assertEquals(
-      "Create event 1 createArgumentsBlob must be empty",
-      createdEvent1.createArgumentsBlob.isEmpty,
-      true,
     )
     assert(
       createdEvent1.getCreateArguments.fields.forall(_.label.nonEmpty),
@@ -734,29 +698,6 @@ class InterfaceSubscriptionsIT extends LedgerTestSuite {
 
     val actualValue = assertDefined(view.viewValue, "Value is not defined")
     checkValue(actualValue)
-  }
-
-  private def interfaceFilter(party: String, includeCreateArgumentsBlob: Boolean) = {
-    val ifaceFilter = new InterfaceFilter(
-      interfaceId = Some(Tag.unwrap(I.id)),
-      includeInterfaceView = false,
-      includeCreateArgumentsBlob = includeCreateArgumentsBlob,
-    )
-    val filters = new InclusiveFilters(interfaceFilters = List(ifaceFilter))
-    new TransactionFilter(Map(party -> new Filters(Some(filters))))
-  }
-
-  private def assertIsBlobProduced(
-      eventsWithBlob: Vector[CreatedEvent],
-      createArgumentsBlobNonEmpty: Boolean,
-  ): Unit = {
-    val createdEventWithBlob = eventsWithBlob.head
-    assertEquals(
-      "Create event 1 template ID",
-      createdEventWithBlob.templateId.get.toString,
-      Tag.unwrap(T1.id).toString,
-    )
-    assertEquals(createdEventWithBlob.createArgumentsBlob.nonEmpty, createArgumentsBlobNonEmpty)
   }
 
 }

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
@@ -30,6 +30,13 @@ import com.google.protobuf.timestamp.Timestamp
 import scalaz.syntax.tag._
 import com.daml.ledger.api.v1.commands.{DisclosedContract => ProtoDisclosedContract}
 import ProtoDisclosedContract.{Arguments => ProtoArguments}
+import com.daml.ledger.api.v1.transaction_filter.{
+  Filters,
+  InclusiveFilters,
+  InterfaceFilter,
+  TransactionFilter,
+}
+import com.daml.ledger.test.modelext.TestExtension.IDelegated
 
 import java.time.temporal.ChronoUnit
 import scala.concurrent.{ExecutionContext, Future}
@@ -45,7 +52,12 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     enabled = _.explicitDisclosure,
   )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
     for {
-      testContext <- initializeTest(ledger, owner, delegate)
+      testContext <- initializeTest(
+        ledger,
+        owner,
+        delegate,
+        filterTxBy(owner, template = byTemplate, interface = None),
+      )
 
       // Exercise a choice on the Delegation that fetches the Delegated contract
       // Fails because the submitter doesn't see the contract being fetched
@@ -66,13 +78,56 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
   })
 
   test(
+    "EDCorrectBlobDisclosure",
+    "Submission is successful if the correct disclosure as Blob is provided",
+    allocate(Parties(2)),
+    enabled = _.explicitDisclosure,
+  )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
+    for {
+      testContext <- initializeTest(
+        ledger,
+        owner,
+        delegate,
+        filterTxBy(
+          owner,
+          template = None,
+          interface = byInterface(includeCreateArgumentsBlob = true),
+        ),
+      )
+
+      // Exercise a choice on the Delegation that fetches the Delegated contract
+      // Fails because the submitter doesn't see the contract being fetched
+      exerciseFetchError <- testContext
+        .exerciseFetchDelegated()
+        .mustFail("the submitter does not see the contract")
+
+      // Exercise the same choice, this time using correct explicit disclosure
+      _ <- testContext.exerciseFetchDelegated(testContext.disclosedContract)
+    } yield {
+      assertEquals(testContext.disclosedContract.arguments.isCreateArgumentsBlob, true)
+
+      assertGrpcError(
+        exerciseFetchError,
+        LedgerApiErrors.ConsistencyErrors.ContractNotFound,
+        None,
+        checkDefiniteAnswerMetadata = true,
+      )
+    }
+  })
+
+  test(
     "EDSuperfluousDisclosure",
     "Submission is successful when unnecessary disclosed contract is provided",
     allocate(Parties(2)),
     enabled = _.explicitDisclosure,
   )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
     for {
-      testContext <- initializeTest(ledger, owner, delegate)
+      testContext <- initializeTest(
+        ledger,
+        owner,
+        delegate,
+        filterTxBy(owner, template = byTemplate, interface = None),
+      )
 
       dummyCid <- ledger.create(owner, Dummy(owner))
       dummyTxs <- ledger.flatTransactionsByTemplateId(Dummy.id, owner)
@@ -192,7 +247,12 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     enabled = _.explicitDisclosure,
   )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
     for {
-      testContext <- initializeTest(ledger, owner, delegate)
+      testContext <- initializeTest(
+        ledger,
+        owner,
+        delegate,
+        filterTxBy(owner, template = byTemplate, interface = None),
+      )
 
       // Archive the disclosed contract
       _ <- ledger.exercise(owner, testContext.delegatedCid.exerciseArchive())
@@ -267,7 +327,12 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     enabled = _.explicitDisclosure,
   )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
     for {
-      testContext <- initializeTest(ledger, owner, delegate)
+      testContext <- initializeTest(
+        ledger,
+        owner,
+        delegate,
+        filterTxBy(owner, template = byTemplate, interface = None),
+      )
 
       //      // TODO ED: Enable once the check is implemented in command interpretation
       //      // Exercise a choice using invalid explicit disclosure (bad contract key)
@@ -327,7 +392,12 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     enabled = _.explicitDisclosure,
   )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
     for {
-      testContext <- initializeTest(ledger, owner, delegate)
+      testContext <- initializeTest(
+        ledger,
+        owner,
+        delegate,
+        filterTxBy(owner, template = byTemplate, interface = None),
+      )
 
       // This payload does not typecheck, it has different fields than the corresponding template
       malformedArgument = Record(
@@ -437,7 +507,12 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     enabled = _.explicitDisclosure,
   )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
     for {
-      testContext <- initializeTest(ledger, owner, delegate)
+      testContext <- initializeTest(
+        ledger,
+        owner,
+        delegate,
+        filterTxBy(owner, template = byTemplate, interface = None),
+      )
 
       _ <- ledger.create(owner, Dummy(owner))
       dummyTxs <- ledger.flatTransactionsByTemplateId(Dummy.id, owner)
@@ -484,7 +559,12 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     enabled = _.explicitDisclosure,
   )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
     for {
-      testContext <- initializeTest(ledger, owner, delegate)
+      testContext <- initializeTest(
+        ledger,
+        owner,
+        delegate,
+        filterTxBy(owner, template = byTemplate, interface = None),
+      )
 
       // Exercise a choice with a disclosed contract
       _ <- testContext.exerciseFetchDelegated(testContext.disclosedContract)
@@ -581,7 +661,12 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
     enabled = feature => !feature.explicitDisclosure,
   )(implicit ec => { case Participants(Participant(ledger, owner, delegate)) =>
     for {
-      testContext <- initializeTest(ledger, owner, delegate)
+      testContext <- initializeTest(
+        ledger,
+        owner,
+        delegate,
+        filterTxBy(owner, template = byTemplate, interface = None),
+      )
 
       exerciseFetchError <- testContext
         .exerciseFetchDelegated(testContext.disclosedContract)
@@ -721,6 +806,7 @@ object ExplicitDisclosureIT {
       ledger: ParticipantTestContext,
       owner: binding.Primitive.Party,
       delegate: binding.Primitive.Party,
+      transactionFilter: TransactionFilter,
   )(implicit ec: ExecutionContext): Future[TestContext] = {
     val contractKey = ledger.nextKeyId()
 
@@ -734,7 +820,7 @@ object ExplicitDisclosureIT {
       delegatedCid <- ledger.create(owner, Delegated(owner, contractKey))
 
       // Get the contract payload from the transaction stream of the owner
-      delegatedTx <- ledger.flatTransactionsByTemplateId(Delegated.id, owner)
+      delegatedTx <- ledger.flatTransactions(ledger.getTransactionsRequest(transactionFilter))
       createDelegatedEvent = createdEvents(delegatedTx.head).head
 
       // Copy the actual Delegated contract to a disclosed contract (which can be shared out of band).
@@ -750,6 +836,33 @@ object ExplicitDisclosureIT {
       disclosedContract = disclosedContract,
     )
   }
+
+  private def filterTxBy(
+      owner: binding.Primitive.Party,
+      template: Option[value.Identifier],
+      interface: Option[InterfaceFilter],
+  ): TransactionFilter =
+    new TransactionFilter(
+      Map(
+        owner.unwrap -> new Filters(
+          Some(
+            InclusiveFilters(
+              template.toList,
+              interface.toList,
+            )
+          )
+        )
+      )
+    )
+
+  private def byTemplate: Option[value.Identifier] = Some(Delegated.id.unwrap)
+  private def byInterface(includeCreateArgumentsBlob: Boolean): Option[InterfaceFilter] = Some(
+    InterfaceFilter(
+      Some(IDelegated.id.unwrap),
+      includeInterfaceView = true,
+      includeCreateArgumentsBlob = includeCreateArgumentsBlob,
+    )
+  )
 
   private def createEventToDisclosedContract(ev: CreatedEvent): DisclosedContract = {
     val arguments = (ev.createArguments, ev.createArgumentsBlob) match {

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
@@ -469,12 +469,10 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
       // Exercise a choice using invalid explicit disclosure (bad payload)
       _ <- testContext
         .exerciseFetchDelegated(
-          testContext.disclosedContract
-            .update(
-              _.arguments := ProtoArguments.CreateArguments(
-                Delegated(delegate, testContext.contractKey).arguments
-              )
-            )
+          testContext.disclosedContract,
+          // Provide a superfluous disclosed contract with mismatching contract arguments
+          dummyDisclosedContract
+            .update(_.arguments := ProtoArguments.CreateArguments(Dummy(delegate).arguments)),
         )
     } yield ()
   })

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
@@ -745,13 +745,22 @@ object ExplicitDisclosureIT {
     )
   }
 
-  private def createEventToDisclosedContract(ev: CreatedEvent): DisclosedContract =
+  private def createEventToDisclosedContract(ev: CreatedEvent): DisclosedContract = {
+    val arguments = (ev.createArguments, ev.createArgumentsBlob) match {
+      case (Some(createArguments), _) =>
+        DisclosedContract.Arguments.Record(createArguments)
+      case (_, Some(createArgumentsBlob)) =>
+        DisclosedContract.Arguments.Blob(createArgumentsBlob)
+      case _ =>
+        sys.error("createEvent arguments are empty")
+    }
     DisclosedContract(
       templateId = ev.templateId,
       contractId = ev.contractId,
-//      arguments = ev.createArguments,
+      arguments = arguments,
       metadata = ev.metadata,
     )
+  }
 
   private def exerciseWithKey_byKey_request(
       ledger: ParticipantTestContext,

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
@@ -28,6 +28,8 @@ import com.daml.lf.data.Ref.{DottedName, Identifier, PackageId, QualifiedName}
 import com.google.protobuf.ByteString
 import com.google.protobuf.timestamp.Timestamp
 import scalaz.syntax.tag._
+import com.daml.ledger.api.v1.commands.{DisclosedContract => ProtoDisclosedContract}
+import ProtoDisclosedContract.{Arguments => ProtoArguments}
 
 import java.time.temporal.ChronoUnit
 import scala.concurrent.{ExecutionContext, Future}
@@ -288,7 +290,11 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
       errorBadPayload <- testContext
         .exerciseFetchDelegated(
           testContext.disclosedContract
-          // .update(_.arguments := Delegated(delegate, testContext.contractKey).arguments)
+            .update(
+              _.arguments := ProtoArguments.Record(
+                Delegated(delegate, testContext.contractKey).arguments
+              )
+            )
         )
         .mustFail("using an invalid disclosed contract payload")
     } yield {
@@ -332,7 +338,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
       errorMalformedPayload <- testContext
         .exerciseFetchDelegated(
           testContext.disclosedContract
-          // .update(_.arguments := malformedArgument)
+            .update(_.arguments := ProtoArguments.Record(malformedArgument))
         )
         .mustFail("using a malformed contract argument")
 
@@ -355,7 +361,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
       // Exercise a choice using an invalid disclosed contract (empty create arguments)
       errorMissingArguments <- testContext
         .exerciseFetchDelegated(
-          // testContext.disclosedContract.update(_.modify(_.clearArguments))
+          testContext.disclosedContract.update(_.modify(_.clearArguments))
         )
         .mustFail("using a disclosed contract with empty arguments")
 
@@ -466,7 +472,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
           testContext.disclosedContract,
           // Provide a superfluous disclosed contract with mismatching contract arguments
           dummyDisclosedContract
-            .update(_.arguments := Dummy(delegate).arguments),
+            .update(_.arguments := ProtoArguments.Record(Dummy(delegate).arguments)),
         )
     } yield ()
   })

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
@@ -291,7 +291,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
         .exerciseFetchDelegated(
           testContext.disclosedContract
             .update(
-              _.arguments := ProtoArguments.Record(
+              _.arguments := ProtoArguments.CreateArguments(
                 Delegated(delegate, testContext.contractKey).arguments
               )
             )
@@ -338,7 +338,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
       errorMalformedPayload <- testContext
         .exerciseFetchDelegated(
           testContext.disclosedContract
-            .update(_.arguments := ProtoArguments.Record(malformedArgument))
+            .update(_.arguments := ProtoArguments.CreateArguments(malformedArgument))
         )
         .mustFail("using a malformed contract argument")
 
@@ -469,10 +469,12 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
       // Exercise a choice using invalid explicit disclosure (bad payload)
       _ <- testContext
         .exerciseFetchDelegated(
-          testContext.disclosedContract,
-          // Provide a superfluous disclosed contract with mismatching contract arguments
-          dummyDisclosedContract
-            .update(_.arguments := ProtoArguments.Record(Dummy(delegate).arguments)),
+          testContext.disclosedContract
+            .update(
+              _.arguments := ProtoArguments.CreateArguments(
+                Delegated(delegate, testContext.contractKey).arguments
+              )
+            )
         )
     } yield ()
   })
@@ -754,9 +756,9 @@ object ExplicitDisclosureIT {
   private def createEventToDisclosedContract(ev: CreatedEvent): DisclosedContract = {
     val arguments = (ev.createArguments, ev.createArgumentsBlob) match {
       case (Some(createArguments), _) =>
-        DisclosedContract.Arguments.Record(createArguments)
+        DisclosedContract.Arguments.CreateArguments(createArguments)
       case (_, Some(createArgumentsBlob)) =>
-        DisclosedContract.Arguments.Blob(createArgumentsBlob)
+        DisclosedContract.Arguments.CreateArgumentsBlob(createArgumentsBlob)
       case _ =>
         sys.error("createEvent arguments are empty")
     }

--- a/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
+++ b/ledger/ledger-api-tests/suites/src/main/scala/com/daml/ledger/api/testtool/suites/v1_dev/ExplicitDisclosureIT.scala
@@ -288,7 +288,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
       errorBadPayload <- testContext
         .exerciseFetchDelegated(
           testContext.disclosedContract
-            .update(_.arguments := Delegated(delegate, testContext.contractKey).arguments)
+          // .update(_.arguments := Delegated(delegate, testContext.contractKey).arguments)
         )
         .mustFail("using an invalid disclosed contract payload")
     } yield {
@@ -332,7 +332,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
       errorMalformedPayload <- testContext
         .exerciseFetchDelegated(
           testContext.disclosedContract
-            .update(_.arguments := malformedArgument)
+          // .update(_.arguments := malformedArgument)
         )
         .mustFail("using a malformed contract argument")
 
@@ -355,7 +355,7 @@ final class ExplicitDisclosureIT extends LedgerTestSuite {
       // Exercise a choice using an invalid disclosed contract (empty create arguments)
       errorMissingArguments <- testContext
         .exerciseFetchDelegated(
-          testContext.disclosedContract.update(_.modify(_.clearArguments))
+          // testContext.disclosedContract.update(_.modify(_.clearArguments))
         )
         .mustFail("using a disclosed contract with empty arguments")
 
@@ -749,7 +749,7 @@ object ExplicitDisclosureIT {
     DisclosedContract(
       templateId = ev.templateId,
       contractId = ev.contractId,
-      arguments = ev.createArguments,
+//      arguments = ev.createArguments,
       metadata = ev.metadata,
     )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -580,7 +580,7 @@ object IndexServiceImpl {
     transactionFilter.filtersByParty.view.collect {
       case (party, Filters(None)) =>
         party
-      case (party, Filters(Some(InclusiveFilters(templateIds, interfaceFilters))))
+      case (party, Filters(Some(InclusiveFilters(templateIds, interfaceFilters, _))))
           if templateIds.isEmpty && interfaceFilters.isEmpty =>
         party
     }.toSet

--- a/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/IndexServiceImpl.scala
@@ -580,7 +580,7 @@ object IndexServiceImpl {
     transactionFilter.filtersByParty.view.collect {
       case (party, Filters(None)) =>
         party
-      case (party, Filters(Some(InclusiveFilters(templateIds, interfaceFilters, _))))
+      case (party, Filters(Some(InclusiveFilters(templateIds, interfaceFilters))))
           if templateIds.isEmpty && interfaceFilters.isEmpty =>
         party
     }.toSet

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/EventProjectionProperties.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/EventProjectionProperties.scala
@@ -34,7 +34,7 @@ final case class EventProjectionProperties private[dao] (
       .flatMap(_.getOrElse(templateId, Set.empty[Identifier]))
       .toSet
 
-    RenderResult(renderContractArguments, interfacesToRender)
+    RenderResult(false, renderContractArguments, interfacesToRender)
   }
 
 }
@@ -42,15 +42,16 @@ final case class EventProjectionProperties private[dao] (
 object EventProjectionProperties {
 
   case class RenderResult(
+      contractArgumentsBlob: Boolean,
       contractArguments: Boolean,
       interfaces: Set[Identifier],
   )
 
-  /** @param transactionFilter Transaction filter as defined by the consumer of the API.
-    * @param verbose                 enriching in verbose mode
-    * @param interfaceImplementedBy  The relation between an interface id and template id.
-    *                                If template has no relation to the interface,
-    *                                an empty Set must be returned.
+  /** @param transactionFilter     Transaction filter as defined by the consumer of the API.
+    * @param verbose                enriching in verbose mode
+    * @param interfaceImplementedBy The relation between an interface id and template id.
+    *                               If template has no relation to the interface,
+    *                               an empty Set must be returned.
     */
   def apply(
       transactionFilter: domain.TransactionFilter,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/EventProjectionProperties.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/EventProjectionProperties.scala
@@ -4,9 +4,9 @@
 package com.daml.platform.store.dao
 
 import com.daml.ledger.api.domain
-import com.daml.ledger.api.domain.{Filters, InterfaceFilter}
+import com.daml.ledger.api.domain.{Filters, InclusiveFilters}
 import com.daml.lf.data.Ref.{Identifier, Party}
-import com.daml.platform.store.dao.EventProjectionProperties.{InterfaceViewFilter, RenderResult}
+import com.daml.platform.store.dao.EventProjectionProperties.RenderResult
 
 /**  This class encapsulates the logic of how contract arguments and interface views are
   *  being projected to the consumer based on the filter criteria and the relation between
@@ -16,50 +16,40 @@ import com.daml.platform.store.dao.EventProjectionProperties.{InterfaceViewFilte
   * @param witnessTemplateIdFilter populate contract_argument, and contract_key. If templateId set is empty: populate.
   * @param witnessInterfaceViewFilter populate interface_views. The Map of templates to interfaces,
   *                              and the set of implementor templates cannot be empty.
+  * @param witnessContractArgumentBlob populate contract_arguments_blob.
   */
 final case class EventProjectionProperties private[dao] (
     verbose: Boolean,
     // Map(eventWitnessParty, Set(templateId))
     witnessTemplateIdFilter: Map[String, Set[Identifier]] = Map.empty,
     // Map(eventWitnessParty, Map(templateId -> Set(interfaceId)))
-    witnessInterfaceViewFilter: Map[String, Map[Identifier, InterfaceViewFilter]] = Map.empty,
+    witnessInterfaceViewFilter: Map[String, Map[Identifier, Set[Identifier]]] = Map.empty,
+    // Set of parties which require to populate contractArgumentBlob
+    witnessContractArgumentBlob: Set[String] = Set.empty,
 ) {
   def render(witnesses: Set[String], templateId: Identifier): RenderResult = {
     val renderContractArguments: Boolean = witnesses.view
       .flatMap(witnessTemplateIdFilter.get)
       .exists(templates => templates.isEmpty || templates(templateId))
 
-    val interfacesToRender: InterfaceViewFilter = witnesses.view
+    val interfacesToRender: Set[Identifier] = witnesses.view
       .flatMap(witnessInterfaceViewFilter.get(_).iterator)
-      .foldLeft(InterfaceViewFilter.Empty)(_ append (templateId, _))
+      .flatMap(_.getOrElse(templateId, Set.empty[Identifier]))
+      .toSet
+
+    val contractArgumentsBlob =
+      witnesses.intersect(witnessContractArgumentBlob).nonEmpty
 
     RenderResult(
-      interfacesToRender.contractArgumentsBlob,
+      contractArgumentsBlob,
       renderContractArguments,
-      interfacesToRender.interfaces,
+      interfacesToRender,
     )
   }
 
 }
 
 object EventProjectionProperties {
-
-  case class InterfaceViewFilter(interfaces: Set[Identifier], contractArgumentsBlob: Boolean) {
-    def append(
-        templateId: Identifier,
-        interfaceFilterMap: Map[Identifier, InterfaceViewFilter],
-    ): InterfaceViewFilter = {
-      val other = interfaceFilterMap.getOrElse(templateId, InterfaceViewFilter.Empty)
-      InterfaceViewFilter(
-        interfaces ++ other.interfaces,
-        contractArgumentsBlob || other.contractArgumentsBlob,
-      )
-    }
-  }
-
-  object InterfaceViewFilter {
-    val Empty = InterfaceViewFilter(Set.empty[Identifier], false)
-  }
 
   case class RenderResult(
       contractArgumentsBlob: Boolean,
@@ -83,6 +73,9 @@ object EventProjectionProperties {
       witnessTemplateIdFilter = witnessTemplateIdFilter(transactionFilter),
       witnessInterfaceViewFilter =
         witnessInterfaceViewFilter(transactionFilter, interfaceImplementedBy),
+      witnessContractArgumentBlob = transactionFilter.filtersByParty.iterator.collect {
+        case (party, Filters(Some(InclusiveFilters(_, _, true)))) => party.toString
+      }.toSet,
     )
 
   private def witnessTemplateIdFilter(
@@ -103,33 +96,16 @@ object EventProjectionProperties {
   private def witnessInterfaceViewFilter(
       domainTransactionFilter: domain.TransactionFilter,
       interfaceImplementedBy: Identifier => Set[Identifier],
-  ): Map[String, Map[Identifier, InterfaceViewFilter]] = (for {
+  ): Map[String, Map[Identifier, Set[Identifier]]] = (for {
     (party, filters) <- domainTransactionFilter.filtersByParty.iterator
     inclusiveFilters <- filters.inclusive.iterator
     interfaceFilter <- inclusiveFilters.interfaceFilters.iterator
+    if interfaceFilter.includeView
     implementor <- interfaceImplementedBy(interfaceFilter.interfaceId).iterator
-  } yield (
-    party,
-    implementor,
-    interfaceFilter,
-  ))
-    .toSet[(Party, Identifier, InterfaceFilter)]
-    .groupMap(_._1) { case (_, templateId, interfaceFilter) =>
-      templateId -> interfaceFilter
-    }
-    .map { case (partyId, templateAndInterfaceFilterPairs) =>
-      (
-        partyId.toString,
-        templateAndInterfaceFilterPairs
-          .groupMap(_._1)(_._2)
-          .view
-          .mapValues(interfaceFilters =>
-            InterfaceViewFilter(
-              interfaceFilters.filter(_.includeView).map(_.interfaceId),
-              interfaceFilters.exists(_.includeCreateArgumentsBlob),
-            )
-          )
-          .toMap,
-      )
+  } yield (party, implementor, interfaceFilter.interfaceId))
+    .toSet[(Party, Identifier, Identifier)]
+    .groupMap(_._1) { case (_, templateId, interfaceId) => templateId -> interfaceId }
+    .map { case (partyId, templateAndInterfacePairs) =>
+      (partyId.toString, templateAndInterfacePairs.groupMap(_._1)(_._2))
     }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
@@ -39,6 +39,8 @@ import com.daml.platform.participant.util.LfEngineToApi
 import com.daml.platform.store.dao.EventProjectionProperties
 import com.daml.platform.store.dao.events.LfValueTranslation.ApiContractData
 import com.daml.platform.store.serialization.{Compression, ValueSerializer}
+import com.google.protobuf
+import com.google.protobuf.any.Any
 import com.google.rpc.Status
 import com.google.rpc.status.{Status => ProtoStatus}
 import io.grpc.Status.Code
@@ -267,7 +269,7 @@ final class LfValueTranslation(
       )
     } yield raw.partial.copy(
       createArguments = apiContractData.createArguments,
-      createArgumentsBlob = apiContractData.createArgumentsBlob,
+      createArgumentsBlob = apiContractData.createArgumentsBlob.map(Any.fromJavaProto),
       contractKey = apiContractData.contractKey,
       interfaceViews = apiContractData.interfaceViews,
     )
@@ -353,13 +355,18 @@ final class LfValueTranslation(
       ).flatMap(toInterfaceView(eventProjectionProperties.verbose, interfaceId))
     )
 
+    val asyncContractArgumentsBlob = condFuture(renderResult.contractArgumentsBlob)(
+      Future(ValueSerializer.serializeValueAny(value, "Cannot serialize contractArgumentsBlob"))
+    )
+
     for {
       contractArguments <- asyncContractArguments
+      contractArgumentsBlob <- asyncContractArgumentsBlob
       contractKey <- asyncContractKey
       interfaceViews <- asyncInterfaceViews
     } yield ApiContractData(
       createArguments = contractArguments,
-      createArgumentsBlob = None,
+      createArgumentsBlob = contractArgumentsBlob,
       contractKey = contractKey,
       interfaceViews = interfaceViews,
     )
@@ -475,7 +482,7 @@ object LfValueTranslation {
 
   case class ApiContractData(
       createArguments: Option[ApiRecord],
-      createArgumentsBlob: Option[com.google.protobuf.any.Any],
+      createArgumentsBlob: Option[protobuf.Any],
       contractKey: Option[ApiValue],
       interfaceViews: Seq[InterfaceView],
   )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
@@ -40,7 +40,6 @@ import com.daml.platform.store.dao.EventProjectionProperties
 import com.daml.platform.store.dao.events.LfValueTranslation.ApiContractData
 import com.daml.platform.store.serialization.{Compression, ValueSerializer}
 import com.google.protobuf
-import com.google.protobuf.any.Any
 import com.google.rpc.Status
 import com.google.rpc.status.{Status => ProtoStatus}
 import io.grpc.Status.Code
@@ -269,7 +268,7 @@ final class LfValueTranslation(
       )
     } yield raw.partial.copy(
       createArguments = apiContractData.createArguments,
-      createArgumentsBlob = apiContractData.createArgumentsBlob.map(Any.fromJavaProto),
+      createArgumentsBlob = apiContractData.createArgumentsBlob,
       contractKey = apiContractData.contractKey,
       interfaceViews = apiContractData.interfaceViews,
     )
@@ -482,7 +481,7 @@ object LfValueTranslation {
 
   case class ApiContractData(
       createArguments: Option[ApiRecord],
-      createArgumentsBlob: Option[protobuf.Any],
+      createArgumentsBlob: Option[protobuf.any.Any],
       contractKey: Option[ApiValue],
       interfaceViews: Seq[InterfaceView],
   )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
@@ -267,6 +267,7 @@ final class LfValueTranslation(
       )
     } yield raw.partial.copy(
       createArguments = apiContractData.createArguments,
+      createArgumentsBlob = apiContractData.createArgumentsBlob,
       contractKey = apiContractData.contractKey,
       interfaceViews = apiContractData.interfaceViews,
     )
@@ -358,6 +359,7 @@ final class LfValueTranslation(
       interfaceViews <- asyncInterfaceViews
     } yield ApiContractData(
       createArguments = contractArguments,
+      createArgumentsBlob = None,
       contractKey = contractKey,
       interfaceViews = interfaceViews,
     )
@@ -473,6 +475,7 @@ object LfValueTranslation {
 
   case class ApiContractData(
       createArguments: Option[ApiRecord],
+      createArgumentsBlob: Option[com.google.protobuf.any.Any],
       contractKey: Option[ApiValue],
       interfaceViews: Seq[InterfaceView],
   )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionLogUpdatesConversions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionLogUpdatesConversions.scala
@@ -28,6 +28,7 @@ import com.daml.platform.store.dao.EventProjectionProperties
 import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.interfaces.TransactionLogUpdate.{CreatedEvent, ExercisedEvent}
 import com.daml.platform.{ApiOffset, TemplatePartiesFilter, Value}
+import com.google.protobuf.any.Any
 import com.google.protobuf.timestamp.Timestamp
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -429,7 +430,7 @@ private[events] object TransactionLogUpdatesConversions {
           templateId = Some(LfEngineToApi.toApiIdentifier(createdEvent.templateId)),
           contractKey = apiContractData.contractKey,
           createArguments = apiContractData.createArguments,
-          createArgumentsBlob = apiContractData.createArgumentsBlob,
+          createArgumentsBlob = apiContractData.createArgumentsBlob.map(Any.fromJavaProto),
           interfaceViews = apiContractData.interfaceViews,
           witnessParties = requestingParties.view.filter(createdWitnesses(createdEvent)).toSeq,
           signatories = createdEvent.createSignatories.toSeq,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionLogUpdatesConversions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionLogUpdatesConversions.scala
@@ -429,6 +429,7 @@ private[events] object TransactionLogUpdatesConversions {
           templateId = Some(LfEngineToApi.toApiIdentifier(createdEvent.templateId)),
           contractKey = apiContractData.contractKey,
           createArguments = apiContractData.createArguments,
+          createArgumentsBlob = apiContractData.createArgumentsBlob,
           interfaceViews = apiContractData.interfaceViews,
           witnessParties = requestingParties.view.filter(createdWitnesses(createdEvent)).toSeq,
           signatories = createdEvent.createSignatories.toSeq,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionLogUpdatesConversions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionLogUpdatesConversions.scala
@@ -28,7 +28,6 @@ import com.daml.platform.store.dao.EventProjectionProperties
 import com.daml.platform.store.interfaces.TransactionLogUpdate
 import com.daml.platform.store.interfaces.TransactionLogUpdate.{CreatedEvent, ExercisedEvent}
 import com.daml.platform.{ApiOffset, TemplatePartiesFilter, Value}
-import com.google.protobuf.any.Any
 import com.google.protobuf.timestamp.Timestamp
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -430,7 +429,7 @@ private[events] object TransactionLogUpdatesConversions {
           templateId = Some(LfEngineToApi.toApiIdentifier(createdEvent.templateId)),
           contractKey = apiContractData.contractKey,
           createArguments = apiContractData.createArguments,
-          createArgumentsBlob = apiContractData.createArgumentsBlob.map(Any.fromJavaProto),
+          createArgumentsBlob = apiContractData.createArgumentsBlob,
           interfaceViews = apiContractData.interfaceViews,
           witnessParties = requestingParties.view.filter(createdWitnesses(createdEvent)).toSeq,
           signatories = createdEvent.createSignatories.toSeq,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/serialization/ValueSerializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/serialization/ValueSerializer.scala
@@ -4,9 +4,9 @@
 package com.daml.platform.store.serialization
 
 import java.io.InputStream
-
 import com.daml.lf.value.Value.VersionedValue
 import com.daml.lf.value.{ValueCoder, ValueOuterClass}
+import com.google.protobuf.Any
 
 private[platform] object ValueSerializer {
 
@@ -17,6 +17,13 @@ private[platform] object ValueSerializer {
     ValueCoder
       .encodeVersionedValue(ValueCoder.CidEncoder, value)
       .fold(error => sys.error(s"$errorContext (${error.errorMessage})"), _.toByteArray)
+
+  def serializeValueAny(
+      value: VersionedValue,
+      errorContext: => String,
+  ): Any = ValueCoder
+    .encodeVersionedValue(ValueCoder.CidEncoder, value)
+    .fold(error => sys.error(s"$errorContext (${error.errorMessage})"), Any.pack(_))
 
   private def deserializeValueHelper(
       stream: InputStream,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/serialization/ValueSerializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/serialization/ValueSerializer.scala
@@ -6,7 +6,8 @@ package com.daml.platform.store.serialization
 import java.io.InputStream
 import com.daml.lf.value.Value.VersionedValue
 import com.daml.lf.value.{ValueCoder, ValueOuterClass}
-import com.google.protobuf.Any
+import com.google.protobuf.any.Any
+import com.google.protobuf.{Any => JavaAny}
 
 private[platform] object ValueSerializer {
 
@@ -23,7 +24,10 @@ private[platform] object ValueSerializer {
       errorContext: => String,
   ): Any = ValueCoder
     .encodeVersionedValue(ValueCoder.CidEncoder, value)
-    .fold(error => sys.error(s"$errorContext (${error.errorMessage})"), Any.pack(_))
+    .fold(
+      error => sys.error(s"$errorContext (${error.errorMessage})"),
+      versionedValue => Any.fromJavaProto(JavaAny.pack(versionedValue)),
+    )
 
   private def deserializeValueHelper(
       stream: InputStream,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/IndexServiceImplSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/IndexServiceImplSpec.scala
@@ -39,7 +39,7 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     val memoFunc = memoizedTransactionFilterProjection(
       view,
       TransactionFilter(
-        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true)))))
+        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true, true)))))
       ),
       true,
     )
@@ -188,7 +188,7 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     templateFilter(
       PackageMetadata(),
       TransactionFilter(
-        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true)))))
+        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true, true)))))
       ),
     ) shouldBe Map.empty
   }
@@ -197,7 +197,7 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     templateFilter(
       PackageMetadata(interfacesImplementedBy = Map(iface1 -> Set(template1))),
       TransactionFilter(
-        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true)))))
+        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true, true)))))
       ),
     ) shouldBe Map(template1 -> Set(party))
   }
@@ -206,7 +206,11 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     templateFilter(
       PackageMetadata(interfacesImplementedBy = Map(iface1 -> Set(template2))),
       TransactionFilter(
-        Map(party -> Filters(InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, true)))))
+        Map(
+          party -> Filters(
+            InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, true, true)))
+          )
+        )
       ),
     ) shouldBe Map(template1 -> Set(party), template2 -> Set(party))
   }
@@ -222,8 +226,8 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
             InclusiveFilters(
               templateIds = Set(template3),
               interfaceFilters = Set(
-                InterfaceFilter(iface1, true),
-                InterfaceFilter(iface2, true),
+                InterfaceFilter(iface1, true, true),
+                InterfaceFilter(iface2, true, true),
               ),
             )
           )
@@ -255,7 +259,7 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   it should "return an unknown interface for not known interface" in new Scope {
     checkUnknownTemplatesOrInterfaces(
       new TransactionFilter(
-        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true)))))
+        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true, true)))))
       ),
       PackageMetadata(),
     ) shouldBe List(Right(iface1))
@@ -264,7 +268,7 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   it should "return zero unknown interfaces for known interface" in new Scope {
     checkUnknownTemplatesOrInterfaces(
       new TransactionFilter(
-        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true)))))
+        Map(party -> Filters(InclusiveFilters(Set(), Set(InterfaceFilter(iface1, true, true)))))
       ),
       PackageMetadata(interfaces = Set(iface1)),
     ) shouldBe List()
@@ -282,9 +286,11 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     checkUnknownTemplatesOrInterfaces(
       new TransactionFilter(
         Map(
-          party -> Filters(InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, true)))),
+          party -> Filters(
+            InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, true, true)))
+          ),
           party2 -> Filters(
-            InclusiveFilters(Set(template2, template3), Set(InterfaceFilter(iface2, true)))
+            InclusiveFilters(Set(template2, template3), Set(InterfaceFilter(iface2, true, true)))
           ),
         )
       ),

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/IndexServiceImplSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/IndexServiceImplSpec.scala
@@ -56,7 +56,7 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
         EventProjectionProperties(
           true,
           Map.empty[String, Set[Identifier]],
-          Map(party.toString -> Map(template1 -> InterfaceViewFilter(Set(iface1), false))),
+          Map(party.toString -> Map(template1 -> InterfaceViewFilter(Set(iface1), true))),
         ),
       )
     ) // filter gets complicated, filters template1 for iface1, projects iface1
@@ -80,8 +80,8 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
           Map.empty[String, Set[Identifier]],
           Map(
             party.toString -> Map(
-              template1 -> InterfaceViewFilter(Set(iface1), false),
-              template2 -> InterfaceViewFilter(Set(iface1), false),
+              template1 -> InterfaceViewFilter(Set(iface1), true),
+              template2 -> InterfaceViewFilter(Set(iface1), true),
             )
           ),
         ),

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/index/IndexServiceImplSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/index/IndexServiceImplSpec.scala
@@ -17,6 +17,7 @@ import com.daml.platform.index.IndexServiceImpl.{
 }
 import com.daml.platform.index.IndexServiceImplSpec.Scope
 import com.daml.platform.store.dao.EventProjectionProperties
+import com.daml.platform.store.dao.EventProjectionProperties.InterfaceViewFilter
 import com.daml.platform.store.packagemeta.PackageMetadataView
 import com.daml.platform.store.packagemeta.PackageMetadataView.PackageMetadata
 import org.mockito.MockitoSugar
@@ -55,7 +56,7 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
         EventProjectionProperties(
           true,
           Map.empty[String, Set[Identifier]],
-          Map(party.toString -> Map(template1 -> Set(iface1))),
+          Map(party.toString -> Map(template1 -> InterfaceViewFilter(Set(iface1), false))),
         ),
       )
     ) // filter gets complicated, filters template1 for iface1, projects iface1
@@ -77,7 +78,12 @@ class IndexServiceImplSpec extends AnyFlatSpec with Matchers with MockitoSugar {
         EventProjectionProperties(
           true,
           Map.empty[String, Set[Identifier]],
-          Map(party.toString -> Map(template1 -> Set(iface1), template2 -> Set(iface1))),
+          Map(
+            party.toString -> Map(
+              template1 -> InterfaceViewFilter(Set(iface1), false),
+              template2 -> InterfaceViewFilter(Set(iface1), false),
+            )
+          ),
         ),
       )
     ) // filter gets even more complicated, filters template1 and template2 for iface1, projects iface1 for both templates

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
@@ -57,8 +57,8 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
     EventProjectionProperties(
       new TransactionFilter(
         Map(
-          party -> Filters(Some(InclusiveFilters(Set.empty, Set.empty, false))),
-          party2 -> Filters(Some(InclusiveFilters(Set(template1), Set.empty, false))),
+          party -> Filters(Some(InclusiveFilters(Set.empty, Set.empty))),
+          party2 -> Filters(Some(InclusiveFilters(Set(template1), Set.empty))),
         )
       ),
       true,
@@ -74,8 +74,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Some(
         InclusiveFilters(
           Set.empty,
-          Set(InterfaceFilter(iface1, includeView = true)),
-          includeCreateArgumentsBlob = false,
+          Set(InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false)),
         )
       )
     )
@@ -89,8 +88,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Some(
         InclusiveFilters(
           Set.empty,
-          Set(InterfaceFilter(iface1, includeView = false)),
-          includeCreateArgumentsBlob = false,
+          Set(InterfaceFilter(iface1, includeView = false, includeCreateArgumentsBlob = false)),
         )
       )
     )
@@ -105,8 +103,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Some(
         InclusiveFilters(
           Set(template1),
-          Set(InterfaceFilter(iface1, includeView = true)),
-          includeCreateArgumentsBlob = false,
+          Set(InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false)),
         )
       )
     )
@@ -125,10 +122,9 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
         InclusiveFilters(
           Set.empty,
           Set(
-            InterfaceFilter(iface1, includeView = true),
-            InterfaceFilter(iface2, includeView = true),
+            InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false),
+            InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = false),
           ),
-          includeCreateArgumentsBlob = false,
         )
       )
     )
@@ -145,10 +141,9 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
             InclusiveFilters(
               Set.empty,
               Set(
-                InterfaceFilter(iface1, includeView = false),
-                InterfaceFilter(iface2, includeView = true),
+                InterfaceFilter(iface1, includeView = false, includeCreateArgumentsBlob = false),
+                InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = false),
               ),
-              includeCreateArgumentsBlob = false,
             )
           )
         ),
@@ -157,10 +152,9 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
             InclusiveFilters(
               Set.empty,
               Set(
-                InterfaceFilter(iface1, includeView = true),
-                InterfaceFilter(iface2, includeView = true),
+                InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false),
+                InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = false),
               ),
-              includeCreateArgumentsBlob = false,
             )
           )
         ),
@@ -176,7 +170,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
 
   it should "project contract arguments blob in case of match by interface" in new Scope {
     val transactionFilter = new TransactionFilter(
-      Map(party -> Filters(InclusiveFilters(Set.empty, Set(InterfaceFilter(iface1, false)), true)))
+      Map(party -> Filters(InclusiveFilters(Set.empty, Set(InterfaceFilter(iface1, false, true)))))
     )
     EventProjectionProperties(transactionFilter, true, interfaceImpl).render(
       Set(party),
@@ -188,7 +182,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
     val transactionFilter = new TransactionFilter(
       Map(
         party -> Filters(
-          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, false)), true)
+          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, false, true)))
         )
       )
     )
@@ -202,7 +196,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
     val transactionFilter = new TransactionFilter(
       Map(
         party -> Filters(
-          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, true)), true)
+          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, true, true)))
         )
       )
     )
@@ -210,6 +204,26 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Set(party),
       template1,
     ) shouldBe RenderResult(true, true, Set(iface1))
+  }
+
+  it should "project contract arguments blob in case of at least a single interface requesting it" in new Scope {
+    val transactionFilter = new TransactionFilter(
+      Map(
+        party -> Filters(
+          InclusiveFilters(
+            Set.empty,
+            Set(
+              InterfaceFilter(iface1, false, includeCreateArgumentsBlob = true),
+              InterfaceFilter(iface2, false, includeCreateArgumentsBlob = false),
+            ),
+          )
+        )
+      )
+    )
+    EventProjectionProperties(transactionFilter, true, interfaceImpl).render(
+      Set(party),
+      template1,
+    ) shouldBe RenderResult(true, false, Set.empty)
   }
 }
 
@@ -232,10 +246,10 @@ object EventProjectionPropertiesSpec {
     val noFilter = new TransactionFilter(Map())
     val wildcardFilter = new TransactionFilter(Map(party -> Filters(None)))
     val emptyInclusiveFilters = new TransactionFilter(
-      Map(party -> Filters(Some(InclusiveFilters(Set.empty, Set.empty, false))))
+      Map(party -> Filters(Some(InclusiveFilters(Set.empty, Set.empty))))
     )
     def templateFilterFor(templateId: Ref.Identifier): Option[InclusiveFilters] = Some(
-      InclusiveFilters(Set(templateId), Set.empty, false)
+      InclusiveFilters(Set(templateId), Set.empty)
     )
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
@@ -168,6 +168,63 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "project contract arguments blob in case of match by interface" in new Scope {
+    val transactionFilter = new TransactionFilter(
+      Map(party -> Filters(InclusiveFilters(Set.empty, Set(InterfaceFilter(iface1, false, true)))))
+    )
+    EventProjectionProperties(transactionFilter, true, interfaceImpl).render(
+      Set(party),
+      template1,
+    ) shouldBe RenderResult(true, false, Set.empty)
+  }
+
+  it should "project contract arguments blob in case of match by interface and template" in new Scope {
+    val transactionFilter = new TransactionFilter(
+      Map(
+        party -> Filters(
+          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, false, true)))
+        )
+      )
+    )
+    EventProjectionProperties(transactionFilter, true, interfaceImpl).render(
+      Set(party),
+      template1,
+    ) shouldBe RenderResult(true, true, Set.empty)
+  }
+
+  it should "project contract arguments blob in case of match by interface and template with include the view" in new Scope {
+    val transactionFilter = new TransactionFilter(
+      Map(
+        party -> Filters(
+          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, true, true)))
+        )
+      )
+    )
+    EventProjectionProperties(transactionFilter, true, interfaceImpl).render(
+      Set(party),
+      template1,
+    ) shouldBe RenderResult(true, true, Set(iface1))
+  }
+
+  it should "project contract arguments blob in case of at least a single interface requesting it" in new Scope {
+    val transactionFilter = new TransactionFilter(
+      Map(
+        party -> Filters(
+          InclusiveFilters(
+            Set.empty,
+            Set(
+              InterfaceFilter(iface1, false, includeCreateArgumentsBlob = true),
+              InterfaceFilter(iface2, false, includeCreateArgumentsBlob = false),
+            ),
+          )
+        )
+      )
+    )
+    EventProjectionProperties(transactionFilter, true, interfaceImpl).render(
+      Set(party),
+      template1,
+    ) shouldBe RenderResult(true, false, Set.empty)
+  }
 }
 
 object EventProjectionPropertiesSpec {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
@@ -225,6 +225,25 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       template1,
     ) shouldBe RenderResult(true, false, Set.empty)
   }
+
+  it should "not project contract arguments blob in case of no match by interface" in new Scope {
+    val transactionFilter = new TransactionFilter(
+      Map(
+        party -> Filters(
+          InclusiveFilters(
+            Set.empty,
+            Set(
+              InterfaceFilter(iface1, false, includeCreateArgumentsBlob = true)
+            ),
+          )
+        )
+      )
+    )
+    EventProjectionProperties(transactionFilter, true, interfaceImpl).render(
+      Set(party),
+      template2,
+    ) shouldBe RenderResult(false, false, Set.empty)
+  }
 }
 
 object EventProjectionPropertiesSpec {

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
@@ -57,8 +57,8 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
     EventProjectionProperties(
       new TransactionFilter(
         Map(
-          party -> Filters(Some(InclusiveFilters(Set.empty, Set.empty))),
-          party2 -> Filters(Some(InclusiveFilters(Set(template1), Set.empty))),
+          party -> Filters(Some(InclusiveFilters(Set.empty, Set.empty, false))),
+          party2 -> Filters(Some(InclusiveFilters(Set(template1), Set.empty, false))),
         )
       ),
       true,
@@ -74,7 +74,8 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Some(
         InclusiveFilters(
           Set.empty,
-          Set(InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false)),
+          Set(InterfaceFilter(iface1, includeView = true)),
+          includeCreateArgumentsBlob = false,
         )
       )
     )
@@ -88,7 +89,8 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Some(
         InclusiveFilters(
           Set.empty,
-          Set(InterfaceFilter(iface1, includeView = false, includeCreateArgumentsBlob = false)),
+          Set(InterfaceFilter(iface1, includeView = false)),
+          includeCreateArgumentsBlob = false,
         )
       )
     )
@@ -103,7 +105,8 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Some(
         InclusiveFilters(
           Set(template1),
-          Set(InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false)),
+          Set(InterfaceFilter(iface1, includeView = true)),
+          includeCreateArgumentsBlob = false,
         )
       )
     )
@@ -122,9 +125,10 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
         InclusiveFilters(
           Set.empty,
           Set(
-            InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false),
-            InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = false),
+            InterfaceFilter(iface1, includeView = true),
+            InterfaceFilter(iface2, includeView = true),
           ),
+          includeCreateArgumentsBlob = false,
         )
       )
     )
@@ -141,9 +145,10 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
             InclusiveFilters(
               Set.empty,
               Set(
-                InterfaceFilter(iface1, includeView = false, includeCreateArgumentsBlob = false),
-                InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = false),
+                InterfaceFilter(iface1, includeView = false),
+                InterfaceFilter(iface2, includeView = true),
               ),
+              includeCreateArgumentsBlob = false,
             )
           )
         ),
@@ -152,9 +157,10 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
             InclusiveFilters(
               Set.empty,
               Set(
-                InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false),
-                InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = false),
+                InterfaceFilter(iface1, includeView = true),
+                InterfaceFilter(iface2, includeView = true),
               ),
+              includeCreateArgumentsBlob = false,
             )
           )
         ),
@@ -170,7 +176,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
 
   it should "project contract arguments blob in case of match by interface" in new Scope {
     val transactionFilter = new TransactionFilter(
-      Map(party -> Filters(InclusiveFilters(Set.empty, Set(InterfaceFilter(iface1, false, true)))))
+      Map(party -> Filters(InclusiveFilters(Set.empty, Set(InterfaceFilter(iface1, false)), true)))
     )
     EventProjectionProperties(transactionFilter, true, interfaceImpl).render(
       Set(party),
@@ -182,7 +188,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
     val transactionFilter = new TransactionFilter(
       Map(
         party -> Filters(
-          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, false, true)))
+          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, false)), true)
         )
       )
     )
@@ -196,7 +202,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
     val transactionFilter = new TransactionFilter(
       Map(
         party -> Filters(
-          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, true, true)))
+          InclusiveFilters(Set(template1), Set(InterfaceFilter(iface1, true)), true)
         )
       )
     )
@@ -204,26 +210,6 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Set(party),
       template1,
     ) shouldBe RenderResult(true, true, Set(iface1))
-  }
-
-  it should "project contract arguments blob in case of at least a single interface requesting it" in new Scope {
-    val transactionFilter = new TransactionFilter(
-      Map(
-        party -> Filters(
-          InclusiveFilters(
-            Set.empty,
-            Set(
-              InterfaceFilter(iface1, false, includeCreateArgumentsBlob = true),
-              InterfaceFilter(iface2, false, includeCreateArgumentsBlob = false),
-            ),
-          )
-        )
-      )
-    )
-    EventProjectionProperties(transactionFilter, true, interfaceImpl).render(
-      Set(party),
-      template1,
-    ) shouldBe RenderResult(true, false, Set.empty)
   }
 }
 
@@ -246,10 +232,10 @@ object EventProjectionPropertiesSpec {
     val noFilter = new TransactionFilter(Map())
     val wildcardFilter = new TransactionFilter(Map(party -> Filters(None)))
     val emptyInclusiveFilters = new TransactionFilter(
-      Map(party -> Filters(Some(InclusiveFilters(Set.empty, Set.empty))))
+      Map(party -> Filters(Some(InclusiveFilters(Set.empty, Set.empty, false))))
     )
     def templateFilterFor(templateId: Ref.Identifier): Option[InclusiveFilters] = Some(
-      InclusiveFilters(Set(templateId), Set.empty)
+      InclusiveFilters(Set(templateId), Set.empty, false)
     )
   }
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/EventProjectionPropertiesSpec.scala
@@ -74,7 +74,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Some(
         InclusiveFilters(
           Set.empty,
-          Set(InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = true)),
+          Set(InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false)),
         )
       )
     )
@@ -88,7 +88,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Some(
         InclusiveFilters(
           Set.empty,
-          Set(InterfaceFilter(iface1, includeView = false, includeCreateArgumentsBlob = true)),
+          Set(InterfaceFilter(iface1, includeView = false, includeCreateArgumentsBlob = false)),
         )
       )
     )
@@ -103,7 +103,7 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
       Some(
         InclusiveFilters(
           Set(template1),
-          Set(InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = true)),
+          Set(InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false)),
         )
       )
     )
@@ -122,8 +122,8 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
         InclusiveFilters(
           Set.empty,
           Set(
-            InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = true),
-            InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = true),
+            InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false),
+            InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = false),
           ),
         )
       )
@@ -141,8 +141,8 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
             InclusiveFilters(
               Set.empty,
               Set(
-                InterfaceFilter(iface1, includeView = false, includeCreateArgumentsBlob = true),
-                InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = true),
+                InterfaceFilter(iface1, includeView = false, includeCreateArgumentsBlob = false),
+                InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = false),
               ),
             )
           )
@@ -152,8 +152,8 @@ class EventProjectionPropertiesSpec extends AnyFlatSpec with Matchers {
             InclusiveFilters(
               Set.empty,
               Set(
-                InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = true),
-                InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = true),
+                InterfaceFilter(iface1, includeView = true, includeCreateArgumentsBlob = false),
+                InterfaceFilter(iface2, includeView = true, includeCreateArgumentsBlob = false),
               ),
             )
           )

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionConversionSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionConversionSpec.scala
@@ -22,6 +22,7 @@ final class TransactionConversionSpec extends AnyWordSpec with Matchers {
           None,
           None,
           None,
+          None,
           Seq.empty,
           Seq.empty,
           Seq.empty,

--- a/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/AcsBench.scala
+++ b/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/AcsBench.scala
@@ -58,7 +58,7 @@ class AcsBench extends TestCommands with InfAwait {
   ): Option[String] = {
     val events = response.activeContracts.toSet
     events.collectFirst {
-      case CreatedEvent(contractId, _, Some(id), _, _, _, _, _, _, _, _) if id == template =>
+      case CreatedEvent(contractId, _, Some(id), _, _, _, _, _, _, _, _, _) if id == template =>
         contractId
     }
   }

--- a/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/TestHelper.scala
+++ b/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/TestHelper.scala
@@ -130,7 +130,7 @@ trait TestHelper {
       templateId: Identifier
   )(response: GetActiveContractsResponse): List[String] =
     response.activeContracts.toList.collect {
-      case CreatedEvent(_, contractId, Some(actualTemplateId), _, _, _, _, _, _, _, _)
+      case CreatedEvent(_, contractId, Some(actualTemplateId), _, _, _, _, _, _, _, _, _)
           if IdentifierEqual.equal(actualTemplateId, templateId) =>
         contractId
     }

--- a/ledger/test-common/BUILD.bazel
+++ b/ledger/test-common/BUILD.bazel
@@ -89,6 +89,7 @@ carbon_test_names = [
     "carbonv1",
     "carbonv2",  #carbonv2 depends on carbon v1
     "carbonv3",  #carbonv3 depends on carbon v2
+    "modelext",  #modelext depends on model
 ]
 
 general_test_names = [
@@ -112,6 +113,7 @@ da_scala_dar_resources_library(
     data_dependencies = {
         "carbonv2": ["//ledger/test-common:carbonv1-tests-%s.build"],
         "carbonv3": ["//ledger/test-common:carbonv2-tests-%s.build"],
+        "modelext": ["//ledger/test-common:model-tests-%s.build"],
     },
     enable_scenarios = True,
     exclusions = {

--- a/ledger/test-common/src/main/daml/modelext/TestExtension.daml
+++ b/ledger/test-common/src/main/daml/modelext/TestExtension.daml
@@ -1,0 +1,13 @@
+-- Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module TestExtension where
+
+import Test
+
+data EmptyInterfaceView = EmptyInterfaceView {}
+
+interface IDelegated where
+  viewtype EmptyInterfaceView
+  interface instance IDelegated for Test.Delegated where
+    view = EmptyInterfaceView

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -201,11 +201,15 @@
   type: jar-scala
 - target: //ledger/test-common:carbonv2-tests-1.15.scala
   type: jar-scala
+- target: //ledger/test-common:modelext-tests-1.15.scala
+  type: jar-scala
 - target: //ledger/test-common:carbonv1-tests-1.dev.scala
   type: jar-scala
 - target: //ledger/test-common:carbonv2-tests-1.dev.scala
   type: jar-scala
 - target: //ledger/test-common:carbonv3-tests-1.dev.scala
+  type: jar-scala
+- target: //ledger/test-common:modelext-tests-1.dev.scala
   type: jar-scala
 - target: //ledger-service/lf-value-json:lf-value-json
   type: jar-scala


### PR DESCRIPTION
CHANGELOG_BEGIN

[Ledger API]: Introduce an ability to expose contract arguments as blob if matched by the interface filter using `include_create_arguments_blob` flag in the ``InterfaceFilter``.
Introduce an ability to provide `DisclosedContract.arguments` as a blob instead of a typed `Record`.

CHANGELOG_END

<!--
# Pull Request Checklist

- Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- Include appropriate tests
- Set a descriptive title and thorough description
- Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- Normal production system change, include purpose of change in description
- If you mean to change the status of a component, please make sure you keep [the Component Status page](https://github.com/digital-asset/daml/blob/main/docs/source/support/component-statuses.rst) up to date.

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
-->
